### PR TITLE
Add support for code generator property name hints

### DIFF
--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -11,16 +11,18 @@ for describing APIs that can't be represented in the specification.
 
 ### Code generator property name hints
 
-Some APIs do not define the body as a structured object, but accept a generic instead.
+In some cases you need to tell to language generators how to name a property.
+This might happen because the default name cannot be used in the language or because
+some APIs do not define the body as a structured object, but accept a generic instead.
 In those cases you should add a js doc tag to suggest to language generators what
 property name should be used.
-Currently, only property name hints for the body are supported.
+
+It's important to mention that language generators **don't have to** respect the name hint.
+It is only a suggestion or it might apply only to specific languages.
 
 The js tag should be used as follows:
 ```ts
-  /**
-   * @codegen_param_name <property_name>
-   */
+  /** @identifier document */
   body: TDocument
 ```
 
@@ -39,10 +41,29 @@ interface IndexRequest<TDocument> extends RequestBase {
   query_parameters?: {
     ...
   }
-  /**
-   * @codegen_param_name document
-   */
+  /** @identifier document */
   body?: TDocument
+}
+```
+
+Another example with enums:
+
+```ts
+enum DateMathTimeUnit {
+  /** @identifier Second */
+  s = 0,
+  /** @identifier Minute */
+  m = 1,
+  /** @identifier Hour */
+  h = 2,
+  /** @identifier Day */
+  d = 3,
+  /** @identifier Week */
+  w = 4,
+  /** @identifier Month */
+  M = 5,
+  /** @identifier Year */
+  y = 6
 }
 ```
 

--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -9,6 +9,43 @@ the basic types [here](https://www.typescriptlang.org/docs/handbook/basic-types.
 while in [behaviors](./behaviors.md) you can find the list of special interfaces used
 for describing APIs that can't be represented in the specification.
 
+### Code generator property name hints
+
+Some APIs do not define the body as a structured object, but accept a generic instead.
+In those cases you should add a js doc tag to suggest to language generators what
+property name should be used.
+Currently, only property name hints for the body are supported.
+
+The js tag should be used as follows:
+```ts
+  /**
+   * @codegen_param_name <property_name>
+   */
+  body: TDocument
+```
+
+Fo example: 
+```ts
+/**
+ * @rest_spec_name index
+ * @since 0.0.0
+ * @stability stable
+ * @class_serializer IndexRequestFormatter`1`
+ */
+interface IndexRequest<TDocument> extends RequestBase {
+  path_parts?: {
+    ...
+  }
+  query_parameters?: {
+    ...
+  }
+  /**
+   * @codegen_param_name document
+   */
+  body?: TDocument
+}
+```
+
 ### Dictionary
 
 Represents a dynamic key value map:

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -38360,6 +38360,7 @@
           }
         }
       },
+      "codegenBodyName": "document",
       "generics": [
         "TDocument"
       ],
@@ -50089,6 +50090,7 @@
           }
         }
       },
+      "codegenBodyName": "contents",
       "generics": [
         "TBody"
       ],
@@ -62909,6 +62911,7 @@
           }
         }
       },
+      "codegenBodyName": "document",
       "generics": [
         "TDocument"
       ],

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -38360,7 +38360,7 @@
           }
         }
       },
-      "codegenBodyName": "document",
+      "bodyIdentifier": "document",
       "generics": [
         "TDocument"
       ],
@@ -50090,7 +50090,7 @@
           }
         }
       },
-      "codegenBodyName": "contents",
+      "bodyIdentifier": "contents",
       "generics": [
         "TBody"
       ],
@@ -62911,7 +62911,7 @@
           }
         }
       },
-      "codegenBodyName": "document",
+      "bodyIdentifier": "document",
       "generics": [
         "TDocument"
       ],

--- a/specification/compiler/model/build-model.ts
+++ b/specification/compiler/model/build-model.ts
@@ -49,7 +49,8 @@ import {
   modelInherits,
   modelProperty,
   modelType,
-  modelTypeAlias
+  modelTypeAlias,
+  parseJsDocTags
 } from './utils'
 
 const specsFolder = join(__dirname, '..', '..', 'specs')
@@ -217,6 +218,10 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
         } else if (property.properties.length > 0) {
           type.body = { kind: 'properties', properties: property.properties }
         }
+
+        if (property.codegen_param_name != null) {
+          type.codegenBodyName = property.codegen_param_name
+        }
       }
     }
 
@@ -315,14 +320,14 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
  * differently as are described as nested objects, and the body could have two
  * different types, `model.Property[]` (a normal object) or `model.ValueOf` (eg: an array or generic)
  */
-function visitRequestProperty (member: PropertyDeclaration | PropertySignature): { name: string, properties: model.Property[], valueOf: model.ValueOf | null } {
+function visitRequestProperty (member: PropertyDeclaration | PropertySignature): { name: string, properties: model.Property[], valueOf: model.ValueOf | null, codegen_param_name?: string } {
   const properties: model.Property[] = []
   let valueOf: model.ValueOf | null = null
 
   const name = member.getName()
   const value = member.getTypeNode()
   assert(value, `The property ${name} is not defined`)
-
+  const tags = parseJsDocTags(member.getJsDocs())
   // Request classes have three top level properties:
   // - path_parts
   // - query_parameters
@@ -346,7 +351,7 @@ function visitRequestProperty (member: PropertyDeclaration | PropertySignature):
     })
   }
 
-  return { name, properties, valueOf }
+  return { name, properties, valueOf, codegen_param_name: tags.codegen_param_name }
 }
 
 function formatDanglingPath (path: string): string {

--- a/specification/compiler/model/build-model.ts
+++ b/specification/compiler/model/build-model.ts
@@ -219,8 +219,8 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
           type.body = { kind: 'properties', properties: property.properties }
         }
 
-        if (property.codegen_param_name != null) {
-          type.codegenBodyName = property.codegen_param_name
+        if (property.identifier != null) {
+          type.bodyIdentifier = property.identifier
         }
       }
     }
@@ -320,7 +320,7 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
  * differently as are described as nested objects, and the body could have two
  * different types, `model.Property[]` (a normal object) or `model.ValueOf` (eg: an array or generic)
  */
-function visitRequestProperty (member: PropertyDeclaration | PropertySignature): { name: string, properties: model.Property[], valueOf: model.ValueOf | null, codegen_param_name?: string } {
+function visitRequestProperty (member: PropertyDeclaration | PropertySignature): { name: string, properties: model.Property[], valueOf: model.ValueOf | null, identifier?: string } {
   const properties: model.Property[] = []
   let valueOf: model.ValueOf | null = null
 
@@ -351,7 +351,7 @@ function visitRequestProperty (member: PropertyDeclaration | PropertySignature):
     })
   }
 
-  return { name, properties, valueOf, codegen_param_name: tags.codegen_param_name }
+  return { name, properties, valueOf, identifier: tags.identifier }
 }
 
 function formatDanglingPath (path: string): string {

--- a/specification/compiler/model/metamodel.ts
+++ b/specification/compiler/model/metamodel.ts
@@ -208,6 +208,11 @@ export class Request extends BaseType {
   body?: ValueBody | PropertiesBody
   behaviors?: Implements[]
   attachedBehaviors?: string[]
+  /**
+   * The parameter name language generator should use,
+   * normally used when the entire body is a generic.
+   */
+  codegenBodyName?: string
 }
 
 export class ValueBody {

--- a/specification/compiler/model/metamodel.ts
+++ b/specification/compiler/model/metamodel.ts
@@ -212,7 +212,7 @@ export class Request extends BaseType {
    * The parameter name language generator should use,
    * normally used when the entire body is a generic.
    */
-  codegenBodyName?: string
+  bodyIdentifier?: string
 }
 
 export class ValueBody {

--- a/specification/specs/document/single/create/CreateRequest.ts
+++ b/specification/specs/document/single/create/CreateRequest.ts
@@ -38,5 +38,8 @@ interface CreateRequest<TDocument> extends RequestBase {
     version_type?: VersionType
     wait_for_active_shards?: string
   }
+  /**
+   * @codegen_param_name document
+   */
   body?: TDocument
 }

--- a/specification/specs/document/single/create/CreateRequest.ts
+++ b/specification/specs/document/single/create/CreateRequest.ts
@@ -38,8 +38,6 @@ interface CreateRequest<TDocument> extends RequestBase {
     version_type?: VersionType
     wait_for_active_shards?: string
   }
-  /**
-   * @codegen_param_name document
-   */
+  /** @identifier document */
   body?: TDocument
 }

--- a/specification/specs/document/single/index/IndexRequest.ts
+++ b/specification/specs/document/single/index/IndexRequest.ts
@@ -42,5 +42,8 @@ interface IndexRequest<TDocument> extends RequestBase {
     wait_for_active_shards?: string
     require_alias?: boolean
   }
+  /**
+   * @codegen_param_name document
+   */
   body?: TDocument
 }

--- a/specification/specs/document/single/index/IndexRequest.ts
+++ b/specification/specs/document/single/index/IndexRequest.ts
@@ -42,8 +42,6 @@ interface IndexRequest<TDocument> extends RequestBase {
     wait_for_active_shards?: string
     require_alias?: boolean
   }
-  /**
-   * @codegen_param_name document
-   */
+  /** @identifier document */
   body?: TDocument
 }

--- a/specification/specs/x_pack/text_structure/FindStructure.ts
+++ b/specification/specs/x_pack/text_structure/FindStructure.ts
@@ -38,9 +38,7 @@ interface FindStructureRequest<TBody> {
     timestamp_field?: Field
     timestamp_format?: string
   }
-  /**
-   * @codegen_param_name contents
-   */
+  /** @identifier contents */
   body: TBody
 }
 

--- a/specification/specs/x_pack/text_structure/FindStructure.ts
+++ b/specification/specs/x_pack/text_structure/FindStructure.ts
@@ -38,6 +38,9 @@ interface FindStructureRequest<TBody> {
     timestamp_field?: Field
     timestamp_format?: string
   }
+  /**
+   * @codegen_param_name contents
+   */
   body: TBody
 }
 


### PR DESCRIPTION
This will allow the JSON model to suggest to language generators how to call the requests body parameter if it's a generic and not a structured object.

It's extremely useful for clients that abstract away the HTTP lingo from the surface API of the client.

Example usage:
```ts
/**
 * @rest_spec_name index
 * @since 0.0.0
 * @stability stable
 * @class_serializer IndexRequestFormatter`1`
 */
interface IndexRequest<TDocument> extends RequestBase {
  path_parts?: {
    ...
  }
  query_parameters?: {
    ...
  }
  /** @identifier document */
  body?: TDocument
}
```

How it will look like in the JSON model:
```jsonc
"bodyIdentifier": "document",
```