### PR TITLE
Remove duplicated properties

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -47731,29 +47731,6 @@
       },
       "properties": [
         {
-          "name": "dynamic",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DynamicMapping",
-                  "namespace": "_types.mapping"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
-        {
           "name": "enabled",
           "required": false,
           "type": {
@@ -47761,28 +47738,6 @@
             "type": {
               "name": "boolean",
               "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "properties",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "PropertyName",
-                "namespace": "_types"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Property",
-                "namespace": "_types.mapping"
-              }
             }
           }
         },
@@ -47971,29 +47926,6 @@
       },
       "properties": [
         {
-          "name": "dynamic",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DynamicMapping",
-                  "namespace": "_types.mapping"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
-        {
           "name": "enabled",
           "required": false,
           "type": {
@@ -48001,28 +47933,6 @@
             "type": {
               "name": "boolean",
               "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "properties",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "PropertyName",
-                "namespace": "_types"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Property",
-                "namespace": "_types.mapping"
-              }
             }
           }
         },
@@ -50169,17 +50079,6 @@
               "namespace": "_types"
             }
           }
-        },
-        {
-          "name": "boost",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "float",
-              "namespace": "_types"
-            }
-          }
         }
       ]
     },
@@ -50672,17 +50571,6 @@
             "type": {
               "name": "FunctionScoreMode",
               "namespace": "_types.query_dsl"
-            }
-          }
-        },
-        {
-          "name": "boost",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "float",
-              "namespace": "_types"
             }
           }
         }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -49849,17 +49849,6 @@
               "namespace": "_types.query_dsl"
             }
           }
-        },
-        {
-          "name": "boost",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "float",
-              "namespace": "_types"
-            }
-          }
         }
       ]
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3825,9 +3825,7 @@ export interface MappingMurmur3HashProperty extends MappingDocValuesPropertyBase
 }
 
 export interface MappingNestedProperty extends MappingCorePropertyBase {
-  dynamic?: boolean | MappingDynamicMapping
   enabled?: boolean
-  properties?: Record<PropertyName, MappingProperty>
   include_in_parent?: boolean
   include_in_root?: boolean
   type: 'nested'
@@ -3847,9 +3845,7 @@ export interface MappingNumberProperty extends MappingDocValuesPropertyBase {
 export type MappingNumberType = 'float' | 'half_float' | 'scaled_float' | 'double' | 'integer' | 'long' | 'short' | 'byte' | 'unsigned_long'
 
 export interface MappingObjectProperty extends MappingCorePropertyBase {
-  dynamic?: boolean | MappingDynamicMapping
   enabled?: boolean
-  properties?: Record<PropertyName, MappingProperty>
   type?: 'object'
 }
 
@@ -4070,7 +4066,6 @@ export interface QueryDslDecayPlacement<TOrigin = unknown, TScale = unknown> {
 export interface QueryDslDisMaxQuery extends QueryDslQueryBase {
   queries?: QueryDslQueryContainer[]
   tie_breaker?: double
-  boost?: float
 }
 
 export interface QueryDslDistanceFeatureQuery extends QueryDslQueryBase {
@@ -4121,7 +4116,6 @@ export interface QueryDslFunctionScoreQuery extends QueryDslQueryBase {
   min_score?: double
   query?: QueryDslQueryContainer
   score_mode?: QueryDslFunctionScoreMode
-  boost?: float
 }
 
 export interface QueryDslFuzzyQuery extends QueryDslQueryBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4042,7 +4042,6 @@ export interface QueryDslCommonTermsQuery extends QueryDslQueryBase {
 
 export interface QueryDslConstantScoreQuery extends QueryDslQueryBase {
   filter?: QueryDslQueryContainer
-  boost?: float
 }
 
 export interface QueryDslDateDecayFunctionKeys extends QueryDslDecayFunctionBase {

--- a/specification/_types/mapping/complex.ts
+++ b/specification/_types/mapping/complex.ts
@@ -38,17 +38,13 @@ export class FlattenedProperty extends PropertyBase {
 }
 
 export class NestedProperty extends CorePropertyBase {
-  dynamic?: boolean | DynamicMapping
   enabled?: boolean
-  properties?: Dictionary<PropertyName, Property>
   include_in_parent?: boolean
   include_in_root?: boolean
   type: 'nested'
 }
 
 export class ObjectProperty extends CorePropertyBase {
-  dynamic?: boolean | DynamicMapping
   enabled?: boolean
-  properties?: Dictionary<PropertyName, Property>
   type?: 'object'
 }

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -42,7 +42,6 @@ export class BoostingQuery extends QueryBase {
 
 export class ConstantScoreQuery extends QueryBase {
   filter?: QueryContainer
-  boost?: float
 }
 
 export class DisMaxQuery extends QueryBase {

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -48,7 +48,6 @@ export class ConstantScoreQuery extends QueryBase {
 export class DisMaxQuery extends QueryBase {
   queries?: QueryContainer[]
   tie_breaker?: double
-  boost?: float
 }
 
 export class FunctionScoreQuery extends QueryBase {
@@ -58,7 +57,6 @@ export class FunctionScoreQuery extends QueryBase {
   min_score?: double
   query?: QueryContainer
   score_mode?: FunctionScoreMode
-  boost?: float
 }
 
 export class ScoreFunctionBase {


### PR DESCRIPTION
During .NET code gen I identified a few types which duplicate properties defined on types they derive from. This causes compilation errors in the C# code. This PR removes the duplicated properties.