### PR TITLE
Fix "container_property" naming discrepancy

### DIFF
--- a/compiler/model/metamodel.ts
+++ b/compiler/model/metamodel.ts
@@ -136,7 +136,7 @@ export class Property {
   /** An optional set of aliases for `name` */
   aliases?: string[]
   /** If the enclosing class is a variants container, is this a property of the container and not a variant? */
-  container_property?: boolean
+  containerProperty?: boolean
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -611,7 +611,7 @@ function hoistPropertyAnnotations (property: model.Property, jsDocs: JSDoc[]): v
       }
     } else if (tag === 'variant') {
       assert(jsDocs, value === 'container_property', `Unknown 'variant' value '${value}' on property ${property.name}`)
-      property.container_property = true
+      property.containerProperty = true
     } else {
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on property ${property.name}`)
     }

--- a/compiler/steps/validate-model.ts
+++ b/compiler/steps/validate-model.ts
@@ -460,7 +460,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     validateProperties(typeDef.properties, openGenerics)
 
     if (typeDef.variants?.kind === 'container') {
-      const variants = typeDef.properties.filter(prop => !(prop.container_property ?? false))
+      const variants = typeDef.properties.filter(prop => !(prop.containerProperty ?? false))
       if (variants.length === 1) {
         // Single-variant containers must have a required property
         if (!variants[0].required) {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -34745,7 +34745,7 @@
       },
       "properties": [
         {
-          "container_property": true,
+          "containerProperty": true,
           "name": "aggs",
           "required": false,
           "type": {
@@ -34768,7 +34768,7 @@
           }
         },
         {
-          "container_property": true,
+          "containerProperty": true,
           "name": "meta",
           "required": false,
           "type": {


### PR DESCRIPTION
`container_property` in the metamodel should be `containerProperty` to be consistent with the camelCase convention used in that file.