### PR TITLE
[WIP] Add "base_class" variants attribute

### DIFF
--- a/compiler/model/metamodel.ts
+++ b/compiler/model/metamodel.ts
@@ -164,15 +164,22 @@ export type Variants = ExternalTag | InternalTag | Container
 
 export class ExternalTag {
   kind: 'external_tag'
+  /**
+   * Base class for all variants, if any. This is a hint for OOP language generators that can use this base class
+   * as a type that can be assigned any of the variants.
+   */
+  baseClass?: TypeName
 }
 
 export class InternalTag {
   kind: 'internal_tag'
+  baseClass?: TypeName
   tag: string // Name of the property that holds the variant tag
 }
 
 export class Container {
   kind: 'container'
+  baseClass?: TypeName
 }
 
 /**


### PR DESCRIPTION
Adds a `base_class` attribute to the `@variants` jsdoc tag. It is a hint for object-oriented language generators indicating the base class that is common to all variants. This attribute applies to all kinds of variants (containers, internal & external).

**[WIP]:** this PR doesn't correctly resolve the namespace of the `base_class` value (need help from @delvedor): it uses the namespace from the _current_ sourcefile, which is likely to be ok in many cases, but will fail on more complex module structures.