### PR TITLE
Review/update/fix query definitions

### DIFF
--- a/compiler/model/metamodel.ts
+++ b/compiler/model/metamodel.ts
@@ -207,6 +207,11 @@ export class Interface extends BaseType {
    */
   attachedBehaviors?: string[]
   properties: Property[]
+  /**
+   * The property that can be used as a shortcut for the entire data structure in the JSON.
+   */
+  shortcutProperty?: string
+
   /** Identify containers */
   variants?: Container
 }

--- a/docs/behaviors.md
+++ b/docs/behaviors.md
@@ -6,16 +6,23 @@ Behaviors should be used via `implements` in the specification.
 
 You can find all the special classes and aliases in in the [modeling guide](./modeling-guide.md).
 
-## AdditionalProperties
+## AdditionalProperties & AdditionalProperty
 
 In some places in the specification an object consists of the union of a set of known properties
-and a set of runtime injected properties. Meaning that object should theoretically extend Dictionary but expose
-a set of known keys and possibly. The object might already be part of an object graph and have a parent class.
-This puts it into a bind that needs a client specific solution.
+and a set of runtime injected properties. Meaning that object should theoretically extend `Dictionary` but expose
+a set of known keys. The object might also be part of an object graph and have a parent class.
+This puts it into a bin that needs a client specific solution.
 We therefore document the requirement to behave like a dictionary for unknown properties with this interface.
 
 ```ts
 class IpRangeBucket implements AdditionalProperties<AggregateName, Aggregate> {}
+```
+
+There are also many places where we expect only one runtime-defined property, such as in field-related queries. To capture that uniqueness constraint, we can use the `AdditionalProperty` (singular) behavior.
+
+```ts
+class GeoBoundingBoxQuery extends QueryBase
+  implements AdditionalProperty<Field, BoundingBox>
 ```
 
 ## CommonQueryParameters

--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -317,6 +317,25 @@ class AggregationContainer {
   avg?: AverageAggregation
   ...
 ```
+
+### Shortcut properties
+
+In many places Elasticsearch accepts a property value to be either a complete data structure or a single value, that value being a shortcut for a property in the data structure.
+
+A typical example can be found in queries such as term query: `{"term": {"some_field": {"value": "some_text"}}}` can also be written as `{"term": {"some_field": "some_text"}}`.
+
+This could be modelled as a union of `SomeClass | string`, but this notation doesn't capture the relation between the string variant and the corresponding field (`value` in the above example).
+
+To capture this information and also simplify the spec by avoiding the union, we use the `@shortcut_property` JSDoc tag:
+
+```ts
+/** @shortcut_property value */
+export class TermQuery extends QueryBase {
+  value: string | float | boolean
+  case_insensitive?: boolean
+}
+```
+
 ### Additional information
 
 If needed, you can specify additional information on each type with the approariate JSDoc tag.

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -16279,7 +16279,9 @@
             }
           },
           {
-            "description": "deprecated since 7.0.0",
+            "deprecation": {
+              "version": "7.0.0"
+            },
             "name": "_type",
             "required": false,
             "type": {
@@ -20973,7 +20975,9 @@
       },
       "path": [
         {
-          "description": "Deprecated with 7.0.0",
+          "deprecation": {
+            "version": "7.0.0"
+          },
           "name": "scroll_id",
           "required": false,
           "type": {
@@ -21001,7 +21005,9 @@
           }
         },
         {
-          "description": "Deprecated with 7.0.0",
+          "deprecation": {
+            "version": "7.0.0"
+          },
           "name": "scroll_id",
           "required": false,
           "type": {
@@ -23137,6 +23143,49 @@
     {
       "kind": "interface",
       "name": {
+        "name": "FieldAndFormat",
+        "namespace": "_global.search._types"
+      },
+      "properties": [
+        {
+          "name": "field",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Field",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "format",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "include_unmapped",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "shortcutProperty": "field"
+    },
+    {
+      "kind": "interface",
+      "name": {
         "name": "FieldCollapse",
         "namespace": "_global.search._types"
       },
@@ -23265,8 +23314,8 @@
             {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Field",
+                "namespace": "_types"
               }
             },
             {
@@ -24327,10 +24376,13 @@
           "name": "docvalue_fields",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Fields",
-              "namespace": "_types"
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "FieldAndFormat",
+                "namespace": "_global.search._types"
+              }
             }
           }
         },
@@ -24374,8 +24426,8 @@
             "key": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Field",
+                "namespace": "_types"
               }
             },
             "kind": "dictionary_of",
@@ -24443,6 +24495,29 @@
               }
             ],
             "kind": "union_of"
+          }
+        },
+        {
+          "name": "stored_field",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "track_scores",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
           }
         },
         {
@@ -25734,8 +25809,8 @@
             {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Field",
+                "namespace": "_types"
               }
             },
             {
@@ -29648,6 +29723,21 @@
       ]
     },
     {
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/mapping-date-format.html",
+      "kind": "type_alias",
+      "name": {
+        "name": "DateFormat",
+        "namespace": "_types"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "string",
+          "namespace": "internal"
+        }
+      }
+    },
+    {
       "kind": "type_alias",
       "name": {
         "name": "DateMath",
@@ -30676,6 +30766,17 @@
           "name": "number",
           "namespace": "internal"
         }
+      }
+    },
+    {
+      "description": "A GeoJson shape, that can also use Elasticsearch's `envelope` extension.",
+      "kind": "type_alias",
+      "name": {
+        "name": "GeoShape",
+        "namespace": "_types"
+      },
+      "type": {
+        "kind": "user_defined_value"
       }
     },
     {
@@ -31792,6 +31893,7 @@
       }
     },
     {
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-term-rewrite.html",
       "kind": "type_alias",
       "name": {
         "name": "MultiTermQueryRewrite",
@@ -32873,23 +32975,11 @@
         "namespace": "_types"
       },
       "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "number",
-              "namespace": "internal"
-            }
-          }
-        ],
-        "kind": "union_of"
+        "kind": "instance_of",
+        "type": {
+          "name": "string",
+          "namespace": "internal"
+        }
       }
     },
     {
@@ -32978,6 +33068,17 @@
             "type": {
               "name": "Script",
               "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "ignore_failure",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
             }
           }
         }
@@ -34043,6 +34144,20 @@
       "kind": "type_alias",
       "name": {
         "name": "TimeSpan",
+        "namespace": "_types"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "string",
+          "namespace": "internal"
+        }
+      }
+    },
+    {
+      "kind": "type_alias",
+      "name": {
+        "name": "TimeZone",
         "namespace": "_types"
       },
       "type": {
@@ -44933,26 +45048,14 @@
         "namespace": "_types.analysis"
       },
       "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          },
-          {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
+        "kind": "array_of",
+        "value": {
+          "kind": "instance_of",
+          "type": {
+            "name": "string",
+            "namespace": "internal"
           }
-        ],
-        "kind": "union_of"
+        }
       }
     },
     {
@@ -49997,7 +50100,7 @@
       "properties": [
         {
           "name": "negative_boost",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -50008,7 +50111,7 @@
         },
         {
           "name": "negative",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -50019,7 +50122,7 @@
         },
         {
           "name": "positive",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -50031,6 +50134,7 @@
       ]
     },
     {
+      "description": "A geo bounding box. The various coordinates can be mixed. When set, `wkt` takes precedence over all other fields.",
       "kind": "interface",
       "name": {
         "name": "BoundingBox",
@@ -50056,6 +50160,72 @@
             "type": {
               "name": "GeoLocation",
               "namespace": "_types.query_dsl"
+            }
+          }
+        },
+        {
+          "name": "top_right",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "GeoLocation",
+              "namespace": "_types.query_dsl"
+            }
+          }
+        },
+        {
+          "name": "bottom_left",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "GeoLocation",
+              "namespace": "_types.query_dsl"
+            }
+          }
+        },
+        {
+          "name": "top",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "left",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "right",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "bottom",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
             }
           }
         },
@@ -50097,23 +50267,33 @@
       }
     },
     {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "or"
+        },
+        {
+          "name": "and"
+        }
+      ],
+      "name": {
+        "name": "CombinedFieldsOperator",
+        "namespace": "_types.query_dsl"
+      }
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl"
+        }
+      },
       "kind": "interface",
       "name": {
         "name": "CombinedFieldsQuery",
         "namespace": "_types.query_dsl"
       },
       "properties": [
-        {
-          "name": "query",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
         {
           "name": "fields",
           "required": true,
@@ -50129,8 +50309,8 @@
           }
         },
         {
-          "name": "operator",
-          "required": false,
+          "name": "query",
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -50138,8 +50318,70 @@
               "namespace": "internal"
             }
           }
+        },
+        {
+          "name": "auto_generate_synonyms_phrase_query",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "operator",
+          "required": false,
+          "serverDefault": "or",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "CombinedFieldsOperator",
+              "namespace": "_types.query_dsl"
+            }
+          }
+        },
+        {
+          "name": "mimimum_should_match",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "MinimumShouldMatch",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "zero_terms_query",
+          "required": false,
+          "serverDefault": "none",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "CombinedFieldsZeroTerms",
+              "namespace": "_types.query_dsl"
+            }
+          }
         }
       ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "none"
+        },
+        {
+          "name": "all"
+        }
+      ],
+      "name": {
+        "name": "CombinedFieldsZeroTerms",
+        "namespace": "_types.query_dsl"
+      }
     },
     {
       "inherits": {
@@ -50211,7 +50453,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -50220,7 +50462,8 @@
             }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "query"
     },
     {
       "inherits": {
@@ -50237,7 +50480,7 @@
       "properties": [
         {
           "name": "filter",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -50250,7 +50493,7 @@
     },
     {
       "attachedBehaviors": [
-        "AdditionalProperties"
+        "AdditionalProperty"
       ],
       "behaviors": [
         {
@@ -50258,8 +50501,8 @@
             {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Field",
+                "namespace": "_types"
               }
             },
             {
@@ -50287,7 +50530,7 @@
             }
           ],
           "type": {
-            "name": "AdditionalProperties",
+            "name": "AdditionalProperty",
             "namespace": "_spec_utils"
           }
         }
@@ -50304,6 +50547,118 @@
         "namespace": "_types.query_dsl"
       },
       "properties": []
+    },
+    {
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateMath",
+              "namespace": "_types"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        ],
+        "type": {
+          "name": "DistanceFeatureQueryBase",
+          "namespace": "_types.query_dsl"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "DateDistanceFeatureQuery",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": []
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "RangeQueryBase",
+          "namespace": "_types.query_dsl"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "DateRangeQuery",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": [
+        {
+          "name": "gt",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateMath",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "gte",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateMath",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "lt",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateMath",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "lte",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateMath",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "format",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateFormat",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "time_zone",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TimeZone",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "variantName": "date"
     },
     {
       "kind": "type_alias",
@@ -50442,7 +50797,7 @@
       "properties": [
         {
           "name": "queries",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "array_of",
             "value": {
@@ -50457,6 +50812,7 @@
         {
           "name": "tie_breaker",
           "required": false,
+          "serverDefault": "0.0",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -50468,6 +50824,42 @@
       ]
     },
     {
+      "kind": "type_alias",
+      "name": {
+        "name": "DistanceFeatureQuery",
+        "namespace": "_types.query_dsl"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "GeoDistanceFeatureQuery",
+              "namespace": "_types.query_dsl"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateDistanceFeatureQuery",
+              "namespace": "_types.query_dsl"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
+      "generics": [
+        {
+          "name": "TOrigin",
+          "namespace": "_types.query_dsl"
+        },
+        {
+          "name": "TDistance",
+          "namespace": "_types.query_dsl"
+        }
+      ],
       "inherits": {
         "type": {
           "name": "QueryBase",
@@ -50476,69 +50868,35 @@
       },
       "kind": "interface",
       "name": {
-        "name": "DistanceFeatureQuery",
+        "name": "DistanceFeatureQueryBase",
         "namespace": "_types.query_dsl"
       },
       "properties": [
         {
           "name": "origin",
-          "required": false,
+          "required": true,
           "type": {
-            "items": [
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "number",
-                    "namespace": "internal"
-                  }
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "GeoCoordinate",
-                  "namespace": "_types.query_dsl"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateMath",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "TOrigin",
+              "namespace": "_types.query_dsl"
+            }
           }
         },
         {
           "name": "pivot",
-          "required": false,
+          "required": true,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Distance",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Time",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "TDistance",
+              "namespace": "_types.query_dsl"
+            }
           }
         },
         {
           "name": "field",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -50564,7 +50922,7 @@
       "properties": [
         {
           "name": "field",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -50584,7 +50942,7 @@
       "properties": [
         {
           "name": "id",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -50827,6 +51185,7 @@
           }
         },
         {
+          "containerProperty": true,
           "name": "filter",
           "required": false,
           "type": {
@@ -50838,6 +51197,7 @@
           }
         },
         {
+          "containerProperty": true,
           "name": "weight",
           "required": false,
           "type": {
@@ -50848,7 +51208,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "enum",
@@ -51033,12 +51396,44 @@
           "name": "value",
           "required": true,
           "type": {
-            "kind": "user_defined_value"
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "value"
     },
     {
+      "attachedBehaviors": [
+        "AdditionalProperty"
+      ],
+      "behaviors": [
+        {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "BoundingBox",
+                "namespace": "_types.query_dsl"
+              }
+            }
+          ],
+          "type": {
+            "name": "AdditionalProperty",
+            "namespace": "_spec_utils"
+          }
+        }
+      ],
       "inherits": {
         "type": {
           "name": "QueryBase",
@@ -51052,17 +51447,9 @@
       },
       "properties": [
         {
-          "name": "bounding_box",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "BoundingBox",
-              "namespace": "_types.query_dsl"
-            }
-          }
-        },
-        {
+          "deprecation": {
+            "version": "7.14.0"
+          },
           "name": "type",
           "required": false,
           "type": {
@@ -51076,33 +51463,12 @@
         {
           "name": "validation_method",
           "required": false,
+          "serverDefault": "'strict'",
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "GeoValidationMethod",
               "namespace": "_types.query_dsl"
-            }
-          }
-        },
-        {
-          "name": "top_left",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "LatLon",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "bottom_right",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "LatLon",
-              "namespace": "_types"
             }
           }
         }
@@ -51147,7 +51513,7 @@
     },
     {
       "attachedBehaviors": [
-        "AdditionalProperties"
+        "AdditionalProperty"
       ],
       "behaviors": [
         {
@@ -51155,8 +51521,8 @@
             {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Field",
+                "namespace": "_types"
               }
             },
             {
@@ -51184,7 +51550,7 @@
             }
           ],
           "type": {
-            "name": "AdditionalProperties",
+            "name": "AdditionalProperty",
             "namespace": "_spec_utils"
           }
         }
@@ -51203,8 +51569,38 @@
       "properties": []
     },
     {
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "GeoCoordinate",
+              "namespace": "_types.query_dsl"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "Distance",
+              "namespace": "_types"
+            }
+          }
+        ],
+        "type": {
+          "name": "DistanceFeatureQueryBase",
+          "namespace": "_types.query_dsl"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "GeoDistanceFeatureQuery",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": []
+    },
+    {
       "attachedBehaviors": [
-        "AdditionalProperties"
+        "AdditionalProperty"
       ],
       "behaviors": [
         {
@@ -51212,8 +51608,8 @@
             {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Field",
+                "namespace": "_types"
               }
             },
             {
@@ -51225,7 +51621,7 @@
             }
           ],
           "type": {
-            "name": "AdditionalProperties",
+            "name": "AdditionalProperty",
             "namespace": "_spec_utils"
           }
         }
@@ -51256,6 +51652,7 @@
         {
           "name": "distance_type",
           "required": false,
+          "serverDefault": "'arc'",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51267,6 +51664,7 @@
         {
           "name": "validation_method",
           "required": false,
+          "serverDefault": "'strict'",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51330,6 +51728,59 @@
       }
     },
     {
+      "kind": "interface",
+      "name": {
+        "name": "GeoPolygonPoints",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": [
+        {
+          "name": "points",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "GeoLocation",
+                "namespace": "_types.query_dsl"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "attachedBehaviors": [
+        "AdditionalProperty"
+      ],
+      "behaviors": [
+        {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "GeoPolygonPoints",
+                "namespace": "_types.query_dsl"
+              }
+            }
+          ],
+          "type": {
+            "name": "AdditionalProperty",
+            "namespace": "_spec_utils"
+          }
+        }
+      ],
+      "deprecation": {
+        "version": "7.12.0 Use geo-shape instead."
+      },
       "inherits": {
         "type": {
           "name": "QueryBase",
@@ -51343,22 +51794,9 @@
       },
       "properties": [
         {
-          "name": "points",
-          "required": false,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "GeoLocation",
-                "namespace": "_types.query_dsl"
-              }
-            }
-          }
-        },
-        {
           "name": "validation_method",
           "required": false,
+          "serverDefault": "'strict'",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51372,44 +51810,18 @@
     {
       "kind": "interface",
       "name": {
-        "name": "GeoShape",
+        "name": "GeoShapeFieldQuery",
         "namespace": "_types.query_dsl"
       },
       "properties": [
         {
-          "name": "type",
+          "name": "shape",
           "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "inherits": {
-        "type": {
-          "name": "QueryBase",
-          "namespace": "_types.query_dsl"
-        }
-      },
-      "kind": "interface",
-      "name": {
-        "name": "GeoShapeQuery",
-        "namespace": "_types.query_dsl"
-      },
-      "properties": [
-        {
-          "name": "ignore_unmapped",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
+              "name": "GeoShape",
+              "namespace": "_types"
             }
           }
         },
@@ -51434,15 +51846,57 @@
               "namespace": "_types"
             }
           }
-        },
+        }
+      ]
+    },
+    {
+      "attachedBehaviors": [
+        "AdditionalProperty"
+      ],
+      "behaviors": [
         {
-          "name": "shape",
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "GeoShapeFieldQuery",
+                "namespace": "_types.query_dsl"
+              }
+            }
+          ],
+          "type": {
+            "name": "AdditionalProperty",
+            "namespace": "_spec_utils"
+          }
+        }
+      ],
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "GeoShapeQuery",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": [
+        {
+          "name": "ignore_unmapped",
           "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GeoShape",
-              "namespace": "_types.query_dsl"
+              "name": "boolean",
+              "namespace": "internal"
             }
           }
         }
@@ -51482,6 +51936,7 @@
         {
           "name": "ignore_unmapped",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51525,7 +51980,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51537,6 +51992,7 @@
         {
           "name": "score_mode",
           "required": false,
+          "serverDefault": "'none'",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51547,7 +52003,7 @@
         },
         {
           "name": "type",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51574,6 +52030,7 @@
         {
           "name": "ignore_unmapped",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51595,7 +52052,7 @@
         },
         {
           "name": "parent_type",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51606,7 +52063,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51618,6 +52075,7 @@
         {
           "name": "score",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51645,29 +52103,11 @@
           "name": "values",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Id",
-                    "namespace": "_types"
-                  }
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "long",
-                    "namespace": "_types"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "Ids",
+              "namespace": "_types"
+            }
           }
         }
       ]
@@ -51681,7 +52121,7 @@
       "properties": [
         {
           "name": "intervals",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "array_of",
             "value": {
@@ -51696,6 +52136,7 @@
         {
           "name": "max_gaps",
           "required": false,
+          "serverDefault": "-1",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51707,6 +52148,7 @@
         {
           "name": "ordered",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51737,7 +52179,7 @@
       "properties": [
         {
           "name": "intervals",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "array_of",
             "value": {
@@ -51946,7 +52388,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -51980,6 +52425,7 @@
         {
           "name": "prefix_length",
           "required": false,
+          "serverDefault": "0",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -51990,7 +52436,7 @@
         },
         {
           "name": "term",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52002,6 +52448,7 @@
         {
           "name": "transpositions",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52044,6 +52491,7 @@
         {
           "name": "max_gaps",
           "required": false,
+          "serverDefault": "-1",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52055,6 +52503,7 @@
         {
           "name": "ordered",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52065,7 +52514,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52118,7 +52567,7 @@
         },
         {
           "name": "prefix",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52219,7 +52668,10 @@
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "kind": "interface",
@@ -52241,7 +52693,7 @@
         },
         {
           "name": "pattern",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52309,10 +52761,13 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Fields",
-              "namespace": "_types"
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
             }
           }
         },
@@ -52320,23 +52775,11 @@
           "name": "_id",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Id",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "number",
-                  "namespace": "internal"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
           }
         },
         {
@@ -52393,6 +52836,29 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "name": "version",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionNumber",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "version_type",
+          "required": false,
+          "serverDefault": "'internal'",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionType",
+              "namespace": "_types"
+            }
+          }
         }
       ]
     },
@@ -52408,19 +52874,7 @@
         "name": "MatchAllQuery",
         "namespace": "_types.query_dsl"
       },
-      "properties": [
-        {
-          "name": "norm_field",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
+      "properties": []
     },
     {
       "inherits": {
@@ -52525,7 +52979,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52534,7 +52988,8 @@
             }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "query"
     },
     {
       "inherits": {
@@ -52587,7 +53042,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52618,7 +53073,8 @@
             }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "query"
     },
     {
       "inherits": {
@@ -52646,7 +53102,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52658,6 +53114,7 @@
         {
           "name": "slop",
           "required": false,
+          "serverDefault": "0",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52665,8 +53122,20 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "name": "zero_terms_query",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ZeroTermsQuery",
+              "namespace": "_types.query_dsl"
+            }
+          }
         }
-      ]
+      ],
+      "shortcutProperty": "query"
     },
     {
       "inherits": {
@@ -52695,6 +53164,7 @@
         {
           "name": "auto_generate_synonyms_phrase_query",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52704,6 +53174,9 @@
           }
         },
         {
+          "deprecation": {
+            "version": "7.3.0"
+          },
           "name": "cutoff_frequency",
           "required": false,
           "type": {
@@ -52739,6 +53212,7 @@
         {
           "name": "fuzzy_transpositions",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52750,6 +53224,7 @@
         {
           "name": "lenient",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52761,6 +53236,7 @@
         {
           "name": "max_expansions",
           "required": false,
+          "serverDefault": "50",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52783,6 +53259,7 @@
         {
           "name": "operator",
           "required": false,
+          "serverDefault": "'or'",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52794,6 +53271,7 @@
         {
           "name": "prefix_length",
           "required": false,
+          "serverDefault": "0",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52804,7 +53282,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "items": [
               {
@@ -52835,6 +53313,7 @@
         {
           "name": "zero_terms_query",
           "required": false,
+          "serverDefault": "'none'",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52843,7 +53322,8 @@
             }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "query"
     },
     {
       "inherits": {
@@ -52881,19 +53361,35 @@
           }
         },
         {
-          "name": "fields",
+          "name": "fail_on_unsupported_field",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "Fields",
-              "namespace": "_types"
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "fields",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
             }
           }
         },
         {
           "name": "include",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52904,7 +53400,7 @@
         },
         {
           "name": "like",
-          "required": false,
+          "required": true,
           "type": {
             "items": [
               {
@@ -52942,6 +53438,7 @@
         {
           "name": "max_query_terms",
           "required": false,
+          "serverDefault": "25",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52964,6 +53461,7 @@
         {
           "name": "min_doc_freq",
           "required": false,
+          "serverDefault": "5",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52986,6 +53484,7 @@
         {
           "name": "min_term_freq",
           "required": false,
+          "serverDefault": "2",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -52997,6 +53496,7 @@
         {
           "name": "min_word_length",
           "required": false,
+          "serverDefault": "0",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53089,6 +53589,7 @@
         {
           "name": "version_type",
           "required": false,
+          "serverDefault": "'internal'",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53126,6 +53627,7 @@
         {
           "name": "auto_generate_synonyms_phrase_query",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53135,6 +53637,9 @@
           }
         },
         {
+          "deprecation": {
+            "version": "7.3.0"
+          },
           "name": "cutoff_frequency",
           "required": false,
           "type": {
@@ -53181,6 +53686,7 @@
         {
           "name": "fuzzy_transpositions",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53192,6 +53698,7 @@
         {
           "name": "lenient",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53203,6 +53710,7 @@
         {
           "name": "max_expansions",
           "required": false,
+          "serverDefault": "50",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53225,6 +53733,7 @@
         {
           "name": "operator",
           "required": false,
+          "serverDefault": "'or'",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53236,6 +53745,7 @@
         {
           "name": "prefix_length",
           "required": false,
+          "serverDefault": "0",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53246,7 +53756,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53280,22 +53790,12 @@
         {
           "name": "type",
           "required": false,
+          "serverDefault": "'best_fields'",
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "TextQueryType",
               "namespace": "_types.query_dsl"
-            }
-          }
-        },
-        {
-          "name": "use_dis_max",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
             }
           }
         },
@@ -53334,82 +53834,6 @@
       }
     },
     {
-      "attachedBehaviors": [
-        "AdditionalProperties"
-      ],
-      "behaviors": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "TQuery",
-                "namespace": "_types.query_dsl"
-              }
-            }
-          ],
-          "type": {
-            "name": "AdditionalProperties",
-            "namespace": "_spec_utils"
-          }
-        }
-      ],
-      "description": "Queries can either be in the form of\n{ type: { field: { ...query_details...including_boost_and_name } } }\n||\n{ type: { boost: _, _name: _, field: { ...query_details... } } }",
-      "generics": [
-        {
-          "name": "TQuery",
-          "namespace": "_types.query_dsl"
-        }
-      ],
-      "kind": "interface",
-      "name": {
-        "name": "NamedQuery",
-        "namespace": "_types.query_dsl"
-      },
-      "properties": [
-        {
-          "name": "boost",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "float",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "_name",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "ignore_unmapped",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
-    },
-    {
       "inherits": {
         "type": {
           "name": "QueryBase",
@@ -53425,6 +53849,7 @@
         {
           "name": "ignore_unmapped",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53446,7 +53871,7 @@
         },
         {
           "name": "path",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53457,7 +53882,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53469,6 +53894,7 @@
         {
           "name": "score_mode",
           "required": false,
+          "serverDefault": "'avg'",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53504,8 +53930,68 @@
       }
     },
     {
+      "inherits": {
+        "type": {
+          "name": "RangeQueryBase",
+          "namespace": "_types.query_dsl"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "NumberRangeQuery",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": [
+        {
+          "name": "gt",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "gte",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "lt",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "lte",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "variantName": "number"
+    },
+    {
       "attachedBehaviors": [
-        "AdditionalProperties"
+        "AdditionalProperty"
       ],
       "behaviors": [
         {
@@ -53513,8 +53999,8 @@
             {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Field",
+                "namespace": "_types"
               }
             },
             {
@@ -53542,7 +54028,7 @@
             }
           ],
           "type": {
-            "name": "AdditionalProperties",
+            "name": "AdditionalProperty",
             "namespace": "_spec_utils"
           }
         }
@@ -53568,12 +54054,6 @@
         },
         {
           "name": "or"
-        },
-        {
-          "name": "AND"
-        },
-        {
-          "name": "OR"
         }
       ],
       "name": {
@@ -53608,6 +54088,7 @@
         {
           "name": "ignore_unmapped",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53661,7 +54142,7 @@
         },
         {
           "name": "field",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53689,6 +54170,17 @@
             "type": {
               "name": "IndexName",
               "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "name",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
           }
         },
@@ -53742,36 +54234,21 @@
       "properties": [
         {
           "name": "ids",
-          "required": false,
+          "required": true,
           "type": {
-            "items": [
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Id",
-                    "namespace": "_types"
-                  }
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "long",
-                    "namespace": "_types"
-                  }
-                }
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Id",
+                "namespace": "_types"
               }
-            ],
-            "kind": "union_of"
+            }
           }
         },
         {
           "name": "organic",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -53816,8 +54293,22 @@
               "namespace": "internal"
             }
           }
+        },
+        {
+          "name": "case_insensitive",
+          "required": false,
+          "serverDefault": false,
+          "since": "7.10.0",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
         }
-      ]
+      ],
+      "shortcutProperty": "value"
     },
     {
       "kind": "interface",
@@ -53838,6 +54329,7 @@
           }
         },
         {
+          "identifier": "query_name",
           "name": "_name",
           "required": false,
           "type": {
@@ -53880,6 +54372,9 @@
           }
         },
         {
+          "deprecation": {
+            "version": "7.3.0"
+          },
           "name": "common",
           "required": false,
           "type": {
@@ -53893,23 +54388,11 @@
             "kind": "dictionary_of",
             "singleKey": true,
             "value": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "CommonTermsQuery",
-                    "namespace": "_types.query_dsl"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "CommonTermsQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -53951,46 +54434,11 @@
           "name": "distance_feature",
           "required": false,
           "type": {
-            "items": [
-              {
-                "key": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Field",
-                    "namespace": "_types"
-                  }
-                },
-                "kind": "dictionary_of",
-                "singleKey": true,
-                "value": {
-                  "items": [
-                    {
-                      "kind": "instance_of",
-                      "type": {
-                        "name": "DistanceFeatureQuery",
-                        "namespace": "_types.query_dsl"
-                      }
-                    },
-                    {
-                      "kind": "instance_of",
-                      "type": {
-                        "name": "string",
-                        "namespace": "internal"
-                      }
-                    }
-                  ],
-                  "kind": "union_of"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DistanceFeatureQuery",
-                  "namespace": "_types.query_dsl"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "DistanceFeatureQuery",
+              "namespace": "_types.query_dsl"
+            }
           }
         },
         {
@@ -54029,23 +54477,11 @@
             "kind": "dictionary_of",
             "singleKey": true,
             "value": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "FuzzyQuery",
-                    "namespace": "_types.query_dsl"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "FuzzyQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54053,30 +54489,9 @@
           "name": "geo_bounding_box",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "GeoBoundingBoxQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "GeoBoundingBoxQuery",
               "namespace": "_types.query_dsl"
             }
           }
@@ -54096,30 +54511,9 @@
           "name": "geo_polygon",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "GeoPolygonQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "GeoPolygonQuery",
               "namespace": "_types.query_dsl"
             }
           }
@@ -54128,30 +54522,9 @@
           "name": "geo_shape",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "GeoShapeQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "GeoShapeQuery",
               "namespace": "_types.query_dsl"
             }
           }
@@ -54193,31 +54566,21 @@
           "name": "intervals",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "IntervalsQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "IntervalsQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54225,45 +54588,21 @@
           "name": "match",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "MatchQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "float",
-                      "namespace": "_types"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "boolean",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "MatchQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54282,31 +54621,21 @@
           "name": "match_bool_prefix",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "MatchBoolPrefixQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "MatchBoolPrefixQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54325,31 +54654,21 @@
           "name": "match_phrase",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "MatchPhraseQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "MatchPhraseQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54357,31 +54676,21 @@
           "name": "match_phrase_prefix",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "MatchPhrasePrefixQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "MatchPhrasePrefixQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54455,31 +54764,21 @@
           "name": "prefix",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "PrefixQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "PrefixQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54498,19 +54797,21 @@
           "name": "range",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "RangeQuery",
-                  "namespace": "_types.query_dsl"
-                }
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "RangeQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54518,30 +54819,9 @@
           "name": "rank_feature",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "RankFeatureQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "RankFeatureQuery",
               "namespace": "_types.query_dsl"
             }
           }
@@ -54550,31 +54830,21 @@
           "name": "regexp",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "RegexpQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "RegexpQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54604,30 +54874,9 @@
           "name": "shape",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "ShapeQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "ShapeQuery",
               "namespace": "_types.query_dsl"
             }
           }
@@ -54724,31 +54973,21 @@
           "name": "span_term",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SpanTermQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "SpanTermQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54764,59 +55003,24 @@
           }
         },
         {
-          "name": "template",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "QueryTemplate",
-              "namespace": "_types.query_dsl"
-            }
-          }
-        },
-        {
           "name": "term",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "TermQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "float",
-                      "namespace": "_types"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "boolean",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "TermQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54824,43 +55028,9 @@
           "name": "terms",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "TermsQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "array_of",
-                    "value": {
-                      "kind": "instance_of",
-                      "type": {
-                        "name": "string",
-                        "namespace": "internal"
-                      }
-                    }
-                  },
-                  {
-                    "kind": "array_of",
-                    "value": {
-                      "kind": "instance_of",
-                      "type": {
-                        "name": "long",
-                        "namespace": "_types"
-                      }
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "TermsQuery",
               "namespace": "_types.query_dsl"
             }
           }
@@ -54869,31 +55039,21 @@
           "name": "terms_set",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "TermsSetQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "TermsSetQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54901,31 +55061,21 @@
           "name": "wildcard",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "WildcardQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "WildcardQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -54965,6 +55115,7 @@
         {
           "name": "allow_leading_wildcard",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -54987,6 +55138,7 @@
         {
           "name": "analyze_wildcard",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -54998,6 +55150,7 @@
         {
           "name": "auto_generate_synonyms_phrase_query",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55020,6 +55173,7 @@
         {
           "name": "default_operator",
           "required": false,
+          "serverDefault": "'or'",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55031,6 +55185,7 @@
         {
           "name": "enable_position_increments",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55042,6 +55197,7 @@
         {
           "name": "escape",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55054,10 +55210,13 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Fields",
-              "namespace": "_types"
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
             }
           }
         },
@@ -55075,6 +55234,7 @@
         {
           "name": "fuzzy_max_expansions",
           "required": false,
+          "serverDefault": "50",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55119,6 +55279,7 @@
         {
           "name": "lenient",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55130,6 +55291,7 @@
         {
           "name": "max_determinized_states",
           "required": false,
+          "serverDefault": "10000",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55162,7 +55324,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55221,39 +55383,20 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "TimeZone",
+              "namespace": "_types"
             }
           }
         },
         {
           "name": "type",
           "required": false,
+          "serverDefault": "'best_fields'",
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "TextQueryType",
               "namespace": "_types.query_dsl"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "QueryTemplate",
-        "namespace": "_types.query_dsl"
-      },
-      "properties": [
-        {
-          "name": "source",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
             }
           }
         }
@@ -55309,6 +55452,32 @@
       ]
     },
     {
+      "kind": "type_alias",
+      "name": {
+        "name": "RangeQuery",
+        "namespace": "_types.query_dsl"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateRangeQuery",
+              "namespace": "_types.query_dsl"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "NumberRangeQuery",
+              "namespace": "_types.query_dsl"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
       "inherits": {
         "type": {
           "name": "QueryBase",
@@ -55317,102 +55486,10 @@
       },
       "kind": "interface",
       "name": {
-        "name": "RangeQuery",
+        "name": "RangeQueryBase",
         "namespace": "_types.query_dsl"
       },
       "properties": [
-        {
-          "name": "gt",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "double",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateMath",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
-        {
-          "name": "gte",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "double",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateMath",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
-        {
-          "name": "lt",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "double",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateMath",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
-        {
-          "name": "lte",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "double",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateMath",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
         {
           "name": "relation",
           "required": false,
@@ -55422,63 +55499,6 @@
               "name": "RangeRelation",
               "namespace": "_types.query_dsl"
             }
-          }
-        },
-        {
-          "name": "time_zone",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "from",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "double",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateMath",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
-        {
-          "name": "to",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "double",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateMath",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
           }
         }
       ]
@@ -55512,6 +55532,109 @@
     {
       "inherits": {
         "type": {
+          "name": "RankFeatureFunction",
+          "namespace": "_types.query_dsl"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "RankFeatureFunctionLinear",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": []
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "RankFeatureFunction",
+          "namespace": "_types.query_dsl"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "RankFeatureFunctionLogarithm",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": [
+        {
+          "name": "scaling_factor",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "float",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "RankFeatureFunction",
+          "namespace": "_types.query_dsl"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "RankFeatureFunctionSaturation",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": [
+        {
+          "name": "pivot",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "float",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "RankFeatureFunction",
+          "namespace": "_types.query_dsl"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "RankFeatureFunctionSigmoid",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": [
+        {
+          "name": "pivot",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "float",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "exponent",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "float",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
           "name": "QueryBase",
           "namespace": "_types.query_dsl"
         }
@@ -55523,12 +55646,56 @@
       },
       "properties": [
         {
-          "name": "function",
+          "name": "field",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Field",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "saturation",
           "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "RankFeatureFunction",
+              "name": "RankFeatureFunctionSaturation",
+              "namespace": "_types.query_dsl"
+            }
+          }
+        },
+        {
+          "name": "log",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "RankFeatureFunctionLogarithm",
+              "namespace": "_types.query_dsl"
+            }
+          }
+        },
+        {
+          "name": "linear",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "RankFeatureFunctionLinear",
+              "namespace": "_types.query_dsl"
+            }
+          }
+        },
+        {
+          "name": "sigmoid",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "RankFeatureFunctionSigmoid",
               "namespace": "_types.query_dsl"
             }
           }
@@ -55549,6 +55716,19 @@
       },
       "properties": [
         {
+          "name": "case_insensitive",
+          "required": false,
+          "serverDefault": false,
+          "since": "7.10.0",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "name": "flags",
           "required": false,
           "type": {
@@ -55562,6 +55742,7 @@
         {
           "name": "max_determinized_states",
           "required": false,
+          "serverDefault": "10000",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55571,8 +55752,19 @@
           }
         },
         {
-          "name": "value",
+          "name": "rewrite",
           "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "MultiTermQueryRewrite",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "value",
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55581,7 +55773,8 @@
             }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "value"
     },
     {
       "kind": "interface",
@@ -55629,7 +55822,7 @@
       "properties": [
         {
           "name": "script",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55680,8 +55873,19 @@
       },
       "properties": [
         {
-          "name": "query",
+          "name": "min_score",
           "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "float",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "query",
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55692,7 +55896,7 @@
         },
         {
           "name": "script",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55704,15 +55908,9 @@
       ]
     },
     {
-      "inherits": {
-        "type": {
-          "name": "QueryBase",
-          "namespace": "_types.query_dsl"
-        }
-      },
       "kind": "interface",
       "name": {
-        "name": "ShapeQuery",
+        "name": "ShapeFieldQuery",
         "namespace": "_types.query_dsl"
       },
       "properties": [
@@ -55756,11 +55954,52 @@
             "kind": "instance_of",
             "type": {
               "name": "GeoShape",
-              "namespace": "_types.query_dsl"
+              "namespace": "_types"
             }
           }
         }
       ]
+    },
+    {
+      "attachedBehaviors": [
+        "AdditionalProperty"
+      ],
+      "behaviors": [
+        {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "ShapeFieldQuery",
+                "namespace": "_types.query_dsl"
+              }
+            }
+          ],
+          "type": {
+            "name": "AdditionalProperty",
+            "namespace": "_spec_utils"
+          }
+        }
+      ],
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "ShapeQuery",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": []
     },
     {
       "kind": "enum",
@@ -55837,6 +56076,7 @@
         {
           "name": "analyze_wildcard",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55848,6 +56088,7 @@
         {
           "name": "auto_generate_synonyms_phrase_query",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55859,6 +56100,7 @@
         {
           "name": "default_operator",
           "required": false,
+          "serverDefault": "'or'",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55871,10 +56113,13 @@
           "name": "fields",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Fields",
-              "namespace": "_types"
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
             }
           }
         },
@@ -55937,6 +56182,7 @@
         {
           "name": "lenient",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55958,7 +56204,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -55995,7 +56241,7 @@
       "properties": [
         {
           "name": "big",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56006,7 +56252,7 @@
         },
         {
           "name": "little",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56032,7 +56278,7 @@
       "properties": [
         {
           "name": "field",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56043,7 +56289,7 @@
         },
         {
           "name": "query",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56069,7 +56315,7 @@
       "properties": [
         {
           "name": "end",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56080,7 +56326,7 @@
         },
         {
           "name": "match",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56100,50 +56346,14 @@
       },
       "kind": "interface",
       "name": {
-        "name": "SpanGapQuery",
-        "namespace": "_types.query_dsl"
-      },
-      "properties": [
-        {
-          "name": "field",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Field",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "width",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "inherits": {
-        "type": {
-          "name": "QueryBase",
-          "namespace": "_types.query_dsl"
-        }
-      },
-      "kind": "interface",
-      "name": {
         "name": "SpanMultiTermQuery",
         "namespace": "_types.query_dsl"
       },
       "properties": [
         {
+          "description": "Should be a multi term query (one of wildcard, fuzzy, prefix, range or regexp query)",
           "name": "match",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56169,7 +56379,7 @@
       "properties": [
         {
           "name": "clauses",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "array_of",
             "value": {
@@ -56231,7 +56441,7 @@
         },
         {
           "name": "exclude",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56242,7 +56452,7 @@
         },
         {
           "name": "include",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56254,6 +56464,7 @@
         {
           "name": "post",
           "required": false,
+          "serverDefault": "0",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56265,6 +56476,7 @@
         {
           "name": "pre",
           "required": false,
+          "serverDefault": "0",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56290,7 +56502,7 @@
       "properties": [
         {
           "name": "clauses",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "array_of",
             "value": {
@@ -56305,12 +56517,6 @@
       ]
     },
     {
-      "inherits": {
-        "type": {
-          "name": "QueryBase",
-          "namespace": "_types.query_dsl"
-        }
-      },
       "kind": "interface",
       "name": {
         "name": "SpanQuery",
@@ -56321,30 +56527,9 @@
           "name": "span_containing",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SpanContainingQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "SpanContainingQuery",
               "namespace": "_types.query_dsl"
             }
           }
@@ -56353,30 +56538,9 @@
           "name": "field_masking_span",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SpanFieldMaskingQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "SpanFieldMaskingQuery",
               "namespace": "_types.query_dsl"
             }
           }
@@ -56385,63 +56549,33 @@
           "name": "span_first",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SpanFirstQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "SpanFirstQuery",
               "namespace": "_types.query_dsl"
             }
           }
         },
         {
+          "description": "Can only be used as a clause in a span_near query",
           "name": "span_gap",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SpanGapQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "integer",
-                      "namespace": "_types"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
             }
           }
         },
@@ -56460,30 +56594,9 @@
           "name": "span_near",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SpanNearQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "SpanNearQuery",
               "namespace": "_types.query_dsl"
             }
           }
@@ -56492,30 +56605,9 @@
           "name": "span_not",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SpanNotQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "SpanNotQuery",
               "namespace": "_types.query_dsl"
             }
           }
@@ -56524,30 +56616,9 @@
           "name": "span_or",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SpanOrQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "SpanOrQuery",
               "namespace": "_types.query_dsl"
             }
           }
@@ -56556,31 +56627,21 @@
           "name": "span_term",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SpanTermQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
               }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "NamedQuery",
-              "namespace": "_types.query_dsl"
+            },
+            "kind": "dictionary_of",
+            "singleKey": true,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "SpanTermQuery",
+                "namespace": "_types.query_dsl"
+              }
             }
           }
         },
@@ -56588,35 +56649,17 @@
           "name": "span_within",
           "required": false,
           "type": {
-            "generics": [
-              {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SpanWithinQuery",
-                      "namespace": "_types.query_dsl"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
-            ],
             "kind": "instance_of",
             "type": {
-              "name": "NamedQuery",
+              "name": "SpanWithinQuery",
               "namespace": "_types.query_dsl"
             }
           }
         }
-      ]
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "inherits": {
@@ -56642,7 +56685,8 @@
             }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "value"
     },
     {
       "inherits": {
@@ -56659,7 +56703,7 @@
       "properties": [
         {
           "name": "big",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56670,7 +56714,7 @@
         },
         {
           "name": "little",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56696,7 +56740,7 @@
       "properties": [
         {
           "name": "value",
-          "required": false,
+          "required": true,
           "type": {
             "items": [
               {
@@ -56723,39 +56767,32 @@
             ],
             "kind": "union_of"
           }
+        },
+        {
+          "name": "case_insensitive",
+          "required": false,
+          "since": "7.10.0",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
         }
-      ]
+      ],
+      "shortcutProperty": "value"
     },
     {
-      "inherits": {
-        "type": {
-          "name": "QueryBase",
-          "namespace": "_types.query_dsl"
-        }
-      },
       "kind": "interface",
       "name": {
-        "name": "TermsQuery",
+        "name": "TermsLookup",
         "namespace": "_types.query_dsl"
       },
       "properties": [
         {
-          "name": "terms",
-          "required": false,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          }
-        },
-        {
           "name": "index",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56766,7 +56803,7 @@
         },
         {
           "name": "id",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -56777,12 +56814,12 @@
         },
         {
           "name": "path",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "Field",
+              "namespace": "_types"
             }
           }
         },
@@ -56800,6 +56837,58 @@
       ]
     },
     {
+      "attachedBehaviors": [
+        "AdditionalProperty"
+      ],
+      "behaviors": [
+        {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
+            },
+            {
+              "items": [
+                {
+                  "kind": "array_of",
+                  "value": {
+                    "kind": "instance_of",
+                    "type": {
+                      "name": "string",
+                      "namespace": "internal"
+                    }
+                  }
+                },
+                {
+                  "kind": "array_of",
+                  "value": {
+                    "kind": "instance_of",
+                    "type": {
+                      "name": "long",
+                      "namespace": "_types"
+                    }
+                  }
+                },
+                {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "TermsLookup",
+                    "namespace": "_types.query_dsl"
+                  }
+                }
+              ],
+              "kind": "union_of"
+            }
+          ],
+          "type": {
+            "name": "AdditionalProperty",
+            "namespace": "_spec_utils"
+          }
+        }
+      ],
       "inherits": {
         "type": {
           "name": "QueryBase",
@@ -56808,7 +56897,15 @@
       },
       "kind": "interface",
       "name": {
-        "name": "TermsSetQuery",
+        "name": "TermsQuery",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": []
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "TermsSetFieldQuery",
         "namespace": "_types.query_dsl"
       },
       "properties": [
@@ -56836,7 +56933,7 @@
         },
         {
           "name": "terms",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "array_of",
             "value": {
@@ -56849,6 +56946,47 @@
           }
         }
       ]
+    },
+    {
+      "attachedBehaviors": [
+        "AdditionalProperty"
+      ],
+      "behaviors": [
+        {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "Field",
+                "namespace": "_types"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "TermsSetFieldQuery",
+                "namespace": "_types.query_dsl"
+              }
+            }
+          ],
+          "type": {
+            "name": "AdditionalProperty",
+            "namespace": "_spec_utils"
+          }
+        }
+      ],
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "TermsSetQuery",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": []
     },
     {
       "kind": "enum",
@@ -56990,6 +57128,18 @@
       },
       "properties": [
         {
+          "name": "case_insensitive",
+          "required": false,
+          "since": "7.10.0",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "name": "rewrite",
           "required": false,
           "type": {
@@ -57011,7 +57161,8 @@
             }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "value"
     },
     {
       "kind": "enum",
@@ -143908,6 +144059,25 @@
           }
         }
       ]
+    },
+    {
+      "description": "In some places in the specification an object consists of a static set of properties and a single additional property\nwith an arbitrary name but a statically defined type. This is typically used for configurations associated\nto a single field. Meaning that object should theoretically extend SingleKeyDictionary but expose\na set of known keys. And possibly the object might already be part of an object graph and have a parent class.\nThis puts it into a bind that needs a client specific solution.\nWe therefore document the requirement to accept a single unknown property with this interface.",
+      "generics": [
+        {
+          "name": "TKey",
+          "namespace": "_spec_utils"
+        },
+        {
+          "name": "TValue",
+          "namespace": "_spec_utils"
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "AdditionalProperty",
+        "namespace": "_spec_utils"
+      },
+      "properties": []
     },
     {
       "description": "Implements a set of common query parameters all Cat API's support.\nSince these can break the request structure these are listed explicitly as a behavior.",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1241,9 +1241,7 @@
         "Request: query parameter 'allow_no_indices' does not exist in the json spec",
         "Request: query parameter 'expand_wildcards' does not exist in the json spec",
         "Request: query parameter 'ignore_throttled' does not exist in the json spec",
-        "Request: query parameter 'ignore_unavailable' does not exist in the json spec",
-        "enum definition _types.query_dsl:Operator - Duplicate enum member identifier 'AND'",
-        "enum definition _types.query_dsl:Operator - Duplicate enum member identifier 'OR'"
+        "Request: query parameter 'ignore_unavailable' does not exist in the json spec"
       ],
       "response": [
         "type_alias definition _types.aggregations:Aggregate / union_of / instance_of - Non-leaf type cannot be used here: '_types.aggregations:MultiBucketAggregate'",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1129,6 +1129,12 @@ export interface SearchDocValueField {
   format?: string
 }
 
+export interface SearchFieldAndFormat {
+  field: Field
+  format?: string
+  include_unmapped?: boolean
+}
+
 export interface SearchFieldCollapse {
   field: Field
   inner_hits?: SearchInnerHits | SearchInnerHits[]
@@ -1242,15 +1248,17 @@ export interface SearchInnerHits {
   size?: integer
   from?: integer
   collapse?: SearchFieldCollapse
-  docvalue_fields?: Fields
+  docvalue_fields?: (SearchFieldAndFormat | Field)[]
   explain?: boolean
   highlight?: SearchHighlight
   ignore_unmapped?: boolean
-  script_fields?: Record<string, ScriptField>
+  script_fields?: Record<Field, ScriptField>
   seq_no_primary_term?: boolean
   fields?: Fields
   sort?: SearchSort
   _source?: boolean | SearchSourceFilter
+  stored_field?: Fields
+  track_scores?: boolean
   version?: boolean
 }
 
@@ -1820,6 +1828,8 @@ export interface DateField {
   include_unmapped?: boolean
 }
 
+export type DateFormat = string
+
 export type DateMath = string
 
 export type DateMathTime = string
@@ -1933,6 +1943,8 @@ export type Fuzziness = string | integer
 export type GeoDistanceType = 'arc' | 'plane'
 
 export type GeoHashPrecision = number
+
+export type GeoShape = any
 
 export type GeoShapeRelation = 'intersects' | 'disjoint' | 'within' | 'contains'
 
@@ -2171,7 +2183,7 @@ export interface Retries {
   search: long
 }
 
-export type Routing = string | number
+export type Routing = string
 
 export type Script = InlineScript | IndexedScript | string
 
@@ -2182,6 +2194,7 @@ export interface ScriptBase {
 
 export interface ScriptField {
   script: Script
+  ignore_failure?: boolean
 }
 
 export type ScriptLanguage = 'painless' | 'expression' | 'mustache' | 'java'
@@ -2303,6 +2316,8 @@ export type ThreadType = 'cpu' | 'wait' | 'block'
 export type Time = string | integer
 
 export type TimeSpan = string
+
+export type TimeZone = string
 
 export type Timestamp = string
 
@@ -3533,7 +3548,7 @@ export interface AnalysisStopTokenFilter extends AnalysisTokenFilterBase {
   stopwords_path?: string
 }
 
-export type AnalysisStopWords = string | string[]
+export type AnalysisStopWords = string[]
 
 export type AnalysisSynonymFormat = 'solr' | 'wordnet'
 
@@ -4031,24 +4046,37 @@ export interface QueryDslBoolQuery extends QueryDslQueryBase {
 }
 
 export interface QueryDslBoostingQuery extends QueryDslQueryBase {
-  negative_boost?: double
-  negative?: QueryDslQueryContainer
-  positive?: QueryDslQueryContainer
+  negative_boost: double
+  negative: QueryDslQueryContainer
+  positive: QueryDslQueryContainer
 }
 
 export interface QueryDslBoundingBox {
   bottom_right?: QueryDslGeoLocation
   top_left?: QueryDslGeoLocation
+  top_right?: QueryDslGeoLocation
+  bottom_left?: QueryDslGeoLocation
+  top?: double
+  left?: double
+  right?: double
+  bottom?: double
   wkt?: string
 }
 
 export type QueryDslChildScoreMode = 'none' | 'avg' | 'sum' | 'max' | 'min'
 
-export interface QueryDslCombinedFieldsQuery {
-  query: string
+export type QueryDslCombinedFieldsOperator = 'or' | 'and'
+
+export interface QueryDslCombinedFieldsQuery extends QueryDslQueryBase {
   fields: Field[]
-  operator?: string
+  query: string
+  auto_generate_synonyms_phrase_query?: boolean
+  operator?: QueryDslCombinedFieldsOperator
+  mimimum_should_match?: MinimumShouldMatch
+  zero_terms_query?: QueryDslCombinedFieldsZeroTerms
 }
+
+export type QueryDslCombinedFieldsZeroTerms = 'none' | 'all'
 
 export interface QueryDslCommonTermsQuery extends QueryDslQueryBase {
   analyzer?: string
@@ -4056,17 +4084,29 @@ export interface QueryDslCommonTermsQuery extends QueryDslQueryBase {
   high_freq_operator?: QueryDslOperator
   low_freq_operator?: QueryDslOperator
   minimum_should_match?: MinimumShouldMatch
-  query?: string
+  query: string
 }
 
 export interface QueryDslConstantScoreQuery extends QueryDslQueryBase {
-  filter?: QueryDslQueryContainer
+  filter: QueryDslQueryContainer
 }
 
 export interface QueryDslDateDecayFunctionKeys extends QueryDslDecayFunctionBase {
 }
 export type QueryDslDateDecayFunction = QueryDslDateDecayFunctionKeys |
     { [property: string]: QueryDslDecayPlacement<DateMath, Time> }
+
+export interface QueryDslDateDistanceFeatureQuery extends QueryDslDistanceFeatureQueryBase<DateMath, Time> {
+}
+
+export interface QueryDslDateRangeQuery extends QueryDslRangeQueryBase {
+  gt?: DateMath
+  gte?: DateMath
+  lt?: DateMath
+  lte?: DateMath
+  format?: DateFormat
+  time_zone?: TimeZone
+}
 
 export type QueryDslDecayFunction = QueryDslDateDecayFunction | QueryDslNumericDecayFunction | QueryDslGeoDecayFunction
 
@@ -4082,22 +4122,24 @@ export interface QueryDslDecayPlacement<TOrigin = unknown, TScale = unknown> {
 }
 
 export interface QueryDslDisMaxQuery extends QueryDslQueryBase {
-  queries?: QueryDslQueryContainer[]
+  queries: QueryDslQueryContainer[]
   tie_breaker?: double
 }
 
-export interface QueryDslDistanceFeatureQuery extends QueryDslQueryBase {
-  origin?: number[] | QueryDslGeoCoordinate | DateMath
-  pivot?: Distance | Time
-  field?: Field
+export type QueryDslDistanceFeatureQuery = QueryDslGeoDistanceFeatureQuery | QueryDslDateDistanceFeatureQuery
+
+export interface QueryDslDistanceFeatureQueryBase<TOrigin = unknown, TDistance = unknown> extends QueryDslQueryBase {
+  origin: TOrigin
+  pivot: TDistance
+  field: Field
 }
 
 export interface QueryDslExistsQuery extends QueryDslQueryBase {
-  field?: Field
+  field: Field
 }
 
 export interface QueryDslFieldLookup {
-  id?: Id
+  id: Id
   index?: IndexName
   path?: Field
   routing?: Routing
@@ -4142,16 +4184,15 @@ export interface QueryDslFuzzyQuery extends QueryDslQueryBase {
   rewrite?: MultiTermQueryRewrite
   transpositions?: boolean
   fuzziness?: Fuzziness
-  value: any
+  value: string
 }
 
-export interface QueryDslGeoBoundingBoxQuery extends QueryDslQueryBase {
-  bounding_box?: QueryDslBoundingBox
+export interface QueryDslGeoBoundingBoxQueryKeys extends QueryDslQueryBase {
   type?: QueryDslGeoExecution
   validation_method?: QueryDslGeoValidationMethod
-  top_left?: LatLon
-  bottom_right?: LatLon
 }
+export type QueryDslGeoBoundingBoxQuery = QueryDslGeoBoundingBoxQueryKeys |
+    { [property: string]: QueryDslBoundingBox }
 
 export type QueryDslGeoCoordinate = string | double[] | QueryDslThreeDimensionalPoint
 
@@ -4159,6 +4200,9 @@ export interface QueryDslGeoDecayFunctionKeys extends QueryDslDecayFunctionBase 
 }
 export type QueryDslGeoDecayFunction = QueryDslGeoDecayFunctionKeys |
     { [property: string]: QueryDslDecayPlacement<QueryDslGeoLocation, Distance> }
+
+export interface QueryDslGeoDistanceFeatureQuery extends QueryDslDistanceFeatureQueryBase<QueryDslGeoCoordinate, Distance> {
+}
 
 export interface QueryDslGeoDistanceQueryKeys extends QueryDslQueryBase {
   distance?: Distance
@@ -4172,21 +4216,27 @@ export type QueryDslGeoExecution = 'memory' | 'indexed'
 
 export type QueryDslGeoLocation = string | double[] | QueryDslTwoDimensionalPoint
 
-export interface QueryDslGeoPolygonQuery extends QueryDslQueryBase {
-  points?: QueryDslGeoLocation[]
+export interface QueryDslGeoPolygonPoints {
+  points: QueryDslGeoLocation[]
+}
+
+export interface QueryDslGeoPolygonQueryKeys extends QueryDslQueryBase {
   validation_method?: QueryDslGeoValidationMethod
 }
+export type QueryDslGeoPolygonQuery = QueryDslGeoPolygonQueryKeys |
+    { [property: string]: QueryDslGeoPolygonPoints }
 
-export interface QueryDslGeoShape {
-  type?: string
-}
-
-export interface QueryDslGeoShapeQuery extends QueryDslQueryBase {
-  ignore_unmapped?: boolean
+export interface QueryDslGeoShapeFieldQuery {
+  shape?: GeoShape
   indexed_shape?: QueryDslFieldLookup
   relation?: GeoShapeRelation
-  shape?: QueryDslGeoShape
 }
+
+export interface QueryDslGeoShapeQueryKeys extends QueryDslQueryBase {
+  ignore_unmapped?: boolean
+}
+export type QueryDslGeoShapeQuery = QueryDslGeoShapeQueryKeys |
+    { [property: string]: QueryDslGeoShapeFieldQuery }
 
 export type QueryDslGeoValidationMethod = 'coerce' | 'ignore_malformed' | 'strict'
 
@@ -4195,32 +4245,32 @@ export interface QueryDslHasChildQuery extends QueryDslQueryBase {
   inner_hits?: SearchInnerHits
   max_children?: integer
   min_children?: integer
-  query?: QueryDslQueryContainer
+  query: QueryDslQueryContainer
   score_mode?: QueryDslChildScoreMode
-  type?: RelationName
+  type: RelationName
 }
 
 export interface QueryDslHasParentQuery extends QueryDslQueryBase {
   ignore_unmapped?: boolean
   inner_hits?: SearchInnerHits
-  parent_type?: RelationName
-  query?: QueryDslQueryContainer
+  parent_type: RelationName
+  query: QueryDslQueryContainer
   score?: boolean
 }
 
 export interface QueryDslIdsQuery extends QueryDslQueryBase {
-  values?: Id[] | long[]
+  values?: Ids
 }
 
 export interface QueryDslIntervalsAllOf {
-  intervals?: QueryDslIntervalsContainer[]
+  intervals: QueryDslIntervalsContainer[]
   max_gaps?: integer
   ordered?: boolean
   filter?: QueryDslIntervalsFilter
 }
 
 export interface QueryDslIntervalsAnyOf {
-  intervals?: QueryDslIntervalsContainer[]
+  intervals: QueryDslIntervalsContainer[]
   filter?: QueryDslIntervalsFilter
 }
 
@@ -4249,7 +4299,7 @@ export interface QueryDslIntervalsFuzzy {
   analyzer?: string
   fuzziness?: Fuzziness
   prefix_length?: integer
-  term?: string
+  term: string
   transpositions?: boolean
   use_field?: Field
 }
@@ -4258,14 +4308,14 @@ export interface QueryDslIntervalsMatch {
   analyzer?: string
   max_gaps?: integer
   ordered?: boolean
-  query?: string
+  query: string
   use_field?: Field
   filter?: QueryDslIntervalsFilter
 }
 
 export interface QueryDslIntervalsPrefix {
   analyzer?: string
-  prefix?: string
+  prefix: string
   use_field?: Field
 }
 
@@ -4280,7 +4330,7 @@ export interface QueryDslIntervalsQuery extends QueryDslQueryBase {
 
 export interface QueryDslIntervalsWildcard {
   analyzer?: string
-  pattern?: string
+  pattern: string
   use_field?: Field
 }
 
@@ -4288,16 +4338,17 @@ export type QueryDslLike = string | QueryDslLikeDocument
 
 export interface QueryDslLikeDocument {
   doc?: any
-  fields?: Fields
-  _id?: Id | number
+  fields?: Field[]
+  _id?: Id
   _type?: Type
   _index?: IndexName
   per_field_analyzer?: Record<Field, string>
   routing?: Routing
+  version?: VersionNumber
+  version_type?: VersionType
 }
 
 export interface QueryDslMatchAllQuery extends QueryDslQueryBase {
-  norm_field?: string
 }
 
 export interface QueryDslMatchBoolPrefixQuery extends QueryDslQueryBase {
@@ -4309,7 +4360,7 @@ export interface QueryDslMatchBoolPrefixQuery extends QueryDslQueryBase {
   minimum_should_match?: MinimumShouldMatch
   operator?: QueryDslOperator
   prefix_length?: integer
-  query?: string
+  query: string
 }
 
 export interface QueryDslMatchNoneQuery extends QueryDslQueryBase {
@@ -4318,15 +4369,16 @@ export interface QueryDslMatchNoneQuery extends QueryDslQueryBase {
 export interface QueryDslMatchPhrasePrefixQuery extends QueryDslQueryBase {
   analyzer?: string
   max_expansions?: integer
-  query?: string
+  query: string
   slop?: integer
   zero_terms_query?: QueryDslZeroTermsQuery
 }
 
 export interface QueryDslMatchPhraseQuery extends QueryDslQueryBase {
   analyzer?: string
-  query?: string
+  query: string
   slop?: integer
+  zero_terms_query?: QueryDslZeroTermsQuery
 }
 
 export interface QueryDslMatchQuery extends QueryDslQueryBase {
@@ -4341,16 +4393,17 @@ export interface QueryDslMatchQuery extends QueryDslQueryBase {
   minimum_should_match?: MinimumShouldMatch
   operator?: QueryDslOperator
   prefix_length?: integer
-  query?: string | float | boolean
+  query: string | float | boolean
   zero_terms_query?: QueryDslZeroTermsQuery
 }
 
 export interface QueryDslMoreLikeThisQuery extends QueryDslQueryBase {
   analyzer?: string
   boost_terms?: double
-  fields?: Fields
+  fail_on_unsupported_field?: boolean
+  fields?: Field[]
   include?: boolean
-  like?: QueryDslLike | QueryDslLike[]
+  like: QueryDslLike | QueryDslLike[]
   max_doc_freq?: integer
   max_query_terms?: integer
   max_word_length?: integer
@@ -4379,40 +4432,38 @@ export interface QueryDslMultiMatchQuery extends QueryDslQueryBase {
   minimum_should_match?: MinimumShouldMatch
   operator?: QueryDslOperator
   prefix_length?: integer
-  query?: string
+  query: string
   slop?: integer
   tie_breaker?: double
   type?: QueryDslTextQueryType
-  use_dis_max?: boolean
   zero_terms_query?: QueryDslZeroTermsQuery
 }
 
 export type QueryDslMultiValueMode = 'min' | 'max' | 'avg' | 'sum'
 
-export interface QueryDslNamedQueryKeys<TQuery = unknown> {
-  boost?: float
-  _name?: string
-  ignore_unmapped?: boolean
-}
-export type QueryDslNamedQuery<TQuery = unknown> = QueryDslNamedQueryKeys<TQuery> |
-    { [property: string]: TQuery }
-
 export interface QueryDslNestedQuery extends QueryDslQueryBase {
   ignore_unmapped?: boolean
   inner_hits?: SearchInnerHits
-  path?: Field
-  query?: QueryDslQueryContainer
+  path: Field
+  query: QueryDslQueryContainer
   score_mode?: QueryDslNestedScoreMode
 }
 
 export type QueryDslNestedScoreMode = 'avg' | 'sum' | 'min' | 'max' | 'none'
+
+export interface QueryDslNumberRangeQuery extends QueryDslRangeQueryBase {
+  gt?: double
+  gte?: double
+  lt?: double
+  lte?: double
+}
 
 export interface QueryDslNumericDecayFunctionKeys extends QueryDslDecayFunctionBase {
 }
 export type QueryDslNumericDecayFunction = QueryDslNumericDecayFunctionKeys |
     { [property: string]: QueryDslDecayPlacement<double, double> }
 
-export type QueryDslOperator = 'and' | 'or' | 'AND' | 'OR'
+export type QueryDslOperator = 'and' | 'or'
 
 export interface QueryDslParentIdQuery extends QueryDslQueryBase {
   id?: Id
@@ -4423,22 +4474,24 @@ export interface QueryDslParentIdQuery extends QueryDslQueryBase {
 export interface QueryDslPercolateQuery extends QueryDslQueryBase {
   document?: any
   documents?: any[]
-  field?: Field
+  field: Field
   id?: Id
   index?: IndexName
+  name?: string
   preference?: string
   routing?: Routing
   version?: VersionNumber
 }
 
 export interface QueryDslPinnedQuery extends QueryDslQueryBase {
-  ids?: Id[] | long[]
-  organic?: QueryDslQueryContainer
+  ids: Id[]
+  organic: QueryDslQueryContainer
 }
 
 export interface QueryDslPrefixQuery extends QueryDslQueryBase {
   rewrite?: MultiTermQueryRewrite
   value: string
+  case_insensitive?: boolean
 }
 
 export interface QueryDslQueryBase {
@@ -4453,38 +4506,38 @@ export interface QueryDslQueryContainer {
   combined_fields?: QueryDslCombinedFieldsQuery
   constant_score?: QueryDslConstantScoreQuery
   dis_max?: QueryDslDisMaxQuery
-  distance_feature?: Record<Field, QueryDslDistanceFeatureQuery | string> | QueryDslDistanceFeatureQuery
+  distance_feature?: QueryDslDistanceFeatureQuery
   exists?: QueryDslExistsQuery
   function_score?: QueryDslFunctionScoreQuery
   fuzzy?: Record<Field, QueryDslFuzzyQuery | string>
-  geo_bounding_box?: QueryDslNamedQuery<QueryDslGeoBoundingBoxQuery | string>
+  geo_bounding_box?: QueryDslGeoBoundingBoxQuery
   geo_distance?: QueryDslGeoDistanceQuery
-  geo_polygon?: QueryDslNamedQuery<QueryDslGeoPolygonQuery | string>
-  geo_shape?: QueryDslNamedQuery<QueryDslGeoShapeQuery | string>
+  geo_polygon?: QueryDslGeoPolygonQuery
+  geo_shape?: QueryDslGeoShapeQuery
   has_child?: QueryDslHasChildQuery
   has_parent?: QueryDslHasParentQuery
   ids?: QueryDslIdsQuery
-  intervals?: QueryDslNamedQuery<QueryDslIntervalsQuery | string>
-  match?: QueryDslNamedQuery<QueryDslMatchQuery | string | float | boolean>
+  intervals?: Record<Field, QueryDslIntervalsQuery>
+  match?: Record<Field, QueryDslMatchQuery | string | float | boolean>
   match_all?: QueryDslMatchAllQuery
-  match_bool_prefix?: QueryDslNamedQuery<QueryDslMatchBoolPrefixQuery | string>
+  match_bool_prefix?: Record<Field, QueryDslMatchBoolPrefixQuery | string>
   match_none?: QueryDslMatchNoneQuery
-  match_phrase?: QueryDslNamedQuery<QueryDslMatchPhraseQuery | string>
-  match_phrase_prefix?: QueryDslNamedQuery<QueryDslMatchPhrasePrefixQuery | string>
+  match_phrase?: Record<Field, QueryDslMatchPhraseQuery | string>
+  match_phrase_prefix?: Record<Field, QueryDslMatchPhrasePrefixQuery | string>
   more_like_this?: QueryDslMoreLikeThisQuery
   multi_match?: QueryDslMultiMatchQuery
   nested?: QueryDslNestedQuery
   parent_id?: QueryDslParentIdQuery
   percolate?: QueryDslPercolateQuery
   pinned?: QueryDslPinnedQuery
-  prefix?: QueryDslNamedQuery<QueryDslPrefixQuery | string>
+  prefix?: Record<Field, QueryDslPrefixQuery | string>
   query_string?: QueryDslQueryStringQuery
-  range?: QueryDslNamedQuery<QueryDslRangeQuery>
-  rank_feature?: QueryDslNamedQuery<QueryDslRankFeatureQuery | string>
-  regexp?: QueryDslNamedQuery<QueryDslRegexpQuery | string>
+  range?: Record<Field, QueryDslRangeQuery>
+  rank_feature?: QueryDslRankFeatureQuery
+  regexp?: Record<Field, QueryDslRegexpQuery | string>
   script?: QueryDslScriptQuery
   script_score?: QueryDslScriptScoreQuery
-  shape?: QueryDslNamedQuery<QueryDslShapeQuery | string>
+  shape?: QueryDslShapeQuery
   simple_query_string?: QueryDslSimpleQueryStringQuery
   span_containing?: QueryDslSpanContainingQuery
   field_masking_span?: QueryDslSpanFieldMaskingQuery
@@ -4493,13 +4546,12 @@ export interface QueryDslQueryContainer {
   span_near?: QueryDslSpanNearQuery
   span_not?: QueryDslSpanNotQuery
   span_or?: QueryDslSpanOrQuery
-  span_term?: QueryDslNamedQuery<QueryDslSpanTermQuery | string>
+  span_term?: Record<Field, QueryDslSpanTermQuery | string>
   span_within?: QueryDslSpanWithinQuery
-  template?: QueryDslQueryTemplate
-  term?: QueryDslNamedQuery<QueryDslTermQuery | string | float | boolean>
-  terms?: QueryDslNamedQuery<QueryDslTermsQuery | string[] | long[]>
-  terms_set?: QueryDslNamedQuery<QueryDslTermsSetQuery | string>
-  wildcard?: QueryDslNamedQuery<QueryDslWildcardQuery | string>
+  term?: Record<Field, QueryDslTermQuery | string | float | boolean>
+  terms?: QueryDslTermsQuery
+  terms_set?: Record<Field, QueryDslTermsSetQuery>
+  wildcard?: Record<Field, QueryDslWildcardQuery | string>
   type?: QueryDslTypeQuery
 }
 
@@ -4512,7 +4564,7 @@ export interface QueryDslQueryStringQuery extends QueryDslQueryBase {
   default_operator?: QueryDslOperator
   enable_position_increments?: boolean
   escape?: boolean
-  fields?: Fields
+  fields?: Field[]
   fuzziness?: Fuzziness
   fuzzy_max_expansions?: integer
   fuzzy_prefix_length?: integer
@@ -4522,17 +4574,13 @@ export interface QueryDslQueryStringQuery extends QueryDslQueryBase {
   max_determinized_states?: integer
   minimum_should_match?: MinimumShouldMatch
   phrase_slop?: double
-  query?: string
+  query: string
   quote_analyzer?: string
   quote_field_suffix?: string
   rewrite?: MultiTermQueryRewrite
   tie_breaker?: double
-  time_zone?: string
+  time_zone?: TimeZone
   type?: QueryDslTextQueryType
-}
-
-export interface QueryDslQueryTemplate {
-  source: string
 }
 
 export interface QueryDslRandomScoreFunction extends QueryDslScoreFunctionBase {
@@ -4540,15 +4588,10 @@ export interface QueryDslRandomScoreFunction extends QueryDslScoreFunctionBase {
   seed?: long | string
 }
 
-export interface QueryDslRangeQuery extends QueryDslQueryBase {
-  gt?: double | DateMath
-  gte?: double | DateMath
-  lt?: double | DateMath
-  lte?: double | DateMath
+export type QueryDslRangeQuery = QueryDslDateRangeQuery | QueryDslNumberRangeQuery
+
+export interface QueryDslRangeQueryBase extends QueryDslQueryBase {
   relation?: QueryDslRangeRelation
-  time_zone?: string
-  from?: double | DateMath
-  to?: double | DateMath
 }
 
 export type QueryDslRangeRelation = 'within' | 'contains' | 'intersects'
@@ -4556,14 +4599,36 @@ export type QueryDslRangeRelation = 'within' | 'contains' | 'intersects'
 export interface QueryDslRankFeatureFunction {
 }
 
+export interface QueryDslRankFeatureFunctionLinear extends QueryDslRankFeatureFunction {
+}
+
+export interface QueryDslRankFeatureFunctionLogarithm extends QueryDslRankFeatureFunction {
+  scaling_factor: float
+}
+
+export interface QueryDslRankFeatureFunctionSaturation extends QueryDslRankFeatureFunction {
+  pivot?: float
+}
+
+export interface QueryDslRankFeatureFunctionSigmoid extends QueryDslRankFeatureFunction {
+  pivot: float
+  exponent: float
+}
+
 export interface QueryDslRankFeatureQuery extends QueryDslQueryBase {
-  function?: QueryDslRankFeatureFunction
+  field: Field
+  saturation?: QueryDslRankFeatureFunctionSaturation
+  log?: QueryDslRankFeatureFunctionLogarithm
+  linear?: QueryDslRankFeatureFunctionLinear
+  sigmoid?: QueryDslRankFeatureFunctionSigmoid
 }
 
 export interface QueryDslRegexpQuery extends QueryDslQueryBase {
+  case_insensitive?: boolean
   flags?: string
   max_determinized_states?: integer
-  value?: string
+  rewrite?: MultiTermQueryRewrite
+  value: string
 }
 
 export interface QueryDslScoreFunctionBase {
@@ -4572,7 +4637,7 @@ export interface QueryDslScoreFunctionBase {
 }
 
 export interface QueryDslScriptQuery extends QueryDslQueryBase {
-  script?: Script
+  script: Script
 }
 
 export interface QueryDslScriptScoreFunction extends QueryDslScoreFunctionBase {
@@ -4580,16 +4645,22 @@ export interface QueryDslScriptScoreFunction extends QueryDslScoreFunctionBase {
 }
 
 export interface QueryDslScriptScoreQuery extends QueryDslQueryBase {
-  query?: QueryDslQueryContainer
-  script?: Script
+  min_score?: float
+  query: QueryDslQueryContainer
+  script: Script
 }
 
-export interface QueryDslShapeQuery extends QueryDslQueryBase {
+export interface QueryDslShapeFieldQuery {
   ignore_unmapped?: boolean
   indexed_shape?: QueryDslFieldLookup
   relation?: ShapeRelation
-  shape?: QueryDslGeoShape
+  shape?: GeoShape
 }
+
+export interface QueryDslShapeQueryKeys extends QueryDslQueryBase {
+}
+export type QueryDslShapeQuery = QueryDslShapeQueryKeys |
+    { [property: string]: QueryDslShapeFieldQuery }
 
 export type QueryDslSimpleQueryStringFlags = 'NONE' | 'AND' | 'OR' | 'NOT' | 'PREFIX' | 'PHRASE' | 'PRECEDENCE' | 'ESCAPE' | 'WHITESPACE' | 'FUZZY' | 'NEAR' | 'SLOP' | 'ALL'
 
@@ -4598,70 +4669,65 @@ export interface QueryDslSimpleQueryStringQuery extends QueryDslQueryBase {
   analyze_wildcard?: boolean
   auto_generate_synonyms_phrase_query?: boolean
   default_operator?: QueryDslOperator
-  fields?: Fields
+  fields?: Field[]
   flags?: QueryDslSimpleQueryStringFlags | string
   fuzzy_max_expansions?: integer
   fuzzy_prefix_length?: integer
   fuzzy_transpositions?: boolean
   lenient?: boolean
   minimum_should_match?: MinimumShouldMatch
-  query?: string
+  query: string
   quote_field_suffix?: string
 }
 
 export interface QueryDslSpanContainingQuery extends QueryDslQueryBase {
-  big?: QueryDslSpanQuery
-  little?: QueryDslSpanQuery
+  big: QueryDslSpanQuery
+  little: QueryDslSpanQuery
 }
 
 export interface QueryDslSpanFieldMaskingQuery extends QueryDslQueryBase {
-  field?: Field
-  query?: QueryDslSpanQuery
+  field: Field
+  query: QueryDslSpanQuery
 }
 
 export interface QueryDslSpanFirstQuery extends QueryDslQueryBase {
-  end?: integer
-  match?: QueryDslSpanQuery
-}
-
-export interface QueryDslSpanGapQuery extends QueryDslQueryBase {
-  field?: Field
-  width?: integer
+  end: integer
+  match: QueryDslSpanQuery
 }
 
 export interface QueryDslSpanMultiTermQuery extends QueryDslQueryBase {
-  match?: QueryDslQueryContainer
+  match: QueryDslQueryContainer
 }
 
 export interface QueryDslSpanNearQuery extends QueryDslQueryBase {
-  clauses?: QueryDslSpanQuery[]
+  clauses: QueryDslSpanQuery[]
   in_order?: boolean
   slop?: integer
 }
 
 export interface QueryDslSpanNotQuery extends QueryDslQueryBase {
   dist?: integer
-  exclude?: QueryDslSpanQuery
-  include?: QueryDslSpanQuery
+  exclude: QueryDslSpanQuery
+  include: QueryDslSpanQuery
   post?: integer
   pre?: integer
 }
 
 export interface QueryDslSpanOrQuery extends QueryDslQueryBase {
-  clauses?: QueryDslSpanQuery[]
+  clauses: QueryDslSpanQuery[]
 }
 
-export interface QueryDslSpanQuery extends QueryDslQueryBase {
-  span_containing?: QueryDslNamedQuery<QueryDslSpanContainingQuery | string>
-  field_masking_span?: QueryDslNamedQuery<QueryDslSpanFieldMaskingQuery | string>
-  span_first?: QueryDslNamedQuery<QueryDslSpanFirstQuery | string>
-  span_gap?: QueryDslNamedQuery<QueryDslSpanGapQuery | integer>
+export interface QueryDslSpanQuery {
+  span_containing?: QueryDslSpanContainingQuery
+  field_masking_span?: QueryDslSpanFieldMaskingQuery
+  span_first?: QueryDslSpanFirstQuery
+  span_gap?: Record<Field, integer>
   span_multi?: QueryDslSpanMultiTermQuery
-  span_near?: QueryDslNamedQuery<QueryDslSpanNearQuery | string>
-  span_not?: QueryDslNamedQuery<QueryDslSpanNotQuery | string>
-  span_or?: QueryDslNamedQuery<QueryDslSpanOrQuery | string>
-  span_term?: QueryDslNamedQuery<QueryDslSpanTermQuery | string>
-  span_within?: QueryDslNamedQuery<QueryDslSpanWithinQuery | string>
+  span_near?: QueryDslSpanNearQuery
+  span_not?: QueryDslSpanNotQuery
+  span_or?: QueryDslSpanOrQuery
+  span_term?: Record<Field, QueryDslSpanTermQuery | string>
+  span_within?: QueryDslSpanWithinQuery
 }
 
 export interface QueryDslSpanTermQuery extends QueryDslQueryBase {
@@ -4669,27 +4735,37 @@ export interface QueryDslSpanTermQuery extends QueryDslQueryBase {
 }
 
 export interface QueryDslSpanWithinQuery extends QueryDslQueryBase {
-  big?: QueryDslSpanQuery
-  little?: QueryDslSpanQuery
+  big: QueryDslSpanQuery
+  little: QueryDslSpanQuery
 }
 
 export interface QueryDslTermQuery extends QueryDslQueryBase {
-  value?: string | float | boolean
+  value: string | float | boolean
+  case_insensitive?: boolean
 }
 
-export interface QueryDslTermsQuery extends QueryDslQueryBase {
-  terms?: string[]
-  index?: IndexName
-  id?: Id
-  path?: string
+export interface QueryDslTermsLookup {
+  index: IndexName
+  id: Id
+  path: Field
   routing?: Routing
 }
 
-export interface QueryDslTermsSetQuery extends QueryDslQueryBase {
+export interface QueryDslTermsQueryKeys extends QueryDslQueryBase {
+}
+export type QueryDslTermsQuery = QueryDslTermsQueryKeys |
+    { [property: string]: string[] | long[] | QueryDslTermsLookup }
+
+export interface QueryDslTermsSetFieldQuery {
   minimum_should_match_field?: Field
   minimum_should_match_script?: Script
-  terms?: string[]
+  terms: string[]
 }
+
+export interface QueryDslTermsSetQueryKeys extends QueryDslQueryBase {
+}
+export type QueryDslTermsSetQuery = QueryDslTermsSetQueryKeys |
+    { [property: string]: QueryDslTermsSetFieldQuery }
 
 export type QueryDslTextQueryType = 'best_fields' | 'most_fields' | 'cross_fields' | 'phrase' | 'phrase_prefix' | 'bool_prefix'
 
@@ -4709,6 +4785,7 @@ export interface QueryDslTypeQuery extends QueryDslQueryBase {
 }
 
 export interface QueryDslWildcardQuery extends QueryDslQueryBase {
+  case_insensitive?: boolean
   rewrite?: MultiTermQueryRewrite
   value: string
 }
@@ -15268,6 +15345,9 @@ export interface SpecUtilsCommonQueryParameters {
   human?: boolean
   pretty?: boolean
   source_query_string?: string
+}
+
+export interface SpecUtilsAdditionalProperty<TKey = unknown, TValue = unknown> {
 }
 
 export interface SpecUtilsCommonCatQueryParameters {

--- a/specification/_global/get/GetResponse.ts
+++ b/specification/_global/get/GetResponse.ts
@@ -38,7 +38,7 @@ export class Response<TDocument> {
     _routing?: string
     _seq_no?: SequenceNumber
     _source?: TDocument
-    /** deprecated since 7.0.0 */
+    /** @obsolete 7.0.0 */
     _type?: Type
     _version?: VersionNumber
   }

--- a/specification/_global/scroll/ScrollRequest.ts
+++ b/specification/_global/scroll/ScrollRequest.ts
@@ -28,7 +28,7 @@ import { Time } from '@_types/Time'
  */
 export interface Request extends RequestBase {
   path_parts?: {
-    /** Deprecated with 7.0.0 */
+    /** @obsolete 7.0.0 */
     scroll_id?: Id
   }
   query_parameters?: {
@@ -38,7 +38,7 @@ export interface Request extends RequestBase {
      * @server_default 1d
      */
     scroll?: Time
-    /** Deprecated with 7.0.0 */
+    /** @obsolete 7.0.0 */
     scroll_id?: ScrollId
     /**
      * If true, the API response’s hit.total property is returned as an integer. If false, the API response’s hit.total property is returned as an object.

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -114,14 +114,24 @@ export class InnerHits {
   size?: integer
   from?: integer
   collapse?: FieldCollapse
-  docvalue_fields?: Fields
+  docvalue_fields?: FieldAndFormat[]
   explain?: boolean
   highlight?: Highlight
   ignore_unmapped?: boolean
-  script_fields?: Dictionary<string, ScriptField>
+  script_fields?: Dictionary<Field, ScriptField>
   seq_no_primary_term?: boolean
   fields?: Fields
   sort?: Sort
   _source?: boolean | SourceFilter
+  stored_field?: Fields
+  /** @server_default false */
+  track_scores?: boolean
   version?: boolean
+}
+
+/** @shortcut_property field */
+export class FieldAndFormat {
+  field: Field
+  format?: string
+  include_unmapped?: boolean
 }

--- a/specification/_global/search/_types/sort.ts
+++ b/specification/_global/search/_types/sort.ts
@@ -56,7 +56,7 @@ export class ScoreSort {
   order?: SortOrder
 }
 export class GeoDistanceSort
-  implements AdditionalProperties<string, GeoLocation | GeoLocation[]> {
+  implements AdditionalProperties<Field, GeoLocation | GeoLocation[]> {
   mode?: SortMode
   distance_type?: GeoDistanceType
   order?: SortOrder
@@ -70,7 +70,7 @@ export class ScriptSort {
 }
 
 export class SortContainer
-  implements AdditionalProperties<string, FieldSort | SortOrder> {
+  implements AdditionalProperties<Field, FieldSort | SortOrder> {
   _score?: ScoreSort
   _doc?: ScoreSort
   _geo_distance?: GeoDistanceSort

--- a/specification/_spec_utils/behaviors.ts
+++ b/specification/_spec_utils/behaviors.ts
@@ -37,6 +37,17 @@ import { Time } from '@_types/Time'
 export interface AdditionalProperties<TKey, TValue> {}
 
 /**
+ * In some places in the specification an object consists of a static set of properties and a single additional property
+ * with an arbitrary name but a statically defined type. This is typically used for configurations associated
+ * to a single field. Meaning that object should theoretically extend SingleKeyDictionary but expose
+ * a set of known keys. And possibly the object might already be part of an object graph and have a parent class.
+ * This puts it into a bind that needs a client specific solution.
+ * We therefore document the requirement to accept a single unknown property with this interface.
+ * @behavior Defines a trait that a single unknown property for the class should be typed to TValue
+ */
+export interface AdditionalProperty<TKey, TValue> {}
+
+/**
  * Implements a set of common query parameters all API's support.
  * Since these can break the request structure these are listed explicitly as a behavior.
  * Its up to individual clients to define support although `error_trace` and `pretty` are

--- a/specification/_types/Geo.ts
+++ b/specification/_types/Geo.ts
@@ -18,6 +18,7 @@
  */
 
 import { double } from './Numeric'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class DistanceParsed {
   precision: double
@@ -42,6 +43,9 @@ export enum GeoDistanceType {
   arc = 0,
   plane = 1
 }
+
+/** A GeoJson shape, that can also use Elasticsearch's `envelope` extension. */
+export type GeoShape = UserDefinedValue
 
 export enum GeoShapeRelation {
   intersects = 0,

--- a/specification/_types/Scripting.ts
+++ b/specification/_types/Scripting.ts
@@ -47,8 +47,10 @@ export class IndexedScript extends ScriptBase {
   id: Id
 }
 
+// 'string' is a shortcut for InlineScript.source
 export type Script = InlineScript | IndexedScript | string
 
 export class ScriptField {
   script: Script
+  ignore_failure?: boolean
 }

--- a/specification/_types/Time.ts
+++ b/specification/_types/Time.ts
@@ -40,6 +40,11 @@ export type DateMath = string
 export type DateMathExpression = string
 export type DateMathTime = string
 
+export type TimeZone = string
+
+/** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/7.x/mapping-date-format.html */
+export type DateFormat = string
+
 export enum DateMathOperation {
   '+' = 0,
   '-' = 1

--- a/specification/_types/analysis/StopWords.ts
+++ b/specification/_types/analysis/StopWords.ts
@@ -23,4 +23,4 @@
  * Also accepts an array of stop words.
  * @class_serializer: StopWordsFormatter
  */
-export type StopWords = string | string[]
+export type StopWords = string[]

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -50,7 +50,7 @@ export type IndexPatterns = IndexPattern[]
 export type Type = string
 export type Types = Type | Type[]
 
-export type Routing = string | number
+export type Routing = string
 export type LongId = string
 //TODO encode metrics as API specific enums
 export type IndexMetrics = string
@@ -98,6 +98,7 @@ export type PropertyName = string
 export type RelationName = string
 export type TaskId = string | integer
 export type Fuzziness = string | integer
+/** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-term-rewrite.html */
 export type MultiTermQueryRewrite = string
 
 /** Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.  */

--- a/specification/_types/query_dsl/MatchAllQuery.ts
+++ b/specification/_types/query_dsl/MatchAllQuery.ts
@@ -19,6 +19,4 @@
 
 import { QueryBase } from './abstractions'
 
-export class MatchAllQuery extends QueryBase {
-  norm_field?: string
-}
+export class MatchAllQuery extends QueryBase {}

--- a/specification/_types/query_dsl/Operator.ts
+++ b/specification/_types/query_dsl/Operator.ts
@@ -17,9 +17,9 @@
  * under the License.
  */
 
+// Note: corresponding server enum is uppercase, but parsing is case-insensitive. Tests only use lower-case identifiers
+// so we only keep those.
 export enum Operator {
   and = 0,
-  or = 1,
-  AND = 2,
-  OR = 3
+  or = 1
 }

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { AdditionalProperties } from '@spec_utils/behaviors'
+import { AdditionalProperties, AdditionalProperty } from '@spec_utils/behaviors'
 import { Field, MinimumShouldMatch } from '@_types/common'
 import { Distance } from '@_types/Geo'
 import { double, float, long } from '@_types/Numeric'
@@ -35,17 +35,18 @@ export class BoolQuery extends QueryBase {
 }
 
 export class BoostingQuery extends QueryBase {
-  negative_boost?: double
-  negative?: QueryContainer
-  positive?: QueryContainer
+  negative_boost: double
+  negative: QueryContainer
+  positive: QueryContainer
 }
 
 export class ConstantScoreQuery extends QueryBase {
-  filter?: QueryContainer
+  filter: QueryContainer
 }
 
 export class DisMaxQuery extends QueryBase {
-  queries?: QueryContainer[]
+  queries: QueryContainer[]
+  /** @server_default 0.0 */
   tie_breaker?: double
 }
 
@@ -94,22 +95,26 @@ export class DecayFunctionBase extends ScoreFunctionBase {
 
 export class NumericDecayFunction
   extends DecayFunctionBase
-  implements AdditionalProperties<string, DecayPlacement<double, double>> {}
+  implements AdditionalProperty<Field, DecayPlacement<double, double>> {}
 
 export class DateDecayFunction
   extends DecayFunctionBase
-  implements AdditionalProperties<string, DecayPlacement<DateMath, Time>> {}
+  implements AdditionalProperty<Field, DecayPlacement<DateMath, Time>> {}
 
 export class GeoDecayFunction
   extends DecayFunctionBase
-  implements
-    AdditionalProperties<string, DecayPlacement<GeoLocation, Distance>> {}
+  implements AdditionalProperty<Field, DecayPlacement<GeoLocation, Distance>> {}
 
 export type DecayFunction =
   | DateDecayFunction
   | NumericDecayFunction
   | GeoDecayFunction
 
+/** @variants container */
+// This container is valid without a variant. Also, despite being documented as a function, 'weight' is actually a
+// container property that can be combined with a function. From SearchModule#registerScoreFunctions in ES:
+// Weight doesn't have its own parser, so every function supports it out of the box. Can be a single function too when
+// not associated to any other function, which is why it needs to be registered manually here.
 export class FunctionScoreContainer {
   exp?: DecayFunction
   gauss?: DecayFunction
@@ -117,7 +122,10 @@ export class FunctionScoreContainer {
   field_value_factor?: FieldValueFactorScoreFunction
   random_score?: RandomScoreFunction
   script_score?: ScriptScoreFunction
+
+  /** @variant container_property */
   filter?: QueryContainer
+  /** @variant container_property */
   weight?: double
 }
 

--- a/specification/_types/query_dsl/fulltext.ts
+++ b/specification/_types/query_dsl/fulltext.ts
@@ -28,14 +28,18 @@ import { double, float, integer } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 import { QueryBase } from './abstractions'
 import { Operator } from './Operator'
+import { DateMath, TimeZone } from '@_types/Time'
 
+/**
+ * @shortcut_property query
+ */
 export class CommonTermsQuery extends QueryBase {
   analyzer?: string
   cutoff_frequency?: double
   high_freq_operator?: Operator
   low_freq_operator?: Operator
   minimum_should_match?: MinimumShouldMatch
-  query?: string
+  query: string
 }
 
 export class Intervals {
@@ -43,20 +47,20 @@ export class Intervals {
 }
 
 export class IntervalsAllOf {
-  intervals?: IntervalsContainer[]
+  intervals: IntervalsContainer[]
+  /** @server_default -1 */
   max_gaps?: integer
+  /** @server_default false */
   ordered?: boolean
   filter?: IntervalsFilter
 }
 
 export class IntervalsAnyOf {
-  intervals?: IntervalsContainer[]
+  intervals: IntervalsContainer[]
   filter?: IntervalsFilter
 }
 
-/**
- * @variants container
- */
+/** @variants container */
 export class IntervalsContainer {
   all_of?: IntervalsAllOf
   any_of?: IntervalsAnyOf
@@ -66,6 +70,8 @@ export class IntervalsContainer {
   wildcard?: IntervalsWildcard
 }
 
+/** @variants container */
+// Note: doc says filters are queries, but they're actually intervals
 export class IntervalsFilter {
   after?: IntervalsContainer
   before?: IntervalsContainer
@@ -81,27 +87,33 @@ export class IntervalsFilter {
 export class IntervalsFuzzy {
   analyzer?: string
   fuzziness?: Fuzziness
+  /** @server_default 0 */
   prefix_length?: integer
-  term?: string
+  term: string
+  /** @server_default true */
   transpositions?: boolean
   use_field?: Field
 }
 
 export class IntervalsMatch {
   analyzer?: string
+  /** @server_default -1 */
   max_gaps?: integer
+  /** @server_default false */
   ordered?: boolean
-  query?: string
+  query: string
   use_field?: Field
   filter?: IntervalsFilter
 }
 
 export class IntervalsPrefix {
   analyzer?: string
-  prefix?: string
+  prefix: string
   use_field?: Field
 }
 
+/** @variants container */
+// Note: similar to IntervalsContainer, but has to be duplicated because of the QueryBase parent class
 export class IntervalsQuery extends QueryBase {
   all_of?: IntervalsAllOf
   any_of?: IntervalsAnyOf
@@ -113,26 +125,38 @@ export class IntervalsQuery extends QueryBase {
 
 export class IntervalsWildcard {
   analyzer?: string
-  pattern?: string
+  pattern: string
   use_field?: Field
 }
 
+/** @shortcut_property query */
 export class MatchQuery extends QueryBase {
   analyzer?: string
+  /** @server_default true */
   auto_generate_synonyms_phrase_query?: boolean
+  /** @obsolete 7.3.0 */
   cutoff_frequency?: double
   fuzziness?: Fuzziness
   fuzzy_rewrite?: MultiTermQueryRewrite
+  /** @server_default true */
   fuzzy_transpositions?: boolean
+  /** @server_default false */
   lenient?: boolean
+  /** @server_default 50 */
   max_expansions?: integer
   minimum_should_match?: MinimumShouldMatch
+  /** @server_default 'or' */
   operator?: Operator
+  /** @server_default 0 */
   prefix_length?: integer
-  query?: string | float | boolean
+  // FIXME: docs states "date" as a possible format. Add DateMath, or DateMathTime?
+  //        Should also be consisitent with MultiMatchQuery.query
+  query: string | float | boolean
+  /** @server_default 'none' */
   zero_terms_query?: ZeroTermsQuery
 }
 
+/** @shortcut_property query */
 export class MatchBoolPrefixQuery extends QueryBase {
   analyzer?: string
   fuzziness?: Fuzziness
@@ -142,41 +166,52 @@ export class MatchBoolPrefixQuery extends QueryBase {
   minimum_should_match?: MinimumShouldMatch
   operator?: Operator
   prefix_length?: integer
-  query?: string
+  query: string
 }
 
+/** @shortcut_property query */
 export class MatchPhraseQuery extends QueryBase {
   analyzer?: string
-  query?: string
+  query: string
+  /** @server_default 0 */
   slop?: integer
+  zero_terms_query?: ZeroTermsQuery
 }
 
+/** @shortcut_property query */
 export class MatchPhrasePrefixQuery extends QueryBase {
   analyzer?: string
   max_expansions?: integer
-  query?: string
+  query: string
   slop?: integer
   zero_terms_query?: ZeroTermsQuery
 }
 
 export class MultiMatchQuery extends QueryBase {
   analyzer?: string
+  /** @server_default true */
   auto_generate_synonyms_phrase_query?: boolean
+  /** @obsolete 7.3.0 */
   cutoff_frequency?: double
   fields?: Fields
   fuzziness?: Fuzziness
   fuzzy_rewrite?: MultiTermQueryRewrite
+  /** @server_default true */
   fuzzy_transpositions?: boolean
+  /** @server_default false */
   lenient?: boolean
+  /** @server_default 50 */
   max_expansions?: integer
   minimum_should_match?: MinimumShouldMatch
+  /** @server_default 'or' */
   operator?: Operator
+  /** @server_default 0 */
   prefix_length?: integer
-  query?: string
+  query: string
   slop?: integer
   tie_breaker?: double
+  /** @server_default 'best_fields' */
   type?: TextQueryType
-  use_dis_max?: boolean
   zero_terms_query?: ZeroTermsQuery
 }
 
@@ -195,30 +230,40 @@ export enum ZeroTermsQuery {
 }
 
 export class QueryStringQuery extends QueryBase {
+  /** @server_default true */
   allow_leading_wildcard?: boolean
   analyzer?: string
+  /** @server_default false */
   analyze_wildcard?: boolean
+  /** @server_default true */
   auto_generate_synonyms_phrase_query?: boolean
   default_field?: Field
+  /** @server_default 'or' */
   default_operator?: Operator
+  /** @server_default true */
   enable_position_increments?: boolean
+  /** @server_default false */
   escape?: boolean
-  fields?: Fields
+  fields?: Field[]
   fuzziness?: Fuzziness
+  /** @server_default 50 */
   fuzzy_max_expansions?: integer
   fuzzy_prefix_length?: integer
   fuzzy_rewrite?: MultiTermQueryRewrite
   fuzzy_transpositions?: boolean
+  /** @server_default false */
   lenient?: boolean
+  /** @server_default 10000 */
   max_determinized_states?: integer
   minimum_should_match?: MinimumShouldMatch
   phrase_slop?: double
-  query?: string
+  query: string
   quote_analyzer?: string
   quote_field_suffix?: string
   rewrite?: MultiTermQueryRewrite
   tie_breaker?: double
-  time_zone?: string
+  time_zone?: TimeZone
+  /** @server_default 'best_fields' */
   type?: TextQueryType
 }
 
@@ -240,16 +285,20 @@ export enum SimpleQueryStringFlags {
 
 export class SimpleQueryStringQuery extends QueryBase {
   analyzer?: string
+  /** @server_default false */
   analyze_wildcard?: boolean
+  /** @server_default true */
   auto_generate_synonyms_phrase_query?: boolean
+  /** @server_default 'or' */
   default_operator?: Operator
-  fields?: Fields
+  fields?: Field[]
   flags?: SimpleQueryStringFlags | string
   fuzzy_max_expansions?: integer
   fuzzy_prefix_length?: integer
   fuzzy_transpositions?: boolean
+  /** @server_default false */
   lenient?: boolean
   minimum_should_match?: MinimumShouldMatch
-  query?: string
+  query: string
   quote_field_suffix?: string
 }

--- a/specification/_types/query_dsl/geo.ts
+++ b/specification/_types/query_dsl/geo.ts
@@ -17,28 +17,44 @@
  * under the License.
  */
 
-import { AdditionalProperties } from '@spec_utils/behaviors'
+import { AdditionalProperties, AdditionalProperty } from '@spec_utils/behaviors'
 import {
   Distance,
   GeoDistanceType,
+  GeoShape,
   GeoShapeRelation,
   LatLon
 } from '@_types/Geo'
 import { double } from '@_types/Numeric'
 import { FieldLookup, QueryBase } from './abstractions'
+import { Field } from '@_types/common'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
+/**
+ * A geo bounding box. The various coordinates can be mixed. When set, `wkt` takes precedence over all other fields.
+ */
 export class BoundingBox {
   bottom_right?: GeoLocation
   top_left?: GeoLocation
+
+  top_right?: GeoLocation
+  bottom_left?: GeoLocation
+
+  top?: double
+  left?: double
+  right?: double
+  bottom?: double
+
   wkt?: string
 }
 
-export class GeoBoundingBoxQuery extends QueryBase {
-  bounding_box?: BoundingBox
+export class GeoBoundingBoxQuery
+  extends QueryBase
+  implements AdditionalProperty<Field, BoundingBox> {
+  /** @obsolete 7.14.0 */
   type?: GeoExecution
+  /** @server_default 'strict' */
   validation_method?: GeoValidationMethod
-  top_left?: LatLon
-  bottom_right?: LatLon
 }
 
 export enum GeoExecution {
@@ -48,14 +64,23 @@ export enum GeoExecution {
 
 export class GeoDistanceQuery
   extends QueryBase
-  implements AdditionalProperties<string, GeoLocation> {
+  implements AdditionalProperty<Field, GeoLocation> {
   distance?: Distance
+  /** @server_default 'arc' */
   distance_type?: GeoDistanceType
+  /** @server_default 'strict' */
   validation_method?: GeoValidationMethod
 }
 
-export class GeoPolygonQuery extends QueryBase {
-  points?: GeoLocation[]
+export class GeoPolygonPoints {
+  points: GeoLocation[]
+}
+
+/** @obsolete 7.12.0 Use geo-shape instead. */
+export class GeoPolygonQuery
+  extends QueryBase
+  implements AdditionalProperty<Field, GeoPolygonPoints> {
+  /** @server_default 'strict' */
   validation_method?: GeoValidationMethod
 }
 
@@ -64,15 +89,18 @@ export enum GeoFormat {
   WellKnownText = 1
 }
 
-export class GeoShape {
-  type?: string
-}
-
-export class GeoShapeQuery extends QueryBase {
-  ignore_unmapped?: boolean
+export class GeoShapeFieldQuery {
+  shape?: GeoShape
   indexed_shape?: FieldLookup
   relation?: GeoShapeRelation
-  shape?: GeoShape
+}
+
+// GeoShape query doesn't follow the common pattern of having a single field-name property
+// holding also the query base fields (boost and _name)
+export class GeoShapeQuery
+  extends QueryBase
+  implements AdditionalProperty<Field, GeoShapeFieldQuery> {
+  ignore_unmapped?: boolean
 }
 
 export enum CharacterType {

--- a/specification/_types/query_dsl/joining.ts
+++ b/specification/_types/query_dsl/joining.ts
@@ -31,28 +31,34 @@ export enum ChildScoreMode {
 }
 
 export class HasChildQuery extends QueryBase {
+  /** @server_default false */
   ignore_unmapped?: boolean
   inner_hits?: InnerHits
   max_children?: integer
   min_children?: integer
-  query?: QueryContainer
+  query: QueryContainer
+  /** @server_default 'none' */
   score_mode?: ChildScoreMode
-  type?: RelationName
+  type: RelationName
 }
 
 export class HasParentQuery extends QueryBase {
+  /** @server_default false */
   ignore_unmapped?: boolean
   inner_hits?: InnerHits
-  parent_type?: RelationName
-  query?: QueryContainer
+  parent_type: RelationName
+  query: QueryContainer
+  /** @server_default false */
   score?: boolean
 }
 
 export class NestedQuery extends QueryBase {
+  /** @server_default false */
   ignore_unmapped?: boolean
   inner_hits?: InnerHits
-  path?: Field
-  query?: QueryContainer
+  path: Field
+  query: QueryContainer
+  /** @server_default 'avg' */
   score_mode?: NestedScoreMode
 }
 
@@ -66,6 +72,7 @@ export enum NestedScoreMode {
 
 export class ParentIdQuery extends QueryBase {
   id?: Id
+  /** @server_default false */
   ignore_unmapped?: boolean
   type?: RelationName
 }

--- a/specification/_types/query_dsl/span.ts
+++ b/specification/_types/query_dsl/span.ts
@@ -19,70 +19,77 @@
 
 import { Field } from '@_types/common'
 import { integer } from '@_types/Numeric'
-import { NamedQuery, QueryBase, QueryContainer } from './abstractions'
+import { QueryBase, QueryContainer } from './abstractions'
+import { SingleKeyDictionary } from '@spec_utils/Dictionary'
 
 export class SpanContainingQuery extends QueryBase {
-  big?: SpanQuery
-  little?: SpanQuery
+  big: SpanQuery
+  little: SpanQuery
 }
 
 export class SpanFieldMaskingQuery extends QueryBase {
-  field?: Field
-  query?: SpanQuery
+  field: Field
+  query: SpanQuery
 }
 
 export class SpanFirstQuery extends QueryBase {
-  end?: integer
-  match?: SpanQuery
+  end: integer
+  match: SpanQuery
 }
 
 export class SpanGapQuery extends QueryBase {
-  field?: Field
+  field: Field
   width?: integer
 }
 
 export class SpanMultiTermQuery extends QueryBase {
-  match?: QueryContainer
+  /** Should be a multi term query (one of wildcard, fuzzy, prefix, range or regexp query) */
+  match: QueryContainer
 }
 
 export class SpanNearQuery extends QueryBase {
-  clauses?: SpanQuery[]
+  clauses: SpanQuery[]
   in_order?: boolean
   slop?: integer
 }
 
 export class SpanNotQuery extends QueryBase {
   dist?: integer
-  exclude?: SpanQuery
-  include?: SpanQuery
+  exclude: SpanQuery
+  include: SpanQuery
+  /** @server_default 0 */
   post?: integer
+  /** @server_default 0 */
   pre?: integer
 }
 
 export class SpanOrQuery extends QueryBase {
-  clauses?: SpanQuery[]
+  clauses: SpanQuery[]
 }
 
+/** @shortcut_property value */
 export class SpanTermQuery extends QueryBase {
   value: string
 }
 
 export class SpanWithinQuery extends QueryBase {
-  big?: SpanQuery
-  little?: SpanQuery
+  big: SpanQuery
+  little: SpanQuery
 }
 
-export class SpanQuery extends QueryBase {
-  span_containing?: NamedQuery<SpanContainingQuery | string>
-  field_masking_span?: NamedQuery<SpanFieldMaskingQuery | string>
-  span_first?: NamedQuery<SpanFirstQuery | string>
-  span_gap?: NamedQuery<SpanGapQuery | integer>
+/** @variants container */
+export class SpanQuery {
+  span_containing?: SpanContainingQuery
+  field_masking_span?: SpanFieldMaskingQuery
+  span_first?: SpanFirstQuery
+  /** Can only be used as a clause in a span_near query */
+  span_gap?: SingleKeyDictionary<Field, integer>
   span_multi?: SpanMultiTermQuery
-  span_near?: NamedQuery<SpanNearQuery | string>
-  span_not?: NamedQuery<SpanNotQuery | string>
-  span_or?: NamedQuery<SpanOrQuery | string>
-  span_term?: NamedQuery<SpanTermQuery | string>
-  span_within?: NamedQuery<SpanWithinQuery | string>
+  span_near?: SpanNearQuery
+  span_not?: SpanNotQuery
+  span_or?: SpanOrQuery
+  span_term?: SingleKeyDictionary<Field, SpanTermQuery>
+  span_within?: SpanWithinQuery
 }
 
 export class SpanSubQuery extends QueryBase {}

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -22,50 +22,73 @@ import {
   Field,
   Fuzziness,
   Id,
+  Ids,
   IndexName,
   MultiTermQueryRewrite,
   Routing
 } from '@_types/common'
 import { double, float, integer, long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
-import { DateMath } from '@_types/Time'
+import { DateFormat, DateMath, TimeZone } from '@_types/Time'
 import { QueryBase } from './abstractions'
+import { AdditionalProperty } from '@spec_utils/behaviors'
 
 export class ExistsQuery extends QueryBase {
-  field?: Field
+  field: Field
 }
 
+/** @shortcut_property value */
 export class FuzzyQuery extends QueryBase {
   max_expansions?: integer
   prefix_length?: integer
   rewrite?: MultiTermQueryRewrite
   transpositions?: boolean
   fuzziness?: Fuzziness
-  value: UserDefinedValue
-}
-
-export class IdsQuery extends QueryBase {
-  values?: Id[] | long[]
-}
-
-export class PrefixQuery extends QueryBase {
-  rewrite?: MultiTermQueryRewrite
+  // ES is lenient and accepts any primitive type, but ultimately converts it to a string.
+  // Changing this field definition from UserDefinedValue to string breaks a recording produced from Nest tests,
+  // but Nest is probably also overly flexible here and exposes an option that should not exist.
   value: string
 }
 
-export class RangeQuery extends QueryBase {
-  gt?: double | DateMath
-  gte?: double | DateMath
-  lt?: double | DateMath
-  lte?: double | DateMath
-  relation?: RangeRelation
-
-  time_zone?: string
-
-  //TODO obsolete, update yaml tests to no longer use this
-  from?: double | DateMath
-  to?: double | DateMath
+export class IdsQuery extends QueryBase {
+  values?: Ids
 }
+
+/** @shortcut_property value */
+export class PrefixQuery extends QueryBase {
+  rewrite?: MultiTermQueryRewrite
+  value: string
+  /**
+   * @server_default false
+   * @since 7.10.0
+   */
+  case_insensitive?: boolean
+}
+
+export class RangeQueryBase extends QueryBase {
+  relation?: RangeRelation
+}
+
+/** @variant name=date */
+export class DateRangeQuery extends RangeQueryBase {
+  gt?: DateMath
+  gte?: DateMath
+  lt?: DateMath
+  lte?: DateMath
+
+  format?: DateFormat
+  time_zone?: TimeZone
+}
+
+/** @variant name=number */
+export class NumberRangeQuery extends RangeQueryBase {
+  gt?: double
+  gte?: double
+  lt?: double
+  lte?: double
+}
+
+export type RangeQuery = DateRangeQuery | NumberRangeQuery
 
 export enum RangeRelation {
   within = 0,
@@ -73,35 +96,56 @@ export enum RangeRelation {
   intersects = 2
 }
 
+/** @shortcut_property value */
 export class RegexpQuery extends QueryBase {
+  /**
+   * @since 7.10.0
+   * @server_default false
+   */
+  case_insensitive?: boolean
   flags?: string
+  /** @server_default 10000 */
   max_determinized_states?: integer
-  value?: string
+  rewrite?: MultiTermQueryRewrite
+  value: string
 }
 
+/** @shortcut_property value */
 export class TermQuery extends QueryBase {
-  value?: string | float | boolean
+  value: string | float | boolean
+  /** @since 7.10.0 */
+  case_insensitive?: boolean
 }
 
-export class TermsQuery extends QueryBase {
-  terms?: string[]
-  index?: IndexName
-  id?: Id
-  path?: string
+export class TermsQuery
+  extends QueryBase
+  implements AdditionalProperty<Field, string[] | long[] | TermsLookup> {}
+
+export class TermsLookup {
+  index: IndexName
+  id: Id
+  path: Field
   routing?: Routing
 }
 
-export class TermsSetQuery extends QueryBase {
+export class TermsSetQuery
+  extends QueryBase
+  implements AdditionalProperty<Field, TermsSetFieldQuery> {}
+
+export class TermsSetFieldQuery {
   minimum_should_match_field?: Field
   minimum_should_match_script?: Script
-  terms?: string[]
+  terms: string[]
 }
 
 export class TypeQuery extends QueryBase {
   value: string
 }
 
+/** @shortcut_property value */
 export class WildcardQuery extends QueryBase {
+  /** @since 7.10.0 */
+  case_insensitive?: boolean
   rewrite?: MultiTermQueryRewrite
   value: string
 }


### PR DESCRIPTION
This PR is an exhaustive review/update/fix of the 53 query definitions.

### Fixing/updating query definitions

Query definitions follow one of 3 different patterns, driven by where the base query fields (`boost` and `_name`) appear in the data structure:

- a regular structure extending `QueryBase`: all queries that do not target a single field (e.g. boolean query)
- a `SinglekeyDictionary<Field, SomeQuery>`: queries where the structure is a single property for the field name, with a nested structure that holds the base fields (e.g. term query)
- a class implementing `AdditionalProperty<Field, SomeFieldQuery>`: queries where the top-level structure contains a single field name and also the base query fields. Used mostly in geo queries, e.g. geo polygon query.

The specification of the query definitions has been verified:

- by looking a the doc and trying the examples,
- by reading the ES server source code to disambiguate things that were not apparent in the doc (e.g. location of base query fields),
- and have been verified to pass the flight recorder validation.

There are however 3 additional validation errors coming from Nest tests where Nest is overly flexible, allowing numbers where strings are the only values that semantically make sense. These tests succeed in Nest because ES is overly lenient and (most often) accepts any primitive type where it expects a string, but we should not encode this leniency in the spec where it doesn't make sense from a semantic perspective.

### AdditionalProperty behavior

This PR introduces a new behavior, `AdditionalProperty`, which is to `SingleKeyDictionary` what `AdditionalProperties` is to `Dictionary`: it is used to model field queries, where only one single field can be the target of a query.

This distinction is important for statically typed languages where dictionaries/records with a single key can be code-generated differently from regular dictionaries.

### Shortcut properties

This PR introduces a new `@shortcut_property` jsdoc tag: it indicates that a property of a class can be used as a shortcut. This is used for many field query types that have single required field, such as term query: `{"term": {"some_field": {"value": "some_text"}}}` can also be written as `{"term": {"some_field": "some_text"}}`. The class is then defined as follows:

```typescript
/** @shortcut_property value */
export class TermQuery extends QueryBase {
  value: string | float | boolean
  case_insensitive?: boolean
}
```

Defining the shortcut in the class definition rather than on fields using it is consistent with the implementation in the ES code base: shortcut notations are implemented in the JSON deserialization of classes and not at the class usage location.

The TypeScript generator has been updated to expand shortcut properties as union types at the usage location.

### Misc

This PR also adds a number of `@server_default`, `@obsolete` and `@since` annotations and adds or updates a few common types.