### PR TITLE
Add @identifier annotation to _nodes properties

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -116461,6 +116461,7 @@
         {
           "description": "Contains statistics about the number of nodes selected by the request’s node filters.",
           "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes",
+          "identifier": "node_stats",
           "name": "_nodes",
           "required": true,
           "type": {
@@ -123198,6 +123199,7 @@
         "kind": "properties",
         "properties": [
           {
+            "identifier": "node_stats",
             "name": "_nodes",
             "required": true,
             "type": {
@@ -123287,6 +123289,7 @@
         "kind": "properties",
         "properties": [
           {
+            "identifier": "node_stats",
             "name": "_nodes",
             "required": true,
             "type": {
@@ -123391,6 +123394,18 @@
         "kind": "properties",
         "properties": [
           {
+            "identifier": "node_stats",
+            "name": "_nodes",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "NodeStatistics",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
             "name": "cluster_name",
             "required": true,
             "type": {
@@ -123420,17 +123435,6 @@
                   "name": "ClusterNode",
                   "namespace": "security._types"
                 }
-              }
-            }
-          },
-          {
-            "name": "_nodes",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "NodeStatistics",
-                "namespace": "_types"
               }
             }
           }
@@ -123480,6 +123484,7 @@
         "kind": "properties",
         "properties": [
           {
+            "identifier": "node_stats",
             "name": "_nodes",
             "required": true,
             "type": {
@@ -123591,6 +123596,7 @@
         "kind": "properties",
         "properties": [
           {
+            "identifier": "node_stats",
             "name": "_nodes",
             "required": true,
             "type": {
@@ -139682,6 +139688,18 @@
         "kind": "properties",
         "properties": [
           {
+            "identifier": "node_stats",
+            "name": "_nodes",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "NodeStatistics",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
             "name": "cluster_name",
             "required": true,
             "type": {
@@ -139714,17 +139732,6 @@
                   "name": "WatcherNodeStats",
                   "namespace": "watcher.stats"
                 }
-              }
-            }
-          },
-          {
-            "name": "_nodes",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "NodeStatistics",
-                "namespace": "_types"
               }
             }
           }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12833,9 +12833,9 @@ export interface SecurityClearCachedRealmsRequest extends RequestBase {
 }
 
 export interface SecurityClearCachedRealmsResponse {
+  _nodes: NodeStatistics
   cluster_name: Name
   nodes: Record<string, SecurityClusterNode>
-  _nodes: NodeStatistics
 }
 
 export interface SecurityClearCachedRolesRequest extends RequestBase {
@@ -14760,10 +14760,10 @@ export interface WatcherStatsRequest extends RequestBase {
 }
 
 export interface WatcherStatsResponse {
+  _nodes: NodeStatistics
   cluster_name: Name
   manually_stopped: boolean
   stats: WatcherStatsWatcherNodeStats[]
-  _nodes: NodeStatistics
 }
 
 export interface WatcherStatsWatchRecordQueuedStats {

--- a/specification/nodes/_types/NodesResponseBase.ts
+++ b/specification/nodes/_types/NodesResponseBase.ts
@@ -23,6 +23,7 @@ export class NodesResponseBase {
   /**
    * Contains statistics about the number of nodes selected by the request’s node filters.
    * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes
+   * @identifier node_stats
    */
   _nodes: NodeStatistics
 }

--- a/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheResponse.ts
+++ b/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheResponse.ts
@@ -24,6 +24,7 @@ import { NodeStatistics } from '@_types/Node'
 
 export class Response {
   body: {
+    /** @identifier node_stats */
     _nodes: NodeStatistics
     cluster_name: Name
     nodes: Dictionary<string, ClusterNode>

--- a/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesResponse.ts
+++ b/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesResponse.ts
@@ -24,6 +24,7 @@ import { NodeStatistics } from '@_types/Node'
 
 export class Response {
   body: {
+    /** @identifier node_stats */
     _nodes: NodeStatistics
     cluster_name: Name
     nodes: Dictionary<string, ClusterNode>

--- a/specification/security/clear_cached_realms/SecurityClearCachedRealmsResponse.ts
+++ b/specification/security/clear_cached_realms/SecurityClearCachedRealmsResponse.ts
@@ -24,8 +24,9 @@ import { NodeStatistics } from '@_types/Node'
 
 export class Response {
   body: {
+    /** @identifier node_stats */
+    _nodes: NodeStatistics
     cluster_name: Name
     nodes: Dictionary<string, ClusterNode>
-    _nodes: NodeStatistics
   }
 }

--- a/specification/security/clear_cached_roles/ClearCachedRolesResponse.ts
+++ b/specification/security/clear_cached_roles/ClearCachedRolesResponse.ts
@@ -24,6 +24,7 @@ import { NodeStatistics } from '@_types/Node'
 
 export class Response {
   body: {
+    /** @identifier node_stats */
     _nodes: NodeStatistics
     cluster_name: Name
     nodes: Dictionary<string, ClusterNode>

--- a/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensResponse.ts
+++ b/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensResponse.ts
@@ -24,6 +24,7 @@ import { NodeStatistics } from '@_types/Node'
 
 export class Response {
   body: {
+    /** @identifier node_stats */
     _nodes: NodeStatistics
     cluster_name: Name
     nodes: Dictionary<string, ClusterNode>

--- a/specification/watcher/stats/WatcherStatsResponse.ts
+++ b/specification/watcher/stats/WatcherStatsResponse.ts
@@ -23,9 +23,10 @@ import { WatcherNodeStats } from './types'
 
 export class Response {
   body: {
+    /** @identifier node_stats */
+    _nodes: NodeStatistics
     cluster_name: Name
     manually_stopped: boolean
     stats: WatcherNodeStats[]
-    _nodes: NodeStatistics
   }
 }


### PR DESCRIPTION
Some properties in the ES API have a leading underscore, e.g. `_id`, `_source`, `_nodes`, etc.

In languages where JSON properties can be renamed, it's nicer from a DX perspective to remove these leading underscores from the generated property identifiers. Leading underscores also have special meanings in some languages like private in Python or unused in Rust.

Removing leading underscores from property names however is causing issues in classes that have a `_nodes: NodeStatistics` property that also contain a `nodes` property.

This PR adds `@identifier node_stats` to all `_nodes: NodeStatistics` properties.