### PR TITLE
Remove error from WriteResponseBase

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -34728,17 +34728,6 @@
               "namespace": "internal"
             }
           }
-        },
-        {
-          "name": "error",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "ErrorCause",
-              "namespace": "_types"
-            }
-          }
         }
       ]
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2366,7 +2366,6 @@ export interface WriteResponseBase {
   _type?: Type
   _version: VersionNumber
   forced_refresh?: boolean
-  error?: ErrorCause
 }
 
 export type double = number

--- a/specification/_types/Base.ts
+++ b/specification/_types/Base.ts
@@ -44,7 +44,6 @@ export class WriteResponseBase {
   _type?: Type
   _version: VersionNumber
   forced_refresh?: boolean
-  error?: ErrorCause
 }
 
 export class AcknowledgedResponseBase {


### PR DESCRIPTION
Remove the error from `WriteResponseBase` which may conflict with error handling defined in individual clients (as it did with .NET).