### PR TITLE
[ML] Add datafeed_config to create anomaly detection job request and response

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -101709,6 +101709,230 @@
     {
       "kind": "interface",
       "name": {
+        "name": "DatafeedConfig",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "aggregations",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "AggregationContainer",
+                "namespace": "_types.aggregations"
+              }
+            }
+          }
+        },
+        {
+          "name": "aggs",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "AggregationContainer",
+                "namespace": "_types.aggregations"
+              }
+            }
+          }
+        },
+        {
+          "name": "chunking_config",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ChunkingConfig",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "datafeed_id",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "delayed_data_check_config",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DelayedDataCheckConfig",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "frequency",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Timestamp",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "indexes",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
+          "name": "indices",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
+          "name": "indices_options",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DatafeedIndicesOptions",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "job_id",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "max_empty_searches",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "query",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "QueryContainer",
+              "namespace": "_types.query_dsl"
+            }
+          }
+        },
+        {
+          "name": "query_delay",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Timestamp",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "runtime_mappings",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "RuntimeFields",
+              "namespace": "_types.mapping"
+            }
+          }
+        },
+        {
+          "name": "script_fields",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "ScriptField",
+                "namespace": "_types"
+              }
+            }
+          }
+        },
+        {
+          "name": "scroll_size",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
         "name": "DatafeedIndicesOptions",
         "namespace": "ml._types"
       },
@@ -104655,7 +104879,7 @@
       "properties": [
         {
           "name": "allow_lazy_open",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -104709,6 +104933,28 @@
           }
         },
         {
+          "name": "custom_settings",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "CustomSettings",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "daily_model_snapshot_retention_after_days",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "name": "data_description",
           "required": true,
           "type": {
@@ -104720,8 +104966,30 @@
           }
         },
         {
-          "name": "description",
+          "name": "datafeed_config",
           "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Datafeed",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "deleting",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "description",
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -104732,12 +105000,26 @@
         },
         {
           "name": "finished_time",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "integer",
               "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "groups",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
             }
           }
         },
@@ -104764,8 +105046,30 @@
           }
         },
         {
-          "name": "model_snapshot_id",
+          "name": "job_version",
           "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "model_plot_config",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ModelPlotConfig",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "model_snapshot_id",
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -104787,7 +105091,206 @@
         },
         {
           "name": "renormalization_window_days",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "results_index_name",
           "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "results_retention_days",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "JobConfig",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "allow_lazy_open",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "analysis_config",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "AnalysisConfig",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "analysis_limits",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "AnalysisLimits",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "background_persist_interval",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "custom_settings",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "CustomSettings",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "daily_model_snapshot_retention_after_days",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "data_description",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DataDescription",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "datafeed_config",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DatafeedConfig",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "description",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "groups",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
+          "name": "job_id",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "job_type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "model_plot_config",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ModelPlotConfig",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "model_snapshot_retention_days",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "renormalization_window_days",
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -104809,75 +105312,6 @@
         },
         {
           "name": "results_retention_days",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "groups",
-          "required": false,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          }
-        },
-        {
-          "name": "model_plot_config",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "ModelPlotConfig",
-              "namespace": "ml._types"
-            }
-          }
-        },
-        {
-          "name": "custom_settings",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "CustomSettings",
-              "namespace": "ml._types"
-            }
-          }
-        },
-        {
-          "name": "job_version",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "VersionString",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "deleting",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "daily_model_snapshot_retention_after_days",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -112126,7 +112560,7 @@
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "Job",
+                "name": "JobConfig",
                 "namespace": "ml._types"
               }
             }
@@ -112137,7 +112571,7 @@
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "Datafeed",
+                "name": "DatafeedConfig",
                 "namespace": "ml._types"
               }
             }
@@ -113288,7 +113722,7 @@
           },
           {
             "name": "data_description",
-            "required": false,
+            "required": true,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -113303,7 +113737,7 @@
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "Datafeed",
+                "name": "DatafeedConfig",
                 "namespace": "ml._types"
               }
             }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -113276,6 +113276,17 @@
             }
           },
           {
+            "name": "daily_model_snapshot_retention_after_days",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "long",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
             "name": "data_description",
             "required": false,
             "type": {
@@ -113287,13 +113298,24 @@
             }
           },
           {
-            "name": "daily_model_snapshot_retention_after_days",
+            "name": "datafeed_config",
             "required": false,
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "long",
-                "namespace": "_types"
+                "name": "Datafeed",
+                "namespace": "ml._types"
+              }
+            }
+          },
+          {
+            "name": "description",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
               }
             }
           },
@@ -113312,17 +113334,6 @@
             }
           },
           {
-            "name": "description",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
             "name": "model_plot_config",
             "required": false,
             "type": {
@@ -113335,6 +113346,17 @@
           },
           {
             "name": "model_snapshot_retention_days",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "long",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "name": "renormalization_window_days",
             "required": false,
             "type": {
               "kind": "instance_of",
@@ -113422,7 +113444,7 @@
           },
           {
             "name": "analysis_limits",
-            "required": false,
+            "required": true,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -113433,7 +113455,7 @@
           },
           {
             "name": "background_persist_interval",
-            "required": true,
+            "required": false,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -113465,6 +113487,17 @@
             }
           },
           {
+            "name": "daily_model_snapshot_retention_after_days",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "long",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
             "name": "data_description",
             "required": true,
             "type": {
@@ -113476,13 +113509,24 @@
             }
           },
           {
-            "name": "daily_model_snapshot_retention_after_days",
+            "name": "datafeed_config",
             "required": false,
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "long",
-                "namespace": "_types"
+                "name": "Datafeed",
+                "namespace": "ml._types"
+              }
+            }
+          },
+          {
+            "name": "description",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
               }
             }
           },
@@ -113497,17 +113541,6 @@
                   "name": "string",
                   "namespace": "internal"
                 }
-              }
-            }
-          },
-          {
-            "name": "description",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
               }
             }
           },
@@ -113534,6 +113567,17 @@
             }
           },
           {
+            "name": "job_version",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
             "name": "model_plot_config",
             "required": false,
             "type": {
@@ -113546,7 +113590,7 @@
           },
           {
             "name": "model_snapshot_id",
-            "required": true,
+            "required": false,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -113568,7 +113612,7 @@
           },
           {
             "name": "renormalization_window_days",
-            "required": true,
+            "required": false,
             "type": {
               "kind": "instance_of",
               "type": {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -104967,7 +104967,7 @@
         },
         {
           "name": "datafeed_config",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10243,6 +10243,25 @@ export interface MlDatafeed {
   indices_options?: MlDatafeedIndicesOptions
 }
 
+export interface MlDatafeedConfig {
+  aggregations?: Record<string, AggregationsAggregationContainer>
+  aggs?: Record<string, AggregationsAggregationContainer>
+  chunking_config?: MlChunkingConfig
+  datafeed_id?: Id
+  delayed_data_check_config?: MlDelayedDataCheckConfig
+  frequency?: Timestamp
+  indexes?: string[]
+  indices: string[]
+  indices_options?: MlDatafeedIndicesOptions
+  job_id?: Id
+  max_empty_searches?: integer
+  query: QueryDslQueryContainer
+  query_delay?: Timestamp
+  runtime_mappings?: MappingRuntimeFields
+  script_fields?: Record<string, ScriptField>
+  scroll_size?: integer
+}
+
 export interface MlDatafeedIndicesOptions {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
@@ -10591,27 +10610,48 @@ export interface MlInfluence {
 }
 
 export interface MlJob {
-  allow_lazy_open?: boolean
+  allow_lazy_open: boolean
   analysis_config: MlAnalysisConfig
   analysis_limits?: MlAnalysisLimits
   background_persist_interval: Time
   create_time: integer
+  custom_settings?: MlCustomSettings
+  daily_model_snapshot_retention_after_days?: long
   data_description: MlDataDescription
-  description: string
-  finished_time: integer
+  datafeed_config: MlDatafeed
+  deleting?: boolean
+  description?: string
+  finished_time?: integer
+  groups?: string[]
   job_id: Id
   job_type: string
-  model_snapshot_id: Id
+  job_version: VersionString
+  model_plot_config?: MlModelPlotConfig
+  model_snapshot_id?: Id
   model_snapshot_retention_days: long
-  renormalization_window_days: long
+  renormalization_window_days?: long
+  results_index_name: IndexName
+  results_retention_days?: long
+}
+
+export interface MlJobConfig {
+  allow_lazy_open?: boolean
+  analysis_config: MlAnalysisConfig
+  analysis_limits?: MlAnalysisLimits
+  background_persist_interval?: Time
+  custom_settings?: MlCustomSettings
+  daily_model_snapshot_retention_after_days?: long
+  data_description: MlDataDescription
+  datafeed_config?: MlDatafeedConfig
+  description?: string
+  groups?: string[]
+  job_id?: Id
+  job_type?: string
+  model_plot_config?: MlModelPlotConfig
+  model_snapshot_retention_days?: long
+  renormalization_window_days?: long
   results_index_name?: IndexName
   results_retention_days?: long
-  groups?: string[]
-  model_plot_config?: MlModelPlotConfig
-  custom_settings?: MlCustomSettings
-  job_version?: VersionString
-  deleting?: boolean
-  daily_model_snapshot_retention_after_days?: long
 }
 
 export interface MlJobForecastStatistics {
@@ -11479,8 +11519,8 @@ export interface MlPreviewDataFrameAnalyticsResponse {
 export interface MlPreviewDatafeedRequest extends RequestBase {
   datafeed_id?: Id
   body?: {
-    job_config?: MlJob
-    datafeed_config?: MlDatafeed
+    job_config?: MlJobConfig
+    datafeed_config?: MlDatafeedConfig
   }
 }
 
@@ -11604,8 +11644,8 @@ export interface MlPutJobRequest extends RequestBase {
     background_persist_interval: Time
     custom_settings?: MlCustomSettings
     daily_model_snapshot_retention_after_days?: long
-    data_description?: MlDataDescription
-    datafeed_config?: MlDatafeed
+    data_description: MlDataDescription
+    datafeed_config?: MlDatafeedConfig
     description?: string
     groups?: string[]
     model_plot_config?: MlModelPlotConfig

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10618,7 +10618,7 @@ export interface MlJob {
   custom_settings?: MlCustomSettings
   daily_model_snapshot_retention_after_days?: long
   data_description: MlDataDescription
-  datafeed_config: MlDatafeed
+  datafeed_config?: MlDatafeed
   deleting?: boolean
   description?: string
   finished_time?: integer

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11603,12 +11603,14 @@ export interface MlPutJobRequest extends RequestBase {
     analysis_limits?: MlAnalysisLimits
     background_persist_interval: Time
     custom_settings?: MlCustomSettings
-    data_description?: MlDataDescription
     daily_model_snapshot_retention_after_days?: long
-    groups?: string[]
+    data_description?: MlDataDescription
+    datafeed_config?: MlDatafeed
     description?: string
+    groups?: string[]
     model_plot_config?: MlModelPlotConfig
     model_snapshot_retention_days?: long
+    renormalization_window_days?: long
     results_index_name?: IndexName
     results_retention_days?: long
   }
@@ -11617,20 +11619,22 @@ export interface MlPutJobRequest extends RequestBase {
 export interface MlPutJobResponse {
   allow_lazy_open: boolean
   analysis_config: MlAnalysisConfig
-  analysis_limits?: MlAnalysisLimits
-  background_persist_interval: Time
+  analysis_limits: MlAnalysisLimits
+  background_persist_interval?: Time
   create_time: DateString
   custom_settings?: MlCustomSettings
+  daily_model_snapshot_retention_after_days: long
   data_description: MlDataDescription
-  daily_model_snapshot_retention_after_days?: long
+  datafeed_config?: MlDatafeed
+  description?: string
   groups?: string[]
-  description: string
   job_id: Id
   job_type: string
+  job_version: string
   model_plot_config?: MlModelPlotConfig
-  model_snapshot_id: Id
+  model_snapshot_id?: Id
   model_snapshot_retention_days: long
-  renormalization_window_days: long
+  renormalization_window_days?: long
   results_index_name: string
   results_retention_days?: long
 }

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -45,6 +45,24 @@ export class Datafeed {
   runtime_mappings?: RuntimeFields
   indices_options?: DatafeedIndicesOptions
 }
+export class DatafeedConfig {
+  aggregations?: Dictionary<string, AggregationContainer>
+  aggs?: Dictionary<string, AggregationContainer>
+  chunking_config?: ChunkingConfig
+  datafeed_id?: Id
+  delayed_data_check_config?: DelayedDataCheckConfig
+  frequency?: Timestamp
+  indexes?: string[]
+  indices: string[]
+  indices_options?: DatafeedIndicesOptions
+  job_id?: Id
+  max_empty_searches?: integer
+  query: QueryContainer
+  query_delay?: Timestamp
+  runtime_mappings?: RuntimeFields
+  script_fields?: Dictionary<string, ScriptField>
+  scroll_size?: integer
+}
 
 export class DelayedDataCheckConfig {
   check_window?: Time // default: null

--- a/specification/ml/_types/Job.ts
+++ b/specification/ml/_types/Job.ts
@@ -26,6 +26,7 @@ import { double, integer, long } from '@_types/Numeric'
 import { DateString, Time } from '@_types/Time'
 import { DiscoveryNode } from './DiscoveryNode'
 import { ModelSizeStats } from './Model'
+import { Datafeed, DatafeedConfig } from '@ml/_types/Datafeed'
 
 export enum JobState {
   closing = 0,
@@ -43,29 +44,49 @@ export class JobStatistics {
 }
 
 export class Job {
-  allow_lazy_open?: boolean
+  allow_lazy_open: boolean
   analysis_config: AnalysisConfig
   analysis_limits?: AnalysisLimits
   background_persist_interval: Time
   create_time: integer
+  custom_settings?: CustomSettings
+  daily_model_snapshot_retention_after_days?: long
   data_description: DataDescription
-  description: string
-  finished_time: integer
+  datafeed_config: Datafeed
+  deleting?: boolean
+  description?: string
+  finished_time?: integer
+  groups?: string[]
   job_id: Id
   job_type: string
-  model_snapshot_id: Id
-  model_snapshot_retention_days: long
-  renormalization_window_days: long
-  results_index_name?: IndexName
-  results_retention_days?: long
-  groups?: string[]
+  job_version: VersionString
   model_plot_config?: ModelPlotConfig
-  custom_settings?: CustomSettings
-  job_version?: VersionString
-  deleting?: boolean
-  daily_model_snapshot_retention_after_days?: long
+  model_snapshot_id?: Id
+  model_snapshot_retention_days: long
+  renormalization_window_days?: long
+  results_index_name: IndexName
+  results_retention_days?: long
 }
 
+export class JobConfig {
+  allow_lazy_open?: boolean
+  analysis_config: AnalysisConfig
+  analysis_limits?: AnalysisLimits
+  background_persist_interval?: Time
+  custom_settings?: CustomSettings
+  daily_model_snapshot_retention_after_days?: long
+  data_description: DataDescription
+  datafeed_config?: DatafeedConfig
+  description?: string
+  groups?: string[]
+  job_id?: Id
+  job_type?: string
+  model_plot_config?: ModelPlotConfig
+  model_snapshot_retention_days?: long
+  renormalization_window_days?: long
+  results_index_name?: IndexName
+  results_retention_days?: long
+}
 export class JobStats {
   assignment_explanation: string
   data_counts: DataCounts

--- a/specification/ml/_types/Job.ts
+++ b/specification/ml/_types/Job.ts
@@ -52,7 +52,7 @@ export class Job {
   custom_settings?: CustomSettings
   daily_model_snapshot_retention_after_days?: long
   data_description: DataDescription
-  datafeed_config: Datafeed
+  datafeed_config?: Datafeed
   deleting?: boolean
   description?: string
   finished_time?: integer

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
@@ -19,8 +19,8 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
-import { Job } from '@ml/_types/Job'
-import { Datafeed } from '@ml/_types/Datafeed'
+import { DatafeedConfig } from '@ml/_types/Datafeed'
+import { JobConfig } from '@ml/_types/Job'
 
 /**
  * @rest_spec_name ml.preview_datafeed
@@ -32,7 +32,7 @@ export interface Request extends RequestBase {
     datafeed_id?: Id
   }
   body?: {
-    job_config?: Job
-    datafeed_config?: Datafeed
+    job_config?: JobConfig
+    datafeed_config?: DatafeedConfig
   }
 }

--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -25,7 +25,7 @@ import { RequestBase } from '@_types/Base'
 import { Id, IndexName } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { Time } from '@_types/Time'
-import { Datafeed } from '@ml/_types/Datafeed'
+import { DatafeedConfig } from '@ml/_types/Datafeed'
 
 /**
  * @rest_spec_name ml.put_job
@@ -43,8 +43,8 @@ export interface Request extends RequestBase {
     background_persist_interval: Time
     custom_settings?: CustomSettings
     daily_model_snapshot_retention_after_days?: long
-    data_description?: DataDescription
-    datafeed_config?: Datafeed
+    data_description: DataDescription
+    datafeed_config?: DatafeedConfig
     description?: string
     groups?: string[]
     model_plot_config?: ModelPlotConfig

--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -25,6 +25,7 @@ import { RequestBase } from '@_types/Base'
 import { Id, IndexName } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { Time } from '@_types/Time'
+import { Datafeed } from '@ml/_types/Datafeed'
 
 /**
  * @rest_spec_name ml.put_job
@@ -41,12 +42,14 @@ export interface Request extends RequestBase {
     analysis_limits?: AnalysisLimits
     background_persist_interval: Time
     custom_settings?: CustomSettings
-    data_description?: DataDescription
     daily_model_snapshot_retention_after_days?: long
-    groups?: string[]
+    data_description?: DataDescription
+    datafeed_config?: Datafeed
     description?: string
+    groups?: string[]
     model_plot_config?: ModelPlotConfig
     model_snapshot_retention_days?: long
+    renormalization_window_days?: long
     results_index_name?: IndexName
     results_retention_days?: long
   }

--- a/specification/ml/put_job/MlPutJobResponse.ts
+++ b/specification/ml/put_job/MlPutJobResponse.ts
@@ -24,25 +24,28 @@ import { CustomSettings } from '@ml/_types/Settings'
 import { Id } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { DateString, Time } from '@_types/Time'
+import { Datafeed } from '@ml/_types/Datafeed'
 
 export class Response {
   body: {
     allow_lazy_open: boolean
     analysis_config: AnalysisConfig
-    analysis_limits?: AnalysisLimits
-    background_persist_interval: Time
+    analysis_limits: AnalysisLimits
+    background_persist_interval?: Time
     create_time: DateString
     custom_settings?: CustomSettings
+    daily_model_snapshot_retention_after_days: long
     data_description: DataDescription
-    daily_model_snapshot_retention_after_days?: long
+    datafeed_config?: Datafeed
+    description?: string
     groups?: string[]
-    description: string
     job_id: Id
     job_type: string
+    job_version: string
     model_plot_config?: ModelPlotConfig
-    model_snapshot_id: Id
+    model_snapshot_id?: Id
     model_snapshot_retention_days: long
-    renormalization_window_days: long
+    renormalization_window_days?: long
     results_index_name: string
     results_retention_days?: long
   }


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/74265

This PR adds the datafeed_config object to the put_job specifications, as well as a missing renormalization_window_days property. It also sorts the properties alphabetically so it'll be easier to compare to the docs in https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-put-job.html
