### PR TITLE
Generate version and hash fields in schema output

### DIFF
--- a/.github/workflows/update-model-info.yml
+++ b/.github/workflows/update-model-info.yml
@@ -1,0 +1,35 @@
+name: Update model info
+
+on:
+  push:
+    branches:
+      - "main"
+      - "7.*"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+
+    - name: Install
+      run: |
+        npm install --prefix compiler
+
+    - name: Update model info
+      run: |
+        npm run generate-schema --prefix compiler
+
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Update model info
+        push_options: --force-with-lease
+        file_pattern: output/schema/schema.json
+

--- a/.github/workflows/update-model-info.yml
+++ b/.github/workflows/update-model-info.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - "main"
       - "7.*"
+    paths:
+      - 'specification/**'
 
 jobs:
   build:

--- a/compiler/model/metamodel.ts
+++ b/compiler/model/metamodel.ts
@@ -376,6 +376,7 @@ export class UrlTemplate {
 export class Model {
   _info?: {
     version: string
+    hash: string
     title: string
     license: {
       name: string

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -1,5 +1,6 @@
 {
   "_info": {
+    "hash": "#",
     "license": {
       "name": "Apache 2.0",
       "url": "https://github.com/elastic/elasticsearch-specification/blob/master/LICENSE"


### PR DESCRIPTION
This pr introduces a new github action that is executed every time some code is pushed in `main` or `7.*` branches.
It also updates the info step of the compiler to update the `version` and `hash` fields to use the current git values if the compiler is being run from a base branch, leave those fields as is otherwise.

NOTE: It will require a test run in the main branch to be sure that everything works as expected.

Related: #499