### PR TITLE
Require the use of STACK_VERSION when running validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,28 +191,28 @@ git clone https://github.com/elastic/elasticsearch-specification.git
 git clone https://github.com/elastic/clients-flight-recorder.git
 
 cd elasticsearch-specification
-./run-validations.sh
+STACK_VERSION=... ./run-validations.sh
 ```
 
 The last command above will install all the dependencies and run, download
 the test recordings and finally validate the specification.
-If you need to download the recordings again, run `PULL_LATEST=true ./run-validations.sh`.
+If you need to download the recordings again, run `STACK_VERSION=... PULL_LATEST=true ./run-validations.sh`.
 
 You can validate a specific API with the `--api` option, same goes for `--request` and `--response`.
 For example, the following command validates the index request api:
 
 ```js
-./run-validations.sh --api index --request
+STACK_VERSION=... ./run-validations.sh --api index --request
 ```
 The following command validates the index response api:
 
 ```js
-./run-validations.sh --api index --response
+STACK_VERSION=... ./run-validations.sh --api index --response
 ```
 The following command validates the index request and response api:
 
 ```js
-./run-validations.sh --api index --request --response
+STACK_VERSION=... ./run-validations.sh --api index --request --response
 ```
 
 Once you see the errors, you can fix the original definition in `/specification`
@@ -222,7 +222,7 @@ Finally open a pull request with your changes.
 Namespaced APIs can be validated in the same way, for example:
 
 ```js
-./run-validations.sh --api cat.health --request
+STACK_VERSION=... ./run-validations.sh --api cat.health --request
 ```
 
 ## FAQ
@@ -263,7 +263,7 @@ Very likely the recordings on your machine are stale, you can download
 the latest version with:
 
 ```sh
-PULL_LATEST=true ./run-validations.sh
+STACK_VERSION=... PULL_LATEST=true ./run-validations.sh
 ```
 
 You should pull the latest change from the `client-flight-recorder` as well.

--- a/docs/validation-example.md
+++ b/docs/validation-example.md
@@ -16,7 +16,7 @@ The example assumes that you have already performed the necessary steps to run a
 if not, take a look at the [README](./README.md).
 
 ```sh
-./run-validations --api index --request
+STACK_VERSION=... ./run-validations --api index --request
 ```
 
 You will see an output like the following:
@@ -82,7 +82,7 @@ open it with your favourite editor and perform the fix
 Finally run the validation again:
 
 ```sh
-./run-validations --api index --request
+STACK_VERSION=... ./run-validations --api index --request
 ```
 
 If there are no more errors, open a pr with the fix.

--- a/run-validations.sh
+++ b/run-validations.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+
+function require_stack_version() {
+  if [[ -z $STACK_VERSION ]]; then
+    echo -e "\033[31;1mERROR:\033[0m Required environment variable [STACK_VERSION] not set\033[0m"
+    exit 1
+  fi
+}
+
+require_stack_version
+
 set -euo pipefail
 
 npm install --prefix compiler
@@ -14,15 +24,6 @@ if [[ ! -f "${recorderScript}" ]]; then
   echo "Skipping running spec validation tests, not found: ${recorderScript}"
   exit
 fi
-
-function require_stack_version() {
-  if [[ -z $STACK_VERSION ]]; then
-    echo -e "\033[31;1mERROR:\033[0m Required environment variable [STACK_VERSION] not set\033[0m"
-    exit 1
-  fi
-}
-
-require_stack_version
 
 # assumes the flight recorder is checked out next to generator
 pushd "${recorderFolder}"

--- a/run-validations.sh
+++ b/run-validations.sh
@@ -15,11 +15,20 @@ if [[ ! -f "${recorderScript}" ]]; then
   exit
 fi
 
+function require_stack_version() {
+  if [[ -z $STACK_VERSION ]]; then
+    echo -e "\033[31;1mERROR:\033[0m Required environment variable [STACK_VERSION] not set\033[0m"
+    exit 1
+  fi
+}
+
+require_stack_version
+
 # assumes the flight recorder is checked out next to generator
 pushd "${recorderFolder}"
 function finish { popd; }
 trap finish EXIT
-./run-validations.sh $@
+STACK_VERSION=${STACK_VERSION} ./run-validations.sh $@
 
 
 


### PR DESCRIPTION
As titled. This will tell the flight recorder which branch to use.

Related: #499 