### PR TITLE
Fix IndicesDataStreamsStatsRequest duplicate property

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -86061,17 +86061,6 @@
               "namespace": "_types"
             }
           }
-        },
-        {
-          "name": "human",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
         }
       ]
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8556,7 +8556,6 @@ export interface IndicesDataStreamsStatsDataStreamsStatsItem {
 export interface IndicesDataStreamsStatsRequest extends RequestBase {
   name?: IndexName
   expand_wildcards?: ExpandWildcards
-  human?: boolean
 }
 
 export interface IndicesDataStreamsStatsResponse {

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -31,7 +31,6 @@ export interface Request extends RequestBase {
   }
   query_parameters?: {
     expand_wildcards?: ExpandWildcards // default: open
-    human?: boolean // default: false
   }
   body?: {}
 }


### PR DESCRIPTION
Remove human property which comes from CommonQueryParameters. I discovered this conflict when generating the .NET class for this type.