### PR TITLE
Fix MainError duplicated property

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -31759,20 +31759,6 @@
               }
             }
           }
-        },
-        {
-          "name": "root_cause",
-          "required": true,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "ErrorCause",
-                "namespace": "_types"
-              }
-            }
-          }
         }
       ]
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2036,7 +2036,6 @@ export type LifecycleOperationMode = 'RUNNING' | 'STOPPING' | 'STOPPED'
 
 export interface MainError extends ErrorCause {
   headers?: Record<string, string>
-  root_cause: ErrorCause[]
 }
 
 export interface MergesStats {

--- a/specification/_types/Errors.ts
+++ b/specification/_types/Errors.ts
@@ -66,7 +66,6 @@ export class ErrorCause {
 
 export class MainError extends ErrorCause {
   headers?: Dictionary<string, string>
-  root_cause: ErrorCause[]
 }
 
 export class ShardFailure {


### PR DESCRIPTION
`MainError` includes a `root_cause` property which is a duplicate of the property from `ErrorCause` which it extends.