### PR TITLE
Validate 'ml.preview_datafeed' API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -7565,7 +7565,7 @@
         "namespace": "ml.preview_datafeed"
       },
       "since": "5.4.0",
-      "stability": "TODO",
+      "stability": "stable",
       "urls": [
         {
           "methods": [
@@ -101961,28 +101961,22 @@
           "name": "indexes",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Indices",
+              "namespace": "_types"
             }
           }
         },
         {
           "description": "An array of index names. Wildcards are supported.",
           "name": "indices",
-          "required": true,
+          "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Indices",
+              "namespace": "_types"
             }
           }
         },
@@ -102024,7 +102018,7 @@
         {
           "description": "The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch.",
           "name": "query",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -112911,23 +112905,17 @@
     },
     {
       "body": {
-        "kind": "properties",
-        "properties": [
-          {
-            "name": "data",
-            "required": true,
+        "kind": "value",
+        "value": {
+          "kind": "array_of",
+          "value": {
+            "kind": "instance_of",
             "type": {
-              "kind": "array_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "TDocument",
-                  "namespace": "ml.preview_datafeed"
-                }
-              }
+              "name": "TDocument",
+              "namespace": "ml.preview_datafeed"
             }
           }
-        ]
+        }
       },
       "generics": [
         {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10325,12 +10325,12 @@ export interface MlDatafeedConfig {
   datafeed_id?: Id
   delayed_data_check_config?: MlDelayedDataCheckConfig
   frequency?: Timestamp
-  indexes?: string[]
-  indices: string[]
+  indexes?: Indices
+  indices?: Indices
   indices_options?: MlDatafeedIndicesOptions
   job_id?: Id
   max_empty_searches?: integer
-  query: QueryDslQueryContainer
+  query?: QueryDslQueryContainer
   query_delay?: Timestamp
   runtime_mappings?: MappingRuntimeFields
   script_fields?: Record<string, ScriptField>
@@ -11612,9 +11612,7 @@ export interface MlPreviewDatafeedRequest extends RequestBase {
   }
 }
 
-export interface MlPreviewDatafeedResponse<TDocument = unknown> {
-  data: TDocument[]
-}
+export type MlPreviewDatafeedResponse<TDocument = unknown> = TDocument[]
 
 export interface MlPutCalendarRequest extends RequestBase {
   calendar_id: Id

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -66,11 +66,11 @@ export class DatafeedConfig {
    * The interval at which scheduled queries are made while the datafeed runs in real time. The default value is either the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket span. For example: `150s`. When frequency is shorter than the bucket span, interim results for the last (partial) bucket are written then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value must be divisible by the interval of the date histogram aggregation.
    */
   frequency?: Timestamp
-  indexes?: string[]
+  indexes?: Indices
   /**
    * An array of index names. Wildcards are supported.
    */
-  indices: string[]
+  indices?: Indices
   /**
    * Specifies index expansion options that are used during search.
    */
@@ -83,7 +83,7 @@ export class DatafeedConfig {
   /**
    * The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch.
    */
-  query: QueryContainer
+  query?: QueryContainer
   /**
    * The number of seconds behind real time that data is queried. For example, if data from 10:04 a.m. might not be searchable in Elasticsearch until 10:06 a.m., set this property to 120 seconds. The default value is randomly selected between `60s` and `120s`. This randomness improves the query performance when there are multiple jobs running on the same node.
    */

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
@@ -25,7 +25,7 @@ import { JobConfig } from '@ml/_types/Job'
 /**
  * @rest_spec_name ml.preview_datafeed
  * @since 5.4.0
- * @stability TODO
+ * @stability stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedResponse.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response<TDocument> {
-  body: {
-    data: TDocument[]
-  }
+  body: Array<TDocument>
 }


### PR DESCRIPTION
Got an error for having an array of `TDocument` as a response body:

```
> elasticsearch-client-specification@0.0.1 generate-schema /home/sethmlarson/elasticsearch-specification/compiler
> ts-node index.ts

Error: Children should be PropertySignature or PropertyDeclaration but is TypeReference instead
At: /home/sethmlarson/elasticsearch-specification/specification/ml/preview_datafeed/MlPreviewDatafeedResponse.ts:21:8

19  
20  export class Response<TDocument> {
21    body: TDocument[]
22  }
23  

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! elasticsearch-client-specification@0.0.1 generate-schema: `ts-node index.ts`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the elasticsearch-client-specification@0.0.1 generate-schema script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/sethmlarson/.npm/_logs/2021-07-29T19_21_45_101Z-debug.log
Makefile:38: recipe for target 'spec-generate' failed
make: *** [spec-generate] Error 1
```

Closes https://github.com/elastic/elasticsearch-specification/issues/377