### PR TITLE
Add 'ml.reset_job' API and 'MlJob.blocked'

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -7836,9 +7836,16 @@
       "description": "Resets an existing anomaly detection job.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-reset-job.html",
       "name": "ml.reset_job",
-      "request": null,
+      "request": {
+        "name": "Request",
+        "namespace": "ml.reset_job"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "Response",
+        "namespace": "ml.reset_job"
+      },
+      "since": "7.14.0",
       "stability": "stable",
       "urls": [
         {
@@ -105148,6 +105155,17 @@
           }
         },
         {
+          "name": "blocked",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "JobBlocked",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
           "name": "create_time",
           "required": false,
           "type": {
@@ -105360,6 +105378,55 @@
           }
         }
       ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "JobBlocked",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "reason",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "JobBlockedReason",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "task_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TaskId",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "delete"
+        },
+        {
+          "name": "reset"
+        },
+        {
+          "name": "revert"
+        }
+      ],
+      "name": {
+        "name": "JobBlockedReason",
+        "namespace": "ml._types"
+      }
     },
     {
       "kind": "interface",
@@ -114616,6 +114683,71 @@
       "name": {
         "name": "Response",
         "namespace": "ml.put_trained_model_alias"
+      }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "no_body"
+      },
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "request",
+      "name": {
+        "name": "Request",
+        "namespace": "ml.reset_job"
+      },
+      "path": [
+        {
+          "description": "The ID of the job to reset.",
+          "name": "job_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "description": "Should this request wait until the operation has completed before returning.",
+          "name": "wait_for_completion",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "response",
+      "name": {
+        "name": "Response",
+        "namespace": "ml.reset_job"
       }
     },
     {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -105399,7 +105399,7 @@
         },
         {
           "name": "task_id",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1212,7 +1212,7 @@
     },
     "ml.reset_job": {
       "request": [
-        "Missing request & response"
+        "Request: should not have a body"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10719,7 +10719,7 @@ export interface MlJob {
 
 export interface MlJobBlocked {
   reason: MlJobBlockedReason
-  task_id: TaskId
+  task_id?: TaskId
 }
 
 export type MlJobBlockedReason = 'delete' | 'reset' | 'revert'

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10695,6 +10695,7 @@ export interface MlJob {
   analysis_config: MlAnalysisConfig
   analysis_limits?: MlAnalysisLimits
   background_persist_interval?: Time
+  blocked?: MlJobBlocked
   create_time?: integer
   custom_settings?: MlCustomSettings
   daily_model_snapshot_retention_after_days?: long
@@ -10715,6 +10716,13 @@ export interface MlJob {
   results_retention_days?: long
   system_annotations_retention_days?: long
 }
+
+export interface MlJobBlocked {
+  reason: MlJobBlockedReason
+  task_id: TaskId
+}
+
+export type MlJobBlockedReason = 'delete' | 'reset' | 'revert'
 
 export interface MlJobConfig {
   allow_lazy_open?: boolean
@@ -11789,6 +11797,14 @@ export interface MlPutTrainedModelAliasRequest extends RequestBase {
 }
 
 export interface MlPutTrainedModelAliasResponse extends AcknowledgedResponseBase {
+}
+
+export interface MlResetJobRequest extends RequestBase {
+  job_id: Id
+  wait_for_completion?: boolean
+}
+
+export interface MlResetJobResponse extends AcknowledgedResponseBase {
 }
 
 export interface MlRevertModelSnapshotRequest extends RequestBase {

--- a/specification/ml/_types/Job.ts
+++ b/specification/ml/_types/Job.ts
@@ -21,7 +21,7 @@ import { AnalysisConfig, AnalysisLimits } from '@ml/_types/Analysis'
 import { ModelPlotConfig } from '@ml/_types/ModelPlot'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { CustomSettings } from '@ml/_types/Settings'
-import { Field, Id, IndexName, VersionString } from '@_types/common'
+import { Field, Id, TaskId, IndexName, VersionString } from '@_types/common'
 import { double, integer, long } from '@_types/Numeric'
 import { DateString, Time } from '@_types/Time'
 import { DiscoveryNode } from './DiscoveryNode'
@@ -48,6 +48,7 @@ export class Job {
   analysis_config: AnalysisConfig
   analysis_limits?: AnalysisLimits
   background_persist_interval?: Time
+  blocked?: JobBlocked
   create_time?: integer
   custom_settings?: CustomSettings
   daily_model_snapshot_retention_after_days?: long
@@ -158,4 +159,15 @@ export class DataDescription {
    */
   time_format?: string
   field_delimiter?: string
+}
+
+export class JobBlocked {
+  reason: JobBlockedReason
+  task_id: TaskId
+}
+
+export enum JobBlockedReason {
+  delete = 0,
+  reset = 1,
+  revert = 2
 }

--- a/specification/ml/_types/Job.ts
+++ b/specification/ml/_types/Job.ts
@@ -163,7 +163,7 @@ export class DataDescription {
 
 export class JobBlocked {
   reason: JobBlockedReason
-  task_id: TaskId
+  task_id?: TaskId
 }
 
 export enum JobBlockedReason {

--- a/specification/ml/reset_job/MlResetJobRequest.ts
+++ b/specification/ml/reset_job/MlResetJobRequest.ts
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+
+/**
+ * @rest_spec_name ml.reset_job
+ * @since 7.14.0
+ * @stability stable
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /** The ID of the job to reset. */
+    job_id: Id
+  }
+  query_parameters?: {
+    /**
+     * Should this request wait until the operation has completed before returning.
+     * @server_default true
+     */
+    wait_for_completion?: boolean
+  }
+}

--- a/specification/ml/reset_job/MlResetJobResponse.ts
+++ b/specification/ml/reset_job/MlResetJobResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response extends AcknowledgedResponseBase {}


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-specification/issues/494

@jgowdyelastic can you take a look and verify this matches what you expect?
There don't seem to be any YAML tests for the `blocked` attribute (can we get one or more of these?)