### PR TITLE
Add identifier for `_source` property in `source` type.

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -20425,6 +20425,7 @@
           }
         },
         {
+          "identifier": "source_fields",
           "name": "_source",
           "required": false,
           "type": {

--- a/specification/_global/reindex/types.ts
+++ b/specification/_global/reindex/types.ts
@@ -49,6 +49,7 @@ export class Source {
   size?: integer
   slice?: SlicedScroll
   sort?: Sort
+  /** @identifier source_fields */
   _source?: Fields
 }
 


### PR DESCRIPTION
In .NET properties of a type cannot be named the same as the enclosing class. The `source` type includes an `_source`  property which currently conflicts. This could be handled in the .NET generator but perhaps this property can be more clearly named. 