### PR TITLE
Skip version update when updating the rest-api-spec

### DIFF
--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Generate output
         run: |
-          make contrib
+          SKIP_VERSION_UPDATE=true make contrib
 
       - name: Debug git status
         run: |

--- a/compiler/steps/add-info.ts
+++ b/compiler/steps/add-info.ts
@@ -33,7 +33,7 @@ export default async function addInfo (model: model.Model, jsonSpec: Map<string,
   const branch = execSync('git branch --show-current').toString().trim()
   const isBaseBranch = branch === 'main' || branch.startsWith('7.')
 
-  if (isBaseBranch) {
+  if (isBaseBranch && process.env.SKIP_VERSION_UPDATE !== 'true') {
     model._info = {
       version: branch,
       hash: execSync('git rev-parse --short HEAD').toString().trim(),


### PR DESCRIPTION
As titled.
The issue was that the `update-rest-api-json.yml` action runs itself on main, and then creates a branch if there are changes, which triggers a version field change.

Fixes https://github.com/elastic/elasticsearch-specification/pull/526