### PR TITLE
Remove ML system_annotations_retention_days setting

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -105393,17 +105393,6 @@
               "namespace": "_types"
             }
           }
-        },
-        {
-          "name": "system_annotations_retention_days",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
-          }
         }
       ]
     },
@@ -105644,17 +105633,6 @@
         },
         {
           "name": "results_retention_days",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "system_annotations_retention_days",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -114261,18 +114239,6 @@
                 "namespace": "_types"
               }
             }
-          },
-          {
-            "description": "Advanced configuration option. The period of time (in days) that automatically created annotations are retained. Age is calculated relative to the timestamp of the latest bucket result. If this property has a non-null value, once per day at 00:30 (server time), annotations that are the specified number of days older than the latest bucket result are deleted from Elasticsearch. The default value is null, which means all annotations are retained. User created annotations are never deleted automatically.",
-            "name": "system_annotations_retention_days",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "long",
-                "namespace": "_types"
-              }
-            }
           }
         ]
       },
@@ -114521,17 +114487,6 @@
           },
           {
             "name": "results_retention_days",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "long",
-                "namespace": "_types"
-              }
-            }
-          },
-          {
-            "name": "system_annotations_retention_days",
             "required": false,
             "type": {
               "kind": "instance_of",
@@ -115850,18 +115805,6 @@
               "type": {
                 "name": "PerPartitionCategorization",
                 "namespace": "ml._types"
-              }
-            }
-          },
-          {
-            "description": "Advanced configuration option. The period of time (in days) that automatically created annotations are retained. Age is calculated relative to the timestamp of the latest bucket result. If this property has a non-null value, once per day at 00:30 (server time), annotations that are the specified number of days older than the latest bucket result are deleted from Elasticsearch. The default value is null, which means all annotations are retained. User created annotations are never deleted automatically.",
-            "name": "system_annotations_retention_days",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "long",
-                "namespace": "_types"
               }
             }
           }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10717,7 +10717,6 @@ export interface MlJob {
   renormalization_window_days?: long
   results_index_name: IndexName
   results_retention_days?: long
-  system_annotations_retention_days?: long
 }
 
 export interface MlJobBlocked {
@@ -10745,7 +10744,6 @@ export interface MlJobConfig {
   renormalization_window_days?: long
   results_index_name?: IndexName
   results_retention_days?: long
-  system_annotations_retention_days?: long
 }
 
 export interface MlJobForecastStatistics {
@@ -11752,7 +11750,6 @@ export interface MlPutJobRequest extends RequestBase {
     renormalization_window_days?: long
     results_index_name?: IndexName
     results_retention_days?: long
-    system_annotations_retention_days?: long
   }
 }
 
@@ -11777,7 +11774,6 @@ export interface MlPutJobResponse {
   renormalization_window_days?: long
   results_index_name: string
   results_retention_days?: long
-  system_annotations_retention_days?: long
 }
 
 export interface MlPutTrainedModelRequest extends RequestBase {
@@ -11934,7 +11930,6 @@ export interface MlUpdateJobRequest extends RequestBase {
     groups?: string[]
     detectors?: MlDetector[]
     per_partition_categorization?: MlPerPartitionCategorization
-    system_annotations_retention_days?: long
   }
 }
 

--- a/specification/ml/_types/Job.ts
+++ b/specification/ml/_types/Job.ts
@@ -67,7 +67,6 @@ export class Job {
   renormalization_window_days?: long
   results_index_name: IndexName
   results_retention_days?: long
-  system_annotations_retention_days?: long
 }
 
 export class JobConfig {
@@ -88,7 +87,6 @@ export class JobConfig {
   renormalization_window_days?: long
   results_index_name?: IndexName
   results_retention_days?: long
-  system_annotations_retention_days?: long
 }
 export class JobStats {
   assignment_explanation?: string

--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -104,9 +104,5 @@ export interface Request extends RequestBase {
      * Advanced configuration option. The period of time (in days) that results are retained. Age is calculated relative to the timestamp of the latest bucket result. If this property has a non-null value, once per day at 00:30 (server time), results that are the specified number of days older than the latest bucket result are deleted from Elasticsearch. The default value is null, which means all results are retained.
      */
     results_retention_days?: long
-    /**
-     * Advanced configuration option. The period of time (in days) that automatically created annotations are retained. Age is calculated relative to the timestamp of the latest bucket result. If this property has a non-null value, once per day at 00:30 (server time), annotations that are the specified number of days older than the latest bucket result are deleted from Elasticsearch. The default value is null, which means all annotations are retained. User created annotations are never deleted automatically.
-     */
-    system_annotations_retention_days?: long
   }
 }

--- a/specification/ml/put_job/MlPutJobResponse.ts
+++ b/specification/ml/put_job/MlPutJobResponse.ts
@@ -48,6 +48,5 @@ export class Response {
     renormalization_window_days?: long
     results_index_name: string
     results_retention_days?: long
-    system_annotations_retention_days?: long
   }
 }

--- a/specification/ml/update_job/MlUpdateJobRequest.ts
+++ b/specification/ml/update_job/MlUpdateJobRequest.ts
@@ -89,9 +89,5 @@ export interface Request extends RequestBase {
      * Settings related to how categorization interacts with partition fields.
      */
     per_partition_categorization?: PerPartitionCategorization
-    /**
-     * Advanced configuration option. The period of time (in days) that automatically created annotations are retained. Age is calculated relative to the timestamp of the latest bucket result. If this property has a non-null value, once per day at 00:30 (server time), annotations that are the specified number of days older than the latest bucket result are deleted from Elasticsearch. The default value is null, which means all annotations are retained. User created annotations are never deleted automatically.
-     */
-    system_annotations_retention_days?: long
   }
 }


### PR DESCRIPTION
This is a reversion of #522.

We decided not to add a new setting after all, but to
use results_retention_days for both results and system
annotations (on the basis that system annotations are
a type of result).

This setting has been added and removed within the 7.15
development cycle so there are no implications for
anyone using released product.

Relates to elastic/elasticsearch#76096