### PR TITLE
[ML] Add 'model_prune_window' field to AD job config

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -100061,6 +100061,18 @@
           }
         },
         {
+          "description": "Advanced configuration option, which affects the pruning of models that have not been updated for the given time duration. The value of this option must be at least two whole multiples of `bucket_span`. If not set, a default value is not supplied.",
+          "name": "model_prune_window",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "description": "The size of the window in which to expect data that is out of time order. If you specify a non-zero value, it must be greater than or equal to one second. NOTE: Latency is only applicable when you send data by using the post data API.",
           "name": "latency",
           "required": false,

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10136,6 +10136,7 @@ export interface MlAnalysisConfig {
   categorization_filters?: string[]
   detectors: MlDetector[]
   influencers?: Field[]
+  model_prune_window?: Time
   latency?: Time
   multivariate_by_fields?: boolean
   per_partition_categorization?: MlPerPartitionCategorization

--- a/specification/ml/_types/Analysis.ts
+++ b/specification/ml/_types/Analysis.ts
@@ -55,7 +55,7 @@ export class AnalysisConfig {
    * Advanced configuration option, which affects the pruning of models that have not been updated for the given time duration. The value of this option must be at least two whole multiples of `bucket_span`. If not set, a default value is not supplied.
    */
   model_prune_window?: Time
-   /**
+  /**
    * The size of the window in which to expect data that is out of time order. If you specify a non-zero value, it must be greater than or equal to one second. NOTE: Latency is only applicable when you send data by using the post data API.
    * @server_default 0
    */

--- a/specification/ml/_types/Analysis.ts
+++ b/specification/ml/_types/Analysis.ts
@@ -52,6 +52,10 @@ export class AnalysisConfig {
    */
   influencers?: Field[]
   /**
+   * Advanced configuration option, which affects the pruning of models that have not been updated for the given time duration. The value of this option must be at least two whole multiples of `bucket_span`. If not set, a default value is not supplied.
+   */
+  model_prune_window?: Time
+   /**
    * The size of the window in which to expect data that is out of time order. If you specify a non-zero value, it must be greater than or equal to one second. NOTE: Latency is only applicable when you send data by using the post data API.
    * @server_default 0
    */


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/75741

