### PR TITLE
Make search_after type the same as Hit.sort

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -21509,25 +21509,10 @@
             "name": "search_after",
             "required": false,
             "type": {
-              "kind": "array_of",
-              "value": {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "integer",
-                      "namespace": "_types"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "SortResults",
+                "namespace": "_global.search._types"
               }
             }
           },
@@ -58264,9 +58249,10 @@
             "name": "search_after",
             "required": false,
             "type": {
-              "kind": "array_of",
-              "value": {
-                "kind": "user_defined_value"
+              "kind": "instance_of",
+              "type": {
+                "name": "SortResults",
+                "namespace": "_global.search._types"
               }
             }
           },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1014,7 +1014,7 @@ export interface SearchRequest extends RequestBase {
     query?: QueryDslQueryContainer
     rescore?: SearchRescore | SearchRescore[]
     script_fields?: Record<string, ScriptField>
-    search_after?: (integer | string)[]
+    search_after?: SearchSortResults
     size?: integer
     slice?: SlicedScroll
     sort?: SearchSort
@@ -4884,7 +4884,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
     rescore?: SearchRescore[]
     routing?: Routing
     script_fields?: Record<string, ScriptField>
-    search_after?: any[]
+    search_after?: SearchSortResults
     search_type?: SearchType
     sequence_number_primary_term?: boolean
     size?: integer

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -43,7 +43,7 @@ import { FieldCollapse } from './_types/FieldCollapse'
 import { Highlight } from './_types/highlighting'
 import { PointInTimeReference } from './_types/PointInTimeReference'
 import { Rescore } from './_types/rescoring'
-import { Sort } from './_types/sort'
+import { Sort, SortResults } from './_types/sort'
 import { DocValueField, SourceFilter } from './_types/SourceFilter'
 import { SuggestContainer } from './_types/suggester'
 
@@ -118,7 +118,7 @@ export interface Request extends RequestBase {
     query?: QueryContainer
     rescore?: Rescore | Rescore[]
     script_fields?: Dictionary<string, ScriptField>
-    search_after?: Array<integer | string>
+    search_after?: SortResults
     size?: integer
     slice?: SlicedScroll
     sort?: Sort

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -21,7 +21,7 @@ import { FieldCollapse } from '@global/search/_types/FieldCollapse'
 import { Highlight } from '@global/search/_types/highlighting'
 import { PointInTimeReference } from '@global/search/_types/PointInTimeReference'
 import { Rescore } from '@global/search/_types/rescoring'
-import { Sort } from '@global/search/_types/sort'
+import { Sort, SortResults } from '@global/search/_types/sort'
 import { SourceFilter } from '@global/search/_types/SourceFilter'
 import { SuggestContainer } from '@global/search/_types/suggester'
 import { Dictionary } from '@spec_utils/Dictionary'
@@ -92,7 +92,7 @@ export interface Request extends RequestBase {
     rescore?: Rescore[]
     routing?: Routing
     script_fields?: Dictionary<string, ScriptField>
-    search_after?: UserDefinedValue[]
+    search_after?: SortResults
     search_type?: SearchType
     sequence_number_primary_term?: boolean
     size?: integer


### PR DESCRIPTION
It's common to do `search_after = hits[-1].sort` so type-wise we should ensure this works out.