### PR TITLE
Script lang can be a custom string

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -33153,11 +33153,23 @@
           "name": "lang",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "ScriptLanguage",
-              "namespace": "_types"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "ScriptLanguage",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
@@ -34142,11 +34154,23 @@
           "name": "lang",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "ScriptLanguage",
-              "namespace": "_types"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "ScriptLanguage",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2187,7 +2187,7 @@ export type Routing = string
 export type Script = InlineScript | IndexedScript | string
 
 export interface ScriptBase {
-  lang?: ScriptLanguage
+  lang?: ScriptLanguage | string
   params?: Record<string, any>
 }
 
@@ -2300,7 +2300,7 @@ export interface StoreStats {
 }
 
 export interface StoredScript {
-  lang?: ScriptLanguage
+  lang?: ScriptLanguage | string
   source: string
 }
 

--- a/specification/_types/Scripting.ts
+++ b/specification/_types/Scripting.ts
@@ -26,16 +26,16 @@ export enum ScriptLanguage {
   painless = 0,
   expression = 1,
   mustache = 2,
-  java = 0
+  java = 3
 }
 
 export class StoredScript {
-  lang?: ScriptLanguage
+  lang?: ScriptLanguage | string
   source: string
 }
 
 export class ScriptBase {
-  lang?: ScriptLanguage
+  lang?: ScriptLanguage | string
   params?: Dictionary<string, UserDefinedValue>
 }
 


### PR DESCRIPTION
As titled, see https://github.com/elastic/elasticsearch-js/issues/1518.

I'm not sure defining the type like this makes sense. It might be worth just define `lang` as `string`.