### PR TITLE
Add CODEOWNERS configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/specification/ml @elastic/ml-core & @elastic/ml-ui
+/specification/ml/** @elastic/ml-core & @elastic/ml-ui

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/specification/ml @elastic/ml-core & @elastic/ml-ui

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/specification/ml/** @elastic/ml-core & @elastic/ml-ui
+/specification/ml/** @elastic/ml-core @elastic/ml-ui


### PR DESCRIPTION
As titled, for now, I've configured only the `ml` subfolder, in the future, we should identify more teams.

https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners