### PR TITLE
[ML] Fixes model_prune_window description

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -21308,7 +21308,7 @@
             }
           },
           {
-            "description": "Starting document offset. By default, you cannot page through more than 10,000\nhits using the from and size parameters. To page through more hits, use the\nsearch_after parameter.",
+            "description": "Starting document offset. By default, you cannot page through more than 10,000 hits using the from and size parameters. To page through more hits, use the search_after parameter.",
             "name": "from",
             "required": false,
             "serverDefault": "0",
@@ -21332,7 +21332,7 @@
             }
           },
           {
-            "description": "Number of hits matching the query to count accurately. If true, the exact\nnumber of hits is returned at the cost of some performance. If false, the\nresponse does not include the total number of hits matching the query.\nDefaults to 10,000 hits.",
+            "description": "Number of hits matching the query to count accurately. If true, the exact number of hits is returned at the cost of some performance. If false, the response does not include the total number of hits matching the query. Defaults to 10,000 hits.",
             "name": "track_total_hits",
             "required": false,
             "type": {
@@ -21382,7 +21382,7 @@
             }
           },
           {
-            "description": "Array of wildcard (*) patterns. The request returns doc values for field\nnames matching these patterns in the hits.fields property of the response.",
+            "description": "Array of wildcard (*) patterns. The request returns doc values for field names matching these patterns in the hits.fields property of the response.",
             "name": "docvalue_fields",
             "required": false,
             "type": {
@@ -21421,7 +21421,7 @@
             }
           },
           {
-            "description": "Minimum _score for matching documents. Documents with a lower _score are\nnot included in the search results.",
+            "description": "Minimum _score for matching documents. Documents with a lower _score are not included in the search results.",
             "name": "min_score",
             "required": false,
             "type": {
@@ -21527,7 +21527,7 @@
             }
           },
           {
-            "description": "The number of hits to return. By default, you cannot page through more\nthan 10,000 hits using the from and size parameters. To page through more\nhits, use the search_after parameter.",
+            "description": "The number of hits to return. By default, you cannot page through more than 10,000 hits using the from and size parameters. To page through more hits, use the search_after parameter.",
             "name": "size",
             "required": false,
             "serverDefault": "10",
@@ -21562,7 +21562,7 @@
             }
           },
           {
-            "description": "Indicates which source fields are returned for matching documents. These\nfields are returned in the hits._source property of the search response.",
+            "description": "Indicates which source fields are returned for matching documents. These fields are returned in the hits._source property of the search response.",
             "name": "_source",
             "required": false,
             "type": {
@@ -21593,7 +21593,7 @@
             }
           },
           {
-            "description": "Array of wildcard (*) patterns. The request returns values for field names\nmatching these patterns in the hits.fields property of the response.",
+            "description": "Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.",
             "name": "fields",
             "required": false,
             "type": {
@@ -21654,7 +21654,7 @@
             }
           },
           {
-            "description": "Maximum number of documents to collect for each shard. If a query reaches this\nlimit, Elasticsearch terminates the query early. Elasticsearch collects documents\nbefore sorting. Defaults to 0, which does not terminate query execution early.",
+            "description": "Maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. Defaults to 0, which does not terminate query execution early.",
             "name": "terminate_after",
             "required": false,
             "serverDefault": "0",
@@ -21667,7 +21667,7 @@
             }
           },
           {
-            "description": "Specifies the period of time to wait for a response from each shard. If no response\nis received before the timeout expires, the request fails and returns an error.\nDefaults to no timeout.",
+            "description": "Specifies the period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.",
             "name": "timeout",
             "required": false,
             "type": {
@@ -21705,7 +21705,7 @@
             }
           },
           {
-            "description": "If true, returns sequence number and primary term of the last modification\nof each hit. See Optimistic concurrency control.",
+            "description": "If true, returns sequence number and primary term of the last modification of each hit. See Optimistic concurrency control.",
             "name": "seq_no_primary_term",
             "required": false,
             "type": {
@@ -21717,7 +21717,7 @@
             }
           },
           {
-            "description": "List of stored fields to return as part of a hit. If no fields are specified,\nno stored fields are included in the response. If this field is specified, the _source\nparameter defaults to false. You can pass _source: true to return both source fields\nand stored fields in the search response.",
+            "description": "List of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this field is specified, the _source parameter defaults to false. You can pass _source: true to return both source fields and stored fields in the search response.",
             "name": "stored_fields",
             "required": false,
             "type": {
@@ -21729,7 +21729,7 @@
             }
           },
           {
-            "description": "Limits the search to a point in time (PIT). If you provide a PIT, you\ncannot specify an <index> in the request path.",
+            "description": "Limits the search to a point in time (PIT). If you provide a PIT, you cannot specify an <index> in the request path.",
             "name": "pit",
             "required": false,
             "type": {
@@ -21741,7 +21741,7 @@
             }
           },
           {
-            "description": "Defines one or more runtime fields in the search request. These fields take\nprecedence over mapped fields with the same name.",
+            "description": "Defines one or more runtime fields in the search request. These fields take precedence over mapped fields with the same name.",
             "name": "runtime_mappings",
             "required": false,
             "type": {
@@ -21753,7 +21753,7 @@
             }
           },
           {
-            "description": "Stats groups to associate with the search. Each group maintains a statistics\naggregation for its associated searches. You can retrieve these stats using\nthe indices stats API.",
+            "description": "Stats groups to associate with the search. Each group maintains a statistics aggregation for its associated searches. You can retrieve these stats using the indices stats API.",
             "name": "stats",
             "required": false,
             "type": {
@@ -100151,7 +100151,7 @@
           }
         },
         {
-          "description": "Advanced configuration option. Affects the pruning of models that have not been updated for the given time duration. The value must be set to a multiple of the `bucket_span`. If set too low, important information may be removed from the model. Typically, set to `30d` or longer. If not set, model pruning only occurs if the model memory status reaches the soft limit (`model_memory_limit`) or the hard limit (`xpack.ml.max_model_memory_limit`).",
+          "description": "Advanced configuration option. Affects the pruning of models that have not been updated for the given time duration. The value must be set to a multiple of the `bucket_span`. If set too low, important information may be removed from the model. Typically, set to `30d` or longer. If not set, model pruning only occurs if the model memory status reaches the soft limit or the hard limit.",
           "name": "model_prune_window",
           "required": false,
           "type": {

--- a/specification/ml/_types/Analysis.ts
+++ b/specification/ml/_types/Analysis.ts
@@ -52,7 +52,7 @@ export class AnalysisConfig {
    */
   influencers: Field[]
   /**
-   * Advanced configuration option. Affects the pruning of models that have not been updated for the given time duration. The value must be set to a multiple of the `bucket_span`. If set too low, important information may be removed from the model. Typically, set to `30d` or longer. If not set, model pruning only occurs if the model memory status reaches the soft limit (`model_memory_limit`) or the hard limit (`xpack.ml.max_model_memory_limit`).
+   * Advanced configuration option. Affects the pruning of models that have not been updated for the given time duration. The value must be set to a multiple of the `bucket_span`. If set too low, important information may be removed from the model. Typically, set to `30d` or longer. If not set, model pruning only occurs if the model memory status reaches the soft limit or the hard limit.
    */
   model_prune_window?: Time
   /**


### PR DESCRIPTION
## Overview

This PR removes references of two model memory limit-related settings from  `model_prune_window` description as they seem equal to the soft and hard limits, but it is not the case.