### PR TITLE
Use a single property for indexes/indices

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -113577,21 +113577,10 @@
             }
           },
           {
+            "aliases": [
+              "indexes"
+            ],
             "name": "indices",
-            "required": false,
-            "type": {
-              "kind": "array_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              }
-            }
-          },
-          {
-            "name": "indexes",
             "required": false,
             "type": {
               "kind": "array_of",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11682,7 +11682,6 @@ export interface MlPutDatafeedRequest extends RequestBase {
     delayed_data_check_config?: MlDelayedDataCheckConfig
     frequency?: Time
     indices?: string[]
-    indexes?: string[]
     indices_options?: MlDatafeedIndicesOptions
     job_id?: Id
     max_empty_searches?: integer

--- a/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
@@ -52,8 +52,8 @@ export interface Request extends RequestBase {
     chunking_config?: ChunkingConfig
     delayed_data_check_config?: DelayedDataCheckConfig
     frequency?: Time
+    /** @aliases indexes */
     indices?: string[]
-    indexes?: string[]
     indices_options?: DatafeedIndicesOptions
     job_id?: Id
     max_empty_searches?: integer


### PR DESCRIPTION
Follow-up to PR #518 - removes the `indexes` property from `ml.put_datafeed` and replace it with an alias on `indices`. Both values are accepted server-side but end up in the same property, and only `indices` is used in serialization.

/cc @sethmlarson and @stevejgordon for information