### PR TITLE
Rename 'source_enabled' to '_source', prefix '_'

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -15070,18 +15070,30 @@
           }
         },
         {
-          "name": "source_enabled",
+          "name": "_source",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "boolean",
+                  "namespace": "internal"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "Fields",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
-          "name": "source_excludes",
+          "name": "_source_excludes",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -15092,7 +15104,7 @@
           }
         },
         {
-          "name": "source_includes",
+          "name": "_source_includes",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -15246,18 +15258,30 @@
           }
         },
         {
-          "name": "source_enabled",
+          "name": "_source",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "boolean",
+                  "namespace": "internal"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "Fields",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
-          "name": "source_excludes",
+          "name": "_source_excludes",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -15268,7 +15292,7 @@
           }
         },
         {
-          "name": "source_includes",
+          "name": "_source_includes",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -16241,14 +16265,27 @@
           }
         },
         {
-          "name": "source_enabled",
+          "description": "True or false to return the _source field or not, or a list of fields to return.",
+          "name": "_source",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "boolean",
+                  "namespace": "internal"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "Fields",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
@@ -16308,30 +16345,6 @@
               "name": "VersionType",
               "namespace": "_types"
             }
-          }
-        },
-        {
-          "description": "True or false to return the _source field or not, or a list of fields to return.",
-          "name": "_source",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
           }
         }
       ]
@@ -28929,18 +28942,30 @@
           }
         },
         {
-          "name": "source_enabled",
+          "name": "_source",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "boolean",
+                  "namespace": "internal"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "Fields",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
-          "name": "source_excludes",
+          "name": "_source_excludes",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -28951,7 +28976,7 @@
           }
         },
         {
-          "name": "source_includes",
+          "name": "_source_includes",
           "required": false,
           "type": {
             "kind": "instance_of",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -271,9 +271,9 @@ export interface ExistsRequest extends RequestBase {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  source_enabled?: boolean
-  source_excludes?: Fields
-  source_includes?: Fields
+  _source?: boolean | Fields
+  _source_excludes?: Fields
+  _source_includes?: Fields
   stored_fields?: Fields
   version?: VersionNumber
   version_type?: VersionType
@@ -289,9 +289,9 @@ export interface ExistsSourceRequest extends RequestBase {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  source_enabled?: boolean
-  source_excludes?: Fields
-  source_includes?: Fields
+  _source?: boolean | Fields
+  _source_excludes?: Fields
+  _source_includes?: Fields
   version?: VersionNumber
   version_type?: VersionType
 }
@@ -401,13 +401,12 @@ export interface GetRequest extends RequestBase {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  source_enabled?: boolean
+  _source?: boolean | Fields
   _source_excludes?: Fields
   _source_includes?: Fields
   stored_fields?: Fields
   version?: VersionNumber
   version_type?: VersionType
-  _source?: boolean | Fields
 }
 
 export interface GetResponse<TDocument = unknown> {
@@ -1712,9 +1711,9 @@ export interface UpdateByQueryRequest extends RequestBase {
   size?: long
   slices?: long
   sort?: string[]
-  source_enabled?: boolean
-  source_excludes?: Fields
-  source_includes?: Fields
+  _source?: boolean | Fields
+  _source_excludes?: Fields
+  _source_includes?: Fields
   stats?: string[]
   terminate_after?: long
   timeout?: Time

--- a/specification/_global/exists/DocumentExistsRequest.ts
+++ b/specification/_global/exists/DocumentExistsRequest.ts
@@ -44,9 +44,9 @@ export interface Request extends RequestBase {
     realtime?: boolean
     refresh?: boolean
     routing?: Routing
-    source_enabled?: boolean
-    source_excludes?: Fields
-    source_includes?: Fields
+    _source?: boolean | Fields
+    _source_excludes?: Fields
+    _source_includes?: Fields
     stored_fields?: Fields
     version?: VersionNumber
     version_type?: VersionType

--- a/specification/_global/exists_source/SourceExistsRequest.ts
+++ b/specification/_global/exists_source/SourceExistsRequest.ts
@@ -44,9 +44,9 @@ export interface Request extends RequestBase {
     realtime?: boolean
     refresh?: boolean
     routing?: Routing
-    source_enabled?: boolean
-    source_excludes?: Fields
-    source_includes?: Fields
+    _source?: boolean | Fields
+    _source_excludes?: Fields
+    _source_includes?: Fields
     version?: VersionNumber
     version_type?: VersionType
   }

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -62,7 +62,10 @@ export interface Request extends RequestBase {
      * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#get-routing
      */
     routing?: Routing
-    source_enabled?: boolean
+    /**
+     * True or false to return the _source field or not, or a list of fields to return.
+     */
+    _source?: boolean | Fields
     /**
      * A comma-separated list of source fields to exclude in the response.
      */
@@ -80,9 +83,5 @@ export interface Request extends RequestBase {
      * Specific version type: internal, external, external_gte.
      */
     version_type?: VersionType
-    /**
-     * True or false to return the _source field or not, or a list of fields to return.
-     */
-    _source?: boolean | Fields
   }
 }

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -70,9 +70,9 @@ export interface Request extends RequestBase {
     size?: long
     slices?: long
     sort?: string[]
-    source_enabled?: boolean
-    source_excludes?: Fields
-    source_includes?: Fields
+    _source?: boolean | Fields
+    _source_excludes?: Fields
+    _source_includes?: Fields
     stats?: string[]
     terminate_after?: long
     timeout?: Time


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-specification/pull/547 somehow targetted `7.x` instead of `main` so obviously wasn't backported properly. Fixing that issue with this PR.