### PR TITLE
Fix required properties

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -20882,7 +20882,19 @@
         "name": "Request",
         "namespace": "_global.render_search_template"
       },
-      "path": [],
+      "path": [
+        {
+          "name": "id",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
       "query": []
     },
     {
@@ -81996,7 +82008,7 @@
       "path": [
         {
           "name": "policy",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -82714,7 +82726,7 @@
       "path": [
         {
           "name": "policy",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -90005,7 +90017,7 @@
       "path": [
         {
           "name": "index",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -112666,7 +112678,7 @@
         {
           "description": "A string that uniquely identifies a calendar.",
           "name": "calendar_id",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -124372,7 +124384,7 @@
       "path": [
         {
           "name": "ids",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1339,12 +1339,6 @@
       ],
       "response": []
     },
-    "render_search_template": {
-      "request": [
-        "Endpoint has \"@stability: TODO"
-      ],
-      "response": []
-    },
     "rollup.delete_job": {
       "request": [
         "Endpoint has \"@stability: TODO"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -901,6 +901,7 @@ export interface ReindexRethrottleResponse {
 }
 
 export interface RenderSearchTemplateRequest extends RequestBase {
+  id?: Id
   body?: {
     file?: string
     params?: Record<string, any>
@@ -8047,7 +8048,7 @@ export interface IlmPolicy {
 }
 
 export interface IlmDeleteLifecycleRequest extends RequestBase {
-  policy?: Name
+  policy: Name
 }
 
 export interface IlmDeleteLifecycleResponse extends AcknowledgedResponseBase {
@@ -8135,7 +8136,7 @@ export interface IlmMoveToStepStepKey {
 }
 
 export interface IlmPutLifecycleRequest extends RequestBase {
-  policy?: Name
+  policy: Name
   body?: {
     policy?: IlmPolicy
   }
@@ -8957,7 +8958,7 @@ export interface IndicesPutIndexTemplateResponse extends AcknowledgedResponseBas
 }
 
 export interface IndicesPutMappingRequest extends RequestBase {
-  index?: Indices
+  index: Indices
   type?: Type
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
@@ -11554,7 +11555,7 @@ export interface MlOpenJobResponse {
 }
 
 export interface MlPostCalendarEventsRequest extends RequestBase {
-  calendar_id?: Id
+  calendar_id: Id
   body?: {
     events: MlCalendarEvent[]
   }
@@ -12942,7 +12943,7 @@ export interface SecurityChangePasswordResponse {
 }
 
 export interface SecurityClearApiKeyCacheRequest extends RequestBase {
-  ids?: Ids
+  ids: Ids
 }
 
 export interface SecurityClearApiKeyCacheResponse {

--- a/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
+++ b/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
@@ -20,6 +20,7 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name render_search_template
@@ -27,6 +28,9 @@ import { RequestBase } from '@_types/Base'
  * @stability TODO
  */
 export interface Request extends RequestBase {
+  path_parts?: {
+    id?: Id
+  }
   query_parameters?: {}
   body?: {
     file?: string

--- a/specification/ilm/delete_lifecycle/DeleteLifecycleRequest.ts
+++ b/specification/ilm/delete_lifecycle/DeleteLifecycleRequest.ts
@@ -27,6 +27,6 @@ import { Name } from '@_types/common'
  */
 export interface Request extends RequestBase {
   path_parts?: {
-    policy?: Name
+    policy: Name
   }
 }

--- a/specification/ilm/put_lifecycle/PutLifecycleRequest.ts
+++ b/specification/ilm/put_lifecycle/PutLifecycleRequest.ts
@@ -28,7 +28,7 @@ import { Name } from '@_types/common'
  */
 export interface Request extends RequestBase {
   path_parts?: {
-    policy?: Name
+    policy: Name
   }
   body?: {
     policy?: Policy

--- a/specification/indices/put_mapping/IndicesPutMappingRequest.ts
+++ b/specification/indices/put_mapping/IndicesPutMappingRequest.ts
@@ -44,7 +44,7 @@ import { Time } from '@_types/Time'
  */
 export interface Request extends RequestBase {
   path_parts?: {
-    index?: Indices
+    index: Indices
     type?: Type
   }
   query_parameters?: {

--- a/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
+++ b/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
@@ -29,7 +29,7 @@ import { CalendarEvent } from '../_types/CalendarEvent'
 export interface Request extends RequestBase {
   path_parts?: {
     /** A string that uniquely identifies a calendar. */
-    calendar_id?: Id
+    calendar_id: Id
   }
   body: {
     /** A list of one of more scheduled events. The event’s start and end times may be specified as integer milliseconds since the epoch or as a string in ISO 8601 format. */

--- a/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
+++ b/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
@@ -27,6 +27,6 @@ import { Ids } from '@_types/common'
  */
 export interface Request extends RequestBase {
   path_parts?: {
-    ids?: Ids
+    ids: Ids
   }
 }


### PR DESCRIPTION
This pr fixes a bunch of `path_parts` that should be required.

This change will break the validation for [`security.clear_api_key_cache`](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html), our test are sending requests without `ids`, but in both docs and rest-api-spec `ids` is required.