### PR TITLE
Validate the 'update' API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -12253,7 +12253,7 @@
         "namespace": "_global.update"
       },
       "since": "0.0.0",
-      "stability": "TODO",
+      "stability": "stable",
       "urls": [
         {
           "methods": [
@@ -28219,8 +28219,10 @@
         "kind": "properties",
         "properties": [
           {
+            "description": "Set to false to disable setting 'result' in the response to 'noop' if no change to the document occurred.",
             "name": "detect_noop",
             "required": false,
+            "serverDefault": true,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -28230,6 +28232,7 @@
             }
           },
           {
+            "description": "A partial update to an existing document.",
             "name": "doc",
             "required": false,
             "type": {
@@ -28241,8 +28244,10 @@
             }
           },
           {
+            "description": "Set to true to use the contents of 'doc' as the value of 'upsert'",
             "name": "doc_as_upsert",
             "required": false,
+            "serverDefault": false,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -28252,6 +28257,7 @@
             }
           },
           {
+            "description": "Script to execute to update the document.",
             "name": "script",
             "required": false,
             "type": {
@@ -28263,8 +28269,10 @@
             }
           },
           {
+            "description": "Set to true to execute the script whether or not the document exists.",
             "name": "scripted_upsert",
             "required": false,
+            "serverDefault": false,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -28274,8 +28282,10 @@
             }
           },
           {
+            "description": "Set to false to disable source retrieval. You can also specify a comma-separated list of the fields you want to retrieve.",
             "name": "_source",
             "required": false,
+            "serverDefault": "true",
             "type": {
               "items": [
                 {
@@ -28297,6 +28307,7 @@
             }
           },
           {
+            "description": "If the document does not already exist, the contents of 'upsert' are inserted as a new document. If the document exists, the 'script' is executed.",
             "name": "upsert",
             "required": false,
             "type": {
@@ -28367,6 +28378,7 @@
       ],
       "query": [
         {
+          "description": "Only perform the operation if the document has this primary term.",
           "name": "if_primary_term",
           "required": false,
           "type": {
@@ -28378,6 +28390,7 @@
           }
         },
         {
+          "description": "Only perform the operation if the document has this sequence number.",
           "name": "if_seq_no",
           "required": false,
           "type": {
@@ -28389,8 +28402,10 @@
           }
         },
         {
+          "description": "The script language.",
           "name": "lang",
           "required": false,
+          "serverDefault": "painless",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -28400,8 +28415,10 @@
           }
         },
         {
+          "description": "If 'true', Elasticsearch refreshes the affected shards to make this operation visible to search, if 'wait_for' then wait for a refresh to make this operation visible to search, if 'false' do nothing with refreshes.",
           "name": "refresh",
           "required": false,
+          "serverDefault": "false",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -28411,8 +28428,10 @@
           }
         },
         {
+          "description": "If true, the destination must be an index alias.",
           "name": "require_alias",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -28422,8 +28441,10 @@
           }
         },
         {
+          "description": "Specify how many times should the operation be retried when a conflict occurs.",
           "name": "retry_on_conflict",
           "required": false,
+          "serverDefault": 0,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -28433,6 +28454,7 @@
           }
         },
         {
+          "description": "Custom value used to route operations to a specific shard.",
           "name": "routing",
           "required": false,
           "type": {
@@ -28444,19 +28466,10 @@
           }
         },
         {
-          "name": "source_enabled",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
+          "description": "Period to wait for dynamic mapping updates and active shards. This guarantees Elasticsearch waits for at least the timeout before failing. The actual wait time could be longer, particularly when multiple waits occur.",
           "name": "timeout",
           "required": false,
+          "serverDefault": "1m",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -28466,8 +28479,10 @@
           }
         },
         {
+          "description": "The number of shard copies that must be active before proceeding with the operations. Set to 'all' or any positive integer up to the total number of shards in the index (number_of_replicas+1). Defaults to 1 meaning the primary shard.",
           "name": "wait_for_active_shards",
           "required": false,
+          "serverDefault": "1",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -28477,8 +28492,10 @@
           }
         },
         {
+          "description": "Set to false to disable source retrieval. You can also specify a comma-separated list of the fields you want to retrieve.",
           "name": "_source",
           "required": false,
+          "serverDefault": "true",
           "type": {
             "items": [
               {
@@ -28500,6 +28517,7 @@
           }
         },
         {
+          "description": "Specify the source fields you want to exclude.",
           "name": "_source_excludes",
           "required": false,
           "type": {
@@ -28511,6 +28529,7 @@
           }
         },
         {
+          "description": "Specify the source fields you want to retrieve.",
           "name": "_source_includes",
           "required": false,
           "type": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1825,12 +1825,6 @@
       ],
       "response": []
     },
-    "update": {
-      "request": [
-        "Endpoint has \"@stability: TODO"
-      ],
-      "response": []
-    },
     "update_by_query": {
       "request": [
         "Endpoint has \"@stability: TODO"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1664,7 +1664,6 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
   require_alias?: boolean
   retry_on_conflict?: long
   routing?: Routing
-  source_enabled?: boolean
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
   _source?: boolean | Fields

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -36,7 +36,7 @@ import { Time } from '@_types/Time'
 /**
  * @rest_spec_name update
  * @since 0.0.0
- * @stability TODO
+ * @stability stable
  */
 export interface Request<TDocument, TPartialDocument> extends RequestBase {
   path_parts?: {
@@ -45,29 +45,106 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
     type?: Type
   }
   query_parameters?: {
+    /**
+     * Only perform the operation if the document has this primary term.
+     */
     if_primary_term?: long
+    /**
+     * Only perform the operation if the document has this sequence number.
+     */
     if_seq_no?: SequenceNumber
+    /**
+     * The script language.
+     * @server_default painless
+     */
     lang?: string
+    /**
+     * If 'true', Elasticsearch refreshes the affected shards to make this operation
+     * visible to search, if 'wait_for' then wait for a refresh to make this operation
+     * visible to search, if 'false' do nothing with refreshes.
+     * @server_default false
+     */
     refresh?: Refresh
+    /**
+     * If true, the destination must be an index alias.
+     * @server_default false
+     */
     require_alias?: boolean
+    /**
+     * Specify how many times should the operation be retried when a conflict occurs.
+     * @server_default 0
+     */
     retry_on_conflict?: long
+    /**
+     * Custom value used to route operations to a specific shard.
+     */
     routing?: Routing
-    source_enabled?: boolean
+    /**
+     * Period to wait for dynamic mapping updates and active shards.
+     * This guarantees Elasticsearch waits for at least the timeout before failing.
+     * The actual wait time could be longer, particularly when multiple waits occur.
+     * @server_default 1m
+     */
     timeout?: Time
+    /**
+     * The number of shard copies that must be active before proceeding with the operations.
+     * Set to 'all' or any positive integer up to the total number of shards in the index
+     * (number_of_replicas+1). Defaults to 1 meaning the primary shard.
+     * @server_default 1
+     */
     wait_for_active_shards?: WaitForActiveShards
+    /**
+     * Set to false to disable source retrieval. You can also specify a comma-separated
+     * list of the fields you want to retrieve.
+     * @server_default true
+     */
     _source?: boolean | Fields
+    /**
+     * Specify the source fields you want to exclude.
+     */
     _source_excludes?: Fields
+    /**
+     * Specify the source fields you want to retrieve.
+     */
     _source_includes?: Fields
   }
   body?: {
+    /**
+     * Set to false to disable setting 'result' in the response
+     * to 'noop' if no change to the document occurred.
+     * @server_default true
+     */
     detect_noop?: boolean
-    /** @prop_serializer SourceFormatter`1 */
+    /**
+     * A partial update to an existing document.
+     * @prop_serializer SourceFormatter`1
+     */
     doc?: TPartialDocument
+    /**
+     * Set to true to use the contents of 'doc' as the value of 'upsert'
+     * @server_default false
+     */
     doc_as_upsert?: boolean
+    /**
+     * Script to execute to update the document.
+     */
     script?: Script
+    /**
+     * Set to true to execute the script whether or not the document exists.
+     * @server_default false
+     */
     scripted_upsert?: boolean
+    /**
+     * Set to false to disable source retrieval. You can also specify a comma-separated
+     * list of the fields you want to retrieve.
+     * @server_default true
+     */
     _source?: boolean | SourceFilter
-    /** @prop_serializer SourceFormatter`1 */
+    /**
+     * If the document does not already exist, the contents of 'upsert' are inserted as a
+     * new document. If the document exists, the 'script' is executed.
+     * @prop_serializer SourceFormatter`1
+     */
     upsert?: TDocument
   }
 }


### PR DESCRIPTION
Two test cases use strings for the `routing` parameter, will have to fix that in rest-api-spec.