### PR TITLE
Fix addDescription step

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -13008,7 +13008,7 @@
       },
       "path": [
         {
-          "description": "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices",
+          "description": "Default index for items which don't provide one",
           "name": "index",
           "required": false,
           "type": {
@@ -13020,7 +13020,7 @@
           }
         },
         {
-          "description": "A comma-separated list of document types to search; leave empty to perform the operation on all types",
+          "description": "Default document type for items which don't provide one",
           "name": "type",
           "required": false,
           "type": {
@@ -13034,6 +13034,7 @@
       ],
       "query": [
         {
+          "description": "The pipeline id to preprocess incoming documents with",
           "name": "pipeline",
           "required": false,
           "type": {
@@ -13045,6 +13046,7 @@
           }
         },
         {
+          "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -13056,6 +13058,7 @@
           }
         },
         {
+          "description": "Specific routing value",
           "name": "routing",
           "required": false,
           "type": {
@@ -13067,6 +13070,7 @@
           }
         },
         {
+          "description": "True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request",
           "name": "_source",
           "required": false,
           "type": {
@@ -13090,6 +13094,7 @@
           }
         },
         {
+          "description": "Default list of fields to exclude from the returned _source field, can be overridden on each sub-request",
           "name": "_source_excludes",
           "required": false,
           "type": {
@@ -13101,6 +13106,7 @@
           }
         },
         {
+          "description": "Default list of fields to extract and return from the _source field, can be overridden on each sub-request",
           "name": "_source_includes",
           "required": false,
           "type": {
@@ -13112,6 +13118,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -13123,6 +13130,7 @@
           }
         },
         {
+          "description": "Default document type for items which don't provide one",
           "name": "type",
           "required": false,
           "type": {
@@ -13134,6 +13142,7 @@
           }
         },
         {
+          "description": "Sets the number of shard copies that must be active before proceeding with the bulk operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -13145,6 +13154,7 @@
           }
         },
         {
+          "description": "Sets require_alias for all incoming documents. Defaults to unset (false)",
           "name": "require_alias",
           "required": false,
           "type": {
@@ -13502,6 +13512,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of scroll IDs to clear",
           "name": "scroll_id",
           "required": false,
           "type": {
@@ -13650,6 +13661,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of indices to restrict the results",
           "name": "index",
           "required": false,
           "type": {
@@ -13661,6 +13673,7 @@
           }
         },
         {
+          "description": "A comma-separated list of types to restrict the results",
           "name": "type",
           "required": false,
           "type": {
@@ -13674,6 +13687,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -13685,6 +13699,7 @@
           }
         },
         {
+          "description": "The analyzer to use for the query string",
           "name": "analyzer",
           "required": false,
           "type": {
@@ -13696,6 +13711,7 @@
           }
         },
         {
+          "description": "Specify whether wildcard and prefix queries should be analyzed (default: false)",
           "name": "analyze_wildcard",
           "required": false,
           "type": {
@@ -13707,6 +13723,7 @@
           }
         },
         {
+          "description": "The default operator for query string query (AND or OR)",
           "name": "default_operator",
           "required": false,
           "type": {
@@ -13718,6 +13735,7 @@
           }
         },
         {
+          "description": "The field to use as default where no field prefix is given in the query string",
           "name": "df",
           "required": false,
           "type": {
@@ -13729,6 +13747,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -13740,6 +13759,7 @@
           }
         },
         {
+          "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled",
           "name": "ignore_throttled",
           "required": false,
           "type": {
@@ -13751,6 +13771,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -13762,6 +13783,7 @@
           }
         },
         {
+          "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored",
           "name": "lenient",
           "required": false,
           "type": {
@@ -13773,6 +13795,7 @@
           }
         },
         {
+          "description": "Include only documents with a specific `_score` value in the result",
           "name": "min_score",
           "required": false,
           "type": {
@@ -13784,6 +13807,7 @@
           }
         },
         {
+          "description": "Specify the node or shard the operation should be performed on (default: random)",
           "name": "preference",
           "required": false,
           "type": {
@@ -13806,6 +13830,7 @@
           }
         },
         {
+          "description": "A comma-separated list of specific routing values",
           "name": "routing",
           "required": false,
           "type": {
@@ -13817,6 +13842,7 @@
           }
         },
         {
+          "description": "The maximum count for each shard, upon reaching which the query execution will terminate early",
           "name": "terminate_after",
           "required": false,
           "type": {
@@ -13828,6 +13854,7 @@
           }
         },
         {
+          "description": "Query in the Lucene query string syntax",
           "name": "q",
           "required": false,
           "type": {
@@ -13908,6 +13935,7 @@
       },
       "path": [
         {
+          "description": "Document ID",
           "name": "id",
           "required": true,
           "type": {
@@ -13919,6 +13947,7 @@
           }
         },
         {
+          "description": "The name of the index",
           "name": "index",
           "required": true,
           "type": {
@@ -13930,6 +13959,7 @@
           }
         },
         {
+          "description": "The type of the document",
           "name": "type",
           "required": false,
           "type": {
@@ -13943,6 +13973,7 @@
       ],
       "query": [
         {
+          "description": "The pipeline id to preprocess incoming documents with",
           "name": "pipeline",
           "required": false,
           "type": {
@@ -13954,6 +13985,7 @@
           }
         },
         {
+          "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -13965,6 +13997,7 @@
           }
         },
         {
+          "description": "Specific routing value",
           "name": "routing",
           "required": false,
           "type": {
@@ -13976,6 +14009,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -13987,6 +14021,7 @@
           }
         },
         {
+          "description": "Explicit version number for concurrency control",
           "name": "version",
           "required": false,
           "type": {
@@ -13998,6 +14033,7 @@
           }
         },
         {
+          "description": "Specific version type",
           "name": "version_type",
           "required": false,
           "type": {
@@ -14009,6 +14045,7 @@
           }
         },
         {
+          "description": "Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -14058,6 +14095,7 @@
       },
       "path": [
         {
+          "description": "The document ID",
           "name": "id",
           "required": true,
           "type": {
@@ -14069,6 +14107,7 @@
           }
         },
         {
+          "description": "The name of the index",
           "name": "index",
           "required": true,
           "type": {
@@ -14080,6 +14119,7 @@
           }
         },
         {
+          "description": "The type of the document",
           "name": "type",
           "required": false,
           "type": {
@@ -14093,6 +14133,7 @@
       ],
       "query": [
         {
+          "description": "only perform the delete operation if the last operation that has changed the document has the specified primary term",
           "name": "if_primary_term",
           "required": false,
           "type": {
@@ -14104,6 +14145,7 @@
           }
         },
         {
+          "description": "only perform the delete operation if the last operation that has changed the document has the specified sequence number",
           "name": "if_seq_no",
           "required": false,
           "type": {
@@ -14115,6 +14157,7 @@
           }
         },
         {
+          "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -14126,6 +14169,7 @@
           }
         },
         {
+          "description": "Specific routing value",
           "name": "routing",
           "required": false,
           "type": {
@@ -14137,6 +14181,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -14148,6 +14193,7 @@
           }
         },
         {
+          "description": "Explicit version number for concurrency control",
           "name": "version",
           "required": false,
           "type": {
@@ -14159,6 +14205,7 @@
           }
         },
         {
+          "description": "Specific version type",
           "name": "version_type",
           "required": false,
           "type": {
@@ -14170,6 +14217,7 @@
           }
         },
         {
+          "description": "Sets the number of shard copies that must be active before proceeding with the delete operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -14254,6 +14302,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": true,
           "type": {
@@ -14265,6 +14314,7 @@
           }
         },
         {
+          "description": "A comma-separated list of document types to search; leave empty to perform the operation on all types",
           "name": "type",
           "required": false,
           "type": {
@@ -14278,6 +14328,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -14289,6 +14340,7 @@
           }
         },
         {
+          "description": "The analyzer to use for the query string",
           "name": "analyzer",
           "required": false,
           "type": {
@@ -14300,6 +14352,7 @@
           }
         },
         {
+          "description": "Specify whether wildcard and prefix queries should be analyzed (default: false)",
           "name": "analyze_wildcard",
           "required": false,
           "type": {
@@ -14311,6 +14364,7 @@
           }
         },
         {
+          "description": "What to do when the delete by query hits version conflicts?",
           "name": "conflicts",
           "required": false,
           "type": {
@@ -14322,6 +14376,7 @@
           }
         },
         {
+          "description": "The default operator for query string query (AND or OR)",
           "name": "default_operator",
           "required": false,
           "type": {
@@ -14333,6 +14388,7 @@
           }
         },
         {
+          "description": "The field to use as default where no field prefix is given in the query string",
           "name": "df",
           "required": false,
           "type": {
@@ -14344,6 +14400,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -14355,6 +14412,7 @@
           }
         },
         {
+          "description": "Starting offset (default: 0)",
           "name": "from",
           "required": false,
           "type": {
@@ -14366,6 +14424,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -14377,6 +14436,7 @@
           }
         },
         {
+          "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored",
           "name": "lenient",
           "required": false,
           "type": {
@@ -14388,6 +14448,7 @@
           }
         },
         {
+          "description": "Maximum number of documents to process (default: all documents)",
           "name": "max_docs",
           "required": false,
           "type": {
@@ -14399,6 +14460,7 @@
           }
         },
         {
+          "description": "Specify the node or shard the operation should be performed on (default: random)",
           "name": "preference",
           "required": false,
           "type": {
@@ -14410,6 +14472,7 @@
           }
         },
         {
+          "description": "Should the effected indexes be refreshed?",
           "name": "refresh",
           "required": false,
           "type": {
@@ -14421,6 +14484,7 @@
           }
         },
         {
+          "description": "Specify if request cache should be used for this request or not, defaults to index level setting",
           "name": "request_cache",
           "required": false,
           "type": {
@@ -14432,6 +14496,7 @@
           }
         },
         {
+          "description": "The throttle for this request in sub-requests per second. -1 means no throttle.",
           "name": "requests_per_second",
           "required": false,
           "type": {
@@ -14443,6 +14508,7 @@
           }
         },
         {
+          "description": "A comma-separated list of specific routing values",
           "name": "routing",
           "required": false,
           "type": {
@@ -14454,6 +14520,7 @@
           }
         },
         {
+          "description": "Query in the Lucene query string syntax",
           "name": "q",
           "required": false,
           "type": {
@@ -14465,6 +14532,7 @@
           }
         },
         {
+          "description": "Specify how long a consistent view of the index should be maintained for scrolled search",
           "name": "scroll",
           "required": false,
           "type": {
@@ -14476,6 +14544,7 @@
           }
         },
         {
+          "description": "Size on the scroll request powering the delete by query",
           "name": "scroll_size",
           "required": false,
           "type": {
@@ -14487,6 +14556,7 @@
           }
         },
         {
+          "description": "Explicit timeout for each search request. Defaults to no timeout.",
           "name": "search_timeout",
           "required": false,
           "type": {
@@ -14498,6 +14568,7 @@
           }
         },
         {
+          "description": "Search operation type",
           "name": "search_type",
           "required": false,
           "type": {
@@ -14509,6 +14580,7 @@
           }
         },
         {
+          "description": "Deprecated, please use `max_docs` instead",
           "name": "size",
           "required": false,
           "type": {
@@ -14520,6 +14592,7 @@
           }
         },
         {
+          "description": "The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.",
           "name": "slices",
           "required": false,
           "type": {
@@ -14531,6 +14604,7 @@
           }
         },
         {
+          "description": "A comma-separated list of <field>:<direction> pairs",
           "name": "sort",
           "required": false,
           "type": {
@@ -14545,6 +14619,7 @@
           }
         },
         {
+          "description": "True or false to return the _source field or not, or a list of fields to return",
           "name": "_source",
           "required": false,
           "type": {
@@ -14568,6 +14643,7 @@
           }
         },
         {
+          "description": "A list of fields to exclude from the returned _source field",
           "name": "_source_excludes",
           "required": false,
           "type": {
@@ -14579,6 +14655,7 @@
           }
         },
         {
+          "description": "A list of fields to extract and return from the _source field",
           "name": "_source_includes",
           "required": false,
           "type": {
@@ -14590,6 +14667,7 @@
           }
         },
         {
+          "description": "Specific 'tag' of the request for logging and statistical purposes",
           "name": "stats",
           "required": false,
           "type": {
@@ -14604,6 +14682,7 @@
           }
         },
         {
+          "description": "The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.",
           "name": "terminate_after",
           "required": false,
           "type": {
@@ -14615,6 +14694,7 @@
           }
         },
         {
+          "description": "Time each individual bulk request should wait for shards that are unavailable.",
           "name": "timeout",
           "required": false,
           "type": {
@@ -14626,6 +14706,7 @@
           }
         },
         {
+          "description": "Specify whether to return document version as part of a hit",
           "name": "version",
           "required": false,
           "type": {
@@ -14637,6 +14718,7 @@
           }
         },
         {
+          "description": "Sets the number of shard copies that must be active before proceeding with the delete by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -14648,6 +14730,7 @@
           }
         },
         {
+          "description": "Should the request should block until the delete by query is complete.",
           "name": "wait_for_completion",
           "required": false,
           "type": {
@@ -14849,6 +14932,7 @@
       },
       "path": [
         {
+          "description": "The task id to rethrottle",
           "name": "task_id",
           "required": true,
           "type": {
@@ -14862,6 +14946,7 @@
       ],
       "query": [
         {
+          "description": "The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.",
           "name": "requests_per_second",
           "required": false,
           "type": {
@@ -14911,6 +14996,7 @@
       },
       "path": [
         {
+          "description": "Script ID",
           "name": "id",
           "required": true,
           "type": {
@@ -14924,6 +15010,7 @@
       ],
       "query": [
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -14935,6 +15022,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -14984,6 +15072,7 @@
       },
       "path": [
         {
+          "description": "The document ID",
           "name": "id",
           "required": true,
           "type": {
@@ -14995,6 +15084,7 @@
           }
         },
         {
+          "description": "The name of the index",
           "name": "index",
           "required": true,
           "type": {
@@ -15006,6 +15096,7 @@
           }
         },
         {
+          "description": "The type of the document (use `_all` to fetch the first document matching the ID across all types)",
           "name": "type",
           "required": false,
           "type": {
@@ -15019,6 +15110,7 @@
       ],
       "query": [
         {
+          "description": "Specify the node or shard the operation should be performed on (default: random)",
           "name": "preference",
           "required": false,
           "type": {
@@ -15030,6 +15122,7 @@
           }
         },
         {
+          "description": "Specify whether to perform the operation in realtime or search mode",
           "name": "realtime",
           "required": false,
           "type": {
@@ -15041,6 +15134,7 @@
           }
         },
         {
+          "description": "Refresh the shard containing the document before performing the operation",
           "name": "refresh",
           "required": false,
           "type": {
@@ -15052,6 +15146,7 @@
           }
         },
         {
+          "description": "Specific routing value",
           "name": "routing",
           "required": false,
           "type": {
@@ -15063,6 +15158,7 @@
           }
         },
         {
+          "description": "True or false to return the _source field or not, or a list of fields to return",
           "name": "_source",
           "required": false,
           "type": {
@@ -15086,6 +15182,7 @@
           }
         },
         {
+          "description": "A list of fields to exclude from the returned _source field",
           "name": "_source_excludes",
           "required": false,
           "type": {
@@ -15097,6 +15194,7 @@
           }
         },
         {
+          "description": "A list of fields to extract and return from the _source field",
           "name": "_source_includes",
           "required": false,
           "type": {
@@ -15108,6 +15206,7 @@
           }
         },
         {
+          "description": "A comma-separated list of stored fields to return in the response",
           "name": "stored_fields",
           "required": false,
           "type": {
@@ -15119,6 +15218,7 @@
           }
         },
         {
+          "description": "Explicit version number for concurrency control",
           "name": "version",
           "required": false,
           "type": {
@@ -15130,6 +15230,7 @@
           }
         },
         {
+          "description": "Specific version type",
           "name": "version_type",
           "required": false,
           "type": {
@@ -15172,6 +15273,7 @@
       },
       "path": [
         {
+          "description": "The document ID",
           "name": "id",
           "required": true,
           "type": {
@@ -15183,6 +15285,7 @@
           }
         },
         {
+          "description": "The name of the index",
           "name": "index",
           "required": true,
           "type": {
@@ -15194,6 +15297,7 @@
           }
         },
         {
+          "description": "The type of the document; deprecated and optional starting with 7.0",
           "name": "type",
           "required": false,
           "type": {
@@ -15207,6 +15311,7 @@
       ],
       "query": [
         {
+          "description": "Specify the node or shard the operation should be performed on (default: random)",
           "name": "preference",
           "required": false,
           "type": {
@@ -15218,6 +15323,7 @@
           }
         },
         {
+          "description": "Specify whether to perform the operation in realtime or search mode",
           "name": "realtime",
           "required": false,
           "type": {
@@ -15229,6 +15335,7 @@
           }
         },
         {
+          "description": "Refresh the shard containing the document before performing the operation",
           "name": "refresh",
           "required": false,
           "type": {
@@ -15240,6 +15347,7 @@
           }
         },
         {
+          "description": "Specific routing value",
           "name": "routing",
           "required": false,
           "type": {
@@ -15251,6 +15359,7 @@
           }
         },
         {
+          "description": "True or false to return the _source field or not, or a list of fields to return",
           "name": "_source",
           "required": false,
           "type": {
@@ -15274,6 +15383,7 @@
           }
         },
         {
+          "description": "A list of fields to exclude from the returned _source field",
           "name": "_source_excludes",
           "required": false,
           "type": {
@@ -15285,6 +15395,7 @@
           }
         },
         {
+          "description": "A list of fields to extract and return from the _source field",
           "name": "_source_includes",
           "required": false,
           "type": {
@@ -15296,6 +15407,7 @@
           }
         },
         {
+          "description": "Explicit version number for concurrency control",
           "name": "version",
           "required": false,
           "type": {
@@ -15307,6 +15419,7 @@
           }
         },
         {
+          "description": "Specific version type",
           "name": "version_type",
           "required": false,
           "type": {
@@ -15452,6 +15565,7 @@
       },
       "path": [
         {
+          "description": "The document ID",
           "name": "id",
           "required": true,
           "type": {
@@ -15463,6 +15577,7 @@
           }
         },
         {
+          "description": "The name of the index",
           "name": "index",
           "required": true,
           "type": {
@@ -15474,6 +15589,7 @@
           }
         },
         {
+          "description": "The type of the document",
           "name": "type",
           "required": false,
           "type": {
@@ -15487,6 +15603,7 @@
       ],
       "query": [
         {
+          "description": "The analyzer for the query string query",
           "name": "analyzer",
           "required": false,
           "type": {
@@ -15498,6 +15615,7 @@
           }
         },
         {
+          "description": "Specify whether wildcards and prefix queries in the query string query should be analyzed (default: false)",
           "name": "analyze_wildcard",
           "required": false,
           "type": {
@@ -15509,6 +15627,7 @@
           }
         },
         {
+          "description": "The default operator for query string query (AND or OR)",
           "name": "default_operator",
           "required": false,
           "type": {
@@ -15520,6 +15639,7 @@
           }
         },
         {
+          "description": "The default field for query string query (default: _all)",
           "name": "df",
           "required": false,
           "type": {
@@ -15531,6 +15651,7 @@
           }
         },
         {
+          "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored",
           "name": "lenient",
           "required": false,
           "type": {
@@ -15542,6 +15663,7 @@
           }
         },
         {
+          "description": "Specify the node or shard the operation should be performed on (default: random)",
           "name": "preference",
           "required": false,
           "type": {
@@ -15564,6 +15686,7 @@
           }
         },
         {
+          "description": "Specific routing value",
           "name": "routing",
           "required": false,
           "type": {
@@ -15575,6 +15698,7 @@
           }
         },
         {
+          "description": "True or false to return the _source field or not, or a list of fields to return",
           "name": "_source",
           "required": false,
           "type": {
@@ -15598,6 +15722,7 @@
           }
         },
         {
+          "description": "A list of fields to exclude from the returned _source field",
           "name": "_source_excludes",
           "required": false,
           "type": {
@@ -15609,6 +15734,7 @@
           }
         },
         {
+          "description": "A list of fields to extract and return from the _source field",
           "name": "_source_includes",
           "required": false,
           "type": {
@@ -15620,6 +15746,7 @@
           }
         },
         {
+          "description": "A comma-separated list of stored fields to return in the response",
           "name": "stored_fields",
           "required": false,
           "type": {
@@ -15631,6 +15758,7 @@
           }
         },
         {
+          "description": "Query in the Lucene query string syntax",
           "name": "q",
           "required": false,
           "type": {
@@ -16024,6 +16152,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -16037,6 +16166,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -16048,6 +16178,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -16059,6 +16190,7 @@
           }
         },
         {
+          "description": "A comma-separated list of field names",
           "name": "fields",
           "required": false,
           "type": {
@@ -16070,6 +16202,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -16081,6 +16214,7 @@
           }
         },
         {
+          "description": "Indicates whether unmapped fields should be included in the response.",
           "name": "include_unmapped",
           "required": false,
           "type": {
@@ -16193,6 +16327,7 @@
           }
         },
         {
+          "description": "The type of the document (use `_all` to fetch the first document matching the ID across all types)",
           "name": "type",
           "required": false,
           "type": {
@@ -16306,6 +16441,7 @@
           }
         },
         {
+          "description": "A comma-separated list of stored fields to return in the response",
           "name": "stored_fields",
           "required": false,
           "type": {
@@ -16500,6 +16636,7 @@
       },
       "path": [
         {
+          "description": "Script ID",
           "name": "id",
           "required": true,
           "type": {
@@ -16902,6 +17039,7 @@
       },
       "path": [
         {
+          "description": "Document ID",
           "name": "id",
           "required": false,
           "type": {
@@ -16913,6 +17051,7 @@
           }
         },
         {
+          "description": "The name of the index",
           "name": "index",
           "required": true,
           "type": {
@@ -16924,6 +17063,7 @@
           }
         },
         {
+          "description": "The type of the document",
           "name": "type",
           "required": false,
           "type": {
@@ -16937,6 +17077,7 @@
       ],
       "query": [
         {
+          "description": "only perform the index operation if the last operation that has changed the document has the specified primary term",
           "name": "if_primary_term",
           "required": false,
           "type": {
@@ -16948,6 +17089,7 @@
           }
         },
         {
+          "description": "only perform the index operation if the last operation that has changed the document has the specified sequence number",
           "name": "if_seq_no",
           "required": false,
           "type": {
@@ -16959,6 +17101,7 @@
           }
         },
         {
+          "description": "Explicit operation type. Defaults to `index` for requests with an explicit document ID, and to `create`for requests without an explicit document ID",
           "name": "op_type",
           "required": false,
           "type": {
@@ -16970,6 +17113,7 @@
           }
         },
         {
+          "description": "The pipeline id to preprocess incoming documents with",
           "name": "pipeline",
           "required": false,
           "type": {
@@ -16981,6 +17125,7 @@
           }
         },
         {
+          "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` (the default) then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -16992,6 +17137,7 @@
           }
         },
         {
+          "description": "Specific routing value",
           "name": "routing",
           "required": false,
           "type": {
@@ -17003,6 +17149,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -17014,6 +17161,7 @@
           }
         },
         {
+          "description": "Explicit version number for concurrency control",
           "name": "version",
           "required": false,
           "type": {
@@ -17025,6 +17173,7 @@
           }
         },
         {
+          "description": "Specific version type",
           "name": "version_type",
           "required": false,
           "type": {
@@ -17036,6 +17185,7 @@
           }
         },
         {
+          "description": "Sets the number of shard copies that must be active before proceeding with the index operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -17047,6 +17197,7 @@
           }
         },
         {
+          "description": "When true, requires destination to be an alias. Default is false",
           "name": "require_alias",
           "required": false,
           "type": {
@@ -17499,6 +17650,7 @@
       },
       "path": [
         {
+          "description": "The name of the index",
           "name": "index",
           "required": false,
           "type": {
@@ -17510,6 +17662,7 @@
           }
         },
         {
+          "description": "The type of the document",
           "name": "type",
           "required": false,
           "type": {
@@ -17523,6 +17676,7 @@
       ],
       "query": [
         {
+          "description": "Specify the node or shard the operation should be performed on (default: random)",
           "name": "preference",
           "required": false,
           "type": {
@@ -17534,6 +17688,7 @@
           }
         },
         {
+          "description": "Specify whether to perform the operation in realtime or search mode",
           "name": "realtime",
           "required": false,
           "type": {
@@ -17545,6 +17700,7 @@
           }
         },
         {
+          "description": "Refresh the shard containing the document before performing the operation",
           "name": "refresh",
           "required": false,
           "type": {
@@ -17556,6 +17712,7 @@
           }
         },
         {
+          "description": "Specific routing value",
           "name": "routing",
           "required": false,
           "type": {
@@ -17567,6 +17724,7 @@
           }
         },
         {
+          "description": "True or false to return the _source field or not, or a list of fields to return",
           "name": "_source",
           "required": false,
           "type": {
@@ -17590,6 +17748,7 @@
           }
         },
         {
+          "description": "A list of fields to exclude from the returned _source field",
           "name": "_source_excludes",
           "required": false,
           "type": {
@@ -17601,6 +17760,7 @@
           }
         },
         {
+          "description": "A list of fields to extract and return from the _source field",
           "name": "_source_includes",
           "required": false,
           "type": {
@@ -17612,6 +17772,7 @@
           }
         },
         {
+          "description": "A comma-separated list of stored fields to return in the response",
           "name": "stored_fields",
           "required": false,
           "type": {
@@ -17972,6 +18133,7 @@
           }
         },
         {
+          "description": "A comma-separated list of document types to use as default",
           "name": "type",
           "required": false,
           "type": {
@@ -18260,6 +18422,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to use as default",
           "name": "index",
           "required": false,
           "type": {
@@ -18271,6 +18434,7 @@
           }
         },
         {
+          "description": "A comma-separated list of document types to use as default",
           "name": "type",
           "required": false,
           "type": {
@@ -18284,6 +18448,7 @@
       ],
       "query": [
         {
+          "description": "Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution",
           "name": "ccs_minimize_roundtrips",
           "required": false,
           "type": {
@@ -18295,6 +18460,7 @@
           }
         },
         {
+          "description": "Controls the maximum number of concurrent searches the multi search api will execute",
           "name": "max_concurrent_searches",
           "required": false,
           "type": {
@@ -18306,6 +18472,7 @@
           }
         },
         {
+          "description": "Search operation type",
           "name": "search_type",
           "required": false,
           "type": {
@@ -18317,6 +18484,7 @@
           }
         },
         {
+          "description": "Indicates whether hits.total should be rendered as an integer or an object in the rest search response",
           "name": "rest_total_hits_as_int",
           "required": false,
           "type": {
@@ -18328,6 +18496,7 @@
           }
         },
         {
+          "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response",
           "name": "typed_keys",
           "required": false,
           "type": {
@@ -18654,6 +18823,7 @@
       },
       "path": [
         {
+          "description": "The index in which the document resides.",
           "name": "index",
           "required": false,
           "type": {
@@ -18665,6 +18835,7 @@
           }
         },
         {
+          "description": "The type of the document.",
           "name": "type",
           "required": false,
           "type": {
@@ -18678,6 +18849,7 @@
       ],
       "query": [
         {
+          "description": "A comma-separated list of fields to return. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".",
           "name": "fields",
           "required": false,
           "type": {
@@ -18689,6 +18861,7 @@
           }
         },
         {
+          "description": "Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".",
           "name": "field_statistics",
           "required": false,
           "type": {
@@ -18700,6 +18873,7 @@
           }
         },
         {
+          "description": "Specifies if term offsets should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".",
           "name": "offsets",
           "required": false,
           "type": {
@@ -18711,6 +18885,7 @@
           }
         },
         {
+          "description": "Specifies if term payloads should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".",
           "name": "payloads",
           "required": false,
           "type": {
@@ -18722,6 +18897,7 @@
           }
         },
         {
+          "description": "Specifies if term positions should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".",
           "name": "positions",
           "required": false,
           "type": {
@@ -18733,6 +18909,7 @@
           }
         },
         {
+          "description": "Specify the node or shard the operation should be performed on (default: random) .Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".",
           "name": "preference",
           "required": false,
           "type": {
@@ -18744,6 +18921,7 @@
           }
         },
         {
+          "description": "Specifies if requests are real-time as opposed to near-real-time (default: true).",
           "name": "realtime",
           "required": false,
           "type": {
@@ -18755,6 +18933,7 @@
           }
         },
         {
+          "description": "Specific routing value. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".",
           "name": "routing",
           "required": false,
           "type": {
@@ -18766,6 +18945,7 @@
           }
         },
         {
+          "description": "Specifies if total term frequency and document frequency should be returned. Applies to all returned documents unless otherwise specified in body \"params\" or \"docs\".",
           "name": "term_statistics",
           "required": false,
           "type": {
@@ -18777,6 +18957,7 @@
           }
         },
         {
+          "description": "Explicit version number for concurrency control",
           "name": "version",
           "required": false,
           "type": {
@@ -18788,6 +18969,7 @@
           }
         },
         {
+          "description": "Specific version type",
           "name": "version_type",
           "required": false,
           "type": {
@@ -18932,6 +19114,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to open point in time; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": true,
           "type": {
@@ -18945,6 +19128,7 @@
       ],
       "query": [
         {
+          "description": "Specific the time to live for the point in time",
           "name": "keep_alive",
           "required": false,
           "type": {
@@ -19044,6 +19228,7 @@
       },
       "path": [
         {
+          "description": "Script ID",
           "name": "id",
           "required": true,
           "type": {
@@ -19055,6 +19240,7 @@
           }
         },
         {
+          "description": "Script context",
           "name": "context",
           "required": false,
           "type": {
@@ -19068,6 +19254,7 @@
       ],
       "query": [
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -19079,6 +19266,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -19741,6 +19929,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -19765,6 +19954,7 @@
           }
         },
         {
+          "description": "Search operation type",
           "name": "search_type",
           "required": false,
           "type": {
@@ -20090,6 +20280,7 @@
       "path": [],
       "query": [
         {
+          "description": "Should the affected indexes be refreshed?",
           "name": "refresh",
           "required": false,
           "type": {
@@ -20101,6 +20292,7 @@
           }
         },
         {
+          "description": "The throttle to set on this request in sub-requests per second. -1 means no throttle.",
           "name": "requests_per_second",
           "required": false,
           "type": {
@@ -20112,6 +20304,7 @@
           }
         },
         {
+          "description": "Control how long to keep the search context alive",
           "name": "scroll",
           "required": false,
           "type": {
@@ -20123,6 +20316,7 @@
           }
         },
         {
+          "description": "The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.",
           "name": "slices",
           "required": false,
           "type": {
@@ -20134,6 +20328,7 @@
           }
         },
         {
+          "description": "Time each individual bulk request should wait for shards that are unavailable.",
           "name": "timeout",
           "required": false,
           "type": {
@@ -20145,6 +20340,7 @@
           }
         },
         {
+          "description": "Sets the number of shard copies that must be active before proceeding with the reindex operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -20156,6 +20352,7 @@
           }
         },
         {
+          "description": "Should the request should block until the reindex is complete.",
           "name": "wait_for_completion",
           "required": false,
           "type": {
@@ -20763,6 +20960,7 @@
       },
       "path": [
         {
+          "description": "The task id to rethrottle",
           "name": "task_id",
           "required": true,
           "type": {
@@ -20776,6 +20974,7 @@
       ],
       "query": [
         {
+          "description": "The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.",
           "name": "requests_per_second",
           "required": false,
           "type": {
@@ -20884,6 +21083,7 @@
       },
       "path": [
         {
+          "description": "The id of the stored search template",
           "name": "id",
           "required": false,
           "type": {
@@ -21157,6 +21357,7 @@
           "deprecation": {
             "version": "7.0.0"
           },
+          "description": "The scroll ID",
           "name": "scroll_id",
           "required": false,
           "type": {
@@ -21187,6 +21388,7 @@
           "deprecation": {
             "version": "7.0.0"
           },
+          "description": "The scroll ID for scrolled search",
           "name": "scroll_id",
           "required": false,
           "type": {
@@ -21805,6 +22007,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -21816,6 +22019,7 @@
           }
         },
         {
+          "description": "A comma-separated list of document types to search; leave empty to perform the operation on all types",
           "name": "type",
           "required": false,
           "type": {
@@ -21829,6 +22033,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -21840,6 +22045,7 @@
           }
         },
         {
+          "description": "Indicate if an error should be returned if there is a partial search failure or timeout",
           "name": "allow_partial_search_results",
           "required": false,
           "type": {
@@ -21851,6 +22057,7 @@
           }
         },
         {
+          "description": "The analyzer to use for the query string",
           "name": "analyzer",
           "required": false,
           "type": {
@@ -21862,6 +22069,7 @@
           }
         },
         {
+          "description": "Specify whether wildcard and prefix queries should be analyzed (default: false)",
           "name": "analyze_wildcard",
           "required": false,
           "type": {
@@ -21873,6 +22081,7 @@
           }
         },
         {
+          "description": "The number of shard results that should be reduced at once on the coordinating node. This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.",
           "name": "batched_reduce_size",
           "required": false,
           "type": {
@@ -21884,6 +22093,7 @@
           }
         },
         {
+          "description": "Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution",
           "name": "ccs_minimize_roundtrips",
           "required": false,
           "type": {
@@ -21895,6 +22105,7 @@
           }
         },
         {
+          "description": "The default operator for query string query (AND or OR)",
           "name": "default_operator",
           "required": false,
           "type": {
@@ -21906,6 +22117,7 @@
           }
         },
         {
+          "description": "The field to use as default where no field prefix is given in the query string",
           "name": "df",
           "required": false,
           "type": {
@@ -21917,6 +22129,7 @@
           }
         },
         {
+          "description": "A comma-separated list of fields to return as the docvalue representation of a field for each hit",
           "name": "docvalue_fields",
           "required": false,
           "type": {
@@ -21928,6 +22141,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -21939,6 +22153,7 @@
           }
         },
         {
+          "description": "Specify whether to return detailed information about score computation as part of a hit",
           "name": "explain",
           "required": false,
           "type": {
@@ -21950,6 +22165,7 @@
           }
         },
         {
+          "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled",
           "name": "ignore_throttled",
           "required": false,
           "type": {
@@ -21961,6 +22177,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -21972,6 +22189,7 @@
           }
         },
         {
+          "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored",
           "name": "lenient",
           "required": false,
           "type": {
@@ -21983,6 +22201,7 @@
           }
         },
         {
+          "description": "The number of concurrent shard requests per node this search executes concurrently. This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests",
           "name": "max_concurrent_shard_requests",
           "required": false,
           "type": {
@@ -21994,6 +22213,7 @@
           }
         },
         {
+          "description": "The minimum compatible version that all shards involved in search should have for this request to be successful",
           "name": "min_compatible_shard_node",
           "required": false,
           "type": {
@@ -22005,6 +22225,7 @@
           }
         },
         {
+          "description": "Specify the node or shard the operation should be performed on (default: random)",
           "name": "preference",
           "required": false,
           "type": {
@@ -22016,6 +22237,7 @@
           }
         },
         {
+          "description": "A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method ie. if date filters are mandatory to match but the shard bounds and the query are disjoint.",
           "name": "pre_filter_shard_size",
           "required": false,
           "type": {
@@ -22027,6 +22249,7 @@
           }
         },
         {
+          "description": "Specify if request cache should be used for this request or not, defaults to index level setting",
           "name": "request_cache",
           "required": false,
           "type": {
@@ -22038,6 +22261,7 @@
           }
         },
         {
+          "description": "A comma-separated list of specific routing values",
           "name": "routing",
           "required": false,
           "type": {
@@ -22049,6 +22273,7 @@
           }
         },
         {
+          "description": "Specify how long a consistent view of the index should be maintained for scrolled search",
           "name": "scroll",
           "required": false,
           "type": {
@@ -22060,6 +22285,7 @@
           }
         },
         {
+          "description": "Search operation type",
           "name": "search_type",
           "required": false,
           "type": {
@@ -22071,6 +22297,7 @@
           }
         },
         {
+          "description": "Specific 'tag' of the request for logging and statistical purposes",
           "name": "stats",
           "required": false,
           "type": {
@@ -22085,6 +22312,7 @@
           }
         },
         {
+          "description": "A comma-separated list of stored fields to return as part of a hit",
           "name": "stored_fields",
           "required": false,
           "type": {
@@ -22108,6 +22336,7 @@
           }
         },
         {
+          "description": "Specify suggest mode",
           "name": "suggest_mode",
           "required": false,
           "type": {
@@ -22119,6 +22348,7 @@
           }
         },
         {
+          "description": "How many suggestions to return in response",
           "name": "suggest_size",
           "required": false,
           "type": {
@@ -22142,6 +22372,7 @@
           }
         },
         {
+          "description": "The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.",
           "name": "terminate_after",
           "required": false,
           "type": {
@@ -22153,6 +22384,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -22164,6 +22396,7 @@
           }
         },
         {
+          "description": "Indicate if the number of documents that match the query should be tracked",
           "name": "track_total_hits",
           "required": false,
           "type": {
@@ -22187,6 +22420,7 @@
           }
         },
         {
+          "description": "Whether to calculate and return scores even if they are not used for sorting",
           "name": "track_scores",
           "required": false,
           "type": {
@@ -22198,6 +22432,7 @@
           }
         },
         {
+          "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response",
           "name": "typed_keys",
           "required": false,
           "type": {
@@ -22209,6 +22444,7 @@
           }
         },
         {
+          "description": "Indicates whether hits.total should be rendered as an integer or an object in the rest search response",
           "name": "rest_total_hits_as_int",
           "required": false,
           "type": {
@@ -22220,6 +22456,7 @@
           }
         },
         {
+          "description": "Specify whether to return document version as part of a hit",
           "name": "version",
           "required": false,
           "type": {
@@ -22231,6 +22468,7 @@
           }
         },
         {
+          "description": "True or false to return the _source field or not, or a list of fields to return",
           "name": "_source",
           "required": false,
           "type": {
@@ -22254,6 +22492,7 @@
           }
         },
         {
+          "description": "A list of fields to exclude from the returned _source field",
           "name": "_source_excludes",
           "required": false,
           "type": {
@@ -22265,6 +22504,7 @@
           }
         },
         {
+          "description": "A list of fields to extract and return from the _source field",
           "name": "_source_includes",
           "required": false,
           "type": {
@@ -22276,6 +22516,7 @@
           }
         },
         {
+          "description": "Specify whether to return sequence number and primary term of the last modification of each hit",
           "name": "seq_no_primary_term",
           "required": false,
           "type": {
@@ -22287,6 +22528,7 @@
           }
         },
         {
+          "description": "Query in the Lucene query string syntax",
           "name": "q",
           "required": false,
           "type": {
@@ -22298,6 +22540,7 @@
           }
         },
         {
+          "description": "Number of hits to return (default: 10)",
           "name": "size",
           "required": false,
           "type": {
@@ -22309,6 +22552,7 @@
           }
         },
         {
+          "description": "Starting offset (default: 0)",
           "name": "from",
           "required": false,
           "type": {
@@ -22320,6 +22564,7 @@
           }
         },
         {
+          "description": "A comma-separated list of <field>:<direction> pairs",
           "name": "sort",
           "required": false,
           "type": {
@@ -26935,6 +27180,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -26948,6 +27194,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -26959,6 +27206,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -26970,6 +27218,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -26981,6 +27230,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -26992,6 +27242,7 @@
           }
         },
         {
+          "description": "Specify the node or shard the operation should be performed on (default: random)",
           "name": "preference",
           "required": false,
           "type": {
@@ -27003,6 +27254,7 @@
           }
         },
         {
+          "description": "Specific routing value",
           "name": "routing",
           "required": false,
           "type": {
@@ -27184,6 +27436,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -27195,6 +27448,7 @@
           }
         },
         {
+          "description": "A comma-separated list of document types to search; leave empty to perform the operation on all types",
           "name": "type",
           "required": false,
           "type": {
@@ -27208,6 +27462,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "serverDefault": true,
@@ -27220,6 +27475,7 @@
           }
         },
         {
+          "description": "Indicates whether network round-trips should be minimized as part of cross-cluster search requests execution",
           "name": "ccs_minimize_roundtrips",
           "required": false,
           "serverDefault": false,
@@ -27232,6 +27488,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -27255,6 +27512,7 @@
           }
         },
         {
+          "description": "Whether specified concrete, expanded or aliased indices should be ignored when throttled",
           "name": "ignore_throttled",
           "required": false,
           "serverDefault": true,
@@ -27267,6 +27525,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "serverDefault": false,
@@ -27279,6 +27538,7 @@
           }
         },
         {
+          "description": "Specify the node or shard the operation should be performed on (default: random)",
           "name": "preference",
           "required": false,
           "type": {
@@ -27290,6 +27550,7 @@
           }
         },
         {
+          "description": "Specify whether to profile the query execution",
           "name": "profile",
           "required": false,
           "serverDefault": false,
@@ -27302,6 +27563,7 @@
           }
         },
         {
+          "description": "A comma-separated list of specific routing values",
           "name": "routing",
           "required": false,
           "type": {
@@ -27313,6 +27575,7 @@
           }
         },
         {
+          "description": "Specify how long a consistent view of the index should be maintained for scrolled search",
           "name": "scroll",
           "required": false,
           "type": {
@@ -27324,6 +27587,7 @@
           }
         },
         {
+          "description": "Search operation type",
           "name": "search_type",
           "required": false,
           "type": {
@@ -27349,6 +27613,7 @@
           }
         },
         {
+          "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response",
           "name": "typed_keys",
           "required": false,
           "serverDefault": false,
@@ -27804,6 +28069,7 @@
       },
       "path": [
         {
+          "description": "The index in which the document resides.",
           "name": "index",
           "required": true,
           "type": {
@@ -27815,6 +28081,7 @@
           }
         },
         {
+          "description": "The id of the document, when not specified a doc param should be supplied.",
           "name": "id",
           "required": false,
           "type": {
@@ -27826,6 +28093,7 @@
           }
         },
         {
+          "description": "The type of the document.",
           "name": "type",
           "required": false,
           "type": {
@@ -27839,6 +28107,7 @@
       ],
       "query": [
         {
+          "description": "A comma-separated list of fields to return.",
           "name": "fields",
           "required": false,
           "type": {
@@ -27850,6 +28119,7 @@
           }
         },
         {
+          "description": "Specifies if document count, sum of document frequencies and sum of total term frequencies should be returned.",
           "name": "field_statistics",
           "required": false,
           "type": {
@@ -27861,6 +28131,7 @@
           }
         },
         {
+          "description": "Specifies if term offsets should be returned.",
           "name": "offsets",
           "required": false,
           "type": {
@@ -27872,6 +28143,7 @@
           }
         },
         {
+          "description": "Specifies if term payloads should be returned.",
           "name": "payloads",
           "required": false,
           "type": {
@@ -27883,6 +28155,7 @@
           }
         },
         {
+          "description": "Specifies if term positions should be returned.",
           "name": "positions",
           "required": false,
           "type": {
@@ -27894,6 +28167,7 @@
           }
         },
         {
+          "description": "Specify the node or shard the operation should be performed on (default: random).",
           "name": "preference",
           "required": false,
           "type": {
@@ -27905,6 +28179,7 @@
           }
         },
         {
+          "description": "Specifies if request is real-time as opposed to near-real-time (default: true).",
           "name": "realtime",
           "required": false,
           "type": {
@@ -27916,6 +28191,7 @@
           }
         },
         {
+          "description": "Specific routing value.",
           "name": "routing",
           "required": false,
           "type": {
@@ -27927,6 +28203,7 @@
           }
         },
         {
+          "description": "Specifies if total term frequency and document frequency should be returned.",
           "name": "term_statistics",
           "required": false,
           "type": {
@@ -27938,6 +28215,7 @@
           }
         },
         {
+          "description": "Explicit version number for concurrency control",
           "name": "version",
           "required": false,
           "type": {
@@ -27949,6 +28227,7 @@
           }
         },
         {
+          "description": "Specific version type",
           "name": "version_type",
           "required": false,
           "type": {
@@ -28355,6 +28634,7 @@
       },
       "path": [
         {
+          "description": "Document ID",
           "name": "id",
           "required": true,
           "type": {
@@ -28366,6 +28646,7 @@
           }
         },
         {
+          "description": "The name of the index",
           "name": "index",
           "required": true,
           "type": {
@@ -28377,6 +28658,7 @@
           }
         },
         {
+          "description": "The type of the document",
           "name": "type",
           "required": false,
           "type": {
@@ -28675,6 +28957,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": true,
           "type": {
@@ -28686,6 +28969,7 @@
           }
         },
         {
+          "description": "A comma-separated list of document types to search; leave empty to perform the operation on all types",
           "name": "type",
           "required": false,
           "type": {
@@ -28699,6 +28983,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -28710,6 +28995,7 @@
           }
         },
         {
+          "description": "The analyzer to use for the query string",
           "name": "analyzer",
           "required": false,
           "type": {
@@ -28721,6 +29007,7 @@
           }
         },
         {
+          "description": "Specify whether wildcard and prefix queries should be analyzed (default: false)",
           "name": "analyze_wildcard",
           "required": false,
           "type": {
@@ -28732,6 +29019,7 @@
           }
         },
         {
+          "description": "What to do when the update by query hits version conflicts?",
           "name": "conflicts",
           "required": false,
           "type": {
@@ -28743,6 +29031,7 @@
           }
         },
         {
+          "description": "The default operator for query string query (AND or OR)",
           "name": "default_operator",
           "required": false,
           "type": {
@@ -28754,6 +29043,7 @@
           }
         },
         {
+          "description": "The field to use as default where no field prefix is given in the query string",
           "name": "df",
           "required": false,
           "type": {
@@ -28765,6 +29055,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -28776,6 +29067,7 @@
           }
         },
         {
+          "description": "Starting offset (default: 0)",
           "name": "from",
           "required": false,
           "type": {
@@ -28787,6 +29079,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -28798,6 +29091,7 @@
           }
         },
         {
+          "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored",
           "name": "lenient",
           "required": false,
           "type": {
@@ -28809,6 +29103,7 @@
           }
         },
         {
+          "description": "Ingest pipeline to set on index requests made by this action. (default: none)",
           "name": "pipeline",
           "required": false,
           "type": {
@@ -28820,6 +29115,7 @@
           }
         },
         {
+          "description": "Specify the node or shard the operation should be performed on (default: random)",
           "name": "preference",
           "required": false,
           "type": {
@@ -28842,6 +29138,7 @@
           }
         },
         {
+          "description": "Should the affected indexes be refreshed?",
           "name": "refresh",
           "required": false,
           "type": {
@@ -28853,6 +29150,7 @@
           }
         },
         {
+          "description": "Specify if request cache should be used for this request or not, defaults to index level setting",
           "name": "request_cache",
           "required": false,
           "type": {
@@ -28864,6 +29162,7 @@
           }
         },
         {
+          "description": "The throttle to set on this request in sub-requests per second. -1 means no throttle.",
           "name": "requests_per_second",
           "required": false,
           "type": {
@@ -28875,6 +29174,7 @@
           }
         },
         {
+          "description": "A comma-separated list of specific routing values",
           "name": "routing",
           "required": false,
           "type": {
@@ -28886,6 +29186,7 @@
           }
         },
         {
+          "description": "Specify how long a consistent view of the index should be maintained for scrolled search",
           "name": "scroll",
           "required": false,
           "type": {
@@ -28897,6 +29198,7 @@
           }
         },
         {
+          "description": "Size on the scroll request powering the update by query",
           "name": "scroll_size",
           "required": false,
           "type": {
@@ -28908,6 +29210,7 @@
           }
         },
         {
+          "description": "Explicit timeout for each search request. Defaults to no timeout.",
           "name": "search_timeout",
           "required": false,
           "type": {
@@ -28919,6 +29222,7 @@
           }
         },
         {
+          "description": "Search operation type",
           "name": "search_type",
           "required": false,
           "type": {
@@ -28930,6 +29234,7 @@
           }
         },
         {
+          "description": "Deprecated, please use `max_docs` instead",
           "name": "size",
           "required": false,
           "type": {
@@ -28941,6 +29246,7 @@
           }
         },
         {
+          "description": "The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`.",
           "name": "slices",
           "required": false,
           "type": {
@@ -28952,6 +29258,7 @@
           }
         },
         {
+          "description": "A comma-separated list of <field>:<direction> pairs",
           "name": "sort",
           "required": false,
           "type": {
@@ -28966,6 +29273,7 @@
           }
         },
         {
+          "description": "True or false to return the _source field or not, or a list of fields to return",
           "name": "_source",
           "required": false,
           "type": {
@@ -28989,6 +29297,7 @@
           }
         },
         {
+          "description": "A list of fields to exclude from the returned _source field",
           "name": "_source_excludes",
           "required": false,
           "type": {
@@ -29000,6 +29309,7 @@
           }
         },
         {
+          "description": "A list of fields to extract and return from the _source field",
           "name": "_source_includes",
           "required": false,
           "type": {
@@ -29011,6 +29321,7 @@
           }
         },
         {
+          "description": "Specific 'tag' of the request for logging and statistical purposes",
           "name": "stats",
           "required": false,
           "type": {
@@ -29025,6 +29336,7 @@
           }
         },
         {
+          "description": "The maximum number of documents to collect for each shard, upon reaching which the query execution will terminate early.",
           "name": "terminate_after",
           "required": false,
           "type": {
@@ -29036,6 +29348,7 @@
           }
         },
         {
+          "description": "Time each individual bulk request should wait for shards that are unavailable.",
           "name": "timeout",
           "required": false,
           "type": {
@@ -29047,6 +29360,7 @@
           }
         },
         {
+          "description": "Specify whether to return document version as part of a hit",
           "name": "version",
           "required": false,
           "type": {
@@ -29058,6 +29372,7 @@
           }
         },
         {
+          "description": "Should the document increment the version number (internal) on hit or not (reindex)",
           "name": "version_type",
           "required": false,
           "type": {
@@ -29069,6 +29384,7 @@
           }
         },
         {
+          "description": "Sets the number of shard copies that must be active before proceeding with the update by query operation. Defaults to 1, meaning the primary shard only. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -29080,6 +29396,7 @@
           }
         },
         {
+          "description": "Should the request should block until the update by query operation is complete.",
           "name": "wait_for_completion",
           "required": false,
           "type": {
@@ -29281,6 +29598,7 @@
       },
       "path": [
         {
+          "description": "The task id to rethrottle",
           "name": "task_id",
           "required": true,
           "type": {
@@ -29294,6 +29612,7 @@
       ],
       "query": [
         {
+          "description": "The throttle to set on this request in floating sub-requests per second. -1 means set no throttle.",
           "name": "requests_per_second",
           "required": false,
           "type": {
@@ -57811,6 +58130,7 @@
       },
       "path": [
         {
+          "description": "The async search ID",
           "name": "id",
           "required": true,
           "type": {
@@ -57861,6 +58181,7 @@
       },
       "path": [
         {
+          "description": "The async search ID",
           "name": "id",
           "required": true,
           "type": {
@@ -57874,6 +58195,7 @@
       ],
       "query": [
         {
+          "description": "Specify the time interval in which the results (partial or final) for this search will be available",
           "name": "keep_alive",
           "required": false,
           "type": {
@@ -57885,6 +58207,7 @@
           }
         },
         {
+          "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response",
           "name": "typed_keys",
           "required": false,
           "type": {
@@ -57896,6 +58219,7 @@
           }
         },
         {
+          "description": "Specify the time that the request should block waiting for the final response",
           "name": "wait_for_completion_timeout",
           "required": false,
           "type": {
@@ -57960,6 +58284,7 @@
       },
       "path": [
         {
+          "description": "The async search ID",
           "name": "id",
           "required": true,
           "type": {
@@ -58704,6 +59029,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -58717,6 +59043,7 @@
       ],
       "query": [
         {
+          "description": "The number of shard results that should be reduced at once on the coordinating node. This value should be used as the granularity at which progress results will be made available.",
           "name": "batched_reduce_size",
           "required": false,
           "type": {
@@ -58728,6 +59055,7 @@
           }
         },
         {
+          "description": "Specify the time that the request should block waiting for the final response",
           "name": "wait_for_completion_timeout",
           "required": false,
           "type": {
@@ -58739,6 +59067,7 @@
           }
         },
         {
+          "description": "Control whether the response should be stored in the cluster if it completed within the provided [wait_for_completion] time (default: false)",
           "name": "keep_on_completion",
           "required": false,
           "type": {
@@ -58750,6 +59079,7 @@
           }
         },
         {
+          "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response",
           "name": "typed_keys",
           "required": false,
           "type": {
@@ -58856,6 +59186,7 @@
       },
       "path": [
         {
+          "description": "the name of the autoscaling policy",
           "name": "name",
           "required": true,
           "type": {
@@ -59148,6 +59479,7 @@
       },
       "path": [
         {
+          "description": "the name of the autoscaling policy",
           "name": "name",
           "required": true,
           "type": {
@@ -59205,6 +59537,7 @@
       },
       "path": [
         {
+          "description": "the name of the autoscaling policy",
           "name": "name",
           "required": true,
           "type": {
@@ -59386,6 +59719,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of alias names to return",
           "name": "name",
           "required": false,
           "type": {
@@ -59399,6 +59733,7 @@
       ],
       "query": [
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -59598,6 +59933,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of node IDs or names to limit the returned information",
           "name": "node_id",
           "required": false,
           "type": {
@@ -59611,6 +59947,7 @@
       ],
       "query": [
         {
+          "description": "The unit in which to display byte values",
           "name": "bytes",
           "required": false,
           "type": {
@@ -59723,6 +60060,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to limit the returned information",
           "name": "index",
           "required": false,
           "type": {
@@ -59867,6 +60205,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of fields to return the fielddata size",
           "name": "fields",
           "required": false,
           "type": {
@@ -59880,6 +60219,7 @@
       ],
       "query": [
         {
+          "description": "The unit in which to display byte values",
           "name": "bytes",
           "required": false,
           "type": {
@@ -60182,6 +60522,7 @@
           }
         },
         {
+          "description": "Set to false to disable timestamping",
           "name": "ts",
           "required": false,
           "type": {
@@ -62296,6 +62637,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to limit the returned information",
           "name": "index",
           "required": false,
           "type": {
@@ -62309,6 +62651,7 @@
       ],
       "query": [
         {
+          "description": "The unit in which to display byte values",
           "name": "bytes",
           "required": false,
           "type": {
@@ -62320,6 +62663,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -62331,6 +62675,7 @@
           }
         },
         {
+          "description": "A health status (\"green\", \"yellow\", or \"red\" to filter only indices matching the specified health status",
           "name": "health",
           "required": false,
           "type": {
@@ -62342,6 +62687,7 @@
           }
         },
         {
+          "description": "If set to true segment stats will include stats for segments that are not currently loaded into memory",
           "name": "include_unloaded_segments",
           "required": false,
           "type": {
@@ -62353,6 +62699,7 @@
           }
         },
         {
+          "description": "Set to true to return stats only for primary shards",
           "name": "pri",
           "required": false,
           "type": {
@@ -62767,6 +63114,7 @@
       },
       "path": [
         {
+          "description": "The ID of the data frame analytics to fetch",
           "name": "id",
           "required": false,
           "type": {
@@ -62780,6 +63128,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no configs. (This includes `_all` string or when no configs have been specified)",
           "name": "allow_no_match",
           "required": false,
           "type": {
@@ -62791,6 +63140,7 @@
           }
         },
         {
+          "description": "The unit in which to display byte values",
           "name": "bytes",
           "required": false,
           "type": {
@@ -63039,6 +63389,7 @@
       },
       "path": [
         {
+          "description": "The ID of the datafeeds stats to fetch",
           "name": "datafeed_id",
           "required": false,
           "type": {
@@ -63052,6 +63403,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
           "name": "allow_no_datafeeds",
           "required": false,
           "type": {
@@ -64066,6 +64418,7 @@
       },
       "path": [
         {
+          "description": "The ID of the jobs stats to fetch",
           "name": "job_id",
           "required": false,
           "type": {
@@ -64079,6 +64432,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
           "name": "allow_no_jobs",
           "required": false,
           "type": {
@@ -64090,6 +64444,7 @@
           }
         },
         {
+          "description": "The unit in which to display byte values",
           "name": "bytes",
           "required": false,
           "type": {
@@ -64143,6 +64498,7 @@
       },
       "path": [
         {
+          "description": "The ID of the trained models stats to fetch",
           "name": "model_id",
           "required": false,
           "type": {
@@ -64156,6 +64512,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no trained models. (This includes `_all` string or when no trained models have been specified)",
           "name": "allow_no_match",
           "required": false,
           "type": {
@@ -64167,6 +64524,7 @@
           }
         },
         {
+          "description": "The unit in which to display byte values",
           "name": "bytes",
           "required": false,
           "type": {
@@ -64178,6 +64536,7 @@
           }
         },
         {
+          "description": "skips a number of trained models",
           "name": "from",
           "required": false,
           "type": {
@@ -64189,6 +64548,7 @@
           }
         },
         {
+          "description": "specifies a max number of trained models to get",
           "name": "size",
           "required": false,
           "type": {
@@ -66195,6 +66555,7 @@
       "path": [],
       "query": [
         {
+          "description": "The unit in which to display byte values",
           "name": "bytes",
           "required": false,
           "type": {
@@ -66206,6 +66567,7 @@
           }
         },
         {
+          "description": "Return the full node ID instead of the shortened version (default: false)",
           "name": "full_id",
           "required": false,
           "type": {
@@ -66922,6 +67284,7 @@
       },
       "path": [
         {
+          "description": "Comma-separated list or wildcard expression of index names to limit the returned information",
           "name": "index",
           "required": false,
           "type": {
@@ -66935,6 +67298,7 @@
       ],
       "query": [
         {
+          "description": "If `true`, the response only includes ongoing shard recoveries",
           "name": "active_only",
           "required": false,
           "type": {
@@ -66946,6 +67310,7 @@
           }
         },
         {
+          "description": "The unit in which to display byte values",
           "name": "bytes",
           "required": false,
           "type": {
@@ -66957,6 +67322,7 @@
           }
         },
         {
+          "description": "If `true`, the response includes detailed information about shard recoveries",
           "name": "detailed",
           "required": false,
           "type": {
@@ -67091,6 +67457,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to limit the returned information",
           "name": "index",
           "required": false,
           "type": {
@@ -67104,6 +67471,7 @@
       ],
       "query": [
         {
+          "description": "The unit in which to display byte values",
           "name": "bytes",
           "required": false,
           "type": {
@@ -67396,6 +67764,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to limit the returned information",
           "name": "index",
           "required": false,
           "type": {
@@ -67409,6 +67778,7 @@
       ],
       "query": [
         {
+          "description": "The unit in which to display byte values",
           "name": "bytes",
           "required": false,
           "type": {
@@ -68660,6 +69030,7 @@
       },
       "path": [
         {
+          "description": "Name of repository from which to fetch the snapshot information",
           "name": "repository",
           "required": false,
           "type": {
@@ -68673,6 +69044,7 @@
       ],
       "query": [
         {
+          "description": "Set to true to ignore unavailable snapshots",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -68936,6 +69308,7 @@
       "path": [],
       "query": [
         {
+          "description": "A comma-separated list of actions that should be returned. Leave empty to return all.",
           "name": "actions",
           "required": false,
           "type": {
@@ -68950,6 +69323,7 @@
           }
         },
         {
+          "description": "Return detailed task information (default: false)",
           "name": "detailed",
           "required": false,
           "type": {
@@ -69273,6 +69647,7 @@
       },
       "path": [
         {
+          "description": "A pattern that returned template names must match",
           "name": "name",
           "required": false,
           "type": {
@@ -69412,6 +69787,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of regular-expressions to filter the thread pools in the output",
           "name": "thread_pool_patterns",
           "required": false,
           "type": {
@@ -69425,6 +69801,7 @@
       ],
       "query": [
         {
+          "description": "The multiplier in which to display values",
           "name": "size",
           "required": false,
           "type": {
@@ -69799,6 +70176,7 @@
       },
       "path": [
         {
+          "description": "The id of the transform for which to get stats. '_all' or '*' implies all transforms",
           "name": "transform_id",
           "required": false,
           "type": {
@@ -69812,6 +70190,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)",
           "name": "allow_no_match",
           "required": false,
           "type": {
@@ -69823,6 +70202,7 @@
           }
         },
         {
+          "description": "skips a number of transform configs, defaults to 0",
           "name": "from",
           "required": false,
           "type": {
@@ -69834,6 +70214,7 @@
           }
         },
         {
+          "description": "specifies a max number of transforms to get, defaults to 100",
           "name": "size",
           "required": false,
           "type": {
@@ -70801,6 +71182,7 @@
       },
       "path": [
         {
+          "description": "The name of the auto follow pattern.",
           "name": "name",
           "required": true,
           "type": {
@@ -70985,6 +71367,7 @@
       },
       "path": [
         {
+          "description": "The name of the follower index",
           "name": "index",
           "required": true,
           "type": {
@@ -70998,6 +71381,7 @@
       ],
       "query": [
         {
+          "description": "Sets the number of shard copies that must be active before returning. Defaults to 0. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -71273,6 +71657,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index patterns; use `_all` to perform the operation on all indices",
           "name": "index",
           "required": true,
           "type": {
@@ -71332,6 +71717,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index patterns; use `_all` to perform the operation on all indices",
           "name": "index",
           "required": true,
           "type": {
@@ -71437,6 +71823,7 @@
       },
       "path": [
         {
+          "description": "the name of the leader index for which specified follower retention leases should be removed",
           "name": "index",
           "required": true,
           "type": {
@@ -71648,6 +72035,7 @@
       },
       "path": [
         {
+          "description": "The name of the auto follow pattern that should pause discovering new indices to follow.",
           "name": "name",
           "required": true,
           "type": {
@@ -71698,6 +72086,7 @@
       },
       "path": [
         {
+          "description": "The name of the follower index that should pause following its leader index.",
           "name": "index",
           "required": true,
           "type": {
@@ -71921,6 +72310,7 @@
       },
       "path": [
         {
+          "description": "The name of the auto follow pattern.",
           "name": "name",
           "required": true,
           "type": {
@@ -71971,6 +72361,7 @@
       },
       "path": [
         {
+          "description": "The name of the auto follow pattern to resume discovering new indices to follow.",
           "name": "name",
           "required": true,
           "type": {
@@ -72133,6 +72524,7 @@
       },
       "path": [
         {
+          "description": "The name of the follow index to resume following.",
           "name": "index",
           "required": true,
           "type": {
@@ -72373,6 +72765,7 @@
       },
       "path": [
         {
+          "description": "The name of the follower index that should be turned into a regular index.",
           "name": "index",
           "required": true,
           "type": {
@@ -74730,6 +75123,7 @@
       },
       "path": [
         {
+          "description": "The name of the template",
           "name": "name",
           "required": true,
           "type": {
@@ -74743,6 +75137,7 @@
       ],
       "query": [
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "serverDefault": "30s",
@@ -74755,6 +75150,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "serverDefault": "30s",
@@ -74921,6 +75317,7 @@
       },
       "path": [
         {
+          "description": "The comma separated names of the component templates",
           "name": "name",
           "required": false,
           "type": {
@@ -74946,6 +75343,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "serverDefault": false,
@@ -74958,6 +75356,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "serverDefault": "30s",
@@ -75018,6 +75417,7 @@
       "path": [],
       "query": [
         {
+          "description": "Return settings in flat format (default: false)",
           "name": "flat_settings",
           "required": false,
           "type": {
@@ -75029,6 +75429,7 @@
           }
         },
         {
+          "description": "Whether to return all default clusters setting.",
           "name": "include_defaults",
           "required": false,
           "type": {
@@ -75040,6 +75441,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -75051,6 +75453,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -75282,6 +75685,7 @@
       ],
       "query": [
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -75793,6 +76197,7 @@
       "path": [],
       "query": [
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -75804,6 +76209,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "serverDefault": "30s",
@@ -76012,6 +76418,7 @@
       },
       "path": [
         {
+          "description": "The name of the template",
           "name": "name",
           "required": true,
           "type": {
@@ -76025,6 +76432,7 @@
       ],
       "query": [
         {
+          "description": "Whether the index template should only be added if new or can also replace an existing one",
           "name": "create",
           "required": false,
           "serverDefault": false,
@@ -76037,6 +76445,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "serverDefault": "30s",
@@ -76126,6 +76535,7 @@
       "path": [],
       "query": [
         {
+          "description": "Return settings in flat format (default: false)",
           "name": "flat_settings",
           "required": false,
           "type": {
@@ -76137,6 +76547,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "serverDefault": "30s",
@@ -76149,6 +76560,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "serverDefault": "30s",
@@ -77318,6 +77730,7 @@
       },
       "path": [
         {
+          "description": "Limit the information returned to the specified metrics",
           "name": "metric",
           "required": false,
           "type": {
@@ -77329,6 +77742,7 @@
           }
         },
         {
+          "description": "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -77342,6 +77756,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "serverDefault": true,
@@ -77354,6 +77769,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -77365,6 +77781,7 @@
           }
         },
         {
+          "description": "Return settings in flat format (default: false)",
           "name": "flat_settings",
           "required": false,
           "serverDefault": false,
@@ -77377,6 +77794,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "serverDefault": false,
@@ -77389,6 +77807,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "serverDefault": false,
@@ -77401,6 +77820,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "serverDefault": "30s",
@@ -77413,6 +77833,7 @@
           }
         },
         {
+          "description": "Wait for the metadata version to be equal or greater than the specified metadata version",
           "name": "wait_for_metadata_version",
           "required": false,
           "type": {
@@ -77424,6 +77845,7 @@
           }
         },
         {
+          "description": "The maximum time to wait for wait_for_metadata_version before timing out",
           "name": "wait_for_timeout",
           "required": false,
           "type": {
@@ -79239,6 +79661,7 @@
       ],
       "query": [
         {
+          "description": "Return settings in flat format (default: false)",
           "name": "flat_settings",
           "required": false,
           "type": {
@@ -79542,6 +79965,7 @@
       },
       "path": [
         {
+          "description": "The UUID of the dangling index",
           "name": "index_uuid",
           "required": true,
           "type": {
@@ -79555,6 +79979,7 @@
       ],
       "query": [
         {
+          "description": "Must be set to true in order to delete the dangling index",
           "name": "accept_data_loss",
           "required": true,
           "type": {
@@ -79566,6 +79991,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -79577,6 +80003,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -79626,6 +80053,7 @@
       },
       "path": [
         {
+          "description": "The UUID of the dangling index",
           "name": "index_uuid",
           "required": true,
           "type": {
@@ -79639,6 +80067,7 @@
       ],
       "query": [
         {
+          "description": "Must be set to true in order to import the dangling index",
           "name": "accept_data_loss",
           "required": true,
           "type": {
@@ -79650,6 +80079,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -79661,6 +80091,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -79925,6 +80356,7 @@
       },
       "path": [
         {
+          "description": "The name of the enrich policy",
           "name": "name",
           "required": true,
           "type": {
@@ -80016,6 +80448,7 @@
       },
       "path": [
         {
+          "description": "The name of the enrich policy",
           "name": "name",
           "required": true,
           "type": {
@@ -80029,6 +80462,7 @@
       ],
       "query": [
         {
+          "description": "Should the request should block until the execution is complete.",
           "name": "wait_for_completion",
           "required": false,
           "type": {
@@ -80095,6 +80529,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of enrich policy names",
           "name": "name",
           "required": false,
           "type": {
@@ -80178,6 +80613,7 @@
       },
       "path": [
         {
+          "description": "The name of the enrich policy",
           "name": "name",
           "required": true,
           "type": {
@@ -81141,6 +81577,7 @@
       },
       "path": [
         {
+          "description": "The name of the index to scope the operation",
           "name": "index",
           "required": true,
           "type": {
@@ -81853,6 +82290,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": true,
           "type": {
@@ -81864,6 +82302,7 @@
           }
         },
         {
+          "description": "A comma-separated list of document types to search; leave empty to perform the operation on all types",
           "name": "type",
           "required": false,
           "type": {
@@ -81877,6 +82316,7 @@
       ],
       "query": [
         {
+          "description": "Specific routing value",
           "name": "routing",
           "required": false,
           "type": {
@@ -81888,6 +82328,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -82145,6 +82586,7 @@
       },
       "path": [
         {
+          "description": "The name of the index lifecycle policy",
           "name": "policy",
           "required": true,
           "type": {
@@ -82480,6 +82922,7 @@
       },
       "path": [
         {
+          "description": "The name of the index to explain",
           "name": "index",
           "required": true,
           "type": {
@@ -82493,6 +82936,7 @@
       ],
       "query": [
         {
+          "description": "filters the indices included in the response to ones in an ILM error state, implies only_managed",
           "name": "only_errors",
           "required": false,
           "type": {
@@ -82504,6 +82948,7 @@
           }
         },
         {
+          "description": "filters the indices included in the response to ones managed by ILM",
           "name": "only_managed",
           "required": false,
           "type": {
@@ -82624,6 +83069,7 @@
       },
       "path": [
         {
+          "description": "The name of the index lifecycle policy",
           "name": "policy",
           "required": false,
           "type": {
@@ -82758,6 +83204,7 @@
       },
       "path": [
         {
+          "description": "The name of the index whose lifecycle step is to change",
           "name": "index",
           "required": true,
           "type": {
@@ -82863,6 +83310,7 @@
       },
       "path": [
         {
+          "description": "The name of the index lifecycle policy",
           "name": "policy",
           "required": true,
           "type": {
@@ -82913,6 +83361,7 @@
       },
       "path": [
         {
+          "description": "The name of the index to remove policy on",
           "name": "index",
           "required": true,
           "type": {
@@ -82983,6 +83432,7 @@
       },
       "path": [
         {
+          "description": "The name of the indices (comma-separated) whose failed lifecycle step is to be retry",
           "name": "index",
           "required": true,
           "type": {
@@ -84828,6 +85278,7 @@
       },
       "path": [
         {
+          "description": "A comma separated list of indices to add a block to",
           "name": "index",
           "required": true,
           "type": {
@@ -84839,6 +85290,7 @@
           }
         },
         {
+          "description": "The block to add (one of read, write, read_only or metadata)",
           "name": "block",
           "required": true,
           "type": {
@@ -84852,6 +85304,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -84863,6 +85316,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -84874,6 +85328,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -84885,6 +85340,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -84896,6 +85352,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -85438,6 +85895,7 @@
       },
       "path": [
         {
+          "description": "The name of the index to scope the operation",
           "name": "index",
           "required": false,
           "type": {
@@ -85571,6 +86029,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index name to limit the operation",
           "name": "index",
           "required": false,
           "type": {
@@ -85584,6 +86043,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -85595,6 +86055,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -85606,6 +86067,7 @@
           }
         },
         {
+          "description": "Clear field data",
           "name": "fielddata",
           "required": false,
           "type": {
@@ -85617,6 +86079,7 @@
           }
         },
         {
+          "description": "A comma-separated list of fields to clear when using the `fielddata` parameter (default: all)",
           "name": "fields",
           "required": false,
           "type": {
@@ -85628,6 +86091,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -85639,6 +86103,7 @@
           }
         },
         {
+          "description": "Clear query caches",
           "name": "query",
           "required": false,
           "type": {
@@ -85650,6 +86115,7 @@
           }
         },
         {
+          "description": "Clear request cache",
           "name": "request",
           "required": false,
           "type": {
@@ -85741,6 +86207,7 @@
       },
       "path": [
         {
+          "description": "The name of the source index to clone",
           "name": "index",
           "required": true,
           "type": {
@@ -85752,6 +86219,7 @@
           }
         },
         {
+          "description": "The name of the target index to clone into",
           "name": "target",
           "required": true,
           "type": {
@@ -85765,6 +86233,7 @@
       ],
       "query": [
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -85776,6 +86245,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -85787,6 +86257,7 @@
           }
         },
         {
+          "description": "Set the number of active shards to wait for on the cloned index before the operation returns.",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -85924,6 +86395,7 @@
       },
       "path": [
         {
+          "description": "A comma separated list of indices to close",
           "name": "index",
           "required": true,
           "type": {
@@ -85937,6 +86409,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -85948,6 +86421,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -85959,6 +86433,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -85970,6 +86445,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -85981,6 +86457,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -85992,6 +86469,7 @@
           }
         },
         {
+          "description": "Sets the number of active shards to wait for before the operation returns. Set to `index-setting` to wait according to the index setting `index.write.wait_for_active_shards`, or `all` to wait for all shards, or an integer. Defaults to `0`.",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -86151,6 +86629,7 @@
       },
       "path": [
         {
+          "description": "The name of the index",
           "name": "index",
           "required": true,
           "type": {
@@ -86164,6 +86643,7 @@
       ],
       "query": [
         {
+          "description": "Whether a type should be expected in the body of the mappings.",
           "name": "include_type_name",
           "required": false,
           "type": {
@@ -86175,6 +86655,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -86186,6 +86667,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -86197,6 +86679,7 @@
           }
         },
         {
+          "description": "Set the number of active shards to wait for before the operation returns.",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -86269,6 +86752,7 @@
       },
       "path": [
         {
+          "description": "The name of the data stream",
           "name": "name",
           "required": true,
           "type": {
@@ -86383,6 +86867,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of data stream names; use `_all` or empty string to perform the operation on all data streams",
           "name": "name",
           "required": false,
           "type": {
@@ -86509,6 +86994,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of indices to delete; use `_all` or `*` string to delete all indices",
           "name": "index",
           "required": true,
           "type": {
@@ -86522,6 +87008,7 @@
       ],
       "query": [
         {
+          "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -86533,6 +87020,7 @@
           }
         },
         {
+          "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -86544,6 +87032,7 @@
           }
         },
         {
+          "description": "Ignore unavailable indexes (default: false)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -86555,6 +87044,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -86566,6 +87056,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -86615,6 +87106,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names (supports wildcards); use `_all` for all indices",
           "name": "index",
           "required": true,
           "type": {
@@ -86626,6 +87118,7 @@
           }
         },
         {
+          "description": "A comma-separated list of aliases to delete (supports wildcards); use `_all` to delete all aliases for the specified indices.",
           "name": "name",
           "required": true,
           "type": {
@@ -86639,6 +87132,7 @@
       ],
       "query": [
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -86650,6 +87144,7 @@
           }
         },
         {
+          "description": "Explicit timestamp for the document",
           "name": "timeout",
           "required": false,
           "type": {
@@ -86699,6 +87194,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of data streams to delete; use `*` to delete all data streams",
           "name": "name",
           "required": true,
           "type": {
@@ -86749,6 +87245,7 @@
       },
       "path": [
         {
+          "description": "The name of the template",
           "name": "name",
           "required": true,
           "type": {
@@ -86799,6 +87296,7 @@
       },
       "path": [
         {
+          "description": "The name of the template",
           "name": "name",
           "required": true,
           "type": {
@@ -86812,6 +87310,7 @@
       ],
       "query": [
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -86823,6 +87322,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -86872,6 +87372,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names",
           "name": "index",
           "required": true,
           "type": {
@@ -86885,6 +87386,7 @@
       ],
       "query": [
         {
+          "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -86896,6 +87398,7 @@
           }
         },
         {
+          "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -86907,6 +87410,7 @@
           }
         },
         {
+          "description": "Return settings in flat format (default: false)",
           "name": "flat_settings",
           "required": false,
           "type": {
@@ -86918,6 +87422,7 @@
           }
         },
         {
+          "description": "Ignore unavailable indexes (default: false)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -86929,6 +87434,7 @@
           }
         },
         {
+          "description": "Whether to return all default setting for each of the indices.",
           "name": "include_defaults",
           "required": false,
           "type": {
@@ -86940,6 +87446,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -86982,6 +87489,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of alias names to return",
           "name": "name",
           "required": true,
           "type": {
@@ -86993,6 +87501,7 @@
           }
         },
         {
+          "description": "A comma-separated list of index names to filter aliases",
           "name": "index",
           "required": false,
           "type": {
@@ -87006,6 +87515,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -87017,6 +87527,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -87028,6 +87539,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -87039,6 +87551,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -87139,6 +87652,7 @@
       },
       "path": [
         {
+          "description": "The comma separated names of the index templates",
           "name": "name",
           "required": true,
           "type": {
@@ -87152,6 +87666,7 @@
       ],
       "query": [
         {
+          "description": "Return settings in flat format (default: false)",
           "name": "flat_settings",
           "required": false,
           "type": {
@@ -87163,6 +87678,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -87174,6 +87690,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -87216,6 +87733,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names; use `_all` to check the types across all indices",
           "name": "index",
           "required": true,
           "type": {
@@ -87227,6 +87745,7 @@
           }
         },
         {
+          "description": "A comma-separated list of document types to check",
           "name": "type",
           "required": true,
           "type": {
@@ -87240,6 +87759,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -87251,6 +87771,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -87262,6 +87783,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -87273,6 +87795,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -87315,6 +87838,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names; use `_all` or empty string for all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -87328,6 +87852,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -87339,6 +87864,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -87350,6 +87876,7 @@
           }
         },
         {
+          "description": "Whether a flush should be forced even if it is not necessarily needed ie. if no changes will be committed to the index. This is useful if transaction log IDs should be incremented even if no uncommitted changes are present. (This setting can be considered as internal)",
           "name": "force",
           "required": false,
           "type": {
@@ -87361,6 +87888,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -87372,6 +87900,7 @@
           }
         },
         {
+          "description": "If set to true the flush operation will block until the flush can be executed if another flush operation is already executing. The default is true. If set to false the flush will be skipped iff if another flush operation is already running.",
           "name": "wait_if_ongoing",
           "required": false,
           "type": {
@@ -87421,6 +87950,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names; use `_all` or empty string for all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -87434,6 +87964,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -87445,6 +87976,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -87456,6 +87988,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -87533,6 +88066,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -87546,6 +88080,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -87557,6 +88092,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -87568,6 +88104,7 @@
           }
         },
         {
+          "description": "Specify whether the index should be flushed after performing the operation (default: true)",
           "name": "flush",
           "required": false,
           "type": {
@@ -87579,6 +88116,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -87590,6 +88128,7 @@
           }
         },
         {
+          "description": "The number of segments the index should be merged into (default: dynamic)",
           "name": "max_num_segments",
           "required": false,
           "type": {
@@ -87601,6 +88140,7 @@
           }
         },
         {
+          "description": "Specify whether the operation should only expunge deleted documents",
           "name": "only_expunge_deletes",
           "required": false,
           "type": {
@@ -87650,6 +88190,7 @@
       },
       "path": [
         {
+          "description": "The name of the index to freeze",
           "name": "index",
           "required": true,
           "type": {
@@ -87663,6 +88204,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -87674,6 +88216,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -87685,6 +88228,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -87696,6 +88240,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -87707,6 +88252,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -87718,6 +88264,7 @@
           }
         },
         {
+          "description": "Sets the number of active shards to wait for before the operation returns.",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -87793,6 +88340,7 @@
       ],
       "query": [
         {
+          "description": "Ignore if a wildcard expression resolves to no concrete indices (default: false)",
           "name": "allow_no_indices",
           "required": false,
           "serverDefault": true,
@@ -87981,6 +88529,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of alias names to return",
           "name": "name",
           "required": false,
           "type": {
@@ -87992,6 +88541,7 @@
           }
         },
         {
+          "description": "A comma-separated list of index names to filter aliases",
           "name": "index",
           "required": false,
           "type": {
@@ -88005,6 +88555,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -88016,6 +88567,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -88027,6 +88579,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -88038,6 +88591,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -88278,6 +88832,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of data streams to get; use `*` to get all data streams",
           "name": "name",
           "required": false,
           "type": {
@@ -88291,6 +88846,7 @@
       ],
       "query": [
         {
+          "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -88349,6 +88905,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of fields",
           "name": "fields",
           "required": true,
           "type": {
@@ -88360,6 +88917,7 @@
           }
         },
         {
+          "description": "A comma-separated list of index names",
           "name": "index",
           "required": false,
           "type": {
@@ -88371,6 +88929,7 @@
           }
         },
         {
+          "description": "A comma-separated list of document types",
           "name": "type",
           "required": false,
           "type": {
@@ -88384,6 +88943,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -88395,6 +88955,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -88406,6 +88967,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -88417,6 +88979,7 @@
           }
         },
         {
+          "description": "Whether the default mapping values should be returned as well",
           "name": "include_defaults",
           "required": false,
           "type": {
@@ -88428,6 +88991,7 @@
           }
         },
         {
+          "description": "Whether a type should be returned in the body of the mappings.",
           "name": "include_type_name",
           "required": false,
           "type": {
@@ -88439,6 +89003,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -88883,6 +89448,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names",
           "name": "index",
           "required": false,
           "type": {
@@ -88894,6 +89460,7 @@
           }
         },
         {
+          "description": "A comma-separated list of document types",
           "name": "type",
           "required": false,
           "type": {
@@ -88907,6 +89474,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -88918,6 +89486,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -88929,6 +89498,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -88940,6 +89510,7 @@
           }
         },
         {
+          "description": "Whether to add the type name to the response (default: false)",
           "name": "include_type_name",
           "required": false,
           "type": {
@@ -88951,6 +89522,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -88962,6 +89534,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -89027,6 +89600,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -89038,6 +89612,7 @@
           }
         },
         {
+          "description": "The name of the settings that should be included",
           "name": "name",
           "required": false,
           "type": {
@@ -89051,6 +89626,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -89062,6 +89638,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -89073,6 +89650,7 @@
           }
         },
         {
+          "description": "Return settings in flat format (default: false)",
           "name": "flat_settings",
           "required": false,
           "type": {
@@ -89084,6 +89662,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -89095,6 +89674,7 @@
           }
         },
         {
+          "description": "Whether to return all default setting for each of the indices.",
           "name": "include_defaults",
           "required": false,
           "type": {
@@ -89106,6 +89686,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -89117,6 +89698,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -89182,6 +89764,7 @@
       },
       "path": [
         {
+          "description": "The comma separated names of the index templates",
           "name": "name",
           "required": false,
           "type": {
@@ -89195,6 +89778,7 @@
       ],
       "query": [
         {
+          "description": "Return settings in flat format (default: false)",
           "name": "flat_settings",
           "required": false,
           "type": {
@@ -89206,6 +89790,7 @@
           }
         },
         {
+          "description": "Whether a type should be returned in the body of the mappings.",
           "name": "include_type_name",
           "required": false,
           "type": {
@@ -89217,6 +89802,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -89228,6 +89814,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -89365,6 +89952,7 @@
       },
       "path": [
         {
+          "description": "The name of the alias to migrate",
           "name": "name",
           "required": true,
           "type": {
@@ -89415,6 +90003,7 @@
       },
       "path": [
         {
+          "description": "A comma separated list of indices to open",
           "name": "index",
           "required": true,
           "type": {
@@ -89428,6 +90017,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -89439,6 +90029,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -89450,6 +90041,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -89461,6 +90053,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -89472,6 +90065,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -89483,6 +90077,7 @@
           }
         },
         {
+          "description": "Sets the number of active shards to wait for before the operation returns.",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -89544,6 +90139,7 @@
       },
       "path": [
         {
+          "description": "The name of the data stream",
           "name": "name",
           "required": true,
           "type": {
@@ -89657,6 +90253,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names the alias should point to (supports wildcards); use `_all` to perform the operation on all indices.",
           "name": "index",
           "required": true,
           "type": {
@@ -89668,6 +90265,7 @@
           }
         },
         {
+          "description": "The name of the alias to be created or updated",
           "name": "name",
           "required": true,
           "type": {
@@ -89681,6 +90279,7 @@
       ],
       "query": [
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -89692,6 +90291,7 @@
           }
         },
         {
+          "description": "Explicit timestamp for the document",
           "name": "timeout",
           "required": false,
           "type": {
@@ -90154,6 +90754,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names the mapping should be added to (supports wildcards); use `_all` or omit to add the mapping on all indices.",
           "name": "index",
           "required": true,
           "type": {
@@ -90165,6 +90766,7 @@
           }
         },
         {
+          "description": "The name of the document type",
           "name": "type",
           "required": false,
           "type": {
@@ -90178,6 +90780,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -90189,6 +90792,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -90200,6 +90804,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -90211,6 +90816,7 @@
           }
         },
         {
+          "description": "Whether a type should be expected in the body of the mappings.",
           "name": "include_type_name",
           "required": false,
           "type": {
@@ -90222,6 +90828,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -90233,6 +90840,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -90244,6 +90852,7 @@
           }
         },
         {
+          "description": "When true, applies mappings only to the write index of an alias or data stream",
           "name": "write_index_only",
           "required": false,
           "type": {
@@ -90326,6 +90935,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -90339,6 +90949,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -90350,6 +90961,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -90361,6 +90973,7 @@
           }
         },
         {
+          "description": "Return settings in flat format (default: false)",
           "name": "flat_settings",
           "required": false,
           "type": {
@@ -90372,6 +90985,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -90383,6 +90997,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -90394,6 +91009,7 @@
           }
         },
         {
+          "description": "Whether to update existing settings. If set to `true` existing settings on an index remain unchanged, the default is `false`",
           "name": "preserve_existing",
           "required": false,
           "type": {
@@ -90405,6 +91021,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -90555,6 +91172,7 @@
       },
       "path": [
         {
+          "description": "The name of the template",
           "name": "name",
           "required": true,
           "type": {
@@ -90568,6 +91186,7 @@
       ],
       "query": [
         {
+          "description": "Whether the index template should only be added if new or can also replace an existing one",
           "name": "create",
           "required": false,
           "type": {
@@ -90590,6 +91209,7 @@
           }
         },
         {
+          "description": "Whether a type should be returned in the body of the mappings.",
           "name": "include_type_name",
           "required": false,
           "type": {
@@ -90601,6 +91221,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -91181,6 +91802,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -91194,6 +91816,7 @@
       ],
       "query": [
         {
+          "description": "Display only those recoveries that are currently on-going",
           "name": "active_only",
           "required": false,
           "type": {
@@ -91205,6 +91828,7 @@
           }
         },
         {
+          "description": "Whether to display detailed information about shard recovery",
           "name": "detailed",
           "required": false,
           "type": {
@@ -91583,6 +92207,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -91596,6 +92221,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -91607,6 +92233,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -91618,6 +92245,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -91715,6 +92343,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to reload analyzers for",
           "name": "index",
           "required": true,
           "type": {
@@ -91728,6 +92357,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -91739,6 +92369,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -91750,6 +92381,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -91819,6 +92451,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of names or wildcard expressions",
           "name": "name",
           "required": true,
           "type": {
@@ -91832,6 +92465,7 @@
       ],
       "query": [
         {
+          "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -92137,6 +92771,7 @@
       },
       "path": [
         {
+          "description": "The name of the alias to rollover",
           "name": "alias",
           "required": true,
           "type": {
@@ -92148,6 +92783,7 @@
           }
         },
         {
+          "description": "The name of the rollover index",
           "name": "new_index",
           "required": false,
           "type": {
@@ -92161,6 +92797,7 @@
       ],
       "query": [
         {
+          "description": "If set to true the rollover action will only be validated but not actually performed even if a condition matches. The default is false",
           "name": "dry_run",
           "required": false,
           "type": {
@@ -92172,6 +92809,7 @@
           }
         },
         {
+          "description": "Whether a type should be included in the body of the mappings.",
           "name": "include_type_name",
           "required": false,
           "type": {
@@ -92183,6 +92821,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -92194,6 +92833,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -92205,6 +92845,7 @@
           }
         },
         {
+          "description": "Set the number of active shards to wait for on the newly created rollover index before the operation returns.",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -92431,6 +93072,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -92444,6 +93086,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -92455,6 +93098,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -92466,6 +93110,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -92477,6 +93122,7 @@
           }
         },
         {
+          "description": "Includes detailed memory usage by Lucene.",
           "name": "verbose",
           "required": false,
           "type": {
@@ -92821,6 +93467,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -92834,6 +93481,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -92845,6 +93493,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -92856,6 +93505,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -92867,6 +93517,7 @@
           }
         },
         {
+          "description": "A comma-separated list of statuses used to filter on shards to get store information for",
           "name": "status",
           "required": false,
           "type": {
@@ -93166,6 +93817,7 @@
       },
       "path": [
         {
+          "description": "The name of the source index to shrink",
           "name": "index",
           "required": true,
           "type": {
@@ -93177,6 +93829,7 @@
           }
         },
         {
+          "description": "The name of the target index to shrink into",
           "name": "target",
           "required": true,
           "type": {
@@ -93190,6 +93843,7 @@
       ],
       "query": [
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -93201,6 +93855,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -93212,6 +93867,7 @@
           }
         },
         {
+          "description": "Set the number of active shards to wait for on the shrunken index before the operation returns.",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -93518,6 +94174,7 @@
       },
       "path": [
         {
+          "description": "The name of the source index to split",
           "name": "index",
           "required": true,
           "type": {
@@ -93529,6 +94186,7 @@
           }
         },
         {
+          "description": "The name of the target index to split into",
           "name": "target",
           "required": true,
           "type": {
@@ -93542,6 +94200,7 @@
       ],
       "query": [
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -93553,6 +94212,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -93564,6 +94224,7 @@
           }
         },
         {
+          "description": "Set the number of active shards to wait for on the shrunken index before the operation returns.",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -93915,6 +94576,7 @@
       },
       "path": [
         {
+          "description": "Limit the information returned the specific metrics.",
           "name": "metric",
           "required": false,
           "type": {
@@ -93926,6 +94588,7 @@
           }
         },
         {
+          "description": "A comma-separated list of index names; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -93939,6 +94602,7 @@
       ],
       "query": [
         {
+          "description": "A comma-separated list of fields for `fielddata` and `suggest` index metric (supports wildcards)",
           "name": "completion_fields",
           "required": false,
           "type": {
@@ -93950,6 +94614,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -93961,6 +94626,7 @@
           }
         },
         {
+          "description": "A comma-separated list of fields for `fielddata` index metric (supports wildcards)",
           "name": "fielddata_fields",
           "required": false,
           "type": {
@@ -93972,6 +94638,7 @@
           }
         },
         {
+          "description": "A comma-separated list of fields for `fielddata` and `completion` index metric (supports wildcards)",
           "name": "fields",
           "required": false,
           "type": {
@@ -93983,6 +94650,7 @@
           }
         },
         {
+          "description": "If set to false stats will also collected from closed indices if explicitly specified or if expand_wildcards expands to closed indices",
           "name": "forbid_closed_indices",
           "required": false,
           "type": {
@@ -93994,6 +94662,7 @@
           }
         },
         {
+          "description": "A comma-separated list of search groups for `search` index metric",
           "name": "groups",
           "required": false,
           "type": {
@@ -94020,6 +94689,7 @@
           }
         },
         {
+          "description": "Whether to report the aggregated disk usage of each one of the Lucene index files (only applies if segment stats are requested)",
           "name": "include_segment_file_sizes",
           "required": false,
           "type": {
@@ -94031,6 +94701,7 @@
           }
         },
         {
+          "description": "If set to true segment stats will include stats for segments that are not currently loaded into memory",
           "name": "include_unloaded_segments",
           "required": false,
           "type": {
@@ -94042,6 +94713,7 @@
           }
         },
         {
+          "description": "Return stats aggregated at cluster, index or shard level",
           "name": "level",
           "required": false,
           "type": {
@@ -94053,6 +94725,7 @@
           }
         },
         {
+          "description": "A comma-separated list of document types for the `indexing` index metric",
           "name": "types",
           "required": false,
           "type": {
@@ -94873,6 +95546,7 @@
       },
       "path": [
         {
+          "description": "The name of the index to unfreeze",
           "name": "index",
           "required": true,
           "type": {
@@ -94886,6 +95560,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -94897,6 +95572,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -94908,6 +95584,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -94919,6 +95596,7 @@
           }
         },
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -94930,6 +95608,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -94941,6 +95620,7 @@
           }
         },
         {
+          "description": "Sets the number of active shards to wait for before the operation returns.",
           "name": "wait_for_active_shards",
           "required": false,
           "type": {
@@ -95027,6 +95707,7 @@
       "path": [],
       "query": [
         {
+          "description": "Specify timeout for connection to master",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -95038,6 +95719,7 @@
           }
         },
         {
+          "description": "Request timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -95234,6 +95916,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names to restrict the operation; use `_all` or empty string to perform the operation on all indices",
           "name": "index",
           "required": false,
           "type": {
@@ -95245,6 +95928,7 @@
           }
         },
         {
+          "description": "A comma-separated list of document types to restrict the operation; leave empty to perform the operation on all types",
           "name": "type",
           "required": false,
           "type": {
@@ -95258,6 +95942,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -95269,6 +95954,7 @@
           }
         },
         {
+          "description": "Execute validation on all shards instead of one random shard per index",
           "name": "all_shards",
           "required": false,
           "type": {
@@ -95280,6 +95966,7 @@
           }
         },
         {
+          "description": "The analyzer to use for the query string",
           "name": "analyzer",
           "required": false,
           "type": {
@@ -95291,6 +95978,7 @@
           }
         },
         {
+          "description": "Specify whether wildcard and prefix queries should be analyzed (default: false)",
           "name": "analyze_wildcard",
           "required": false,
           "type": {
@@ -95302,6 +95990,7 @@
           }
         },
         {
+          "description": "The default operator for query string query (AND or OR)",
           "name": "default_operator",
           "required": false,
           "type": {
@@ -95313,6 +96002,7 @@
           }
         },
         {
+          "description": "The field to use as default where no field prefix is given in the query string",
           "name": "df",
           "required": false,
           "type": {
@@ -95324,6 +96014,7 @@
           }
         },
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -95335,6 +96026,7 @@
           }
         },
         {
+          "description": "Return detailed information about the error",
           "name": "explain",
           "required": false,
           "type": {
@@ -95346,6 +96038,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -95357,6 +96050,7 @@
           }
         },
         {
+          "description": "Specify whether format-based query failures (such as providing text to a numeric field) should be ignored",
           "name": "lenient",
           "required": false,
           "type": {
@@ -95379,6 +96073,7 @@
           }
         },
         {
+          "description": "Provide a more detailed explanation showing the actual Lucene query that will be executed.",
           "name": "rewrite",
           "required": false,
           "type": {
@@ -95390,6 +96085,7 @@
           }
         },
         {
+          "description": "Query in the Lucene query string syntax",
           "name": "q",
           "required": false,
           "type": {
@@ -98182,6 +98878,7 @@
       },
       "path": [
         {
+          "description": "Pipeline ID",
           "name": "id",
           "required": true,
           "type": {
@@ -98195,6 +98892,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -98206,6 +98904,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -98453,6 +99152,7 @@
       },
       "path": [
         {
+          "description": "Comma separated list of pipeline ids. Wildcards supported",
           "name": "id",
           "required": false,
           "type": {
@@ -98466,6 +99166,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "serverDefault": "30s",
@@ -98478,6 +99179,7 @@
           }
         },
         {
+          "description": "Return pipelines without their definitions (default: false)",
           "name": "summary",
           "required": false,
           "serverDefault": false,
@@ -99001,6 +99703,7 @@
       },
       "path": [
         {
+          "description": "Pipeline ID",
           "name": "id",
           "required": false,
           "type": {
@@ -99014,6 +99717,7 @@
       ],
       "query": [
         {
+          "description": "Verbose mode. Display data output for each processor in executed pipeline",
           "name": "verbose",
           "required": false,
           "type": {
@@ -99428,6 +100132,7 @@
       "path": [],
       "query": [
         {
+          "description": "If the active license is an enterprise license, return type as 'enterprise' (default: false)",
           "name": "accept_enterprise",
           "required": false,
           "type": {
@@ -99439,6 +100144,7 @@
           }
         },
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -99644,6 +100350,7 @@
       "path": [],
       "query": [
         {
+          "description": "whether the user has acknowledged acknowledge messages (default: false)",
           "name": "acknowledge",
           "required": false,
           "type": {
@@ -99722,6 +100429,7 @@
       "path": [],
       "query": [
         {
+          "description": "whether the user has acknowledged acknowledge messages (default: false)",
           "name": "acknowledge",
           "required": false,
           "type": {
@@ -99832,6 +100540,7 @@
       "path": [],
       "query": [
         {
+          "description": "whether the user has acknowledged acknowledge messages (default: false)",
           "name": "acknowledge",
           "required": false,
           "type": {
@@ -100129,6 +100838,7 @@
       },
       "path": [
         {
+          "description": "The ID of the Pipeline",
           "name": "id",
           "required": true,
           "type": {
@@ -100172,6 +100882,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of Pipeline IDs",
           "name": "id",
           "required": true,
           "type": {
@@ -100240,6 +100951,7 @@
       },
       "path": [
         {
+          "description": "The ID of the Pipeline",
           "name": "id",
           "required": true,
           "type": {
@@ -107955,6 +108667,7 @@
       },
       "path": [
         {
+          "description": "The name of the job to close",
           "name": "job_id",
           "required": true,
           "type": {
@@ -107968,6 +108681,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
           "name": "allow_no_jobs",
           "required": false,
           "type": {
@@ -107979,6 +108693,7 @@
           }
         },
         {
+          "description": "True if the job should be forcefully closed",
           "name": "force",
           "required": false,
           "type": {
@@ -107990,6 +108705,7 @@
           }
         },
         {
+          "description": "Controls the time to wait until a job has closed. Default to 30 minutes",
           "name": "timeout",
           "required": false,
           "serverDefault": "30s",
@@ -108046,6 +108762,7 @@
       },
       "path": [
         {
+          "description": "The ID of the calendar to delete",
           "name": "calendar_id",
           "required": true,
           "type": {
@@ -108096,6 +108813,7 @@
       },
       "path": [
         {
+          "description": "The ID of the calendar to modify",
           "name": "calendar_id",
           "required": true,
           "type": {
@@ -108107,6 +108825,7 @@
           }
         },
         {
+          "description": "The ID of the event to remove from the calendar",
           "name": "event_id",
           "required": true,
           "type": {
@@ -108157,6 +108876,7 @@
       },
       "path": [
         {
+          "description": "The ID of the calendar to modify",
           "name": "calendar_id",
           "required": true,
           "type": {
@@ -108168,6 +108888,7 @@
           }
         },
         {
+          "description": "The ID of the job to remove from the calendar",
           "name": "job_id",
           "required": true,
           "type": {
@@ -108324,6 +109045,7 @@
       },
       "path": [
         {
+          "description": "The ID of the datafeed to delete",
           "name": "datafeed_id",
           "required": true,
           "type": {
@@ -108337,6 +109059,7 @@
       ],
       "query": [
         {
+          "description": "True if the datafeed should be forcefully deleted",
           "name": "force",
           "required": false,
           "type": {
@@ -108411,6 +109134,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job(s) to perform expired data hygiene for",
           "name": "job_id",
           "required": false,
           "type": {
@@ -108424,6 +109148,7 @@
       ],
       "query": [
         {
+          "description": "The desired requests per second for the deletion processes.",
           "name": "requests_per_second",
           "required": false,
           "type": {
@@ -108435,6 +109160,7 @@
           }
         },
         {
+          "description": "How long can the underlying delete processes run until they are canceled",
           "name": "timeout",
           "required": false,
           "serverDefault": "8h",
@@ -108491,6 +109217,7 @@
       },
       "path": [
         {
+          "description": "The ID of the filter to delete",
           "name": "filter_id",
           "required": true,
           "type": {
@@ -108541,6 +109268,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job from which to delete forecasts",
           "name": "job_id",
           "required": true,
           "type": {
@@ -108552,6 +109280,7 @@
           }
         },
         {
+          "description": "The ID of the forecast to delete, can be comma delimited list. Leaving blank implies `_all`",
           "name": "forecast_id",
           "required": false,
           "type": {
@@ -108565,6 +109294,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if `_all` matches no forecasts",
           "name": "allow_no_forecasts",
           "required": false,
           "type": {
@@ -108576,6 +109306,7 @@
           }
         },
         {
+          "description": "Controls the time to wait until the forecast(s) are deleted. Default to 30 seconds",
           "name": "timeout",
           "required": false,
           "type": {
@@ -108625,6 +109356,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job to delete",
           "name": "job_id",
           "required": true,
           "type": {
@@ -108638,6 +109370,7 @@
       ],
       "query": [
         {
+          "description": "True if the job should be forcefully deleted",
           "name": "force",
           "required": false,
           "type": {
@@ -108649,6 +109382,7 @@
           }
         },
         {
+          "description": "Should this request wait until the operation has completed before returning",
           "name": "wait_for_completion",
           "required": false,
           "type": {
@@ -108698,6 +109432,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job to fetch",
           "name": "job_id",
           "required": true,
           "type": {
@@ -108709,6 +109444,7 @@
           }
         },
         {
+          "description": "The ID of the snapshot to delete",
           "name": "snapshot_id",
           "required": true,
           "type": {
@@ -108759,6 +109495,7 @@
       },
       "path": [
         {
+          "description": "The ID of the trained model to delete",
           "name": "model_id",
           "required": true,
           "type": {
@@ -108809,6 +109546,7 @@
       },
       "path": [
         {
+          "description": "The trained model alias to delete",
           "name": "model_alias",
           "required": true,
           "type": {
@@ -108820,6 +109558,7 @@
           }
         },
         {
+          "description": "The trained model where the model alias is assigned",
           "name": "model_id",
           "required": true,
           "type": {
@@ -109957,6 +110696,7 @@
       },
       "path": [
         {
+          "description": "The name of the job to flush",
           "name": "job_id",
           "required": true,
           "type": {
@@ -109970,6 +110710,7 @@
       ],
       "query": [
         {
+          "description": "Skips time to the given value without generating results or updating the model for the skipped interval",
           "name": "skip_time",
           "required": false,
           "type": {
@@ -110060,6 +110801,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job to forecast for",
           "name": "job_id",
           "required": true,
           "type": {
@@ -110215,6 +110957,7 @@
       },
       "path": [
         {
+          "description": "ID of the job to get bucket results from",
           "name": "job_id",
           "required": true,
           "type": {
@@ -110226,6 +110969,7 @@
           }
         },
         {
+          "description": "The timestamp of the desired single bucket result",
           "name": "timestamp",
           "required": false,
           "type": {
@@ -110239,6 +110983,7 @@
       ],
       "query": [
         {
+          "description": "skips a number of buckets",
           "name": "from",
           "required": false,
           "type": {
@@ -110250,6 +110995,7 @@
           }
         },
         {
+          "description": "specifies a max number of buckets to get",
           "name": "size",
           "required": false,
           "type": {
@@ -110261,6 +111007,7 @@
           }
         },
         {
+          "description": "Exclude interim results",
           "name": "exclude_interim",
           "required": false,
           "serverDefault": false,
@@ -110273,6 +111020,7 @@
           }
         },
         {
+          "description": "Sort buckets by a particular field",
           "name": "sort",
           "required": false,
           "type": {
@@ -110284,6 +111032,7 @@
           }
         },
         {
+          "description": "Set the sort direction",
           "name": "desc",
           "required": false,
           "serverDefault": false,
@@ -110296,6 +111045,7 @@
           }
         },
         {
+          "description": "Start time filter for buckets",
           "name": "start",
           "required": false,
           "type": {
@@ -110307,6 +111057,7 @@
           }
         },
         {
+          "description": "End time filter for buckets",
           "name": "end",
           "required": false,
           "type": {
@@ -110422,6 +111173,7 @@
       },
       "path": [
         {
+          "description": "The ID of the calendar containing the events",
           "name": "calendar_id",
           "required": true,
           "type": {
@@ -110435,6 +111187,7 @@
       ],
       "query": [
         {
+          "description": "Get events for the job. When this option is used calendar_id must be '_all'",
           "name": "job_id",
           "required": false,
           "type": {
@@ -110446,6 +111199,7 @@
           }
         },
         {
+          "description": "Get events before this time",
           "name": "end",
           "required": false,
           "type": {
@@ -110457,6 +111211,7 @@
           }
         },
         {
+          "description": "Skips a number of events",
           "name": "from",
           "required": false,
           "type": {
@@ -110468,6 +111223,7 @@
           }
         },
         {
+          "description": "Get events after this time",
           "name": "start",
           "required": false,
           "type": {
@@ -110479,6 +111235,7 @@
           }
         },
         {
+          "description": "Specifies a max number of events to get",
           "name": "size",
           "required": false,
           "type": {
@@ -110743,6 +111500,7 @@
       ],
       "query": [
         {
+          "description": "skips a number of categories",
           "name": "from",
           "required": false,
           "type": {
@@ -110754,6 +111512,7 @@
           }
         },
         {
+          "description": "specifies a max number of categories to get",
           "name": "size",
           "required": false,
           "type": {
@@ -110849,6 +111608,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)",
           "name": "allow_no_match",
           "required": false,
           "serverDefault": true,
@@ -110973,6 +111733,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)",
           "name": "allow_no_match",
           "required": false,
           "serverDefault": true,
@@ -111083,6 +111844,7 @@
       },
       "path": [
         {
+          "description": "The ID of the datafeeds stats to fetch",
           "name": "datafeed_id",
           "required": false,
           "type": {
@@ -111096,6 +111858,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
           "name": "allow_no_datafeeds",
           "required": false,
           "type": {
@@ -111165,6 +111928,7 @@
       },
       "path": [
         {
+          "description": "The ID of the datafeeds to fetch",
           "name": "datafeed_id",
           "required": false,
           "type": {
@@ -111178,6 +111942,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
           "name": "allow_no_datafeeds",
           "required": false,
           "type": {
@@ -111189,6 +111954,7 @@
           }
         },
         {
+          "description": "Omits fields that are illegal to set on datafeed PUT",
           "name": "exclude_generated",
           "required": false,
           "type": {
@@ -111258,6 +112024,7 @@
       },
       "path": [
         {
+          "description": "The ID of the filter to fetch",
           "name": "filter_id",
           "required": false,
           "type": {
@@ -111271,6 +112038,7 @@
       ],
       "query": [
         {
+          "description": "skips a number of filters",
           "name": "from",
           "required": false,
           "type": {
@@ -111282,6 +112050,7 @@
           }
         },
         {
+          "description": "specifies a max number of filters to get",
           "name": "size",
           "required": false,
           "type": {
@@ -111534,6 +112303,7 @@
       },
       "path": [
         {
+          "description": "The ID of the jobs stats to fetch",
           "name": "job_id",
           "required": false,
           "type": {
@@ -111547,6 +112317,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
           "name": "allow_no_jobs",
           "required": false,
           "type": {
@@ -111616,6 +112387,7 @@
       },
       "path": [
         {
+          "description": "The ID of the jobs to fetch",
           "name": "job_id",
           "required": false,
           "type": {
@@ -111629,6 +112401,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
           "name": "allow_no_match",
           "required": false,
           "serverDefault": true,
@@ -111641,6 +112414,7 @@
           }
         },
         {
+          "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
           "name": "allow_no_jobs",
           "required": false,
           "serverDefault": true,
@@ -111653,6 +112427,7 @@
           }
         },
         {
+          "description": "Omits fields that are illegal to set on job PUT",
           "name": "exclude_generated",
           "required": false,
           "serverDefault": false,
@@ -112015,6 +112790,7 @@
           }
         },
         {
+          "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
           "name": "allow_no_match",
           "required": false,
           "type": {
@@ -112166,6 +112942,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job",
           "name": "job_id",
           "required": true,
           "type": {
@@ -112179,6 +112956,7 @@
       ],
       "query": [
         {
+          "description": "Exclude interim results",
           "name": "exclude_interim",
           "required": false,
           "serverDefault": false,
@@ -112191,6 +112969,7 @@
           }
         },
         {
+          "description": "skips a number of records",
           "name": "from",
           "required": false,
           "type": {
@@ -112202,6 +112981,7 @@
           }
         },
         {
+          "description": "specifies a max number of records to get",
           "name": "size",
           "required": false,
           "type": {
@@ -112213,6 +112993,7 @@
           }
         },
         {
+          "description": "Start time filter for records",
           "name": "start",
           "required": false,
           "type": {
@@ -112224,6 +113005,7 @@
           }
         },
         {
+          "description": "End time filter for records",
           "name": "end",
           "required": false,
           "type": {
@@ -112844,6 +113626,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job to open",
           "name": "job_id",
           "required": true,
           "type": {
@@ -112989,6 +113772,7 @@
       },
       "path": [
         {
+          "description": "The name of the job receiving the data",
           "name": "job_id",
           "required": true,
           "type": {
@@ -113002,6 +113786,7 @@
       ],
       "query": [
         {
+          "description": "Optional parameter to specify the end of the bucket resetting range",
           "name": "reset_end",
           "required": false,
           "type": {
@@ -113013,6 +113798,7 @@
           }
         },
         {
+          "description": "Optional parameter to specify the start of the bucket resetting range",
           "name": "reset_start",
           "required": false,
           "type": {
@@ -113397,6 +114183,7 @@
       },
       "path": [
         {
+          "description": "The ID of the datafeed to preview",
           "name": "datafeed_id",
           "required": false,
           "type": {
@@ -113475,6 +114262,7 @@
       },
       "path": [
         {
+          "description": "The ID of the calendar to create",
           "name": "calendar_id",
           "required": true,
           "type": {
@@ -114097,6 +114885,7 @@
       },
       "path": [
         {
+          "description": "The ID of the datafeed to create",
           "name": "datafeed_id",
           "required": true,
           "type": {
@@ -114110,6 +114899,7 @@
       ],
       "query": [
         {
+          "description": "Ignore if the source indices expressions resolves to no concrete indices (default: true)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -114121,6 +114911,7 @@
           }
         },
         {
+          "description": "Whether source index expressions should get expanded to open or closed indices (default: open)",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -114132,6 +114923,7 @@
           }
         },
         {
+          "description": "Ignore indices that are marked as throttled (default: true)",
           "name": "ignore_throttled",
           "required": false,
           "type": {
@@ -114143,6 +114935,7 @@
           }
         },
         {
+          "description": "Ignore unavailable indexes (default: false)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -114393,6 +115186,7 @@
       },
       "path": [
         {
+          "description": "The ID of the filter to create",
           "name": "filter_id",
           "required": true,
           "type": {
@@ -115168,6 +115962,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job to fetch",
           "name": "job_id",
           "required": true,
           "type": {
@@ -115179,6 +115974,7 @@
           }
         },
         {
+          "description": "The ID of the snapshot to revert to",
           "name": "snapshot_id",
           "required": true,
           "type": {
@@ -115236,6 +116032,7 @@
       "path": [],
       "query": [
         {
+          "description": "Whether to enable upgrade_mode ML setting or not. Defaults to false.",
           "name": "enabled",
           "required": false,
           "type": {
@@ -115247,6 +116044,7 @@
           }
         },
         {
+          "description": "Controls the time to wait before action times out. Defaults to 30 seconds",
           "name": "timeout",
           "required": false,
           "type": {
@@ -115296,6 +116094,7 @@
       },
       "path": [
         {
+          "description": "The ID of the data frame analytics to start",
           "name": "id",
           "required": true,
           "type": {
@@ -115409,6 +116208,7 @@
       },
       "path": [
         {
+          "description": "The ID of the datafeed to start",
           "name": "datafeed_id",
           "required": true,
           "type": {
@@ -115422,6 +116222,7 @@
       ],
       "query": [
         {
+          "description": "The start time from where the datafeed should begin",
           "name": "start",
           "required": false,
           "type": {
@@ -115502,6 +116303,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no data frame analytics. (This includes `_all` string or when no data frame analytics have been specified)",
           "name": "allow_no_match",
           "required": false,
           "serverDefault": true,
@@ -115610,6 +116412,7 @@
       },
       "path": [
         {
+          "description": "The ID of the datafeed to stop",
           "name": "datafeed_id",
           "required": true,
           "type": {
@@ -115623,6 +116426,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
           "name": "allow_no_match",
           "required": false,
           "serverDefault": true,
@@ -115635,6 +116439,7 @@
           }
         },
         {
+          "description": "True if the datafeed should be forcefully stopped.",
           "name": "force",
           "required": false,
           "serverDefault": false,
@@ -115952,6 +116757,7 @@
       },
       "path": [
         {
+          "description": "The ID of the filter to update",
           "name": "filter_id",
           "required": true,
           "type": {
@@ -116300,6 +117106,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job to fetch",
           "name": "job_id",
           "required": true,
           "type": {
@@ -116311,6 +117118,7 @@
           }
         },
         {
+          "description": "The ID of the snapshot to update",
           "name": "snapshot_id",
           "required": true,
           "type": {
@@ -116687,6 +117495,7 @@
           "deprecation": {
             "version": "7.0.0"
           },
+          "description": "Default document type for items which don't provide one",
           "name": "type",
           "required": false,
           "type": {
@@ -118713,6 +119522,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes",
           "name": "node_id",
           "required": false,
           "type": {
@@ -118726,6 +119536,7 @@
       ],
       "query": [
         {
+          "description": "Don't show threads that are in known-idle places, such as waiting on a socket select or pulling from an empty task queue (default: true)",
           "name": "ignore_idle_threads",
           "required": false,
           "type": {
@@ -118737,6 +119548,7 @@
           }
         },
         {
+          "description": "The interval for the second sampling of threads",
           "name": "interval",
           "required": false,
           "type": {
@@ -118748,6 +119560,7 @@
           }
         },
         {
+          "description": "Number of samples of thread stacktrace (default: 10)",
           "name": "snapshots",
           "required": false,
           "type": {
@@ -118759,6 +119572,7 @@
           }
         },
         {
+          "description": "Specify the number of threads to provide information for (default: 3)",
           "name": "threads",
           "required": false,
           "type": {
@@ -118781,6 +119595,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -121387,6 +122202,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of node IDs to span the reload/reinit call. Should stay empty because reloading usually involves all cluster nodes.",
           "name": "node_id",
           "required": false,
           "type": {
@@ -121400,6 +122216,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -121507,6 +122324,7 @@
           }
         },
         {
+          "description": "Limit the information returned to the specified metrics",
           "name": "metric",
           "required": false,
           "type": {
@@ -121646,6 +122464,7 @@
           }
         },
         {
+          "description": "If set to true segment stats will include stats for segments that are not currently loaded into memory",
           "name": "include_unloaded_segments",
           "required": false,
           "type": {
@@ -121800,6 +122619,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes",
           "name": "node_id",
           "required": false,
           "type": {
@@ -121811,6 +122631,7 @@
           }
         },
         {
+          "description": "Limit the information returned to the specified metrics",
           "name": "metric",
           "required": false,
           "type": {
@@ -121824,6 +122645,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -122144,6 +122966,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job to delete",
           "name": "id",
           "required": true,
           "type": {
@@ -122317,6 +123140,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job(s) to fetch. Accepts glob patterns, or left blank for all jobs",
           "name": "id",
           "required": false,
           "type": {
@@ -122708,6 +123532,7 @@
       },
       "path": [
         {
+          "description": "The ID of the index to check rollup capabilities on, or left blank for all jobs",
           "name": "id",
           "required": false,
           "type": {
@@ -122891,6 +123716,7 @@
       },
       "path": [
         {
+          "description": "The rollup index or index pattern to obtain rollup capabilities from.",
           "name": "index",
           "required": true,
           "type": {
@@ -123137,6 +123963,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job to create",
           "name": "id",
           "required": true,
           "type": {
@@ -123314,6 +124141,7 @@
       },
       "path": [
         {
+          "description": "The indices or index-pattern(s) (containing rollup or regular data) that should be searched",
           "name": "index",
           "required": true,
           "type": {
@@ -123325,6 +124153,7 @@
           }
         },
         {
+          "description": "The doc type inside the index",
           "name": "type",
           "required": false,
           "type": {
@@ -123338,6 +124167,7 @@
       ],
       "query": [
         {
+          "description": "Indicates whether hits.total should be rendered as an integer or an object in the rest search response",
           "name": "rest_total_hits_as_int",
           "required": false,
           "type": {
@@ -123349,6 +124179,7 @@
           }
         },
         {
+          "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response",
           "name": "typed_keys",
           "required": false,
           "type": {
@@ -123485,6 +124316,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job to start",
           "name": "id",
           "required": true,
           "type": {
@@ -123541,6 +124373,7 @@
       },
       "path": [
         {
+          "description": "The ID of the job to stop",
           "name": "id",
           "required": true,
           "type": {
@@ -123554,6 +124387,7 @@
       ],
       "query": [
         {
+          "description": "Block for (at maximum) the specified duration while waiting for the job to stop.  Defaults to 30s.",
           "name": "timeout",
           "required": false,
           "type": {
@@ -123565,6 +124399,7 @@
           }
         },
         {
+          "description": "True if the API should block until the job has fully stopped, false if should be executed async. Defaults to false.",
           "name": "wait_for_completion",
           "required": false,
           "type": {
@@ -123638,6 +124473,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names",
           "name": "index",
           "required": false,
           "type": {
@@ -123651,6 +124487,7 @@
       ],
       "query": [
         {
+          "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
           "name": "expand_wildcards",
           "required": false,
           "type": {
@@ -123662,6 +124499,7 @@
           }
         },
         {
+          "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
           "name": "allow_no_indices",
           "required": false,
           "type": {
@@ -123673,6 +124511,7 @@
           }
         },
         {
+          "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -123848,6 +124687,7 @@
       },
       "path": [
         {
+          "description": "The name of the repository containing the snapshot of the index to mount",
           "name": "repository",
           "required": true,
           "type": {
@@ -123859,6 +124699,7 @@
           }
         },
         {
+          "description": "The name of the snapshot of the index to mount",
           "name": "snapshot",
           "required": true,
           "type": {
@@ -123872,6 +124713,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "serverDefault": "30s",
@@ -123884,6 +124726,7 @@
           }
         },
         {
+          "description": "Should this request wait until the operation has completed before returning",
           "name": "wait_for_completion",
           "required": false,
           "serverDefault": false,
@@ -123896,6 +124739,7 @@
           }
         },
         {
+          "description": "Selects the kind of local storage used to accelerate searches. Experimental, and defaults to `full_copy`",
           "name": "storage",
           "required": false,
           "serverDefault": "full_copy",
@@ -123952,6 +124796,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of index names",
           "name": "index",
           "required": false,
           "type": {
@@ -123965,6 +124810,7 @@
       ],
       "query": [
         {
+          "description": "Return stats aggregated at cluster, index or shard level",
           "name": "level",
           "required": false,
           "type": {
@@ -124647,6 +125493,7 @@
       },
       "path": [
         {
+          "description": "The username of the user to change the password for",
           "name": "username",
           "required": false,
           "type": {
@@ -124660,6 +125507,7 @@
       ],
       "query": [
         {
+          "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -124703,6 +125551,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of IDs of API keys to clear from the cache",
           "name": "ids",
           "required": true,
           "type": {
@@ -124793,6 +125642,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of application names",
           "name": "application",
           "required": true,
           "type": {
@@ -124883,6 +125733,7 @@
       },
       "path": [
         {
+          "description": "Comma-separated list of realms to clear",
           "name": "realms",
           "required": true,
           "type": {
@@ -124896,6 +125747,7 @@
       ],
       "query": [
         {
+          "description": "Comma-separated list of usernames to clear from the cache",
           "name": "usernames",
           "required": false,
           "type": {
@@ -124988,6 +125840,7 @@
       },
       "path": [
         {
+          "description": "Role name",
           "name": "name",
           "required": true,
           "type": {
@@ -125078,6 +125931,7 @@
       },
       "path": [
         {
+          "description": "An identifier for the namespace",
           "name": "namespace",
           "required": true,
           "type": {
@@ -125089,6 +125943,7 @@
           }
         },
         {
+          "description": "An identifier for the service name",
           "name": "service",
           "required": true,
           "type": {
@@ -125100,6 +125955,7 @@
           }
         },
         {
+          "description": "A comma-separated list of service token names",
           "name": "name",
           "required": true,
           "type": {
@@ -125288,6 +126144,7 @@
       "path": [],
       "query": [
         {
+          "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -125427,6 +126284,7 @@
       },
       "path": [
         {
+          "description": "An identifier for the namespace",
           "name": "namespace",
           "required": true,
           "type": {
@@ -125438,6 +126296,7 @@
           }
         },
         {
+          "description": "An identifier for the service name",
           "name": "service",
           "required": true,
           "type": {
@@ -125449,6 +126308,7 @@
           }
         },
         {
+          "description": "An identifier for the token name",
           "name": "name",
           "required": true,
           "type": {
@@ -125567,6 +126427,7 @@
       },
       "path": [
         {
+          "description": "Application name",
           "name": "application",
           "required": true,
           "type": {
@@ -125578,6 +126439,7 @@
           }
         },
         {
+          "description": "Privilege name",
           "name": "name",
           "required": true,
           "type": {
@@ -125591,6 +126453,7 @@
       ],
       "query": [
         {
+          "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -125667,6 +126530,7 @@
       },
       "path": [
         {
+          "description": "Role name",
           "name": "name",
           "required": true,
           "type": {
@@ -125680,6 +126544,7 @@
       ],
       "query": [
         {
+          "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -125735,6 +126600,7 @@
       },
       "path": [
         {
+          "description": "Role-mapping name",
           "name": "name",
           "required": true,
           "type": {
@@ -125748,6 +126614,7 @@
       ],
       "query": [
         {
+          "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -125803,6 +126670,7 @@
       },
       "path": [
         {
+          "description": "An identifier for the namespace",
           "name": "namespace",
           "required": true,
           "type": {
@@ -125814,6 +126682,7 @@
           }
         },
         {
+          "description": "An identifier for the service name",
           "name": "service",
           "required": true,
           "type": {
@@ -125825,6 +126694,7 @@
           }
         },
         {
+          "description": "An identifier for the token name",
           "name": "name",
           "required": true,
           "type": {
@@ -125838,6 +126708,7 @@
       ],
       "query": [
         {
+          "description": "If `true` then refresh the affected shards to make this operation visible to search, if `wait_for` (the default) then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -125893,6 +126764,7 @@
       },
       "path": [
         {
+          "description": "username",
           "name": "username",
           "required": true,
           "type": {
@@ -125906,6 +126778,7 @@
       ],
       "query": [
         {
+          "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -125961,6 +126834,7 @@
       },
       "path": [
         {
+          "description": "The username of the user to disable",
           "name": "username",
           "required": true,
           "type": {
@@ -125974,6 +126848,7 @@
       ],
       "query": [
         {
+          "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -126017,6 +126892,7 @@
       },
       "path": [
         {
+          "description": "The username of the user to enable",
           "name": "username",
           "required": true,
           "type": {
@@ -126030,6 +126906,7 @@
       ],
       "query": [
         {
+          "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -126172,6 +127049,7 @@
       "path": [],
       "query": [
         {
+          "description": "API key id of the API key to be retrieved",
           "name": "id",
           "required": false,
           "type": {
@@ -126183,6 +127061,7 @@
           }
         },
         {
+          "description": "API key name of the API key to be retrieved",
           "name": "name",
           "required": false,
           "type": {
@@ -126194,6 +127073,7 @@
           }
         },
         {
+          "description": "flag to query API keys owned by the currently authenticated user",
           "name": "owner",
           "required": false,
           "type": {
@@ -126205,6 +127085,7 @@
           }
         },
         {
+          "description": "realm name of the user who created this API key to be retrieved",
           "name": "realm_name",
           "required": false,
           "type": {
@@ -126216,6 +127097,7 @@
           }
         },
         {
+          "description": "user name of the user who created this API key to be retrieved",
           "name": "username",
           "required": false,
           "type": {
@@ -126332,6 +127214,7 @@
       },
       "path": [
         {
+          "description": "Application name",
           "name": "application",
           "required": false,
           "type": {
@@ -126343,6 +127226,7 @@
           }
         },
         {
+          "description": "Privilege name",
           "name": "name",
           "required": false,
           "type": {
@@ -126502,6 +127386,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of role names",
           "name": "name",
           "required": false,
           "type": {
@@ -126788,6 +127673,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of role-mapping names",
           "name": "name",
           "required": false,
           "type": {
@@ -126854,6 +127740,7 @@
       },
       "path": [
         {
+          "description": "An identifier for the namespace",
           "name": "namespace",
           "required": false,
           "type": {
@@ -126865,6 +127752,7 @@
           }
         },
         {
+          "description": "An identifier for the service name",
           "name": "service",
           "required": false,
           "type": {
@@ -128162,6 +129050,7 @@
       },
       "path": [
         {
+          "description": "Username",
           "name": "user",
           "required": false,
           "type": {
@@ -128678,6 +129567,7 @@
       "path": [],
       "query": [
         {
+          "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -128860,6 +129750,7 @@
       },
       "path": [
         {
+          "description": "Role name",
           "name": "name",
           "required": true,
           "type": {
@@ -128873,6 +129764,7 @@
       ],
       "query": [
         {
+          "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -128991,6 +129883,7 @@
       },
       "path": [
         {
+          "description": "Role-mapping name",
           "name": "name",
           "required": true,
           "type": {
@@ -129004,6 +129897,7 @@
       ],
       "query": [
         {
+          "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -129187,6 +130081,7 @@
       },
       "path": [
         {
+          "description": "The username of the User",
           "name": "username",
           "required": true,
           "type": {
@@ -129200,6 +130095,7 @@
       ],
       "query": [
         {
+          "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
           "name": "refresh",
           "required": false,
           "type": {
@@ -129255,6 +130151,7 @@
       },
       "path": [
         {
+          "description": "The node id of node to be removed from the shutdown state",
           "name": "node_id",
           "required": true,
           "type": {
@@ -129442,6 +130339,7 @@
       },
       "path": [
         {
+          "description": "Which node for which to retrieve the shutdown status",
           "name": "node_id",
           "required": true,
           "type": {
@@ -129560,6 +130458,7 @@
       },
       "path": [
         {
+          "description": "The node id of node to be shut down",
           "name": "node_id",
           "required": true,
           "type": {
@@ -130092,6 +130991,7 @@
       },
       "path": [
         {
+          "description": "The id of the snapshot lifecycle policy to remove",
           "name": "policy_id",
           "required": true,
           "type": {
@@ -130142,6 +131042,7 @@
       },
       "path": [
         {
+          "description": "The id of the snapshot lifecycle policy to be executed",
           "name": "policy_id",
           "required": true,
           "type": {
@@ -130236,6 +131137,7 @@
       },
       "path": [
         {
+          "description": "Comma-separated list of snapshot lifecycle policies to retrieve",
           "name": "policy_id",
           "required": false,
           "type": {
@@ -130549,6 +131451,7 @@
       },
       "path": [
         {
+          "description": "The id of the snapshot lifecycle policy",
           "name": "policy_id",
           "required": true,
           "type": {
@@ -131716,6 +132619,7 @@
       },
       "path": [
         {
+          "description": "A repository name",
           "name": "repository",
           "required": true,
           "type": {
@@ -131729,6 +132633,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -131740,6 +132645,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -131808,6 +132714,7 @@
       },
       "path": [
         {
+          "description": "A repository name",
           "name": "repository",
           "required": true,
           "type": {
@@ -131819,6 +132726,7 @@
           }
         },
         {
+          "description": "The name of the snapshot to clone from",
           "name": "snapshot",
           "required": true,
           "type": {
@@ -131830,6 +132738,7 @@
           }
         },
         {
+          "description": "The name of the cloned snapshot to create",
           "name": "target_snapshot",
           "required": true,
           "type": {
@@ -131843,6 +132752,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -132125,6 +133035,7 @@
       },
       "path": [
         {
+          "description": "A repository name",
           "name": "repository",
           "required": true,
           "type": {
@@ -132138,6 +133049,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -132149,6 +133061,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -132160,6 +133073,7 @@
           }
         },
         {
+          "description": "Whether to verify the repository after creation",
           "name": "verify",
           "required": false,
           "type": {
@@ -132209,6 +133123,7 @@
       },
       "path": [
         {
+          "description": "A repository name",
           "name": "repository",
           "required": true,
           "type": {
@@ -132220,6 +133135,7 @@
           }
         },
         {
+          "description": "A snapshot name",
           "name": "snapshot",
           "required": true,
           "type": {
@@ -132233,6 +133149,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -132282,6 +133199,7 @@
       },
       "path": [
         {
+          "description": "Name of the snapshot repository to unregister. Wildcard (`*`) patterns are supported.",
           "name": "repository",
           "required": true,
           "type": {
@@ -132295,6 +133213,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -132306,6 +133225,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -132355,6 +133275,7 @@
       },
       "path": [
         {
+          "description": "A repository name",
           "name": "repository",
           "required": true,
           "type": {
@@ -132366,6 +133287,7 @@
           }
         },
         {
+          "description": "A comma-separated list of snapshot names",
           "name": "snapshot",
           "required": true,
           "type": {
@@ -132379,6 +133301,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -132390,6 +133313,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -132401,6 +133325,7 @@
           }
         },
         {
+          "description": "Whether to show verbose snapshot info or only show the basic info found in the repository index blob",
           "name": "verbose",
           "required": false,
           "type": {
@@ -132412,6 +133337,7 @@
           }
         },
         {
+          "description": "Whether to include details of each index in the snapshot, if those details are available. Defaults to false.",
           "name": "index_details",
           "required": false,
           "since": "7.13.0",
@@ -132541,6 +133467,7 @@
       },
       "path": [
         {
+          "description": "A comma-separated list of repository names",
           "name": "repository",
           "required": false,
           "type": {
@@ -132554,6 +133481,7 @@
       ],
       "query": [
         {
+          "description": "Return local information, do not retrieve the state from master node (default: false)",
           "name": "local",
           "required": false,
           "type": {
@@ -132565,6 +133493,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -132734,6 +133663,7 @@
       },
       "path": [
         {
+          "description": "A repository name",
           "name": "repository",
           "required": true,
           "type": {
@@ -132745,6 +133675,7 @@
           }
         },
         {
+          "description": "A snapshot name",
           "name": "snapshot",
           "required": true,
           "type": {
@@ -132758,6 +133689,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -132769,6 +133701,7 @@
           }
         },
         {
+          "description": "Should this request wait until the operation has completed before returning",
           "name": "wait_for_completion",
           "required": false,
           "type": {
@@ -132869,6 +133802,7 @@
       },
       "path": [
         {
+          "description": "A repository name",
           "name": "repository",
           "required": false,
           "type": {
@@ -132880,6 +133814,7 @@
           }
         },
         {
+          "description": "A comma-separated list of snapshot names",
           "name": "snapshot",
           "required": false,
           "type": {
@@ -132893,6 +133828,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown",
           "name": "ignore_unavailable",
           "required": false,
           "type": {
@@ -132904,6 +133840,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -132982,6 +133919,7 @@
       },
       "path": [
         {
+          "description": "A repository name",
           "name": "repository",
           "required": true,
           "type": {
@@ -132995,6 +133933,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout for connection to master node",
           "name": "master_timeout",
           "required": false,
           "type": {
@@ -133006,6 +133945,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -133276,6 +134216,7 @@
       "path": [],
       "query": [
         {
+          "description": "a short version of the Accept header, e.g. json, yaml",
           "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-rest-format.html#sql-rest-format",
           "name": "format",
           "required": false,
@@ -134166,6 +135107,7 @@
       },
       "path": [
         {
+          "description": "Cancel the task with specified task id (node_id:task_number)",
           "name": "task_id",
           "required": false,
           "type": {
@@ -134179,6 +135121,7 @@
       ],
       "query": [
         {
+          "description": "A comma-separated list of actions that should be cancelled. Leave empty to cancel all.",
           "name": "actions",
           "required": false,
           "type": {
@@ -134205,6 +135148,7 @@
           }
         },
         {
+          "description": "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes",
           "name": "nodes",
           "required": false,
           "type": {
@@ -134219,6 +135163,7 @@
           }
         },
         {
+          "description": "Cancel tasks with specified parent task id (node_id:task_number). Set to -1 to cancel all.",
           "name": "parent_task_id",
           "required": false,
           "type": {
@@ -134230,6 +135175,7 @@
           }
         },
         {
+          "description": "Should the request block until the cancellation of the task and its descendant tasks is completed. Defaults to false",
           "name": "wait_for_completion",
           "required": false,
           "type": {
@@ -134310,6 +135256,7 @@
       },
       "path": [
         {
+          "description": "Return the task with specified id (node_id:task_number)",
           "name": "task_id",
           "required": true,
           "type": {
@@ -134323,6 +135270,7 @@
       ],
       "query": [
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -134334,6 +135282,7 @@
           }
         },
         {
+          "description": "Wait for the matching tasks to complete (default: false)",
           "name": "wait_for_completion",
           "required": false,
           "type": {
@@ -134423,6 +135372,7 @@
       "path": [],
       "query": [
         {
+          "description": "A comma-separated list of actions that should be returned. Leave empty to return all.",
           "name": "actions",
           "required": false,
           "type": {
@@ -134449,6 +135399,7 @@
           }
         },
         {
+          "description": "Return detailed task information (default: false)",
           "name": "detailed",
           "required": false,
           "type": {
@@ -134460,6 +135411,7 @@
           }
         },
         {
+          "description": "Group tasks by nodes or parent/child relationships",
           "name": "group_by",
           "required": false,
           "type": {
@@ -134471,6 +135423,7 @@
           }
         },
         {
+          "description": "A comma-separated list of node IDs or names to limit the returned information; use `_local` to return information from the node you're connecting to, leave empty to get information from all nodes",
           "name": "nodes",
           "required": false,
           "type": {
@@ -134485,6 +135438,7 @@
           }
         },
         {
+          "description": "Return tasks with specified parent task id (node_id:task_number). Set to -1 to return all.",
           "name": "parent_task_id",
           "required": false,
           "type": {
@@ -134496,6 +135450,7 @@
           }
         },
         {
+          "description": "Explicit operation timeout",
           "name": "timeout",
           "required": false,
           "type": {
@@ -134507,6 +135462,7 @@
           }
         },
         {
+          "description": "Wait for the matching tasks to complete (default: false)",
           "name": "wait_for_completion",
           "required": false,
           "type": {
@@ -134892,6 +135848,7 @@
           }
         },
         {
+          "description": "Optional parameter to specify the timestamp field in the file",
           "name": "timestamp_field",
           "required": false,
           "type": {
@@ -135561,6 +136518,7 @@
       },
       "path": [
         {
+          "description": "The id of the transform to delete",
           "name": "transform_id",
           "required": true,
           "type": {
@@ -135574,6 +136532,7 @@
       ],
       "query": [
         {
+          "description": "When `true`, the transform is deleted regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be deleted.",
           "name": "force",
           "required": false,
           "type": {
@@ -135623,6 +136582,7 @@
       },
       "path": [
         {
+          "description": "The id or comma delimited list of id expressions of the transforms to get, '_all' or '*' implies get all transforms",
           "name": "transform_id",
           "required": false,
           "type": {
@@ -135636,6 +136596,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)",
           "name": "allow_no_match",
           "required": false,
           "type": {
@@ -135647,6 +136608,7 @@
           }
         },
         {
+          "description": "skips a number of transform configs, defaults to 0",
           "name": "from",
           "required": false,
           "type": {
@@ -135658,6 +136620,7 @@
           }
         },
         {
+          "description": "specifies a max number of transforms to get, defaults to 100",
           "name": "size",
           "required": false,
           "type": {
@@ -135669,6 +136632,7 @@
           }
         },
         {
+          "description": "Omits fields that are illegal to set on transform PUT",
           "name": "exclude_generated",
           "required": false,
           "type": {
@@ -135877,6 +136841,7 @@
       },
       "path": [
         {
+          "description": "The id of the transform for which to get stats. '_all' or '*' implies all transforms",
           "name": "transform_id",
           "required": true,
           "type": {
@@ -135890,6 +136855,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)",
           "name": "allow_no_match",
           "required": false,
           "type": {
@@ -135901,6 +136867,7 @@
           }
         },
         {
+          "description": "skips a number of transform stats, defaults to 0",
           "name": "from",
           "required": false,
           "type": {
@@ -135912,6 +136879,7 @@
           }
         },
         {
+          "description": "specifies a max number of transform stats to get, defaults to 100",
           "name": "size",
           "required": false,
           "type": {
@@ -136534,6 +137502,7 @@
       },
       "path": [
         {
+          "description": "The id of the transform to start",
           "name": "transform_id",
           "required": true,
           "type": {
@@ -136547,6 +137516,7 @@
       ],
       "query": [
         {
+          "description": "Controls the time to wait for the transform to start",
           "name": "timeout",
           "required": false,
           "type": {
@@ -136596,6 +137566,7 @@
       },
       "path": [
         {
+          "description": "The id of the transform to stop",
           "name": "transform_id",
           "required": true,
           "type": {
@@ -136609,6 +137580,7 @@
       ],
       "query": [
         {
+          "description": "Whether to ignore if a wildcard expression matches no transforms. (This includes `_all` string or when no transforms have been specified)",
           "name": "allow_no_match",
           "required": false,
           "type": {
@@ -136620,6 +137592,7 @@
           }
         },
         {
+          "description": "Whether to force stop a failed transform or not. Default to false",
           "name": "force",
           "required": false,
           "type": {
@@ -136631,6 +137604,7 @@
           }
         },
         {
+          "description": "Controls the time to wait until the transform has stopped. Default to 30 seconds",
           "name": "timeout",
           "required": false,
           "type": {
@@ -136642,6 +137616,7 @@
           }
         },
         {
+          "description": "Whether to wait for the transform to reach a checkpoint before stopping. Default to false",
           "name": "wait_for_checkpoint",
           "required": false,
           "type": {
@@ -136653,6 +137628,7 @@
           }
         },
         {
+          "description": "Whether to wait for the transform to fully stop before returning or not. Default to false",
           "name": "wait_for_completion",
           "required": false,
           "type": {
@@ -140519,6 +141495,7 @@
       },
       "path": [
         {
+          "description": "Watch ID",
           "name": "watch_id",
           "required": true,
           "type": {
@@ -140530,6 +141507,7 @@
           }
         },
         {
+          "description": "A comma-separated list of the action ids to be acked",
           "name": "action_id",
           "required": false,
           "type": {
@@ -140586,6 +141564,7 @@
       },
       "path": [
         {
+          "description": "Watch ID",
           "name": "watch_id",
           "required": true,
           "type": {
@@ -140642,6 +141621,7 @@
       },
       "path": [
         {
+          "description": "Watch ID",
           "name": "watch_id",
           "required": true,
           "type": {
@@ -140698,6 +141678,7 @@
       },
       "path": [
         {
+          "description": "Watch ID",
           "name": "id",
           "required": true,
           "type": {
@@ -140873,6 +141854,7 @@
       },
       "path": [
         {
+          "description": "Watch ID",
           "name": "id",
           "required": false,
           "type": {
@@ -140886,6 +141868,7 @@
       ],
       "query": [
         {
+          "description": "indicates whether the watch should execute in debug mode",
           "name": "debug",
           "required": false,
           "type": {
@@ -141074,6 +142057,7 @@
       },
       "path": [
         {
+          "description": "Watch ID",
           "name": "id",
           "required": true,
           "type": {
@@ -141286,6 +142270,7 @@
       },
       "path": [
         {
+          "description": "Watch ID",
           "name": "id",
           "required": true,
           "type": {
@@ -141299,6 +142284,7 @@
       ],
       "query": [
         {
+          "description": "Specify whether the watch is in/active by default",
           "name": "active",
           "required": false,
           "type": {
@@ -141310,6 +142296,7 @@
           }
         },
         {
+          "description": "only update the watch if the last operation that has changed the watch has the specified primary term",
           "name": "if_primary_term",
           "required": false,
           "type": {
@@ -141332,6 +142319,7 @@
           }
         },
         {
+          "description": "Explicit version number for concurrency control",
           "name": "version",
           "required": false,
           "type": {
@@ -142481,6 +143469,7 @@
       "path": [],
       "query": [
         {
+          "description": "Comma-separated list of info categories. Can be any of: build, license, features",
           "name": "categories",
           "required": false,
           "type": {
@@ -144371,6 +145360,7 @@
       "path": [],
       "query": [
         {
+          "description": "Specify timeout for watch write operation",
           "name": "master_timeout",
           "required": false,
           "type": {


### PR DESCRIPTION
This pr updates the `addDescription` step of the compiler which wasn't updated with the last iteration of the spec.
Now, if a path or query parameter does not contain a description in the input specification, the description will be pulled from the rest-api-spec.