### PR TITLE
Add additional compiler warnings

### DIFF
--- a/specification/_global/clear_scroll/ClearScrollRequest.ts
+++ b/specification/_global/clear_scroll/ClearScrollRequest.ts
@@ -29,7 +29,6 @@ export interface Request extends RequestBase {
   path_parts?: {
     scroll_id?: Ids
   }
-  query_parameters?: {}
   body?: {
     scroll_id?: Ids
   }

--- a/specification/_global/close_point_in_time/ClosePointInTimeRequest.ts
+++ b/specification/_global/close_point_in_time/ClosePointInTimeRequest.ts
@@ -26,8 +26,6 @@ import { Id } from '@_types/common'
  * @stability TODO
  */
 export interface Request extends RequestBase {
-  path_parts?: {}
-  query_parameters?: {}
   body?: {
     id: Id
   }

--- a/specification/_global/delete/DeleteRequest.ts
+++ b/specification/_global/delete/DeleteRequest.ts
@@ -53,5 +53,4 @@ export interface Request extends RequestBase {
     version_type?: VersionType
     wait_for_active_shards?: WaitForActiveShards
   }
-  body?: {}
 }

--- a/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
+++ b/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
@@ -33,5 +33,4 @@ export interface Request extends RequestBase {
   query_parameters?: {
     requests_per_second?: long
   }
-  body?: {}
 }

--- a/specification/_global/delete_script/DeleteScriptRequest.ts
+++ b/specification/_global/delete_script/DeleteScriptRequest.ts
@@ -34,5 +34,4 @@ export interface Request extends RequestBase {
     master_timeout?: Time
     timeout?: Time
   }
-  body?: {}
 }

--- a/specification/_global/exists/DocumentExistsRequest.ts
+++ b/specification/_global/exists/DocumentExistsRequest.ts
@@ -51,5 +51,4 @@ export interface Request extends RequestBase {
     version?: VersionNumber
     version_type?: VersionType
   }
-  body?: {}
 }

--- a/specification/_global/exists_source/SourceExistsRequest.ts
+++ b/specification/_global/exists_source/SourceExistsRequest.ts
@@ -50,5 +50,4 @@ export interface Request extends RequestBase {
     version?: VersionNumber
     version_type?: VersionType
   }
-  body?: {}
 }

--- a/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
+++ b/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
@@ -33,5 +33,4 @@ export interface Request extends RequestBase {
   query_parameters?: {
     keep_alive?: Time
   }
-  body?: {}
 }

--- a/specification/_global/ping/PingRequest.ts
+++ b/specification/_global/ping/PingRequest.ts
@@ -24,7 +24,4 @@ import { RequestBase } from '@_types/Base'
  * @since 0.0.0
  * @stability TODO
  */
-export interface Request extends RequestBase {
-  query_parameters?: {}
-  body?: {}
-}
+export interface Request extends RequestBase {}

--- a/specification/_global/reindex_rethrottle/ReindexRethrottleRequest.ts
+++ b/specification/_global/reindex_rethrottle/ReindexRethrottleRequest.ts
@@ -33,5 +33,4 @@ export interface Request extends RequestBase {
   query_parameters?: {
     requests_per_second?: long
   }
-  body?: {}
 }

--- a/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
+++ b/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
@@ -31,7 +31,6 @@ export interface Request extends RequestBase {
   path_parts?: {
     id?: Id
   }
-  query_parameters?: {}
   body?: {
     file?: string
     params?: Dictionary<string, UserDefinedValue>

--- a/specification/_global/scripts_painless_execute/ExecutePainlessScriptRequest.ts
+++ b/specification/_global/scripts_painless_execute/ExecutePainlessScriptRequest.ts
@@ -27,7 +27,6 @@ import { PainlessContextSetup } from './types'
  * @stability TODO
  */
 export interface Request extends RequestBase {
-  query_parameters?: {}
   body?: {
     context?: string
     context_setup?: PainlessContextSetup

--- a/specification/_global/update_by_query_rethrottle/UpdateByQueryRethrottleRequest.ts
+++ b/specification/_global/update_by_query_rethrottle/UpdateByQueryRethrottleRequest.ts
@@ -33,5 +33,4 @@ export interface Request extends RequestBase {
   query_parameters?: {
     requests_per_second?: long
   }
-  body?: {}
 }

--- a/specification/async_search/get/AsyncSearchGetRequest.ts
+++ b/specification/async_search/get/AsyncSearchGetRequest.ts
@@ -35,5 +35,4 @@ export interface Request extends RequestBase {
     typed_keys?: boolean
     wait_for_completion_timeout?: Time
   }
-  body?: {}
 }

--- a/specification/async_search/status/AsyncSearchStatusRequest.ts
+++ b/specification/async_search/status/AsyncSearchStatusRequest.ts
@@ -29,5 +29,4 @@ export interface Request extends RequestBase {
   path_parts?: {
     id: Id
   }
-  query_parameters?: {}
 }

--- a/specification/cat/aliases/CatAliasesRequest.ts
+++ b/specification/cat/aliases/CatAliasesRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends CatRequestBase {
   query_parameters?: {
     expand_wildcards?: ExpandWildcards
   }
-  body?: {}
 }

--- a/specification/cat/allocation/CatAllocationRequest.ts
+++ b/specification/cat/allocation/CatAllocationRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends CatRequestBase {
   query_parameters?: {
     bytes?: Bytes
   }
-  body?: {}
 }

--- a/specification/cat/count/CatCountRequest.ts
+++ b/specification/cat/count/CatCountRequest.ts
@@ -29,6 +29,4 @@ export interface Request extends CatRequestBase {
   path_parts?: {
     index?: Indices
   }
-  query_parameters?: {}
-  body?: {}
 }

--- a/specification/cat/fielddata/CatFielddataRequest.ts
+++ b/specification/cat/fielddata/CatFielddataRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends CatRequestBase {
   query_parameters?: {
     bytes?: Bytes
   }
-  body?: {}
 }

--- a/specification/cat/health/CatHealthRequest.ts
+++ b/specification/cat/health/CatHealthRequest.ts
@@ -29,5 +29,4 @@ export interface Request extends CatRequestBase {
     include_timestamp?: boolean
     ts?: boolean
   }
-  body?: {}
 }

--- a/specification/cat/help/CatHelpRequest.ts
+++ b/specification/cat/help/CatHelpRequest.ts
@@ -24,7 +24,4 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @since 0.0.0
  * @stability TODO
  */
-export interface Request extends CatRequestBase {
-  query_parameters?: {}
-  body?: {}
-}
+export interface Request extends CatRequestBase {}

--- a/specification/cat/indices/CatIndicesRequest.ts
+++ b/specification/cat/indices/CatIndicesRequest.ts
@@ -36,5 +36,4 @@ export interface Request extends CatRequestBase {
     include_unloaded_segments?: boolean
     pri?: boolean
   }
-  body?: {}
 }

--- a/specification/cat/master/CatMasterRequest.ts
+++ b/specification/cat/master/CatMasterRequest.ts
@@ -24,7 +24,4 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @since 0.0.0
  * @stability TODO
  */
-export interface Request extends CatRequestBase {
-  query_parameters?: {}
-  body?: {}
-}
+export interface Request extends CatRequestBase {}

--- a/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
+++ b/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
@@ -33,5 +33,4 @@ export interface Request extends CatRequestBase {
     allow_no_match?: boolean
     bytes?: Bytes
   }
-  body?: {}
 }

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends CatRequestBase {
   query_parameters?: {
     allow_no_datafeeds?: boolean
   }
-  body?: {}
 }

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -33,5 +33,4 @@ export interface Request extends CatRequestBase {
     allow_no_jobs?: boolean
     bytes?: Bytes
   }
-  body?: {}
 }

--- a/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
+++ b/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
@@ -36,5 +36,4 @@ export interface Request extends CatRequestBase {
     from?: integer
     size?: integer
   }
-  body?: {}
 }

--- a/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
+++ b/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
@@ -24,7 +24,4 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @since 0.0.0
  * @stability TODO
  */
-export interface Request extends CatRequestBase {
-  query_parameters?: {}
-  body?: {}
-}
+export interface Request extends CatRequestBase {}

--- a/specification/cat/nodes/CatNodesRequest.ts
+++ b/specification/cat/nodes/CatNodesRequest.ts
@@ -30,5 +30,4 @@ export interface Request extends CatRequestBase {
     bytes?: Bytes
     full_id?: boolean | string
   }
-  body?: {}
 }

--- a/specification/cat/pending_tasks/CatPendingTasksRequest.ts
+++ b/specification/cat/pending_tasks/CatPendingTasksRequest.ts
@@ -24,7 +24,4 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @since 0.0.0
  * @stability TODO
  */
-export interface Request extends CatRequestBase {
-  query_parameters?: {}
-  body?: {}
-}
+export interface Request extends CatRequestBase {}

--- a/specification/cat/plugins/CatPluginsRequest.ts
+++ b/specification/cat/plugins/CatPluginsRequest.ts
@@ -24,7 +24,4 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @since 0.0.0
  * @stability TODO
  */
-export interface Request extends CatRequestBase {
-  query_parameters?: {}
-  body?: {}
-}
+export interface Request extends CatRequestBase {}

--- a/specification/cat/recovery/CatRecoveryRequest.ts
+++ b/specification/cat/recovery/CatRecoveryRequest.ts
@@ -34,5 +34,4 @@ export interface Request extends CatRequestBase {
     bytes?: Bytes
     detailed?: boolean
   }
-  body?: {}
 }

--- a/specification/cat/repositories/CatRepositoriesRequest.ts
+++ b/specification/cat/repositories/CatRepositoriesRequest.ts
@@ -24,7 +24,4 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @since 2.1.0
  * @stability TODO
  */
-export interface Request extends CatRequestBase {
-  query_parameters?: {}
-  body?: {}
-}
+export interface Request extends CatRequestBase {}

--- a/specification/cat/segments/CatSegmentsRequest.ts
+++ b/specification/cat/segments/CatSegmentsRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends CatRequestBase {
   query_parameters?: {
     bytes?: Bytes
   }
-  body?: {}
 }

--- a/specification/cat/shards/CatShardsRequest.ts
+++ b/specification/cat/shards/CatShardsRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends CatRequestBase {
   query_parameters?: {
     bytes?: Bytes
   }
-  body?: {}
 }

--- a/specification/cat/snapshots/CatSnapshotsRequest.ts
+++ b/specification/cat/snapshots/CatSnapshotsRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends CatRequestBase {
   query_parameters?: {
     ignore_unavailable?: boolean
   }
-  body?: {}
 }

--- a/specification/cat/tasks/CatTasksRequest.ts
+++ b/specification/cat/tasks/CatTasksRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends CatRequestBase {
     node_id?: string[]
     parent_task?: long
   }
-  body?: {}
 }

--- a/specification/cat/templates/CatTemplatesRequest.ts
+++ b/specification/cat/templates/CatTemplatesRequest.ts
@@ -29,6 +29,4 @@ export interface Request extends CatRequestBase {
   path_parts?: {
     name?: Name
   }
-  query_parameters?: {}
-  body?: {}
 }

--- a/specification/cat/thread_pool/CatThreadPoolRequest.ts
+++ b/specification/cat/thread_pool/CatThreadPoolRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends CatRequestBase {
   query_parameters?: {
     size?: Size | boolean
   }
-  body?: {}
 }

--- a/specification/cat/transforms/CatTransformsRequest.ts
+++ b/specification/cat/transforms/CatTransformsRequest.ts
@@ -35,5 +35,4 @@ export interface Request extends CatRequestBase {
     from?: integer
     size?: integer
   }
-  body?: {}
 }

--- a/specification/ccr/put_auto_follow_pattern/PutAutoFollowPatternRequest.ts
+++ b/specification/ccr/put_auto_follow_pattern/PutAutoFollowPatternRequest.ts
@@ -33,7 +33,6 @@ export interface Request extends RequestBase {
   path_parts?: {
     name: Name // param name in docs: auto_follow_pattern_name
   }
-  query_parameters?: {}
   body?: {
     remote_cluster: string
     follow_index_pattern?: IndexPattern

--- a/specification/cluster/exists_component_template/ClusterComponentTemplateExistsRequest.ts
+++ b/specification/cluster/exists_component_template/ClusterComponentTemplateExistsRequest.ts
@@ -49,5 +49,4 @@ export interface Request extends RequestBase {
      */
     local?: boolean
   }
-  body?: {}
 }

--- a/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
+++ b/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends RequestBase {
     master_timeout?: Time
     timeout?: Time
   }
-  body?: {}
 }

--- a/specification/cluster/pending_tasks/ClusterPendingTasksRequest.ts
+++ b/specification/cluster/pending_tasks/ClusterPendingTasksRequest.ts
@@ -31,5 +31,4 @@ export interface Request extends RequestBase {
     /** @server_default 30s */
     master_timeout?: Time
   }
-  body?: {}
 }

--- a/specification/enrich/execute_policy/ExecuteEnrichPolicyRequest.ts
+++ b/specification/enrich/execute_policy/ExecuteEnrichPolicyRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends RequestBase {
   query_parameters?: {
     wait_for_completion?: boolean
   }
-  body?: {}
 }

--- a/specification/enrich/stats/EnrichStatsRequest.ts
+++ b/specification/enrich/stats/EnrichStatsRequest.ts
@@ -24,7 +24,4 @@ import { RequestBase } from '@_types/Base'
  * @since 7.5.0
  * @stability TODO
  */
-export interface Request extends RequestBase {
-  query_parameters?: {}
-  body?: {}
-}
+export interface Request extends RequestBase {}

--- a/specification/indices/add_block/IndicesAddBlockRequest.ts
+++ b/specification/indices/add_block/IndicesAddBlockRequest.ts
@@ -38,7 +38,6 @@ export interface Request extends RequestBase {
     master_timeout?: Time // default: 30s
     timeout?: Time // default: 30s
   }
-  body?: {}
 }
 
 export enum IndicesBlockOptions {

--- a/specification/indices/analyze/IndicesAnalyzeRequest.ts
+++ b/specification/indices/analyze/IndicesAnalyzeRequest.ts
@@ -33,7 +33,6 @@ export interface Request extends RequestBase {
   path_parts?: {
     index?: IndexName
   }
-  query_parameters?: {}
   body?: {
     analyzer?: string
     attributes?: string[]

--- a/specification/indices/clear_cache/IndicesIndicesClearCacheRequest.ts
+++ b/specification/indices/clear_cache/IndicesIndicesClearCacheRequest.ts
@@ -38,5 +38,4 @@ export interface Request extends RequestBase {
     query?: boolean
     request?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/close/CloseIndexRequest.ts
+++ b/specification/indices/close/CloseIndexRequest.ts
@@ -38,5 +38,4 @@ export interface Request extends RequestBase {
     timeout?: Time
     wait_for_active_shards?: WaitForActiveShards
   }
-  body?: {}
 }

--- a/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
+++ b/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
@@ -29,6 +29,4 @@ export interface Request extends RequestBase {
   path_parts?: {
     name: DataStreamName
   }
-  query_parameters?: {}
-  body?: {}
 }

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends RequestBase {
   query_parameters?: {
     expand_wildcards?: ExpandWildcards // default: open
   }
-  body?: {}
 }

--- a/specification/indices/delete/IndicesDeleteRequest.ts
+++ b/specification/indices/delete/IndicesDeleteRequest.ts
@@ -37,5 +37,4 @@ export interface Request extends RequestBase {
     master_timeout?: Time
     timeout?: Time
   }
-  body?: {}
 }

--- a/specification/indices/delete_alias/IndicesDeleteAliasRequest.ts
+++ b/specification/indices/delete_alias/IndicesDeleteAliasRequest.ts
@@ -35,5 +35,4 @@ export interface Request extends RequestBase {
     master_timeout?: Time
     timeout?: Time
   }
-  body?: {}
 }

--- a/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
+++ b/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
@@ -29,6 +29,4 @@ export interface Request extends RequestBase {
   path_parts?: {
     name: DataStreamName
   }
-  query_parameters?: {}
-  body?: {}
 }

--- a/specification/indices/delete_template/IndicesDeleteTemplateRequest.ts
+++ b/specification/indices/delete_template/IndicesDeleteTemplateRequest.ts
@@ -34,5 +34,4 @@ export interface Request extends RequestBase {
     master_timeout?: Time
     timeout?: Time
   }
-  body?: {}
 }

--- a/specification/indices/exists/IndicesExistsRequest.ts
+++ b/specification/indices/exists/IndicesExistsRequest.ts
@@ -37,5 +37,4 @@ export interface Request extends RequestBase {
     include_defaults?: boolean
     local?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
+++ b/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
@@ -36,5 +36,4 @@ export interface Request extends RequestBase {
     ignore_unavailable?: boolean
     local?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/exists_template/IndicesExistsTemplateRequest.ts
+++ b/specification/indices/exists_template/IndicesExistsTemplateRequest.ts
@@ -35,5 +35,4 @@ export interface Request extends RequestBase {
     local?: boolean
     master_timeout?: Time
   }
-  body?: {}
 }

--- a/specification/indices/exists_type/IndicesExistsTypeRequest.ts
+++ b/specification/indices/exists_type/IndicesExistsTypeRequest.ts
@@ -36,5 +36,4 @@ export interface Request extends RequestBase {
     ignore_unavailable?: boolean
     local?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/flush/IndicesFlushRequest.ts
+++ b/specification/indices/flush/IndicesFlushRequest.ts
@@ -36,5 +36,4 @@ export interface Request extends RequestBase {
     ignore_unavailable?: boolean
     wait_if_ongoing?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/flush_synced/IndicesFlushSyncedRequest.ts
+++ b/specification/indices/flush_synced/IndicesFlushSyncedRequest.ts
@@ -34,5 +34,4 @@ export interface Request extends RequestBase {
     expand_wildcards?: ExpandWildcards
     ignore_unavailable?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/forcemerge/IndicesForceMergeRequest.ts
+++ b/specification/indices/forcemerge/IndicesForceMergeRequest.ts
@@ -38,5 +38,4 @@ export interface Request extends RequestBase {
     max_num_segments?: long
     only_expunge_deletes?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/freeze/IndicesFreezeRequest.ts
+++ b/specification/indices/freeze/IndicesFreezeRequest.ts
@@ -38,5 +38,4 @@ export interface Request extends RequestBase {
     timeout?: Time
     wait_for_active_shards?: WaitForActiveShards
   }
-  body?: {}
 }

--- a/specification/indices/get/IndicesGetRequest.ts
+++ b/specification/indices/get/IndicesGetRequest.ts
@@ -70,5 +70,4 @@ export interface Request extends RequestBase {
      */
     master_timeout?: Time
   }
-  body?: {}
 }

--- a/specification/indices/get_alias/IndicesGetAliasRequest.ts
+++ b/specification/indices/get_alias/IndicesGetAliasRequest.ts
@@ -36,5 +36,4 @@ export interface Request extends RequestBase {
     ignore_unavailable?: boolean
     local?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/get_field_mapping/IndicesGetFieldMappingRequest.ts
+++ b/specification/indices/get_field_mapping/IndicesGetFieldMappingRequest.ts
@@ -39,5 +39,4 @@ export interface Request extends RequestBase {
     include_type_name?: boolean
     local?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/get_mapping/IndicesGetMappingRequest.ts
+++ b/specification/indices/get_mapping/IndicesGetMappingRequest.ts
@@ -39,5 +39,4 @@ export interface Request extends RequestBase {
     local?: boolean
     master_timeout?: Time
   }
-  body?: {}
 }

--- a/specification/indices/get_settings/IndicesGetSettingsRequest.ts
+++ b/specification/indices/get_settings/IndicesGetSettingsRequest.ts
@@ -40,5 +40,4 @@ export interface Request extends RequestBase {
     local?: boolean
     master_timeout?: Time
   }
-  body?: {}
 }

--- a/specification/indices/get_template/IndicesGetTemplateRequest.ts
+++ b/specification/indices/get_template/IndicesGetTemplateRequest.ts
@@ -36,5 +36,4 @@ export interface Request extends RequestBase {
     local?: boolean
     master_timeout?: Time
   }
-  body?: {}
 }

--- a/specification/indices/get_upgrade/IndicesGetUpgradeRequest.ts
+++ b/specification/indices/get_upgrade/IndicesGetUpgradeRequest.ts
@@ -28,5 +28,4 @@ export interface Request extends RequestBase {
   path_parts: {
     stub: string
   }
-  query_parameters?: {}
 }

--- a/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
+++ b/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
@@ -29,6 +29,4 @@ export interface Request extends RequestBase {
   path_parts?: {
     name: IndexName
   }
-  query_parameters?: {}
-  body?: {}
 }

--- a/specification/indices/open/IndicesOpenRequest.ts
+++ b/specification/indices/open/IndicesOpenRequest.ts
@@ -38,5 +38,4 @@ export interface Request extends RequestBase {
     timeout?: Time
     wait_for_active_shards?: WaitForActiveShards
   }
-  body?: {}
 }

--- a/specification/indices/promote_data_stream/IndicesPromoteDataStreamRequest.ts
+++ b/specification/indices/promote_data_stream/IndicesPromoteDataStreamRequest.ts
@@ -29,6 +29,4 @@ export interface Request extends RequestBase {
   path_parts?: {
     name: IndexName
   }
-  query_parameters?: {}
-  body?: {}
 }

--- a/specification/indices/recovery/IndicesRecoveryRequest.ts
+++ b/specification/indices/recovery/IndicesRecoveryRequest.ts
@@ -33,5 +33,4 @@ export interface Request extends RequestBase {
     active_only?: boolean
     detailed?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/refresh/IndicesRefreshRequest.ts
+++ b/specification/indices/refresh/IndicesRefreshRequest.ts
@@ -34,5 +34,4 @@ export interface Request extends RequestBase {
     expand_wildcards?: ExpandWildcards
     ignore_unavailable?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/reload_search_analyzers/ReloadSearchAnalyzersRequest.ts
+++ b/specification/indices/reload_search_analyzers/ReloadSearchAnalyzersRequest.ts
@@ -34,5 +34,4 @@ export interface Request extends RequestBase {
     expand_wildcards?: ExpandWildcards
     ignore_unavailable?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/resolve_index/ResolveIndexRequest.ts
+++ b/specification/indices/resolve_index/ResolveIndexRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends RequestBase {
   query_parameters?: {
     expand_wildcards?: ExpandWildcards
   }
-  body?: {}
 }

--- a/specification/indices/segments/IndicesSegmentsRequest.ts
+++ b/specification/indices/segments/IndicesSegmentsRequest.ts
@@ -35,5 +35,4 @@ export interface Request extends RequestBase {
     ignore_unavailable?: boolean
     verbose?: boolean
   }
-  body?: {}
 }

--- a/specification/indices/shard_stores/IndicesShardStoresRequest.ts
+++ b/specification/indices/shard_stores/IndicesShardStoresRequest.ts
@@ -35,5 +35,4 @@ export interface Request extends RequestBase {
     ignore_unavailable?: boolean
     status?: string | string[]
   }
-  body?: {}
 }

--- a/specification/indices/stats/IndicesStatsRequest.ts
+++ b/specification/indices/stats/IndicesStatsRequest.ts
@@ -49,5 +49,4 @@ export interface Request extends RequestBase {
     level?: Level
     types?: Types
   }
-  body?: {}
 }

--- a/specification/indices/unfreeze/IndicesUnfreezeRequest.ts
+++ b/specification/indices/unfreeze/IndicesUnfreezeRequest.ts
@@ -38,5 +38,4 @@ export interface Request extends RequestBase {
     timeout?: Time
     wait_for_active_shards?: string
   }
-  body?: {}
 }

--- a/specification/security/clear_cached_realms/SecurityClearCachedRealmsRequest.ts
+++ b/specification/security/clear_cached_realms/SecurityClearCachedRealmsRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends RequestBase {
   query_parameters?: {
     usernames?: string[]
   }
-  body?: {}
 }

--- a/specification/security/delete_role_mapping/SecurityDeleteRoleMappingRequest.ts
+++ b/specification/security/delete_role_mapping/SecurityDeleteRoleMappingRequest.ts
@@ -32,5 +32,4 @@ export interface Request extends RequestBase {
   query_parameters?: {
     refresh?: Refresh
   }
-  body?: {}
 }

--- a/specification/security/delete_service_token/DeleteServiceTokenRequest.ts
+++ b/specification/security/delete_service_token/DeleteServiceTokenRequest.ts
@@ -34,5 +34,4 @@ export interface Request extends RequestBase {
   query_parameters?: {
     refresh?: Refresh
   }
-  body?: {}
 }

--- a/specification/security/get_token/GetUserAccessTokenRequest.ts
+++ b/specification/security/get_token/GetUserAccessTokenRequest.ts
@@ -28,7 +28,6 @@ import { AccessTokenGrantType } from './types'
  * @stability TODO
  */
 export interface Request extends RequestBase {
-  query_parameters?: {}
   body?: {
     grant_type?: AccessTokenGrantType
     scope?: string

--- a/specification/security/has_privileges/SecurityHasPrivilegesRequest.ts
+++ b/specification/security/has_privileges/SecurityHasPrivilegesRequest.ts
@@ -30,7 +30,6 @@ export interface Request extends RequestBase {
   path_parts?: {
     user?: Name
   }
-  query_parameters?: {}
   body?: {
     application?: ApplicationPrivilegesCheck[]
     cluster?: string[]

--- a/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
+++ b/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
@@ -26,7 +26,6 @@ import { Id, Name, Username } from '@_types/common'
  * @stability TODO
  */
 export interface Request extends RequestBase {
-  query_parameters?: {}
   body?: {
     id?: Id
     ids?: Id[]

--- a/specification/snapshot/cleanup_repository/SnapshotCleanupRepositoryRequest.ts
+++ b/specification/snapshot/cleanup_repository/SnapshotCleanupRepositoryRequest.ts
@@ -34,5 +34,4 @@ export interface Request extends RequestBase {
     master_timeout?: Time
     timeout?: Time
   }
-  body?: {}
 }

--- a/specification/snapshot/delete/SnapshotDeleteRequest.ts
+++ b/specification/snapshot/delete/SnapshotDeleteRequest.ts
@@ -34,5 +34,4 @@ export interface Request extends RequestBase {
   query_parameters?: {
     master_timeout?: Time
   }
-  body?: {}
 }

--- a/specification/snapshot/get_repository/SnapshotGetRepositoryRequest.ts
+++ b/specification/snapshot/get_repository/SnapshotGetRepositoryRequest.ts
@@ -34,5 +34,4 @@ export interface Request extends RequestBase {
     local?: boolean
     master_timeout?: Time
   }
-  body?: {}
 }

--- a/specification/snapshot/status/SnapshotStatusRequest.ts
+++ b/specification/snapshot/status/SnapshotStatusRequest.ts
@@ -35,5 +35,4 @@ export interface Request extends RequestBase {
     ignore_unavailable?: boolean // default: false
     master_timeout?: Time
   }
-  body?: {}
 }

--- a/specification/snapshot/verify_repository/SnapshotVerifyRepositoryRequest.ts
+++ b/specification/snapshot/verify_repository/SnapshotVerifyRepositoryRequest.ts
@@ -34,5 +34,4 @@ export interface Request extends RequestBase {
     master_timeout?: Time
     timeout?: Time
   }
-  body?: {}
 }

--- a/specification/sql/translate/TranslateSqlRequest.ts
+++ b/specification/sql/translate/TranslateSqlRequest.ts
@@ -27,7 +27,6 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
  * @stability TODO
  */
 export interface Request extends RequestBase {
-  query_parameters?: {}
   body?: {
     fetch_size?: integer
     filter?: QueryContainer

--- a/specification/ssl/certificates/GetCertificatesRequest.ts
+++ b/specification/ssl/certificates/GetCertificatesRequest.ts
@@ -24,7 +24,4 @@ import { RequestBase } from '@_types/Base'
  * @since 6.2.0
  * @stability TODO
  */
-export interface Request extends RequestBase {
-  query_parameters?: {}
-  body?: {}
-}
+export interface Request extends RequestBase {}

--- a/specification/tasks/cancel/CancelTasksRequest.ts
+++ b/specification/tasks/cancel/CancelTasksRequest.ts
@@ -35,5 +35,4 @@ export interface Request extends RequestBase {
     parent_task_id?: string
     wait_for_completion?: boolean
   }
-  body?: {}
 }

--- a/specification/tasks/get/GetTaskRequest.ts
+++ b/specification/tasks/get/GetTaskRequest.ts
@@ -34,5 +34,4 @@ export interface Request extends RequestBase {
     timeout?: Time
     wait_for_completion?: boolean
   }
-  body?: {}
 }

--- a/specification/tasks/list/ListTasksRequest.ts
+++ b/specification/tasks/list/ListTasksRequest.ts
@@ -36,5 +36,4 @@ export interface Request extends RequestBase {
     timeout?: Time
     wait_for_completion?: boolean
   }
-  body?: {}
 }

--- a/specification/watcher/activate_watch/WatcherActivateWatchRequest.ts
+++ b/specification/watcher/activate_watch/WatcherActivateWatchRequest.ts
@@ -29,6 +29,4 @@ export interface Request extends RequestBase {
   path_parts?: {
     watch_id: Name
   }
-  query_parameters?: {}
-  body?: {}
 }

--- a/specification/watcher/deactivate_watch/DeactivateWatchRequest.ts
+++ b/specification/watcher/deactivate_watch/DeactivateWatchRequest.ts
@@ -29,6 +29,4 @@ export interface Request extends RequestBase {
   path_parts?: {
     watch_id: Name
   }
-  query_parameters?: {}
-  body?: {}
 }

--- a/specification/watcher/start/WatcherStartRequest.ts
+++ b/specification/watcher/start/WatcherStartRequest.ts
@@ -24,7 +24,4 @@ import { RequestBase } from '@_types/Base'
  * @since 0.0.0
  * @stability TODO
  */
-export interface Request extends RequestBase {
-  query_parameters?: {}
-  body?: {}
-}
+export interface Request extends RequestBase {}

--- a/specification/watcher/stop/WatcherStopRequest.ts
+++ b/specification/watcher/stop/WatcherStopRequest.ts
@@ -24,7 +24,4 @@ import { RequestBase } from '@_types/Base'
  * @since 0.0.0
  * @stability TODO
  */
-export interface Request extends RequestBase {
-  query_parameters?: {}
-  body?: {}
-}
+export interface Request extends RequestBase {}


### PR DESCRIPTION
This pr introduces additional compiler warnings:
- You can't use `Void` in request bodies
- You can't specify an empty `path_parts`
- You can't specify an empty `query_parameters`
- You can't specify an empty `body`

Closes: #580