### PR TITLE
Fix stubbed rollup API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -9204,7 +9204,7 @@
         "namespace": "rollup.rollup"
       },
       "since": "7.13.0",
-      "stability": "TODO",
+      "stability": "experimental",
       "urls": [
         {
           "methods": [
@@ -123999,20 +123999,10 @@
         "CommonQueryParameters"
       ],
       "body": {
-        "kind": "properties",
-        "properties": [
-          {
-            "name": "stub",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "_types"
-              }
-            }
-          }
-        ]
+        "kind": "value",
+        "value": {
+          "kind": "user_defined_value"
+        }
       },
       "inherits": {
         "type": {
@@ -124027,47 +124017,36 @@
       },
       "path": [
         {
-          "name": "stubb",
+          "name": "index",
           "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "IndexName",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "rollup_index",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
               "namespace": "_types"
             }
           }
         }
       ],
-      "query": [
-        {
-          "name": "stuba",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
+      "query": []
     },
     {
       "body": {
-        "kind": "properties",
-        "properties": [
-          {
-            "name": "stub",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "_types"
-              }
-            }
-          }
-        ]
+        "kind": "value",
+        "value": {
+          "kind": "user_defined_value"
+        }
       },
       "kind": "response",
       "name": {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -124017,6 +124017,7 @@
       },
       "path": [
         {
+          "description": "The index to roll up",
           "name": "index",
           "required": true,
           "type": {
@@ -124028,6 +124029,7 @@
           }
         },
         {
+          "description": "The name of the rollup index to create",
           "name": "rollup_index",
           "required": true,
           "type": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1351,12 +1351,6 @@
       ],
       "response": []
     },
-    "rollup.rollup": {
-      "request": [
-        "Endpoint has \"@stability: TODO"
-      ],
-      "response": []
-    },
     "rollup.start_job": {
       "request": [
         "Endpoint has \"@stability: TODO"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12768,16 +12768,12 @@ export interface RollupPutJobResponse extends AcknowledgedResponseBase {
 }
 
 export interface RollupRollupRequest extends RequestBase {
-  stubb: integer
-  stuba: integer
-  body?: {
-    stub: integer
-  }
+  index: IndexName
+  rollup_index: IndexName
+  body?: any
 }
 
-export interface RollupRollupResponse {
-  stub: integer
-}
+export type RollupRollupResponse = any
 
 export interface RollupRollupSearchRequest extends RequestBase {
   index: Indices

--- a/specification/rollup/rollup/RollupRequest.ts
+++ b/specification/rollup/rollup/RollupRequest.ts
@@ -17,22 +17,19 @@
  * under the License.
  */
 
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RequestBase } from '@_types/Base'
-import { integer } from '@_types/Numeric'
+import { IndexName } from '@_types/common'
 
 /**
  * @rest_spec_name rollup.rollup
  * @since 7.13.0
- * @stability TODO
+ * @stability experimental
  */
 export interface Request extends RequestBase {
   path_parts?: {
-    stubb: integer
+    index: IndexName
+    rollup_index: IndexName
   }
-  query_parameters?: {
-    stuba: integer
-  }
-  body?: {
-    stub: integer
-  }
+  body?: UserDefinedValue // TODO: This API is experimental and no docs exist describing it. Requires reverse engineering if made stable
 }

--- a/specification/rollup/rollup/RollupResponse.ts
+++ b/specification/rollup/rollup/RollupResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { integer } from '@_types/Numeric'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
-  body: { stub: integer }
+  body: UserDefinedValue // TODO: This API is experimental and no docs exist describing it. Requires reverse engineering if made stable
 }


### PR DESCRIPTION
As this API is not documented, quite complex, and experimental, we have agreed to treat the request and response body as `UserDefinedValue` for now. I'm awaiting some feedback from the Elasticsearch engineers to understand if this API is valid still.