### PR TITLE
Fix shutdown get node API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -32608,8 +32608,8 @@
           {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "NodeId",
+              "namespace": "_types"
             }
           },
           {
@@ -32617,8 +32617,8 @@
             "value": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "NodeId",
+                "namespace": "_types"
               }
             }
           }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -32604,11 +32604,26 @@
         "namespace": "_types"
       },
       "type": {
-        "kind": "instance_of",
-        "type": {
-          "name": "string",
-          "namespace": "internal"
-        }
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        ],
+        "kind": "union_of"
       }
     },
     {
@@ -130324,13 +130339,10 @@
           "name": "node_id",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "NodeId",
-                "namespace": "_types"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "NodeIds",
+              "namespace": "_types"
             }
           }
         }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2083,7 +2083,7 @@ export interface NodeAttributes {
 
 export type NodeId = string
 
-export type NodeIds = string
+export type NodeIds = string | string[]
 
 export type NodeName = string
 
@@ -13508,7 +13508,7 @@ export interface ShutdownGetNodePluginsStatus {
 }
 
 export interface ShutdownGetNodeRequest extends RequestBase {
-  node_id: NodeId[]
+  node_id: NodeIds
 }
 
 export interface ShutdownGetNodeResponse {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2083,7 +2083,7 @@ export interface NodeAttributes {
 
 export type NodeId = string
 
-export type NodeIds = string | string[]
+export type NodeIds = NodeId | NodeId[]
 
 export type NodeName = string
 

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -40,7 +40,7 @@ export type ActionIds = string // TODO: check if this should be an array of Acti
 export type Id = string
 export type Ids = Id | Id[]
 export type NodeId = string
-export type NodeIds = string | string[]
+export type NodeIds = NodeId | NodeId[]
 
 export type IndexName = string
 export type Indices = string | string[]

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -40,6 +40,7 @@ export type ActionIds = string // TODO: check if this should be an array of Acti
 export type Id = string
 export type Ids = Id | Id[]
 export type NodeId = string
+export type NodeIds = string | string[]
 
 export type IndexName = string
 export type Indices = string | string[]
@@ -93,7 +94,6 @@ export type Uuid = string
 // _seq_no
 export type SequenceNumber = integer
 
-export type NodeIds = string
 export type PropertyName = string
 export type RelationName = string
 export type TaskId = string | integer

--- a/specification/shutdown/get_node/ShutdownGetNodeRequest.ts
+++ b/specification/shutdown/get_node/ShutdownGetNodeRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { NodeId } from '@_types/common'
+import { NodeIds } from '@_types/common'
 
 /**
  * @rest_spec_name shutdown.get_node
@@ -27,6 +27,6 @@ import { NodeId } from '@_types/common'
  */
 export interface Request extends RequestBase {
   path_parts: {
-    node_id: NodeId[]
+    node_id: NodeIds
   }
 }


### PR DESCRIPTION
- Updates NodeIds to be a union of `string` and `string[]` to align with other types.
- Updates Shutdown Get Node to use NodeIds rather than `NodeId[]` for the path part.