### PR TITLE
Fix slm.put_lifecycle Request

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -130630,8 +130630,10 @@
       },
       "properties": [
         {
+          "description": "If false, the snapshot fails if any data stream or index in indices is missing or closed. If true, the snapshot ignores missing or closed data streams and indices.",
           "name": "ignore_unavailable",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -130641,17 +130643,7 @@
           }
         },
         {
-          "name": "include_global_state",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
+          "description": "A comma-separated list of data streams and indices to include in the snapshot. Multi-index syntax is supported. By default, a snapshot includes all data streams and indices in the cluster. If this argument is provided, the snapshot only includes the specified data streams and clusters.",
           "name": "indices",
           "required": true,
           "type": {
@@ -130659,6 +130651,59 @@
             "type": {
               "name": "Indices",
               "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "If true, the current global state is included in the snapshot.",
+          "name": "include_global_state",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "A list of feature states to be included in this snapshot. A list of features available for inclusion in the snapshot and their descriptions be can be retrieved using the get features API. Each feature state includes one or more system indices containing data necessary for the function of that feature. Providing an empty array will include no feature states in the snapshot, regardless of the value of include_global_state. By default, all available feature states will be included in the snapshot if include_global_state is true, or no feature states if include_global_state is false.",
+          "name": "feature_states",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
+          "description": "Attaches arbitrary metadata to the snapshot, such as a record of who took the snapshot, why it was taken, or any other useful data. Metadata must be less than 1024 bytes.",
+          "name": "metadata",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "If false, the entire snapshot will fail if one or more indices included in the snapshot do not have all primary shards available.",
+          "name": "partial",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
             }
           }
         }
@@ -130820,6 +130865,7 @@
       },
       "properties": [
         {
+          "description": "Time period after which a snapshot is considered expired and eligible for deletion. SLM deletes expired snapshots based on the slm.retention_schedule.",
           "name": "expire_after",
           "required": true,
           "type": {
@@ -130831,6 +130877,7 @@
           }
         },
         {
+          "description": "Maximum number of snapshots to retain, even if the snapshots have not yet expired. If the number of snapshots in the repository exceeds this limit, the policy retains the most recent snapshots and deletes older snapshots.",
           "name": "max_count",
           "required": true,
           "type": {
@@ -130842,6 +130889,7 @@
           }
         },
         {
+          "description": "Minimum number of snapshots to retain, even if the snapshots have expired.",
           "name": "min_count",
           "required": true,
           "type": {
@@ -131515,6 +131563,7 @@
         "kind": "properties",
         "properties": [
           {
+            "description": "Configuration for each snapshot created by the policy.",
             "name": "config",
             "required": false,
             "type": {
@@ -131526,6 +131575,7 @@
             }
           },
           {
+            "description": "Name automatically assigned to each snapshot created by the policy. Date math is supported. To prevent conflicting snapshot names, a UUID is automatically appended to each snapshot name.",
             "name": "name",
             "required": false,
             "type": {
@@ -131537,6 +131587,7 @@
             }
           },
           {
+            "description": "Repository used to store snapshots created by this policy. This repository must exist prior to the policy’s creation. You can create a repository using the snapshot repository API.",
             "name": "repository",
             "required": false,
             "type": {
@@ -131548,6 +131599,7 @@
             }
           },
           {
+            "description": "Retention rules used to retain and delete snapshots created by the policy.",
             "name": "retention",
             "required": false,
             "type": {
@@ -131559,6 +131611,7 @@
             }
           },
           {
+            "description": "Periodic or absolute schedule at which the policy creates snapshots. SLM applies schedule changes immediately.",
             "name": "schedule",
             "required": false,
             "type": {
@@ -131584,7 +131637,7 @@
       },
       "path": [
         {
-          "description": "The id of the snapshot lifecycle policy",
+          "description": "ID for the snapshot lifecycle policy you want to create or update.",
           "name": "policy_id",
           "required": true,
           "type": {
@@ -131596,7 +131649,34 @@
           }
         }
       ],
-      "query": []
+      "query": [
+        {
+          "description": "Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.",
+          "name": "master_timeout",
+          "required": false,
+          "serverDefault": "30s",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.",
+          "name": "timeout",
+          "required": false,
+          "serverDefault": "30s",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
     },
     {
       "body": {
@@ -138701,18 +138781,19 @@
       }
     },
     {
-      "inherits": {
-        "type": {
-          "name": "ScheduleBase",
-          "namespace": "watcher._types"
-        }
-      },
-      "kind": "interface",
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cron-expressions.html",
+      "kind": "type_alias",
       "name": {
         "name": "CronExpression",
         "namespace": "watcher._types"
       },
-      "properties": []
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "string",
+          "namespace": "internal"
+        }
+      }
     },
     {
       "kind": "interface",
@@ -140371,14 +140452,6 @@
         "name": "ResponseContentType",
         "namespace": "watcher._types"
       }
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "ScheduleBase",
-        "namespace": "watcher._types"
-      },
-      "properties": []
     },
     {
       "kind": "interface",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1652,6 +1652,12 @@
       ],
       "response": []
     },
+    "slm.put_lifecycle": {
+      "request": [
+        "Endpoint has \"@stability: TODO"
+      ],
+      "response": []
+    },
     "slm.start": {
       "request": [
         "Endpoint has \"@stability: TODO"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13544,8 +13544,11 @@ export interface ShutdownPutNodeResponse extends AcknowledgedResponseBase {
 
 export interface SlmConfiguration {
   ignore_unavailable?: boolean
-  include_global_state?: boolean
   indices: Indices
+  include_global_state?: boolean
+  feature_states?: string[]
+  metadata?: Metadata
+  partial?: boolean
 }
 
 export interface SlmInProgress {
@@ -13657,6 +13660,8 @@ export interface SlmGetStatusResponse {
 
 export interface SlmPutLifecycleRequest extends RequestBase {
   policy_id: Name
+  master_timeout?: Time
+  timeout?: Time
   body?: {
     config?: SlmConfiguration
     name?: Name
@@ -14474,9 +14479,7 @@ export type WatcherConditionType = 'always' | 'never' | 'script' | 'compare' | '
 
 export type WatcherConnectionScheme = 'http' | 'https'
 
-export interface WatcherCronExpression {
-  [key: string]: never
-}
+export type WatcherCronExpression = string
 
 export interface WatcherDailySchedule {
   at: string[] | WatcherTimeOfDay
@@ -14683,10 +14686,6 @@ export interface WatcherQueryWatch {
 }
 
 export type WatcherResponseContentType = 'json' | 'yaml' | 'text'
-
-export interface WatcherScheduleBase {
-  [key: string]: never
-}
 
 export interface WatcherScheduleContainer {
   cron?: WatcherCronExpression

--- a/specification/slm/_types/SnapshotLifecycle.ts
+++ b/specification/slm/_types/SnapshotLifecycle.ts
@@ -18,7 +18,14 @@
  */
 
 import { CronExpression } from '@watcher/_types/Schedule'
-import { Id, Indices, Name, Uuid, VersionNumber } from '@_types/common'
+import {
+  Id,
+  Indices,
+  Metadata,
+  Name,
+  Uuid,
+  VersionNumber
+} from '@_types/common'
 import { integer, long } from '@_types/Numeric'
 import { DateString, EpochMillis, Time } from '@_types/Time'
 
@@ -69,15 +76,50 @@ export class Policy {
 }
 
 export class Retention {
+  /**
+   * Time period after which a snapshot is considered expired and eligible for deletion. SLM deletes expired snapshots based on the slm.retention_schedule.
+   */
   expire_after: Time
+  /**
+   * Maximum number of snapshots to retain, even if the snapshots have not yet expired. If the number of snapshots in the repository exceeds this limit, the policy retains the most recent snapshots and deletes older snapshots.
+   */
   max_count: integer
+  /**
+   * Minimum number of snapshots to retain, even if the snapshots have expired.
+   */
   min_count: integer
 }
 
 export class Configuration {
+  /**
+   * If false, the snapshot fails if any data stream or index in indices is missing or closed. If true, the snapshot ignores missing or closed data streams and indices.
+   * @server_default false
+   */
   ignore_unavailable?: boolean
-  include_global_state?: boolean
+  /**
+   * A comma-separated list of data streams and indices to include in the snapshot. Multi-index syntax is supported.
+   * By default, a snapshot includes all data streams and indices in the cluster. If this argument is provided, the snapshot only includes the specified data streams and clusters.
+   */
   indices: Indices
+  /**
+   * If true, the current global state is included in the snapshot.
+   * @server_default true
+   */
+  include_global_state?: boolean
+  /**
+   * A list of feature states to be included in this snapshot. A list of features available for inclusion in the snapshot and their descriptions be can be retrieved using the get features API.
+   * Each feature state includes one or more system indices containing data necessary for the function of that feature. Providing an empty array will include no feature states in the snapshot, regardless of the value of include_global_state. By default, all available feature states will be included in the snapshot if include_global_state is true, or no feature states if include_global_state is false.
+   */
+  feature_states?: string[]
+  /**
+   * Attaches arbitrary metadata to the snapshot, such as a record of who took the snapshot, why it was taken, or any other useful data. Metadata must be less than 1024 bytes.
+   */
+  metadata?: Metadata
+  /**
+   * If false, the entire snapshot will fail if one or more indices included in the snapshot do not have all primary shards available.
+   * @server_default false
+   */
+  partial?: boolean
 }
 
 export class InProgress {

--- a/specification/slm/put_lifecycle/PutSnapshotLifecycleRequest.ts
+++ b/specification/slm/put_lifecycle/PutSnapshotLifecycleRequest.ts
@@ -21,6 +21,7 @@ import { Configuration, Retention } from '@slm/_types/SnapshotLifecycle'
 import { CronExpression } from '@watcher/_types/Schedule'
 import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
+import { Time } from '@_types/Time'
 
 /**
  * @rest_spec_name slm.put_lifecycle
@@ -28,14 +29,44 @@ import { Name } from '@_types/common'
  * @stability TODO
  */
 export interface Request extends RequestBase {
-  path_parts?: {
+  path_parts: {
+    /**
+     * ID for the snapshot lifecycle policy you want to create or update.
+     */
     policy_id: Name
   }
+  query_parameters?: {
+    /**
+     * Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
+    master_timeout?: Time
+    /**
+     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
+    timeout?: Time
+  }
   body?: {
+    /**
+     * Configuration for each snapshot created by the policy.
+     */
     config?: Configuration
+    /**
+     * Name automatically assigned to each snapshot created by the policy. Date math is supported. To prevent conflicting snapshot names, a UUID is automatically appended to each snapshot name.
+     */
     name?: Name
+    /**
+     * Repository used to store snapshots created by this policy. This repository must exist prior to the policy’s creation. You can create a repository using the snapshot repository API.
+     */
     repository?: string
+    /**
+     * Retention rules used to retain and delete snapshots created by the policy.
+     */
     retention?: Retention
+    /**
+     * Periodic or absolute schedule at which the policy creates snapshots. SLM applies schedule changes immediately.
+     */
     schedule?: CronExpression
   }
 }

--- a/specification/watcher/_types/Schedule.ts
+++ b/specification/watcher/_types/Schedule.ts
@@ -20,11 +20,15 @@
 import { integer, long } from '@_types/Numeric'
 import { DateString, Time } from '@_types/Time'
 
-export class Schedule {}
+// TODO remove
+// export class Schedule {}
+// export class ScheduleBase {}
 
-export class ScheduleBase {}
-
-export class CronExpression extends ScheduleBase {}
+/**
+ * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/cron-expressions.html
+ */
+export type CronExpression = string
+//export class CronExpression extends ScheduleBase {}
 
 export class DailySchedule {
   at: string[] | TimeOfDay
@@ -44,7 +48,8 @@ export class HourlySchedule {
   minute: integer[]
 }
 
-export class Interval extends ScheduleBase {
+export class Interval {
+  // extends ScheduleBase {
   factor: long
   unit: IntervalUnit
 }


### PR DESCRIPTION
as titled.

Problem was that `CronExpression` was a class extending `ScheduleBase` which is an empty object, hence the correct type string could not be casted.

Commented out obsolete classes.

Will also fix, `slm.get_lifecycle` response