### PR TITLE
Add 'search_mvt' API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -9073,6 +9073,38 @@
     },
     {
       "accept": [
+        "application/vnd.mapbox-vector-tile"
+      ],
+      "contentType": [
+        "application/json"
+      ],
+      "description": "Searches a vector tile for geospatial values. Returns results as a binary Mapbox vector tile.",
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html",
+      "name": "search_mvt",
+      "request": {
+        "name": "Request",
+        "namespace": "_global.search_mvt"
+      },
+      "requestBodyRequired": false,
+      "response": {
+        "name": "Response",
+        "namespace": "_global.search_mvt"
+      },
+      "since": "7.15.0",
+      "stability": "experimental",
+      "urls": [
+        {
+          "methods": [
+            "GET",
+            "POST"
+          ],
+          "path": "/{index}/_mvt/{field}/{zoom}/{x}/{y}"
+        }
+      ],
+      "visibility": "public"
+    },
+    {
+      "accept": [
         "application/json"
       ],
       "description": "Returns information about the indices and shards that a search request would be executed against.",
@@ -26674,6 +26706,318 @@
       "name": {
         "name": "TotalHitsRelation",
         "namespace": "_global.search._types"
+      }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "description": "Sub-aggregations for the geotile_grid. Supports the following aggregation types: - avg - cardinality - max - min - sum",
+            "name": "aggs",
+            "required": false,
+            "type": {
+              "key": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              },
+              "kind": "dictionary_of",
+              "singleKey": false,
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "AggregationContainer",
+                  "namespace": "_types.aggregations"
+                }
+              }
+            }
+          },
+          {
+            "description": "If false, the meta layer’s feature is the bounding box of the tile. If true, the meta layer’s feature is a bounding box resulting from a geo_bounds aggregation. The aggregation runs on <field> values that intersect the <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting bounding box may be larger than the vector tile.",
+            "name": "exact_bounds",
+            "required": false,
+            "serverDefault": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "Size, in pixels, of a side of the tile. Vector tiles are square with equal sides.",
+            "name": "extent",
+            "required": false,
+            "serverDefault": 4096,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "description": "Fields to return in the `hits` layer. Supports wildcards (`*`). This parameter does not support fields with array values. Fields with array values may return inconsistent results.",
+            "name": "fields",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Fields",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "description": "Additional zoom levels available through the aggs layer. For example, if <zoom> is 7 and grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results don’t include the aggs layer.",
+            "name": "grid_precision",
+            "required": false,
+            "serverDefault": 8,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "description": "Determines the geometry type for features in the aggs layer. In the aggs layer, each feature represents a geotile_grid cell. If 'grid' each feature is a Polygon of the cells bounding box. If 'point' each feature is a Point that is the centroid of the cell.",
+            "name": "grid_type",
+            "required": false,
+            "serverDefault": "grid",
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "GridType",
+                "namespace": "_global.search_mvt._types"
+              }
+            }
+          },
+          {
+            "description": "Query DSL used to filter documents for the search.",
+            "name": "query",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "QueryContainer",
+                "namespace": "_types.query_dsl"
+              }
+            }
+          },
+          {
+            "description": "Defines one or more runtime fields in the search request. These fields take precedence over mapped fields with the same name.",
+            "name": "runtime_mappings",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "RuntimeFields",
+                "namespace": "_types.mapping"
+              }
+            }
+          },
+          {
+            "description": "Maximum number of features to return in the hits layer. Accepts 0-10000. If 0, results don’t include the hits layer.",
+            "name": "size",
+            "required": false,
+            "serverDefault": 10000,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "description": "Sorts features in the hits layer. By default, the API calculates a bounding box for each feature. It sorts features based on this box’s diagonal length, from longest to shortest.",
+            "name": "sort",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Sort",
+                "namespace": "_global.search._types"
+              }
+            }
+          }
+        ]
+      },
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "request",
+      "name": {
+        "name": "Request",
+        "namespace": "_global.search_mvt"
+      },
+      "path": [
+        {
+          "description": "Comma-separated list of data streams, indices, or aliases to search",
+          "name": "index",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Indices",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Field containing geospatial data to return",
+          "name": "field",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Field",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Zoom level for the vector tile to search",
+          "name": "zoom",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "X coordinate for the vector tile to search",
+          "name": "x",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Y coordinate for the vector tile to search",
+          "name": "y",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "description": "If false, the meta layer’s feature is the bounding box of the tile. If true, the meta layer’s feature is a bounding box resulting from a geo_bounds aggregation. The aggregation runs on <field> values that intersect the <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting bounding box may be larger than the vector tile.",
+          "name": "exact_bounds",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "Size, in pixels, of a side of the tile. Vector tiles are square with equal sides.",
+          "name": "extent",
+          "required": false,
+          "serverDefault": 4096,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Additional zoom levels available through the aggs layer. For example, if <zoom> is 7 and grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results don’t include the aggs layer.",
+          "name": "grid_precision",
+          "required": false,
+          "serverDefault": 8,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Determines the geometry type for features in the aggs layer. In the aggs layer, each feature represents a geotile_grid cell. If 'grid' each feature is a Polygon of the cells bounding box. If 'point' each feature is a Point that is the centroid of the cell.",
+          "name": "grid_type",
+          "required": false,
+          "serverDefault": "grid",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "GridType",
+              "namespace": "_global.search_mvt._types"
+            }
+          }
+        },
+        {
+          "description": "Maximum number of features to return in the hits layer. Accepts 0-10000. If 0, results don’t include the hits layer.",
+          "name": "size",
+          "required": false,
+          "serverDefault": 10000,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
+      "kind": "response",
+      "name": {
+        "name": "Response",
+        "namespace": "_global.search_mvt"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "grid"
+        },
+        {
+          "name": "point"
+        }
+      ],
+      "name": {
+        "name": "GridType",
+        "namespace": "_global.search_mvt._types"
       }
     },
     {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -9056,31 +9056,6 @@
       "description": "Searches a vector tile for geospatial values. Returns results as a binary Mapbox vector tile.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html",
       "name": "search_mvt",
-      "request": null,
-      "requestBodyRequired": false,
-      "response": null,
-      "stability": "experimental",
-      "urls": [
-        {
-          "methods": [
-            "GET",
-            "POST"
-          ],
-          "path": "/{index}/_mvt/{field}/{zoom}/{x}/{y}"
-        }
-      ],
-      "visibility": "public"
-    },
-    {
-      "accept": [
-        "application/vnd.mapbox-vector-tile"
-      ],
-      "contentType": [
-        "application/json"
-      ],
-      "description": "Searches a vector tile for geospatial values. Returns results as a binary Mapbox vector tile.",
-      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html",
-      "name": "search_mvt",
       "request": {
         "name": "Request",
         "namespace": "_global.search_mvt"
@@ -26996,8 +26971,10 @@
     },
     {
       "body": {
-        "kind": "properties",
-        "properties": []
+        "kind": "value",
+        "value": {
+          "kind": "user_defined_value"
+        }
       },
       "kind": "response",
       "name": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1396,12 +1396,6 @@
       ],
       "response": []
     },
-    "search_mvt": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "search_shards": {
       "request": [
         "Endpoint has \"@stability: TODO"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1505,6 +1505,36 @@ export interface SearchTotalHits {
 
 export type SearchTotalHitsRelation = 'eq' | 'gte'
 
+export interface SearchMvtRequest extends RequestBase {
+  index: Indices
+  field: Field
+  zoom: integer
+  x: integer
+  y: integer
+  exact_bounds?: boolean
+  extent?: integer
+  grid_precision?: integer
+  grid_type?: SearchMvtGridType
+  size?: integer
+  body?: {
+    aggs?: Record<string, AggregationsAggregationContainer>
+    exact_bounds?: boolean
+    extent?: integer
+    fields?: Fields
+    grid_precision?: integer
+    grid_type?: SearchMvtGridType
+    query?: QueryDslQueryContainer
+    runtime_mappings?: MappingRuntimeFields
+    size?: integer
+    sort?: SearchSort
+  }
+}
+
+export interface SearchMvtResponse {
+}
+
+export type SearchMvtGridType = 'grid' | 'point'
+
 export interface SearchShardsRequest extends RequestBase {
   index?: Indices
   allow_no_indices?: boolean

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1530,8 +1530,7 @@ export interface SearchMvtRequest extends RequestBase {
   }
 }
 
-export interface SearchMvtResponse {
-}
+export type SearchMvtResponse = any
 
 export type SearchMvtGridType = 'grid' | 'point'
 

--- a/specification/_global/search_mvt/SearchMvtRequest.ts
+++ b/specification/_global/search_mvt/SearchMvtRequest.ts
@@ -1,0 +1,154 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Dictionary } from '@spec_utils/Dictionary'
+import { RequestBase } from '@_types/Base'
+import { Field, Fields, Indices } from '@_types/common'
+import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
+import { GridType } from './_types/GridType'
+import { Sort } from '@global/search/_types/sort'
+import { QueryContainer } from '@_types/query_dsl/abstractions'
+import { RuntimeFields } from '@_types/mapping/RuntimeFields'
+import { integer } from '@_types/Numeric'
+
+/**
+ * @rest_spec_name search_mvt
+ * @since 7.15.0
+ * @stability experimental
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /* List of indices, data streams, or aliases to search */
+    index: Indices
+    /* Field containing geospatial data to return */
+    field: Field
+    /* Zoom level of the vector tile to search */
+    zoom: integer
+    /* X coordinate for the vector tile to search */
+    x: integer
+    /* Y coordinate for the vector tile to search */
+    y: integer
+  }
+  query_parameters?: {
+    /**
+     * If false, the meta layer’s feature is the bounding box of the tile.
+     * If true, the meta layer’s feature is a bounding box resulting from a
+     * geo_bounds aggregation. The aggregation runs on <field> values that intersect
+     * the <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting
+     * bounding box may be larger than the vector tile.
+     * @server_default false
+     */
+    exact_bounds?: boolean
+    /**
+     * Size, in pixels, of a side of the tile. Vector tiles are square with equal sides.
+     * @server_default 4096
+     */
+    extent?: integer
+    /**
+     * Additional zoom levels available through the aggs layer. For example, if <zoom> is 7
+     * and grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results
+     * don’t include the aggs layer.
+     * @server_default 8
+     */
+    grid_precision?: integer
+    /**
+     * Determines the geometry type for features in the aggs layer. In the aggs layer,
+     * each feature represents a geotile_grid cell. If 'grid' each feature is a Polygon
+     * of the cells bounding box. If 'point' each feature is a Point that is the centroid
+     * of the cell.
+     * @server_default grid
+     */
+    grid_type?: GridType
+    /**
+     * Maximum number of features to return in the hits layer. Accepts 0-10000.
+     * If 0, results don’t include the hits layer.
+     * @server_default 10000
+     */
+    size?: integer
+  }
+  body?: {
+    /**
+     * Sub-aggregations for the geotile_grid.
+     *
+     * Supports the following aggregation types:
+     * - avg
+     * - cardinality
+     * - max
+     * - min
+     * - sum
+     */
+    aggs?: Dictionary<string, AggregationContainer>
+    /**
+     * If false, the meta layer’s feature is the bounding box of the tile.
+     * If true, the meta layer’s feature is a bounding box resulting from a
+     * geo_bounds aggregation. The aggregation runs on <field> values that intersect
+     * the <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting
+     * bounding box may be larger than the vector tile.
+     * @server_default false
+     */
+    exact_bounds?: boolean
+    /**
+     * Size, in pixels, of a side of the tile. Vector tiles are square with equal sides.
+     * @server_default 4096
+     */
+    extent?: integer
+    /**
+     * Fields to return in the `hits` layer. Supports wildcards (`*`).
+     * This parameter does not support fields with array values. Fields with array
+     * values may return inconsistent results.
+     */
+    fields?: Fields
+    /**
+     * Additional zoom levels available through the aggs layer. For example, if <zoom> is 7
+     * and grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results
+     * don’t include the aggs layer.
+     * @server_default 8
+     */
+    grid_precision?: integer
+    /**
+     * Determines the geometry type for features in the aggs layer. In the aggs layer,
+     * each feature represents a geotile_grid cell. If 'grid' each feature is a Polygon
+     * of the cells bounding box. If 'point' each feature is a Point that is the centroid
+     * of the cell.
+     * @server_default grid
+     */
+    grid_type?: GridType
+    /**
+     * Query DSL used to filter documents for the search.
+     */
+    query?: QueryContainer
+    /**
+     * Defines one or more runtime fields in the search request. These fields take
+     * precedence over mapped fields with the same name.
+     */
+    runtime_mappings?: RuntimeFields
+    /**
+     * Maximum number of features to return in the hits layer. Accepts 0-10000.
+     * If 0, results don’t include the hits layer.
+     * @server_default 10000
+     */
+    size?: integer
+    /**
+     * Sorts features in the hits layer. By default, the API calculates a bounding
+     * box for each feature. It sorts features based on this box’s diagonal length,
+     * from longest to shortest.
+     */
+    sort?: Sort
+  }
+}

--- a/specification/_global/search_mvt/SearchMvtResponse.ts
+++ b/specification/_global/search_mvt/SearchMvtResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class Response {
+  body: any
+}

--- a/specification/_global/search_mvt/SearchMvtResponse.ts
+++ b/specification/_global/search_mvt/SearchMvtResponse.ts
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+
 export class Response {
-  body: any
+  body: UserDefinedValue
 }

--- a/specification/_global/search_mvt/_types/GridType.ts
+++ b/specification/_global/search_mvt/_types/GridType.ts
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export enum GridType {
+  grid = 0,
+  point = 1
+}


### PR DESCRIPTION
This API is different than others because it's response body is a binary format. Wasn't sure how else to represent this except for `any`? Currently there aren't any test cases for this API but I plan on adding some.

cc @iverase 