### PR TITLE
Update rest-api-spec action

### DIFF
--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        branch: [main, 7.x, 7.14]
+        branch: ['main', '7.x', '7.14', '7.15']
 
     steps:
       - uses: actions/checkout@v2
@@ -50,3 +50,13 @@ jobs:
           commit-message: 'Update rest-api-spec'
           delete-branch: true
           team-reviewers: elastic/clients-team
+
+      - name: Open an issue if the action fails
+        if: ${{ failure() }}
+        uses: nashmaniac/create-issue-action@v1.1
+        with:
+          title: rest-api-spec update failed
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: bug
+          body: The rest-api-spec action is currently failing, see [here](https://github.com/elastic/elasticsearch-specification/actions/workflows/update-rest-api-json.yml).
+


### PR DESCRIPTION
As titled. This should fix the current issue once merged with https://github.com/elastic/elasticsearch-specification/pull/654. Furthermore, if it fails it will now open an issue.