### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+output/dangling-types/dangling.csv linguist-generated=true
+output/schema/schema.json linguist-generated=true
+output/schema/validation-errors.json linguist-generated=true
+output/typescript/types.ts linguist-generated=true

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "_info": {
-    "hash": "foobartest",
+    "hash": "10ed7d4",
     "license": {
       "name": "Apache 2.0",
       "url": "https://github.com/elastic/elasticsearch-specification/blob/master/LICENSE"

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "_info": {
-    "hash": "10ed7d4",
+    "hash": "foobartest",
     "license": {
       "name": "Apache 2.0",
       "url": "https://github.com/elastic/elasticsearch-specification/blob/master/LICENSE"


### PR DESCRIPTION
This file [**should** instruct github](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/customizing-how-changed-files-appear-on-github) not to show the diff for every file inside `output/**` by default.
This should help reviewers who are not used or do not know the repo structure, hinting them directly at which files they should review.