### PR TITLE
Type aliases for multiple items use correct alias

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -31360,8 +31360,8 @@
           {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "IndexName",
+              "namespace": "_types"
             }
           },
           {
@@ -31369,8 +31369,8 @@
             "value": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "IndexName",
+                "namespace": "_types"
               }
             }
           }
@@ -31939,8 +31939,8 @@
           {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "Name",
+              "namespace": "_types"
             }
           },
           {
@@ -31948,8 +31948,8 @@
             "value": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Name",
+                "namespace": "_types"
               }
             }
           }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1991,7 +1991,7 @@ export interface IndexingStats {
   types?: Record<string, IndexingStats>
 }
 
-export type Indices = string | string[]
+export type Indices = IndexName | IndexName[]
 
 export interface IndicesResponseBase extends AcknowledgedResponseBase {
   _shards?: ShardStatistics
@@ -2054,7 +2054,7 @@ export type MultiTermQueryRewrite = string
 
 export type Name = string
 
-export type Names = string | string[]
+export type Names = Name | Name[]
 
 export type Namespace = string
 

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -43,7 +43,7 @@ export type NodeId = string
 export type NodeIds = NodeId | NodeId[]
 
 export type IndexName = string
-export type Indices = string | string[]
+export type Indices = IndexName | IndexName[]
 export type IndexAlias = string
 export type IndexPattern = string
 export type IndexPatterns = IndexPattern[]
@@ -58,7 +58,7 @@ export type IndexMetrics = string
 export type Metrics = string | string[]
 
 export type Name = string
-export type Names = string | string[]
+export type Names = Name | Name[]
 
 export type Namespace = string
 export type Service = string


### PR DESCRIPTION
`Indices` and `Names` should use the related type alias rather than `string`.

Note: I've left `Metrics` for the time being as this is a little more nuanced. We likely want the individual metrics to be constrained (enum?) to the correct values. Right now, string is more permissive until we agree a design for this.