### PR TITLE
Update path parts for SearchMvtRequest

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -26908,8 +26908,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
-              "namespace": "_types"
+              "name": "ZoomLevel",
+              "namespace": "_global.search_mvt._types"
             }
           }
         },
@@ -26920,8 +26920,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
-              "namespace": "_types"
+              "name": "Coordinate",
+              "namespace": "_global.search_mvt._types"
             }
           }
         },
@@ -26932,8 +26932,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
-              "namespace": "_types"
+              "name": "Coordinate",
+              "namespace": "_global.search_mvt._types"
             }
           }
         }
@@ -27020,6 +27020,20 @@
       }
     },
     {
+      "kind": "type_alias",
+      "name": {
+        "name": "Coordinate",
+        "namespace": "_global.search_mvt._types"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "integer",
+          "namespace": "_types"
+        }
+      }
+    },
+    {
       "kind": "enum",
       "members": [
         {
@@ -27032,6 +27046,20 @@
       "name": {
         "name": "GridType",
         "namespace": "_global.search_mvt._types"
+      }
+    },
+    {
+      "kind": "type_alias",
+      "name": {
+        "name": "ZoomLevel",
+        "namespace": "_global.search_mvt._types"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "integer",
+          "namespace": "_types"
+        }
       }
     },
     {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1511,9 +1511,9 @@ export type SearchTotalHitsRelation = 'eq' | 'gte'
 export interface SearchMvtRequest extends RequestBase {
   index: Indices
   field: Field
-  zoom: integer
-  x: integer
-  y: integer
+  zoom: SearchMvtZoomLevel
+  x: SearchMvtCoordinate
+  y: SearchMvtCoordinate
   exact_bounds?: boolean
   extent?: integer
   grid_precision?: integer
@@ -1535,7 +1535,11 @@ export interface SearchMvtRequest extends RequestBase {
 
 export type SearchMvtResponse = any
 
+export type SearchMvtCoordinate = integer
+
 export type SearchMvtGridType = 'grid' | 'point'
+
+export type SearchMvtZoomLevel = integer
 
 export interface SearchShardsRequest extends RequestBase {
   index?: Indices

--- a/specification/_global/search_mvt/SearchMvtRequest.ts
+++ b/specification/_global/search_mvt/SearchMvtRequest.ts
@@ -22,10 +22,12 @@ import { RequestBase } from '@_types/Base'
 import { Field, Fields, Indices } from '@_types/common'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import { GridType } from './_types/GridType'
+import { Coordinate } from './_types/Coordinate'
 import { Sort } from '@global/search/_types/sort'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { integer } from '@_types/Numeric'
+import { ZoomLevel } from './_types/ZoomLevel'
 
 /**
  * @rest_spec_name search_mvt
@@ -39,11 +41,11 @@ export interface Request extends RequestBase {
     /* Field containing geospatial data to return */
     field: Field
     /* Zoom level of the vector tile to search */
-    zoom: integer
+    zoom: ZoomLevel
     /* X coordinate for the vector tile to search */
-    x: integer
+    x: Coordinate
     /* Y coordinate for the vector tile to search */
-    y: integer
+    y: Coordinate
   }
   query_parameters: {
     /**

--- a/specification/_global/search_mvt/_types/Coordinate.ts
+++ b/specification/_global/search_mvt/_types/Coordinate.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { integer } from '@_types/Numeric'
 
 export type Coordinate = integer

--- a/specification/_global/search_mvt/_types/Coordinate.ts
+++ b/specification/_global/search_mvt/_types/Coordinate.ts
@@ -1,0 +1,3 @@
+import { integer } from '@_types/Numeric'
+
+export type Coordinate = integer

--- a/specification/_global/search_mvt/_types/ZoomLevel.ts
+++ b/specification/_global/search_mvt/_types/ZoomLevel.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { integer } from '@_types/Numeric'
 
 export type ZoomLevel = integer

--- a/specification/_global/search_mvt/_types/ZoomLevel.ts
+++ b/specification/_global/search_mvt/_types/ZoomLevel.ts
@@ -1,0 +1,3 @@
+import { integer } from '@_types/Numeric'
+
+export type ZoomLevel = integer


### PR DESCRIPTION
As discussed on today's sync, I've updated the path parts for the SearchMvtRequest to use type aliases which are more descriptive. I've opted not to reuse `GeoTilePrecision` for `zoom` for the time being. It's not clear if these are exactly the same thing, despite being constrained to the same range of values. Once #477 is concluded, we may change these to constrain their inputs.