### PR TITLE
Remove unused NEST options from APIs

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -20882,19 +20882,6 @@
                 "namespace": "_types"
               }
             }
-          },
-          {
-            "description": "If true, the API response’s hit.total property is returned as an integer. If false, the API response’s hit.total property is returned as an object.",
-            "name": "rest_total_hits_as_int",
-            "required": false,
-            "serverDefault": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "boolean",
-                "namespace": "internal"
-              }
-            }
           }
         ]
       },
@@ -20961,17 +20948,6 @@
           "name": "rest_total_hits_as_int",
           "required": false,
           "serverDefault": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "total_hits_as_integer",
-          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -27273,6 +27249,19 @@
         "kind": "properties",
         "properties": [
           {
+            "name": "explain",
+            "required": false,
+            "serverDefault": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "ID of the search template to use. If no source is specified,\nthis parameter is required.",
             "name": "id",
             "required": false,
             "type": {
@@ -27302,6 +27291,19 @@
             }
           },
           {
+            "name": "profile",
+            "required": false,
+            "serverDefault": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "An inline search template. Supports the same parameters as the search API's\nrequest body. Also supports Mustache variables. If no id is specified, this\nparameter is required.",
             "name": "source",
             "required": false,
             "type": {
@@ -27327,7 +27329,7 @@
       },
       "path": [
         {
-          "description": "A comma-separated list of index names to search; use `_all` or empty string to perform the operation on all indices",
+          "description": "Comma-separated list of data streams, indices,\nand aliases to search. Supports wildcards (*).",
           "name": "index",
           "required": false,
           "type": {
@@ -27379,9 +27381,10 @@
           }
         },
         {
-          "description": "server_default false",
+          "description": "Specify whether to return detailed information about score computation as part of a hit",
           "name": "explain",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -27442,7 +27445,7 @@
           }
         },
         {
-          "description": "A comma-separated list of specific routing values",
+          "description": "Custom value used to route operations to a specific shard.",
           "name": "routing",
           "required": false,
           "type": {
@@ -27454,7 +27457,7 @@
           }
         },
         {
-          "description": "Specify how long a consistent view of the index should be maintained for scrolled search",
+          "description": "Specifies how long a consistent view of the index\nshould be maintained for scrolled search.",
           "name": "scroll",
           "required": false,
           "type": {
@@ -27466,7 +27469,7 @@
           }
         },
         {
-          "description": "Search operation type",
+          "description": "The type of the search operation.",
           "name": "search_type",
           "required": false,
           "type": {
@@ -27479,7 +27482,7 @@
         },
         {
           "description": "If true, hits.total are rendered as an integer in the response.",
-          "name": "total_hits_as_integer",
+          "name": "rest_total_hits_as_int",
           "required": false,
           "serverDefault": false,
           "since": "7.0.0",

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -13470,17 +13470,6 @@
           }
         },
         {
-          "name": "query_on_query_string",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "description": "A comma-separated list of specific routing values",
           "name": "routing",
           "required": false,
@@ -15279,17 +15268,6 @@
         {
           "description": "Specify the node or shard the operation should be performed on (default: random)",
           "name": "preference",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "query_on_query_string",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -28994,17 +28972,6 @@
         {
           "description": "Specify the node or shard the operation should be performed on (default: random)",
           "name": "preference",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "query_on_query_string",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -58782,17 +58749,6 @@
               "type": {
                 "name": "QueryContainer",
                 "namespace": "_types.query_dsl"
-              }
-            }
-          },
-          {
-            "name": "query_on_query_string",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
               }
             }
           },
@@ -96246,17 +96202,6 @@
             "kind": "instance_of",
             "type": {
               "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "query_on_query_string",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
               "namespace": "internal"
             }
           }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1682,12 +1682,6 @@
       ],
       "response": []
     },
-    "scroll": {
-      "request": [
-        "Request: query parameter 'total_hits_as_integer' does not exist in the json spec"
-      ],
-      "response": []
-    },
     "search": {
       "request": [],
       "response": [
@@ -1703,13 +1697,6 @@
     "search_shards": {
       "request": [
         "Request: should not have a body"
-      ],
-      "response": []
-    },
-    "search_template": {
-      "request": [
-        "Request: query parameter 'total_hits_as_integer' does not exist in the json spec",
-        "Request: missing json spec query parameter 'rest_total_hits_as_int'"
       ],
       "response": []
     },

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -571,12 +571,6 @@
       ],
       "response": []
     },
-    "count": {
-      "request": [
-        "Request: query parameter 'query_on_query_string' does not exist in the json spec"
-      ],
-      "response": []
-    },
     "dangling_indices.delete_dangling_index": {
       "request": [
         "Request: should not have a body"
@@ -726,12 +720,6 @@
     "exists_source": {
       "request": [
         "Request: should not have a body"
-      ],
-      "response": []
-    },
-    "explain": {
-      "request": [
-        "Request: query parameter 'query_on_query_string' does not exist in the json spec"
       ],
       "response": []
     },
@@ -1167,12 +1155,6 @@
     "indices.unfreeze": {
       "request": [
         "Request: should not have a body"
-      ],
-      "response": []
-    },
-    "indices.validate_query": {
-      "request": [
-        "Request: query parameter 'query_on_query_string' does not exist in the json spec"
       ],
       "response": []
     },
@@ -2184,7 +2166,6 @@
     },
     "update_by_query": {
       "request": [
-        "Request: query parameter 'query_on_query_string' does not exist in the json spec",
         "Request: query parameter 'size' does not exist in the json spec",
         "Request: missing json spec query parameter 'q'",
         "Request: missing json spec query parameter 'max_docs'"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -137,7 +137,6 @@ export interface CountRequest extends RequestBase {
   lenient?: boolean
   min_score?: double
   preference?: string
-  query_on_query_string?: string
   routing?: Routing
   terminate_after?: long
   q?: string
@@ -316,7 +315,6 @@ export interface ExplainRequest extends RequestBase {
   df?: string
   lenient?: boolean
   preference?: string
-  query_on_query_string?: string
   routing?: Routing
   _source?: boolean | Fields
   _source_excludes?: Fields
@@ -1722,7 +1720,6 @@ export interface UpdateByQueryRequest extends RequestBase {
   lenient?: boolean
   pipeline?: string
   preference?: string
-  query_on_query_string?: string
   refresh?: boolean
   request_cache?: boolean
   requests_per_second?: long
@@ -4934,7 +4931,6 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
     profile?: boolean
     pit?: SearchPointInTimeReference
     query?: QueryDslQueryContainer
-    query_on_query_string?: string
     request_cache?: boolean
     rescore?: SearchRescore[]
     routing?: Routing
@@ -9610,7 +9606,6 @@ export interface IndicesValidateQueryRequest extends RequestBase {
   explain?: boolean
   ignore_unavailable?: boolean
   lenient?: boolean
-  query_on_query_string?: string
   rewrite?: boolean
   q?: string
   body?: {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -932,11 +932,9 @@ export interface ScrollRequest extends RequestBase {
   scroll_id?: Id
   scroll?: Time
   rest_total_hits_as_int?: boolean
-  total_hits_as_integer?: boolean
   body?: {
     scroll?: Time
     scroll_id: ScrollId
-    rest_total_hits_as_int?: boolean
   }
 }
 
@@ -1573,11 +1571,13 @@ export interface SearchTemplateRequest extends RequestBase {
   routing?: Routing
   scroll?: Time
   search_type?: SearchType
-  total_hits_as_integer?: boolean
+  rest_total_hits_as_int?: boolean
   typed_keys?: boolean
   body?: {
+    explain?: boolean
     id?: Id
     params?: Record<string, any>
+    profile?: boolean
     source?: string
   }
 }

--- a/specification/_global/count/CountRequest.ts
+++ b/specification/_global/count/CountRequest.ts
@@ -48,7 +48,6 @@ export interface Request extends RequestBase {
     lenient?: boolean
     min_score?: double
     preference?: string
-    query_on_query_string?: string
     routing?: Routing
     terminate_after?: long
     q?: string

--- a/specification/_global/explain/ExplainRequest.ts
+++ b/specification/_global/explain/ExplainRequest.ts
@@ -38,7 +38,6 @@ export interface Request extends RequestBase {
     df?: string
     lenient?: boolean
     preference?: string
-    query_on_query_string?: string
     routing?: Routing
     _source?: boolean | Fields
     _source_excludes?: Fields

--- a/specification/_global/scroll/ScrollRequest.ts
+++ b/specification/_global/scroll/ScrollRequest.ts
@@ -45,7 +45,6 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     rest_total_hits_as_int?: boolean
-    total_hits_as_integer?: boolean
   }
   body: {
     /**
@@ -56,10 +55,5 @@ export interface Request extends RequestBase {
     scroll?: Time
     /** Scroll ID of the search. */
     scroll_id: ScrollId
-    /**
-     * If true, the API response’s hit.total property is returned as an integer. If false, the API response’s hit.total property is returned as an object.
-     * @server_default false
-     */
-    rest_total_hits_as_int?: boolean
   }
 }

--- a/specification/_global/search_template/SearchTemplateRequest.ts
+++ b/specification/_global/search_template/SearchTemplateRequest.ts
@@ -36,6 +36,10 @@ import { Time } from '@_types/Time'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Comma-separated list of data streams, indices,
+     * and aliases to search. Supports wildcards (*).
+     */
     index?: Indices
   }
   query_parameters: {
@@ -44,7 +48,7 @@ export interface Request extends RequestBase {
     /** @server_default false */
     ccs_minimize_roundtrips?: boolean
     expand_wildcards?: ExpandWildcards
-    /** server_default false */
+    /** @server_default false */
     explain?: boolean
     /** @server_default true */
     ignore_throttled?: boolean
@@ -53,21 +57,40 @@ export interface Request extends RequestBase {
     preference?: string
     /** @server_default false */
     profile?: boolean
+    /** Custom value used to route operations to a specific shard. */
     routing?: Routing
+    /**
+     * Specifies how long a consistent view of the index
+     * should be maintained for scrolled search.
+     */
     scroll?: Time
+    /** The type of the search operation. */
     search_type?: SearchType
     /**
      * If true, hits.total are rendered as an integer in the response.
      * @since 7.0.0
      * @server_default false
      */
-    total_hits_as_integer?: boolean
+    rest_total_hits_as_int?: boolean
     /** @server_default false */
     typed_keys?: boolean
   }
   body: {
+    /** @server_default false */
+    explain?: boolean
+    /**
+     * ID of the search template to use. If no source is specified,
+     * this parameter is required.
+     */
     id?: Id
     params?: Dictionary<string, UserDefinedValue>
+    /** @server_default false */
+    profile?: boolean
+    /**
+     * An inline search template. Supports the same parameters as the search API's
+     * request body. Also supports Mustache variables. If no id is specified, this
+     * parameter is required.
+     */
     source?: string
   }
 }

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -56,7 +56,6 @@ export interface Request extends RequestBase {
     lenient?: boolean
     pipeline?: string
     preference?: string
-    query_on_query_string?: string
     refresh?: boolean
     request_cache?: boolean
     requests_per_second?: long

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -87,7 +87,6 @@ export interface Request extends RequestBase {
     profile?: boolean
     pit?: PointInTimeReference
     query?: QueryContainer
-    query_on_query_string?: string
     request_cache?: boolean
     rescore?: Rescore[]
     routing?: Routing

--- a/specification/indices/validate_query/IndicesValidateQueryRequest.ts
+++ b/specification/indices/validate_query/IndicesValidateQueryRequest.ts
@@ -47,7 +47,6 @@ export interface Request extends RequestBase {
     explain?: boolean
     ignore_unavailable?: boolean
     lenient?: boolean
-    query_on_query_string?: string
     rewrite?: boolean
     q?: string
   }


### PR DESCRIPTION
Noticed these options on multiple APIs which looks like an artifact from the past? Removed as it didn't seem to be used/documented on the Elasticsearch side.