### PR TITLE
Add support for endpoint description

### DIFF
--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -518,6 +518,15 @@ export function hoistRequestAnnotations (
   const knownRequestAnnotations = [
     'since', 'rest_spec_name', 'stability', 'visibility', 'behavior', 'class_serializer'
   ]
+  // in most of the cases the jsDocs comes in a single block,
+  // but it can happen that the user defines multiple single line jsDoc.
+  // We want to enforce a single jsDoc block.
+  assert(jsDocs, jsDocs.length < 2, 'Use a single multiline jsDoc block instead of multiple single line blocks')
+
+  if (jsDocs.length === 1) {
+    const description = jsDocs[0].getDescription()
+    if (description.length > 0) request.description = description.trim()
+  }
   const tags = parseJsDocTags(jsDocs)
   const apiName = tags.rest_spec_name
   // TODO (@typescript-eslint/strict-boolean-expressions) is no fun

--- a/compiler/steps/add-description.ts
+++ b/compiler/steps/add-description.ts
@@ -54,6 +54,10 @@ export default async function addDescription (model: model.Model, jsonSpec: Map<
         }
       }
     }
+
+    if (spec.documentation.description != null) {
+      requestDefinition.description = requestDefinition.description ?? spec.documentation.description
+    }
   }
 
   return model

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -12676,6 +12676,7 @@
           }
         }
       },
+      "description": "Allows to perform multiple index/update/delete operations in a single request.",
       "generics": [
         {
           "name": "TSource",
@@ -13186,6 +13187,7 @@
           }
         ]
       },
+      "description": "Explicitly clears the search context for a scroll.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -13267,6 +13269,7 @@
           }
         ]
       },
+      "description": "Close a point in time",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -13335,6 +13338,7 @@
           }
         ]
       },
+      "description": "Returns number of documents matching a query.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -13580,6 +13584,7 @@
           }
         }
       },
+      "description": "Creates a new document in the index.\n\nReturns a 409 response when a document with a same ID already exists in the index.",
       "generics": [
         {
           "name": "TDocument",
@@ -13746,6 +13751,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Removes a document from the index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -13953,6 +13959,7 @@
           }
         ]
       },
+      "description": "Deletes documents matching the provided query.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -14570,6 +14577,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Changes the number of requests per second for a particular Delete By Query operation.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -14634,6 +14642,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes a script.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -14710,6 +14719,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about whether a document exists in an index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -14899,6 +14909,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about whether a document source exists in an index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -15191,6 +15202,7 @@
           }
         ]
       },
+      "description": "Returns information about why a specific matches (or doesn't match) a query.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -15766,6 +15778,7 @@
           }
         ]
       },
+      "description": "Returns the information about the capabilities of fields among multiple indices.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -15917,6 +15930,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns a document.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -16238,6 +16252,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns a script.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -16440,6 +16455,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns all script contexts.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -16521,6 +16537,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns available script types, languages and contexts",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -16583,6 +16600,7 @@
         "kind": "properties",
         "properties": []
       },
+      "description": "Returns the source of a document.",
       "inherits": {
         "type": {
           "name": "Request",
@@ -16635,6 +16653,7 @@
           }
         }
       },
+      "description": "Creates or updates a document in an index.",
       "generics": [
         {
           "name": "TDocument",
@@ -16837,6 +16856,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns basic information about the cluster.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -17240,6 +17260,7 @@
           }
         ]
       },
+      "description": "Allows to get multiple documents in one request.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -17699,6 +17720,7 @@
           }
         }
       },
+      "description": "Allows to execute several search operations in one request.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -17988,6 +18010,7 @@
           }
         }
       },
+      "description": "Allows to execute several search template operations in one request.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -18377,6 +18400,7 @@
           }
         ]
       },
+      "description": "Returns multiple termvectors in one request.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -18682,6 +18706,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Open a point in time that can be used in subsequent searches",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -18752,6 +18777,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns whether the cluster is running.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -18796,6 +18822,7 @@
           }
         ]
       },
+      "description": "Creates or updates a script.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -19470,6 +19497,7 @@
           }
         ]
       },
+      "description": "Allows to evaluate the quality of ranked search results over a set of typical search queries",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -19847,6 +19875,7 @@
           }
         ]
       },
+      "description": "Allows to copy documents from one index to another, optionally filtering the source\ndocuments by a query, changing the destination index settings, or fetching the\ndocuments from a remote cluster.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -20528,6 +20557,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Changes the number of requests per second for a particular Reindex operation.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -20651,6 +20681,7 @@
           }
         ]
       },
+      "description": "Allows to use the Mustache language to pre-render a search definition.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -20831,6 +20862,7 @@
           }
         ]
       },
+      "description": "Allows an arbitrary script to be executed and a result to be returned",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -20909,6 +20941,7 @@
           }
         ]
       },
+      "description": "Allows to retrieve a large numbers of results from a single search request.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -21551,6 +21584,7 @@
           }
         ]
       },
+      "description": "Returns results matching a query.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -26850,6 +26884,7 @@
           }
         ]
       },
+      "description": "Searches a vector tile for geospatial values. Returns results as a binary Mapbox vector tile.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -27058,6 +27093,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about the indices and shards that a search request would be executed against.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -27340,6 +27376,7 @@
           }
         ]
       },
+      "description": "Allows to use the Mustache language to pre-render a search definition.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -27700,6 +27737,7 @@
           }
         ]
       },
+      "description": "The terms enum API  can be used to discover terms in the index that begin with the provided string. It is designed for low-latency look-ups used in auto-complete scenarios.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -27956,6 +27994,7 @@
           }
         ]
       },
+      "description": "Returns information and statistics about terms in the fields of a particular document.",
       "generics": [
         {
           "name": "TDocument",
@@ -28505,6 +28544,7 @@
           }
         ]
       },
+      "description": "Updates a document with a script or partial document.",
       "generics": [
         {
           "name": "TDocument",
@@ -28838,6 +28878,7 @@
           }
         ]
       },
+      "description": "Performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -29455,6 +29496,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Changes the number of requests per second for a particular Update By Query operation.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -58223,6 +58265,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an async search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -58274,6 +58317,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves the results of a previously submitted async search request given its ID.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -58377,6 +58421,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves the status of a previously submitted async search request given its ID.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -59122,6 +59167,7 @@
           }
         ]
       },
+      "description": "Executes a search request asynchronously.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -59279,6 +59325,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -59517,6 +59564,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Gets the current autoscaling capacity based on the configured autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -59572,6 +59620,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves an autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -59630,6 +59679,7 @@
           }
         }
       },
+      "description": "Creates a new autoscaling policy. Designed for indirect use by ECE/ESS and ECK. Direct use is not supported.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -59812,6 +59862,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Shows information about currently configured aliases to indices including filter and routing infos.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -60026,6 +60077,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -60153,6 +60205,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Provides quick access to the document count of the entire cluster, or individual indices.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -60298,6 +60351,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Shows how much heap memory is currently being used by fielddata on every data node in the cluster.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -60603,6 +60657,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns a concise representation of the cluster health.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -60689,6 +60744,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns help for the Cat APIs.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -62730,6 +62786,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about indices: number of primaries and replicas, document counts, disk size, ...",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -62909,6 +62966,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about the master node.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -63207,6 +63265,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Gets configuration and usage information about data frame analytics jobs.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -63482,6 +63541,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Gets configuration and usage information about datafeeds.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -64511,6 +64571,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Gets configuration and usage information about anomaly detection jobs.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -64591,6 +64652,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Gets configuration and usage information about inference trained models.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -65091,6 +65153,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about custom node attributes.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -66647,6 +66710,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns basic statistics about performance of cluster nodes.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -66795,6 +66859,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns a concise representation of the cluster pending tasks.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -66933,6 +66998,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about installed plugins across nodes node.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -67377,6 +67443,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about index shard recoveries, both on-going completed.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -67508,6 +67575,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about snapshot repositories registered in the cluster.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -67550,6 +67618,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Provides low-level information about the segments in the shards of an index.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -67857,6 +67926,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Provides a detailed view of shard allocation on nodes.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -69123,6 +69193,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns all snapshots in a specific repository.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -69400,6 +69471,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about the tasks currently executing on one or more nodes in the cluster.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -69740,6 +69812,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about existing templates.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -69880,6 +69953,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns cluster-wide thread pool statistics per node.\nBy default the active, queue and rejected statistics are returned for all thread pools.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -70268,6 +70342,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Gets configuration and usage information about transforms.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -71274,6 +71349,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes auto-follow patterns.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -71459,6 +71535,7 @@
           }
         ]
       },
+      "description": "Creates a new follower index configured to follow the referenced leader index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -71749,6 +71826,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves information about all follower indices, including parameters and status for each follower index",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -71809,6 +71887,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves follower stats. return shard-level stats about the following tasks associated with each shard for the specified indices.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -71915,6 +71994,7 @@
           }
         ]
       },
+      "description": "Removes the follower retention leases from the leader.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -72084,6 +72164,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Gets configured auto-follow patterns. Returns the specified auto-follow pattern collection.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -72144,6 +72225,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Pauses an auto-follow pattern",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -72195,6 +72277,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Pauses a follower index. The follower index will not fetch any additional operations from the leader index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -72446,6 +72529,7 @@
           }
         ]
       },
+      "description": "Creates a new named collection of auto-follow patterns against a specified remote cluster. Newly created indices on the remote cluster matching any of the specified patterns will be automatically configured as follower indices.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -72497,6 +72581,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Resumes an auto-follow pattern that has been paused",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -72660,6 +72745,7 @@
           }
         ]
       },
+      "description": "Resumes a follower index that has been paused",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -72846,6 +72932,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Gets all stats related to cross-cluster replication.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -72901,6 +72988,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Stops the following task associated with a follower index and removes index metadata and settings associated with cross-cluster replication.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -74718,6 +74806,7 @@
           }
         ]
       },
+      "description": "Provides explanations for shard allocations in the cluster.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -75259,6 +75348,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes a component template",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -75337,6 +75427,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Clears cluster voting config exclusions.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -75382,6 +75473,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about whether a particular component template exist",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -75453,6 +75545,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns one or more component templates",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -75552,6 +75645,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns cluster settings.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -75807,6 +75901,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns basic information about the health of the cluster.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -76332,6 +76427,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns a list of any cluster-level changes (e.g. create index, update mapping,\nallocate or fail shard) which have not yet been executed.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -76405,6 +76501,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Updates the cluster voting config exclusions by node ids or node names.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -76554,6 +76651,7 @@
           }
         ]
       },
+      "description": "Creates or updates a component template",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -76670,6 +76768,7 @@
           }
         ]
       },
+      "description": "Updates the cluster settings.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -76999,6 +77098,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "The cluster remote info API allows you to retrieve all of the configured\nremote cluster information. It returns connection and endpoint information\nkeyed by the configured remote cluster alias.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -77345,6 +77445,7 @@
           }
         ]
       },
+      "description": "Allows to manually change the allocation of individual shards in the cluster.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -77920,6 +78021,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns a comprehensive information about the state of the cluster.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -79868,6 +79970,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns high-level overview of cluster statistics.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -80186,6 +80289,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes the specified dangling index",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -80274,6 +80378,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Imports the specified dangling index",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -80415,6 +80520,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns all dangling indices.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -80577,6 +80683,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an existing enrich policy and its enrich index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -80669,6 +80776,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Creates the enrich index for an existing enrich policy.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -80750,6 +80858,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Gets information about an enrich policy.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -80834,6 +80943,7 @@
           }
         ]
       },
+      "description": "Creates a new enrich policy.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -80980,6 +81090,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Gets enrich coordinator statistics and information about enrich policies that are currently executing.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -81337,6 +81448,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an async EQL search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -81388,6 +81500,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns async results from previously executed Event Query Language (EQL) search",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -81479,6 +81592,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns the status of a previously submitted async or stored Event Query Language (EQL) search",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -81798,6 +81912,7 @@
           }
         ]
       },
+      "description": "Returns results matching a query expressed in Event Query Language (EQL)",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -82021,6 +82136,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Gets a list of features which can be included in snapshots using the feature_states field when creating a snapshot",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -82068,6 +82184,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Resets the internal state of features, usually by deleting system indices",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -82511,6 +82628,7 @@
           }
         ]
       },
+      "description": "Explore extracted and summarized information about the documents and terms in an index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -82795,6 +82913,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes the specified lifecycle policy definition. A currently used policy cannot be deleted.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -83131,6 +83250,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves information about the index's current lifecycle state, such as the currently executing phase, action, and step.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -83278,6 +83398,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns the specified policy definition. Includes the policy version and last modified date.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -83345,6 +83466,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves the current index lifecycle management (ILM) status.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -83413,6 +83535,7 @@
           }
         ]
       },
+      "description": "Manually moves an index into the specified step and executes that step.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -83519,6 +83642,7 @@
           }
         ]
       },
+      "description": "Creates a lifecycle policy",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -83570,6 +83694,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Removes the assigned lifecycle policy and stops managing the specified index",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -83641,6 +83766,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retries executing the policy for an index that is in the ERROR step.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -83692,6 +83818,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Start the index lifecycle management (ILM) plugin.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -83753,6 +83880,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Halts all lifecycle management operations and stops the index lifecycle management (ILM) plugin",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -85487,6 +85615,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Adds a block to an index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -86104,6 +86233,7 @@
           }
         ]
       },
+      "description": "Performs the analysis process on a text and return the tokens breakdown of the text.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -86238,6 +86368,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Clears all or specific caches for one or more indices.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -86416,6 +86547,7 @@
           }
         ]
       },
+      "description": "Clones an index",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -86604,6 +86736,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Closes an index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -86839,6 +86972,7 @@
           }
         ]
       },
+      "description": "Creates an index with optional settings and mappings.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -86961,6 +87095,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Creates a data stream",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87076,6 +87211,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Provides statistics on operations happening in a data stream.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87203,6 +87339,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87315,6 +87452,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an alias.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87403,6 +87541,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes a data stream.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87467,6 +87606,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an index template.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87518,6 +87658,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an index template.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87594,6 +87735,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Analyzes the disk usage of each field of an index or data stream",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87745,6 +87887,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about whether a particular index exists.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87862,6 +88005,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about whether a particular alias exists.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -87967,6 +88111,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about whether a particular index template exists.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -88025,6 +88170,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about whether a particular index template exists.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -88106,6 +88252,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about whether a particular document type exists. (DEPRECATED)",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -88211,6 +88358,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Performs the flush operation on one or more indices.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -88323,6 +88471,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Performs the force merge operation on one or more indices.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -88447,6 +88596,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Freezes an index. A frozen index has almost no overhead on the cluster (except for maintaining its metadata in memory) and is read-only.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -88583,6 +88733,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about one or more indices.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -88786,6 +88937,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns an alias.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -89089,6 +89241,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns data streams.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -89162,6 +89315,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns mapping for one or more fields.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -89587,6 +89741,7 @@
           }
         ]
       },
+      "description": "Returns an index template.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -89692,6 +89847,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns mappings for one or more indices.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -89831,6 +89987,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns settings for one or more indices.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -89995,6 +90152,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns an index template.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -90110,6 +90268,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Migrates an alias to a data stream",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -90161,6 +90320,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Opens an index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -90297,6 +90457,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Promotes a data stream from a replicated data stream managed by CCR to a regular data stream",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -90401,6 +90562,7 @@
           }
         ]
       },
+      "description": "Creates or updates an alias.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -90625,6 +90787,7 @@
           }
         ]
       },
+      "description": "Creates or updates an index template.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -90881,6 +91044,7 @@
           }
         ]
       },
+      "description": "Updates the index mappings.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -91049,6 +91213,7 @@
           }
         }
       },
+      "description": "Updates the index settings.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -91292,6 +91457,7 @@
           }
         ]
       },
+      "description": "Creates or updates an index template.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -91935,6 +92101,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about ongoing index shard recoveries.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -92340,6 +92507,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Performs the refresh operation in one or more indices.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -92476,6 +92644,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Reloads an index's search analyzers and their resources.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -92584,6 +92753,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about any matching indices, aliases, and data streams",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -92904,6 +93074,7 @@
           }
         ]
       },
+      "description": "Updates an alias to point to a new index when the existing index\nis considered to be too large or too old.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -93204,6 +93375,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Provides low-level information about segments in a Lucene index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -93599,6 +93771,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Provides store information for shard copies of indices.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -93949,6 +94122,7 @@
           }
         ]
       },
+      "description": "Allow to shrink an existing index into a new index with fewer primary shards.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -94128,6 +94302,7 @@
           }
         ]
       },
+      "description": "Simulate matching the given index name against the index templates in the system",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -94214,6 +94389,7 @@
           }
         }
       },
+      "description": "Simulate resolving the given template name or body",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -94414,6 +94590,7 @@
           }
         ]
       },
+      "description": "Allows you to split an existing index into a new index with more primary shards.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -94816,6 +94993,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Provides statistics on operations happening in an index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -95786,6 +95964,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Unfreezes an index. When a frozen index is unfrozen, the index goes through the normal recovery process and becomes writeable again.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -95946,6 +96125,7 @@
           }
         ]
       },
+      "description": "Updates index aliases.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -96075,6 +96255,7 @@
           }
         ]
       },
+      "description": "Allows a user to validate a potentially expensive query without executing it.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -99026,6 +99207,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes a pipeline.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -99232,6 +99414,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns statistical information about geoip databases",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -99300,6 +99483,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns a pipeline.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -99394,6 +99578,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns a list of the built-in patterns.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -99517,6 +99702,7 @@
           }
         ]
       },
+      "description": "Creates or updates a pipeline.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -99851,6 +100037,7 @@
           }
         ]
       },
+      "description": "Allows to simulate a pipeline with example documents.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -100100,6 +100287,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes licensing information for the cluster",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -100279,6 +100467,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves licensing information for the cluster",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -100348,6 +100537,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves information about the status of the basic license.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -100392,6 +100582,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves information about the status of the trial license.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -100497,6 +100688,7 @@
           }
         ]
       },
+      "description": "Updates the license for the cluster.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -100576,6 +100768,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Starts an indefinite basic license.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -100687,6 +100880,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "starts a limited time trial license.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -100986,6 +101180,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes Logstash Pipelines used by Central Management",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -101030,6 +101225,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves Logstash Pipelines used by Central Management",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -101099,6 +101295,7 @@
           }
         }
       },
+      "description": "Adds and updates Logstash Pipelines used for Central Management",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -101220,6 +101417,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -108815,6 +109013,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Closes one or more anomaly detection jobs. A job can be opened and closed multiple times throughout its lifecycle.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -108910,6 +109109,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes a calendar.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -108961,6 +109161,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes scheduled events from a calendar.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109024,6 +109225,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes anomaly detection jobs from a calendar.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109115,6 +109317,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an existing data frame analytics job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109193,6 +109396,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an existing datafeed.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109282,6 +109486,7 @@
           }
         ]
       },
+      "description": "Deletes expired and unused machine learning data.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109365,6 +109570,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes a filter.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109416,6 +109622,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes forecasts from a machine learning job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109504,6 +109711,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an existing anomaly detection job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109580,6 +109788,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an existing model snapshot.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109643,6 +109852,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an existing trained inference model that is currently not referenced by an ingest pipeline.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109694,6 +109904,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes a model alias that refers to the trained model",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -109814,6 +110025,7 @@
           }
         ]
       },
+      "description": "Estimates the model memory",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -110502,6 +110714,7 @@
           }
         ]
       },
+      "description": "Evaluates the data frame analytics for an annotated index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -110669,6 +110882,7 @@
           }
         ]
       },
+      "description": "Explains a data frame analytics config.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -110788,6 +111002,7 @@
           }
         ]
       },
+      "description": "Forces any buffered data to be processed by the job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -110893,6 +111108,7 @@
           }
         ]
       },
+      "description": "Predicts the future behavior of a time series by using its historical behavior.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -111049,6 +111265,7 @@
           }
         ]
       },
+      "description": "Retrieves anomaly detection job results for one or more buckets.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -111265,6 +111482,7 @@
           }
         ]
       },
+      "description": "Retrieves information about the scheduled events in calendars.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -111457,6 +111675,7 @@
           }
         ]
       },
+      "description": "Retrieves configuration information for calendars.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -111566,6 +111785,7 @@
           }
         ]
       },
+      "description": "Retrieves anomaly detection job results for one or more categories.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -111686,6 +111906,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves configuration information for data frame analytics jobs.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -111811,6 +112032,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves usage information for data frame analytics jobs.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -111936,6 +112158,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves usage information for datafeeds.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -112020,6 +112243,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves configuration information for datafeeds.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -112116,6 +112340,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves filters.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -112225,6 +112450,7 @@
           }
         ]
       },
+      "description": "Retrieves anomaly detection job results for one or more influencers.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -112395,6 +112621,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves usage information for anomaly detection jobs.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -112479,6 +112706,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves configuration information for anomaly detection jobs.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -112614,6 +112842,7 @@
           }
         ]
       },
+      "description": "Retrieves information about model snapshots.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -112783,6 +113012,7 @@
           }
         ]
       },
+      "description": "Retrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -113034,6 +113264,7 @@
           }
         ]
       },
+      "description": "Retrieves anomaly records for an anomaly detection job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -113167,6 +113398,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves configuration information for a trained inference model.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -113328,6 +113560,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves usage information for trained inference models.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -113628,6 +113861,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns defaults and limits used by machine learning.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -113718,6 +113952,7 @@
           }
         ]
       },
+      "description": "Opens one or more anomaly detection jobs.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -113792,6 +114027,7 @@
           }
         ]
       },
+      "description": "Posts scheduled events in a calendar.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -113863,6 +114099,7 @@
           }
         }
       },
+      "description": "Sends data to an anomaly detection job for analysis.",
       "generics": [
         {
           "name": "TData",
@@ -114184,6 +114421,7 @@
           }
         ]
       },
+      "description": "Previews that will be analyzed given a data frame analytics config.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -114280,6 +114518,7 @@
           }
         ]
       },
+      "description": "Previews a datafeed.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -114359,6 +114598,7 @@
           }
         ]
       },
+      "description": "Instantiates a calendar.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -114438,6 +114678,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Adds an anomaly detection job to a calendar.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -114631,6 +114872,7 @@
           }
         ]
       },
+      "description": "Instantiates a data frame analytics job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -114982,6 +115224,7 @@
           }
         ]
       },
+      "description": "Instantiates a datafeed.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -115283,6 +115526,7 @@
           }
         ]
       },
+      "description": "Instantiates a filter.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -115554,6 +115798,7 @@
           }
         ]
       },
+      "description": "Instantiates an anomaly detection job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -116230,6 +116475,7 @@
           }
         ]
       },
+      "description": "Creates an inference trained model.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -116580,6 +116826,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Creates a new model alias (or reassigns an existing one) to refer to the trained model",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -116657,6 +116904,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Resets an existing anomaly detection job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -116735,6 +116983,7 @@
           }
         ]
       },
+      "description": "Reverts to a specific snapshot.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -116804,6 +117053,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Sets a cluster wide upgrade_mode setting that prepares machine learning indices for an upgrade.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -116867,6 +117117,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Starts a data frame analytics job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -116981,6 +117232,7 @@
           }
         ]
       },
+      "description": "Starts one or more datafeeds.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -117062,6 +117314,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Stops one or more data frame analytics jobs.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -117185,6 +117438,7 @@
           }
         ]
       },
+      "description": "Stops one or more datafeeds.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -117322,6 +117576,7 @@
           }
         ]
       },
+      "description": "Updates certain properties of a data frame analytics job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -117530,6 +117785,7 @@
           }
         ]
       },
+      "description": "Updates the description of a filter, adds items, or removes items.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -117798,6 +118054,7 @@
           }
         ]
       },
+      "description": "Updates certain properties of an anomaly detection job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -118113,6 +118370,7 @@
           }
         ]
       },
+      "description": "Updates certain properties of a snapshot.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -118188,6 +118446,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Upgrades a given job snapshot to the current major version.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -118387,6 +118646,7 @@
           }
         ]
       },
+      "description": "Validates an anomaly detection job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -118432,6 +118692,7 @@
           }
         }
       },
+      "description": "Validates an anomaly detection detector.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -118493,6 +118754,7 @@
           }
         }
       },
+      "description": "Used by the monitoring features to send monitoring data.",
       "generics": [
         {
           "name": "TSource",
@@ -120529,6 +120791,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about hot threads on each node in the cluster.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -122986,6 +123249,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about nodes in the cluster.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123209,6 +123473,7 @@
           }
         ]
       },
+      "description": "Reloads secure settings.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123319,6 +123584,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns statistical information about nodes in the cluster.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123626,6 +123892,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns low-level information about REST actions usage on nodes.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -123973,6 +124240,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an existing rollup job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -124147,6 +124415,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves the configuration, stats, and status of rollup jobs.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -124539,6 +124808,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns the capabilities of any rollup jobs that have been configured for a specific index or index pattern.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -124723,6 +124993,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the index where rollup data is stored).",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -124970,6 +125241,7 @@
           }
         ]
       },
+      "description": "Creates a rollup job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -125024,6 +125296,7 @@
           "kind": "user_defined_value"
         }
       },
+      "description": "Rollup an index",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -125129,6 +125402,7 @@
           }
         ]
       },
+      "description": "Enables searching rolled-up data using the standard query DSL.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -125304,6 +125578,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Starts an existing, stopped rollup job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -125361,6 +125636,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Stops an existing, started rollup job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -125461,6 +125737,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Clear the cache of searchable snapshots.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -125665,6 +125942,7 @@
           }
         ]
       },
+      "description": "Mount a snapshot as a searchable index.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -125774,6 +126052,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieve shard-level statistics about searchable snapshots.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -126305,6 +126584,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Enables you to submit a request with a basic auth header to authenticate a user and retrieve information about the authenticated user.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -126497,6 +126777,7 @@
           }
         ]
       },
+      "description": "Changes the passwords of users in the native realm and built-in users.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -126555,6 +126836,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Clear a subset or all entries from the API key cache.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -126646,6 +126928,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Evicts application privileges from the native application privileges cache.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -126737,6 +127020,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Evicts users from the user cache. Can completely clear the cache or evict specific users.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -126844,6 +127128,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Evicts roles from the native role cache.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -126935,6 +127220,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Evicts tokens from the service account token caches.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127147,6 +127433,7 @@
           }
         ]
       },
+      "description": "Creates an API key for access without requiring basic authentication.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127288,6 +127575,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Creates a service account token for access without requiring basic authentication.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127431,6 +127719,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Removes application privileges.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127534,6 +127823,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Removes roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127604,6 +127894,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Removes role mappings.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127674,6 +127965,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes a service account token.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127768,6 +128060,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes users from the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127838,6 +128131,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Disables users in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -127896,6 +128190,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Enables users in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -128052,6 +128347,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves information for one or more API keys.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -128160,6 +128456,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -128218,6 +128515,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves application privileges.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -128390,6 +128688,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -128677,6 +128976,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves role mappings.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -128744,6 +129044,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves information about service accounts.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -129030,6 +129331,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves information of all service credentials for a service account.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -129323,6 +129625,7 @@
           }
         ]
       },
+      "description": "Creates a bearer token for access without requiring basic authentication.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -129464,6 +129767,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves information about users in the native realm and built-in users.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -129546,6 +129850,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves security privileges for the logged in user.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -129798,6 +130103,7 @@
           }
         ]
       },
+      "description": "Creates an API key on behalf of another user.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -130054,6 +130360,7 @@
           }
         ]
       },
+      "description": "Determines whether the specified user has a specified list of privileges.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -130273,6 +130580,7 @@
           }
         ]
       },
+      "description": "Invalidates one or more API keys.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -130405,6 +130713,7 @@
           }
         ]
       },
+      "description": "Invalidates one or more access tokens or refresh tokens.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -130570,6 +130879,7 @@
           }
         }
       },
+      "description": "Adds or updates application privileges.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -130754,6 +131064,7 @@
           }
         ]
       },
+      "description": "Adds and updates roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -130887,6 +131198,7 @@
           }
         ]
       },
+      "description": "Creates and updates role mappings.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -131085,6 +131397,7 @@
           }
         ]
       },
+      "description": "Adds and updates users in the native realm. These users are commonly referred to as native users.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -131155,6 +131468,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Removes a node from the shutdown list",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -131343,6 +131657,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieve status of a node or nodes that are currently marked as shutting down",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -131459,6 +131774,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Adds a node to be shut down",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -132040,6 +132356,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an existing snapshot lifecycle policy.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -132091,6 +132408,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Immediately creates a snapshot according to the lifecycle policy, without waiting for the scheduled time.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -132148,6 +132466,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes any snapshots that are expired according to the policy's retention rules.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -132186,6 +132505,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves one or more snapshot lifecycle policy definitions and information about the latest snapshot attempts.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -132253,6 +132573,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns global and policy-level statistics about actions taken by snapshot lifecycle management.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -132399,6 +132720,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves the status of snapshot lifecycle management (SLM).",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -132505,6 +132827,7 @@
           }
         ]
       },
+      "description": "Creates or updates a snapshot lifecycle policy.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -132583,6 +132906,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Turns on snapshot lifecycle management (SLM).",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -132621,6 +132945,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Turns off snapshot lifecycle management (SLM).",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -133712,6 +134037,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Removes stale data from repository.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -133807,6 +134133,7 @@
           }
         ]
       },
+      "description": "Clones indices from one snapshot into another snapshot in the same repository.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -133986,6 +134313,7 @@
           }
         ]
       },
+      "description": "Creates a snapshot in a repository.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -134129,6 +134457,7 @@
           }
         ]
       },
+      "description": "Creates a repository.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -134217,6 +134546,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes one or more snapshots.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -134293,6 +134623,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes a repository.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -134369,6 +134700,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about a snapshot.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -134591,6 +134923,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about a repository.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -134787,6 +135120,7 @@
           }
         ]
       },
+      "description": "Restores a snapshot.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -134926,6 +135260,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about the status of a snapshot.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -135043,6 +135378,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Verifies a repository.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -135149,6 +135485,7 @@
           }
         ]
       },
+      "description": "Clears the SQL cursor",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -135339,6 +135676,7 @@
           }
         ]
       },
+      "description": "Executes a SQL request",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -135484,6 +135822,7 @@
           }
         ]
       },
+      "description": "Translates SQL into Elasticsearch queries",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -135680,6 +136019,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves information about the X.509 certificates used to encrypt communications in the cluster.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -136231,6 +136571,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Cancels a task, if it can be cancelled through an API.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -136380,6 +136721,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns information about a task.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -136495,6 +136837,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Returns a list of tasks.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -136823,6 +137166,7 @@
           }
         }
       },
+      "description": "Finds the structure of a text file. The text file must contain data that is suitable to be ingested into Elasticsearch.",
       "generics": [
         {
           "name": "TJsonDocument",
@@ -137642,6 +137986,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deletes an existing transform.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -137706,6 +138051,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves configuration information for transforms.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -137965,6 +138311,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves usage information for transforms.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -138497,6 +138844,7 @@
           }
         ]
       },
+      "description": "Previews a transform.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -138575,6 +138923,7 @@
         "kind": "properties",
         "properties": []
       },
+      "description": "Instantiates a transform.",
       "inherits": {
         "type": {
           "name": "Request",
@@ -138639,6 +138988,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Starts one or more transforms.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -138703,6 +139053,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Stops one or more transforms.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -138816,6 +139167,7 @@
         "kind": "properties",
         "properties": []
       },
+      "description": "Updates certain properties of a transform.",
       "inherits": {
         "type": {
           "name": "Request",
@@ -142625,6 +142977,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Acknowledges a watch, manually throttling the execution of the watch's actions.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -142694,6 +143047,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Activates a currently inactive watch.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -142751,6 +143105,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Deactivates a currently active watch.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -142808,6 +143163,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Removes a watch from Watcher.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -142984,6 +143340,7 @@
           }
         ]
       },
+      "description": "Forces the execution of a stored watch.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -143187,6 +143544,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves a watch by its ID.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -143400,6 +143758,7 @@
           }
         ]
       },
+      "description": "Creates a new watch, or updates an existing one.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -143613,6 +143972,7 @@
           }
         ]
       },
+      "description": "Retrieves stored watches.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -143671,6 +144031,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Starts Watcher if it is not already running.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -143709,6 +144070,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves the current Watcher metrics.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -144075,6 +144437,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Stops Watcher if it is running.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -144598,6 +144961,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves information about the installed X-Pack features.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -146489,6 +146853,7 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Retrieves usage information about the installed X-Pack features.",
       "inherits": {
         "type": {
           "name": "RequestBase",


### PR DESCRIPTION
For some reason, we are not outputting the endpoint descriptions in the json, this pr fixes that.
If an endpoint definition is not present in the input spec, the rest-api-spec will be used, in the same way we are doing for the path/query parameters.