### PR TITLE
Add variants to analysis classes, Add IndexState.data_stream

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -43787,6 +43787,106 @@
       ]
     },
     {
+      "kind": "type_alias",
+      "name": {
+        "name": "Analyzer",
+        "namespace": "_types.analysis"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CustomAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "FingerprintAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "KeywordAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "LanguageAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "NoriAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "PatternAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "SimpleAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "StandardAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "StopAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "WhitespaceAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "KuromojiAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          }
+        ],
+        "kind": "union_of"
+      },
+      "variants": {
+        "kind": "internal_tag",
+        "tag": "type"
+      }
+    },
+    {
       "inherits": {
         "type": {
           "name": "TokenFilterBase",
@@ -43799,6 +43899,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "asciifolding"
+          }
+        },
         {
           "name": "preserve_original",
           "required": true,
@@ -43843,6 +43951,10 @@
           }
         ],
         "kind": "union_of"
+      },
+      "variants": {
+        "kind": "internal_tag",
+        "tag": "type"
       }
     },
     {
@@ -43852,17 +43964,6 @@
         "namespace": "_types.analysis"
       },
       "properties": [
-        {
-          "name": "type",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
         {
           "name": "version",
           "required": false,
@@ -43889,6 +43990,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "char_group"
+          }
+        },
         {
           "name": "tokenize_on_chars",
           "required": true,
@@ -43918,6 +44027,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "common_grams"
+          }
+        },
         {
           "name": "common_words",
           "required": true,
@@ -44076,6 +44193,14 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "condition"
+          }
+        },
+        {
           "name": "filter",
           "required": true,
           "type": {
@@ -44097,6 +44222,129 @@
             "type": {
               "name": "Script",
               "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "CustomAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "custom"
+          }
+        },
+        {
+          "name": "char_filter",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
+          "name": "filter",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
+          "name": "position_increment_gap",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "position_offset_gap",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "tokenizer",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "CustomNormalizer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "custom"
+          }
+        },
+        {
+          "name": "char_filter",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
+          "name": "filter",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
             }
           }
         }
@@ -44133,6 +44381,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "delimited_payload"
+          }
+        },
         {
           "name": "delimiter",
           "required": true,
@@ -44186,6 +44442,14 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "edge_ngram"
+          }
+        },
+        {
           "name": "max_gram",
           "required": true,
           "type": {
@@ -44233,6 +44497,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "edge_ngram"
+          }
+        },
         {
           "name": "custom_token_chars",
           "required": true,
@@ -44296,6 +44568,14 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "elision"
+          }
+        },
+        {
           "name": "articles",
           "required": true,
           "type": {
@@ -44323,6 +44603,89 @@
       ]
     },
     {
+      "kind": "interface",
+      "name": {
+        "name": "FingerprintAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "fingerprint"
+          }
+        },
+        {
+          "name": "version",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "max_output_size",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "preserve_original",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "separator",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "stopwords",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "StopWords",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "stopwords_path",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
       "inherits": {
         "type": {
           "name": "TokenFilterBase",
@@ -44335,6 +44698,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "fingerprint"
+          }
+        },
         {
           "name": "max_output_size",
           "required": true,
@@ -44371,7 +44742,16 @@
         "name": "HtmlStripCharFilter",
         "namespace": "_types.analysis"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "html_strip"
+          }
+        }
+      ]
     },
     {
       "inherits": {
@@ -44386,6 +44766,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "hunspell"
+          }
+        },
         {
           "name": "dedup",
           "required": true,
@@ -44444,7 +44832,88 @@
         "name": "HyphenationDecompounderTokenFilter",
         "namespace": "_types.analysis"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "hyphenation_decompounder"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "IcuAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "icu_analyzer"
+          }
+        },
+        {
+          "name": "method",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuNormalizationType",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "mode",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuNormalizationMode",
+              "namespace": "_types.analysis"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "decompose"
+        },
+        {
+          "name": "compose"
+        }
+      ],
+      "name": {
+        "name": "IcuNormalizationMode",
+        "namespace": "_types.analysis"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "nfc"
+        },
+        {
+          "name": "nfkc"
+        },
+        {
+          "name": "nfkc_cf"
+        }
+      ],
+      "name": {
+        "name": "IcuNormalizationType",
+        "namespace": "_types.analysis"
+      }
     },
     {
       "inherits": {
@@ -44458,7 +44927,16 @@
         "name": "KStemTokenFilter",
         "namespace": "_types.analysis"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "kstem"
+          }
+        }
+      ]
     },
     {
       "kind": "enum",
@@ -44488,6 +44966,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "keep_types"
+          }
+        },
         {
           "name": "mode",
           "required": true,
@@ -44529,6 +45015,14 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "keep"
+          }
+        },
+        {
           "name": "keep_words",
           "required": true,
           "type": {
@@ -44567,6 +45061,34 @@
       ]
     },
     {
+      "kind": "interface",
+      "name": {
+        "name": "KeywordAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "keyword"
+          }
+        },
+        {
+          "name": "version",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
       "inherits": {
         "type": {
           "name": "TokenFilterBase",
@@ -44579,6 +45101,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "keyword_marker"
+          }
+        },
         {
           "name": "ignore_case",
           "required": true,
@@ -44642,6 +45172,14 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "keyword"
+          }
+        },
+        {
           "name": "buffer_size",
           "required": true,
           "type": {
@@ -44649,6 +45187,446 @@
             "type": {
               "name": "integer",
               "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "KuromojiAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "kuromoji"
+          }
+        },
+        {
+          "name": "mode",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "KuromojiTokenizationMode",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "user_dictionary",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "KuromojiPartOfSpeechTokenFilter",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "kuromoji_part_of_speech"
+          }
+        },
+        {
+          "name": "stoptags",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "KuromojiReadingFormTokenFilter",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "kuromoji_readingform"
+          }
+        },
+        {
+          "name": "use_romaji",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "KuromojiStemmerTokenFilter",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "kuromoji_stemmer"
+          }
+        },
+        {
+          "name": "minimum_length",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "normal"
+        },
+        {
+          "name": "search"
+        },
+        {
+          "name": "extended"
+        }
+      ],
+      "name": {
+        "name": "KuromojiTokenizationMode",
+        "namespace": "_types.analysis"
+      }
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "KuromojiTokenizer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "kuromoji_tokenizer"
+          }
+        },
+        {
+          "name": "discard_punctuation",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "mode",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "KuromojiTokenizationMode",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "nbest_cost",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "nbest_examples",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "user_dictionary",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "user_dictionary_rules",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "Arabic"
+        },
+        {
+          "name": "Armenian"
+        },
+        {
+          "name": "Basque"
+        },
+        {
+          "name": "Brazilian"
+        },
+        {
+          "name": "Bulgarian"
+        },
+        {
+          "name": "Catalan"
+        },
+        {
+          "name": "Chinese"
+        },
+        {
+          "name": "Cjk"
+        },
+        {
+          "name": "Czech"
+        },
+        {
+          "name": "Danish"
+        },
+        {
+          "name": "Dutch"
+        },
+        {
+          "name": "English"
+        },
+        {
+          "name": "Estonian"
+        },
+        {
+          "name": "Finnish"
+        },
+        {
+          "name": "French"
+        },
+        {
+          "name": "Galician"
+        },
+        {
+          "name": "German"
+        },
+        {
+          "name": "Greek"
+        },
+        {
+          "name": "Hindi"
+        },
+        {
+          "name": "Hungarian"
+        },
+        {
+          "name": "Indonesian"
+        },
+        {
+          "name": "Irish"
+        },
+        {
+          "name": "Italian"
+        },
+        {
+          "name": "Latvian"
+        },
+        {
+          "name": "Norwegian"
+        },
+        {
+          "name": "Persian"
+        },
+        {
+          "name": "Portuguese"
+        },
+        {
+          "name": "Romanian"
+        },
+        {
+          "name": "Russian"
+        },
+        {
+          "name": "Sorani"
+        },
+        {
+          "name": "Spanish"
+        },
+        {
+          "name": "Swedish"
+        },
+        {
+          "name": "Turkish"
+        },
+        {
+          "name": "Thai"
+        }
+      ],
+      "name": {
+        "name": "Language",
+        "namespace": "_types.analysis"
+      }
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "LanguageAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "language"
+          }
+        },
+        {
+          "name": "version",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "language",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Language",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "stem_exclusion",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
+          "name": "stopwords",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "StopWords",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "stopwords_path",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
           }
         }
@@ -44667,6 +45645,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "length"
+          }
+        },
         {
           "name": "max",
           "required": true,
@@ -44703,7 +45689,16 @@
         "name": "LetterTokenizer",
         "namespace": "_types.analysis"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "letter"
+          }
+        }
+      ]
     },
     {
       "inherits": {
@@ -44718,6 +45713,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "limit"
+          }
+        },
         {
           "name": "consume_all_tokens",
           "required": true,
@@ -44756,6 +45759,14 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "lowercase"
+          }
+        },
+        {
           "name": "language",
           "required": true,
           "type": {
@@ -44780,7 +45791,16 @@
         "name": "LowercaseTokenizer",
         "namespace": "_types.analysis"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "lowercase"
+          }
+        }
+      ]
     },
     {
       "inherits": {
@@ -44795,6 +45815,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "mapping"
+          }
+        },
         {
           "name": "mappings",
           "required": true,
@@ -44836,6 +45864,14 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "multiplexer"
+          }
+        },
+        {
           "name": "filters",
           "required": true,
           "type": {
@@ -44876,6 +45912,14 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "ngram"
+          }
+        },
+        {
           "name": "max_gram",
           "required": true,
           "type": {
@@ -44912,6 +45956,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "ngram"
+          }
+        },
         {
           "name": "custom_token_chars",
           "required": true,
@@ -44962,6 +46014,70 @@
       ]
     },
     {
+      "kind": "interface",
+      "name": {
+        "name": "NoriAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "nori"
+          }
+        },
+        {
+          "name": "version",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "decompound_mode",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "NoriDecompoundMode",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "stoptags",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
+          "name": "user_dictionary",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
       "kind": "enum",
       "members": [
         {
@@ -44993,6 +46109,14 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "nori_part_of_speech"
+          }
+        },
+        {
           "name": "stoptags",
           "required": true,
           "type": {
@@ -45021,6 +46145,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "nori_tokenizer"
+          }
+        },
         {
           "name": "decompound_mode",
           "required": true,
@@ -45084,6 +46216,14 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "path_hierarchy"
+          }
+        },
+        {
           "name": "buffer_size",
           "required": true,
           "type": {
@@ -45141,6 +46281,78 @@
       ]
     },
     {
+      "kind": "interface",
+      "name": {
+        "name": "PatternAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "pattern"
+          }
+        },
+        {
+          "name": "version",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "flags",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "lowercase",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "pattern",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "stopwords",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "StopWords",
+              "namespace": "_types.analysis"
+            }
+          }
+        }
+      ]
+    },
+    {
       "inherits": {
         "type": {
           "name": "TokenFilterBase",
@@ -45153,6 +46365,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "pattern_capture"
+          }
+        },
         {
           "name": "patterns",
           "required": true,
@@ -45193,6 +46413,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "pattern_replace"
+          }
+        },
         {
           "name": "flags",
           "required": true,
@@ -45240,7 +46468,16 @@
         "name": "PorterStemTokenFilter",
         "namespace": "_types.analysis"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "porter_stem"
+          }
+        }
+      ]
     },
     {
       "inherits": {
@@ -45255,6 +46492,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "predicate_token_filter"
+          }
+        },
         {
           "name": "script",
           "required": true,
@@ -45280,7 +46525,16 @@
         "name": "RemoveDuplicatesTokenFilter",
         "namespace": "_types.analysis"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "remove_duplicates"
+          }
+        }
+      ]
     },
     {
       "inherits": {
@@ -45294,7 +46548,16 @@
         "name": "ReverseTokenFilter",
         "namespace": "_types.analysis"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "reverse"
+          }
+        }
+      ]
     },
     {
       "inherits": {
@@ -45309,6 +46572,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "shingle"
+          }
+        },
         {
           "name": "filler_token",
           "required": true,
@@ -45372,6 +46643,34 @@
             "type": {
               "name": "string",
               "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "SimpleAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "simple"
+          }
+        },
+        {
+          "name": "version",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
             }
           }
         }
@@ -45466,12 +46765,59 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "snowball"
+          }
+        },
+        {
           "name": "language",
           "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "SnowballLanguage",
+              "namespace": "_types.analysis"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "StandardAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "standard"
+          }
+        },
+        {
+          "name": "max_token_length",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "stopwords",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "StopWords",
               "namespace": "_types.analysis"
             }
           }
@@ -45491,6 +46837,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "standard"
+          }
+        },
         {
           "name": "max_token_length",
           "required": true,
@@ -45517,6 +46871,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "stemmer_override"
+          }
+        },
         {
           "name": "rules",
           "required": true,
@@ -45558,7 +46920,65 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "stemmer"
+          }
+        },
+        {
           "name": "language",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "StopAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "stop"
+          }
+        },
+        {
+          "name": "version",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "stopwords",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "StopWords",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "stopwords_path",
           "required": true,
           "type": {
             "kind": "instance_of",
@@ -45583,6 +47003,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "stop"
+          }
+        },
         {
           "name": "ignore_case",
           "required": false,
@@ -45637,14 +47065,26 @@
         "namespace": "_types.analysis"
       },
       "type": {
-        "kind": "array_of",
-        "value": {
-          "kind": "instance_of",
-          "type": {
-            "name": "string",
-            "namespace": "internal"
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
           }
-        }
+        ],
+        "kind": "union_of"
       }
     },
     {
@@ -45675,6 +47115,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "synonym_graph"
+          }
+        },
         {
           "name": "expand",
           "required": true,
@@ -45770,6 +47218,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "synonym"
+          }
+        },
         {
           "name": "expand",
           "required": true,
@@ -46152,9 +47608,34 @@
               "name": "WordDelimiterTokenFilter",
               "namespace": "_types.analysis"
             }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "KuromojiStemmerTokenFilter",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "KuromojiReadingFormTokenFilter",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "KuromojiPartOfSpeechTokenFilter",
+              "namespace": "_types.analysis"
+            }
           }
         ],
         "kind": "union_of"
+      },
+      "variants": {
+        "kind": "internal_tag",
+        "tag": "type"
       }
     },
     {
@@ -46164,17 +47645,6 @@
         "namespace": "_types.analysis"
       },
       "properties": [
-        {
-          "name": "type",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
         {
           "name": "version",
           "required": false,
@@ -46272,9 +47742,20 @@
               "name": "WhitespaceTokenizer",
               "namespace": "_types.analysis"
             }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "KuromojiTokenizer",
+              "namespace": "_types.analysis"
+            }
           }
         ],
         "kind": "union_of"
+      },
+      "variants": {
+        "kind": "internal_tag",
+        "tag": "type"
       }
     },
     {
@@ -46284,17 +47765,6 @@
         "namespace": "_types.analysis"
       },
       "properties": [
-        {
-          "name": "type",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
         {
           "name": "version",
           "required": false,
@@ -46320,7 +47790,16 @@
         "name": "TrimTokenFilter",
         "namespace": "_types.analysis"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "trim"
+          }
+        }
+      ]
     },
     {
       "inherits": {
@@ -46335,6 +47814,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "truncate"
+          }
+        },
         {
           "name": "length",
           "required": true,
@@ -46362,6 +47849,14 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "uax_url_email"
+          }
+        },
+        {
           "name": "max_token_length",
           "required": true,
           "type": {
@@ -46388,6 +47883,14 @@
       },
       "properties": [
         {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "unique"
+          }
+        },
+        {
           "name": "only_on_same_position",
           "required": true,
           "type": {
@@ -46412,7 +47915,44 @@
         "name": "UppercaseTokenFilter",
         "namespace": "_types.analysis"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "uppercase"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "WhitespaceAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "whitespace"
+          }
+        },
+        {
+          "name": "version",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
     },
     {
       "inherits": {
@@ -46427,6 +47967,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "whitespace"
+          }
+        },
         {
           "name": "max_token_length",
           "required": true,
@@ -46453,6 +48001,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "word_delimiter_graph"
+          }
+        },
         {
           "name": "adjust_offsets",
           "required": true,
@@ -46628,6 +48184,14 @@
         "namespace": "_types.analysis"
       },
       "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "word_delimiter"
+          }
+        },
         {
           "name": "catenate_all",
           "required": true,
@@ -85104,6 +86668,28 @@
       },
       "properties": [
         {
+          "name": "analyzer",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Analyzer",
+                "namespace": "_types.analysis"
+              }
+            }
+          }
+        },
+        {
           "name": "char_filter",
           "required": false,
           "type": {
@@ -85120,6 +86706,50 @@
               "kind": "instance_of",
               "type": {
                 "name": "CharFilter",
+                "namespace": "_types.analysis"
+              }
+            }
+          }
+        },
+        {
+          "name": "filter",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "TokenFilter",
+                "namespace": "_types.analysis"
+              }
+            }
+          }
+        },
+        {
+          "name": "normalizer",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "CustomNormalizer",
                 "namespace": "_types.analysis"
               }
             }
@@ -85208,6 +86838,17 @@
               }
             ],
             "kind": "union_of"
+          }
+        },
+        {
+          "name": "data_stream",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DataStreamName",
+              "namespace": "_types"
+            }
           }
         }
       ]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3350,22 +3350,26 @@ export interface AggregationsWeightedAverageValue {
   script?: Script
 }
 
+export type AnalysisAnalyzer = AnalysisCustomAnalyzer | AnalysisFingerprintAnalyzer | AnalysisKeywordAnalyzer | AnalysisLanguageAnalyzer | AnalysisNoriAnalyzer | AnalysisPatternAnalyzer | AnalysisSimpleAnalyzer | AnalysisStandardAnalyzer | AnalysisStopAnalyzer | AnalysisWhitespaceAnalyzer | AnalysisIcuAnalyzer | AnalysisKuromojiAnalyzer
+
 export interface AnalysisAsciiFoldingTokenFilter extends AnalysisTokenFilterBase {
+  type: 'asciifolding'
   preserve_original: boolean
 }
 
 export type AnalysisCharFilter = AnalysisHtmlStripCharFilter | AnalysisMappingCharFilter | AnalysisPatternReplaceTokenFilter
 
 export interface AnalysisCharFilterBase {
-  type: string
   version?: VersionString
 }
 
 export interface AnalysisCharGroupTokenizer extends AnalysisTokenizerBase {
+  type: 'char_group'
   tokenize_on_chars: string[]
 }
 
 export interface AnalysisCommonGramsTokenFilter extends AnalysisTokenFilterBase {
+  type: 'common_grams'
   common_words: string[]
   common_words_path: string
   ignore_case: boolean
@@ -3383,13 +3387,30 @@ export interface AnalysisCompoundWordTokenFilterBase extends AnalysisTokenFilter
 }
 
 export interface AnalysisConditionTokenFilter extends AnalysisTokenFilterBase {
+  type: 'condition'
   filter: string[]
   script: Script
+}
+
+export interface AnalysisCustomAnalyzer {
+  type: 'custom'
+  char_filter?: string[]
+  filter?: string[]
+  position_increment_gap?: integer
+  position_offset_gap?: integer
+  tokenizer: string
+}
+
+export interface AnalysisCustomNormalizer {
+  type: 'custom'
+  char_filter?: string[]
+  filter?: string[]
 }
 
 export type AnalysisDelimitedPayloadEncoding = 'int' | 'float' | 'identity'
 
 export interface AnalysisDelimitedPayloadTokenFilter extends AnalysisTokenFilterBase {
+  type: 'delimited_payload'
   delimiter: string
   encoding: AnalysisDelimitedPayloadEncoding
 }
@@ -3397,12 +3418,14 @@ export interface AnalysisDelimitedPayloadTokenFilter extends AnalysisTokenFilter
 export type AnalysisEdgeNGramSide = 'front' | 'back'
 
 export interface AnalysisEdgeNGramTokenFilter extends AnalysisTokenFilterBase {
+  type: 'edge_ngram'
   max_gram: integer
   min_gram: integer
   side: AnalysisEdgeNGramSide
 }
 
 export interface AnalysisEdgeNGramTokenizer extends AnalysisTokenizerBase {
+  type: 'edge_ngram'
   custom_token_chars: string
   max_gram: integer
   min_gram: integer
@@ -3410,19 +3433,33 @@ export interface AnalysisEdgeNGramTokenizer extends AnalysisTokenizerBase {
 }
 
 export interface AnalysisElisionTokenFilter extends AnalysisTokenFilterBase {
+  type: 'elision'
   articles: string[]
   articles_case: boolean
 }
 
+export interface AnalysisFingerprintAnalyzer {
+  type: 'fingerprint'
+  version: VersionString
+  max_output_size: integer
+  preserve_original: boolean
+  separator: string
+  stopwords: AnalysisStopWords
+  stopwords_path: string
+}
+
 export interface AnalysisFingerprintTokenFilter extends AnalysisTokenFilterBase {
+  type: 'fingerprint'
   max_output_size: integer
   separator: string
 }
 
 export interface AnalysisHtmlStripCharFilter extends AnalysisCharFilterBase {
+  type: 'html_strip'
 }
 
 export interface AnalysisHunspellTokenFilter extends AnalysisTokenFilterBase {
+  type: 'hunspell'
   dedup: boolean
   dictionary: string
   locale: string
@@ -3430,25 +3467,45 @@ export interface AnalysisHunspellTokenFilter extends AnalysisTokenFilterBase {
 }
 
 export interface AnalysisHyphenationDecompounderTokenFilter extends AnalysisCompoundWordTokenFilterBase {
+  type: 'hyphenation_decompounder'
 }
 
+export interface AnalysisIcuAnalyzer {
+  type: 'icu_analyzer'
+  method: AnalysisIcuNormalizationType
+  mode: AnalysisIcuNormalizationMode
+}
+
+export type AnalysisIcuNormalizationMode = 'decompose' | 'compose'
+
+export type AnalysisIcuNormalizationType = 'nfc' | 'nfkc' | 'nfkc_cf'
+
 export interface AnalysisKStemTokenFilter extends AnalysisTokenFilterBase {
+  type: 'kstem'
 }
 
 export type AnalysisKeepTypesMode = 'include' | 'exclude'
 
 export interface AnalysisKeepTypesTokenFilter extends AnalysisTokenFilterBase {
+  type: 'keep_types'
   mode: AnalysisKeepTypesMode
   types: string[]
 }
 
 export interface AnalysisKeepWordsTokenFilter extends AnalysisTokenFilterBase {
+  type: 'keep'
   keep_words: string[]
   keep_words_case: boolean
   keep_words_path: string
 }
 
+export interface AnalysisKeywordAnalyzer {
+  type: 'keyword'
+  version: VersionString
+}
+
 export interface AnalysisKeywordMarkerTokenFilter extends AnalysisTokenFilterBase {
+  type: 'keyword_marker'
   ignore_case: boolean
   keywords: string[]
   keywords_path: string
@@ -3456,58 +3513,122 @@ export interface AnalysisKeywordMarkerTokenFilter extends AnalysisTokenFilterBas
 }
 
 export interface AnalysisKeywordTokenizer extends AnalysisTokenizerBase {
+  type: 'keyword'
   buffer_size: integer
 }
 
+export interface AnalysisKuromojiAnalyzer {
+  type: 'kuromoji'
+  mode: AnalysisKuromojiTokenizationMode
+  user_dictionary: string
+}
+
+export interface AnalysisKuromojiPartOfSpeechTokenFilter extends AnalysisTokenFilterBase {
+  type: 'kuromoji_part_of_speech'
+  stoptags: string[]
+}
+
+export interface AnalysisKuromojiReadingFormTokenFilter extends AnalysisTokenFilterBase {
+  type: 'kuromoji_readingform'
+  use_romaji: boolean
+}
+
+export interface AnalysisKuromojiStemmerTokenFilter extends AnalysisTokenFilterBase {
+  type: 'kuromoji_stemmer'
+  minimum_length: integer
+}
+
+export type AnalysisKuromojiTokenizationMode = 'normal' | 'search' | 'extended'
+
+export interface AnalysisKuromojiTokenizer extends AnalysisTokenizerBase {
+  type: 'kuromoji_tokenizer'
+  discard_punctuation: boolean
+  mode: AnalysisKuromojiTokenizationMode
+  nbest_cost: integer
+  nbest_examples: string
+  user_dictionary: string
+  user_dictionary_rules: string[]
+}
+
+export type AnalysisLanguage = 'Arabic' | 'Armenian' | 'Basque' | 'Brazilian' | 'Bulgarian' | 'Catalan' | 'Chinese' | 'Cjk' | 'Czech' | 'Danish' | 'Dutch' | 'English' | 'Estonian' | 'Finnish' | 'French' | 'Galician' | 'German' | 'Greek' | 'Hindi' | 'Hungarian' | 'Indonesian' | 'Irish' | 'Italian' | 'Latvian' | 'Norwegian' | 'Persian' | 'Portuguese' | 'Romanian' | 'Russian' | 'Sorani' | 'Spanish' | 'Swedish' | 'Turkish' | 'Thai'
+
+export interface AnalysisLanguageAnalyzer {
+  type: 'language'
+  version: VersionString
+  language: AnalysisLanguage
+  stem_exclusion: string[]
+  stopwords: AnalysisStopWords
+  stopwords_path: string
+}
+
 export interface AnalysisLengthTokenFilter extends AnalysisTokenFilterBase {
+  type: 'length'
   max: integer
   min: integer
 }
 
 export interface AnalysisLetterTokenizer extends AnalysisTokenizerBase {
+  type: 'letter'
 }
 
 export interface AnalysisLimitTokenCountTokenFilter extends AnalysisTokenFilterBase {
+  type: 'limit'
   consume_all_tokens: boolean
   max_token_count: integer
 }
 
 export interface AnalysisLowercaseTokenFilter extends AnalysisTokenFilterBase {
+  type: 'lowercase'
   language: string
 }
 
 export interface AnalysisLowercaseTokenizer extends AnalysisTokenizerBase {
+  type: 'lowercase'
 }
 
 export interface AnalysisMappingCharFilter extends AnalysisCharFilterBase {
+  type: 'mapping'
   mappings: string[]
   mappings_path: string
 }
 
 export interface AnalysisMultiplexerTokenFilter extends AnalysisTokenFilterBase {
+  type: 'multiplexer'
   filters: string[]
   preserve_original: boolean
 }
 
 export interface AnalysisNGramTokenFilter extends AnalysisTokenFilterBase {
+  type: 'ngram'
   max_gram: integer
   min_gram: integer
 }
 
 export interface AnalysisNGramTokenizer extends AnalysisTokenizerBase {
+  type: 'ngram'
   custom_token_chars: string
   max_gram: integer
   min_gram: integer
   token_chars: AnalysisTokenChar[]
 }
 
+export interface AnalysisNoriAnalyzer {
+  type: 'nori'
+  version: VersionString
+  decompound_mode: AnalysisNoriDecompoundMode
+  stoptags: string[]
+  user_dictionary: string
+}
+
 export type AnalysisNoriDecompoundMode = 'discard' | 'none' | 'mixed'
 
 export interface AnalysisNoriPartOfSpeechTokenFilter extends AnalysisTokenFilterBase {
+  type: 'nori_part_of_speech'
   stoptags: string[]
 }
 
 export interface AnalysisNoriTokenizer extends AnalysisTokenizerBase {
+  type: 'nori_tokenizer'
   decompound_mode: AnalysisNoriDecompoundMode
   discard_punctuation: boolean
   user_dictionary: string
@@ -3515,6 +3636,7 @@ export interface AnalysisNoriTokenizer extends AnalysisTokenizerBase {
 }
 
 export interface AnalysisPathHierarchyTokenizer extends AnalysisTokenizerBase {
+  type: 'path_hierarchy'
   buffer_size: integer
   delimiter: string
   replacement: string
@@ -3522,31 +3644,47 @@ export interface AnalysisPathHierarchyTokenizer extends AnalysisTokenizerBase {
   skip: integer
 }
 
+export interface AnalysisPatternAnalyzer {
+  type: 'pattern'
+  version: VersionString
+  flags: string
+  lowercase: boolean
+  pattern: string
+  stopwords: AnalysisStopWords
+}
+
 export interface AnalysisPatternCaptureTokenFilter extends AnalysisTokenFilterBase {
+  type: 'pattern_capture'
   patterns: string[]
   preserve_original: boolean
 }
 
 export interface AnalysisPatternReplaceTokenFilter extends AnalysisTokenFilterBase {
+  type: 'pattern_replace'
   flags: string
   pattern: string
   replacement: string
 }
 
 export interface AnalysisPorterStemTokenFilter extends AnalysisTokenFilterBase {
+  type: 'porter_stem'
 }
 
 export interface AnalysisPredicateTokenFilter extends AnalysisTokenFilterBase {
+  type: 'predicate_token_filter'
   script: Script
 }
 
 export interface AnalysisRemoveDuplicatesTokenFilter extends AnalysisTokenFilterBase {
+  type: 'remove_duplicates'
 }
 
 export interface AnalysisReverseTokenFilter extends AnalysisTokenFilterBase {
+  type: 'reverse'
 }
 
 export interface AnalysisShingleTokenFilter extends AnalysisTokenFilterBase {
+  type: 'shingle'
   filler_token: string
   max_shingle_size: integer
   min_shingle_size: integer
@@ -3555,37 +3693,61 @@ export interface AnalysisShingleTokenFilter extends AnalysisTokenFilterBase {
   token_separator: string
 }
 
+export interface AnalysisSimpleAnalyzer {
+  type: 'simple'
+  version: VersionString
+}
+
 export type AnalysisSnowballLanguage = 'Armenian' | 'Basque' | 'Catalan' | 'Danish' | 'Dutch' | 'English' | 'Finnish' | 'French' | 'German' | 'German2' | 'Hungarian' | 'Italian' | 'Kp' | 'Lovins' | 'Norwegian' | 'Porter' | 'Portuguese' | 'Romanian' | 'Russian' | 'Spanish' | 'Swedish' | 'Turkish'
 
 export interface AnalysisSnowballTokenFilter extends AnalysisTokenFilterBase {
+  type: 'snowball'
   language: AnalysisSnowballLanguage
 }
 
+export interface AnalysisStandardAnalyzer {
+  type: 'standard'
+  max_token_length: integer
+  stopwords: AnalysisStopWords
+}
+
 export interface AnalysisStandardTokenizer extends AnalysisTokenizerBase {
+  type: 'standard'
   max_token_length: integer
 }
 
 export interface AnalysisStemmerOverrideTokenFilter extends AnalysisTokenFilterBase {
+  type: 'stemmer_override'
   rules: string[]
   rules_path: string
 }
 
 export interface AnalysisStemmerTokenFilter extends AnalysisTokenFilterBase {
+  type: 'stemmer'
   language: string
 }
 
+export interface AnalysisStopAnalyzer {
+  type: 'stop'
+  version: VersionString
+  stopwords: AnalysisStopWords
+  stopwords_path: string
+}
+
 export interface AnalysisStopTokenFilter extends AnalysisTokenFilterBase {
+  type: 'stop'
   ignore_case?: boolean
   remove_trailing?: boolean
   stopwords: AnalysisStopWords
   stopwords_path?: string
 }
 
-export type AnalysisStopWords = string[]
+export type AnalysisStopWords = string | string[]
 
 export type AnalysisSynonymFormat = 'solr' | 'wordnet'
 
 export interface AnalysisSynonymGraphTokenFilter extends AnalysisTokenFilterBase {
+  type: 'synonym_graph'
   expand: boolean
   format: AnalysisSynonymFormat
   lenient: boolean
@@ -3596,6 +3758,7 @@ export interface AnalysisSynonymGraphTokenFilter extends AnalysisTokenFilterBase
 }
 
 export interface AnalysisSynonymTokenFilter extends AnalysisTokenFilterBase {
+  type: 'synonym'
   expand: boolean
   format: AnalysisSynonymFormat
   lenient: boolean
@@ -3607,43 +3770,53 @@ export interface AnalysisSynonymTokenFilter extends AnalysisTokenFilterBase {
 
 export type AnalysisTokenChar = 'letter' | 'digit' | 'whitespace' | 'punctuation' | 'symbol' | 'custom'
 
-export type AnalysisTokenFilter = AnalysisAsciiFoldingTokenFilter | AnalysisCommonGramsTokenFilter | AnalysisConditionTokenFilter | AnalysisDelimitedPayloadTokenFilter | AnalysisEdgeNGramTokenFilter | AnalysisElisionTokenFilter | AnalysisFingerprintTokenFilter | AnalysisHunspellTokenFilter | AnalysisHyphenationDecompounderTokenFilter | AnalysisKeepTypesTokenFilter | AnalysisKeepWordsTokenFilter | AnalysisKeywordMarkerTokenFilter | AnalysisKStemTokenFilter | AnalysisLengthTokenFilter | AnalysisLimitTokenCountTokenFilter | AnalysisLowercaseTokenFilter | AnalysisMultiplexerTokenFilter | AnalysisNGramTokenFilter | AnalysisNoriPartOfSpeechTokenFilter | AnalysisPatternCaptureTokenFilter | AnalysisPatternReplaceTokenFilter | AnalysisPorterStemTokenFilter | AnalysisPredicateTokenFilter | AnalysisRemoveDuplicatesTokenFilter | AnalysisReverseTokenFilter | AnalysisShingleTokenFilter | AnalysisSnowballTokenFilter | AnalysisStemmerOverrideTokenFilter | AnalysisStemmerTokenFilter | AnalysisStopTokenFilter | AnalysisSynonymGraphTokenFilter | AnalysisSynonymTokenFilter | AnalysisTrimTokenFilter | AnalysisTruncateTokenFilter | AnalysisUniqueTokenFilter | AnalysisUppercaseTokenFilter | AnalysisWordDelimiterGraphTokenFilter | AnalysisWordDelimiterTokenFilter
+export type AnalysisTokenFilter = AnalysisAsciiFoldingTokenFilter | AnalysisCommonGramsTokenFilter | AnalysisConditionTokenFilter | AnalysisDelimitedPayloadTokenFilter | AnalysisEdgeNGramTokenFilter | AnalysisElisionTokenFilter | AnalysisFingerprintTokenFilter | AnalysisHunspellTokenFilter | AnalysisHyphenationDecompounderTokenFilter | AnalysisKeepTypesTokenFilter | AnalysisKeepWordsTokenFilter | AnalysisKeywordMarkerTokenFilter | AnalysisKStemTokenFilter | AnalysisLengthTokenFilter | AnalysisLimitTokenCountTokenFilter | AnalysisLowercaseTokenFilter | AnalysisMultiplexerTokenFilter | AnalysisNGramTokenFilter | AnalysisNoriPartOfSpeechTokenFilter | AnalysisPatternCaptureTokenFilter | AnalysisPatternReplaceTokenFilter | AnalysisPorterStemTokenFilter | AnalysisPredicateTokenFilter | AnalysisRemoveDuplicatesTokenFilter | AnalysisReverseTokenFilter | AnalysisShingleTokenFilter | AnalysisSnowballTokenFilter | AnalysisStemmerOverrideTokenFilter | AnalysisStemmerTokenFilter | AnalysisStopTokenFilter | AnalysisSynonymGraphTokenFilter | AnalysisSynonymTokenFilter | AnalysisTrimTokenFilter | AnalysisTruncateTokenFilter | AnalysisUniqueTokenFilter | AnalysisUppercaseTokenFilter | AnalysisWordDelimiterGraphTokenFilter | AnalysisWordDelimiterTokenFilter | AnalysisKuromojiStemmerTokenFilter | AnalysisKuromojiReadingFormTokenFilter | AnalysisKuromojiPartOfSpeechTokenFilter
 
 export interface AnalysisTokenFilterBase {
-  type: string
   version?: VersionString
 }
 
-export type AnalysisTokenizer = AnalysisCharGroupTokenizer | AnalysisEdgeNGramTokenizer | AnalysisKeywordTokenizer | AnalysisLetterTokenizer | AnalysisLowercaseTokenizer | AnalysisNGramTokenizer | AnalysisNoriTokenizer | AnalysisPathHierarchyTokenizer | AnalysisStandardTokenizer | AnalysisUaxEmailUrlTokenizer | AnalysisWhitespaceTokenizer
+export type AnalysisTokenizer = AnalysisCharGroupTokenizer | AnalysisEdgeNGramTokenizer | AnalysisKeywordTokenizer | AnalysisLetterTokenizer | AnalysisLowercaseTokenizer | AnalysisNGramTokenizer | AnalysisNoriTokenizer | AnalysisPathHierarchyTokenizer | AnalysisStandardTokenizer | AnalysisUaxEmailUrlTokenizer | AnalysisWhitespaceTokenizer | AnalysisKuromojiTokenizer
 
 export interface AnalysisTokenizerBase {
-  type: string
   version?: VersionString
 }
 
 export interface AnalysisTrimTokenFilter extends AnalysisTokenFilterBase {
+  type: 'trim'
 }
 
 export interface AnalysisTruncateTokenFilter extends AnalysisTokenFilterBase {
+  type: 'truncate'
   length: integer
 }
 
 export interface AnalysisUaxEmailUrlTokenizer extends AnalysisTokenizerBase {
+  type: 'uax_url_email'
   max_token_length: integer
 }
 
 export interface AnalysisUniqueTokenFilter extends AnalysisTokenFilterBase {
+  type: 'unique'
   only_on_same_position: boolean
 }
 
 export interface AnalysisUppercaseTokenFilter extends AnalysisTokenFilterBase {
+  type: 'uppercase'
+}
+
+export interface AnalysisWhitespaceAnalyzer {
+  type: 'whitespace'
+  version: VersionString
 }
 
 export interface AnalysisWhitespaceTokenizer extends AnalysisTokenizerBase {
+  type: 'whitespace'
   max_token_length: integer
 }
 
 export interface AnalysisWordDelimiterGraphTokenFilter extends AnalysisTokenFilterBase {
+  type: 'word_delimiter_graph'
   adjust_offsets: boolean
   catenate_all: boolean
   catenate_numbers: boolean
@@ -3661,6 +3834,7 @@ export interface AnalysisWordDelimiterGraphTokenFilter extends AnalysisTokenFilt
 }
 
 export interface AnalysisWordDelimiterTokenFilter extends AnalysisTokenFilterBase {
+  type: 'word_delimiter'
   catenate_all: boolean
   catenate_numbers: boolean
   catenate_words: boolean
@@ -8399,7 +8573,10 @@ export interface IndicesIndexSettings {
 }
 
 export interface IndicesIndexSettingsAnalysis {
+  analyzer?: Record<string, AnalysisAnalyzer>
   char_filter?: Record<string, AnalysisCharFilter>
+  filter?: Record<string, AnalysisTokenFilter>
+  normalizer?: Record<string, AnalysisCustomNormalizer>
 }
 
 export interface IndicesIndexSettingsLifecycle {
@@ -8410,6 +8587,7 @@ export interface IndicesIndexState {
   aliases?: Record<IndexName, IndicesAlias>
   mappings?: MappingTypeMapping
   settings: IndicesIndexSettings | IndicesIndexStatePrefixedSettings
+  data_stream?: DataStreamName
 }
 
 export interface IndicesIndexStatePrefixedSettings {

--- a/specification/_types/analysis/analyzers.ts
+++ b/specification/_types/analysis/analyzers.ts
@@ -22,21 +22,21 @@ import { integer } from '@_types/Numeric'
 import { Language, SnowballLanguage } from './languages'
 import { StopWords } from './StopWords'
 import { NoriDecompoundMode } from './tokenizers'
+import { IcuAnalyzer } from './icu-plugin'
+import { KuromojiAnalyzer } from './kuromoji-plugin'
 
-export class AnalyzerBase {
-  type: string
-  version: VersionString
-}
-
-export class CustomAnalyzer extends AnalyzerBase {
-  char_filter: string[]
-  filter: string[]
-  position_increment_gap: integer
-  position_offset_gap: integer
+export class CustomAnalyzer {
+  type: 'custom'
+  char_filter?: string[]
+  filter?: string[]
+  position_increment_gap?: integer
+  position_offset_gap?: integer
   tokenizer: string
 }
 
-export class FingerprintAnalyzer extends AnalyzerBase {
+export class FingerprintAnalyzer {
+  type: 'fingerprint'
+  version: VersionString
   max_output_size: integer
   preserve_original: boolean
   separator: string
@@ -44,44 +44,78 @@ export class FingerprintAnalyzer extends AnalyzerBase {
   stopwords_path: string
 }
 
-export class KeywordAnalyzer extends AnalyzerBase {}
+export class KeywordAnalyzer {
+  type: 'keyword'
+  version: VersionString
+}
 
-export class LanguageAnalyzer extends AnalyzerBase {
+export class LanguageAnalyzer {
+  type: 'language'
+  version: VersionString
   language: Language
   stem_exclusion: string[]
   stopwords: StopWords
   stopwords_path: string
-  type: string
 }
 
-export class NoriAnalyzer extends AnalyzerBase {
+export class NoriAnalyzer {
+  type: 'nori'
+  version: VersionString
   decompound_mode: NoriDecompoundMode
   stoptags: string[]
   user_dictionary: string
 }
 
-export class PatternAnalyzer extends AnalyzerBase {
+export class PatternAnalyzer {
+  type: 'pattern'
+  version: VersionString
   flags: string
   lowercase: boolean
   pattern: string
   stopwords: StopWords
 }
 
-export class SimpleAnalyzer extends AnalyzerBase {}
+export class SimpleAnalyzer {
+  type: 'simple'
+  version: VersionString
+}
 
-export class SnowballAnalyzer extends AnalyzerBase {
+export class SnowballAnalyzer {
+  type: 'snowball'
+  version: VersionString
   language: SnowballLanguage
   stopwords: StopWords
 }
 
-export class StandardAnalyzer extends AnalyzerBase {
+export class StandardAnalyzer {
+  type: 'standard'
   max_token_length: integer
   stopwords: StopWords
 }
 
-export class StopAnalyzer extends AnalyzerBase {
+export class StopAnalyzer {
+  type: 'stop'
+  version: VersionString
   stopwords: StopWords
   stopwords_path: string
 }
 
-export class WhitespaceAnalyzer extends AnalyzerBase {}
+export class WhitespaceAnalyzer {
+  type: 'whitespace'
+  version: VersionString
+}
+
+/** @variants internal tag='type' */
+export type Analyzer =
+  | CustomAnalyzer
+  | FingerprintAnalyzer
+  | KeywordAnalyzer
+  | LanguageAnalyzer
+  | NoriAnalyzer
+  | PatternAnalyzer
+  | SimpleAnalyzer
+  | StandardAnalyzer
+  | StopAnalyzer
+  | WhitespaceAnalyzer
+  | IcuAnalyzer
+  | KuromojiAnalyzer

--- a/specification/_types/analysis/char_filters.ts
+++ b/specification/_types/analysis/char_filters.ts
@@ -21,23 +21,27 @@ import { VersionString } from '@_types/common'
 import { PatternReplaceTokenFilter } from './token_filters'
 
 export class CharFilterBase {
-  type: string
   version?: VersionString
 }
 
+/** @variants internal tag='type' */
 export type CharFilter =
   | HtmlStripCharFilter
   | MappingCharFilter
   | PatternReplaceTokenFilter
 
-export class HtmlStripCharFilter extends CharFilterBase {}
+export class HtmlStripCharFilter extends CharFilterBase {
+  type: 'html_strip'
+}
 
 export class MappingCharFilter extends CharFilterBase {
+  type: 'mapping'
   mappings: string[]
   mappings_path: string
 }
 
 export class PatternReplaceCharFilter extends CharFilterBase {
+  type: 'pattern_replace'
   flags: string
   pattern: string
   replacement: string

--- a/specification/_types/analysis/icu-plugin.ts
+++ b/specification/_types/analysis/icu-plugin.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { AnalyzerBase } from './analyzers'
 import { CharFilterBase } from './char_filters'
 import { TokenizerBase } from './tokenizers'
 import { TokenFilterBase } from './token_filters'
@@ -41,10 +40,12 @@ export class IcuNormalizationCharFilter extends CharFilterBase {
 }
 
 export class IcuFoldingTokenFilter extends TokenFilterBase {
+  type: 'icu_folding'
   unicode_set_filter: string
 }
 
 export class IcuCollationTokenFilter extends TokenFilterBase {
+  type: 'icu_collation'
   alternate: IcuCollationAlternate
   caseFirst: IcuCollationCaseFirst
   caseLevel: boolean
@@ -58,7 +59,8 @@ export class IcuCollationTokenFilter extends TokenFilterBase {
   variant: string
 }
 
-export class IcuAnalyzer extends AnalyzerBase {
+export class IcuAnalyzer {
+  type: 'icu_analyzer'
   method: IcuNormalizationType
   mode: IcuNormalizationMode
 }

--- a/specification/_types/analysis/kuromoji-plugin.ts
+++ b/specification/_types/analysis/kuromoji-plugin.ts
@@ -18,30 +18,34 @@
  */
 
 import { integer } from '@_types/Numeric'
-import { AnalyzerBase } from './analyzers'
 import { CharFilterBase } from './char_filters'
 import { TokenizerBase } from './tokenizers'
 import { TokenFilterBase } from './token_filters'
 
-export class KuromojiAnalyzer extends AnalyzerBase {
+export class KuromojiAnalyzer {
+  type: 'kuromoji'
   mode: KuromojiTokenizationMode
   user_dictionary: string
 }
 
 export class KuromojiIterationMarkCharFilter extends CharFilterBase {
+  type: 'kuromoji_iteration_mark'
   normalize_kana: boolean
   normalize_kanji: boolean
 }
 
 export class KuromojiPartOfSpeechTokenFilter extends TokenFilterBase {
+  type: 'kuromoji_part_of_speech'
   stoptags: string[]
 }
 
 export class KuromojiReadingFormTokenFilter extends TokenFilterBase {
+  type: 'kuromoji_readingform'
   use_romaji: boolean
 }
 
 export class KuromojiStemmerTokenFilter extends TokenFilterBase {
+  type: 'kuromoji_stemmer'
   minimum_length: integer
 }
 
@@ -52,6 +56,7 @@ export enum KuromojiTokenizationMode {
 }
 
 export class KuromojiTokenizer extends TokenizerBase {
+  type: 'kuromoji_tokenizer'
   discard_punctuation: boolean
   mode: KuromojiTokenizationMode
   nbest_cost: integer

--- a/specification/_types/analysis/normalizers.ts
+++ b/specification/_types/analysis/normalizers.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-/**
- * Language value, such as _arabic_ or _thai_. Defaults to _english_.
- * Each language value corresponds to a predefined list of stop words in Lucene. See Stop words by language for supported language values and their stop words.
- * Also accepts an array of stop words.
- * @class_serializer: StopWordsFormatter
- */
-export type StopWords = string | string[]
+export class CustomNormalizer {
+  type: 'custom'
+  char_filter?: string[]
+  filter?: string[]
+}

--- a/specification/_types/analysis/phonetic-plugin.ts
+++ b/specification/_types/analysis/phonetic-plugin.ts
@@ -37,7 +37,7 @@ export enum PhoneticEncoder {
 
 export enum PhoneticLanguage {
   any = 0,
-  comomon = 1,
+  common = 1,
   cyrillic = 2,
   english = 3,
   french = 4,
@@ -62,6 +62,7 @@ export enum PhoneticRuleType {
 }
 
 export class PhoneticTokenFilter extends TokenFilterBase {
+  type: 'phonetic'
   encoder: PhoneticEncoder
   languageset: PhoneticLanguage[]
   max_code_len: integer

--- a/specification/_types/analysis/token_filters.ts
+++ b/specification/_types/analysis/token_filters.ts
@@ -22,9 +22,13 @@ import { integer } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 import { SnowballLanguage } from './languages'
 import { StopWords } from './StopWords'
+import {
+  KuromojiStemmerTokenFilter,
+  KuromojiReadingFormTokenFilter,
+  KuromojiPartOfSpeechTokenFilter
+} from './kuromoji-plugin'
 
 export class TokenFilterBase {
-  type: string
   version?: VersionString
 }
 
@@ -38,9 +42,13 @@ export class CompoundWordTokenFilterBase extends TokenFilterBase {
   word_list_path: string
 }
 
-export class DictionaryDecompounderTokenFilter extends CompoundWordTokenFilterBase {}
+export class DictionaryDecompounderTokenFilter extends CompoundWordTokenFilterBase {
+  type: 'dictionary_decompounder'
+}
 
-export class HyphenationDecompounderTokenFilter extends CompoundWordTokenFilterBase {}
+export class HyphenationDecompounderTokenFilter extends CompoundWordTokenFilterBase {
+  type: 'hyphenation_decompounder'
+}
 
 export enum DelimitedPayloadEncoding {
   int = 0,
@@ -49,6 +57,7 @@ export enum DelimitedPayloadEncoding {
 }
 
 export class DelimitedPayloadTokenFilter extends TokenFilterBase {
+  type: 'delimited_payload'
   delimiter: string
   encoding: DelimitedPayloadEncoding
 }
@@ -59,12 +68,14 @@ export enum EdgeNGramSide {
 }
 
 export class EdgeNGramTokenFilter extends TokenFilterBase {
+  type: 'edge_ngram'
   max_gram: integer
   min_gram: integer
   side: EdgeNGramSide
 }
 
 export class ShingleTokenFilter extends TokenFilterBase {
+  type: 'shingle'
   filler_token: string
   max_shingle_size: integer
   min_shingle_size: integer
@@ -74,6 +85,7 @@ export class ShingleTokenFilter extends TokenFilterBase {
 }
 
 export class StopTokenFilter extends TokenFilterBase {
+  type: 'stop'
   ignore_case?: boolean
   remove_trailing?: boolean
   stopwords: StopWords
@@ -86,6 +98,7 @@ export enum SynonymFormat {
 }
 
 export class SynonymGraphTokenFilter extends TokenFilterBase {
+  type: 'synonym_graph'
   expand: boolean
   format: SynonymFormat
   lenient: boolean
@@ -96,6 +109,7 @@ export class SynonymGraphTokenFilter extends TokenFilterBase {
 }
 
 export class SynonymTokenFilter extends TokenFilterBase {
+  type: 'synonym'
   expand: boolean
   format: SynonymFormat
   lenient: boolean
@@ -106,6 +120,7 @@ export class SynonymTokenFilter extends TokenFilterBase {
 }
 
 export class WordDelimiterTokenFilter extends TokenFilterBase {
+  type: 'word_delimiter'
   catenate_all: boolean
   catenate_numbers: boolean
   catenate_words: boolean
@@ -122,6 +137,7 @@ export class WordDelimiterTokenFilter extends TokenFilterBase {
 }
 
 export class WordDelimiterGraphTokenFilter extends TokenFilterBase {
+  type: 'word_delimiter_graph'
   adjust_offsets: boolean
   catenate_all: boolean
   catenate_numbers: boolean
@@ -139,10 +155,12 @@ export class WordDelimiterGraphTokenFilter extends TokenFilterBase {
 }
 
 export class AsciiFoldingTokenFilter extends TokenFilterBase {
+  type: 'asciifolding'
   preserve_original: boolean
 }
 
 export class CommonGramsTokenFilter extends TokenFilterBase {
+  type: 'common_grams'
   common_words: string[]
   common_words_path: string
   ignore_case: boolean
@@ -150,25 +168,34 @@ export class CommonGramsTokenFilter extends TokenFilterBase {
 }
 
 export class ConditionTokenFilter extends TokenFilterBase {
+  type: 'condition'
   filter: string[]
   script: Script
 }
 
 export class ElisionTokenFilter extends TokenFilterBase {
+  type: 'elision'
   articles: string[]
   articles_case: boolean
 }
 
 export class FingerprintTokenFilter extends TokenFilterBase {
+  type: 'fingerprint'
   max_output_size: integer
   separator: string
 }
 
 export class HunspellTokenFilter extends TokenFilterBase {
+  type: 'hunspell'
   dedup: boolean
   dictionary: string
   locale: string
   longest_only: boolean
+}
+
+export class JaStopTokenFilter extends TokenFilterBase {
+  type: 'ja_stop'
+  stopwords: StopWords
 }
 
 export enum KeepTypesMode {
@@ -177,99 +204,129 @@ export enum KeepTypesMode {
 }
 
 export class KeepTypesTokenFilter extends TokenFilterBase {
+  type: 'keep_types'
   mode: KeepTypesMode
   types: string[]
 }
 
 export class KeepWordsTokenFilter extends TokenFilterBase {
+  type: 'keep'
   keep_words: string[]
   keep_words_case: boolean
   keep_words_path: string
 }
 
 export class KeywordMarkerTokenFilter extends TokenFilterBase {
+  type: 'keyword_marker'
   ignore_case: boolean
   keywords: string[]
   keywords_path: string
   keywords_pattern: string
 }
 
-export class KStemTokenFilter extends TokenFilterBase {}
+export class KStemTokenFilter extends TokenFilterBase {
+  type: 'kstem'
+}
 
 export class LengthTokenFilter extends TokenFilterBase {
+  type: 'length'
   max: integer
   min: integer
 }
 
 export class LimitTokenCountTokenFilter extends TokenFilterBase {
+  type: 'limit'
   consume_all_tokens: boolean
   max_token_count: integer
 }
 
 export class LowercaseTokenFilter extends TokenFilterBase {
+  type: 'lowercase'
   language: string
 }
 
 export class MultiplexerTokenFilter extends TokenFilterBase {
+  type: 'multiplexer'
   filters: string[]
   preserve_original: boolean
 }
 
 export class NGramTokenFilter extends TokenFilterBase {
+  type: 'ngram'
   max_gram: integer
   min_gram: integer
 }
 
 export class NoriPartOfSpeechTokenFilter extends TokenFilterBase {
+  type: 'nori_part_of_speech'
   stoptags: string[]
 }
 
 export class PatternCaptureTokenFilter extends TokenFilterBase {
+  type: 'pattern_capture'
   patterns: string[]
   preserve_original: boolean
 }
 
 export class PatternReplaceTokenFilter extends TokenFilterBase {
+  type: 'pattern_replace'
   flags: string
   pattern: string
   replacement: string
 }
 
-export class PorterStemTokenFilter extends TokenFilterBase {}
+export class PorterStemTokenFilter extends TokenFilterBase {
+  type: 'porter_stem'
+}
 
 export class PredicateTokenFilter extends TokenFilterBase {
+  type: 'predicate_token_filter'
   script: Script
 }
 
-export class RemoveDuplicatesTokenFilter extends TokenFilterBase {}
+export class RemoveDuplicatesTokenFilter extends TokenFilterBase {
+  type: 'remove_duplicates'
+}
 
-export class ReverseTokenFilter extends TokenFilterBase {}
+export class ReverseTokenFilter extends TokenFilterBase {
+  type: 'reverse'
+}
 
 export class SnowballTokenFilter extends TokenFilterBase {
+  type: 'snowball'
   language: SnowballLanguage
 }
 
 export class StemmerOverrideTokenFilter extends TokenFilterBase {
+  type: 'stemmer_override'
   rules: string[]
   rules_path: string
 }
 
 export class StemmerTokenFilter extends TokenFilterBase {
+  type: 'stemmer'
   language: string
 }
 
-export class TrimTokenFilter extends TokenFilterBase {}
+export class TrimTokenFilter extends TokenFilterBase {
+  type: 'trim'
+}
 
 export class TruncateTokenFilter extends TokenFilterBase {
+  type: 'truncate'
   length: integer
 }
 
 export class UniqueTokenFilter extends TokenFilterBase {
+  type: 'unique'
   only_on_same_position: boolean
 }
 
-export class UppercaseTokenFilter extends TokenFilterBase {}
+export class UppercaseTokenFilter extends TokenFilterBase {
+  type: 'uppercase'
+}
 
+/** @variants internal tag='type' */
 export type TokenFilter =
   | AsciiFoldingTokenFilter
   | CommonGramsTokenFilter
@@ -310,3 +367,6 @@ export type TokenFilter =
   | UppercaseTokenFilter
   | WordDelimiterGraphTokenFilter
   | WordDelimiterTokenFilter
+  | KuromojiStemmerTokenFilter
+  | KuromojiReadingFormTokenFilter
+  | KuromojiPartOfSpeechTokenFilter

--- a/specification/_types/analysis/tokenizers.ts
+++ b/specification/_types/analysis/tokenizers.ts
@@ -19,13 +19,14 @@
 
 import { VersionString } from '@_types/common'
 import { integer } from '@_types/Numeric'
+import { KuromojiTokenizer } from './kuromoji-plugin'
 
 export class TokenizerBase {
-  type: string
   version?: VersionString
 }
 
 export class EdgeNGramTokenizer extends TokenizerBase {
+  type: 'edge_ngram'
   custom_token_chars: string
   max_gram: integer
   min_gram: integer
@@ -33,6 +34,7 @@ export class EdgeNGramTokenizer extends TokenizerBase {
 }
 
 export class NGramTokenizer extends TokenizerBase {
+  type: 'ngram'
   custom_token_chars: string
   max_gram: integer
   min_gram: integer
@@ -49,16 +51,22 @@ export enum TokenChar {
 }
 
 export class CharGroupTokenizer extends TokenizerBase {
+  type: 'char_group'
   tokenize_on_chars: string[]
 }
 
 export class KeywordTokenizer extends TokenizerBase {
+  type: 'keyword'
   buffer_size: integer
 }
 
-export class LetterTokenizer extends TokenizerBase {}
+export class LetterTokenizer extends TokenizerBase {
+  type: 'letter'
+}
 
-export class LowercaseTokenizer extends TokenizerBase {}
+export class LowercaseTokenizer extends TokenizerBase {
+  type: 'lowercase'
+}
 
 export enum NoriDecompoundMode {
   discard = 0,
@@ -67,6 +75,7 @@ export enum NoriDecompoundMode {
 }
 
 export class NoriTokenizer extends TokenizerBase {
+  type: 'nori_tokenizer'
   decompound_mode: NoriDecompoundMode
   discard_punctuation: boolean
   user_dictionary: string
@@ -74,6 +83,7 @@ export class NoriTokenizer extends TokenizerBase {
 }
 
 export class PathHierarchyTokenizer extends TokenizerBase {
+  type: 'path_hierarchy'
   buffer_size: integer
   delimiter: string
   replacement: string
@@ -82,23 +92,28 @@ export class PathHierarchyTokenizer extends TokenizerBase {
 }
 
 export class PatternTokenizer extends TokenizerBase {
+  type: 'pattern'
   flags: string
   group: integer
   pattern: string
 }
 
 export class StandardTokenizer extends TokenizerBase {
+  type: 'standard'
   max_token_length: integer
 }
 
 export class UaxEmailUrlTokenizer extends TokenizerBase {
+  type: 'uax_url_email'
   max_token_length: integer
 }
 
 export class WhitespaceTokenizer extends TokenizerBase {
+  type: 'whitespace'
   max_token_length: integer
 }
 
+/** @variants internal tag='type' */
 export type Tokenizer =
   | CharGroupTokenizer
   | EdgeNGramTokenizer
@@ -111,3 +126,4 @@ export type Tokenizer =
   | StandardTokenizer
   | UaxEmailUrlTokenizer
   | WhitespaceTokenizer
+  | KuromojiTokenizer

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -19,7 +19,10 @@
 
 import { IndexRouting } from '@indices/_types/IndexRouting'
 import { Dictionary } from '@spec_utils/Dictionary'
+import { Analyzer } from '@_types/analysis/analyzers'
+import { TokenFilter } from '@_types/analysis/token_filters'
 import { CharFilter } from '@_types/analysis/char_filters'
+import { CustomNormalizer } from '@_types/analysis/normalizers'
 import { Name, PipelineName, Uuid, VersionString } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { DateString, Time } from '@_types/Time'
@@ -247,5 +250,8 @@ export class IndexSettingsLifecycle {
 }
 
 export class IndexSettingsAnalysis {
+  analyzer?: Dictionary<string, Analyzer>
   char_filter?: Dictionary<string, CharFilter>
+  filter?: Dictionary<string, TokenFilter>
+  normalizer?: Dictionary<string, CustomNormalizer>
 }

--- a/specification/indices/_types/IndexState.ts
+++ b/specification/indices/_types/IndexState.ts
@@ -18,7 +18,7 @@
  */
 
 import { Dictionary } from '@spec_utils/Dictionary'
-import { IndexName } from '@_types/common'
+import { DataStreamName, IndexName } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { Alias } from './Alias'
 import { IndexSettings } from './IndexSettings'
@@ -27,6 +27,7 @@ export class IndexState {
   aliases?: Dictionary<IndexName, Alias>
   mappings?: TypeMapping
   settings: IndexSettings | IndexStatePrefixedSettings
+  data_stream?: DataStreamName
 }
 
 export class IndexStatePrefixedSettings {


### PR DESCRIPTION
Most of this is adding `@variant` to analyzers, tokenizers, token filters and char filters.

Added `IndexState.data_stream?` to close https://github.com/elastic/elasticsearch-specification/issues/532