### PR TITLE
Add doc_id; remove out-dated links

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -119727,8 +119727,7 @@
             }
           },
           {
-            "description": "Advanced configuration option. The time between each periodic persistence of the model. See Job resources.",
-            "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-job-resource.html",
+            "description": "Advanced configuration option. The time between each periodic persistence of the model.\nThe default value is a randomized value between 3 to 4 hours, which avoids all jobs persisting at exactly the same time. The smallest allowed value is 1 hour. \nFor very large models (several GB), persistence could take 10-20 minutes, so do not set the value too low.\nIf the job is open when you make the update, you must stop the datafeed, close the job, then reopen the job and restart the datafeed for the changes to take effect.",
             "name": "background_persist_interval",
             "required": false,
             "type": {
@@ -119741,7 +119740,7 @@
           },
           {
             "description": "Advanced configuration option. Contains custom meta data about the job. For example, it can contain custom URL information as shown in Adding custom URLs to machine learning results.",
-            "docUrl": "https://www.elastic.co/guide/en/machine-learning/7.12/ml-configuring-url.html",
+            "docId": "ml.customUrls",
             "name": "custom_settings",
             "required": false,
             "type": {
@@ -119774,8 +119773,7 @@
             }
           },
           {
-            "description": "A description of the job. See Job resources.",
-            "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-job-resource.html",
+            "description": "A description of the job.",
             "name": "description",
             "required": false,
             "type": {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -119727,7 +119727,7 @@
             }
           },
           {
-            "description": "Advanced configuration option. The time between each periodic persistence of the model.\nThe default value is a randomized value between 3 to 4 hours, which avoids all jobs persisting at exactly the same time. The smallest allowed value is 1 hour. \nFor very large models (several GB), persistence could take 10-20 minutes, so do not set the value too low.\nIf the job is open when you make the update, you must stop the datafeed, close the job, then reopen the job and restart the datafeed for the changes to take effect.",
+            "description": "Advanced configuration option. The time between each periodic persistence of the model.\nThe default value is a randomized value between 3 to 4 hours, which avoids all jobs persisting at exactly the same time. The smallest allowed value is 1 hour.\nFor very large models (several GB), persistence could take 10-20 minutes, so do not set the value too low.\nIf the job is open when you make the update, you must stop the datafeed, close the job, then reopen the job and restart the datafeed for the changes to take effect.",
             "name": "background_persist_interval",
             "required": false,
             "type": {

--- a/specification/ml/update_job/MlUpdateJobRequest.ts
+++ b/specification/ml/update_job/MlUpdateJobRequest.ts
@@ -45,7 +45,7 @@ export interface Request extends RequestBase {
     analysis_limits?: AnalysisMemoryLimit
     /**
      * Advanced configuration option. The time between each periodic persistence of the model.
-     * The default value is a randomized value between 3 to 4 hours, which avoids all jobs persisting at exactly the same time. The smallest allowed value is 1 hour. 
+     * The default value is a randomized value between 3 to 4 hours, which avoids all jobs persisting at exactly the same time. The smallest allowed value is 1 hour.
      * For very large models (several GB), persistence could take 10-20 minutes, so do not set the value too low.
      * If the job is open when you make the update, you must stop the datafeed, close the job, then reopen the job and restart the datafeed for the changes to take effect.
      */

--- a/specification/ml/update_job/MlUpdateJobRequest.ts
+++ b/specification/ml/update_job/MlUpdateJobRequest.ts
@@ -44,19 +44,20 @@ export interface Request extends RequestBase {
     allow_lazy_open?: boolean
     analysis_limits?: AnalysisMemoryLimit
     /**
-     * Advanced configuration option. The time between each periodic persistence of the model. See Job resources.
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-job-resource.html
+     * Advanced configuration option. The time between each periodic persistence of the model.
+     * The default value is a randomized value between 3 to 4 hours, which avoids all jobs persisting at exactly the same time. The smallest allowed value is 1 hour. 
+     * For very large models (several GB), persistence could take 10-20 minutes, so do not set the value too low.
+     * If the job is open when you make the update, you must stop the datafeed, close the job, then reopen the job and restart the datafeed for the changes to take effect.
      */
     background_persist_interval?: Time
     /**
      * Advanced configuration option. Contains custom meta data about the job. For example, it can contain custom URL information as shown in Adding custom URLs to machine learning results.
-     * @doc_url https://www.elastic.co/guide/en/machine-learning/7.12/ml-configuring-url.html
+     * @doc_id ml.customUrls
      */
     custom_settings?: Dictionary<string, UserDefinedValue>
     categorization_filters?: string[]
     /**
-     * A description of the job. See Job resources.
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-job-resource.html
+     * A description of the job.
      */
     description?: string
     model_plot_config?: ModelPlotConfig


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch-specification/pull/732

This PR tests the new [@doc_id ](https://github.com/elastic/elasticsearch-specification/blob/main/docs/modeling-guide.md#doc_id) functionality. The ml.customUrls keyword in this case should resolve to the same type of URL as exists in https://github.com/elastic/kibana/blob/master/src/core/public/doc_links/doc_links_service.ts

I also removed some links to out-dated URLs that are no longer valid or necessary. 