### PR TITLE
Fix span_gap query definition

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -58687,6 +58687,32 @@
       ]
     },
     {
+      "description": "Can only be used as a clause in a span_near query.",
+      "kind": "type_alias",
+      "name": {
+        "name": "SpanGapQuery",
+        "namespace": "_types.query_dsl"
+      },
+      "type": {
+        "key": {
+          "kind": "instance_of",
+          "type": {
+            "name": "Field",
+            "namespace": "_types"
+          }
+        },
+        "kind": "dictionary_of",
+        "singleKey": true,
+        "value": {
+          "kind": "instance_of",
+          "type": {
+            "name": "integer",
+            "namespace": "_types"
+          }
+        }
+      }
+    },
+    {
       "inherits": {
         "type": {
           "name": "QueryBase",
@@ -58906,25 +58932,13 @@
           }
         },
         {
-          "description": "Can only be used as a clause in a span_near query",
           "name": "span_gap",
           "required": false,
           "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "_types"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": true,
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "_types"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "SpanGapQuery",
+              "namespace": "_types.query_dsl"
             }
           }
         },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4919,6 +4919,8 @@ export interface QueryDslSpanFirstQuery extends QueryDslQueryBase {
   match: QueryDslSpanQuery
 }
 
+export type QueryDslSpanGapQuery = Record<Field, integer>
+
 export interface QueryDslSpanMultiTermQuery extends QueryDslQueryBase {
   match: QueryDslQueryContainer
 }
@@ -4945,7 +4947,7 @@ export interface QueryDslSpanQuery {
   span_containing?: QueryDslSpanContainingQuery
   field_masking_span?: QueryDslSpanFieldMaskingQuery
   span_first?: QueryDslSpanFirstQuery
-  span_gap?: Record<Field, integer>
+  span_gap?: QueryDslSpanGapQuery
   span_multi?: QueryDslSpanMultiTermQuery
   span_near?: QueryDslSpanNearQuery
   span_not?: QueryDslSpanNotQuery

--- a/specification/_types/query_dsl/fulltext.ts
+++ b/specification/_types/query_dsl/fulltext.ts
@@ -61,6 +61,7 @@ export class IntervalsAnyOf {
 }
 
 /** @variants container */
+// Note: similar to IntervalsQuery - see comment there
 export class IntervalsContainer {
   all_of?: IntervalsAllOf
   any_of?: IntervalsAnyOf

--- a/specification/_types/query_dsl/span.ts
+++ b/specification/_types/query_dsl/span.ts
@@ -37,10 +37,9 @@ export class SpanFirstQuery extends QueryBase {
   match: SpanQuery
 }
 
-export class SpanGapQuery extends QueryBase {
-  field: Field
-  width?: integer
-}
+/** Can only be used as a clause in a span_near query. */
+// The integer value is the span width
+export type SpanGapQuery = SingleKeyDictionary<Field, integer>
 
 export class SpanMultiTermQuery extends QueryBase {
   /** Should be a multi term query (one of wildcard, fuzzy, prefix, range or regexp query) */
@@ -82,8 +81,7 @@ export class SpanQuery {
   span_containing?: SpanContainingQuery
   field_masking_span?: SpanFieldMaskingQuery
   span_first?: SpanFirstQuery
-  /** Can only be used as a clause in a span_near query */
-  span_gap?: SingleKeyDictionary<Field, integer>
+  span_gap?: SpanGapQuery
   span_multi?: SpanMultiTermQuery
   span_near?: SpanNearQuery
   span_not?: SpanNotQuery


### PR DESCRIPTION
As titled. The existing definition was most certainly a "Nest-ism".