### PR TITLE
Add security prerequisites for ML create data frame analytics API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -7344,6 +7344,18 @@
         "name": "Response",
         "namespace": "ml.put_data_frame_analytics"
       },
+      "securityPrerequisites": {
+        "cluster": [
+          "manage_ml"
+        ],
+        "index": [
+          "create_index",
+          "index",
+          "manage",
+          "read",
+          "view_index_metadata"
+        ]
+      },
       "since": "7.3.0",
       "stability": "stable",
       "urls": [
@@ -116707,7 +116719,7 @@
           }
         ]
       },
-      "description": "Instantiates a data frame analytics job.",
+      "description": "Instantiates a data frame analytics job.\nThis API creates a data frame analytics job that performs an analysis on the source indices and stores the outcome in a destination index. You must have `read` and `view_index_metadata` security privileges for the source indices. You must have `read`, `create_index`, `manage` and `index` security privileges for the destination index.",
       "inherits": {
         "type": {
           "name": "RequestBase",

--- a/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
+++ b/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
@@ -34,7 +34,7 @@ import { integer } from '@_types/Numeric'
  * @since 7.3.0
  * @stability stable
  * @security_prerequisites_cluster manage_ml
- * @security_prerequisites_index create_index, index, manage, read, view_index_metadata  
+ * @security_prerequisites_index create_index, index, manage, read, view_index_metadata
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
+++ b/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
@@ -28,9 +28,13 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
+ * Instantiates a data frame analytics job.
+ * This API creates a data frame analytics job that performs an analysis on the source indices and stores the outcome in a destination index. You must have `read` and `view_index_metadata` security privileges for the source indices. You must have `read`, `create_index`, `manage` and `index` security privileges for the destination index.
  * @rest_spec_name ml.put_data_frame_analytics
  * @since 7.3.0
  * @stability stable
+ * @security_prerequisites_cluster manage_ml
+ * @security_prerequisites_index create_index, index, manage, read, view_index_metadata  
  */
 export interface Request extends RequestBase {
   path_parts: {


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch-specification/issues/713 and https://github.com/elastic/elasticsearch-specification/pull/717#issuecomment-918844192

This PR tests the addition of security prerequisites to the API spec, in particular for a PR that has different index privileges related to source and destination indices per https://www.elastic.co/guide/en/elasticsearch/reference/master/put-dfanalytics.html#ml-put-dfanalytics-prereq
