### PR TITLE
Updates the spec for ML close anomaly detection jobs API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -5915,6 +5915,11 @@
         "name": "Response",
         "namespace": "ml.close_job"
       },
+      "securityPrerequisites": {
+        "cluster": [
+          "manage_ml"
+        ]
+      },
       "since": "5.4.0",
       "stability": "stable",
       "urls": [
@@ -110848,7 +110853,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Closes one or more anomaly detection jobs. A job can be opened and closed multiple times throughout its lifecycle.",
+      "description": "Closes one or more anomaly detection jobs.\nA job can be opened and closed multiple times throughout its lifecycle. A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results.\nWhen you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data.\nIf you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request.\nWhen a datafeed that has a specified end date stops, it automatically closes its associated job.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -110862,7 +110867,7 @@
       },
       "path": [
         {
-          "description": "The name of the job to close",
+          "description": "Identifier for the anomaly detection job. It can be a job identifier, a group name, or a wildcard expression. You can close multiple anomaly detection jobs in a single API request by using a group name, a comma-separated list of jobs, or a wildcard expression. You can close all jobs by using `_all` or by specifying `*` as the job identifier.",
           "name": "job_id",
           "required": true,
           "type": {
@@ -110876,6 +110881,23 @@
       ],
       "query": [
         {
+          "description": "Specifies what to do when the request: contains wildcard expressions and there are no jobs that match; contains the  `_all` string or no identifiers and there are no matches; or contains wildcard expressions and there are only partial matches. By default, it returns an empty jobs array when there are no matches and the subset of results when there are partial matches.\nIf `false`, the request returns a 404 status code when there are no matches or only partial matches.",
+          "name": "allow_no_match",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "deprecation": {
+            "description": "Use `allow_no_match` instead.",
+            "version": "7.10.0"
+          },
           "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
           "name": "allow_no_jobs",
           "required": false,
@@ -110888,9 +110910,10 @@
           }
         },
         {
-          "description": "True if the job should be forcefully closed",
+          "description": "Use to close a failed job, or to forcefully close a job which has not responded to its initial close request; the request returns without performing the associated actions such as flushing buffers and persisting the model snapshots.\nIf you want the job to be in a consistent state after the close job API returns, do not set to `true`. This parameter should be used only in situations where the job has already failed or where you are not interested in results the job might have recently produced or might produce in the future.",
           "name": "force",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -110900,10 +110923,10 @@
           }
         },
         {
-          "description": "Controls the time to wait until a job has closed. Default to 30 minutes",
+          "description": "Controls the time to wait until a job has closed.",
           "name": "timeout",
           "required": false,
-          "serverDefault": "30s",
+          "serverDefault": "30m",
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1225,12 +1225,6 @@
       ],
       "response": []
     },
-    "ml.close_job": {
-      "request": [
-        "Request: missing json spec query parameter 'allow_no_match'"
-      ],
-      "response": []
-    },
     "ml.delete_calendar": {
       "request": [
         "Request: should not have a body"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11202,6 +11202,7 @@ export interface MlValidationLoss {
 
 export interface MlCloseJobRequest extends RequestBase {
   job_id: Id
+  allow_no_match?: boolean
   allow_no_jobs?: boolean
   force?: boolean
   timeout?: Time

--- a/specification/ml/close_job/MlCloseJobRequest.ts
+++ b/specification/ml/close_job/MlCloseJobRequest.ts
@@ -22,18 +22,43 @@ import { Id } from '@_types/common'
 import { Time } from '@_types/Time'
 
 /**
+ * Closes one or more anomaly detection jobs.
+ * A job can be opened and closed multiple times throughout its lifecycle. A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results.
+ * When you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data.
+ * If you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request.
+ * When a datafeed that has a specified end date stops, it automatically closes its associated job.
  * @rest_spec_name ml.close_job
  * @since 5.4.0
  * @stability stable
+ * @security_prerequisites_cluster manage_ml
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier for the anomaly detection job. It can be a job identifier, a group name, or a wildcard expression. You can close multiple anomaly detection jobs in a single API request by using a group name, a comma-separated list of jobs, or a wildcard expression. You can close all jobs by using `_all` or by specifying `*` as the job identifier.
+     */
     job_id: Id
   }
   query_parameters: {
+    /**
+     * Specifies what to do when the request: contains wildcard expressions and there are no jobs that match; contains the  `_all` string or no identifiers and there are no matches; or contains wildcard expressions and there are only partial matches. By default, it returns an empty jobs array when there are no matches and the subset of results when there are partial matches.
+     * If `false`, the request returns a 404 status code when there are no matches or only partial matches.
+     * @server_default true 
+     */
+    allow_no_match?: boolean
+    /**
+     * @deprecation 7.10.0, Use `allow_no_match` instead.
+     */
     allow_no_jobs?: boolean
+    /**
+     * Use to close a failed job, or to forcefully close a job which has not responded to its initial close request; the request returns without performing the associated actions such as flushing buffers and persisting the model snapshots.
+     * If you want the job to be in a consistent state after the close job API returns, do not set to `true`. This parameter should be used only in situations where the job has already failed or where you are not interested in results the job might have recently produced or might produce in the future.
+     * @server_default false
+     */
     force?: boolean
-    /** @server_default 30s */
+    /** 
+     * Controls the time to wait until a job has closed. 
+     * @server_default 30s */
     timeout?: Time
   }
 }

--- a/specification/ml/close_job/MlCloseJobRequest.ts
+++ b/specification/ml/close_job/MlCloseJobRequest.ts
@@ -43,11 +43,12 @@ export interface Request extends RequestBase {
     /**
      * Specifies what to do when the request: contains wildcard expressions and there are no jobs that match; contains the  `_all` string or no identifiers and there are no matches; or contains wildcard expressions and there are only partial matches. By default, it returns an empty jobs array when there are no matches and the subset of results when there are partial matches.
      * If `false`, the request returns a 404 status code when there are no matches or only partial matches.
-     * @server_default true 
+     * @server_default true
      */
     allow_no_match?: boolean
     /**
-     * @deprecation 7.10.0, Use `allow_no_match` instead.
+     * @obsolete 7.10.0
+     * @obsolete_description Use `allow_no_match` instead.
      */
     allow_no_jobs?: boolean
     /**
@@ -56,9 +57,9 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     force?: boolean
-    /** 
-     * Controls the time to wait until a job has closed. 
-     * @server_default 30s */
+    /**
+     * Controls the time to wait until a job has closed.
+     * @server_default 30m */
     timeout?: Time
   }
 }


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/60601

This PR updates the spec for the close anomaly detection jobs API as follows:
- Adds API description/overview 
- Adds security prerequisites
- Adds missing allow_no_match query parameter
- Deprecates allow_no_jobs 
- Updates timeout default value from 30s to 30m (per [docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-close-job.html) and https://github.com/elastic/elasticsearch/blob/6fbc1b88d8a39bba6ab3c113b9410d0cfbff655a/client/rest-high-level/src/main/java/org/elasticsearch/client/ml/CloseJobRequest.java#L99)