### PR TITLE
Fix Security.Get_User_Privileges

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "_info": {
-    "hash": "f9245cb",
+    "hash": "17a63dead",
     "license": {
       "name": "Apache 2.0",
       "url": "https://github.com/elastic/elasticsearch-specification/blob/master/LICENSE"
@@ -127527,11 +127527,26 @@
           "name": "field_security",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "FieldSecurity",
-              "namespace": "security._types"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "FieldSecurity",
+                  "namespace": "security._types"
+                }
+              },
+              {
+                "kind": "array_of",
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "FieldSecurity",
+                    "namespace": "security._types"
+                  }
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
@@ -127572,6 +127587,16 @@
                 "type": {
                   "name": "string",
                   "namespace": "internal"
+                }
+              },
+              {
+                "kind": "array_of",
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "string",
+                    "namespace": "internal"
+                  }
                 }
               },
               {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13123,10 +13123,10 @@ export interface SecurityGlobalPrivilege {
 export type SecurityIndexPrivilege = 'all' | 'auto_configure' | 'create' | 'create_doc' | 'create_index' | 'delete' | 'delete_index' | 'index' | 'maintenance' | 'manage' | 'manage_follow_index' | 'manage_ilm' | 'manage_leader_index' | 'monitor' | 'read' | 'read_cross_cluster' | 'view_index_metadata' | 'write'
 
 export interface SecurityIndicesPrivileges {
-  field_security?: SecurityFieldSecurity
+  field_security?: SecurityFieldSecurity | SecurityFieldSecurity[]
   names: Indices
   privileges: SecurityIndexPrivilege[]
-  query?: string | QueryDslQueryContainer
+  query?: string | string[] | QueryDslQueryContainer
   allow_restricted_indices?: boolean
 }
 

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -79,7 +79,7 @@ export class IndicesPrivileges {
    * The document fields that the owners of the role have read access to.
    * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/field-and-document-access-control.html
    */
-  field_security?: FieldSecurity
+  field_security?: FieldSecurity | FieldSecurity[]
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
@@ -91,7 +91,7 @@ export class IndicesPrivileges {
   /**
    * A search query that defines the documents the owners of the role have read access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.
    */
-  query?: string | QueryContainer
+  query?: string | string[] | QueryContainer
   /**
    * Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.
    * @server_default false


### PR DESCRIPTION
In the response at least, some `IndicesPrivileges` properties are returned as arrays, potentially containing a single item. Since this type is used for requests also where single items can be sent, I've made these a union.