### PR TITLE
Refresh rank_eval and doc comments guide

### DIFF
--- a/docs/doc-comments-guide.md
+++ b/docs/doc-comments-guide.md
@@ -52,7 +52,7 @@ export interface Request extends RequestBase {
 ([original source code](https://github.com/elastic/elasticsearch-specification/blob/main/specification/_global/rank_eval/RankEvalRequest.ts))
 
 For more information about the tags in this example (and other common tags such
-as @deprecated and @doc_id), refer to the [Modeling Guide](https://github.com/elastic/elasticsearch-specification/blob/main/docs/modeling-guide.md#additional-information).
+as `@deprecated` and `@doc_id`), refer to the [Modeling Guide](https://github.com/elastic/elasticsearch-specification/blob/main/docs/modeling-guide.md#additional-information).
 
 ## Markup language
 

--- a/docs/doc-comments-guide.md
+++ b/docs/doc-comments-guide.md
@@ -13,49 +13,36 @@ Additional lines start with a `*` followed by a space. Long lines are allowed bu
  * Enables you to evaluate the quality of ranked search results over a set of typical search queries.
  * @rest_spec_name rank_eval
  * @since 6.2.0
+ * @stability experimental
  * @index_privileges read
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * List of data streams, indices, and index aliases used to limit the request. Wildcard (`*`) expressions are supported.
-     * 
+     * Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (`*`) expressions are supported.
      * To target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.
      */
     index: Indices
   }
-  query_parameters?: {
+  query_parameters: {
     /**
-     * Accept no matching indices?
-     * 
-     * If `false`, the request returns an error if any wildcard expression, index alias, or _all value targets only
-     * missing or closed indices. This behavior applies even if the request targets other open indices. For example,
-     * a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
-     * 
+     * If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
      * @server_default true
      */
     allow_no_indices?: boolean
-    
     expand_wildcards?: ExpandWildcards
-    
     /**
      * If `true`, missing or closed indices are not included in the response.
      * @server_default false
      */
     ignore_unavailable?: boolean
-    
     search_type?: string
   }
   body: {
-    /**
-     * A set of typical search requests, together with their provided ratings.
-     */
+    /** A set of typical search requests, together with their provided ratings. */
     requests: RankEvalRequestItem[]
-    
     /**
      * Definition of the evaluation metric to calculate.
-     * 
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#_available_evaluation_metrics
      */
     metric?: RankEvalMetric
   }
@@ -64,6 +51,8 @@ export interface Request extends RequestBase {
 
 ([original source code](https://github.com/elastic/elasticsearch-specification/blob/main/specification/_global/rank_eval/RankEvalRequest.ts))
 
+For more information about the tags in this example (and other common tags such
+as @deprecated and @doc_id), refer to the [Modeling Guide](https://github.com/elastic/elasticsearch-specification/blob/main/docs/modeling-guide.md#additional-information).
 
 ## Markup language
 

--- a/docs/doc-comments-guide.md
+++ b/docs/doc-comments-guide.md
@@ -13,7 +13,7 @@ Additional lines start with a `*` followed by a space. Long lines are allowed bu
  * Enables you to evaluate the quality of ranked search results over a set of typical search queries.
  * @rest_spec_name rank_eval
  * @since 6.2.0
- * @stability experimental
+ * @stability stable
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -8613,6 +8613,11 @@
       "description": "Allows to evaluate the quality of ranked search results over a set of typical search queries",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html",
       "name": "rank_eval",
+      "privileges": {
+        "index": [
+          "read"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "_global.rank_eval"
@@ -19531,7 +19536,7 @@
         "kind": "properties",
         "properties": [
           {
-            "description": "A set of typical search requests, together with their provided ratings",
+            "description": "A set of typical search requests, together with their provided ratings.",
             "name": "requests",
             "required": true,
             "type": {
@@ -19546,8 +19551,7 @@
             }
           },
           {
-            "description": "Definition of the evaluation metric to calculate",
-            "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#_available_evaluation_metrics",
+            "description": "Definition of the evaluation metric to calculate.",
             "name": "metric",
             "required": false,
             "type": {
@@ -19560,7 +19564,7 @@
           }
         ]
       },
-      "description": "Allows to evaluate the quality of ranked search results over a set of typical search queries",
+      "description": "Enables you to evaluate the quality of ranked search results over a set of typical search queries.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -19574,7 +19578,7 @@
       },
       "path": [
         {
-          "description": "Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (*) expressions are supported.\nTo target all data streams and indices in a cluster, omit this parameter or use _all or *.",
+          "description": "Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (`*`) expressions are supported.\nTo target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.",
           "name": "index",
           "required": true,
           "type": {
@@ -19588,7 +19592,7 @@
       ],
       "query": [
         {
-          "description": "If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.",
+          "description": "If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.",
           "name": "allow_no_indices",
           "required": false,
           "serverDefault": true,
@@ -19613,7 +19617,7 @@
           }
         },
         {
-          "description": "If true, missing or closed indices are not included in the response.",
+          "description": "If `true`, missing or closed indices are not included in the response.",
           "name": "ignore_unavailable",
           "required": false,
           "serverDefault": false,

--- a/specification/_global/rank_eval/RankEvalRequest.ts
+++ b/specification/_global/rank_eval/RankEvalRequest.ts
@@ -22,38 +22,39 @@ import { ExpandWildcards, Indices } from '@_types/common'
 import { RankEvalMetric, RankEvalRequestItem } from './types'
 
 /**
+ * Enables you to evaluate the quality of ranked search results over a set of typical search queries.
  * @rest_spec_name rank_eval
  * @since 6.2.0
  * @stability experimental
+ * @index_privileges read
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (*) expressions are supported.
-     * To target all data streams and indices in a cluster, omit this parameter or use _all or *.
+     * Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (`*`) expressions are supported.
+     * To target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.
      */
     index: Indices
   }
   query_parameters: {
     /**
-     * If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.
+     * If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
      * @server_default true
      */
     allow_no_indices?: boolean
     expand_wildcards?: ExpandWildcards
     /**
-     * If true, missing or closed indices are not included in the response.
+     * If `true`, missing or closed indices are not included in the response.
      * @server_default false
      */
     ignore_unavailable?: boolean
     search_type?: string
   }
   body: {
-    /** A set of typical search requests, together with their provided ratings */
+    /** A set of typical search requests, together with their provided ratings. */
     requests: RankEvalRequestItem[]
     /**
-     * Definition of the evaluation metric to calculate
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#_available_evaluation_metrics
+     * Definition of the evaluation metric to calculate.
      */
     metric?: RankEvalMetric
   }


### PR DESCRIPTION
Since the [doc comments guide](https://github.com/elastic/elasticsearch-specification/blob/main/docs/doc-comments-guide.md) references the rank evaluation API, this PR adds some missing info to that specification then refreshes the example in the guide. It also adds a link to the [modeling guide](https://github.com/elastic/elasticsearch-specification/blob/main/docs/modeling-guide.md#additional-information), where the tags are explained in greater detail.