### PR TITLE
Update security.put_user

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -132695,7 +132695,7 @@
         {
           "description": "The username of the User",
           "name": "username",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13689,7 +13689,7 @@ export interface SecurityPutRoleMappingResponse {
 }
 
 export interface SecurityPutUserRequest extends RequestBase {
-  username: Username
+  username?: Username
   refresh?: Refresh
   body?: {
     username?: Username

--- a/specification/security/put_user/SecurityPutUserRequest.ts
+++ b/specification/security/put_user/SecurityPutUserRequest.ts
@@ -27,7 +27,10 @@ import { Metadata, Password, Refresh, Username } from '@_types/common'
  */
 export interface Request extends RequestBase {
   path_parts: {
-    username: Username
+    // this should be required, but since it's present in the body
+    // as well, it could cause issues with code generators,
+    // thus let's mark it as optional.
+    username?: Username
   }
   query_parameters: {
     refresh?: Refresh


### PR DESCRIPTION
Usually when a property can be configured both in the path/query and the body, is marked as optional.
This API dopes its own thing and marks the path as required. This can cause issues with code generators.
I propose to mark the path as optional to avoid making the code generators overly complicated to handle this case.