### PR TITLE
Adds missing doc details for ML add events to calendar API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -7152,6 +7152,11 @@
       "description": "Posts scheduled events in a calendar.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-calendar-event.html",
       "name": "ml.post_calendar_events",
+      "privileges": {
+        "cluster": [
+          "manage_ml"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "ml.post_calendar_events"
@@ -103905,6 +103910,7 @@
       },
       "properties": [
         {
+          "description": "A string that uniquely identifies a calendar.",
           "name": "calendar_id",
           "required": false,
           "type": {
@@ -115405,7 +115411,7 @@
         "kind": "properties",
         "properties": [
           {
-            "description": "A list of one of more scheduled events. The event’s start and end times may be specified as integer milliseconds since the epoch or as a string in ISO 8601 format.",
+            "description": "A list of one of more scheduled events. The event’s start and end times can be specified as integer milliseconds since the epoch or as a string in ISO 8601 format.",
             "name": "events",
             "required": true,
             "type": {
@@ -115421,7 +115427,7 @@
           }
         ]
       },
-      "description": "Posts scheduled events in a calendar.",
+      "description": "Adds scheduled events to a calendar.",
       "inherits": {
         "type": {
           "name": "RequestBase",

--- a/specification/ml/_types/CalendarEvent.ts
+++ b/specification/ml/_types/CalendarEvent.ts
@@ -21,6 +21,7 @@ import { Id } from '@_types/common'
 import { EpochMillis } from '@_types/Time'
 
 export class CalendarEvent {
+  /** A string that uniquely identifies a calendar. */
   calendar_id?: Id
   event_id?: Id
   /** A description of the scheduled event. */

--- a/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
+++ b/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
@@ -22,9 +22,11 @@ import { Id } from '@_types/common'
 import { CalendarEvent } from '../_types/CalendarEvent'
 
 /**
+ * Adds scheduled events to a calendar.
  * @rest_spec_name ml.post_calendar_events
  * @since 6.2.0
  * @stability stable
+ * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {
   path_parts: {
@@ -32,7 +34,7 @@ export interface Request extends RequestBase {
     calendar_id: Id
   }
   body: {
-    /** A list of one of more scheduled events. The event’s start and end times may be specified as integer milliseconds since the epoch or as a string in ISO 8601 format. */
+    /** A list of one of more scheduled events. The event’s start and end times can be specified as integer milliseconds since the epoch or as a string in ISO 8601 format. */
     events: CalendarEvent[]
   }
 }


### PR DESCRIPTION
This PR updates [MLPostCalendarEventsRequest.ts](https://github.com/elastic/elasticsearch-specification/blob/main/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts) with info from the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-post-calendar-event.html)