### PR TITLE
Adds missing doc details for ML get calendar APIs

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -6492,6 +6492,11 @@
       "description": "Retrieves information about the scheduled events in calendars.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar-event.html",
       "name": "ml.get_calendar_events",
+      "privileges": {
+        "cluster": [
+          "monitor_ml"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "ml.get_calendar_events"
@@ -6523,6 +6528,11 @@
       "description": "Retrieves configuration information for calendars.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar.html",
       "name": "ml.get_calendars",
+      "privileges": {
+        "cluster": [
+          "monitor_ml"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "ml.get_calendars"
@@ -115624,7 +115634,7 @@
       },
       "path": [
         {
-          "description": "The ID of the calendar containing the events",
+          "description": "A string that uniquely identifies a calendar. You can get information for multiple calendars by using a comma-separated list of ids or a wildcard expression. You can get information for all calendars by using `_all` or `*` or by omitting the calendar identifier.",
           "name": "calendar_id",
           "required": true,
           "type": {
@@ -115638,19 +115648,7 @@
       ],
       "query": [
         {
-          "description": "Get events for the job. When this option is used calendar_id must be '_all'",
-          "name": "job_id",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Id",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Get events before this time",
+          "description": "Specifies to get events with timestamps earlier than this time.",
           "name": "end",
           "required": false,
           "type": {
@@ -115662,9 +115660,10 @@
           }
         },
         {
-          "description": "Skips a number of events",
+          "description": "Skips the specified number of events.",
           "name": "from",
           "required": false,
+          "serverDefault": 0,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -115674,7 +115673,32 @@
           }
         },
         {
-          "description": "Get events after this time",
+          "description": "Specifies to get events for a specific anomaly detection job identifier or job group. It must be used with a calendar identifier of `_all` or `*`.",
+          "name": "job_id",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Specifies the maximum number of events to obtain.",
+          "name": "size",
+          "required": false,
+          "serverDefault": 100,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Specifies to get events with timestamps after this time.",
           "name": "start",
           "required": false,
           "type": {
@@ -115682,18 +115706,6 @@
             "type": {
               "name": "string",
               "namespace": "internal"
-            }
-          }
-        },
-        {
-          "description": "Specifies a max number of events to get",
-          "name": "size",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
             }
           }
         }
@@ -115756,6 +115768,7 @@
           }
         },
         {
+          "description": "A description of the calendar.",
           "name": "description",
           "required": false,
           "type": {
@@ -115791,6 +115804,7 @@
         "kind": "properties",
         "properties": [
           {
+            "description": "This object is supported only when you omit the calendar identifier.",
             "name": "page",
             "required": false,
             "type": {
@@ -115817,7 +115831,7 @@
       },
       "path": [
         {
-          "description": "A string that uniquely identifies a calendar.",
+          "description": "A string that uniquely identifies a calendar. You can get information for multiple calendars by using a comma-separated list of ids or a wildcard expression. You can get information for all calendars by using `_all` or `*` or by omitting the calendar identifier.",
           "name": "calendar_id",
           "required": false,
           "type": {
@@ -115831,9 +115845,10 @@
       ],
       "query": [
         {
-          "description": "Skips the specified number of calendars.",
+          "description": "Skips the specified number of calendars. This parameter is supported only when you omit the calendar identifier.",
           "name": "from",
           "required": false,
+          "serverDefault": 0,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -115843,9 +115858,10 @@
           }
         },
         {
-          "description": "Specifies the maximum number of calendars to obtain.",
+          "description": "Specifies the maximum number of calendars to obtain. This parameter is supported only when you omit the calendar identifier.",
           "name": "size",
           "required": false,
+          "serverDefault": 10000,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11677,11 +11677,11 @@ export interface MlGetBucketsResponse {
 
 export interface MlGetCalendarEventsRequest extends RequestBase {
   calendar_id: Id
-  job_id?: Id
   end?: DateString
   from?: integer
-  start?: string
+  job_id?: Id
   size?: integer
+  start?: string
 }
 
 export interface MlGetCalendarEventsResponse {

--- a/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
+++ b/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { Page } from '@ml/_types/Page'
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
@@ -50,14 +49,5 @@ export interface Request extends RequestBase {
     size?: integer
     /** Specifies to get events with timestamps after this time. */
     start?: string
-  }
-  body: {
-    /** Specifies to get events with timestamps earlier than this time. */
-    end?: DateString
-    /** Specifies to get events for a specific anomaly detection job identifier or job group. It must be used with a calendar identifier of `_all` or `*`. */
-    job_id: Id,
-    page?: Page,
-    /** Specifies to get events with timestamps after this time. */
-    start?: DateString
   }
 }

--- a/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
+++ b/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
@@ -23,21 +23,40 @@ import { integer } from '@_types/Numeric'
 import { DateString } from '@_types/Time'
 
 /**
+ * Retrieves information about the scheduled events in calendars.
  * @rest_spec_name ml.get_calendar_events
  * @since 6.2.0
  * @stability stable
+ * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /** A string that uniquely identifies a calendar. You can get information for multiple calendars by using a comma-separated list of ids or a wildcard expression. You can get information for all calendars by using `_all` or `*` or by omitting the calendar identifier.*/
     calendar_id: Id
   }
   query_parameters: {
-    job_id?: Id // undocumented
-    // these params below should all be in the request body, but the tests are failing
-    // https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar-event.html#ml-get-calendar-event-request-body
+    /** Specifies to get events with timestamps earlier than this time. */
     end?: DateString
+    /** Skips the specified number of events.
+     * @server_default 0
+     */
     from?: integer
-    start?: string
+    /** Specifies to get events for a specific anomaly detection job identifier or job group. It must be used with a calendar identifier of `_all` or `*`. */
+    job_id?: Id 
+    /** Specifies the maximum number of events to obtain.
+     * @server_default 100
+     */
     size?: integer
+    /** Specifies to get events with timestamps after this time. */
+    start?: string
+  }
+  body: {
+    /** Specifies to get events with timestamps earlier than this time. */
+    end?: DateString
+    /** Specifies to get events for a specific anomaly detection job identifier or job group. It must be used with a calendar identifier of `_all` or `*`. */
+    job_id: Id,
+    page?: Page,
+    /** Specifies to get events with timestamps after this time. */
+    start?: DateString
   }
 }

--- a/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
+++ b/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
@@ -42,7 +42,7 @@ export interface Request extends RequestBase {
      */
     from?: integer
     /** Specifies to get events for a specific anomaly detection job identifier or job group. It must be used with a calendar identifier of `_all` or `*`. */
-    job_id?: Id 
+    job_id?: Id
     /** Specifies the maximum number of events to obtain.
      * @server_default 100
      */

--- a/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
+++ b/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { Page } from '@ml/_types/Page'
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'

--- a/specification/ml/get_calendars/MlGetCalendarsRequest.ts
+++ b/specification/ml/get_calendars/MlGetCalendarsRequest.ts
@@ -35,16 +35,17 @@ export interface Request extends RequestBase {
     calendar_id?: Id
   }
   query_parameters: {
-    /** Skips the specified number of calendars.
+    /** Skips the specified number of calendars. This parameter is supported only when you omit the calendar identifier.
      * @server_default 0
     */
     from?: integer
-    /** Specifies the maximum number of calendars to obtain. 
+    /** Specifies the maximum number of calendars to obtain. This parameter is supported only when you omit the calendar identifier.
      * @server_default 10000
     */
     size?: integer
   }
   body: {
+    /** This object is supported only when you omit the calendar identifier. */
     page?: Page
   }
 }

--- a/specification/ml/get_calendars/MlGetCalendarsRequest.ts
+++ b/specification/ml/get_calendars/MlGetCalendarsRequest.ts
@@ -37,11 +37,11 @@ export interface Request extends RequestBase {
   query_parameters: {
     /** Skips the specified number of calendars. This parameter is supported only when you omit the calendar identifier.
      * @server_default 0
-    */
+     */
     from?: integer
     /** Specifies the maximum number of calendars to obtain. This parameter is supported only when you omit the calendar identifier.
      * @server_default 10000
-    */
+     */
     size?: integer
   }
   body: {

--- a/specification/ml/get_calendars/MlGetCalendarsRequest.ts
+++ b/specification/ml/get_calendars/MlGetCalendarsRequest.ts
@@ -23,19 +23,25 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
+ * Retrieves configuration information for calendars.
  * @rest_spec_name ml.get_calendars
  * @since 6.2.0
  * @stability stable
+ * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {
   path_parts: {
-    /** A string that uniquely identifies a calendar. */
+    /** A string that uniquely identifies a calendar. You can get information for multiple calendars by using a comma-separated list of ids or a wildcard expression. You can get information for all calendars by using `_all` or `*` or by omitting the calendar identifier.*/
     calendar_id?: Id
   }
   query_parameters: {
-    /** Skips the specified number of calendars. */
+    /** Skips the specified number of calendars.
+     * @server_default 0
+    */
     from?: integer
-    /** Specifies the maximum number of calendars to obtain. */
+    /** Specifies the maximum number of calendars to obtain. 
+     * @server_default 10000
+    */
     size?: integer
   }
   body: {

--- a/specification/ml/get_calendars/types.ts
+++ b/specification/ml/get_calendars/types.ts
@@ -22,6 +22,7 @@ import { Id } from '@_types/common'
 export class Calendar {
   /** A string that uniquely identifies a calendar. */
   calendar_id: Id
+  /** A description of the calendar. */
   description?: string
   /** An array of anomaly detection job identifiers.  */
   job_ids: Id[]


### PR DESCRIPTION
This PR updates [get_calendar_events](https://github.com/elastic/elasticsearch-specification/tree/main/specification/ml/get_calendar_events) and [get_calendars](https://github.com/elastic/elasticsearch-specification/tree/main/specification/ml/get_calendars) with info from the documentation (https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar-event.html, https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-calendar.html).

NOTE: The request body is omitted from the get calendar events API, per https://github.com/elastic/elasticsearch/issues/79271