### PR TITLE
Removing force push option from the update model info action

### DIFF
--- a/.github/workflows/update-model-info.yml
+++ b/.github/workflows/update-model-info.yml
@@ -32,6 +32,5 @@ jobs:
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Update model info
-        push_options: --force-with-lease
         file_pattern: output/schema/schema.json
 


### PR DESCRIPTION
Prevents dataloss for now until https://github.com/elastic/elasticsearch-specification/issues/854 has been discussed and a solution found.