### PR TITLE
Add documentation for 'ml.delete_calendar*' APIs

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -5945,6 +5945,11 @@
       "description": "Deletes a calendar.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar.html",
       "name": "ml.delete_calendar",
+      "privileges": {
+        "cluster": [
+          "manage_ml"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "ml.delete_calendar"
@@ -6001,6 +6006,11 @@
       "description": "Deletes anomaly detection jobs from a calendar.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar-job.html",
       "name": "ml.delete_calendar_job",
+      "privileges": {
+        "cluster": [
+          "manage_ml"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "ml.delete_calendar_job"
@@ -110565,7 +110575,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Deletes a calendar.",
+      "description": "Removes all scheduled events from a calendar, then deletes it.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -110579,7 +110589,7 @@
       },
       "path": [
         {
-          "description": "The ID of the calendar to delete",
+          "description": "A string that uniquely identifies a calendar.",
           "name": "calendar_id",
           "required": true,
           "type": {
@@ -110695,7 +110705,7 @@
       },
       "path": [
         {
-          "description": "The ID of the calendar to modify",
+          "description": "A string that uniquely identifies a calendar.",
           "name": "calendar_id",
           "required": true,
           "type": {
@@ -110707,7 +110717,7 @@
           }
         },
         {
-          "description": "The ID of the job to remove from the calendar",
+          "description": "An identifier for the anomaly detection jobs. It can be a job identifier, a group name, or a comma-separated list of jobs or groups.",
           "name": "job_id",
           "required": true,
           "type": {
@@ -110726,6 +110736,7 @@
         "kind": "properties",
         "properties": [
           {
+            "description": "A string that uniquely identifies a calendar.",
             "name": "calendar_id",
             "required": true,
             "type": {
@@ -110737,6 +110748,7 @@
             }
           },
           {
+            "description": "A description of the calendar.",
             "name": "description",
             "required": false,
             "type": {
@@ -110748,6 +110760,7 @@
             }
           },
           {
+            "description": "A list of anomaly detection job identifiers or group names.",
             "name": "job_ids",
             "required": true,
             "type": {

--- a/specification/ml/delete_calendar/MlDeleteCalendarRequest.ts
+++ b/specification/ml/delete_calendar/MlDeleteCalendarRequest.ts
@@ -21,12 +21,15 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
+ * Removes all scheduled events from a calendar, then deletes it.
  * @rest_spec_name ml.delete_calendar
  * @since 6.2.0
  * @stability stable
+ * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /** A string that uniquely identifies a calendar. */
     calendar_id: Id
   }
 }

--- a/specification/ml/delete_calendar_event/MlDeleteCalendarEventRequest.ts
+++ b/specification/ml/delete_calendar_event/MlDeleteCalendarEventRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
+ * Deletes scheduled events from a calendar.
  * @rest_spec_name ml.delete_calendar_event
  * @since 6.2.0
  * @stability stable

--- a/specification/ml/delete_calendar_job/MlDeleteCalendarJobRequest.ts
+++ b/specification/ml/delete_calendar_job/MlDeleteCalendarJobRequest.ts
@@ -21,13 +21,17 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
+ * Deletes anomaly detection jobs from a calendar.
  * @rest_spec_name ml.delete_calendar_job
  * @since 6.2.0
  * @stability stable
+ * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /** A string that uniquely identifies a calendar. */
     calendar_id: Id
+    /** An identifier for the anomaly detection jobs. It can be a job identifier, a group name, or a comma-separated list of jobs or groups. */
     job_id: Id
   }
 }

--- a/specification/ml/delete_calendar_job/MlDeleteCalendarJobResponse.ts
+++ b/specification/ml/delete_calendar_job/MlDeleteCalendarJobResponse.ts
@@ -21,8 +21,11 @@ import { Id, Ids } from '@_types/common'
 
 export class Response {
   body: {
+    /** A string that uniquely identifies a calendar. */
     calendar_id: Id
+    /** A description of the calendar. */
     description?: string
+    /** A list of anomaly detection job identifiers or group names. */
     job_ids: Ids
   }
 }


### PR DESCRIPTION
This is a recommit of https://github.com/elastic/elasticsearch-specification/pull/850 which was lost due to https://github.com/elastic/elasticsearch-specification/issues/854