### PR TITLE
Add @aliases support to enum members

### DIFF
--- a/compiler/model/metamodel.ts
+++ b/compiler/model/metamodel.ts
@@ -288,6 +288,8 @@ export class NoBody {
 export class EnumMember {
   /** The identifier to use for this enum */
   name: string
+  /** An optional set of aliases for `name` */
+  aliases?: string[]
   /**
    * If specified takes precedence over `name` when generating code. `name` is always the value
    * to be sent over the wire

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -741,7 +741,7 @@ function hoistEnumMemberAnnotations (member: model.EnumMember, jsDocs: JSDoc[]):
   // We want to enforce a single jsDoc block.
   assert(jsDocs, jsDocs.length < 2, 'Use a single multiline jsDoc block instead of multiple single line blocks')
 
-  const validTags = ['obsolete', 'obsolete_description', 'identifier', 'since']
+  const validTags = ['obsolete', 'obsolete_description', 'identifier', 'since', 'aliases']
   const tags = parseJsDocTags(jsDocs)
   if (jsDocs.length === 1) {
     const description = jsDocs[0].getDescription()
@@ -751,6 +751,8 @@ function hoistEnumMemberAnnotations (member: model.EnumMember, jsDocs: JSDoc[]):
   setTags(jsDocs, member, tags, validTags, (tags, tag, value) => {
     if (tag === 'identifier') {
       member.identifier = value
+    } else if (tag === 'aliases') {
+      member.aliases = value.split(',').map(v => v.trim())
     } else if (tag === 'since') {
       assert(jsDocs, semver.valid(value), `${member.name}'s @since is not valid semver: ${value}`)
       member.since = value

--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -87,6 +87,17 @@ enum MyEnum {
 property: MyEnum
 ```
 
+Some enumerations accept alternate values for some of their members. The `@aliases` jsdoc tac can be used to capture these values:
+
+```ts
+enum Orientation {
+  /** @aliases counterclockwise, ccw */
+  right,
+  /** @aliases clockwise, cw */
+  left
+}
+```
+
 ### User defined value
 
 Represents a value that will be defined by the user and has no specific type.

--- a/typescript-generator/index.ts
+++ b/typescript-generator/index.ts
@@ -349,7 +349,17 @@ function buildResponse (type: M.Response): string {
 }
 
 function buildEnum (type: M.Enum): string {
-  return `export type ${createName(type.name)} = ${type.members.map(m => `'${m.name}'`).join(' | ')}\n`
+  // Flatten all items names and aliases
+  const names = type.members.reduce((accum, item) => {
+    accum.push(item.name)
+    if (item.aliases == null) {
+      return accum
+    } else {
+      return accum.concat(item.aliases)
+    }
+  }, new Array<string>())
+
+  return `export type ${createName(type.name)} = ${names.map(m => `'${m}'`).join(' | ')}\n`
 }
 
 function buildTypeAlias (type: M.TypeAlias): string {


### PR DESCRIPTION
For some enumerations, the ES server accepts aliases for enum members. A typical example is [`GeoOrientation`](https://github.com/elastic/elasticsearch-specification/blob/7783d94c66913fe408715065075f2533f26c43b0/specification/_types/mapping/geo.ts#L30) where [ES interprets](https://github.com/elastic/elasticsearch/blob/7047e202eae7d40beda2ed14a573ee9f0c935538/server/src/main/java/org/elasticsearch/common/geo/Orientation.java#L38) `counterclockwise` and `ccw` as `right`, and `clockwise` and `cw` as `left`.

This PR adds `@aliases` on enumerations to support these use cases.