### PR TITLE
Use aliases for GeoOrientation synonyms

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -50519,40 +50519,18 @@
       "kind": "enum",
       "members": [
         {
+          "aliases": [
+            "counterclockwise",
+            "ccw"
+          ],
           "name": "right"
         },
         {
-          "name": "RIGHT"
-        },
-        {
-          "name": "counterclockwise"
-        },
-        {
-          "name": "COUNTERCLOCKWISE"
-        },
-        {
-          "name": "ccw"
-        },
-        {
-          "name": "CCW"
-        },
-        {
+          "aliases": [
+            "clockwise",
+            "cw"
+          ],
           "name": "left"
-        },
-        {
-          "name": "LEFT"
-        },
-        {
-          "name": "clockwise"
-        },
-        {
-          "name": "CLOCKWISE"
-        },
-        {
-          "name": "cw"
-        },
-        {
-          "name": "CW"
         }
       ],
       "name": {
@@ -50617,6 +50595,8 @@
       ]
     },
     {
+      "description": "The `geo_shape` data type facilitates the indexing of and searching with arbitrary geo shapes such as rectangles\nand polygons.",
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-shape.html",
       "inherits": {
         "type": {
           "name": "DocValuesPropertyBase",
@@ -52049,33 +52029,8 @@
       ]
     },
     {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "right"
-        },
-        {
-          "name": "counterclockwise"
-        },
-        {
-          "name": "ccw"
-        },
-        {
-          "name": "left"
-        },
-        {
-          "name": "clockwise"
-        },
-        {
-          "name": "cw"
-        }
-      ],
-      "name": {
-        "name": "ShapeOrientation",
-        "namespace": "_types.mapping"
-      }
-    },
-    {
+      "description": "The `shape` data type facilitates the indexing of and searching with arbitrary `x, y` cartesian shapes such as\nrectangles and polygons.",
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/shape.html",
       "inherits": {
         "type": {
           "name": "DocValuesPropertyBase",
@@ -52127,7 +52082,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "ShapeOrientation",
+              "name": "GeoOrientation",
               "namespace": "_types.mapping"
             }
           }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -504,14 +504,7 @@
         "Request: query parameter 'flat_settings' does not exist in the json spec",
         "Request: should not have a body"
       ],
-      "response": [
-        "enum definition _types.mapping:GeoOrientation - Duplicate enum member identifier 'RIGHT'",
-        "enum definition _types.mapping:GeoOrientation - Duplicate enum member identifier 'COUNTERCLOCKWISE'",
-        "enum definition _types.mapping:GeoOrientation - Duplicate enum member identifier 'CCW'",
-        "enum definition _types.mapping:GeoOrientation - Duplicate enum member identifier 'LEFT'",
-        "enum definition _types.mapping:GeoOrientation - Duplicate enum member identifier 'CLOCKWISE'",
-        "enum definition _types.mapping:GeoOrientation - Duplicate enum member identifier 'CW'"
-      ]
+      "response": []
     },
     "cluster.get_settings": {
       "request": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4041,7 +4041,7 @@ export interface MappingGenericProperty extends MappingDocValuesPropertyBase {
   type: string
 }
 
-export type MappingGeoOrientation = 'right' | 'RIGHT' | 'counterclockwise' | 'COUNTERCLOCKWISE' | 'ccw' | 'CCW' | 'left' | 'LEFT' | 'clockwise' | 'CLOCKWISE' | 'cw' | 'CW'
+export type MappingGeoOrientation = 'right' | 'counterclockwise' | 'ccw' | 'left' | 'clockwise' | 'cw'
 
 export interface MappingGeoPointProperty extends MappingDocValuesPropertyBase {
   ignore_malformed?: boolean
@@ -4206,13 +4206,11 @@ export interface MappingSearchAsYouTypeProperty extends MappingCorePropertyBase 
   type: 'search_as_you_type'
 }
 
-export type MappingShapeOrientation = 'right' | 'counterclockwise' | 'ccw' | 'left' | 'clockwise' | 'cw'
-
 export interface MappingShapeProperty extends MappingDocValuesPropertyBase {
   coerce?: boolean
   ignore_malformed?: boolean
   ignore_z_value?: boolean
-  orientation?: MappingShapeOrientation
+  orientation?: MappingGeoOrientation
   type: 'shape'
 }
 

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -24,7 +24,12 @@ import { Fields, RelationName } from '@_types/common'
 import { double, integer } from '@_types/Numeric'
 import { DateString } from '@_types/Time'
 import { NestedProperty, ObjectProperty } from './complex'
-import { GeoPointProperty, GeoShapeProperty, PointProperty } from './geo'
+import {
+  GeoPointProperty,
+  GeoShapeProperty,
+  PointProperty,
+  ShapeProperty
+} from './geo'
 import { PropertyBase } from './Property'
 import { RangeProperty } from './range'
 import {
@@ -32,7 +37,6 @@ import {
   GenericProperty,
   IpProperty,
   Murmur3HashProperty,
-  ShapeProperty,
   TokenCountProperty
 } from './specialized'
 import { TermVectorOption } from './TermVectorOption'

--- a/specification/_types/mapping/geo.ts
+++ b/specification/_types/mapping/geo.ts
@@ -28,20 +28,18 @@ export class GeoPointProperty extends DocValuesPropertyBase {
 }
 
 export enum GeoOrientation {
-  right = 0,
-  RIGHT = 1,
-  counterclockwise = 2,
-  COUNTERCLOCKWISE = 3,
-  ccw = 4,
-  CCW = 5,
-  left = 6,
-  LEFT = 7,
-  clockwise = 8,
-  CLOCKWISE = 9,
-  cw = 10,
-  CW = 11
+  /** @aliases counterclockwise, ccw */
+  right,
+  /** @aliases clockwise, cw */
+  left
 }
 
+/**
+ * The `geo_shape` data type facilitates the indexing of and searching with arbitrary geo shapes such as rectangles
+ * and polygons.
+ *
+ * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-shape.html
+ */
 export class GeoShapeProperty extends DocValuesPropertyBase {
   coerce?: boolean
   ignore_malformed?: boolean
@@ -66,4 +64,18 @@ export class PointProperty extends DocValuesPropertyBase {
   ignore_z_value?: boolean
   null_value?: string
   type: 'point'
+}
+
+/**
+ * The `shape` data type facilitates the indexing of and searching with arbitrary `x, y` cartesian shapes such as
+ * rectangles and polygons.
+ *
+ * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/shape.html
+ */
+export class ShapeProperty extends DocValuesPropertyBase {
+  coerce?: boolean
+  ignore_malformed?: boolean
+  ignore_z_value?: boolean
+  orientation?: GeoOrientation
+  type: 'shape'
 }

--- a/specification/_types/mapping/specialized.ts
+++ b/specification/_types/mapping/specialized.ts
@@ -84,23 +84,6 @@ export class Murmur3HashProperty extends DocValuesPropertyBase {
   type: 'murmur3'
 }
 
-export enum ShapeOrientation {
-  right = 0,
-  counterclockwise = 1,
-  ccw = 2,
-  left = 3,
-  clockwise = 4,
-  cw = 5
-}
-
-export class ShapeProperty extends DocValuesPropertyBase {
-  coerce?: boolean
-  ignore_malformed?: boolean
-  ignore_z_value?: boolean
-  orientation?: ShapeOrientation
-  type: 'shape'
-}
-
 export class TokenCountProperty extends DocValuesPropertyBase {
   analyzer?: string
   boost?: double


### PR DESCRIPTION
Uses aliases for `GeoOrientation` synonyms, and removes the duplicate `Orientation` enum.

Also moves `ShapeProperty` to `mapping/geo.ts` where it belongs.
