### PR TITLE
Fix normalizer definition in index settings

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "_info": {
-    "hash": "2ed7027",
+    "hash": "87d4b563c",
     "license": {
       "name": "Apache 2.0",
       "url": "https://github.com/elastic/elasticsearch-specification/blob/master/LICENSE"
@@ -46031,6 +46031,23 @@
       ]
     },
     {
+      "kind": "interface",
+      "name": {
+        "name": "LowercaseNormalizer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "lowercase"
+          }
+        }
+      ]
+    },
+    {
       "inherits": {
         "type": {
           "name": "TokenFilterBase",
@@ -46486,6 +46503,37 @@
           }
         }
       ]
+    },
+    {
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-normalizers.html",
+      "kind": "type_alias",
+      "name": {
+        "name": "Normalizer",
+        "namespace": "_types.analysis"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "LowercaseNormalizer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CustomNormalizer",
+              "namespace": "_types.analysis"
+            }
+          }
+        ],
+        "kind": "union_of"
+      },
+      "variants": {
+        "kind": "internal_tag",
+        "tag": "type"
+      }
     },
     {
       "inherits": {
@@ -86040,7 +86088,7 @@
             "value": {
               "kind": "instance_of",
               "type": {
-                "name": "CustomNormalizer",
+                "name": "Normalizer",
                 "namespace": "_types.analysis"
               }
             }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3580,6 +3580,10 @@ export interface AnalysisLimitTokenCountTokenFilter extends AnalysisTokenFilterB
   max_token_count: integer
 }
 
+export interface AnalysisLowercaseNormalizer {
+  type: 'lowercase'
+}
+
 export interface AnalysisLowercaseTokenFilter extends AnalysisTokenFilterBase {
   type: 'lowercase'
   language: string
@@ -3637,6 +3641,8 @@ export interface AnalysisNoriTokenizer extends AnalysisTokenizerBase {
   user_dictionary: string
   user_dictionary_rules: string[]
 }
+
+export type AnalysisNormalizer = AnalysisLowercaseNormalizer | AnalysisCustomNormalizer
 
 export interface AnalysisPathHierarchyTokenizer extends AnalysisTokenizerBase {
   type: 'path_hierarchy'
@@ -8457,7 +8463,7 @@ export interface IndicesIndexSettingsAnalysis {
   analyzer?: Record<string, AnalysisAnalyzer>
   char_filter?: Record<string, AnalysisCharFilter>
   filter?: Record<string, AnalysisTokenFilter>
-  normalizer?: Record<string, AnalysisCustomNormalizer>
+  normalizer?: Record<string, AnalysisNormalizer>
 }
 
 export interface IndicesIndexSettingsLifecycle {

--- a/specification/_types/analysis/normalizers.ts
+++ b/specification/_types/analysis/normalizers.ts
@@ -17,6 +17,16 @@
  * under the License.
  */
 
+/**
+ * @variants internal tag='type'
+ * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-normalizers.html
+ */
+export type Normalizer = LowercaseNormalizer | CustomNormalizer
+
+export class LowercaseNormalizer {
+  type: 'lowercase'
+}
+
 export class CustomNormalizer {
   type: 'custom'
   char_filter?: string[]

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -22,7 +22,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Analyzer } from '@_types/analysis/analyzers'
 import { TokenFilter } from '@_types/analysis/token_filters'
 import { CharFilter } from '@_types/analysis/char_filters'
-import { CustomNormalizer } from '@_types/analysis/normalizers'
+import { Normalizer } from '@_types/analysis/normalizers'
 import { Name, PipelineName, Uuid, VersionString } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { DateString, Time } from '@_types/Time'
@@ -263,5 +263,5 @@ export class IndexSettingsAnalysis {
   analyzer?: Dictionary<string, Analyzer>
   char_filter?: Dictionary<string, CharFilter>
   filter?: Dictionary<string, TokenFilter>
-  normalizer?: Dictionary<string, CustomNormalizer>
+  normalizer?: Dictionary<string, Normalizer>
 }


### PR DESCRIPTION
This fixes the normalizers definition for index settings. There's one builtin `lowercase` normalizer, and the `custom` normalizer defined as a filter pipeline.