### PR TITLE
Fix TermsSetQuery and GeoDistanceSort

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -23785,7 +23785,7 @@
     },
     {
       "attachedBehaviors": [
-        "AdditionalProperties"
+        "AdditionalProperty"
       ],
       "behaviors": [
         {
@@ -23821,7 +23821,7 @@
             }
           ],
           "type": {
-            "name": "AdditionalProperties",
+            "name": "AdditionalProperty",
             "namespace": "_spec_utils"
           }
         }
@@ -59631,9 +59631,15 @@
       "properties": []
     },
     {
+      "inherits": {
+        "type": {
+          "name": "QueryBase",
+          "namespace": "_types.query_dsl"
+        }
+      },
       "kind": "interface",
       "name": {
-        "name": "TermsSetFieldQuery",
+        "name": "TermsSetQuery",
         "namespace": "_types.query_dsl"
       },
       "properties": [
@@ -59674,47 +59680,6 @@
           }
         }
       ]
-    },
-    {
-      "attachedBehaviors": [
-        "AdditionalProperty"
-      ],
-      "behaviors": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "Field",
-                "namespace": "_types"
-              }
-            },
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "TermsSetFieldQuery",
-                "namespace": "_types.query_dsl"
-              }
-            }
-          ],
-          "type": {
-            "name": "AdditionalProperty",
-            "namespace": "_spec_utils"
-          }
-        }
-      ],
-      "inherits": {
-        "type": {
-          "name": "QueryBase",
-          "namespace": "_types.query_dsl"
-        }
-      },
-      "kind": "interface",
-      "name": {
-        "name": "TermsSetQuery",
-        "namespace": "_types.query_dsl"
-      },
-      "properties": []
     },
     {
       "kind": "enum",
@@ -150236,6 +150201,25 @@
       ]
     },
     {
+      "description": "In some places in the specification an object consists of a static set of properties and a single additional property\nwith an arbitrary name but a statically defined type. This is typically used for configurations associated\nto a single field. Meaning that object should theoretically extend SingleKeyDictionary but expose\na set of known keys. And possibly the object might already be part of an object graph and have a parent class.\nThis puts it into a bind that needs a client specific solution.\nWe therefore document the requirement to accept a single unknown property with this interface.",
+      "generics": [
+        {
+          "name": "TKey",
+          "namespace": "_spec_utils"
+        },
+        {
+          "name": "TValue",
+          "namespace": "_spec_utils"
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "AdditionalProperty",
+        "namespace": "_spec_utils"
+      },
+      "properties": []
+    },
+    {
       "description": "In some places in the specification an object consists of the union of a set of known properties\nand a set of runtime injected properties. Meaning that object should theoretically extend Dictionary but expose\na set of known keys and possibly. The object might already be part of an object graph and have a parent class.\nThis puts it into a bind that needs a client specific solution.\nWe therefore document the requirement to behave like a dictionary for unknown properties with this interface.",
       "generics": [
         {
@@ -150333,25 +150317,6 @@
           }
         }
       ]
-    },
-    {
-      "description": "In some places in the specification an object consists of a static set of properties and a single additional property\nwith an arbitrary name but a statically defined type. This is typically used for configurations associated\nto a single field. Meaning that object should theoretically extend SingleKeyDictionary but expose\na set of known keys. And possibly the object might already be part of an object graph and have a parent class.\nThis puts it into a bind that needs a client specific solution.\nWe therefore document the requirement to accept a single unknown property with this interface.",
-      "generics": [
-        {
-          "name": "TKey",
-          "namespace": "_spec_utils"
-        },
-        {
-          "name": "TValue",
-          "namespace": "_spec_utils"
-        }
-      ],
-      "kind": "interface",
-      "name": {
-        "name": "AdditionalProperty",
-        "namespace": "_spec_utils"
-      },
-      "properties": []
     },
     {
       "description": "Implements a set of common query parameters all Cat API's support.\nSince these can break the request structure these are listed explicitly as a behavior.",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4996,16 +4996,11 @@ export interface QueryDslTermsQueryKeys extends QueryDslQueryBase {
 export type QueryDslTermsQuery = QueryDslTermsQueryKeys |
     { [property: string]: string[] | long[] | QueryDslTermsLookup }
 
-export interface QueryDslTermsSetFieldQuery {
+export interface QueryDslTermsSetQuery extends QueryDslQueryBase {
   minimum_should_match_field?: Field
   minimum_should_match_script?: Script
   terms: string[]
 }
-
-export interface QueryDslTermsSetQueryKeys extends QueryDslQueryBase {
-}
-export type QueryDslTermsSetQuery = QueryDslTermsSetQueryKeys |
-    { [property: string]: QueryDslTermsSetFieldQuery }
 
 export type QueryDslTextQueryType = 'best_fields' | 'most_fields' | 'cross_fields' | 'phrase' | 'phrase_prefix' | 'bool_prefix'
 
@@ -15739,6 +15734,10 @@ export interface XpackUsageWatcherWatchTriggerSchedule extends XpackUsageCounter
   _all: XpackUsageCounter
 }
 
+export interface SpecUtilsAdditionalProperty<TKey = unknown, TValue = unknown> {
+  [key: string]: never
+}
+
 export interface SpecUtilsAdditionalProperties<TKey = unknown, TValue = unknown> {
   [key: string]: never
 }
@@ -15749,10 +15748,6 @@ export interface SpecUtilsCommonQueryParameters {
   human?: boolean
   pretty?: boolean
   source_query_string?: string
-}
-
-export interface SpecUtilsAdditionalProperty<TKey = unknown, TValue = unknown> {
-  [key: string]: never
 }
 
 export interface SpecUtilsCommonCatQueryParameters {

--- a/specification/_global/search/_types/sort.ts
+++ b/specification/_global/search/_types/sort.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { AdditionalProperties } from '@spec_utils/behaviors'
+import { AdditionalProperties, AdditionalProperty } from '@spec_utils/behaviors'
 import { Missing } from '@_types/aggregations/AggregationContainer'
 import { Field } from '@_types/common'
 import { DistanceUnit, GeoDistanceType } from '@_types/Geo'
@@ -56,7 +56,7 @@ export class ScoreSort {
   order?: SortOrder
 }
 export class GeoDistanceSort
-  implements AdditionalProperties<Field, GeoLocation | GeoLocation[]> {
+  implements AdditionalProperty<Field, GeoLocation | GeoLocation[]> {
   mode?: SortMode
   distance_type?: GeoDistanceType
   order?: SortOrder

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -128,11 +128,7 @@ export class TermsLookup {
   routing?: Routing
 }
 
-export class TermsSetQuery
-  extends QueryBase
-  implements AdditionalProperty<Field, TermsSetFieldQuery> {}
-
-export class TermsSetFieldQuery {
+export class TermsSetQuery extends QueryBase {
   minimum_should_match_field?: Field
   minimum_should_match_script?: Script
   terms: string[]


### PR DESCRIPTION
Fixes two issues:
* `TermSetQuery` is defined as a `terms_set?: SingleKeyDictionary<Field, TermsSetQuery>` and doesn't have an additional nesting level
* `GeoDistanceSort` only accepts a single field's location

These issues were not caught by the flight recorder because the definitions were too lazy.