### PR TITLE
Fix SingleKeyDictionary TypeScript generation

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -62,7 +62,7 @@ export interface BulkRequest<TSource = unknown> extends RequestBase {
 
 export interface BulkResponse {
   errors: boolean
-  items: Record<BulkOperationType, BulkResponseItem>[]
+  items: Partial<Record<BulkOperationType, BulkResponseItem>>[]
   took: long
   ingest_took?: long
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3967,7 +3967,7 @@ export interface MappingFieldAliasProperty extends MappingPropertyBase {
 
 export interface MappingFieldMapping {
   full_name: string
-  mapping: Record<string, MappingProperty>
+  mapping: Partial<Record<string, MappingProperty>>
 }
 
 export interface MappingFieldNamesField {
@@ -4738,14 +4738,14 @@ export interface QueryDslQueryBase {
 export interface QueryDslQueryContainer {
   bool?: QueryDslBoolQuery
   boosting?: QueryDslBoostingQuery
-  common?: Record<Field, QueryDslCommonTermsQuery | string>
+  common?: Partial<Record<Field, QueryDslCommonTermsQuery | string>>
   combined_fields?: QueryDslCombinedFieldsQuery
   constant_score?: QueryDslConstantScoreQuery
   dis_max?: QueryDslDisMaxQuery
   distance_feature?: QueryDslDistanceFeatureQuery
   exists?: QueryDslExistsQuery
   function_score?: QueryDslFunctionScoreQuery
-  fuzzy?: Record<Field, QueryDslFuzzyQuery | string | double | boolean>
+  fuzzy?: Partial<Record<Field, QueryDslFuzzyQuery | string | double | boolean>>
   geo_bounding_box?: QueryDslGeoBoundingBoxQuery
   geo_distance?: QueryDslGeoDistanceQuery
   geo_polygon?: QueryDslGeoPolygonQuery
@@ -4753,24 +4753,24 @@ export interface QueryDslQueryContainer {
   has_child?: QueryDslHasChildQuery
   has_parent?: QueryDslHasParentQuery
   ids?: QueryDslIdsQuery
-  intervals?: Record<Field, QueryDslIntervalsQuery>
-  match?: Record<Field, QueryDslMatchQuery | string | float | boolean>
+  intervals?: Partial<Record<Field, QueryDslIntervalsQuery>>
+  match?: Partial<Record<Field, QueryDslMatchQuery | string | float | boolean>>
   match_all?: QueryDslMatchAllQuery
-  match_bool_prefix?: Record<Field, QueryDslMatchBoolPrefixQuery | string>
+  match_bool_prefix?: Partial<Record<Field, QueryDslMatchBoolPrefixQuery | string>>
   match_none?: QueryDslMatchNoneQuery
-  match_phrase?: Record<Field, QueryDslMatchPhraseQuery | string>
-  match_phrase_prefix?: Record<Field, QueryDslMatchPhrasePrefixQuery | string>
+  match_phrase?: Partial<Record<Field, QueryDslMatchPhraseQuery | string>>
+  match_phrase_prefix?: Partial<Record<Field, QueryDslMatchPhrasePrefixQuery | string>>
   more_like_this?: QueryDslMoreLikeThisQuery
   multi_match?: QueryDslMultiMatchQuery
   nested?: QueryDslNestedQuery
   parent_id?: QueryDslParentIdQuery
   percolate?: QueryDslPercolateQuery
   pinned?: QueryDslPinnedQuery
-  prefix?: Record<Field, QueryDslPrefixQuery | string>
+  prefix?: Partial<Record<Field, QueryDslPrefixQuery | string>>
   query_string?: QueryDslQueryStringQuery
-  range?: Record<Field, QueryDslRangeQuery>
+  range?: Partial<Record<Field, QueryDslRangeQuery>>
   rank_feature?: QueryDslRankFeatureQuery
-  regexp?: Record<Field, QueryDslRegexpQuery | string>
+  regexp?: Partial<Record<Field, QueryDslRegexpQuery | string>>
   script?: QueryDslScriptQuery
   script_score?: QueryDslScriptScoreQuery
   shape?: QueryDslShapeQuery
@@ -4782,12 +4782,12 @@ export interface QueryDslQueryContainer {
   span_near?: QueryDslSpanNearQuery
   span_not?: QueryDslSpanNotQuery
   span_or?: QueryDslSpanOrQuery
-  span_term?: Record<Field, QueryDslSpanTermQuery | string>
+  span_term?: Partial<Record<Field, QueryDslSpanTermQuery | string>>
   span_within?: QueryDslSpanWithinQuery
-  term?: Record<Field, QueryDslTermQuery | string | float | boolean>
+  term?: Partial<Record<Field, QueryDslTermQuery | string | float | boolean>>
   terms?: QueryDslTermsQuery
-  terms_set?: Record<Field, QueryDslTermsSetQuery>
-  wildcard?: Record<Field, QueryDslWildcardQuery | string>
+  terms_set?: Partial<Record<Field, QueryDslTermsSetQuery>>
+  wildcard?: Partial<Record<Field, QueryDslWildcardQuery | string>>
   type?: QueryDslTypeQuery
 }
 
@@ -4933,7 +4933,7 @@ export interface QueryDslSpanFirstQuery extends QueryDslQueryBase {
   match: QueryDslSpanQuery
 }
 
-export type QueryDslSpanGapQuery = Record<Field, integer>
+export type QueryDslSpanGapQuery = Partial<Record<Field, integer>>
 
 export interface QueryDslSpanMultiTermQuery extends QueryDslQueryBase {
   match: QueryDslQueryContainer
@@ -4966,7 +4966,7 @@ export interface QueryDslSpanQuery {
   span_near?: QueryDslSpanNearQuery
   span_not?: QueryDslSpanNotQuery
   span_or?: QueryDslSpanOrQuery
-  span_term?: Record<Field, QueryDslSpanTermQuery | string>
+  span_term?: Partial<Record<Field, QueryDslSpanTermQuery | string>>
   span_within?: QueryDslSpanWithinQuery
 }
 
@@ -8941,7 +8941,7 @@ export interface IndicesGetFieldMappingResponse extends DictionaryResponseBase<I
 }
 
 export interface IndicesGetFieldMappingTypeFieldMappings {
-  mappings: Record<Field, MappingFieldMapping>
+  mappings: Partial<Record<Field, MappingFieldMapping>>
 }
 
 export interface IndicesGetIndexTemplateIndexTemplate {
@@ -15539,7 +15539,7 @@ export interface XpackUsageKibanaUrlConfig extends XpackUsageBaseUrlConfig {
 
 export interface XpackUsageMachineLearning extends XpackUsageBase {
   datafeeds: Record<string, XpackUsageDatafeed>
-  jobs: Record<string, MlJob> | Record<string, XpackUsageAllJobs>
+  jobs: Record<string, MlJob> | Partial<Record<string, XpackUsageAllJobs>>
   node_count: integer
   data_frame_analytics_jobs: XpackUsageMlDataFrameAnalyticsJobs
   inference: XpackUsageMlInference

--- a/typescript-generator/index.ts
+++ b/typescript-generator/index.ts
@@ -127,7 +127,7 @@ function buildValue (type: M.ValueOf, openGenerics?: string[], origin?: M.TypeNa
     case 'union_of':
       return type.items.map(t => buildValue(t, openGenerics, origin)).join(' | ')
     case 'dictionary_of':
-      let result = `Record<${buildValue(type.key, openGenerics)}, ${buildValue(type.value, openGenerics)}>`
+      const result = `Record<${buildValue(type.key, openGenerics)}, ${buildValue(type.value, openGenerics)}>`
       return type.singleKey ? `Partial<${result}>` : result
     case 'user_defined_value':
       return 'any'

--- a/typescript-generator/index.ts
+++ b/typescript-generator/index.ts
@@ -126,9 +126,10 @@ function buildValue (type: M.ValueOf, openGenerics?: string[], origin?: M.TypeNa
         : `${buildValue(type.value, openGenerics)}[]`
     case 'union_of':
       return type.items.map(t => buildValue(t, openGenerics, origin)).join(' | ')
-    case 'dictionary_of':
+    case 'dictionary_of': {
       const result = `Record<${buildValue(type.key, openGenerics)}, ${buildValue(type.value, openGenerics)}>`
       return type.singleKey ? `Partial<${result}>` : result
+    }
     case 'user_defined_value':
       return 'any'
     case 'literal_value':

--- a/typescript-generator/index.ts
+++ b/typescript-generator/index.ts
@@ -127,7 +127,8 @@ function buildValue (type: M.ValueOf, openGenerics?: string[], origin?: M.TypeNa
     case 'union_of':
       return type.items.map(t => buildValue(t, openGenerics, origin)).join(' | ')
     case 'dictionary_of':
-      return `Record<${buildValue(type.key, openGenerics)}, ${buildValue(type.value, openGenerics)}>`
+      let result = `Record<${buildValue(type.key, openGenerics)}, ${buildValue(type.value, openGenerics)}>`
+      return type.singleKey ? `Partial<${result}>` : result
     case 'user_defined_value':
       return 'any'
     case 'literal_value':


### PR DESCRIPTION
Generates `Partial<Record<TKey, TValue>>` for single key dictionaries (needed for #890).

Although `Record<TKey, TValue>` works fine for string keys as this is an open-ended type, using an enum causes errors as `Record` expects *all* enum values to exist as properties, and not only one. Using `Partial` makes all keys optional, which allow just one to exist.

Capturing in the type that exactly one of the enum members must exist as a property can probably be achieved by expanding a union with all enum members, but that would substantially complexify the code generator and its output.
