### PR TITLE
Fix bulk request & response

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -12657,7 +12657,7 @@
     {
       "inherits": {
         "type": {
-          "name": "Operation",
+          "name": "WriteOperation",
           "namespace": "_global.bulk"
         }
       },
@@ -12671,21 +12671,7 @@
     {
       "inherits": {
         "type": {
-          "name": "ResponseItemBase",
-          "namespace": "_global.bulk"
-        }
-      },
-      "kind": "interface",
-      "name": {
-        "name": "CreateResponseItem",
-        "namespace": "_global.bulk"
-      },
-      "properties": []
-    },
-    {
-      "inherits": {
-        "type": {
-          "name": "Operation",
+          "name": "OperationBase",
           "namespace": "_global.bulk"
         }
       },
@@ -12699,21 +12685,7 @@
     {
       "inherits": {
         "type": {
-          "name": "ResponseItemBase",
-          "namespace": "_global.bulk"
-        }
-      },
-      "kind": "interface",
-      "name": {
-        "name": "DeleteResponseItem",
-        "namespace": "_global.bulk"
-      },
-      "properties": []
-    },
-    {
-      "inherits": {
-        "type": {
-          "name": "Operation",
+          "name": "WriteOperation",
           "namespace": "_global.bulk"
         }
       },
@@ -12725,23 +12697,9 @@
       "properties": []
     },
     {
-      "inherits": {
-        "type": {
-          "name": "ResponseItemBase",
-          "namespace": "_global.bulk"
-        }
-      },
       "kind": "interface",
       "name": {
-        "name": "IndexResponseItem",
-        "namespace": "_global.bulk"
-      },
-      "properties": []
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "Operation",
+        "name": "OperationBase",
         "namespace": "_global.bulk"
       },
       "properties": [
@@ -12768,23 +12726,34 @@
           }
         },
         {
-          "name": "retry_on_conflict",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
           "name": "routing",
           "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "Routing",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "if_primary_term",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "if_seq_no",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "SequenceNumber",
               "namespace": "_types"
             }
           }
@@ -12867,6 +12836,27 @@
       ],
       "variants": {
         "kind": "container"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "index"
+        },
+        {
+          "name": "create"
+        },
+        {
+          "name": "update"
+        },
+        {
+          "name": "delete"
+        }
+      ],
+      "name": {
+        "name": "OperationType",
+        "namespace": "_global.bulk"
       }
     },
     {
@@ -13099,10 +13089,21 @@
             "type": {
               "kind": "array_of",
               "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "ResponseItemContainer",
-                  "namespace": "_global.bulk"
+                "key": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "OperationType",
+                    "namespace": "_global.bulk"
+                  }
+                },
+                "kind": "dictionary_of",
+                "singleKey": true,
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "ResponseItem",
+                    "namespace": "_global.bulk"
+                  }
                 }
               }
             }
@@ -13140,7 +13141,7 @@
     {
       "kind": "interface",
       "name": {
-        "name": "ResponseItemBase",
+        "name": "ResponseItem",
         "namespace": "_global.bulk"
       },
       "properties": [
@@ -13307,65 +13308,9 @@
       ]
     },
     {
-      "kind": "interface",
-      "name": {
-        "name": "ResponseItemContainer",
-        "namespace": "_global.bulk"
-      },
-      "properties": [
-        {
-          "name": "index",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "IndexResponseItem",
-              "namespace": "_global.bulk"
-            }
-          }
-        },
-        {
-          "name": "create",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "CreateResponseItem",
-              "namespace": "_global.bulk"
-            }
-          }
-        },
-        {
-          "name": "update",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "UpdateResponseItem",
-              "namespace": "_global.bulk"
-            }
-          }
-        },
-        {
-          "name": "delete",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "DeleteResponseItem",
-              "namespace": "_global.bulk"
-            }
-          }
-        }
-      ],
-      "variants": {
-        "kind": "container"
-      }
-    },
-    {
       "inherits": {
         "type": {
-          "name": "Operation",
+          "name": "OperationBase",
           "namespace": "_global.bulk"
         }
       },
@@ -13374,21 +13319,89 @@
         "name": "UpdateOperation",
         "namespace": "_global.bulk"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "require_alias",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "retry_on_conflict",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
     },
     {
       "inherits": {
         "type": {
-          "name": "ResponseItemBase",
+          "name": "OperationBase",
           "namespace": "_global.bulk"
         }
       },
       "kind": "interface",
       "name": {
-        "name": "UpdateResponseItem",
+        "name": "WriteOperation",
         "namespace": "_global.bulk"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "dynamic_templates",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
+          "name": "pipeline",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "require_alias",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "attachedBehaviors": [
@@ -29281,7 +29294,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "integer",
               "namespace": "_types"
             }
           }
@@ -32224,6 +32237,29 @@
       ]
     },
     {
+      "attachedBehaviors": [
+        "AdditionalProperties"
+      ],
+      "behaviors": [
+        {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            {
+              "kind": "user_defined_value"
+            }
+          ],
+          "type": {
+            "name": "AdditionalProperties",
+            "namespace": "_spec_utils"
+          }
+        }
+      ],
       "generics": [
         {
           "name": "TDocument",
@@ -32267,7 +32303,7 @@
         },
         {
           "name": "_seq_no",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -32278,7 +32314,7 @@
         },
         {
           "name": "_primary_term",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -34503,7 +34539,7 @@
       "type": {
         "kind": "instance_of",
         "type": {
-          "name": "integer",
+          "name": "long",
           "namespace": "_types"
         }
       }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17,29 +17,21 @@
  * under the License.
  */
 
-export interface BulkCreateOperation extends BulkOperation {
+export interface BulkCreateOperation extends BulkWriteOperation {
 }
 
-export interface BulkCreateResponseItem extends BulkResponseItemBase {
+export interface BulkDeleteOperation extends BulkOperationBase {
 }
 
-export interface BulkDeleteOperation extends BulkOperation {
+export interface BulkIndexOperation extends BulkWriteOperation {
 }
 
-export interface BulkDeleteResponseItem extends BulkResponseItemBase {
-}
-
-export interface BulkIndexOperation extends BulkOperation {
-}
-
-export interface BulkIndexResponseItem extends BulkResponseItemBase {
-}
-
-export interface BulkOperation {
+export interface BulkOperationBase {
   _id?: Id
   _index?: IndexName
-  retry_on_conflict?: integer
   routing?: Routing
+  if_primary_term?: long
+  if_seq_no?: SequenceNumber
   version?: VersionNumber
   version_type?: VersionType
 }
@@ -50,6 +42,8 @@ export interface BulkOperationContainer {
   update?: BulkUpdateOperation
   delete?: BulkDeleteOperation
 }
+
+export type BulkOperationType = 'index' | 'create' | 'update' | 'delete'
 
 export interface BulkRequest<TSource = unknown> extends RequestBase {
   index?: IndexName
@@ -68,12 +62,12 @@ export interface BulkRequest<TSource = unknown> extends RequestBase {
 
 export interface BulkResponse {
   errors: boolean
-  items: BulkResponseItemContainer[]
+  items: Record<BulkOperationType, BulkResponseItem>[]
   took: long
   ingest_took?: long
 }
 
-export interface BulkResponseItemBase {
+export interface BulkResponseItem {
   _id?: string | null
   _index: string
   status: integer
@@ -88,17 +82,15 @@ export interface BulkResponseItemBase {
   get?: InlineGet<Record<string, any>>
 }
 
-export interface BulkResponseItemContainer {
-  index?: BulkIndexResponseItem
-  create?: BulkCreateResponseItem
-  update?: BulkUpdateResponseItem
-  delete?: BulkDeleteResponseItem
+export interface BulkUpdateOperation extends BulkOperationBase {
+  require_alias?: boolean
+  retry_on_conflict?: integer
 }
 
-export interface BulkUpdateOperation extends BulkOperation {
-}
-
-export interface BulkUpdateResponseItem extends BulkResponseItemBase {
+export interface BulkWriteOperation extends BulkOperationBase {
+  dynamic_templates?: Record<string, string>
+  pipeline?: string
+  require_alias?: boolean
 }
 
 export interface ClearScrollRequest extends RequestBase {
@@ -1713,7 +1705,7 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
   lang?: string
   refresh?: Refresh
   require_alias?: boolean
-  retry_on_conflict?: long
+  retry_on_conflict?: integer
   routing?: Routing
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
@@ -2039,14 +2031,16 @@ export interface IndicesResponseBase extends AcknowledgedResponseBase {
   _shards?: ShardStatistics
 }
 
-export interface InlineGet<TDocument = unknown> {
+export interface InlineGetKeys<TDocument = unknown> {
   fields?: Record<string, any>
   found: boolean
-  _seq_no: SequenceNumber
-  _primary_term: long
+  _seq_no?: SequenceNumber
+  _primary_term?: long
   _routing?: Routing
   _source: TDocument
 }
+export type InlineGet<TDocument = unknown> = InlineGetKeys<TDocument> |
+    { [property: string]: any }
 
 export interface InlineScript extends ScriptBase {
   source: string
@@ -2283,7 +2277,7 @@ export interface SegmentsStats {
   version_map_memory_in_bytes: integer
 }
 
-export type SequenceNumber = integer
+export type SequenceNumber = long
 
 export type Service = string
 

--- a/specification/_global/bulk/BulkResponse.ts
+++ b/specification/_global/bulk/BulkResponse.ts
@@ -18,12 +18,13 @@
  */
 
 import { long } from '@_types/Numeric'
-import { ResponseItemContainer } from './types'
+import { OperationType, ResponseItem } from './types'
+import { SingleKeyDictionary } from '@spec_utils/Dictionary'
 
 export class Response {
   body: {
     errors: boolean
-    items: ResponseItemContainer[]
+    items: SingleKeyDictionary<OperationType, ResponseItem>[]
     took: long
     ingest_took?: long
   }

--- a/specification/_global/bulk/types.ts
+++ b/specification/_global/bulk/types.ts
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-// TODO remap this as a good bulk response item and an error response item
 
 import { InlineGet } from '@_types/common'
 import { Dictionary } from '@spec_utils/Dictionary'
@@ -33,7 +32,7 @@ import { ErrorCause } from '@_types/Errors'
 import { integer, long } from '@_types/Numeric'
 import { ShardStatistics } from '@_types/Stats'
 
-export class ResponseItemBase {
+export class ResponseItem {
   _id?: string | null
   _index: string
   status: integer
@@ -49,29 +48,38 @@ export class ResponseItemBase {
   get?: InlineGet<Dictionary<string, UserDefinedValue>>
 }
 
-/** @variants container */
-export class ResponseItemContainer {
-  index?: IndexResponseItem
-  create?: CreateResponseItem
-  update?: UpdateResponseItem
-  delete?: DeleteResponseItem
+export enum OperationType {
+  index,
+  create,
+  update,
+  delete
 }
 
-export class IndexResponseItem extends ResponseItemBase {}
-
-export class CreateResponseItem extends ResponseItemBase {}
-
-export class UpdateResponseItem extends ResponseItemBase {}
-
-export class DeleteResponseItem extends ResponseItemBase {}
-
-export class Operation {
+export class OperationBase {
   _id?: Id
   _index?: IndexName
-  retry_on_conflict?: integer
   routing?: Routing
+  if_primary_term?: long
+  if_seq_no?: SequenceNumber
   version?: VersionNumber
   version_type?: VersionType
+}
+
+export class WriteOperation extends OperationBase {
+  dynamic_templates?: Dictionary<string, string>
+  pipeline?: string
+  require_alias?: boolean
+}
+
+export class CreateOperation extends WriteOperation {}
+
+export class IndexOperation extends WriteOperation {}
+
+export class DeleteOperation extends OperationBase {}
+
+export class UpdateOperation extends OperationBase {
+  require_alias?: boolean
+  retry_on_conflict?: integer
 }
 
 /** @variants container */
@@ -81,11 +89,3 @@ export class OperationContainer {
   update?: UpdateOperation
   delete?: DeleteOperation
 }
-
-export class IndexOperation extends Operation {}
-
-export class CreateOperation extends Operation {}
-
-export class UpdateOperation extends Operation {}
-
-export class DeleteOperation extends Operation {}

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -29,7 +29,7 @@ import {
   Type,
   WaitForActiveShards
 } from '@_types/common'
-import { long } from '@_types/Numeric'
+import { integer, long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 import { Time } from '@_types/Time'
 
@@ -74,7 +74,7 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
      * Specify how many times should the operation be retried when a conflict occurs.
      * @server_default 0
      */
-    retry_on_conflict?: long
+    retry_on_conflict?: integer
     /**
      * Custom value used to route operations to a specific shard.
      */

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -20,6 +20,7 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { integer, long } from './Numeric'
+import { AdditionalProperties } from '@spec_utils/behaviors'
 
 export class UrlParameter {}
 
@@ -94,7 +95,7 @@ export enum VersionType {
 export type Uuid = string
 
 // _seq_no
-export type SequenceNumber = integer
+export type SequenceNumber = long
 
 export type PropertyName = string
 export type RelationName = string
@@ -287,11 +288,13 @@ export enum WaitForStatus {
   red = 2
 }
 
-export class InlineGet<TDocument> {
+// Additional properties are the meta fields
+export class InlineGet<TDocument>
+  implements AdditionalProperties<string, UserDefinedValue> {
   fields?: Dictionary<string, UserDefinedValue>
   found: boolean
-  _seq_no: SequenceNumber
-  _primary_term: long
+  _seq_no?: SequenceNumber
+  _primary_term?: long
   _routing?: Routing
   _source: TDocument
 }


### PR DESCRIPTION
Depends on https://github.com/elastic/elasticsearch-specification/pull/889 for successful validation. Once it's merged this PR will be rebased but review can happen immediately.

Fixes bulk operation requests: adds missing properties and refines the list of properties that actually exist for each operation type.

Fixes bulk operation responses: uses a single type as all operations have the same result properties, except `update` that also has an optional `get`. Using a single type instead of a container makes iterating through all results much easier.

Also fixes `retry_on_conflict` which is an integer and `SequenceNumer` which is a long.