### PR TITLE
Fix number properties definition

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -35618,6 +35618,20 @@
     {
       "kind": "type_alias",
       "name": {
+        "name": "byte",
+        "namespace": "_types"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "number",
+          "namespace": "internal"
+        }
+      }
+    },
+    {
+      "kind": "type_alias",
+      "name": {
         "name": "double",
         "namespace": "_types"
       },
@@ -35661,6 +35675,20 @@
       "kind": "type_alias",
       "name": {
         "name": "long",
+        "namespace": "_types"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "number",
+          "namespace": "internal"
+        }
+      }
+    },
+    {
+      "kind": "type_alias",
+      "name": {
+        "name": "short",
         "namespace": "_types"
       },
       "type": {
@@ -49099,6 +49127,40 @@
     {
       "inherits": {
         "type": {
+          "name": "StandardNumberProperty",
+          "namespace": "_types.mapping"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "ByteNumberProperty",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "byte"
+          }
+        },
+        {
+          "name": "null_value",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "byte",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
           "name": "DocValuesPropertyBase",
           "namespace": "_types.mapping"
         }
@@ -49737,6 +49799,40 @@
     {
       "inherits": {
         "type": {
+          "name": "StandardNumberProperty",
+          "namespace": "_types.mapping"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "DoubleNumberProperty",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "double"
+          }
+        },
+        {
+          "name": "null_value",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
           "name": "RangePropertyBase",
           "namespace": "_types.mapping"
         }
@@ -50217,6 +50313,40 @@
     {
       "inherits": {
         "type": {
+          "name": "StandardNumberProperty",
+          "namespace": "_types.mapping"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "FloatNumberProperty",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "float"
+          }
+        },
+        {
+          "name": "null_value",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "float",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
           "name": "RangePropertyBase",
           "namespace": "_types.mapping"
         }
@@ -50563,6 +50693,40 @@
     {
       "inherits": {
         "type": {
+          "name": "StandardNumberProperty",
+          "namespace": "_types.mapping"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "HalfFloatNumberProperty",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "half_float"
+          }
+        },
+        {
+          "name": "null_value",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "float",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
           "name": "PropertyBase",
           "namespace": "_types.mapping"
         }
@@ -50634,6 +50798,40 @@
         "name": "IndexOptions",
         "namespace": "_types.mapping"
       }
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "StandardNumberProperty",
+          "namespace": "_types.mapping"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "IntegerNumberProperty",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "integer"
+          }
+        },
+        {
+          "name": "null_value",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
     },
     {
       "inherits": {
@@ -50922,6 +51120,40 @@
     {
       "inherits": {
         "type": {
+          "name": "StandardNumberProperty",
+          "namespace": "_types.mapping"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "LongNumberProperty",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "long"
+          }
+        },
+        {
+          "name": "null_value",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
           "name": "RangePropertyBase",
           "namespace": "_types.mapping"
         }
@@ -51037,6 +51269,81 @@
       ]
     },
     {
+      "kind": "type_alias",
+      "name": {
+        "name": "NumberProperty",
+        "namespace": "_types.mapping"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "FloatNumberProperty",
+              "namespace": "_types.mapping"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "HalfFloatNumberProperty",
+              "namespace": "_types.mapping"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "DoubleNumberProperty",
+              "namespace": "_types.mapping"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IntegerNumberProperty",
+              "namespace": "_types.mapping"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "LongNumberProperty",
+              "namespace": "_types.mapping"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "ShortNumberProperty",
+              "namespace": "_types.mapping"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "ByteNumberProperty",
+              "namespace": "_types.mapping"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "UnsignedLongNumberProperty",
+              "namespace": "_types.mapping"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "ScaledFloatNumberProperty",
+              "namespace": "_types.mapping"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
       "inherits": {
         "type": {
           "name": "DocValuesPropertyBase",
@@ -51045,40 +51352,18 @@
       },
       "kind": "interface",
       "name": {
-        "name": "NumberProperty",
+        "name": "NumberPropertyBase",
         "namespace": "_types.mapping"
       },
       "properties": [
         {
-          "name": "boost",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "coerce",
+          "name": "index",
           "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "boolean",
               "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "fielddata",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "NumericFielddata",
-              "namespace": "indices._types"
             }
           }
         },
@@ -51092,88 +51377,8 @@
               "namespace": "internal"
             }
           }
-        },
-        {
-          "name": "index",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "null_value",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "scaling_factor",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "type",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "NumberType",
-              "namespace": "_types.mapping"
-            }
-          }
         }
       ]
-    },
-    {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "float"
-        },
-        {
-          "name": "half_float"
-        },
-        {
-          "name": "scaled_float"
-        },
-        {
-          "name": "double"
-        },
-        {
-          "name": "integer"
-        },
-        {
-          "name": "long"
-        },
-        {
-          "name": "short"
-        },
-        {
-          "name": "byte"
-        },
-        {
-          "name": "unsigned_long"
-        }
-      ],
-      "name": {
-        "name": "NumberType",
-        "namespace": "_types.mapping"
-      }
     },
     {
       "inherits": {
@@ -51208,6 +51413,21 @@
           }
         }
       ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "fail"
+        },
+        {
+          "name": "continue"
+        }
+      ],
+      "name": {
+        "name": "OnScriptError",
+        "namespace": "_types.mapping"
+      }
     },
     {
       "inherits": {
@@ -51791,6 +52011,62 @@
     {
       "inherits": {
         "type": {
+          "name": "NumberPropertyBase",
+          "namespace": "_types.mapping"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "ScaledFloatNumberProperty",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "scaled_float"
+          }
+        },
+        {
+          "name": "coerce",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "null_value",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "scaling_factor",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
           "name": "CorePropertyBase",
           "namespace": "_types.mapping"
         }
@@ -51969,6 +52245,40 @@
       ]
     },
     {
+      "inherits": {
+        "type": {
+          "name": "StandardNumberProperty",
+          "namespace": "_types.mapping"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "ShortNumberProperty",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "short"
+          }
+        },
+        {
+          "name": "null_value",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "short",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
       "kind": "interface",
       "name": {
         "name": "SizeField",
@@ -52053,6 +52363,54 @@
                 "name": "string",
                 "namespace": "internal"
               }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "NumberPropertyBase",
+          "namespace": "_types.mapping"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "StandardNumberProperty",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "coerce",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "script",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Script",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "on_script_error",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "OnScriptError",
+              "namespace": "_types.mapping"
             }
           }
         }
@@ -52680,6 +53038,40 @@
             "type": {
               "name": "boolean",
               "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "NumberPropertyBase",
+          "namespace": "_types.mapping"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "UnsignedLongNumberProperty",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "unsigned_long"
+          }
+        },
+        {
+          "name": "null_value",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ulong",
+              "namespace": "_types"
             }
           }
         }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2406,6 +2406,8 @@ export interface WriteResponseBase {
   forced_refresh?: boolean
 }
 
+export type byte = number
+
 export type double = number
 
 export type float = number
@@ -2413,6 +2415,8 @@ export type float = number
 export type integer = number
 
 export type long = number
+
+export type short = number
 
 export type uint = number
 
@@ -3884,6 +3888,11 @@ export interface MappingBooleanProperty extends MappingDocValuesPropertyBase {
   type: 'boolean'
 }
 
+export interface MappingByteNumberProperty extends MappingStandardNumberProperty {
+  type: 'byte'
+  null_value?: byte
+}
+
 export interface MappingCompletionProperty extends MappingDocValuesPropertyBase {
   analyzer?: string
   contexts?: MappingSuggestContext[]
@@ -3944,6 +3953,11 @@ export interface MappingDocValuesPropertyBase extends MappingCorePropertyBase {
   doc_values?: boolean
 }
 
+export interface MappingDoubleNumberProperty extends MappingStandardNumberProperty {
+  type: 'double'
+  null_value?: double
+}
+
 export interface MappingDoubleRangeProperty extends MappingRangePropertyBase {
   type: 'double_range'
 }
@@ -3989,6 +4003,11 @@ export interface MappingFlattenedProperty extends MappingPropertyBase {
   type: 'flattened'
 }
 
+export interface MappingFloatNumberProperty extends MappingStandardNumberProperty {
+  type: 'float'
+  null_value?: float
+}
+
 export interface MappingFloatRangeProperty extends MappingRangePropertyBase {
   type: 'float_range'
 }
@@ -4028,6 +4047,11 @@ export interface MappingGeoShapeProperty extends MappingDocValuesPropertyBase {
 
 export type MappingGeoStrategy = 'recursive' | 'term'
 
+export interface MappingHalfFloatNumberProperty extends MappingStandardNumberProperty {
+  type: 'half_float'
+  null_value?: float
+}
+
 export interface MappingHistogramProperty extends MappingPropertyBase {
   ignore_malformed?: boolean
   type: 'histogram'
@@ -4038,6 +4062,11 @@ export interface MappingIndexField {
 }
 
 export type MappingIndexOptions = 'docs' | 'freqs' | 'positions' | 'offsets'
+
+export interface MappingIntegerNumberProperty extends MappingStandardNumberProperty {
+  type: 'integer'
+  null_value?: integer
+}
 
 export interface MappingIntegerRangeProperty extends MappingRangePropertyBase {
   type: 'integer_range'
@@ -4072,6 +4101,11 @@ export interface MappingKeywordProperty extends MappingDocValuesPropertyBase {
   type: 'keyword'
 }
 
+export interface MappingLongNumberProperty extends MappingStandardNumberProperty {
+  type: 'long'
+  null_value?: long
+}
+
 export interface MappingLongRangeProperty extends MappingRangePropertyBase {
   type: 'long_range'
 }
@@ -4089,23 +4123,19 @@ export interface MappingNestedProperty extends MappingCorePropertyBase {
   type: 'nested'
 }
 
-export interface MappingNumberProperty extends MappingDocValuesPropertyBase {
-  boost?: double
-  coerce?: boolean
-  fielddata?: IndicesNumericFielddata
-  ignore_malformed?: boolean
-  index?: boolean
-  null_value?: double
-  scaling_factor?: double
-  type: MappingNumberType
-}
+export type MappingNumberProperty = MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingDoubleNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingShortNumberProperty | MappingByteNumberProperty | MappingUnsignedLongNumberProperty | MappingScaledFloatNumberProperty
 
-export type MappingNumberType = 'float' | 'half_float' | 'scaled_float' | 'double' | 'integer' | 'long' | 'short' | 'byte' | 'unsigned_long'
+export interface MappingNumberPropertyBase extends MappingDocValuesPropertyBase {
+  index?: boolean
+  ignore_malformed?: boolean
+}
 
 export interface MappingObjectProperty extends MappingCorePropertyBase {
   enabled?: boolean
   type?: 'object'
 }
+
+export type MappingOnScriptError = 'fail' | 'continue'
 
 export interface MappingPercolatorProperty extends MappingPropertyBase {
   type: 'percolator'
@@ -4161,6 +4191,13 @@ export type MappingRuntimeFieldType = 'boolean' | 'date' | 'double' | 'geo_point
 
 export type MappingRuntimeFields = Record<Field, MappingRuntimeField>
 
+export interface MappingScaledFloatNumberProperty extends MappingNumberPropertyBase {
+  type: 'scaled_float'
+  coerce?: boolean
+  null_value?: double
+  scaling_factor?: double
+}
+
 export interface MappingSearchAsYouTypeProperty extends MappingCorePropertyBase {
   analyzer?: string
   index?: boolean
@@ -4181,6 +4218,11 @@ export interface MappingShapeProperty extends MappingDocValuesPropertyBase {
   type: 'shape'
 }
 
+export interface MappingShortNumberProperty extends MappingStandardNumberProperty {
+  type: 'short'
+  null_value?: short
+}
+
 export interface MappingSizeField {
   enabled: boolean
 }
@@ -4191,6 +4233,12 @@ export interface MappingSourceField {
   enabled?: boolean
   excludes?: string[]
   includes?: string[]
+}
+
+export interface MappingStandardNumberProperty extends MappingNumberPropertyBase {
+  coerce?: boolean
+  script?: Script
+  on_script_error?: MappingOnScriptError
 }
 
 export interface MappingSuggestContext {
@@ -4250,6 +4298,11 @@ export interface MappingTypeMapping {
   _source?: MappingSourceField
   runtime?: Record<string, MappingRuntimeField>
   enabled?: boolean
+}
+
+export interface MappingUnsignedLongNumberProperty extends MappingNumberPropertyBase {
+  type: 'unsigned_long'
+  null_value?: ulong
 }
 
 export interface MappingVersionProperty extends MappingDocValuesPropertyBase {

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -21,7 +21,15 @@ import { FielddataFrequencyFilter } from '@indices/_types/FielddataFrequencyFilt
 import { NumericFielddata } from '@indices/_types/NumericFielddata'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { Fields, RelationName } from '@_types/common'
-import { double, integer } from '@_types/Numeric'
+import {
+  byte,
+  double,
+  float,
+  integer,
+  long,
+  short,
+  ulong
+} from '@_types/Numeric'
 import { DateString } from '@_types/Time'
 import { NestedProperty, ObjectProperty } from './complex'
 import {
@@ -40,6 +48,7 @@ import {
   TokenCountProperty
 } from './specialized'
 import { TermVectorOption } from './TermVectorOption'
+import { Script } from '@_types/Scripting'
 
 export class CorePropertyBase extends PropertyBase {
   copy_to?: Fields
@@ -128,28 +137,79 @@ export class KeywordProperty extends DocValuesPropertyBase {
   type: 'keyword'
 }
 
-export class NumberProperty extends DocValuesPropertyBase {
-  boost?: double
-  coerce?: boolean
-  fielddata?: NumericFielddata
-  ignore_malformed?: boolean
+export class NumberPropertyBase extends DocValuesPropertyBase {
   index?: boolean
-  null_value?: double
-  scaling_factor?: double
-  type: NumberType
+  ignore_malformed?: boolean
 }
 
-export enum NumberType {
-  float = 0,
-  half_float = 1,
-  scaled_float = 2,
-  double = 3,
-  integer = 4,
-  long = 5,
-  short = 6,
-  byte = 7,
-  unsigned_long = 8
+export enum OnScriptError {
+  fail,
+  continue
 }
+
+export class StandardNumberProperty extends NumberPropertyBase {
+  coerce?: boolean
+  script?: Script
+  on_script_error?: OnScriptError
+}
+
+export class FloatNumberProperty extends StandardNumberProperty {
+  type: 'float'
+  null_value?: float
+}
+
+export class HalfFloatNumberProperty extends StandardNumberProperty {
+  type: 'half_float'
+  null_value?: float
+}
+
+export class DoubleNumberProperty extends StandardNumberProperty {
+  type: 'double'
+  null_value?: double
+}
+
+export class IntegerNumberProperty extends StandardNumberProperty {
+  type: 'integer'
+  null_value?: integer
+}
+
+export class LongNumberProperty extends StandardNumberProperty {
+  type: 'long'
+  null_value?: long
+}
+
+export class ShortNumberProperty extends StandardNumberProperty {
+  type: 'short'
+  null_value?: short
+}
+
+export class ByteNumberProperty extends StandardNumberProperty {
+  type: 'byte'
+  null_value?: byte
+}
+
+export class UnsignedLongNumberProperty extends NumberPropertyBase {
+  type: 'unsigned_long'
+  null_value?: ulong
+}
+
+export class ScaledFloatNumberProperty extends NumberPropertyBase {
+  type: 'scaled_float'
+  coerce?: boolean
+  null_value?: double
+  scaling_factor?: double
+}
+
+export type NumberProperty =
+  | FloatNumberProperty
+  | HalfFloatNumberProperty
+  | DoubleNumberProperty
+  | IntegerNumberProperty
+  | LongNumberProperty
+  | ShortNumberProperty
+  | ByteNumberProperty
+  | UnsignedLongNumberProperty
+  | ScaledFloatNumberProperty
 
 export class PercolatorProperty extends PropertyBase {
   type: 'percolator'


### PR DESCRIPTION
This PR fixes the number field mapping definitions. Instead of having one single class with a `type` discriminant of an enum type, we now have a hierarchy of classes that takes into account the specificities of each type.