### PR TITLE
[ML] Updates spec for GET buckets API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -6579,6 +6579,11 @@
       "description": "Retrieves anomaly detection job results for one or more buckets.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html",
       "name": "ml.get_buckets",
+      "privileges": {
+        "cluster": [
+          "monitor_ml"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "ml.get_buckets"
@@ -112461,8 +112466,10 @@
         "kind": "properties",
         "properties": [
           {
+            "description": "Returns buckets with anomaly scores greater or equal than this value.",
             "name": "anomaly_score",
             "required": false,
+            "serverDefault": 0,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -112472,6 +112479,7 @@
             }
           },
           {
+            "description": "If `true`, the buckets are sorted in descending order.",
             "name": "desc",
             "required": false,
             "serverDefault": false,
@@ -112484,6 +112492,7 @@
             }
           },
           {
+            "description": "If `true`, the output excludes interim results.",
             "name": "exclude_interim",
             "required": false,
             "serverDefault": false,
@@ -112496,6 +112505,7 @@
             }
           },
           {
+            "description": "If true, the output includes anomaly records.",
             "name": "expand",
             "required": false,
             "serverDefault": false,
@@ -112508,19 +112518,10 @@
             }
           },
           {
-            "name": "page",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Page",
-                "namespace": "ml._types"
-              }
-            }
-          },
-          {
+            "description": "Specifies the sort field for the requested buckets.",
             "name": "sort",
             "required": false,
+            "serverDefault": "timestamp",
             "type": {
               "kind": "instance_of",
               "type": {
@@ -112530,8 +112531,10 @@
             }
           },
           {
+            "description": "Returns buckets with timestamps after this time. `-1` means it is unset\nand results are not limited to specific timestamps.",
             "name": "start",
             "required": false,
+            "serverDefault": "-1",
             "type": {
               "kind": "instance_of",
               "type": {
@@ -112541,8 +112544,10 @@
             }
           },
           {
+            "description": "Returns buckets with timestamps earlier than this time. `-1` means it is\nunset and results are not limited to specific timestamps.",
             "name": "end",
             "required": false,
+            "serverDefault": "-1",
             "type": {
               "kind": "instance_of",
               "type": {
@@ -112553,7 +112558,7 @@
           }
         ]
       },
-      "description": "Retrieves anomaly detection job results for one or more buckets.",
+      "description": "Retrieves anomaly detection job results for one or more buckets.\nThe API presents a chronological view of the records, grouped by bucket.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -112567,7 +112572,7 @@
       },
       "path": [
         {
-          "description": "ID of the job to get bucket results from",
+          "description": "Identifier for the anomaly detection job.",
           "name": "job_id",
           "required": true,
           "type": {
@@ -112579,7 +112584,7 @@
           }
         },
         {
-          "description": "The timestamp of the desired single bucket result",
+          "description": "The timestamp of a single bucket result. If you do not specify this\nparameter, the API returns information about all buckets.",
           "name": "timestamp",
           "required": false,
           "type": {
@@ -112593,9 +112598,10 @@
       ],
       "query": [
         {
-          "description": "skips a number of buckets",
+          "description": "Skips the specified number of buckets.",
           "name": "from",
           "required": false,
+          "serverDefault": 0,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -112605,9 +112611,10 @@
           }
         },
         {
-          "description": "specifies a max number of buckets to get",
+          "description": "Specifies the maximum number of buckets to obtain.",
           "name": "size",
           "required": false,
+          "serverDefault": 100,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -112617,7 +112624,7 @@
           }
         },
         {
-          "description": "Exclude interim results",
+          "description": "If `true`, the output excludes interim results.",
           "name": "exclude_interim",
           "required": false,
           "serverDefault": false,
@@ -112630,9 +112637,10 @@
           }
         },
         {
-          "description": "Sort buckets by a particular field",
+          "description": "Specifies the sort field for the requested buckets.",
           "name": "sort",
           "required": false,
+          "serverDefault": "timestamp",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -112642,7 +112650,7 @@
           }
         },
         {
-          "description": "Set the sort direction",
+          "description": "If `true`, the buckets are sorted in descending order.",
           "name": "desc",
           "required": false,
           "serverDefault": false,
@@ -112655,9 +112663,10 @@
           }
         },
         {
-          "description": "Start time filter for buckets",
+          "description": "Returns buckets with timestamps after this time. `-1` means it is unset\nand results are not limited to specific timestamps.",
           "name": "start",
           "required": false,
+          "serverDefault": "-1",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -112667,9 +112676,10 @@
           }
         },
         {
-          "description": "End time filter for buckets",
+          "description": "Returns buckets with timestamps earlier than this time. `-1` means it is\nunset and results are not limited to specific timestamps.",
           "name": "end",
           "required": false,
+          "serverDefault": "-1",
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11380,7 +11380,6 @@ export interface MlGetBucketsRequest extends RequestBase {
     desc?: boolean
     exclude_interim?: boolean
     expand?: boolean
-    page?: MlPage
     sort?: Field
     start?: DateString
     end?: DateString

--- a/specification/ml/get_buckets/MlGetBucketsRequest.ts
+++ b/specification/ml/get_buckets/MlGetBucketsRequest.ts
@@ -24,37 +24,101 @@ import { double, integer } from '@_types/Numeric'
 import { DateString, Timestamp } from '@_types/Time'
 
 /**
+ * Retrieves anomaly detection job results for one or more buckets.
+ * The API presents a chronological view of the records, grouped by bucket.
  * @rest_spec_name ml.get_buckets
  * @since 5.4.0
  * @stability stable
+ * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier for the anomaly detection job.
+     */
     job_id: Id
+    /**
+     * The timestamp of a single bucket result. If you do not specify this
+     * parameter, the API returns information about all buckets.
+     */
     timestamp?: Timestamp
   }
   query_parameters: {
+    /**
+     * Skips the specified number of buckets.
+     * @server_default 0
+     */
     from?: integer
+    /**
+     * Specifies the maximum number of buckets to obtain.
+     * @server_default 100
+     */
     size?: integer
-    /** @server_default false */
+    /**
+     *  If `true`, the output excludes interim results.
+     * @server_default false
+     */
     exclude_interim?: boolean
+    /**
+     * Specifies the sort field for the requested buckets.
+     * @server_default timestamp
+     */
     sort?: Field
-    /** @server_default false */
+    /**
+     * If `true`, the buckets are sorted in descending order.
+     * @server_default false
+     */
     desc?: boolean
+    /**
+     * Returns buckets with timestamps after this time. `-1` means it is unset
+     * and results are not limited to specific timestamps.
+     * @server_default -1
+     */
     start?: DateString
+    /**
+     * Returns buckets with timestamps earlier than this time. `-1` means it is
+     * unset and results are not limited to specific timestamps.
+     * @server_default -1
+     */
     end?: DateString
   }
   body: {
+    /**
+     * Returns buckets with anomaly scores greater or equal than this value.
+     * @server_default 0.0
+     */
     anomaly_score?: double
-    /** @server_default false */
+    /**
+     *  If `true`, the buckets are sorted in descending order.
+     * @server_default false
+     */
     desc?: boolean
-    /** @server_default false */
+    /**
+     * If `true`, the output excludes interim results.
+     * @server_default false
+     */
     exclude_interim?: boolean
-    /** @server_default false */
+    /**
+     * If true, the output includes anomaly records.
+     * @server_default false
+     */
     expand?: boolean
-    page?: Page
+    /**
+     * Specifies the sort field for the requested buckets.
+     * @server_default timestamp
+     */
     sort?: Field
+    /**
+     * Returns buckets with timestamps after this time. `-1` means it is unset
+     * and results are not limited to specific timestamps.
+     * @server_default -1
+     */
     start?: DateString
+    /**
+     * Returns buckets with timestamps earlier than this time. `-1` means it is
+     * unset and results are not limited to specific timestamps.
+     * @server_default -1
+     */
     end?: DateString
   }
 }


### PR DESCRIPTION
## Overview

This PR adds descriptions to the properties of the GET buckets API.

It also removes the `page` property from the API spec as it is not present in the [API documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-get-bucket.html), instead, there are two nested properties `page.from` and `page.size` that are present in the spec as `from` and `size`.
