### PR TITLE
Fine tuning and minor fixes

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "_info": {
-    "hash": "472e543",
+    "hash": "4573a944d",
     "license": {
       "name": "Apache 2.0",
       "url": "https://github.com/elastic/elasticsearch-specification/blob/master/LICENSE"
@@ -31227,7 +31227,7 @@
         },
         {
           "name": "root_cause",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -50029,8 +50029,8 @@
             "key": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Field",
+                "namespace": "_types"
               }
             },
             "kind": "dictionary_of",
@@ -121744,39 +121744,6 @@
         },
         {
           "name": "used_percent",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "total_in_bytes",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "free_in_bytes",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "used_in_bytes",
           "required": true,
           "type": {
             "kind": "instance_of",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1548,9 +1548,6 @@
       "response": [
         "interface definition nodes._types:Process / Property 'mem' / instance_of - Non-leaf type cannot be used here: 'nodes._types:MemoryStats'",
         "interface definition nodes._types:Jvm / Property 'mem' / instance_of - Non-leaf type cannot be used here: 'nodes._types:MemoryStats'",
-        "interface definition nodes._types:ExtendedMemoryStats - Property 'total_in_bytes' is already defined in an ancestor class",
-        "interface definition nodes._types:ExtendedMemoryStats - Property 'free_in_bytes' is already defined in an ancestor class",
-        "interface definition nodes._types:ExtendedMemoryStats - Property 'used_in_bytes' is already defined in an ancestor class",
         "interface definition nodes._types:OperatingSystem / Property 'swap' / instance_of - Non-leaf type cannot be used here: 'nodes._types:MemoryStats'"
       ]
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1916,7 +1916,7 @@ export interface ErrorCauseKeys {
   reason: string
   stack_trace?: string
   caused_by?: ErrorCause | string
-  root_cause: (ErrorCause | string)[]
+  root_cause?: (ErrorCause | string)[]
   suppressed?: (ErrorCause | string)[]
 }
 export type ErrorCause = ErrorCauseKeys |
@@ -3981,7 +3981,7 @@ export interface MappingFieldAliasProperty extends MappingPropertyBase {
 
 export interface MappingFieldMapping {
   full_name: string
-  mapping: Partial<Record<string, MappingProperty>>
+  mapping: Partial<Record<Field, MappingProperty>>
 }
 
 export interface MappingFieldNamesField {
@@ -12368,9 +12368,6 @@ export interface NodesDataPathStats {
 export interface NodesExtendedMemoryStats extends NodesMemoryStats {
   free_percent: integer
   used_percent: integer
-  total_in_bytes: integer
-  free_in_bytes: integer
-  used_in_bytes: integer
 }
 
 export interface NodesFileSystem {

--- a/specification/_types/Errors.ts
+++ b/specification/_types/Errors.ts
@@ -44,7 +44,7 @@ export class ErrorCause
   stack_trace?: string
 
   caused_by?: ErrorCause
-  root_cause: ErrorCause[]
+  root_cause?: ErrorCause[]
   suppressed?: ErrorCause[]
 }
 

--- a/specification/_types/mapping/meta-fields.ts
+++ b/specification/_types/mapping/meta-fields.ts
@@ -19,10 +19,11 @@
 
 import { SingleKeyDictionary } from '@spec_utils/Dictionary'
 import { Property } from './Property'
+import { Field } from '@_types/common'
 
 export class FieldMapping {
   full_name: string
-  mapping: SingleKeyDictionary<string, Property>
+  mapping: SingleKeyDictionary<Field, Property>
 }
 
 export class AllField {

--- a/specification/nodes/_types/Stats.ts
+++ b/specification/nodes/_types/Stats.ts
@@ -128,9 +128,6 @@ export class MemoryStats {
 export class ExtendedMemoryStats extends MemoryStats {
   free_percent: integer
   used_percent: integer
-  total_in_bytes: integer
-  free_in_bytes: integer
-  used_in_bytes: integer
 }
 
 export class Http {


### PR DESCRIPTION
Fixes a few tiny issues on some unrelated types:
- `Error.root_cause` should be optional
- `FieldMapping.mapping` maps fields
- `ExtendedMemoryStats` has some duplicate fields with the parent `ExtendedMemory`, but with different tyles (long vs int)