### PR TITLE
Add missing executing property on PendingTask

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -78377,6 +78377,17 @@
       },
       "properties": [
         {
+          "name": "executing",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "name": "insert_order",
           "required": true,
           "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -7508,6 +7508,7 @@ export interface ClusterHealthShardHealthStats {
 }
 
 export interface ClusterPendingTasksPendingTask {
+  executing: boolean
   insert_order: integer
   priority: string
   source: string

--- a/specification/cluster/pending_tasks/types.ts
+++ b/specification/cluster/pending_tasks/types.ts
@@ -20,6 +20,7 @@
 import { integer } from '@_types/Numeric'
 
 export class PendingTask {
+  executing: boolean
   insert_order: integer
   priority: string
   source: string


### PR DESCRIPTION
Per the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-pending.html#cluster-pending-api-response-body), the pending task should include a `boolean` property named `executing`. This PR adds that missing property.