### PR TITLE
Use the 'name' identifier for all snapshot repository CRUD APIs

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -137172,6 +137172,7 @@
       "path": [
         {
           "description": "A repository name",
+          "identifier": "name",
           "name": "repository",
           "required": true,
           "type": {
@@ -137759,6 +137760,7 @@
       "path": [
         {
           "description": "Name of the snapshot repository to unregister. Wildcard (`*`) patterns are supported.",
+          "identifier": "name",
           "name": "repository",
           "required": true,
           "type": {
@@ -138071,6 +138073,7 @@
       "path": [
         {
           "description": "A comma-separated list of repository names",
+          "identifier": "name",
           "name": "repository",
           "required": false,
           "type": {
@@ -138526,6 +138529,7 @@
       "path": [
         {
           "description": "A repository name",
+          "identifier": "name",
           "name": "repository",
           "required": true,
           "type": {

--- a/specification/snapshot/cleanup_repository/SnapshotCleanupRepositoryRequest.ts
+++ b/specification/snapshot/cleanup_repository/SnapshotCleanupRepositoryRequest.ts
@@ -28,6 +28,7 @@ import { Time } from '@_types/Time'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /** @identifier name */
     repository: Name
   }
   query_parameters: {

--- a/specification/snapshot/delete_repository/SnapshotDeleteRepositoryRequest.ts
+++ b/specification/snapshot/delete_repository/SnapshotDeleteRepositoryRequest.ts
@@ -28,6 +28,7 @@ import { Time } from '@_types/Time'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /** @identifier name */
     repository: Names
   }
   query_parameters: {

--- a/specification/snapshot/get_repository/SnapshotGetRepositoryRequest.ts
+++ b/specification/snapshot/get_repository/SnapshotGetRepositoryRequest.ts
@@ -28,6 +28,7 @@ import { Time } from '@_types/Time'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /** @identifier name */
     repository?: Names
   }
   query_parameters: {

--- a/specification/snapshot/verify_repository/SnapshotVerifyRepositoryRequest.ts
+++ b/specification/snapshot/verify_repository/SnapshotVerifyRepositoryRequest.ts
@@ -28,6 +28,7 @@ import { Time } from '@_types/Time'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /** @identifier name */
     repository: Name
   }
   query_parameters: {


### PR DESCRIPTION
Follow-up to https://github.com/elastic/elasticsearch-specification/pull/906#issuecomment-946835765