### PR TITLE
Error shortcut property is limited to top level errors

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "_info": {
-    "hash": "55bb81c",
+    "hash": "5b8fb2234",
     "license": {
       "name": "Apache 2.0",
       "url": "https://github.com/elastic/elasticsearch-specification/blob/master/LICENSE"
@@ -31302,8 +31302,7 @@
             }
           }
         }
-      ],
-      "shortcutProperty": "reason"
+      ]
     },
     {
       "description": "The response returned by Elasticsearch when request execution did not succeed.",
@@ -31319,7 +31318,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "ErrorCause",
+              "name": "TopLevelError",
               "namespace": "_types"
             }
           }
@@ -35156,6 +35155,24 @@
           "namespace": "internal"
         }
       }
+    },
+    {
+      "attachedBehaviors": [
+        "AdditionalProperties"
+      ],
+      "inherits": {
+        "type": {
+          "name": "ErrorCause",
+          "namespace": "_types"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "TopLevelError",
+        "namespace": "_types"
+      },
+      "properties": [],
+      "shortcutProperty": "reason"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -71,7 +71,7 @@ export interface BulkResponseItem {
   _id?: string | null
   _index: string
   status: integer
-  error?: ErrorCause | string
+  error?: ErrorCause
   _primary_term?: long
   result?: string
   _seq_no?: SequenceNumber
@@ -480,7 +480,7 @@ export interface InfoResponse {
 }
 
 export interface MgetHit<TDocument = unknown> {
-  error?: ErrorCause | string
+  error?: ErrorCause
   fields?: Record<string, any>
   found?: boolean
   _id: Id
@@ -642,7 +642,7 @@ export interface MtermvectorsTermVectorsResult {
   took?: long
   found?: boolean
   term_vectors?: Record<Field, TermvectorsTermVector>
-  error?: ErrorCause | string
+  error?: ErrorCause
 }
 
 export interface OpenPointInTimeRequest extends RequestBase {
@@ -1830,7 +1830,7 @@ export interface AcknowledgedResponseBase {
 export type AggregateName = string
 
 export interface BulkIndexByScrollFailure {
-  cause: ErrorCause | string
+  cause: ErrorCause
   id: Id
   index: IndexName
   status: integer
@@ -1928,15 +1928,15 @@ export interface ErrorCauseKeys {
   type?: string
   reason: string
   stack_trace?: string
-  caused_by?: ErrorCause | string
-  root_cause?: (ErrorCause | string)[]
-  suppressed?: (ErrorCause | string)[]
+  caused_by?: ErrorCause
+  root_cause?: ErrorCause[]
+  suppressed?: ErrorCause[]
 }
 export type ErrorCause = ErrorCauseKeys |
     { [property: string]: any }
 
 export interface ErrorResponseBase {
-  error: ErrorCause | string
+  error: TopLevelError
   status: integer
 }
 
@@ -2136,7 +2136,7 @@ export interface NodeShard {
 }
 
 export interface NodeStatistics {
-  failures?: (ErrorCause | string)[]
+  failures?: ErrorCause[]
   total: integer
   successful: integer
   failed: integer
@@ -2299,7 +2299,7 @@ export type ShapeRelation = 'intersects' | 'disjoint' | 'within'
 export interface ShardFailure {
   index?: IndexName
   node?: string
-  reason: ErrorCause | string
+  reason: ErrorCause
   shard: integer
   status?: string
 }
@@ -2355,6 +2355,11 @@ export type TimeUnit = 'nanos' | 'micros' | 'ms' | 's' | 'm' | 'h' | 'd'
 export type TimeZone = string
 
 export type Timestamp = string
+
+export interface TopLevelErrorKeys extends ErrorCause {
+}
+export type TopLevelError = TopLevelErrorKeys |
+    { [property: string]: any }
 
 export interface Transform {
   [key: string]: never
@@ -7037,7 +7042,7 @@ export interface CcrFollowIndexStats {
 }
 
 export interface CcrReadException {
-  exception: ErrorCause | string
+  exception: ErrorCause
   from_seq_no: SequenceNumber
   retries: integer
 }
@@ -7046,7 +7051,7 @@ export interface CcrShardStats {
   bytes_read: long
   failed_read_requests: long
   failed_write_requests: long
-  fatal_exception?: ErrorCause | string
+  fatal_exception?: ErrorCause
   follower_aliases_version: VersionNumber
   follower_global_checkpoint: long
   follower_index: string
@@ -7250,7 +7255,7 @@ export interface CcrStatsAutoFollowStats {
   number_of_failed_follow_indices: long
   number_of_failed_remote_cluster_state_requests: long
   number_of_successful_follow_indices: long
-  recent_auto_follow_errors: (ErrorCause | string)[]
+  recent_auto_follow_errors: ErrorCause[]
 }
 
 export interface CcrStatsAutoFollowedCluster {
@@ -12324,7 +12329,7 @@ export interface MonitoringBulkRequest<TSource = unknown> extends RequestBase {
 }
 
 export interface MonitoringBulkResponse {
-  error?: ErrorCause | string
+  error?: ErrorCause
   errors: boolean
   ignored: boolean
   took: long
@@ -13769,7 +13774,7 @@ export interface SecurityInvalidateApiKeyRequest extends RequestBase {
 
 export interface SecurityInvalidateApiKeyResponse {
   error_count: integer
-  error_details?: (ErrorCause | string)[]
+  error_details?: ErrorCause[]
   invalidated_api_keys: string[]
   previously_invalidated_api_keys: string[]
 }
@@ -13785,7 +13790,7 @@ export interface SecurityInvalidateTokenRequest extends RequestBase {
 
 export interface SecurityInvalidateTokenResponse {
   error_count: long
-  error_details?: (ErrorCause | string)[]
+  error_details?: ErrorCause[]
   invalidated_tokens: long
   previously_invalidated_tokens: long
 }
@@ -14271,7 +14276,7 @@ export interface SnapshotGetResponse {
 export interface SnapshotGetSnapshotResponseItem {
   repository: Name
   snapshots?: SnapshotSnapshotInfo[]
-  error?: ErrorCause | string
+  error?: ErrorCause
 }
 
 export interface SnapshotGetRepositoryRequest extends RequestBase {
@@ -14467,7 +14472,7 @@ export interface TasksCancelRequest extends RequestBase {
 }
 
 export interface TasksCancelResponse {
-  node_failures?: (ErrorCause | string)[]
+  node_failures?: ErrorCause[]
   nodes: Record<string, TasksTaskExecutingNode>
 }
 
@@ -14481,7 +14486,7 @@ export interface TasksGetResponse {
   completed: boolean
   task: TasksInfo
   response?: TasksStatus
-  error?: ErrorCause | string
+  error?: ErrorCause
 }
 
 export interface TasksListRequest extends RequestBase {
@@ -14495,7 +14500,7 @@ export interface TasksListRequest extends RequestBase {
 }
 
 export interface TasksListResponse {
-  node_failures?: (ErrorCause | string)[]
+  node_failures?: ErrorCause[]
   nodes?: Record<string, TasksTaskExecutingNode>
   tasks?: Record<string, TasksInfo> | TasksInfo[]
 }

--- a/specification/_types/Base.ts
+++ b/specification/_types/Base.ts
@@ -71,9 +71,16 @@ export class ElasticsearchVersionInfo {
  * The response returned by Elasticsearch when request execution did not succeed.
  */
 export class ErrorResponseBase {
-  error: ErrorCause
+  error: TopLevelError
   status: integer
 }
+
+/**
+ * @shortcut_property reason
+ */
+// Shortcut property needed to handle cases where the error is not caused by an exception. They happen only when the
+// HTTP routing layer rejects the request, and thus only at the top level. Example: "GET _cat/foo".
+export class TopLevelError extends ErrorCause {}
 
 export class IndicesResponseBase extends AcknowledgedResponseBase {
   _shards?: ShardStatistics

--- a/specification/_types/Errors.ts
+++ b/specification/_types/Errors.ts
@@ -25,8 +25,6 @@ import { AdditionalProperties } from '@spec_utils/behaviors'
 /**
  * Cause and details about a request failure. This class defines the properties common to all error types.
  * Additional details are also provided, that depend on the error type.
- *
- * @shortcut_property reason
  */
 export class ErrorCause
   implements AdditionalProperties<string, UserDefinedValue> {


### PR DESCRIPTION
The simplified `error: "some text"` representation only exists for top level errors. Adding the `shortcut_property` only on the top level error ensures we generate `ErrorCause | string` in the TypeScript client only where it's really needed.