### PR TITLE
Add missing (deprecated) `type` query parameter

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "_info": {
-    "hash": "8b6d9bf",
+    "hash": "4a8ecc0dc",
     "license": {
       "name": "Apache 2.0",
       "url": "https://github.com/elastic/elasticsearch-specification/blob/master/LICENSE"
@@ -17219,6 +17219,22 @@
             "type": {
               "name": "IndexName",
               "namespace": "_types"
+            }
+          }
+        },
+        {
+          "deprecation": {
+            "description": "",
+            "version": "7.0.0"
+          },
+          "description": "The type of the document.",
+          "name": "type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
           }
         }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -728,10 +728,8 @@
     },
     "get_source": {
       "request": [
-        "Request: missing json spec path parameter 'type'",
         "Request: query parameter 'stored_fields' does not exist in the json spec",
-        "Request: should not have a body",
-        "Url path property 'type' is missing in request definition"
+        "Request: should not have a body"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -439,6 +439,7 @@ export interface GetScriptLanguagesResponse {
 export interface GetSourceRequest {
   id: Id
   index: IndexName
+  type?: string
   preference?: string
   realtime?: boolean
   refresh?: boolean

--- a/specification/_global/get_source/SourceRequest.ts
+++ b/specification/_global/get_source/SourceRequest.ts
@@ -38,6 +38,11 @@ export interface Request {
     id: Id
     /** Name of the index that contains the document. */
     index: IndexName
+    /**
+     * The type of the document.
+     * @deprecated 7.0.0
+     */
+    type?: string
   }
   query_parameters: {
     /**


### PR DESCRIPTION
The 7.x APIs still have type parameters and it was missing from the `get_source` request definition.