### PR TITLE
Add missing wildcard property

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -62072,6 +62072,7 @@
       },
       "properties": [
         {
+          "description": "Allows case insensitive matching of the pattern with the indexed field values when set to true. Default is false which means the case sensitivity of matching depends on the underlying field’s mapping.",
           "name": "case_insensitive",
           "required": false,
           "since": "7.10.0",
@@ -62084,6 +62085,7 @@
           }
         },
         {
+          "description": "Method used to rewrite the query",
           "name": "rewrite",
           "required": false,
           "type": {
@@ -62095,8 +62097,21 @@
           }
         },
         {
+          "description": "Wildcard pattern for terms you wish to find in the provided field. Required, when wildcard is not set.",
           "name": "value",
-          "required": true,
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "Wildcard pattern for terms you wish to find in the provided field. Required, when value is not set.",
+          "name": "wildcard",
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5243,7 +5243,8 @@ export interface QueryDslTypeQuery extends QueryDslQueryBase {
 export interface QueryDslWildcardQuery extends QueryDslQueryBase {
   case_insensitive?: boolean
   rewrite?: MultiTermQueryRewrite
-  value: string
+  value?: string
+  wildcard?: string
 }
 
 export type QueryDslZeroTermsQuery = 'all' | 'none'

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -140,8 +140,15 @@ export class TypeQuery extends QueryBase {
 
 /** @shortcut_property value */
 export class WildcardQuery extends QueryBase {
-  /** @since 7.10.0 */
+  /**
+   * Allows case insensitive matching of the pattern with the indexed field values when set to true. Default is false which means the case sensitivity of matching depends on the underlying field’s mapping.
+   * @since 7.10.0
+   */
   case_insensitive?: boolean
+  /** Method used to rewrite the query */
   rewrite?: MultiTermQueryRewrite
-  value: string
+  /** Wildcard pattern for terms you wish to find in the provided field. Required, when wildcard is not set. */
+  value?: string
+  /** Wildcard pattern for terms you wish to find in the provided field. Required, when value is not set. */
+  wildcard?: string
 }


### PR DESCRIPTION
A wildcard query must have either a `value` or a `wildcard` property. This PR adds the missing property and marks both as optional since either may be set.