### PR TITLE
Amend '@since' to 8.0.0 for 'knn_search' API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -5416,7 +5416,7 @@
         "name": "Response",
         "namespace": "_global.knn_search"
       },
-      "since": "7.16.0",
+      "since": "8.0.0",
       "stability": "experimental",
       "urls": [
         {

--- a/specification/_global/knn_search/KnnSearchRequest.ts
+++ b/specification/_global/knn_search/KnnSearchRequest.ts
@@ -24,7 +24,7 @@ import { DocValueField, SourceFilter } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name knn_search
- * @since 7.16.0
+ * @since 8.0.0
  * @stability experimental
  */
 export interface Request extends RequestBase {


### PR DESCRIPTION
Discovered from [this comment](https://github.com/elastic/elasticsearch-specification/pull/932#issuecomment-952381437) we should have set 8.0 instead of 7.16 for `@since` on this API.