### PR TITLE
Adds descriptions for cat anomaly detectors and cat datafeeds APIs

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -595,6 +595,11 @@
       "description": "Gets configuration and usage information about datafeeds.",
       "docUrl": "http://www.elastic.co/guide/en/elasticsearch/reference/current/cat-datafeeds.html",
       "name": "cat.ml_datafeeds",
+      "privileges": {
+        "cluster": [
+          "monitor_ml"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "cat.ml_datafeeds"
@@ -630,6 +635,11 @@
       "description": "Gets configuration and usage information about anomaly detection jobs.",
       "docUrl": "http://www.elastic.co/guide/en/elasticsearch/reference/current/cat-anomaly-detectors.html",
       "name": "cat.ml_jobs",
+      "privileges": {
+        "cluster": [
+          "monitor_ml"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "cat.ml_jobs"
@@ -66976,7 +66986,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Gets configuration and usage information about datafeeds.",
+      "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -66990,7 +67000,7 @@
       },
       "path": [
         {
-          "description": "The ID of the datafeeds stats to fetch",
+          "description": "A numerical character string that uniquely identifies the datafeed. This identifier can contain lowercase\nalphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric\ncharacters.",
           "name": "datafeed_id",
           "required": false,
           "type": {
@@ -67004,14 +67014,27 @@
       ],
       "query": [
         {
-          "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
-          "name": "allow_no_datafeeds",
+          "description": "Specifies what to do when the request:\n\n* Contains wildcard expressions and there are no datafeeds that match.\n* Contains the `_all` string or no identifiers and there are no matches.\n* Contains wildcard expressions and there are only partial matches.\n\nIf `true`, the API returns an empty datafeeds array when there are no matches and the subset of results when\nthere are partial matches. If `false`, the API returns a 404 status code when there are no matches or only\npartial matches.",
+          "name": "allow_no_match",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "boolean",
               "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "The unit used to display time values.",
+          "name": "time",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TimeUnit",
+              "namespace": "_types"
             }
           }
         }
@@ -68006,7 +68029,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Gets configuration and usage information about anomaly detection jobs.",
+      "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -68020,7 +68043,7 @@
       },
       "path": [
         {
-          "description": "The ID of the jobs stats to fetch",
+          "description": "Identifier for the anomaly detection job.",
           "name": "job_id",
           "required": false,
           "type": {
@@ -68034,9 +68057,10 @@
       ],
       "query": [
         {
-          "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
-          "name": "allow_no_jobs",
+          "description": "Specifies what to do when the request:\n\n* Contains wildcard expressions and there are no jobs that match.\n* Contains the `_all` string or no identifiers and there are no matches.\n* Contains wildcard expressions and there are only partial matches.\n\nIf `true`, the API returns an empty jobs array when there are no matches and the subset of results when there\nare partial matches. If `false`, the API returns a 404 status code when there are no matches or only partial\nmatches.",
+          "name": "allow_no_match",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -68046,13 +68070,25 @@
           }
         },
         {
-          "description": "The unit in which to display byte values",
+          "description": "The unit used to display byte values.",
           "name": "bytes",
           "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "Bytes",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The unit used to display time values.",
+          "name": "time",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TimeUnit",
               "namespace": "_types"
             }
           }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -169,12 +169,11 @@
     },
     "cat.ml_datafeeds": {
       "request": [
-        "Request: missing json spec query parameter 'allow_no_match'",
+        "Request: missing json spec query parameter 'allow_no_datafeeds'",
         "Request: missing json spec query parameter 'format'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",
         "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'time'",
         "Request: missing json spec query parameter 'v'",
         "Request: should not have a body",
         "request definition cat.ml_datafeeds:Request / body - A request with inherited properties must have a PropertyBody"
@@ -183,12 +182,11 @@
     },
     "cat.ml_jobs": {
       "request": [
-        "Request: missing json spec query parameter 'allow_no_match'",
+        "Request: missing json spec query parameter 'allow_no_jobs'",
         "Request: missing json spec query parameter 'format'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",
         "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'time'",
         "Request: missing json spec query parameter 'v'",
         "Request: should not have a body",
         "request definition cat.ml_jobs:Request / body - A request with inherited properties must have a PropertyBody"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5894,7 +5894,8 @@ export interface CatMlDatafeedsDatafeedsRecord {
 
 export interface CatMlDatafeedsRequest extends CatCatRequestBase {
   datafeed_id?: Id
-  allow_no_datafeeds?: boolean
+  allow_no_match?: boolean
+  time?: TimeUnit
 }
 
 export type CatMlDatafeedsResponse = CatMlDatafeedsDatafeedsRecord[]
@@ -6078,8 +6079,9 @@ export interface CatMlJobsJobsRecord {
 
 export interface CatMlJobsRequest extends CatCatRequestBase {
   job_id?: Id
-  allow_no_jobs?: boolean
+  allow_no_match?: boolean
   bytes?: Bytes
+  time?: TimeUnit
 }
 
 export type CatMlJobsResponse = CatMlJobsJobsRecord[]

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -19,17 +19,44 @@
 
 import { CatRequestBase } from '@cat/_types/CatBase'
 import { Id } from '@_types/common'
+import { TimeUnit } from '@_types/Time'
 
 /**
+ * Returns configuration and usage information about datafeeds.
+ * This API returns a maximum of 10,000 datafeeds.
+ * If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`
+ * cluster privileges to use this API. 
  * @rest_spec_name cat.ml_datafeeds
  * @since 7.7.0
  * @stability stable
+ * @cluster_prvileges monitor_ml
  */
 export interface Request extends CatRequestBase {
   path_parts: {
+    /**
+     * A numerical character string that uniquely identifies the datafeed. This identifier can contain lowercase
+     * alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric
+     * characters.
+     */
     datafeed_id?: Id
   }
   query_parameters: {
-    allow_no_datafeeds?: boolean
+    /**
+     * Specifies what to do when the request:
+     * 
+     * * Contains wildcard expressions and there are no datafeeds that match.
+     * * Contains the `_all` string or no identifiers and there are no matches.
+     * * Contains wildcard expressions and there are only partial matches.
+     * 
+     * If `true`, the API returns an empty datafeeds array when there are no matches and the subset of results when
+     * there are partial matches. If `false`, the API returns a 404 status code when there are no matches or only
+     * partial matches.
+     * @server_default true
+     */
+    allow_no_match?: boolean
+    /**
+    * The unit used to display time values.
+    */
+    time?: TimeUnit
   }
 }

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -25,11 +25,11 @@ import { TimeUnit } from '@_types/Time'
  * Returns configuration and usage information about datafeeds.
  * This API returns a maximum of 10,000 datafeeds.
  * If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`
- * cluster privileges to use this API. 
+ * cluster privileges to use this API.
  * @rest_spec_name cat.ml_datafeeds
  * @since 7.7.0
  * @stability stable
- * @cluster_prvileges monitor_ml
+ * @cluster_privileges monitor_ml
  */
 export interface Request extends CatRequestBase {
   path_parts: {
@@ -43,11 +43,11 @@ export interface Request extends CatRequestBase {
   query_parameters: {
     /**
      * Specifies what to do when the request:
-     * 
+     *
      * * Contains wildcard expressions and there are no datafeeds that match.
      * * Contains the `_all` string or no identifiers and there are no matches.
      * * Contains wildcard expressions and there are only partial matches.
-     * 
+     *
      * If `true`, the API returns an empty datafeeds array when there are no matches and the subset of results when
      * there are partial matches. If `false`, the API returns a 404 status code when there are no matches or only
      * partial matches.
@@ -55,8 +55,8 @@ export interface Request extends CatRequestBase {
      */
     allow_no_match?: boolean
     /**
-    * The unit used to display time values.
-    */
+     * The unit used to display time values.
+     */
     time?: TimeUnit
   }
 }

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -19,18 +19,51 @@
 
 import { CatRequestBase } from '@cat/_types/CatBase'
 import { Bytes, Id } from '@_types/common'
+import { TimeUnit } from '@_types/Time'
 
 /**
+ * Returns configuration and usage information for anomaly detection jobs.
+ * This API returns a maximum of 10,000 jobs.
+ * If the Elasticsearch security features are enabled, you must have `monitor_ml`,
+ * `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.
  * @rest_spec_name cat.ml_jobs
  * @since 7.7.0
  * @stability stable
+ * @cluster_privileges monitor_ml
  */
 export interface Request extends CatRequestBase {
   path_parts: {
+    /**
+     * Identifier for the anomaly detection job.
+     */
     job_id?: Id
   }
   query_parameters: {
-    allow_no_jobs?: boolean
+    /**
+     * Specifies what to do when the request:
+     * 
+     * * Contains wildcard expressions and there are no jobs that match.
+     * * Contains the `_all` string or no identifiers and there are no matches.
+     * * Contains wildcard expressions and there are only partial matches.
+     * 
+     * If `true`, the API returns an empty jobs array when there are no matches and the subset of results when there
+     * are partial matches. If `false`, the API returns a 404 status code when there are no matches or only partial
+     * matches.
+     * @server_default true
+     */
+    allow_no_match?: boolean
+    /**
+     * The unit used to display byte values.
+     */
     bytes?: Bytes
+    /**
+     * The unit used to display time values.
+     */
+    time?: TimeUnit
+    /**
+     * Verbose mode. If `true`, the response includes column headings. 
+     * @server_default false
+     */
+    v?: boolean 
   }
 }

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -60,10 +60,5 @@ export interface Request extends CatRequestBase {
      * The unit used to display time values.
      */
     time?: TimeUnit
-    /**
-     * Verbose mode. If `true`, the response includes column headings. 
-     * @server_default false
-     */
-    v?: boolean 
   }
 }

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -41,11 +41,11 @@ export interface Request extends CatRequestBase {
   query_parameters: {
     /**
      * Specifies what to do when the request:
-     * 
+     *
      * * Contains wildcard expressions and there are no jobs that match.
      * * Contains the `_all` string or no identifiers and there are no matches.
      * * Contains wildcard expressions and there are only partial matches.
-     * 
+     *
      * If `true`, the API returns an empty jobs array when there are no matches and the subset of results when there
      * are partial matches. If `false`, the API returns a 404 status code when there are no matches or only partial
      * matches.


### PR DESCRIPTION
Adds descriptions from https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-datafeeds.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-anomaly-detectors.html

Related to https://github.com/elastic/elasticsearch/issues/60732
... also replaces the allow_no_datafeeds and allow_no_jobs with allow_no_match