### PR TITLE
Deprecates allow_no_jobs and allow_no_datafeeds 

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -67375,6 +67375,10 @@
       ],
       "query": [
         {
+          "deprecation": {
+            "description": "Use `allow_no_match` instead.",
+            "version": "7.10.0"
+          },
           "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
           "name": "allow_no_datafeeds",
           "required": false,
@@ -68405,6 +68409,10 @@
       ],
       "query": [
         {
+          "deprecation": {
+            "description": "Use `allow_no_match` instead.",
+            "version": "7.10.0"
+          },
           "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
           "name": "allow_no_jobs",
           "required": false,
@@ -115810,6 +115818,22 @@
       ],
       "query": [
         {
+          "deprecation": {
+            "description": "Use `allow_no_match` instead.",
+            "version": "7.10.0"
+          },
+          "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
+          "name": "allow_no_datafeeds",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "description": "Specifies what to do when the request:\n\n1. Contains wildcard expressions and there are no datafeeds that match.\n2. Contains the `_all` string or no identifiers and there are no matches.\n3. Contains wildcard expressions and there are only partial matches.\n\nThe default value is `true`, which returns an empty `datafeeds` array\nwhen there are no matches and the subset of results when there are\npartial matches. If this parameter is `false`, the request returns a\n`404` status code when there are no matches or only partial matches.",
           "name": "allow_no_match",
           "required": false,
@@ -115894,6 +115918,22 @@
         }
       ],
       "query": [
+        {
+          "deprecation": {
+            "description": "Use `allow_no_match` instead.",
+            "version": "7.10.0"
+          },
+          "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
+          "name": "allow_no_datafeeds",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
         {
           "description": "Specifies what to do when the request:\n\n1. Contains wildcard expressions and there are no datafeeds that match.\n2. Contains the `_all` string or no identifiers and there are no matches.\n3. Contains wildcard expressions and there are only partial matches.\n\nThe default value is `true`, which returns an empty `datafeeds` array\nwhen there are no matches and the subset of results when there are\npartial matches. If this parameter is `false`, the request returns a\n`404` status code when there are no matches or only partial matches.",
           "name": "allow_no_match",
@@ -116282,6 +116322,10 @@
       ],
       "query": [
         {
+          "deprecation": {
+            "description": "Use `allow_no_match` instead.",
+            "version": "7.10.0"
+          },
           "description": "Specifies what to do when the request:\n\n1. Contains wildcard expressions and there are no jobs that match.\n2. Contains the _all string or no identifiers and there are no matches.\n3. Contains wildcard expressions and there are only partial matches.\n\nThe default value is `true`, which returns an empty `jobs` array when\nthere are no matches and the subset of results when there are partial\nmatches. If this parameter is `false`, the request returns a `404` status\ncode when there are no matches or only partial matches.",
           "name": "allow_no_jobs",
           "required": false,
@@ -116382,7 +116426,7 @@
         },
         {
           "deprecation": {
-            "description": "",
+            "description": "Use `allow_no_match` instead.",
             "version": "7.10.0"
           },
           "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
@@ -121124,6 +121168,22 @@
         }
       ],
       "query": [
+        {
+          "deprecation": {
+            "description": "Use `allow_no_match` instead.",
+            "version": "7.10.0"
+          },
+          "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
+          "name": "allow_no_datafeeds",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
         {
           "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
           "name": "allow_no_match",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1344,14 +1344,12 @@
     },
     "ml.get_datafeed_stats": {
       "request": [
-        "Request: missing json spec query parameter 'allow_no_datafeeds'",
         "Request: should not have a body"
       ],
       "response": []
     },
     "ml.get_datafeeds": {
       "request": [
-        "Request: missing json spec query parameter 'allow_no_datafeeds'",
         "Request: should not have a body"
       ],
       "response": []
@@ -1470,7 +1468,6 @@
     },
     "ml.stop_datafeed": {
       "request": [
-        "Request: missing json spec query parameter 'allow_no_datafeeds'",
         "Request: missing json spec query parameter 'timeout'"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11628,6 +11628,7 @@ export interface MlGetDataFrameAnalyticsStatsResponse {
 
 export interface MlGetDatafeedStatsRequest extends RequestBase {
   datafeed_id?: Ids
+  allow_no_datafeeds?: boolean
   allow_no_match?: boolean
 }
 
@@ -11638,6 +11639,7 @@ export interface MlGetDatafeedStatsResponse {
 
 export interface MlGetDatafeedsRequest extends RequestBase {
   datafeed_id?: Ids
+  allow_no_datafeeds?: boolean
   allow_no_match?: boolean
   exclude_generated?: boolean
 }
@@ -12222,6 +12224,7 @@ export interface MlStopDataFrameAnalyticsResponse {
 
 export interface MlStopDatafeedRequest extends RequestBase {
   datafeed_id: Id
+  allow_no_datafeeds?: boolean
   allow_no_match?: boolean
   force?: boolean
   body?: {

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -30,6 +30,9 @@ export interface Request extends CatRequestBase {
     datafeed_id?: Id
   }
   query_parameters: {
+    /**
+     * @deprecated 7.10.0 Use `allow_no_match` instead.
+     */
     allow_no_datafeeds?: boolean
   }
 }

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -30,6 +30,9 @@ export interface Request extends CatRequestBase {
     job_id?: Id
   }
   query_parameters: {
+    /**
+     * @deprecated 7.10.0 Use `allow_no_match` instead.
+     */
     allow_no_jobs?: boolean
     bytes?: Bytes
   }

--- a/specification/ml/get_datafeed_stats/MlGetDatafeedStatsRequest.ts
+++ b/specification/ml/get_datafeed_stats/MlGetDatafeedStatsRequest.ts
@@ -44,6 +44,10 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
+     * @deprecated 7.10.0 Use `allow_no_match` instead.
+     */
+    allow_no_datafeeds?: boolean
+    /**
      * Specifies what to do when the request:
      *
      * 1. Contains wildcard expressions and there are no datafeeds that match.

--- a/specification/ml/get_datafeeds/MlGetDatafeedsRequest.ts
+++ b/specification/ml/get_datafeeds/MlGetDatafeedsRequest.ts
@@ -43,6 +43,10 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
+     * @deprecated 7.10.0 Use `allow_no_match` instead.
+     */
+    allow_no_datafeeds?: boolean
+    /**
      * Specifies what to do when the request:
      *
      * 1. Contains wildcard expressions and there are no datafeeds that match.

--- a/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
+++ b/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
@@ -50,6 +50,7 @@ export interface Request extends RequestBase {
      * matches. If this parameter is `false`, the request returns a `404` status
      * code when there are no matches or only partial matches.
      * @server_default true
+     * @deprecated 7.10.0 Use `allow_no_match` instead.
      */
     allow_no_jobs?: boolean
   }

--- a/specification/ml/get_jobs/MlGetJobsRequest.ts
+++ b/specification/ml/get_jobs/MlGetJobsRequest.ts
@@ -56,7 +56,7 @@ export interface Request extends RequestBase {
      */
     allow_no_match?: boolean
     /**
-     * @deprecated 7.10.0
+     * @deprecated 7.10.0 Use `allow_no_match` instead.
      */
     allow_no_jobs?: boolean
     /**

--- a/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
+++ b/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
@@ -31,6 +31,10 @@ export interface Request extends RequestBase {
     datafeed_id: Id
   }
   query_parameters: {
+    /**
+     * @deprecated 7.10.0 Use `allow_no_match` instead.
+     */
+    allow_no_datafeeds?: boolean
     /** @server_default true */
     allow_no_match?: boolean
     /** @server_default false */


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/60642

This PR adds the @deprecated attribute for the allow_no_datafeeds and allow_no_jobs properties in the appropriate machine learning APIs.