### PR TITLE
Remove allow_no_jobs and allow_no_datafeeds

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -111831,22 +111831,6 @@
           }
         },
         {
-          "deprecation": {
-            "description": "Use `allow_no_match` instead.",
-            "version": "7.10.0"
-          },
-          "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
-          "name": "allow_no_jobs",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "description": "Use to close a failed job, or to forcefully close a job which has not responded to its initial close request; the request returns without performing the associated actions such as flushing buffers and persisting the model snapshots.\nIf you want the job to be in a consistent state after the close job API returns, do not set to `true`. This parameter should be used only in situations where the job has already failed or where you are not interested in results the job might have recently produced or might produce in the future.",
           "name": "force",
           "required": false,
@@ -115446,8 +115430,8 @@
       ],
       "query": [
         {
-          "description": "Specifies what to do when the request:\n\n1. Contains wildcard expressions and there are no jobs that match.\n2. Contains the _all string or no identifiers and there are no matches.\n3. Contains wildcard expressions and there are only partial matches.\n\nThe default value is `true`, which returns an empty `jobs` array when\nthere are no matches and the subset of results when there are partial\nmatches. If this parameter is `false`, the request returns a `404` status\ncode when there are no matches or only partial matches.",
-          "name": "allow_no_jobs",
+          "description": "Specifies what to do when the request:\n\n1. Contains wildcard expressions and there are no jobs that match.\n2. Contains the _all string or no identifiers and there are no matches.\n3. Contains wildcard expressions and there are only partial matches.\n\nIf `true`, the API returns an empty `jobs` array when\nthere are no matches and the subset of results when there are partial\nmatches. If `false`, the API returns a `404` status\ncode when there are no matches or only partial matches.",
+          "name": "allow_no_match",
           "required": false,
           "serverDefault": true,
           "type": {
@@ -115536,22 +115520,6 @@
           "name": "allow_no_match",
           "required": false,
           "serverDefault": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "deprecation": {
-            "description": "",
-            "version": "7.10.0"
-          },
-          "description": "Whether to ignore if a wildcard expression matches no jobs. (This includes `_all` string or when no jobs have been specified)",
-          "name": "allow_no_jobs",
-          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -115800,24 +115768,7 @@
         "CommonQueryParameters"
       ],
       "body": {
-        "kind": "properties",
-        "properties": [
-          {
-            "deprecation": {
-              "description": "",
-              "version": "7.10.0"
-            },
-            "name": "allow_no_jobs",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "boolean",
-                "namespace": "internal"
-              }
-            }
-          }
-        ]
+        "kind": "no_body"
       },
       "description": "Retrieves overall bucket results that summarize the bucket results of\nmultiple anomaly detection jobs.\n\nThe `overall_score` is calculated by combining the scores of all the\nbuckets within the overall bucket span. First, the maximum\n`anomaly_score` per anomaly detection job in the overall bucket is\ncalculated. Then the `top_n` of those scores are averaged to result in\nthe `overall_score`. This means that you can fine-tune the\n`overall_score` so that it is more or less sensitive to the number of\njobs that detect an anomaly at the same time. For example, if you set\n`top_n` to `1`, the `overall_score` is the maximum bucket score in the\noverall bucket. Alternatively, if you set `top_n` to the number of jobs,\nthe `overall_score` is high only when all jobs detect anomalies in that\noverall bucket. If you set the `bucket_span` parameter (to a value\ngreater than its default), the `overall_score` is the maximum\n`overall_score` of the overall buckets that have a span equal to the\njobs' largest bucket span.",
       "inherits": {
@@ -115847,6 +115798,19 @@
       ],
       "query": [
         {
+          "description": "Specifies what to do when the request:\n\n1. Contains wildcard expressions and there are no jobs that match.\n2. Contains the `_all` string or no identifiers and there are no matches.\n3. Contains wildcard expressions and there are only partial matches.\n\nIf `true`, the request returns an empty `jobs` array when there are no\nmatches and the subset of results when there are partial matches. If this\nparameter is `false`, the request returns a `404` status code when there\nare no matches or only partial matches.",
+          "name": "allow_no_match",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "description": "The span of the overall buckets. Must be greater or equal to the largest\nbucket span of the specified anomaly detection jobs, which is the default\nvalue.\n\nBy default, an overall bucket has a span equal to the largest bucket span\nof the specified anomaly detection jobs. To override that behavior, use\nthe optional `bucket_span` parameter.",
           "name": "bucket_span",
           "required": false,
@@ -115855,6 +115819,31 @@
             "type": {
               "name": "Time",
               "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Returns overall buckets with timestamps earlier than this time.",
+          "name": "end",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "If `true`, the output excludes interim results.",
+          "name": "exclude_interim",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
             }
           }
         },
@@ -115883,31 +115872,6 @@
           }
         },
         {
-          "description": "The number of top anomaly detection job bucket scores to be used in the\n`overall_score` calculation.",
-          "name": "top_n",
-          "required": false,
-          "serverDefault": 1,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Returns overall buckets with timestamps earlier than this time.",
-          "name": "end",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Time",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
           "description": "Returns overall buckets with timestamps after this time.",
           "name": "start",
           "required": false,
@@ -115920,28 +115884,15 @@
           }
         },
         {
-          "description": "If `true`, the output excludes interim results.",
-          "name": "exclude_interim",
+          "description": "The number of top anomaly detection job bucket scores to be used in the\n`overall_score` calculation.",
+          "name": "top_n",
           "required": false,
-          "serverDefault": false,
+          "serverDefault": 1,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "description": "Specifies what to do when the request:\n\n1. Contains wildcard expressions and there are no jobs that match.\n2. Contains the `_all` string or no identifiers and there are no matches.\n3. Contains wildcard expressions and there are only partial matches.\n\nIf `true`, the request returns an empty `jobs` array when there are no\nmatches and the subset of results when there are partial matches. If this\nparameter is `false`, the request returns a `404` status code when there\nare no matches or only partial matches.",
-          "name": "allow_no_match",
-          "required": false,
-          "serverDefault": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
+              "name": "integer",
+              "namespace": "_types"
             }
           }
         }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1159,6 +1159,12 @@
       ],
       "response": []
     },
+    "ml.close_job": {
+      "request": [
+        "Request: missing json spec query parameter 'allow_no_jobs'"
+      ],
+      "response": []
+    },
     "ml.delete_calendar": {
       "request": [
         "Request: should not have a body"
@@ -1300,13 +1306,14 @@
     },
     "ml.get_job_stats": {
       "request": [
-        "Request: missing json spec query parameter 'allow_no_match'",
+        "Request: missing json spec query parameter 'allow_no_jobs'",
         "Request: should not have a body"
       ],
       "response": []
     },
     "ml.get_jobs": {
       "request": [
+        "Request: missing json spec query parameter 'allow_no_jobs'",
         "Request: should not have a body"
       ],
       "response": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11223,7 +11223,6 @@ export interface MlValidationLoss {
 export interface MlCloseJobRequest extends RequestBase {
   job_id: Id
   allow_no_match?: boolean
-  allow_no_jobs?: boolean
   force?: boolean
   timeout?: Time
 }
@@ -11647,7 +11646,7 @@ export interface MlGetInfluencersResponse {
 
 export interface MlGetJobStatsRequest extends RequestBase {
   job_id?: Id
-  allow_no_jobs?: boolean
+  allow_no_match?: boolean
 }
 
 export interface MlGetJobStatsResponse {
@@ -11658,7 +11657,6 @@ export interface MlGetJobStatsResponse {
 export interface MlGetJobsRequest extends RequestBase {
   job_id?: Ids
   allow_no_match?: boolean
-  allow_no_jobs?: boolean
   exclude_generated?: boolean
 }
 
@@ -11689,16 +11687,13 @@ export interface MlGetModelSnapshotsResponse {
 
 export interface MlGetOverallBucketsRequest extends RequestBase {
   job_id: Id
-  bucket_span?: Time
-  overall_score?: double | string
-  top_n?: integer
-  end?: Time
-  start?: Time
-  exclude_interim?: boolean
   allow_no_match?: boolean
-  body?: {
-    allow_no_jobs?: boolean
-  }
+  bucket_span?: Time
+  end?: Time
+  exclude_interim?: boolean
+  overall_score?: double | string
+  start?: Time
+  top_n?: integer
 }
 
 export interface MlGetOverallBucketsResponse {

--- a/specification/ml/close_job/MlCloseJobRequest.ts
+++ b/specification/ml/close_job/MlCloseJobRequest.ts
@@ -47,10 +47,6 @@ export interface Request extends RequestBase {
      */
     allow_no_match?: boolean
     /**
-     * @deprecated 7.10.0 Use `allow_no_match` instead.
-     */
-    allow_no_jobs?: boolean
-    /**
      * Use to close a failed job, or to forcefully close a job which has not responded to its initial close request; the request returns without performing the associated actions such as flushing buffers and persisting the model snapshots.
      * If you want the job to be in a consistent state after the close job API returns, do not set to `true`. This parameter should be used only in situations where the job has already failed or where you are not interested in results the job might have recently produced or might produce in the future.
      * @server_default false

--- a/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
+++ b/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
@@ -45,12 +45,12 @@ export interface Request extends RequestBase {
      * 2. Contains the _all string or no identifiers and there are no matches.
      * 3. Contains wildcard expressions and there are only partial matches.
      *
-     * The default value is `true`, which returns an empty `jobs` array when
+     * If `true`, the API returns an empty `jobs` array when
      * there are no matches and the subset of results when there are partial
-     * matches. If this parameter is `false`, the request returns a `404` status
+     * matches. If `false`, the API returns a `404` status
      * code when there are no matches or only partial matches.
      * @server_default true
      */
-    allow_no_jobs?: boolean
+    allow_no_match?: boolean
   }
 }

--- a/specification/ml/get_jobs/MlGetJobsRequest.ts
+++ b/specification/ml/get_jobs/MlGetJobsRequest.ts
@@ -56,10 +56,6 @@ export interface Request extends RequestBase {
      */
     allow_no_match?: boolean
     /**
-     * @deprecated 7.10.0
-     */
-    allow_no_jobs?: boolean
-    /**
      * Indicates if certain fields should be removed from the configuration on
      * retrieval. This allows the configuration to be in an acceptable format to
      * be retrieved and then added to another cluster.

--- a/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
+++ b/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
@@ -59,40 +59,6 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
-     * The span of the overall buckets. Must be greater or equal to the largest
-     * bucket span of the specified anomaly detection jobs, which is the default
-     * value.
-     *
-     * By default, an overall bucket has a span equal to the largest bucket span
-     * of the specified anomaly detection jobs. To override that behavior, use
-     * the optional `bucket_span` parameter.
-     */
-    bucket_span?: Time
-    /**
-     * Returns overall buckets with overall scores greater than or equal to this
-     * value.
-     */
-    overall_score?: double | string
-    /**
-     * The number of top anomaly detection job bucket scores to be used in the
-     * `overall_score` calculation.
-     * @server_default 1
-     */
-    top_n?: integer
-    /**
-     * Returns overall buckets with timestamps earlier than this time.
-     */
-    end?: Time
-    /**
-     * Returns overall buckets with timestamps after this time.
-     */
-    start?: Time
-    /**
-     * If `true`, the output excludes interim results.
-     * @server_default false
-     */
-    exclude_interim?: boolean
-    /**
      * Specifies what to do when the request:
      *
      * 1. Contains wildcard expressions and there are no jobs that match.
@@ -106,11 +72,39 @@ export interface Request extends RequestBase {
      * @server_default true
      */
     allow_no_match?: boolean
-  }
-  body: {
     /**
-     * @deprecated 7.10.0
+     * The span of the overall buckets. Must be greater or equal to the largest
+     * bucket span of the specified anomaly detection jobs, which is the default
+     * value.
+     *
+     * By default, an overall bucket has a span equal to the largest bucket span
+     * of the specified anomaly detection jobs. To override that behavior, use
+     * the optional `bucket_span` parameter.
      */
-    allow_no_jobs?: boolean
+    bucket_span?: Time
+    /**
+     * Returns overall buckets with timestamps earlier than this time.
+     */
+     end?: Time
+    /**
+     * If `true`, the output excludes interim results.
+     * @server_default false
+     */
+     exclude_interim?: boolean
+    /**
+     * Returns overall buckets with overall scores greater than or equal to this
+     * value.
+     */
+    overall_score?: double | string
+    /**
+     * Returns overall buckets with timestamps after this time.
+     */
+     start?: Time
+    /**
+     * The number of top anomaly detection job bucket scores to be used in the
+     * `overall_score` calculation.
+     * @server_default 1
+     */
+    top_n?: integer
   }
 }

--- a/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
+++ b/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
@@ -85,12 +85,12 @@ export interface Request extends RequestBase {
     /**
      * Returns overall buckets with timestamps earlier than this time.
      */
-     end?: Time
+    end?: Time
     /**
      * If `true`, the output excludes interim results.
      * @server_default false
      */
-     exclude_interim?: boolean
+    exclude_interim?: boolean
     /**
      * Returns overall buckets with overall scores greater than or equal to this
      * value.
@@ -99,7 +99,7 @@ export interface Request extends RequestBase {
     /**
      * Returns overall buckets with timestamps after this time.
      */
-     start?: Time
+    start?: Time
     /**
      * The number of top anomaly detection job bucket scores to be used in the
      * `overall_score` calculation.


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/60732

This PR removes the allow_no_jobs and allow_no_datafeeds properties, which have been replaced by allow_no_match in 8.0.  It also sorts the properties in the get overall buckets API.

