### PR TITLE
Add property alias support in requests and responses & improve error message

### DIFF
--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -939,8 +939,8 @@ export function parseVariantNameTag (jsDoc: JSDoc[]): string | undefined {
   }
 
   const [key, name] = tags.variant.split('=')
-  assert(jsDoc, key === 'name', 'The key value should be "name"')
-  assert(jsDoc, typeof name === 'string', 'The key value should be "name"')
+  assert(jsDoc, key === 'name', 'The @variant key should be "name"')
+  assert(jsDoc, typeof name === 'string', 'The @variant key should be "name"')
 
   return name.replace(/'/g, '')
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11937,6 +11937,7 @@ export interface MlPutDatafeedRequest extends RequestBase {
     delayed_data_check_config?: MlDelayedDataCheckConfig
     frequency?: Time
     indices?: string[]
+    indexes?: string[]
     indices_options?: MlDatafeedIndicesOptions
     job_id?: Id
     max_empty_searches?: integer

--- a/typescript-generator/index.ts
+++ b/typescript-generator/index.ts
@@ -315,6 +315,11 @@ function buildRequest (type: M.Request): string {
     code += `  body${isBodyRequired() ? '' : '?'}: {\n`
     for (const property of type.body.properties) {
       code += `    ${cleanPropertyName(property.name)}${property.required ? '' : '?'}: ${buildValue(property.type, openGenerics)}\n`
+      if (Array.isArray(property.aliases)) {
+        for (const alias of property.aliases) {
+          code += `    ${cleanPropertyName(alias)}${property.required ? '' : '?'}: ${buildValue(property.type, openGenerics)}\n`
+        }
+      }
     }
     code += '  }\n'
   } else if (type.body.kind === 'value') {
@@ -340,6 +345,11 @@ function buildResponse (type: M.Response): string {
     let code = `export interface ${createName(type.name)}${buildGenerics(type.generics, openGenerics)}${buildInherits(type, openGenerics)} {\n`
     for (const property of type.body.properties) {
       code += `  ${cleanPropertyName(property.name)}${property.required ? '' : '?'}: ${buildValue(property.type, openGenerics)}\n`
+      if (Array.isArray(property.aliases)) {
+        for (const alias of property.aliases) {
+          code += `    ${cleanPropertyName(alias)}${property.required ? '' : '?'}: ${buildValue(property.type, openGenerics)}\n`
+        }
+      }
     }
     code += '}\n'
     return code


### PR DESCRIPTION
Adds support for `@aliases` to request and response properties (it was only implemented on classes/interfaces)

Also improves error message for the expected `@variant` syntax