### PR TITLE
Dedup aggregrations/aggs fields

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -18013,29 +18013,10 @@
       },
       "properties": [
         {
+          "aliases": [
+            "aggs"
+          ],
           "name": "aggregations",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "AggregationContainer",
-                "namespace": "_types.aggregations"
-              }
-            }
-          }
-        },
-        {
-          "name": "aggs",
           "required": false,
           "type": {
             "key": {
@@ -21599,28 +21580,9 @@
         "kind": "properties",
         "properties": [
           {
-            "name": "aggs",
-            "required": false,
-            "type": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "AggregationContainer",
-                  "namespace": "_types.aggregations"
-                }
-              }
-            }
-          },
-          {
+            "aliases": [
+              "aggs"
+            ],
             "name": "aggregations",
             "required": false,
             "type": {
@@ -60978,8 +60940,8 @@
             "key": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "AggregateName",
+                "namespace": "_types"
               }
             },
             "kind": "dictionary_of",
@@ -61527,28 +61489,9 @@
         "kind": "properties",
         "properties": [
           {
-            "name": "aggs",
-            "required": false,
-            "type": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "AggregationContainer",
-                  "namespace": "_types.aggregations"
-                }
-              }
-            }
-          },
-          {
+            "aliases": [
+              "aggs"
+            ],
             "name": "aggregations",
             "required": false,
             "type": {
@@ -103487,17 +103430,6 @@
             }
           },
           {
-            "name": "acknowledged",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "boolean",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
             "name": "trial_was_started",
             "required": true,
             "type": {
@@ -105963,29 +105895,10 @@
       },
       "properties": [
         {
+          "aliases": [
+            "aggs"
+          ],
           "name": "aggregations",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "AggregationContainer",
-                "namespace": "_types.aggregations"
-              }
-            }
-          }
-        },
-        {
-          "name": "aggs",
           "required": false,
           "type": {
             "key": {
@@ -106187,30 +106100,11 @@
       },
       "properties": [
         {
+          "aliases": [
+            "aggs"
+          ],
           "description": "If set, the datafeed performs aggregation searches. Support for aggregations is limited and should be used only with low cardinality data.",
           "name": "aggregations",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "AggregationContainer",
-                "namespace": "_types.aggregations"
-              }
-            }
-          }
-        },
-        {
-          "name": "aggs",
           "required": false,
           "type": {
             "key": {
@@ -128612,7 +128506,10 @@
         "kind": "properties",
         "properties": [
           {
-            "name": "aggs",
+            "aliases": [
+              "aggs"
+            ],
+            "name": "aggregations",
             "required": false,
             "type": {
               "key": {
@@ -128645,6 +128542,7 @@
             }
           },
           {
+            "description": "Must be zero if set, as rollups work on pre-aggregated data",
             "name": "size",
             "required": false,
             "type": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1125,9 +1125,7 @@
         "Request: missing json spec query parameter 'type'",
         "Request: should not have a body"
       ],
-      "response": [
-        "response definition license.post_start_trial:Response / body - Property 'acknowledged' is already defined in an ancestor class"
-      ]
+      "response": []
     },
     "logstash.delete_pipeline": {
       "request": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -992,8 +992,8 @@ export interface SearchRequest extends RequestBase {
   from?: integer
   sort?: string | string[]
   body?: {
-    aggs?: Record<string, AggregationsAggregationContainer>
     aggregations?: Record<string, AggregationsAggregationContainer>
+    aggs?: Record<string, AggregationsAggregationContainer>
     collapse?: SearchFieldCollapse
     explain?: boolean
     from?: integer
@@ -5124,7 +5124,7 @@ export interface QueryDslWildcardQuery extends QueryDslQueryBase {
 export type QueryDslZeroTermsQuery = 'all' | 'none'
 
 export interface AsyncSearchAsyncSearch<TDocument = unknown> {
-  aggregations?: Record<string, AggregationsAggregate>
+  aggregations?: Record<AggregateName, AggregationsAggregate>
   _clusters?: ClusterStatistics
   fields?: Record<string, any>
   hits: SearchHitsMetadata<TDocument>
@@ -5227,8 +5227,8 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
   from?: integer
   sort?: string | string[]
   body?: {
-    aggs?: Record<string, AggregationsAggregationContainer>
     aggregations?: Record<string, AggregationsAggregationContainer>
+    aggs?: Record<string, AggregationsAggregationContainer>
     collapse?: SearchFieldCollapse
     explain?: boolean
     from?: integer
@@ -10321,7 +10321,6 @@ export interface LicensePostStartTrialRequest extends RequestBase {
 
 export interface LicensePostStartTrialResponse extends AcknowledgedResponseBase {
   error_message?: string
-  acknowledged: boolean
   trial_was_started: boolean
   type: LicenseLicenseType
 }
@@ -13158,6 +13157,7 @@ export interface RollupRollupSearchRequest extends RequestBase {
   rest_total_hits_as_int?: boolean
   typed_keys?: boolean
   body?: {
+    aggregations?: Record<string, AggregationsAggregationContainer>
     aggs?: Record<string, AggregationsAggregationContainer>
     query?: QueryDslQueryContainer
     size?: integer

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -41,8 +41,8 @@ export class Header {
 }
 
 export class Body {
+  /** @aliases aggs */
   aggregations?: Dictionary<string, AggregationContainer>
-  aggs?: Dictionary<string, AggregationContainer>
   query?: QueryContainer
   from?: integer
   size?: integer

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -107,7 +107,7 @@ export interface Request extends RequestBase {
     sort?: string | string[]
   }
   body: {
-    aggs?: Dictionary<string, AggregationContainer>
+    /** @aliases aggs */ // ES uses "aggregations" in serialization
     aggregations?: Dictionary<string, AggregationContainer>
     collapse?: FieldCollapse
     /**

--- a/specification/async_search/_types/AsyncSearch.ts
+++ b/specification/async_search/_types/AsyncSearch.ts
@@ -23,12 +23,12 @@ import { Suggest } from '@global/search/_types/suggester'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Aggregate } from '@_types/aggregations/Aggregate'
-import { Id, SuggestionName } from '@_types/common'
+import { AggregateName, Id, SuggestionName } from '@_types/common'
 import { double, long } from '@_types/Numeric'
 import { ClusterStatistics, ShardStatistics } from '@_types/Stats'
 
 export class AsyncSearch<TDocument> {
-  aggregations?: Dictionary<string, Aggregate>
+  aggregations?: Dictionary<AggregateName, Aggregate>
   _clusters?: ClusterStatistics
   fields?: Dictionary<string, UserDefinedValue>
   hits: HitsMetadata<TDocument>

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -51,6 +51,7 @@ import { SuggestContainer } from '@global/search/_types/suggester'
  * @since 7.7.0
  * @stability stable
  */
+// NOTE: this is a SearchRequest with 3 added parameters: wait_for_completion_timeout, keep_on_completion and keep_alive
 export interface Request extends RequestBase {
   path_parts: {
     index?: Indices
@@ -113,7 +114,7 @@ export interface Request extends RequestBase {
     sort?: string | string[]
   }
   body: {
-    aggs?: Dictionary<string, AggregationContainer>
+    /** @aliases aggs */
     aggregations?: Dictionary<string, AggregationContainer>
     collapse?: FieldCollapse
     /**

--- a/specification/license/post_start_trial/StartTrialLicenseResponse.ts
+++ b/specification/license/post_start_trial/StartTrialLicenseResponse.ts
@@ -23,7 +23,6 @@ import { AcknowledgedResponseBase } from '@_types/Base'
 export class Response extends AcknowledgedResponseBase {
   body: {
     error_message?: string
-    acknowledged: boolean
     trial_was_started: boolean
     type: LicenseType
   }

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -28,8 +28,8 @@ import { Time, Timestamp } from '@_types/Time'
 import { DiscoveryNode } from './DiscoveryNode'
 
 export class Datafeed {
+  /** @aliases aggs */
   aggregations?: Dictionary<string, AggregationContainer>
-  aggs?: Dictionary<string, AggregationContainer>
   chunking_config?: ChunkingConfig
   datafeed_id: Id
   frequency?: Timestamp
@@ -45,12 +45,14 @@ export class Datafeed {
   runtime_mappings?: RuntimeFields
   indices_options?: DatafeedIndicesOptions
 }
+
 export class DatafeedConfig {
   /**
    * If set, the datafeed performs aggregation searches. Support for aggregations is limited and should be used only with low cardinality data.
+   *
+   * @aliases aggs
    */
   aggregations?: Dictionary<string, AggregationContainer>
-  aggs?: Dictionary<string, AggregationContainer>
   /**
    * Datafeeds might be required to search over long time periods, for several months or years. This search is split into time chunks in order to ensure the load on Elasticsearch is managed. Chunking configuration controls how the size of these time chunks are calculated and is an advanced configuration option.
    */

--- a/specification/rollup/rollup_search/RollupSearchRequest.ts
+++ b/specification/rollup/rollup_search/RollupSearchRequest.ts
@@ -39,8 +39,10 @@ export interface Request extends RequestBase {
     typed_keys?: boolean
   }
   body: {
-    aggs?: Dictionary<string, AggregationContainer>
+    /** @aliases aggs */
+    aggregations?: Dictionary<string, AggregationContainer>
     query?: QueryContainer
+    /** Must be zero if set, as rollups work on pre-aggregated data */
     size?: integer
   }
 }


### PR DESCRIPTION
Depends on PR #970

Uses `@aliases` to deduplicate `aggs` and `aggregations` properties in search requests and a few other places. `aggregations` is chosen as the canonical name and `aggs` as an alias as ES uses `aggregations` when serializing objects (and it's also more meaningful).

`SearchMvtRequest` is the only exception, since it only accepts `aggs` with no alias.