### PR TITLE
Fix create index request

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -44808,6 +44808,20 @@
               "name": "KuromojiAnalyzer",
               "namespace": "_types.analysis"
             }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "SnowballAnalyzer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "DutchAnalyzer",
+              "namespace": "_types.analysis"
+            }
           }
         ],
         "kind": "union_of"
@@ -44876,7 +44890,21 @@
           {
             "kind": "instance_of",
             "type": {
-              "name": "PatternReplaceTokenFilter",
+              "name": "PatternReplaceCharFilter",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuNormalizationCharFilter",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "KuromojiIterationMarkCharFilter",
               "namespace": "_types.analysis"
             }
           }
@@ -44942,6 +44970,17 @@
               }
             }
           }
+        },
+        {
+          "name": "max_token_length",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
         }
       ]
     },
@@ -44968,7 +45007,7 @@
         },
         {
           "name": "common_words",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -44982,7 +45021,7 @@
         },
         {
           "name": "common_words_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -44993,7 +45032,7 @@
         },
         {
           "name": "ignore_case",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45004,7 +45043,7 @@
         },
         {
           "name": "query_mode",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45030,7 +45069,7 @@
       "properties": [
         {
           "name": "hyphenation_patterns_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45041,7 +45080,7 @@
         },
         {
           "name": "max_subword_size",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45052,7 +45091,7 @@
         },
         {
           "name": "min_subword_size",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45063,7 +45102,7 @@
         },
         {
           "name": "min_word_size",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45074,7 +45113,7 @@
         },
         {
           "name": "only_longest_match",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45085,7 +45124,7 @@
         },
         {
           "name": "word_list",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -45099,7 +45138,7 @@
         },
         {
           "name": "word_list_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45345,6 +45384,57 @@
       ]
     },
     {
+      "inherits": {
+        "type": {
+          "name": "CompoundWordTokenFilterBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "DictionaryDecompounderTokenFilter",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "dictionary_decompounder"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "DutchAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "dutch"
+          }
+        },
+        {
+          "name": "stopwords",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "StopWords",
+              "namespace": "_types.analysis"
+            }
+          }
+        }
+      ]
+    },
+    {
       "kind": "enum",
       "members": [
         {
@@ -45404,12 +45494,23 @@
         },
         {
           "name": "side",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "EdgeNGramSide",
               "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "preserve_original",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
             }
           }
         }
@@ -45438,7 +45539,7 @@
         },
         {
           "name": "custom_token_chars",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45550,7 +45651,7 @@
         },
         {
           "name": "version",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45594,7 +45695,7 @@
         },
         {
           "name": "stopwords",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45605,7 +45706,7 @@
         },
         {
           "name": "stopwords_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45817,6 +45918,298 @@
       "kind": "enum",
       "members": [
         {
+          "name": "shifted"
+        },
+        {
+          "name": "non-ignorable"
+        }
+      ],
+      "name": {
+        "name": "IcuCollationAlternate",
+        "namespace": "_types.analysis"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "lower"
+        },
+        {
+          "name": "upper"
+        }
+      ],
+      "name": {
+        "name": "IcuCollationCaseFirst",
+        "namespace": "_types.analysis"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "no"
+        },
+        {
+          "name": "identical"
+        }
+      ],
+      "name": {
+        "name": "IcuCollationDecomposition",
+        "namespace": "_types.analysis"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "primary"
+        },
+        {
+          "name": "secondary"
+        },
+        {
+          "name": "tertiary"
+        },
+        {
+          "name": "quaternary"
+        },
+        {
+          "name": "identical"
+        }
+      ],
+      "name": {
+        "name": "IcuCollationStrength",
+        "namespace": "_types.analysis"
+      }
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "IcuCollationTokenFilter",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "icu_collation"
+          }
+        },
+        {
+          "name": "alternate",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuCollationAlternate",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "caseFirst",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuCollationCaseFirst",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "caseLevel",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "country",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "decomposition",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuCollationDecomposition",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "hiraganaQuaternaryMode",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "language",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "numeric",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "strength",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuCollationStrength",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "variableTop",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "variant",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "IcuFoldingTokenFilter",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "icu_folding"
+          }
+        },
+        {
+          "name": "unicode_set_filter",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "CharFilterBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "IcuNormalizationCharFilter",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "icu_normalizer"
+          }
+        },
+        {
+          "name": "mode",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuNormalizationMode",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "name",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuNormalizationType",
+              "namespace": "_types.analysis"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
           "name": "decompose"
         },
         {
@@ -45827,6 +46220,40 @@
         "name": "IcuNormalizationMode",
         "namespace": "_types.analysis"
       }
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "IcuNormalizationTokenFilter",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "icu_normalizer"
+          }
+        },
+        {
+          "name": "name",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuNormalizationType",
+              "namespace": "_types.analysis"
+            }
+          }
+        }
+      ]
     },
     {
       "kind": "enum",
@@ -45845,6 +46272,100 @@
         "name": "IcuNormalizationType",
         "namespace": "_types.analysis"
       }
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "IcuTokenizer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "icu_tokenizer"
+          }
+        },
+        {
+          "name": "rule_files",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "forward"
+        },
+        {
+          "name": "reverse"
+        }
+      ],
+      "name": {
+        "name": "IcuTransformDirection",
+        "namespace": "_types.analysis"
+      }
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "IcuTransformTokenFilter",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "icu_transform"
+          }
+        },
+        {
+          "name": "dir",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuTransformDirection",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "inherits": {
@@ -45907,7 +46428,7 @@
         },
         {
           "name": "mode",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45918,7 +46439,7 @@
         },
         {
           "name": "types",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -45955,7 +46476,7 @@
         },
         {
           "name": "keep_words",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -45969,7 +46490,7 @@
         },
         {
           "name": "keep_words_case",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -45980,7 +46501,7 @@
         },
         {
           "name": "keep_words_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46008,7 +46529,7 @@
         },
         {
           "name": "version",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46042,7 +46563,7 @@
         },
         {
           "name": "ignore_case",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46053,7 +46574,7 @@
         },
         {
           "name": "keywords",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -46067,7 +46588,7 @@
         },
         {
           "name": "keywords_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46078,7 +46599,7 @@
         },
         {
           "name": "keywords_pattern",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46156,6 +46677,51 @@
             "kind": "instance_of",
             "type": {
               "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "CharFilterBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "KuromojiIterationMarkCharFilter",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "kuromoji_iteration_mark"
+          }
+        },
+        {
+          "name": "normalize_kana",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "normalize_kanji",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
               "namespace": "internal"
             }
           }
@@ -46308,7 +46874,7 @@
         },
         {
           "name": "discard_punctuation",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46330,7 +46896,7 @@
         },
         {
           "name": "nbest_cost",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46341,7 +46907,7 @@
         },
         {
           "name": "nbest_examples",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46352,7 +46918,7 @@
         },
         {
           "name": "user_dictionary",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46363,7 +46929,7 @@
         },
         {
           "name": "user_dictionary_rules",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -46372,6 +46938,17 @@
                 "name": "string",
                 "namespace": "internal"
               }
+            }
+          }
+        },
+        {
+          "name": "discard_compound_token",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
             }
           }
         }
@@ -46505,7 +47082,7 @@
         },
         {
           "name": "version",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46541,7 +47118,7 @@
         },
         {
           "name": "stopwords",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46552,7 +47129,7 @@
         },
         {
           "name": "stopwords_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46716,7 +47293,7 @@
         },
         {
           "name": "language",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46869,7 +47446,7 @@
         },
         {
           "name": "max_gram",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46880,12 +47457,23 @@
         },
         {
           "name": "min_gram",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "integer",
               "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "preserve_original",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
             }
           }
         }
@@ -46914,7 +47502,7 @@
         },
         {
           "name": "custom_token_chars",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46978,7 +47566,7 @@
         },
         {
           "name": "version",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -46989,7 +47577,7 @@
         },
         {
           "name": "decompound_mode",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47000,7 +47588,7 @@
         },
         {
           "name": "stoptags",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -47014,7 +47602,7 @@
         },
         {
           "name": "user_dictionary",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47103,7 +47691,7 @@
         },
         {
           "name": "decompound_mode",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47114,7 +47702,7 @@
         },
         {
           "name": "discard_punctuation",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47125,7 +47713,7 @@
         },
         {
           "name": "user_dictionary",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47136,7 +47724,7 @@
         },
         {
           "name": "user_dictionary_rules",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -47276,7 +47864,7 @@
         },
         {
           "name": "version",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47287,7 +47875,7 @@
         },
         {
           "name": "flags",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47298,7 +47886,7 @@
         },
         {
           "name": "lowercase",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47320,7 +47908,7 @@
         },
         {
           "name": "stopwords",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47382,6 +47970,62 @@
     {
       "inherits": {
         "type": {
+          "name": "CharFilterBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "PatternReplaceCharFilter",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "pattern_replace"
+          }
+        },
+        {
+          "name": "flags",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "pattern",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "replacement",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
           "name": "TokenFilterBase",
           "namespace": "_types.analysis"
         }
@@ -47430,6 +48074,277 @@
             "type": {
               "name": "string",
               "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "TokenizerBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "PatternTokenizer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "pattern"
+          }
+        },
+        {
+          "name": "flags",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "group",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "pattern",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "metaphone"
+        },
+        {
+          "name": "double_metaphone"
+        },
+        {
+          "name": "soundex"
+        },
+        {
+          "name": "refined_soundex"
+        },
+        {
+          "name": "caverphone1"
+        },
+        {
+          "name": "caverphone2"
+        },
+        {
+          "name": "cologne"
+        },
+        {
+          "name": "nysiis"
+        },
+        {
+          "name": "koelnerphonetik"
+        },
+        {
+          "name": "haasephonetik"
+        },
+        {
+          "name": "beider_morse"
+        },
+        {
+          "name": "daitch_mokotoff"
+        }
+      ],
+      "name": {
+        "name": "PhoneticEncoder",
+        "namespace": "_types.analysis"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "any"
+        },
+        {
+          "name": "common"
+        },
+        {
+          "name": "cyrillic"
+        },
+        {
+          "name": "english"
+        },
+        {
+          "name": "french"
+        },
+        {
+          "name": "german"
+        },
+        {
+          "name": "hebrew"
+        },
+        {
+          "name": "hungarian"
+        },
+        {
+          "name": "polish"
+        },
+        {
+          "name": "romanian"
+        },
+        {
+          "name": "russian"
+        },
+        {
+          "name": "spanish"
+        }
+      ],
+      "name": {
+        "name": "PhoneticLanguage",
+        "namespace": "_types.analysis"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "generic"
+        },
+        {
+          "name": "ashkenazi"
+        },
+        {
+          "name": "sephardic"
+        }
+      ],
+      "name": {
+        "name": "PhoneticNameType",
+        "namespace": "_types.analysis"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "approx"
+        },
+        {
+          "name": "exact"
+        }
+      ],
+      "name": {
+        "name": "PhoneticRuleType",
+        "namespace": "_types.analysis"
+      }
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "TokenFilterBase",
+          "namespace": "_types.analysis"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "PhoneticTokenFilter",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "phonetic"
+          }
+        },
+        {
+          "name": "encoder",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "PhoneticEncoder",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "languageset",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "PhoneticLanguage",
+                "namespace": "_types.analysis"
+              }
+            }
+          }
+        },
+        {
+          "name": "max_code_len",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "name_type",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "PhoneticNameType",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "replace",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "rule_type",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "PhoneticRuleType",
+              "namespace": "_types.analysis"
             }
           }
         }
@@ -47561,7 +48476,7 @@
         },
         {
           "name": "filler_token",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47572,29 +48487,53 @@
         },
         {
           "name": "max_shingle_size",
-          "required": true,
+          "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "integer",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
           "name": "min_shingle_size",
-          "required": true,
+          "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "integer",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
           "name": "output_unigrams",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47605,7 +48544,7 @@
         },
         {
           "name": "output_unigrams_if_no_shingles",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47616,7 +48555,7 @@
         },
         {
           "name": "token_separator",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47644,12 +48583,62 @@
         },
         {
           "name": "version",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "VersionString",
               "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "SnowballAnalyzer",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "snowball"
+          }
+        },
+        {
+          "name": "version",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "language",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "SnowballLanguage",
+              "namespace": "_types.analysis"
+            }
+          }
+        },
+        {
+          "name": "stopwords",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "StopWords",
+              "namespace": "_types.analysis"
             }
           }
         }
@@ -47781,7 +48770,7 @@
         },
         {
           "name": "max_token_length",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47792,7 +48781,7 @@
         },
         {
           "name": "stopwords",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47826,7 +48815,7 @@
         },
         {
           "name": "max_token_length",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47860,7 +48849,7 @@
         },
         {
           "name": "rules",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -47874,7 +48863,7 @@
         },
         {
           "name": "rules_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47936,7 +48925,7 @@
         },
         {
           "name": "version",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47947,7 +48936,7 @@
         },
         {
           "name": "stopwords",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -47958,7 +48947,7 @@
         },
         {
           "name": "stopwords_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -48104,7 +49093,7 @@
         },
         {
           "name": "expand",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -48115,7 +49104,7 @@
         },
         {
           "name": "format",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -48126,7 +49115,7 @@
         },
         {
           "name": "lenient",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -48137,7 +49126,7 @@
         },
         {
           "name": "synonyms",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -48151,7 +49140,7 @@
         },
         {
           "name": "synonyms_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -48162,7 +49151,7 @@
         },
         {
           "name": "tokenizer",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -48173,7 +49162,7 @@
         },
         {
           "name": "updateable",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -48240,7 +49229,7 @@
         },
         {
           "name": "synonyms",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -48608,6 +49597,55 @@
               "name": "KuromojiPartOfSpeechTokenFilter",
               "namespace": "_types.analysis"
             }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuTokenizer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuCollationTokenFilter",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuFoldingTokenFilter",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuNormalizationTokenFilter",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuTransformTokenFilter",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "PhoneticTokenFilter",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "DictionaryDecompounderTokenFilter",
+              "namespace": "_types.analysis"
+            }
           }
         ],
         "kind": "union_of"
@@ -48728,6 +49766,20 @@
               "name": "KuromojiTokenizer",
               "namespace": "_types.analysis"
             }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "PatternTokenizer",
+              "namespace": "_types.analysis"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "IcuTokenizer",
+              "namespace": "_types.analysis"
+            }
           }
         ],
         "kind": "union_of"
@@ -48837,7 +49889,7 @@
         },
         {
           "name": "max_token_length",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -48871,7 +49923,7 @@
         },
         {
           "name": "only_on_same_position",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -48922,7 +49974,7 @@
         },
         {
           "name": "version",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -48956,7 +50008,7 @@
         },
         {
           "name": "max_token_length",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -48990,7 +50042,7 @@
         },
         {
           "name": "adjust_offsets",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49001,7 +50053,7 @@
         },
         {
           "name": "catenate_all",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49012,7 +50064,7 @@
         },
         {
           "name": "catenate_numbers",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49023,7 +50075,7 @@
         },
         {
           "name": "catenate_words",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49034,7 +50086,7 @@
         },
         {
           "name": "generate_number_parts",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49045,7 +50097,18 @@
         },
         {
           "name": "generate_word_parts",
-          "required": true,
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "ignore_keywords",
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49056,7 +50119,7 @@
         },
         {
           "name": "preserve_original",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49067,7 +50130,7 @@
         },
         {
           "name": "protected_words",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -49081,7 +50144,7 @@
         },
         {
           "name": "protected_words_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49092,7 +50155,7 @@
         },
         {
           "name": "split_on_case_change",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49103,7 +50166,7 @@
         },
         {
           "name": "split_on_numerics",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49114,7 +50177,7 @@
         },
         {
           "name": "stem_english_possessive",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49125,7 +50188,7 @@
         },
         {
           "name": "type_table",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -49139,7 +50202,7 @@
         },
         {
           "name": "type_table_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49173,7 +50236,7 @@
         },
         {
           "name": "catenate_all",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49184,7 +50247,7 @@
         },
         {
           "name": "catenate_numbers",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49195,7 +50258,7 @@
         },
         {
           "name": "catenate_words",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49206,7 +50269,7 @@
         },
         {
           "name": "generate_number_parts",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49217,7 +50280,7 @@
         },
         {
           "name": "generate_word_parts",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49228,7 +50291,7 @@
         },
         {
           "name": "preserve_original",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49239,7 +50302,7 @@
         },
         {
           "name": "protected_words",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -49253,7 +50316,7 @@
         },
         {
           "name": "protected_words_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49264,7 +50327,7 @@
         },
         {
           "name": "split_on_case_change",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49275,7 +50338,7 @@
         },
         {
           "name": "split_on_numerics",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49286,7 +50349,7 @@
         },
         {
           "name": "stem_english_possessive",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -49297,7 +50360,7 @@
         },
         {
           "name": "type_table",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -49311,7 +50374,7 @@
         },
         {
           "name": "type_table_path",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -50010,6 +51073,17 @@
           }
         },
         {
+          "name": "locale",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "name": "type",
           "required": true,
           "type": {
@@ -50054,6 +51128,48 @@
       ]
     },
     {
+      "kind": "interface",
+      "name": {
+        "name": "DenseVectorIndexOptions",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "m",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "ef_construction",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
       "inherits": {
         "type": {
           "name": "PropertyBase",
@@ -50082,6 +51198,39 @@
             "type": {
               "name": "integer",
               "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "similarity",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "index",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "index_options",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DenseVectorIndexOptions",
+              "namespace": "_types.mapping"
             }
           }
         }
@@ -51563,6 +52712,18 @@
           }
         },
         {
+          "description": "[experimental] For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.",
+          "name": "time_series_dimension",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "name": "type",
           "required": true,
           "type": {
@@ -51830,6 +52991,17 @@
             "type": {
               "name": "boolean",
               "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "time_series_metric",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TimeSeriesMetricType",
+              "namespace": "_types.mapping"
             }
           }
         }
@@ -53170,6 +54342,27 @@
           }
         }
       ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "gauge"
+        },
+        {
+          "name": "counter"
+        },
+        {
+          "name": "summary"
+        },
+        {
+          "name": "histogram"
+        }
+      ],
+      "name": {
+        "name": "TimeSeriesMetricType",
+        "namespace": "_types.mapping"
+      }
     },
     {
       "inherits": {
@@ -86565,6 +87758,74 @@
     {
       "kind": "interface",
       "name": {
+        "name": "IndexSegmentSort",
+        "namespace": "indices._types"
+      },
+      "properties": [
+        {
+          "name": "field",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "order",
+          "required": true,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "SegmentSortOrder",
+                  "namespace": "indices._types"
+                }
+              },
+              {
+                "kind": "array_of",
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "SegmentSortOrder",
+                    "namespace": "indices._types"
+                  }
+                }
+              }
+            ],
+            "kind": "union_of"
+          }
+        },
+        {
+          "name": "mode",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "SegmentSortMode",
+              "namespace": "indices._types"
+            }
+          }
+        },
+        {
+          "name": "missing",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "SegmentSortMissing",
+              "namespace": "indices._types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
         "name": "IndexSettingBlocks",
         "namespace": "indices._types"
       },
@@ -86646,6 +87907,76 @@
         "namespace": "indices._types"
       },
       "properties": [
+        {
+          "name": "index",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexSettings",
+              "namespace": "indices._types"
+            }
+          }
+        },
+        {
+          "aliases": [
+            "index.mode"
+          ],
+          "name": "mode",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "aliases": [
+            "index.routing_path"
+          ],
+          "name": "routing_path",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
+          "aliases": [
+            "index.soft_deletes"
+          ],
+          "name": "soft_deletes",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "SoftDeletes",
+              "namespace": "indices._types"
+            }
+          }
+        },
+        {
+          "aliases": [
+            "index.sort"
+          ],
+          "name": "sort",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexSegmentSort",
+              "namespace": "indices._types"
+            }
+          }
+        },
         {
           "aliases": [
             "index.number_of_shards"
@@ -86750,25 +88081,13 @@
           ],
           "name": "routing_partition_size",
           "required": false,
-          "serverDefault": "1",
+          "serverDefault": 1,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "integer",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
           }
         },
         {
@@ -86840,6 +88159,20 @@
             "type": {
               "name": "string",
               "namespace": "internal"
+            }
+          }
+        },
+        {
+          "aliases": [
+            "index.merge.scheduler.max_thread_count"
+          ],
+          "name": "index.merge.scheduler.max_thread_count",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
             }
           }
         },
@@ -87373,6 +88706,20 @@
         },
         {
           "aliases": [
+            "index.translog.flush_threshold_size"
+          ],
+          "name": "translog.flush_threshold_size",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "aliases": [
             "index.query_string.lenient"
           ],
           "name": "query_string.lenient",
@@ -87435,6 +88782,9 @@
           }
         },
         {
+          "aliases": [
+            "index.analysis"
+          ],
           "name": "analysis",
           "required": false,
           "type": {
@@ -87548,6 +88898,28 @@
               "kind": "instance_of",
               "type": {
                 "name": "Normalizer",
+                "namespace": "_types.analysis"
+              }
+            }
+          }
+        },
+        {
+          "name": "tokenizer",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Tokenizer",
                 "namespace": "_types.analysis"
               }
             }
@@ -87755,6 +89127,73 @@
                 "name": "IndexName",
                 "namespace": "_types"
               }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "codegenName": "last",
+          "name": "_last"
+        },
+        {
+          "codegenName": "first",
+          "name": "_first"
+        }
+      ],
+      "name": {
+        "name": "SegmentSortMissing",
+        "namespace": "indices._types"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "min"
+        },
+        {
+          "name": "max"
+        }
+      ],
+      "name": {
+        "name": "SegmentSortMode",
+        "namespace": "indices._types"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "asc"
+        },
+        {
+          "name": "desc"
+        }
+      ],
+      "name": {
+        "name": "SegmentSortOrder",
+        "namespace": "indices._types"
+      }
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "SoftDeletes",
+        "namespace": "indices._types"
+      },
+      "properties": [
+        {
+          "name": "enabled",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
             }
           }
         }
@@ -89237,7 +90676,7 @@
               "key": {
                 "kind": "instance_of",
                 "type": {
-                  "name": "IndexName",
+                  "name": "Name",
                   "namespace": "_types"
                 }
               },
@@ -89257,51 +90696,21 @@
             "name": "mappings",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "key": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  },
-                  "kind": "dictionary_of",
-                  "singleKey": false,
-                  "value": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "TypeMapping",
-                      "namespace": "_types.mapping"
-                    }
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "TypeMapping",
-                    "namespace": "_types.mapping"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "TypeMapping",
+                "namespace": "_types.mapping"
+              }
             }
           },
           {
             "name": "settings",
             "required": false,
             "type": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "kind": "user_defined_value"
+              "kind": "instance_of",
+              "type": {
+                "name": "IndexSettings",
+                "namespace": "indices._types"
               }
             }
           }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -470,7 +470,9 @@
         "Request: query parameter 'flat_settings' does not exist in the json spec",
         "Request: should not have a body"
       ],
-      "response": []
+      "response": [
+        "interface definition indices._types:IndexSettings - Duplicate property name or alias: 'index.merge.scheduler.max_thread_count'"
+      ]
     },
     "cluster.get_settings": {
       "request": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3394,14 +3394,14 @@ export interface AggregationsWeightedAverageValue {
   script?: Script
 }
 
-export type AnalysisAnalyzer = AnalysisCustomAnalyzer | AnalysisFingerprintAnalyzer | AnalysisKeywordAnalyzer | AnalysisLanguageAnalyzer | AnalysisNoriAnalyzer | AnalysisPatternAnalyzer | AnalysisSimpleAnalyzer | AnalysisStandardAnalyzer | AnalysisStopAnalyzer | AnalysisWhitespaceAnalyzer | AnalysisIcuAnalyzer | AnalysisKuromojiAnalyzer
+export type AnalysisAnalyzer = AnalysisCustomAnalyzer | AnalysisFingerprintAnalyzer | AnalysisKeywordAnalyzer | AnalysisLanguageAnalyzer | AnalysisNoriAnalyzer | AnalysisPatternAnalyzer | AnalysisSimpleAnalyzer | AnalysisStandardAnalyzer | AnalysisStopAnalyzer | AnalysisWhitespaceAnalyzer | AnalysisIcuAnalyzer | AnalysisKuromojiAnalyzer | AnalysisSnowballAnalyzer | AnalysisDutchAnalyzer
 
 export interface AnalysisAsciiFoldingTokenFilter extends AnalysisTokenFilterBase {
   type: 'asciifolding'
   preserve_original: boolean
 }
 
-export type AnalysisCharFilter = AnalysisHtmlStripCharFilter | AnalysisMappingCharFilter | AnalysisPatternReplaceTokenFilter
+export type AnalysisCharFilter = AnalysisHtmlStripCharFilter | AnalysisMappingCharFilter | AnalysisPatternReplaceCharFilter | AnalysisIcuNormalizationCharFilter | AnalysisKuromojiIterationMarkCharFilter
 
 export interface AnalysisCharFilterBase {
   version?: VersionString
@@ -3410,24 +3410,25 @@ export interface AnalysisCharFilterBase {
 export interface AnalysisCharGroupTokenizer extends AnalysisTokenizerBase {
   type: 'char_group'
   tokenize_on_chars: string[]
+  max_token_length?: integer
 }
 
 export interface AnalysisCommonGramsTokenFilter extends AnalysisTokenFilterBase {
   type: 'common_grams'
-  common_words: string[]
-  common_words_path: string
-  ignore_case: boolean
-  query_mode: boolean
+  common_words?: string[]
+  common_words_path?: string
+  ignore_case?: boolean
+  query_mode?: boolean
 }
 
 export interface AnalysisCompoundWordTokenFilterBase extends AnalysisTokenFilterBase {
-  hyphenation_patterns_path: string
-  max_subword_size: integer
-  min_subword_size: integer
-  min_word_size: integer
-  only_longest_match: boolean
-  word_list: string[]
-  word_list_path: string
+  hyphenation_patterns_path?: string
+  max_subword_size?: integer
+  min_subword_size?: integer
+  min_word_size?: integer
+  only_longest_match?: boolean
+  word_list?: string[]
+  word_list_path?: string
 }
 
 export interface AnalysisConditionTokenFilter extends AnalysisTokenFilterBase {
@@ -3459,18 +3460,28 @@ export interface AnalysisDelimitedPayloadTokenFilter extends AnalysisTokenFilter
   encoding: AnalysisDelimitedPayloadEncoding
 }
 
+export interface AnalysisDictionaryDecompounderTokenFilter extends AnalysisCompoundWordTokenFilterBase {
+  type: 'dictionary_decompounder'
+}
+
+export interface AnalysisDutchAnalyzer {
+  type: 'dutch'
+  stopwords?: AnalysisStopWords
+}
+
 export type AnalysisEdgeNGramSide = 'front' | 'back'
 
 export interface AnalysisEdgeNGramTokenFilter extends AnalysisTokenFilterBase {
   type: 'edge_ngram'
   max_gram: integer
   min_gram: integer
-  side: AnalysisEdgeNGramSide
+  side?: AnalysisEdgeNGramSide
+  preserve_original?: boolean
 }
 
 export interface AnalysisEdgeNGramTokenizer extends AnalysisTokenizerBase {
   type: 'edge_ngram'
-  custom_token_chars: string
+  custom_token_chars?: string
   max_gram: integer
   min_gram: integer
   token_chars: AnalysisTokenChar[]
@@ -3484,12 +3495,12 @@ export interface AnalysisElisionTokenFilter extends AnalysisTokenFilterBase {
 
 export interface AnalysisFingerprintAnalyzer {
   type: 'fingerprint'
-  version: VersionString
+  version?: VersionString
   max_output_size: integer
   preserve_original: boolean
   separator: string
-  stopwords: AnalysisStopWords
-  stopwords_path: string
+  stopwords?: AnalysisStopWords
+  stopwords_path?: string
 }
 
 export interface AnalysisFingerprintTokenFilter extends AnalysisTokenFilterBase {
@@ -3520,9 +3531,61 @@ export interface AnalysisIcuAnalyzer {
   mode: AnalysisIcuNormalizationMode
 }
 
+export type AnalysisIcuCollationAlternate = 'shifted' | 'non-ignorable'
+
+export type AnalysisIcuCollationCaseFirst = 'lower' | 'upper'
+
+export type AnalysisIcuCollationDecomposition = 'no' | 'identical'
+
+export type AnalysisIcuCollationStrength = 'primary' | 'secondary' | 'tertiary' | 'quaternary' | 'identical'
+
+export interface AnalysisIcuCollationTokenFilter extends AnalysisTokenFilterBase {
+  type: 'icu_collation'
+  alternate: AnalysisIcuCollationAlternate
+  caseFirst: AnalysisIcuCollationCaseFirst
+  caseLevel: boolean
+  country: string
+  decomposition: AnalysisIcuCollationDecomposition
+  hiraganaQuaternaryMode: boolean
+  language: string
+  numeric: boolean
+  strength: AnalysisIcuCollationStrength
+  variableTop?: string
+  variant: string
+}
+
+export interface AnalysisIcuFoldingTokenFilter extends AnalysisTokenFilterBase {
+  type: 'icu_folding'
+  unicode_set_filter: string
+}
+
+export interface AnalysisIcuNormalizationCharFilter extends AnalysisCharFilterBase {
+  type: 'icu_normalizer'
+  mode?: AnalysisIcuNormalizationMode
+  name?: AnalysisIcuNormalizationType
+}
+
 export type AnalysisIcuNormalizationMode = 'decompose' | 'compose'
 
+export interface AnalysisIcuNormalizationTokenFilter extends AnalysisTokenFilterBase {
+  type: 'icu_normalizer'
+  name: AnalysisIcuNormalizationType
+}
+
 export type AnalysisIcuNormalizationType = 'nfc' | 'nfkc' | 'nfkc_cf'
+
+export interface AnalysisIcuTokenizer extends AnalysisTokenizerBase {
+  type: 'icu_tokenizer'
+  rule_files: string
+}
+
+export type AnalysisIcuTransformDirection = 'forward' | 'reverse'
+
+export interface AnalysisIcuTransformTokenFilter extends AnalysisTokenFilterBase {
+  type: 'icu_transform'
+  dir: AnalysisIcuTransformDirection
+  id: string
+}
 
 export interface AnalysisKStemTokenFilter extends AnalysisTokenFilterBase {
   type: 'kstem'
@@ -3532,28 +3595,28 @@ export type AnalysisKeepTypesMode = 'include' | 'exclude'
 
 export interface AnalysisKeepTypesTokenFilter extends AnalysisTokenFilterBase {
   type: 'keep_types'
-  mode: AnalysisKeepTypesMode
-  types: string[]
+  mode?: AnalysisKeepTypesMode
+  types?: string[]
 }
 
 export interface AnalysisKeepWordsTokenFilter extends AnalysisTokenFilterBase {
   type: 'keep'
-  keep_words: string[]
-  keep_words_case: boolean
-  keep_words_path: string
+  keep_words?: string[]
+  keep_words_case?: boolean
+  keep_words_path?: string
 }
 
 export interface AnalysisKeywordAnalyzer {
   type: 'keyword'
-  version: VersionString
+  version?: VersionString
 }
 
 export interface AnalysisKeywordMarkerTokenFilter extends AnalysisTokenFilterBase {
   type: 'keyword_marker'
-  ignore_case: boolean
-  keywords: string[]
-  keywords_path: string
-  keywords_pattern: string
+  ignore_case?: boolean
+  keywords?: string[]
+  keywords_path?: string
+  keywords_pattern?: string
 }
 
 export interface AnalysisKeywordTokenizer extends AnalysisTokenizerBase {
@@ -3565,6 +3628,12 @@ export interface AnalysisKuromojiAnalyzer {
   type: 'kuromoji'
   mode: AnalysisKuromojiTokenizationMode
   user_dictionary?: string
+}
+
+export interface AnalysisKuromojiIterationMarkCharFilter extends AnalysisCharFilterBase {
+  type: 'kuromoji_iteration_mark'
+  normalize_kana: boolean
+  normalize_kanji: boolean
 }
 
 export interface AnalysisKuromojiPartOfSpeechTokenFilter extends AnalysisTokenFilterBase {
@@ -3586,23 +3655,24 @@ export type AnalysisKuromojiTokenizationMode = 'normal' | 'search' | 'extended'
 
 export interface AnalysisKuromojiTokenizer extends AnalysisTokenizerBase {
   type: 'kuromoji_tokenizer'
-  discard_punctuation: boolean
+  discard_punctuation?: boolean
   mode: AnalysisKuromojiTokenizationMode
-  nbest_cost: integer
-  nbest_examples: string
-  user_dictionary: string
-  user_dictionary_rules: string[]
+  nbest_cost?: integer
+  nbest_examples?: string
+  user_dictionary?: string
+  user_dictionary_rules?: string[]
+  discard_compound_token?: boolean
 }
 
 export type AnalysisLanguage = 'Arabic' | 'Armenian' | 'Basque' | 'Brazilian' | 'Bulgarian' | 'Catalan' | 'Chinese' | 'Cjk' | 'Czech' | 'Danish' | 'Dutch' | 'English' | 'Estonian' | 'Finnish' | 'French' | 'Galician' | 'German' | 'Greek' | 'Hindi' | 'Hungarian' | 'Indonesian' | 'Irish' | 'Italian' | 'Latvian' | 'Norwegian' | 'Persian' | 'Portuguese' | 'Romanian' | 'Russian' | 'Sorani' | 'Spanish' | 'Swedish' | 'Turkish' | 'Thai'
 
 export interface AnalysisLanguageAnalyzer {
   type: 'language'
-  version: VersionString
+  version?: VersionString
   language: AnalysisLanguage
   stem_exclusion: string[]
-  stopwords: AnalysisStopWords
-  stopwords_path: string
+  stopwords?: AnalysisStopWords
+  stopwords_path?: string
 }
 
 export interface AnalysisLengthTokenFilter extends AnalysisTokenFilterBase {
@@ -3627,7 +3697,7 @@ export interface AnalysisLowercaseNormalizer {
 
 export interface AnalysisLowercaseTokenFilter extends AnalysisTokenFilterBase {
   type: 'lowercase'
-  language: string
+  language?: string
 }
 
 export interface AnalysisLowercaseTokenizer extends AnalysisTokenizerBase {
@@ -3648,13 +3718,14 @@ export interface AnalysisMultiplexerTokenFilter extends AnalysisTokenFilterBase 
 
 export interface AnalysisNGramTokenFilter extends AnalysisTokenFilterBase {
   type: 'ngram'
-  max_gram: integer
-  min_gram: integer
+  max_gram?: integer
+  min_gram?: integer
+  preserve_original?: boolean
 }
 
 export interface AnalysisNGramTokenizer extends AnalysisTokenizerBase {
   type: 'ngram'
-  custom_token_chars: string
+  custom_token_chars?: string
   max_gram: integer
   min_gram: integer
   token_chars: AnalysisTokenChar[]
@@ -3662,10 +3733,10 @@ export interface AnalysisNGramTokenizer extends AnalysisTokenizerBase {
 
 export interface AnalysisNoriAnalyzer {
   type: 'nori'
-  version: VersionString
-  decompound_mode: AnalysisNoriDecompoundMode
-  stoptags: string[]
-  user_dictionary: string
+  version?: VersionString
+  decompound_mode?: AnalysisNoriDecompoundMode
+  stoptags?: string[]
+  user_dictionary?: string
 }
 
 export type AnalysisNoriDecompoundMode = 'discard' | 'none' | 'mixed'
@@ -3677,10 +3748,10 @@ export interface AnalysisNoriPartOfSpeechTokenFilter extends AnalysisTokenFilter
 
 export interface AnalysisNoriTokenizer extends AnalysisTokenizerBase {
   type: 'nori_tokenizer'
-  decompound_mode: AnalysisNoriDecompoundMode
-  discard_punctuation: boolean
-  user_dictionary: string
-  user_dictionary_rules: string[]
+  decompound_mode?: AnalysisNoriDecompoundMode
+  discard_punctuation?: boolean
+  user_dictionary?: string
+  user_dictionary_rules?: string[]
 }
 
 export type AnalysisNormalizer = AnalysisLowercaseNormalizer | AnalysisCustomNormalizer
@@ -3696,11 +3767,11 @@ export interface AnalysisPathHierarchyTokenizer extends AnalysisTokenizerBase {
 
 export interface AnalysisPatternAnalyzer {
   type: 'pattern'
-  version: VersionString
-  flags: string
-  lowercase: boolean
+  version?: VersionString
+  flags?: string
+  lowercase?: boolean
   pattern: string
-  stopwords: AnalysisStopWords
+  stopwords?: AnalysisStopWords
 }
 
 export interface AnalysisPatternCaptureTokenFilter extends AnalysisTokenFilterBase {
@@ -3709,11 +3780,43 @@ export interface AnalysisPatternCaptureTokenFilter extends AnalysisTokenFilterBa
   preserve_original: boolean
 }
 
+export interface AnalysisPatternReplaceCharFilter extends AnalysisCharFilterBase {
+  type: 'pattern_replace'
+  flags: string
+  pattern: string
+  replacement: string
+}
+
 export interface AnalysisPatternReplaceTokenFilter extends AnalysisTokenFilterBase {
   type: 'pattern_replace'
   flags: string
   pattern: string
   replacement: string
+}
+
+export interface AnalysisPatternTokenizer extends AnalysisTokenizerBase {
+  type: 'pattern'
+  flags: string
+  group: integer
+  pattern: string
+}
+
+export type AnalysisPhoneticEncoder = 'metaphone' | 'double_metaphone' | 'soundex' | 'refined_soundex' | 'caverphone1' | 'caverphone2' | 'cologne' | 'nysiis' | 'koelnerphonetik' | 'haasephonetik' | 'beider_morse' | 'daitch_mokotoff'
+
+export type AnalysisPhoneticLanguage = 'any' | 'common' | 'cyrillic' | 'english' | 'french' | 'german' | 'hebrew' | 'hungarian' | 'polish' | 'romanian' | 'russian' | 'spanish'
+
+export type AnalysisPhoneticNameType = 'generic' | 'ashkenazi' | 'sephardic'
+
+export type AnalysisPhoneticRuleType = 'approx' | 'exact'
+
+export interface AnalysisPhoneticTokenFilter extends AnalysisTokenFilterBase {
+  type: 'phonetic'
+  encoder: AnalysisPhoneticEncoder
+  languageset: AnalysisPhoneticLanguage[]
+  max_code_len?: integer
+  name_type: AnalysisPhoneticNameType
+  replace?: boolean
+  rule_type: AnalysisPhoneticRuleType
 }
 
 export interface AnalysisPorterStemTokenFilter extends AnalysisTokenFilterBase {
@@ -3735,17 +3838,24 @@ export interface AnalysisReverseTokenFilter extends AnalysisTokenFilterBase {
 
 export interface AnalysisShingleTokenFilter extends AnalysisTokenFilterBase {
   type: 'shingle'
-  filler_token: string
-  max_shingle_size: integer
-  min_shingle_size: integer
-  output_unigrams: boolean
-  output_unigrams_if_no_shingles: boolean
-  token_separator: string
+  filler_token?: string
+  max_shingle_size?: integer | string
+  min_shingle_size?: integer | string
+  output_unigrams?: boolean
+  output_unigrams_if_no_shingles?: boolean
+  token_separator?: string
 }
 
 export interface AnalysisSimpleAnalyzer {
   type: 'simple'
-  version: VersionString
+  version?: VersionString
+}
+
+export interface AnalysisSnowballAnalyzer {
+  type: 'snowball'
+  version?: VersionString
+  language: AnalysisSnowballLanguage
+  stopwords?: AnalysisStopWords
 }
 
 export type AnalysisSnowballLanguage = 'Armenian' | 'Basque' | 'Catalan' | 'Danish' | 'Dutch' | 'English' | 'Finnish' | 'French' | 'German' | 'German2' | 'Hungarian' | 'Italian' | 'Kp' | 'Lovins' | 'Norwegian' | 'Porter' | 'Portuguese' | 'Romanian' | 'Russian' | 'Spanish' | 'Swedish' | 'Turkish'
@@ -3757,19 +3867,19 @@ export interface AnalysisSnowballTokenFilter extends AnalysisTokenFilterBase {
 
 export interface AnalysisStandardAnalyzer {
   type: 'standard'
-  max_token_length: integer
-  stopwords: AnalysisStopWords
+  max_token_length?: integer
+  stopwords?: AnalysisStopWords
 }
 
 export interface AnalysisStandardTokenizer extends AnalysisTokenizerBase {
   type: 'standard'
-  max_token_length: integer
+  max_token_length?: integer
 }
 
 export interface AnalysisStemmerOverrideTokenFilter extends AnalysisTokenFilterBase {
   type: 'stemmer_override'
-  rules: string[]
-  rules_path: string
+  rules?: string[]
+  rules_path?: string
 }
 
 export interface AnalysisStemmerTokenFilter extends AnalysisTokenFilterBase {
@@ -3779,9 +3889,9 @@ export interface AnalysisStemmerTokenFilter extends AnalysisTokenFilterBase {
 
 export interface AnalysisStopAnalyzer {
   type: 'stop'
-  version: VersionString
-  stopwords: AnalysisStopWords
-  stopwords_path: string
+  version?: VersionString
+  stopwords?: AnalysisStopWords
+  stopwords_path?: string
 }
 
 export interface AnalysisStopTokenFilter extends AnalysisTokenFilterBase {
@@ -3798,13 +3908,13 @@ export type AnalysisSynonymFormat = 'solr' | 'wordnet'
 
 export interface AnalysisSynonymGraphTokenFilter extends AnalysisTokenFilterBase {
   type: 'synonym_graph'
-  expand: boolean
-  format: AnalysisSynonymFormat
-  lenient: boolean
-  synonyms: string[]
-  synonyms_path: string
-  tokenizer: string
-  updateable: boolean
+  expand?: boolean
+  format?: AnalysisSynonymFormat
+  lenient?: boolean
+  synonyms?: string[]
+  synonyms_path?: string
+  tokenizer?: string
+  updateable?: boolean
 }
 
 export interface AnalysisSynonymTokenFilter extends AnalysisTokenFilterBase {
@@ -3812,7 +3922,7 @@ export interface AnalysisSynonymTokenFilter extends AnalysisTokenFilterBase {
   expand?: boolean
   format?: AnalysisSynonymFormat
   lenient?: boolean
-  synonyms: string[]
+  synonyms?: string[]
   synonyms_path?: string
   tokenizer?: string
   updateable?: boolean
@@ -3820,13 +3930,13 @@ export interface AnalysisSynonymTokenFilter extends AnalysisTokenFilterBase {
 
 export type AnalysisTokenChar = 'letter' | 'digit' | 'whitespace' | 'punctuation' | 'symbol' | 'custom'
 
-export type AnalysisTokenFilter = AnalysisAsciiFoldingTokenFilter | AnalysisCommonGramsTokenFilter | AnalysisConditionTokenFilter | AnalysisDelimitedPayloadTokenFilter | AnalysisEdgeNGramTokenFilter | AnalysisElisionTokenFilter | AnalysisFingerprintTokenFilter | AnalysisHunspellTokenFilter | AnalysisHyphenationDecompounderTokenFilter | AnalysisKeepTypesTokenFilter | AnalysisKeepWordsTokenFilter | AnalysisKeywordMarkerTokenFilter | AnalysisKStemTokenFilter | AnalysisLengthTokenFilter | AnalysisLimitTokenCountTokenFilter | AnalysisLowercaseTokenFilter | AnalysisMultiplexerTokenFilter | AnalysisNGramTokenFilter | AnalysisNoriPartOfSpeechTokenFilter | AnalysisPatternCaptureTokenFilter | AnalysisPatternReplaceTokenFilter | AnalysisPorterStemTokenFilter | AnalysisPredicateTokenFilter | AnalysisRemoveDuplicatesTokenFilter | AnalysisReverseTokenFilter | AnalysisShingleTokenFilter | AnalysisSnowballTokenFilter | AnalysisStemmerOverrideTokenFilter | AnalysisStemmerTokenFilter | AnalysisStopTokenFilter | AnalysisSynonymGraphTokenFilter | AnalysisSynonymTokenFilter | AnalysisTrimTokenFilter | AnalysisTruncateTokenFilter | AnalysisUniqueTokenFilter | AnalysisUppercaseTokenFilter | AnalysisWordDelimiterGraphTokenFilter | AnalysisWordDelimiterTokenFilter | AnalysisKuromojiStemmerTokenFilter | AnalysisKuromojiReadingFormTokenFilter | AnalysisKuromojiPartOfSpeechTokenFilter
+export type AnalysisTokenFilter = AnalysisAsciiFoldingTokenFilter | AnalysisCommonGramsTokenFilter | AnalysisConditionTokenFilter | AnalysisDelimitedPayloadTokenFilter | AnalysisEdgeNGramTokenFilter | AnalysisElisionTokenFilter | AnalysisFingerprintTokenFilter | AnalysisHunspellTokenFilter | AnalysisHyphenationDecompounderTokenFilter | AnalysisKeepTypesTokenFilter | AnalysisKeepWordsTokenFilter | AnalysisKeywordMarkerTokenFilter | AnalysisKStemTokenFilter | AnalysisLengthTokenFilter | AnalysisLimitTokenCountTokenFilter | AnalysisLowercaseTokenFilter | AnalysisMultiplexerTokenFilter | AnalysisNGramTokenFilter | AnalysisNoriPartOfSpeechTokenFilter | AnalysisPatternCaptureTokenFilter | AnalysisPatternReplaceTokenFilter | AnalysisPorterStemTokenFilter | AnalysisPredicateTokenFilter | AnalysisRemoveDuplicatesTokenFilter | AnalysisReverseTokenFilter | AnalysisShingleTokenFilter | AnalysisSnowballTokenFilter | AnalysisStemmerOverrideTokenFilter | AnalysisStemmerTokenFilter | AnalysisStopTokenFilter | AnalysisSynonymGraphTokenFilter | AnalysisSynonymTokenFilter | AnalysisTrimTokenFilter | AnalysisTruncateTokenFilter | AnalysisUniqueTokenFilter | AnalysisUppercaseTokenFilter | AnalysisWordDelimiterGraphTokenFilter | AnalysisWordDelimiterTokenFilter | AnalysisKuromojiStemmerTokenFilter | AnalysisKuromojiReadingFormTokenFilter | AnalysisKuromojiPartOfSpeechTokenFilter | AnalysisIcuTokenizer | AnalysisIcuCollationTokenFilter | AnalysisIcuFoldingTokenFilter | AnalysisIcuNormalizationTokenFilter | AnalysisIcuTransformTokenFilter | AnalysisPhoneticTokenFilter | AnalysisDictionaryDecompounderTokenFilter
 
 export interface AnalysisTokenFilterBase {
   version?: VersionString
 }
 
-export type AnalysisTokenizer = AnalysisCharGroupTokenizer | AnalysisEdgeNGramTokenizer | AnalysisKeywordTokenizer | AnalysisLetterTokenizer | AnalysisLowercaseTokenizer | AnalysisNGramTokenizer | AnalysisNoriTokenizer | AnalysisPathHierarchyTokenizer | AnalysisStandardTokenizer | AnalysisUaxEmailUrlTokenizer | AnalysisWhitespaceTokenizer | AnalysisKuromojiTokenizer
+export type AnalysisTokenizer = AnalysisCharGroupTokenizer | AnalysisEdgeNGramTokenizer | AnalysisKeywordTokenizer | AnalysisLetterTokenizer | AnalysisLowercaseTokenizer | AnalysisNGramTokenizer | AnalysisNoriTokenizer | AnalysisPathHierarchyTokenizer | AnalysisStandardTokenizer | AnalysisUaxEmailUrlTokenizer | AnalysisWhitespaceTokenizer | AnalysisKuromojiTokenizer | AnalysisPatternTokenizer | AnalysisIcuTokenizer
 
 export interface AnalysisTokenizerBase {
   version?: VersionString
@@ -3843,12 +3953,12 @@ export interface AnalysisTruncateTokenFilter extends AnalysisTokenFilterBase {
 
 export interface AnalysisUaxEmailUrlTokenizer extends AnalysisTokenizerBase {
   type: 'uax_url_email'
-  max_token_length: integer
+  max_token_length?: integer
 }
 
 export interface AnalysisUniqueTokenFilter extends AnalysisTokenFilterBase {
   type: 'unique'
-  only_on_same_position: boolean
+  only_on_same_position?: boolean
 }
 
 export interface AnalysisUppercaseTokenFilter extends AnalysisTokenFilterBase {
@@ -3857,47 +3967,48 @@ export interface AnalysisUppercaseTokenFilter extends AnalysisTokenFilterBase {
 
 export interface AnalysisWhitespaceAnalyzer {
   type: 'whitespace'
-  version: VersionString
+  version?: VersionString
 }
 
 export interface AnalysisWhitespaceTokenizer extends AnalysisTokenizerBase {
   type: 'whitespace'
-  max_token_length: integer
+  max_token_length?: integer
 }
 
 export interface AnalysisWordDelimiterGraphTokenFilter extends AnalysisTokenFilterBase {
   type: 'word_delimiter_graph'
-  adjust_offsets: boolean
-  catenate_all: boolean
-  catenate_numbers: boolean
-  catenate_words: boolean
-  generate_number_parts: boolean
-  generate_word_parts: boolean
-  preserve_original: boolean
-  protected_words: string[]
-  protected_words_path: string
-  split_on_case_change: boolean
-  split_on_numerics: boolean
-  stem_english_possessive: boolean
-  type_table: string[]
-  type_table_path: string
+  adjust_offsets?: boolean
+  catenate_all?: boolean
+  catenate_numbers?: boolean
+  catenate_words?: boolean
+  generate_number_parts?: boolean
+  generate_word_parts?: boolean
+  ignore_keywords?: boolean
+  preserve_original?: boolean
+  protected_words?: string[]
+  protected_words_path?: string
+  split_on_case_change?: boolean
+  split_on_numerics?: boolean
+  stem_english_possessive?: boolean
+  type_table?: string[]
+  type_table_path?: string
 }
 
 export interface AnalysisWordDelimiterTokenFilter extends AnalysisTokenFilterBase {
   type: 'word_delimiter'
-  catenate_all: boolean
-  catenate_numbers: boolean
-  catenate_words: boolean
-  generate_number_parts: boolean
-  generate_word_parts: boolean
-  preserve_original: boolean
-  protected_words: string[]
-  protected_words_path: string
-  split_on_case_change: boolean
-  split_on_numerics: boolean
-  stem_english_possessive: boolean
-  type_table: string[]
-  type_table_path: string
+  catenate_all?: boolean
+  catenate_numbers?: boolean
+  catenate_words?: boolean
+  generate_number_parts?: boolean
+  generate_word_parts?: boolean
+  preserve_original?: boolean
+  protected_words?: string[]
+  protected_words_path?: string
+  split_on_case_change?: boolean
+  split_on_numerics?: boolean
+  stem_english_possessive?: boolean
+  type_table?: string[]
+  type_table_path?: string
 }
 
 export interface MappingAggregateMetricDoubleProperty extends MappingPropertyBase {
@@ -3977,6 +4088,7 @@ export interface MappingDateProperty extends MappingDocValuesPropertyBase {
   index?: boolean
   null_value?: DateString
   precision_step?: integer
+  locale?: string
   type: 'date'
 }
 
@@ -3985,9 +4097,18 @@ export interface MappingDateRangeProperty extends MappingRangePropertyBase {
   type: 'date_range'
 }
 
+export interface MappingDenseVectorIndexOptions {
+  type: string
+  m: integer
+  ef_construction: integer
+}
+
 export interface MappingDenseVectorProperty extends MappingPropertyBase {
   type: 'dense_vector'
   dims: integer
+  similarity?: string
+  index?: boolean
+  index_options?: MappingDenseVectorIndexOptions
 }
 
 export type MappingDocValuesProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDateProperty | MappingDateNanosProperty | MappingKeywordProperty | MappingNumberProperty | MappingRangeProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingCompletionProperty | MappingGenericProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingShapeProperty | MappingTokenCountProperty | MappingVersionProperty | MappingWildcardProperty | MappingPointProperty
@@ -4141,6 +4262,7 @@ export interface MappingKeywordProperty extends MappingDocValuesPropertyBase {
   norms?: boolean
   null_value?: string
   split_queries_on_whitespace?: boolean
+  time_series_dimension?: boolean
   type: 'keyword'
 }
 
@@ -4171,6 +4293,7 @@ export type MappingNumberProperty = MappingFloatNumberProperty | MappingHalfFloa
 export interface MappingNumberPropertyBase extends MappingDocValuesPropertyBase {
   index?: boolean
   ignore_malformed?: boolean
+  time_series_metric?: MappingTimeSeriesMetricType
 }
 
 export interface MappingObjectProperty extends MappingCorePropertyBase {
@@ -4315,6 +4438,8 @@ export interface MappingTextProperty extends MappingCorePropertyBase {
   term_vector?: MappingTermVectorOption
   type: 'text'
 }
+
+export type MappingTimeSeriesMetricType = 'gauge' | 'counter' | 'summary' | 'histogram'
 
 export interface MappingTokenCountProperty extends MappingDocValuesPropertyBase {
   analyzer?: string
@@ -8465,6 +8590,13 @@ export interface IndicesIndexRoutingRebalance {
 
 export type IndicesIndexRoutingRebalanceOptions = 'all' | 'primaries' | 'replicas' | 'none'
 
+export interface IndicesIndexSegmentSort {
+  field: Fields
+  order: IndicesSegmentSortOrder | IndicesSegmentSortOrder[]
+  mode?: IndicesSegmentSortMode
+  missing?: IndicesSegmentSortMissing
+}
+
 export interface IndicesIndexSettingBlocks {
   read_only?: boolean
   read_only_allow_delete?: boolean
@@ -8474,6 +8606,15 @@ export interface IndicesIndexSettingBlocks {
 }
 
 export interface IndicesIndexSettings {
+  index?: IndicesIndexSettings
+  mode?: string
+  'index.mode'?: string
+  routing_path?: string[]
+  'index.routing_path'?: string[]
+  soft_deletes?: IndicesSoftDeletes
+  'index.soft_deletes'?: IndicesSoftDeletes
+  sort?: IndicesIndexSegmentSort
+  'index.sort'?: IndicesIndexSegmentSort
   number_of_shards?: integer | string
   'index.number_of_shards'?: integer | string
   number_of_replicas?: integer | string
@@ -8484,8 +8625,8 @@ export interface IndicesIndexSettings {
   'index.check_on_startup'?: IndicesIndexCheckOnStartup
   codec?: string
   'index.codec'?: string
-  routing_partition_size?: integer | string
-  'index.routing_partition_size'?: integer | string
+  routing_partition_size?: integer
+  'index.routing_partition_size'?: integer
   'soft_deletes.retention_lease.period'?: Time
   'index.soft_deletes.retention_lease.period'?: Time
   load_fixed_bitset_filters_eagerly?: boolean
@@ -8494,6 +8635,8 @@ export interface IndicesIndexSettings {
   'index.hidden'?: boolean | string
   auto_expand_replicas?: string
   'index.auto_expand_replicas'?: string
+  'index.merge.scheduler.max_thread_count'?: integer
+  'index.merge.scheduler.max_thread_count'?: integer
   'search.idle.after'?: Time
   'index.search.idle.after'?: Time
   refresh_interval?: Time
@@ -8562,12 +8705,15 @@ export interface IndicesIndexSettings {
   'index.max_slices_per_scroll'?: integer
   'translog.durability'?: string
   'index.translog.durability'?: string
+  'translog.flush_threshold_size'?: string
+  'index.translog.flush_threshold_size'?: string
   'query_string.lenient'?: boolean | string
   'index.query_string.lenient'?: boolean | string
   priority?: integer | string
   'index.priority'?: integer | string
   top_metrics_max_size?: integer
   analysis?: IndicesIndexSettingsAnalysis
+  'index.analysis'?: IndicesIndexSettingsAnalysis
   settings?: IndicesIndexSettings
 }
 
@@ -8576,6 +8722,7 @@ export interface IndicesIndexSettingsAnalysis {
   char_filter?: Record<string, AnalysisCharFilter>
   filter?: Record<string, AnalysisTokenFilter>
   normalizer?: Record<string, AnalysisNormalizer>
+  tokenizer?: Record<string, AnalysisTokenizer>
 }
 
 export interface IndicesIndexSettingsLifecycle {
@@ -8606,6 +8753,16 @@ export type IndicesNumericFielddataFormat = 'array' | 'disabled'
 export interface IndicesOverlappingIndexTemplate {
   name: Name
   index_patterns?: IndexName[]
+}
+
+export type IndicesSegmentSortMissing = '_last' | '_first'
+
+export type IndicesSegmentSortMode = 'min' | 'max'
+
+export type IndicesSegmentSortOrder = 'asc' | 'desc'
+
+export interface IndicesSoftDeletes {
+  enabled: boolean
 }
 
 export interface IndicesStringFielddata {
@@ -8773,9 +8930,9 @@ export interface IndicesCreateRequest extends RequestBase {
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
   body?: {
-    aliases?: Record<IndexName, IndicesAlias>
-    mappings?: Record<string, MappingTypeMapping> | MappingTypeMapping
-    settings?: Record<string, any>
+    aliases?: Record<Name, IndicesAlias>
+    mappings?: MappingTypeMapping
+    settings?: IndicesIndexSettings
   }
 }
 

--- a/specification/_types/analysis/analyzers.ts
+++ b/specification/_types/analysis/analyzers.ts
@@ -36,73 +36,78 @@ export class CustomAnalyzer {
 
 export class FingerprintAnalyzer {
   type: 'fingerprint'
-  version: VersionString
+  version?: VersionString
   max_output_size: integer
   preserve_original: boolean
   separator: string
-  stopwords: StopWords
-  stopwords_path: string
+  stopwords?: StopWords
+  stopwords_path?: string
 }
 
 export class KeywordAnalyzer {
   type: 'keyword'
-  version: VersionString
+  version?: VersionString
 }
 
 export class LanguageAnalyzer {
   type: 'language'
-  version: VersionString
+  version?: VersionString
   language: Language
   stem_exclusion: string[]
-  stopwords: StopWords
-  stopwords_path: string
+  stopwords?: StopWords
+  stopwords_path?: string
+}
+
+export class DutchAnalyzer {
+  type: 'dutch'
+  stopwords?: StopWords
 }
 
 export class NoriAnalyzer {
   type: 'nori'
-  version: VersionString
-  decompound_mode: NoriDecompoundMode
-  stoptags: string[]
-  user_dictionary: string
+  version?: VersionString
+  decompound_mode?: NoriDecompoundMode
+  stoptags?: string[]
+  user_dictionary?: string
 }
 
 export class PatternAnalyzer {
   type: 'pattern'
-  version: VersionString
-  flags: string
-  lowercase: boolean
+  version?: VersionString
+  flags?: string
+  lowercase?: boolean
   pattern: string
-  stopwords: StopWords
+  stopwords?: StopWords
 }
 
 export class SimpleAnalyzer {
   type: 'simple'
-  version: VersionString
+  version?: VersionString
 }
 
 export class SnowballAnalyzer {
   type: 'snowball'
-  version: VersionString
+  version?: VersionString
   language: SnowballLanguage
-  stopwords: StopWords
+  stopwords?: StopWords
 }
 
 export class StandardAnalyzer {
   type: 'standard'
-  max_token_length: integer
-  stopwords: StopWords
+  max_token_length?: integer
+  stopwords?: StopWords
 }
 
 export class StopAnalyzer {
   type: 'stop'
-  version: VersionString
-  stopwords: StopWords
-  stopwords_path: string
+  version?: VersionString
+  stopwords?: StopWords
+  stopwords_path?: string
 }
 
 export class WhitespaceAnalyzer {
   type: 'whitespace'
-  version: VersionString
+  version?: VersionString
 }
 
 /** @variants internal tag='type' */
@@ -119,3 +124,5 @@ export type Analyzer =
   | WhitespaceAnalyzer
   | IcuAnalyzer
   | KuromojiAnalyzer
+  | SnowballAnalyzer
+  | DutchAnalyzer

--- a/specification/_types/analysis/icu-plugin.ts
+++ b/specification/_types/analysis/icu-plugin.ts
@@ -22,21 +22,25 @@ import { TokenizerBase } from './tokenizers'
 import { TokenFilterBase } from './token_filters'
 
 export class IcuTransformTokenFilter extends TokenFilterBase {
+  type: 'icu_transform'
   dir: IcuTransformDirection
   id: string
 }
 
 export class IcuTokenizer extends TokenizerBase {
+  type: 'icu_tokenizer'
   rule_files: string
 }
 
 export class IcuNormalizationTokenFilter extends TokenFilterBase {
+  type: 'icu_normalizer'
   name: IcuNormalizationType
 }
 
 export class IcuNormalizationCharFilter extends CharFilterBase {
-  mode: IcuNormalizationMode
-  name: IcuNormalizationType
+  type: 'icu_normalizer'
+  mode?: IcuNormalizationMode
+  name?: IcuNormalizationType
 }
 
 export class IcuFoldingTokenFilter extends TokenFilterBase {
@@ -55,7 +59,7 @@ export class IcuCollationTokenFilter extends TokenFilterBase {
   language: string
   numeric: boolean
   strength: IcuCollationStrength
-  variableTop: string
+  variableTop?: string
   variant: string
 }
 

--- a/specification/_types/analysis/kuromoji-plugin.ts
+++ b/specification/_types/analysis/kuromoji-plugin.ts
@@ -57,10 +57,11 @@ export enum KuromojiTokenizationMode {
 
 export class KuromojiTokenizer extends TokenizerBase {
   type: 'kuromoji_tokenizer'
-  discard_punctuation: boolean
+  discard_punctuation?: boolean
   mode: KuromojiTokenizationMode
-  nbest_cost: integer
-  nbest_examples: string
-  user_dictionary: string
-  user_dictionary_rules: string[]
+  nbest_cost?: integer
+  nbest_examples?: string
+  user_dictionary?: string
+  user_dictionary_rules?: string[]
+  discard_compound_token?: boolean
 }

--- a/specification/_types/analysis/phonetic-plugin.ts
+++ b/specification/_types/analysis/phonetic-plugin.ts
@@ -65,8 +65,8 @@ export class PhoneticTokenFilter extends TokenFilterBase {
   type: 'phonetic'
   encoder: PhoneticEncoder
   languageset: PhoneticLanguage[]
-  max_code_len: integer
+  max_code_len?: integer
   name_type: PhoneticNameType
-  replace: boolean
+  replace?: boolean
   rule_type: PhoneticRuleType
 }

--- a/specification/_types/analysis/token_filters.ts
+++ b/specification/_types/analysis/token_filters.ts
@@ -27,19 +27,27 @@ import {
   KuromojiReadingFormTokenFilter,
   KuromojiPartOfSpeechTokenFilter
 } from './kuromoji-plugin'
+import {
+  IcuCollationTokenFilter,
+  IcuFoldingTokenFilter,
+  IcuNormalizationTokenFilter,
+  IcuTokenizer,
+  IcuTransformTokenFilter
+} from './icu-plugin'
+import { PhoneticTokenFilter } from './phonetic-plugin'
 
 export class TokenFilterBase {
   version?: VersionString
 }
 
 export class CompoundWordTokenFilterBase extends TokenFilterBase {
-  hyphenation_patterns_path: string
-  max_subword_size: integer
-  min_subword_size: integer
-  min_word_size: integer
-  only_longest_match: boolean
-  word_list: string[]
-  word_list_path: string
+  hyphenation_patterns_path?: string
+  max_subword_size?: integer
+  min_subword_size?: integer
+  min_word_size?: integer
+  only_longest_match?: boolean
+  word_list?: string[]
+  word_list_path?: string
 }
 
 export class DictionaryDecompounderTokenFilter extends CompoundWordTokenFilterBase {
@@ -71,17 +79,18 @@ export class EdgeNGramTokenFilter extends TokenFilterBase {
   type: 'edge_ngram'
   max_gram: integer
   min_gram: integer
-  side: EdgeNGramSide
+  side?: EdgeNGramSide
+  preserve_original?: boolean
 }
 
 export class ShingleTokenFilter extends TokenFilterBase {
   type: 'shingle'
-  filler_token: string
-  max_shingle_size: integer
-  min_shingle_size: integer
-  output_unigrams: boolean
-  output_unigrams_if_no_shingles: boolean
-  token_separator: string
+  filler_token?: string
+  max_shingle_size?: integer | string // TODO: should be only int
+  min_shingle_size?: integer | string // TODO: should be only int
+  output_unigrams?: boolean
+  output_unigrams_if_no_shingles?: boolean
+  token_separator?: string
 }
 
 export class StopTokenFilter extends TokenFilterBase {
@@ -99,13 +108,13 @@ export enum SynonymFormat {
 
 export class SynonymGraphTokenFilter extends TokenFilterBase {
   type: 'synonym_graph'
-  expand: boolean
-  format: SynonymFormat
-  lenient: boolean
-  synonyms: string[]
-  synonyms_path: string
-  tokenizer: string
-  updateable: boolean
+  expand?: boolean
+  format?: SynonymFormat
+  lenient?: boolean
+  synonyms?: string[]
+  synonyms_path?: string
+  tokenizer?: string
+  updateable?: boolean
 }
 
 export class SynonymTokenFilter extends TokenFilterBase {
@@ -113,7 +122,7 @@ export class SynonymTokenFilter extends TokenFilterBase {
   expand?: boolean
   format?: SynonymFormat
   lenient?: boolean
-  synonyms: string[]
+  synonyms?: string[]
   synonyms_path?: string
   tokenizer?: string
   updateable?: boolean
@@ -121,37 +130,38 @@ export class SynonymTokenFilter extends TokenFilterBase {
 
 export class WordDelimiterTokenFilter extends TokenFilterBase {
   type: 'word_delimiter'
-  catenate_all: boolean
-  catenate_numbers: boolean
-  catenate_words: boolean
-  generate_number_parts: boolean
-  generate_word_parts: boolean
-  preserve_original: boolean
-  protected_words: string[]
-  protected_words_path: string
-  split_on_case_change: boolean
-  split_on_numerics: boolean
-  stem_english_possessive: boolean
-  type_table: string[]
-  type_table_path: string
+  catenate_all?: boolean
+  catenate_numbers?: boolean
+  catenate_words?: boolean
+  generate_number_parts?: boolean
+  generate_word_parts?: boolean
+  preserve_original?: boolean
+  protected_words?: string[]
+  protected_words_path?: string
+  split_on_case_change?: boolean
+  split_on_numerics?: boolean
+  stem_english_possessive?: boolean
+  type_table?: string[]
+  type_table_path?: string
 }
 
 export class WordDelimiterGraphTokenFilter extends TokenFilterBase {
   type: 'word_delimiter_graph'
-  adjust_offsets: boolean
-  catenate_all: boolean
-  catenate_numbers: boolean
-  catenate_words: boolean
-  generate_number_parts: boolean
-  generate_word_parts: boolean
-  preserve_original: boolean
-  protected_words: string[]
-  protected_words_path: string
-  split_on_case_change: boolean
-  split_on_numerics: boolean
-  stem_english_possessive: boolean
-  type_table: string[]
-  type_table_path: string
+  adjust_offsets?: boolean
+  catenate_all?: boolean
+  catenate_numbers?: boolean
+  catenate_words?: boolean
+  generate_number_parts?: boolean
+  generate_word_parts?: boolean
+  ignore_keywords?: boolean
+  preserve_original?: boolean
+  protected_words?: string[]
+  protected_words_path?: string
+  split_on_case_change?: boolean
+  split_on_numerics?: boolean
+  stem_english_possessive?: boolean
+  type_table?: string[]
+  type_table_path?: string
 }
 
 export class AsciiFoldingTokenFilter extends TokenFilterBase {
@@ -161,10 +171,10 @@ export class AsciiFoldingTokenFilter extends TokenFilterBase {
 
 export class CommonGramsTokenFilter extends TokenFilterBase {
   type: 'common_grams'
-  common_words: string[]
-  common_words_path: string
-  ignore_case: boolean
-  query_mode: boolean
+  common_words?: string[]
+  common_words_path?: string
+  ignore_case?: boolean
+  query_mode?: boolean
 }
 
 export class ConditionTokenFilter extends TokenFilterBase {
@@ -205,23 +215,23 @@ export enum KeepTypesMode {
 
 export class KeepTypesTokenFilter extends TokenFilterBase {
   type: 'keep_types'
-  mode: KeepTypesMode
-  types: string[]
+  mode?: KeepTypesMode
+  types?: string[]
 }
 
 export class KeepWordsTokenFilter extends TokenFilterBase {
   type: 'keep'
-  keep_words: string[]
-  keep_words_case: boolean
-  keep_words_path: string
+  keep_words?: string[]
+  keep_words_case?: boolean
+  keep_words_path?: string
 }
 
 export class KeywordMarkerTokenFilter extends TokenFilterBase {
   type: 'keyword_marker'
-  ignore_case: boolean
-  keywords: string[]
-  keywords_path: string
-  keywords_pattern: string
+  ignore_case?: boolean
+  keywords?: string[]
+  keywords_path?: string
+  keywords_pattern?: string
 }
 
 export class KStemTokenFilter extends TokenFilterBase {
@@ -242,7 +252,7 @@ export class LimitTokenCountTokenFilter extends TokenFilterBase {
 
 export class LowercaseTokenFilter extends TokenFilterBase {
   type: 'lowercase'
-  language: string
+  language?: string
 }
 
 export class MultiplexerTokenFilter extends TokenFilterBase {
@@ -253,8 +263,9 @@ export class MultiplexerTokenFilter extends TokenFilterBase {
 
 export class NGramTokenFilter extends TokenFilterBase {
   type: 'ngram'
-  max_gram: integer
-  min_gram: integer
+  max_gram?: integer
+  min_gram?: integer
+  preserve_original?: boolean
 }
 
 export class NoriPartOfSpeechTokenFilter extends TokenFilterBase {
@@ -299,8 +310,8 @@ export class SnowballTokenFilter extends TokenFilterBase {
 
 export class StemmerOverrideTokenFilter extends TokenFilterBase {
   type: 'stemmer_override'
-  rules: string[]
-  rules_path: string
+  rules?: string[]
+  rules_path?: string
 }
 
 export class StemmerTokenFilter extends TokenFilterBase {
@@ -319,7 +330,7 @@ export class TruncateTokenFilter extends TokenFilterBase {
 
 export class UniqueTokenFilter extends TokenFilterBase {
   type: 'unique'
-  only_on_same_position: boolean
+  only_on_same_position?: boolean
 }
 
 export class UppercaseTokenFilter extends TokenFilterBase {
@@ -370,3 +381,10 @@ export type TokenFilter =
   | KuromojiStemmerTokenFilter
   | KuromojiReadingFormTokenFilter
   | KuromojiPartOfSpeechTokenFilter
+  | IcuTokenizer
+  | IcuCollationTokenFilter
+  | IcuFoldingTokenFilter
+  | IcuNormalizationTokenFilter
+  | IcuTransformTokenFilter
+  | PhoneticTokenFilter
+  | DictionaryDecompounderTokenFilter

--- a/specification/_types/analysis/tokenizers.ts
+++ b/specification/_types/analysis/tokenizers.ts
@@ -19,6 +19,7 @@
 
 import { VersionString } from '@_types/common'
 import { integer } from '@_types/Numeric'
+import { IcuTokenizer } from './icu-plugin'
 import { KuromojiTokenizer } from './kuromoji-plugin'
 
 export class TokenizerBase {
@@ -27,7 +28,7 @@ export class TokenizerBase {
 
 export class EdgeNGramTokenizer extends TokenizerBase {
   type: 'edge_ngram'
-  custom_token_chars: string
+  custom_token_chars?: string
   max_gram: integer
   min_gram: integer
   token_chars: TokenChar[]
@@ -35,7 +36,7 @@ export class EdgeNGramTokenizer extends TokenizerBase {
 
 export class NGramTokenizer extends TokenizerBase {
   type: 'ngram'
-  custom_token_chars: string
+  custom_token_chars?: string
   max_gram: integer
   min_gram: integer
   token_chars: TokenChar[]
@@ -53,6 +54,7 @@ export enum TokenChar {
 export class CharGroupTokenizer extends TokenizerBase {
   type: 'char_group'
   tokenize_on_chars: string[]
+  max_token_length?: integer
 }
 
 export class KeywordTokenizer extends TokenizerBase {
@@ -76,10 +78,10 @@ export enum NoriDecompoundMode {
 
 export class NoriTokenizer extends TokenizerBase {
   type: 'nori_tokenizer'
-  decompound_mode: NoriDecompoundMode
-  discard_punctuation: boolean
-  user_dictionary: string
-  user_dictionary_rules: string[]
+  decompound_mode?: NoriDecompoundMode
+  discard_punctuation?: boolean
+  user_dictionary?: string
+  user_dictionary_rules?: string[]
 }
 
 export class PathHierarchyTokenizer extends TokenizerBase {
@@ -100,17 +102,17 @@ export class PatternTokenizer extends TokenizerBase {
 
 export class StandardTokenizer extends TokenizerBase {
   type: 'standard'
-  max_token_length: integer
+  max_token_length?: integer
 }
 
 export class UaxEmailUrlTokenizer extends TokenizerBase {
   type: 'uax_url_email'
-  max_token_length: integer
+  max_token_length?: integer
 }
 
 export class WhitespaceTokenizer extends TokenizerBase {
   type: 'whitespace'
-  max_token_length: integer
+  max_token_length?: integer
 }
 
 /** @variants internal tag='type' */
@@ -127,3 +129,5 @@ export type Tokenizer =
   | UaxEmailUrlTokenizer
   | WhitespaceTokenizer
   | KuromojiTokenizer
+  | PatternTokenizer
+  | IcuTokenizer

--- a/specification/_types/mapping/DenseVectorIndexOptions.ts
+++ b/specification/_types/mapping/DenseVectorIndexOptions.ts
@@ -17,35 +17,10 @@
  * under the License.
  */
 
-import { VersionString } from '@_types/common'
-import { IcuNormalizationCharFilter } from './icu-plugin'
-import { KuromojiIterationMarkCharFilter } from './kuromoji-plugin'
+import { integer } from '@_types/Numeric'
 
-export class CharFilterBase {
-  version?: VersionString
-}
-
-/** @variants internal tag='type' */
-export type CharFilter =
-  | HtmlStripCharFilter
-  | MappingCharFilter
-  | PatternReplaceCharFilter
-  | IcuNormalizationCharFilter
-  | KuromojiIterationMarkCharFilter
-
-export class HtmlStripCharFilter extends CharFilterBase {
-  type: 'html_strip'
-}
-
-export class MappingCharFilter extends CharFilterBase {
-  type: 'mapping'
-  mappings: string[]
-  mappings_path?: string
-}
-
-export class PatternReplaceCharFilter extends CharFilterBase {
-  type: 'pattern_replace'
-  flags: string
-  pattern: string
-  replacement: string
+export class DenseVectorIndexOptions {
+  type: string
+  m: integer
+  ef_construction: integer
 }

--- a/specification/_types/mapping/TimeSeriesMetricType.ts
+++ b/specification/_types/mapping/TimeSeriesMetricType.ts
@@ -17,35 +17,9 @@
  * under the License.
  */
 
-import { VersionString } from '@_types/common'
-import { IcuNormalizationCharFilter } from './icu-plugin'
-import { KuromojiIterationMarkCharFilter } from './kuromoji-plugin'
-
-export class CharFilterBase {
-  version?: VersionString
-}
-
-/** @variants internal tag='type' */
-export type CharFilter =
-  | HtmlStripCharFilter
-  | MappingCharFilter
-  | PatternReplaceCharFilter
-  | IcuNormalizationCharFilter
-  | KuromojiIterationMarkCharFilter
-
-export class HtmlStripCharFilter extends CharFilterBase {
-  type: 'html_strip'
-}
-
-export class MappingCharFilter extends CharFilterBase {
-  type: 'mapping'
-  mappings: string[]
-  mappings_path?: string
-}
-
-export class PatternReplaceCharFilter extends CharFilterBase {
-  type: 'pattern_replace'
-  flags: string
-  pattern: string
-  replacement: string
+export enum TimeSeriesMetricType {
+  gauge,
+  counter,
+  summary,
+  histogram
 }

--- a/specification/_types/mapping/complex.ts
+++ b/specification/_types/mapping/complex.ts
@@ -19,6 +19,7 @@
 
 import { double, integer } from '@_types/Numeric'
 import { CorePropertyBase, IndexOptions } from './core'
+import { DenseVectorIndexOptions } from './DenseVectorIndexOptions'
 import { PropertyBase } from './Property'
 
 export class FlattenedProperty extends PropertyBase {
@@ -49,6 +50,9 @@ export class ObjectProperty extends CorePropertyBase {
 export class DenseVectorProperty extends PropertyBase {
   type: 'dense_vector'
   dims: integer
+  similarity?: string
+  index?: boolean
+  index_options?: DenseVectorIndexOptions
 }
 
 export class AggregateMetricDoubleProperty extends PropertyBase {

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -49,6 +49,7 @@ import {
 } from './specialized'
 import { TermVectorOption } from './TermVectorOption'
 import { Script } from '@_types/Scripting'
+import { TimeSeriesMetricType } from './TimeSeriesMetricType'
 
 export class CorePropertyBase extends PropertyBase {
   copy_to?: Fields
@@ -107,6 +108,7 @@ export class DateProperty extends DocValuesPropertyBase {
   index?: boolean
   null_value?: DateString
   precision_step?: integer
+  locale?: string
   type: 'date'
 }
 
@@ -134,12 +136,15 @@ export class KeywordProperty extends DocValuesPropertyBase {
   norms?: boolean
   null_value?: string
   split_queries_on_whitespace?: boolean
+  /** [experimental] For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false. */
+  time_series_dimension?: boolean
   type: 'keyword'
 }
 
 export class NumberPropertyBase extends DocValuesPropertyBase {
   index?: boolean
   ignore_malformed?: boolean
+  time_series_metric?: TimeSeriesMetricType
 }
 
 export enum OnScriptError {

--- a/specification/indices/_types/IndexSegmentSort.ts
+++ b/specification/indices/_types/IndexSegmentSort.ts
@@ -17,35 +17,28 @@
  * under the License.
  */
 
-import { VersionString } from '@_types/common'
-import { IcuNormalizationCharFilter } from './icu-plugin'
-import { KuromojiIterationMarkCharFilter } from './kuromoji-plugin'
+import { Fields } from '@_types/common'
 
-export class CharFilterBase {
-  version?: VersionString
+export class IndexSegmentSort {
+  field: Fields
+  order: SegmentSortOrder | SegmentSortOrder[]
+  mode?: SegmentSortMode
+  missing?: SegmentSortMissing
 }
 
-/** @variants internal tag='type' */
-export type CharFilter =
-  | HtmlStripCharFilter
-  | MappingCharFilter
-  | PatternReplaceCharFilter
-  | IcuNormalizationCharFilter
-  | KuromojiIterationMarkCharFilter
-
-export class HtmlStripCharFilter extends CharFilterBase {
-  type: 'html_strip'
+export enum SegmentSortOrder {
+  asc,
+  desc
 }
 
-export class MappingCharFilter extends CharFilterBase {
-  type: 'mapping'
-  mappings: string[]
-  mappings_path?: string
+export enum SegmentSortMode {
+  min,
+  max
 }
 
-export class PatternReplaceCharFilter extends CharFilterBase {
-  type: 'pattern_replace'
-  flags: string
-  pattern: string
-  replacement: string
+export enum SegmentSortMissing {
+  /** @codegen_name last */
+  '_last',
+  /** @codegen_name first */
+  '_first'
 }

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -26,11 +26,34 @@ import { Normalizer } from '@_types/analysis/normalizers'
 import { Name, PipelineName, Uuid, VersionString } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { DateString, Time } from '@_types/Time'
+import { Tokenizer } from '@_types/analysis/tokenizers'
+import { IndexSegmentSort } from './IndexSegmentSort'
+
+export class SoftDeletes {
+  enabled: boolean
+}
 
 /**
  * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-modules.html#index-modules-settings
  */
 export class IndexSettings {
+  index?: IndexSettings
+  /**
+   * @aliases index.mode
+   */
+  mode?: string
+  /**
+   * @aliases index.routing_path
+   */
+  routing_path?: string[]
+  /**
+   * @aliases index.soft_deletes
+   */
+  soft_deletes?: SoftDeletes
+  /**
+   * @aliases index.sort
+   */
+  sort?: IndexSegmentSort
   /**
    * @server_default 1
    * @aliases index.number_of_shards
@@ -59,7 +82,8 @@ export class IndexSettings {
    * @server_default 1
    * @aliases index.routing_partition_size
    */
-  routing_partition_size?: integer | string // TODO: should be int only
+  routing_partition_size?: integer
+
   /**
    * @aliases index.soft_deletes.retention_lease.period
    * @server_default 12h
@@ -80,6 +104,10 @@ export class IndexSettings {
    * @server_default false
    */
   auto_expand_replicas?: string
+  /**
+   * @aliases index.merge.scheduler.max_thread_count
+   */
+  'index.merge.scheduler.max_thread_count'?: integer
   /**
    * @aliases index.search.idle.after
    * @server_default 30s
@@ -223,6 +251,10 @@ export class IndexSettings {
    */
   'translog.durability'?: string
   /**
+   * @aliases index.translog.flush_threshold_size
+   */
+  'translog.flush_threshold_size'?: string
+  /**
    * @aliases index.query_string.lenient
    */
   'query_string.lenient'?: boolean | string // TODO: should be bool only
@@ -233,6 +265,9 @@ export class IndexSettings {
 
   top_metrics_max_size?: integer
 
+  /**
+   * @aliases index.analysis
+   */
   analysis?: IndexSettingsAnalysis
   settings?: IndexSettings
 }
@@ -264,4 +299,5 @@ export class IndexSettingsAnalysis {
   char_filter?: Dictionary<string, CharFilter>
   filter?: Dictionary<string, TokenFilter>
   normalizer?: Dictionary<string, Normalizer>
+  tokenizer?: Dictionary<string, Tokenizer>
 }

--- a/specification/indices/create/IndicesCreateRequest.ts
+++ b/specification/indices/create/IndicesCreateRequest.ts
@@ -18,10 +18,10 @@
  */
 
 import { Alias } from '@indices/_types/Alias'
+import { IndexSettings } from '@indices/_types/IndexSettings'
 import { Dictionary } from '@spec_utils/Dictionary'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RequestBase } from '@_types/Base'
-import { IndexName, WaitForActiveShards } from '@_types/common'
+import { IndexName, Name, WaitForActiveShards } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { Time } from '@_types/Time'
 
@@ -43,15 +43,15 @@ export interface Request extends RequestBase {
   }
   body: {
     /* Aliases for the index. */
-    aliases?: Dictionary<IndexName, Alias>
+    aliases?: Dictionary<Name, Alias>
     /**
      * Mapping for fields in the index. If specified, this mapping can include:
      * - Field names
      * - Field data types
      * - Mapping parameters
      */
-    mappings?: Dictionary<string, TypeMapping> | TypeMapping
+    mappings?: TypeMapping
     /* Configuration options for the index. */
-    settings?: Dictionary<string, UserDefinedValue>
+    settings?: IndexSettings
   }
 }


### PR DESCRIPTION
This PR updates the create index request type so that it uses just a mapping instance rather than a union, and uses the `IndexSettings` type for settings. This required many tokenizers, char filters, token filters and analyzers to be fixed up due to failing tests.

The remaining failures are due to the flattened, vs object style settings and we will deal with those separately as discussed with @delvedor.

This will require a manual cherry-pick backport once merged since some changes fix additions for the new time series properties which won't be needed for 7.x.