### PR TITLE
Adds descriptions and missing parameters for start and stop datafeed APIs

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -7839,6 +7839,11 @@
       "description": "Starts one or more datafeeds.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html",
       "name": "ml.start_datafeed",
+      "privileges": {
+        "cluster": [
+          "manage_ml"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "ml.start_datafeed"
@@ -7925,6 +7930,11 @@
       "description": "Stops one or more datafeeds.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html",
       "name": "ml.stop_datafeed",
+      "privileges": {
+        "cluster": [
+          "manage_ml"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "ml.stop_datafeed"
@@ -121352,6 +121362,7 @@
         "kind": "properties",
         "properties": [
           {
+            "description": "The time that the datafeed should end, which can be specified by using one of the following formats:\n\n* ISO 8601 format with milliseconds, for example `2017-01-22T06:00:00.000Z`\n* ISO 8601 format without milliseconds, for example `2017-01-22T06:00:00+00:00`\n* Milliseconds since the epoch, for example `1485061200000`\n\nDate-time arguments using either of the ISO 8601 formats must have a time zone designator, where `Z` is accepted\nas an abbreviation for UTC time. When a URL is expected (for example, in browsers), the `+` used in time zone\ndesignators must be encoded as `%2B`.\nThe end time value is exclusive. If you do not specify an end time, the datafeed\nruns continuously.",
             "name": "end",
             "required": false,
             "type": {
@@ -121363,6 +121374,7 @@
             }
           },
           {
+            "description": "The time that the datafeed should begin, which can be specified by using the same formats as the `end` parameter.\nThis value is inclusive.\nIf you do not specify a start time and the datafeed is associated with a new anomaly detection job, the analysis\nstarts from the earliest time for which data is available.\n If restart a stopped datafeed and you specify a start value that is earlier than the timestamp of the latest\nprocessed record, the datafeed continues from 1 millisecond after the timestamp of the latest processed record.",
             "name": "start",
             "required": false,
             "type": {
@@ -121374,6 +121386,7 @@
             }
           },
           {
+            "description": "Specifies the amount of time to wait until a datafeed starts.",
             "name": "timeout",
             "required": false,
             "serverDefault": "20s",
@@ -121387,7 +121400,7 @@
           }
         ]
       },
-      "description": "Starts one or more datafeeds.",
+      "description": "Starts one or more datafeeds.\n\nA datafeed must be started in order to retrieve data from Elasticsearch. A datafeed can be started and stopped\nmultiple times throughout its lifecycle.\n\nBefore you can start a datafeed, the anomaly detection job must be open. Otherwise, an error occurs.\n\nIf you restart a stopped datafeed, it continues processing input data from the next millisecond after it was stopped.\nIf new data was indexed for that exact millisecond between stopping and starting, it will be ignored.\n\nWhen Elasticsearch security features are enabled, your datafeed remembers which roles the last user to create or\nupdate it had at the time of creation or update and runs the query using those same roles. If you provided secondary\nauthorization headers when you created or updated the datafeed, those credentials are used instead.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -121401,7 +121414,7 @@
       },
       "path": [
         {
-          "description": "The ID of the datafeed to start",
+          "description": "A numerical character string that uniquely identifies the datafeed. This identifier can contain lowercase\nalphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric\ncharacters.",
           "name": "datafeed_id",
           "required": true,
           "type": {
@@ -121415,9 +121428,34 @@
       ],
       "query": [
         {
-          "description": "The start time from where the datafeed should begin",
+          "description": "The time that the datafeed should end, which can be specified by using one of the following formats:\n\n* ISO 8601 format with milliseconds, for example `2017-01-22T06:00:00.000Z`\n* ISO 8601 format without milliseconds, for example `2017-01-22T06:00:00+00:00`\n* Milliseconds since the epoch, for example `1485061200000`\n\nDate-time arguments using either of the ISO 8601 formats must have a time zone designator, where `Z` is accepted\nas an abbreviation for UTC time. When a URL is expected (for example, in browsers), the `+` used in time zone\ndesignators must be encoded as `%2B`.\nThe end time value is exclusive. If you do not specify an end time, the datafeed\nruns continuously.",
+          "name": "end",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The time that the datafeed should begin, which can be specified by using the same formats as the `end` parameter.\nThis value is inclusive.\nIf you do not specify a start time and the datafeed is associated with a new anomaly detection job, the analysis\nstarts from the earliest time for which data is available.\nIf you restart a stopped datafeed and specify a start value that is earlier than the timestamp of the latest\nprocessed record, the datafeed continues from 1 millisecond after the timestamp of the latest processed record.",
           "name": "start",
           "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Specifies the amount of time to wait until a datafeed starts.",
+          "name": "timeout",
+          "required": false,
+          "serverDefault": "20s",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -121433,6 +121471,7 @@
         "kind": "properties",
         "properties": [
           {
+            "description": "The ID of the node that the datafeed was started on. If the datafeed is allowed to open lazily and has not yet\nbeen assigned to a node, this value is an empty string.",
             "name": "node",
             "required": true,
             "type": {
@@ -121444,6 +121483,7 @@
             }
           },
           {
+            "description": "For a successful response, this value is always `true`. On failure, an exception is returned instead.",
             "name": "started",
             "required": true,
             "type": {
@@ -121568,6 +121608,20 @@
         "kind": "properties",
         "properties": [
           {
+            "description": "Specifies what to do when the request:\n\n* Contains wildcard expressions and there are no datafeeds that match.\n* Contains the `_all` string or no identifiers and there are no matches.\n* Contains wildcard expressions and there are only partial matches.\n\nIf `true`, the API returns an empty datafeeds array when there are no matches and the subset of results when\nthere are partial matches. If `false`, the API returns a 404 status code when there are no matches or only\npartial matches.",
+            "name": "allow_no_match",
+            "required": false,
+            "serverDefault": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "If `true`, the datafeed is stopped forcefully.",
             "name": "force",
             "required": false,
             "serverDefault": false,
@@ -121580,6 +121634,7 @@
             }
           },
           {
+            "description": "Specifies the amount of time to wait until a datafeed stops.",
             "name": "timeout",
             "required": false,
             "serverDefault": "20s",
@@ -121593,7 +121648,7 @@
           }
         ]
       },
-      "description": "Stops one or more datafeeds.",
+      "description": "Stops one or more datafeeds.\nA datafeed that is stopped ceases to retrieve data from Elasticsearch. A datafeed can be started and stopped\nmultiple times throughout its lifecycle.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -121607,7 +121662,7 @@
       },
       "path": [
         {
-          "description": "The ID of the datafeed to stop",
+          "description": "Identifier for the datafeed. You can stop multiple datafeeds in a single API request by using a comma-separated\nlist of datafeeds or a wildcard expression. You can close all datafeeds by using `_all` or by specifying `*` as\nthe identifier.",
           "name": "datafeed_id",
           "required": true,
           "type": {
@@ -121621,7 +121676,7 @@
       ],
       "query": [
         {
-          "description": "Whether to ignore if a wildcard expression matches no datafeeds. (This includes `_all` string or when no datafeeds have been specified)",
+          "description": "Specifies what to do when the request:\n\n* Contains wildcard expressions and there are no datafeeds that match.\n* Contains the `_all` string or no identifiers and there are no matches.\n* Contains wildcard expressions and there are only partial matches.\n\nIf `true`, the API returns an empty datafeeds array when there are no matches and the subset of results when\nthere are partial matches. If `false`, the API returns a 404 status code when there are no matches or only\npartial matches.",
           "name": "allow_no_match",
           "required": false,
           "serverDefault": true,
@@ -121634,7 +121689,7 @@
           }
         },
         {
-          "description": "True if the datafeed should be forcefully stopped.",
+          "description": "If `true`, the datafeed is stopped forcefully.",
           "name": "force",
           "required": false,
           "serverDefault": false,
@@ -121643,6 +121698,19 @@
             "type": {
               "name": "boolean",
               "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "Specifies the amount of time to wait until a datafeed stops.",
+          "name": "timeout",
+          "required": false,
+          "serverDefault": "20s",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
             }
           }
         }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -121362,7 +121362,7 @@
         "kind": "properties",
         "properties": [
           {
-            "description": "The time that the datafeed should end, which can be specified by using one of the following formats:\n\n* ISO 8601 format with milliseconds, for example `2017-01-22T06:00:00.000Z`\n* ISO 8601 format without milliseconds, for example `2017-01-22T06:00:00+00:00`\n* Milliseconds since the epoch, for example `1485061200000`\n\nDate-time arguments using either of the ISO 8601 formats must have a time zone designator, where `Z` is accepted\nas an abbreviation for UTC time. When a URL is expected (for example, in browsers), the `+` used in time zone\ndesignators must be encoded as `%2B`.\nThe end time value is exclusive. If you do not specify an end time, the datafeed\nruns continuously.",
+            "description": "Refer to the description for the `end` query parameter.",
             "name": "end",
             "required": false,
             "type": {
@@ -121374,7 +121374,7 @@
             }
           },
           {
-            "description": "The time that the datafeed should begin, which can be specified by using the same formats as the `end` parameter.\nThis value is inclusive.\nIf you do not specify a start time and the datafeed is associated with a new anomaly detection job, the analysis\nstarts from the earliest time for which data is available.\n If restart a stopped datafeed and you specify a start value that is earlier than the timestamp of the latest\nprocessed record, the datafeed continues from 1 millisecond after the timestamp of the latest processed record.",
+            "description": "Refer to the description for the `start` query parameter.",
             "name": "start",
             "required": false,
             "type": {
@@ -121386,7 +121386,7 @@
             }
           },
           {
-            "description": "Specifies the amount of time to wait until a datafeed starts.",
+            "description": "Refer to the description for the `timeout` query parameter.",
             "name": "timeout",
             "required": false,
             "serverDefault": "20s",
@@ -121608,7 +121608,7 @@
         "kind": "properties",
         "properties": [
           {
-            "description": "Specifies what to do when the request:\n\n* Contains wildcard expressions and there are no datafeeds that match.\n* Contains the `_all` string or no identifiers and there are no matches.\n* Contains wildcard expressions and there are only partial matches.\n\nIf `true`, the API returns an empty datafeeds array when there are no matches and the subset of results when\nthere are partial matches. If `false`, the API returns a 404 status code when there are no matches or only\npartial matches.",
+            "description": "Refer to the description for the `allow_no_match` query parameter.",
             "name": "allow_no_match",
             "required": false,
             "serverDefault": true,
@@ -121621,7 +121621,7 @@
             }
           },
           {
-            "description": "If `true`, the datafeed is stopped forcefully.",
+            "description": "Refer to the description for the `force` query parameter.",
             "name": "force",
             "required": false,
             "serverDefault": false,
@@ -121634,7 +121634,7 @@
             }
           },
           {
-            "description": "Specifies the amount of time to wait until a datafeed stops.",
+            "description": "Refer to the description for the `timeout` query parameter.",
             "name": "timeout",
             "required": false,
             "serverDefault": "20s",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1424,13 +1424,6 @@
       ],
       "response": []
     },
-    "ml.start_datafeed": {
-      "request": [
-        "Request: missing json spec query parameter 'end'",
-        "Request: missing json spec query parameter 'timeout'"
-      ],
-      "response": []
-    },
     "ml.start_trained_model_deployment": {
       "request": [
         "Missing request & response"
@@ -1439,8 +1432,7 @@
     },
     "ml.stop_datafeed": {
       "request": [
-        "Request: missing json spec query parameter 'allow_no_datafeeds'",
-        "Request: missing json spec query parameter 'timeout'"
+        "Request: missing json spec query parameter 'allow_no_datafeeds'"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12318,7 +12318,9 @@ export interface MlStartDataFrameAnalyticsResponse extends AcknowledgedResponseB
 
 export interface MlStartDatafeedRequest extends RequestBase {
   datafeed_id: Id
+  end?: Time
   start?: Time
+  timeout?: Time
   body?: {
     end?: Time
     start?: Time
@@ -12346,7 +12348,9 @@ export interface MlStopDatafeedRequest extends RequestBase {
   datafeed_id: Id
   allow_no_match?: boolean
   force?: boolean
+  timeout?: Time
   body?: {
+    allow_no_match?: boolean
     force?: boolean
     timeout?: Time
   }

--- a/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
+++ b/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
@@ -22,21 +22,89 @@ import { Id } from '@_types/common'
 import { Time } from '@_types/Time'
 
 /**
+ * Starts one or more datafeeds.
+ * 
+ * A datafeed must be started in order to retrieve data from Elasticsearch. A datafeed can be started and stopped
+ * multiple times throughout its lifecycle.
+ * 
+ * Before you can start a datafeed, the anomaly detection job must be open. Otherwise, an error occurs.
+ * 
+ * If you restart a stopped datafeed, it continues processing input data from the next millisecond after it was stopped.
+ * If new data was indexed for that exact millisecond between stopping and starting, it will be ignored.
+ * 
+ * When Elasticsearch security features are enabled, your datafeed remembers which roles the last user to create or
+ * update it had at the time of creation or update and runs the query using those same roles. If you provided secondary
+ * authorization headers when you created or updated the datafeed, those credentials are used instead.
  * @rest_spec_name ml.start_datafeed
  * @since 5.5.0
  * @stability stable
+ * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * A numerical character string that uniquely identifies the datafeed. This identifier can contain lowercase
+     * alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric
+     * characters.
+     */
     datafeed_id: Id
   }
   query_parameters: {
+    /**
+     * The time that the datafeed should end, which can be specified by using one of the following formats:
+     * 
+     * * ISO 8601 format with milliseconds, for example `2017-01-22T06:00:00.000Z`
+     * * ISO 8601 format without milliseconds, for example `2017-01-22T06:00:00+00:00`
+     * * Milliseconds since the epoch, for example `1485061200000`
+     * 
+     * Date-time arguments using either of the ISO 8601 formats must have a time zone designator, where `Z` is accepted
+     * as an abbreviation for UTC time. When a URL is expected (for example, in browsers), the `+` used in time zone
+     * designators must be encoded as `%2B`.
+     * The end time value is exclusive. If you do not specify an end time, the datafeed
+     * runs continuously.
+     */
+    end?: Time // default ""
+    /**
+     * The time that the datafeed should begin, which can be specified by using the same formats as the `end` parameter.
+     * This value is inclusive.
+     * If you do not specify a start time and the datafeed is associated with a new anomaly detection job, the analysis
+     * starts from the earliest time for which data is available.
+     * If you restart a stopped datafeed and specify a start value that is earlier than the timestamp of the latest
+     * processed record, the datafeed continues from 1 millisecond after the timestamp of the latest processed record.
+     */
     start?: Time // default ""
+    /**
+     * Specifies the amount of time to wait until a datafeed starts. 
+     * @server_default 20s */
+    timeout?: Time
   }
   body: {
+    /**
+     * The time that the datafeed should end, which can be specified by using one of the following formats:
+     * 
+     * * ISO 8601 format with milliseconds, for example `2017-01-22T06:00:00.000Z`
+     * * ISO 8601 format without milliseconds, for example `2017-01-22T06:00:00+00:00`
+     * * Milliseconds since the epoch, for example `1485061200000`
+     * 
+     * Date-time arguments using either of the ISO 8601 formats must have a time zone designator, where `Z` is accepted
+     * as an abbreviation for UTC time. When a URL is expected (for example, in browsers), the `+` used in time zone
+     * designators must be encoded as `%2B`.
+     * The end time value is exclusive. If you do not specify an end time, the datafeed
+     * runs continuously.
+     */
     end?: Time // default ""
+    /**
+     * The time that the datafeed should begin, which can be specified by using the same formats as the `end` parameter.
+     * This value is inclusive.
+     * If you do not specify a start time and the datafeed is associated with a new anomaly detection job, the analysis
+     * starts from the earliest time for which data is available.
+     *  If restart a stopped datafeed and you specify a start value that is earlier than the timestamp of the latest
+     * processed record, the datafeed continues from 1 millisecond after the timestamp of the latest processed record.
+     */
     start?: Time // default ""
-    /** @server_default 20s */
+    /**
+     * Specifies the amount of time to wait until a datafeed starts. 
+     * @server_default 20s */
     timeout?: Time
   }
 }

--- a/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
+++ b/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
@@ -79,31 +79,12 @@ export interface Request extends RequestBase {
     timeout?: Time
   }
   body: {
-    /**
-     * The time that the datafeed should end, which can be specified by using one of the following formats:
-     *
-     * * ISO 8601 format with milliseconds, for example `2017-01-22T06:00:00.000Z`
-     * * ISO 8601 format without milliseconds, for example `2017-01-22T06:00:00+00:00`
-     * * Milliseconds since the epoch, for example `1485061200000`
-     *
-     * Date-time arguments using either of the ISO 8601 formats must have a time zone designator, where `Z` is accepted
-     * as an abbreviation for UTC time. When a URL is expected (for example, in browsers), the `+` used in time zone
-     * designators must be encoded as `%2B`.
-     * The end time value is exclusive. If you do not specify an end time, the datafeed
-     * runs continuously.
-     */
+    /** Refer to the description for the `end` query parameter. */
     end?: Time // default ""
-    /**
-     * The time that the datafeed should begin, which can be specified by using the same formats as the `end` parameter.
-     * This value is inclusive.
-     * If you do not specify a start time and the datafeed is associated with a new anomaly detection job, the analysis
-     * starts from the earliest time for which data is available.
-     *  If restart a stopped datafeed and you specify a start value that is earlier than the timestamp of the latest
-     * processed record, the datafeed continues from 1 millisecond after the timestamp of the latest processed record.
-     */
+    /** Refer to the description for the `start` query parameter.  */
     start?: Time // default ""
     /**
-     * Specifies the amount of time to wait until a datafeed starts.
+     * Refer to the description for the `timeout` query parameter.
      * @server_default 20s */
     timeout?: Time
   }

--- a/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
+++ b/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
@@ -23,15 +23,15 @@ import { Time } from '@_types/Time'
 
 /**
  * Starts one or more datafeeds.
- * 
+ *
  * A datafeed must be started in order to retrieve data from Elasticsearch. A datafeed can be started and stopped
  * multiple times throughout its lifecycle.
- * 
+ *
  * Before you can start a datafeed, the anomaly detection job must be open. Otherwise, an error occurs.
- * 
+ *
  * If you restart a stopped datafeed, it continues processing input data from the next millisecond after it was stopped.
  * If new data was indexed for that exact millisecond between stopping and starting, it will be ignored.
- * 
+ *
  * When Elasticsearch security features are enabled, your datafeed remembers which roles the last user to create or
  * update it had at the time of creation or update and runs the query using those same roles. If you provided secondary
  * authorization headers when you created or updated the datafeed, those credentials are used instead.
@@ -52,11 +52,11 @@ export interface Request extends RequestBase {
   query_parameters: {
     /**
      * The time that the datafeed should end, which can be specified by using one of the following formats:
-     * 
+     *
      * * ISO 8601 format with milliseconds, for example `2017-01-22T06:00:00.000Z`
      * * ISO 8601 format without milliseconds, for example `2017-01-22T06:00:00+00:00`
      * * Milliseconds since the epoch, for example `1485061200000`
-     * 
+     *
      * Date-time arguments using either of the ISO 8601 formats must have a time zone designator, where `Z` is accepted
      * as an abbreviation for UTC time. When a URL is expected (for example, in browsers), the `+` used in time zone
      * designators must be encoded as `%2B`.
@@ -74,18 +74,18 @@ export interface Request extends RequestBase {
      */
     start?: Time // default ""
     /**
-     * Specifies the amount of time to wait until a datafeed starts. 
+     * Specifies the amount of time to wait until a datafeed starts.
      * @server_default 20s */
     timeout?: Time
   }
   body: {
     /**
      * The time that the datafeed should end, which can be specified by using one of the following formats:
-     * 
+     *
      * * ISO 8601 format with milliseconds, for example `2017-01-22T06:00:00.000Z`
      * * ISO 8601 format without milliseconds, for example `2017-01-22T06:00:00+00:00`
      * * Milliseconds since the epoch, for example `1485061200000`
-     * 
+     *
      * Date-time arguments using either of the ISO 8601 formats must have a time zone designator, where `Z` is accepted
      * as an abbreviation for UTC time. When a URL is expected (for example, in browsers), the `+` used in time zone
      * designators must be encoded as `%2B`.
@@ -103,7 +103,7 @@ export interface Request extends RequestBase {
      */
     start?: Time // default ""
     /**
-     * Specifies the amount of time to wait until a datafeed starts. 
+     * Specifies the amount of time to wait until a datafeed starts.
      * @server_default 20s */
     timeout?: Time
   }

--- a/specification/ml/start_datafeed/MlStartDatafeedResponse.ts
+++ b/specification/ml/start_datafeed/MlStartDatafeedResponse.ts
@@ -21,7 +21,14 @@ import { NodeIds } from '@_types/common'
 
 export class Response {
   body: {
+    /**
+     * The ID of the node that the datafeed was started on. If the datafeed is allowed to open lazily and has not yet
+     * been assigned to a node, this value is an empty string.
+     */
     node: NodeIds
+    /**
+     * For a successful response, this value is always `true`. On failure, an exception is returned instead.
+     */
     started: boolean
   }
 }

--- a/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
+++ b/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
@@ -42,18 +42,18 @@ export interface Request extends RequestBase {
   query_parameters: {
     /**
      * Specifies what to do when the request:
-     * 
+     *
      * * Contains wildcard expressions and there are no datafeeds that match.
      * * Contains the `_all` string or no identifiers and there are no matches.
      * * Contains wildcard expressions and there are only partial matches.
-     * 
+     *
      * If `true`, the API returns an empty datafeeds array when there are no matches and the subset of results when
      * there are partial matches. If `false`, the API returns a 404 status code when there are no matches or only
-     * partial matches. 
+     * partial matches.
      * @server_default true */
     allow_no_match?: boolean
     /**
-     * If `true`, the datafeed is stopped forcefully. 
+     * If `true`, the datafeed is stopped forcefully.
      * @server_default false */
     force?: boolean
     /**
@@ -64,18 +64,18 @@ export interface Request extends RequestBase {
   body: {
     /**
      * Specifies what to do when the request:
-     * 
+     *
      * * Contains wildcard expressions and there are no datafeeds that match.
      * * Contains the `_all` string or no identifiers and there are no matches.
      * * Contains wildcard expressions and there are only partial matches.
-     * 
+     *
      * If `true`, the API returns an empty datafeeds array when there are no matches and the subset of results when
      * there are partial matches. If `false`, the API returns a 404 status code when there are no matches or only
-     * partial matches. 
+     * partial matches.
      * @server_default true */
     allow_no_match?: boolean
     /**
-     * If `true`, the datafeed is stopped forcefully. 
+     * If `true`, the datafeed is stopped forcefully.
      * @server_default false */
     force?: boolean
     /**

--- a/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
+++ b/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
@@ -22,24 +22,65 @@ import { Id } from '@_types/common'
 import { Time } from '@_types/Time'
 
 /**
+ * Stops one or more datafeeds.
+ * A datafeed that is stopped ceases to retrieve data from Elasticsearch. A datafeed can be started and stopped
+ * multiple times throughout its lifecycle.
  * @rest_spec_name ml.stop_datafeed
  * @since 5.4.0
  * @stability stable
+ * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier for the datafeed. You can stop multiple datafeeds in a single API request by using a comma-separated
+     * list of datafeeds or a wildcard expression. You can close all datafeeds by using `_all` or by specifying `*` as
+     * the identifier.
+     */
     datafeed_id: Id
   }
   query_parameters: {
-    /** @server_default true */
+    /**
+     * Specifies what to do when the request:
+     * 
+     * * Contains wildcard expressions and there are no datafeeds that match.
+     * * Contains the `_all` string or no identifiers and there are no matches.
+     * * Contains wildcard expressions and there are only partial matches.
+     * 
+     * If `true`, the API returns an empty datafeeds array when there are no matches and the subset of results when
+     * there are partial matches. If `false`, the API returns a 404 status code when there are no matches or only
+     * partial matches. 
+     * @server_default true */
     allow_no_match?: boolean
-    /** @server_default false */
+    /**
+     * If `true`, the datafeed is stopped forcefully. 
+     * @server_default false */
     force?: boolean
+    /**
+     * Specifies the amount of time to wait until a datafeed stops.
+     *  @server_default 20s */
+    timeout?: Time
   }
   body: {
-    /** @server_default false */
+    /**
+     * Specifies what to do when the request:
+     * 
+     * * Contains wildcard expressions and there are no datafeeds that match.
+     * * Contains the `_all` string or no identifiers and there are no matches.
+     * * Contains wildcard expressions and there are only partial matches.
+     * 
+     * If `true`, the API returns an empty datafeeds array when there are no matches and the subset of results when
+     * there are partial matches. If `false`, the API returns a 404 status code when there are no matches or only
+     * partial matches. 
+     * @server_default true */
+    allow_no_match?: boolean
+    /**
+     * If `true`, the datafeed is stopped forcefully. 
+     * @server_default false */
     force?: boolean
-    /** @server_default 20s */
+    /**
+     * Specifies the amount of time to wait until a datafeed stops.
+     *  @server_default 20s */
     timeout?: Time
   }
 }

--- a/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
+++ b/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
@@ -63,23 +63,15 @@ export interface Request extends RequestBase {
   }
   body: {
     /**
-     * Specifies what to do when the request:
-     *
-     * * Contains wildcard expressions and there are no datafeeds that match.
-     * * Contains the `_all` string or no identifiers and there are no matches.
-     * * Contains wildcard expressions and there are only partial matches.
-     *
-     * If `true`, the API returns an empty datafeeds array when there are no matches and the subset of results when
-     * there are partial matches. If `false`, the API returns a 404 status code when there are no matches or only
-     * partial matches.
+     * Refer to the description for the `allow_no_match` query parameter.
      * @server_default true */
     allow_no_match?: boolean
     /**
-     * If `true`, the datafeed is stopped forcefully.
+     * Refer to the description for the `force` query parameter.
      * @server_default false */
     force?: boolean
     /**
-     * Specifies the amount of time to wait until a datafeed stops.
+     * Refer to the description for the `timeout` query parameter.
      *  @server_default 20s */
     timeout?: Time
   }


### PR DESCRIPTION
Relates to https://github.com/elastic/stack-docs/issues/1845

Uses descriptions from https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-start-datafeed.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-stop-datafeed.html

