### PR TITLE
Improve watcher.stats request

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -149478,6 +149478,9 @@
       "kind": "enum",
       "members": [
         {
+          "aliases": [
+            "all"
+          ],
           "name": "_all"
         },
         {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15557,7 +15557,7 @@ export interface WatcherStatsWatchRecordStats extends WatcherStatsWatchRecordQue
   watch_record_id: Id
 }
 
-export type WatcherStatsWatcherMetric = '_all' | 'queued_watches' | 'current_watches' | 'pending_watches'
+export type WatcherStatsWatcherMetric = '_all' | 'all' | 'queued_watches' | 'current_watches' | 'pending_watches'
 
 export interface WatcherStatsWatcherNodeStats {
   current_watches?: WatcherStatsWatchRecordStats[]

--- a/specification/watcher/stats/types.ts
+++ b/specification/watcher/stats/types.ts
@@ -39,6 +39,7 @@ export class WatcherNodeStats {
 }
 
 export enum WatcherMetric {
+  /** @aliases all */
   '_all' = 0,
   'queued_watches' = 1,
   'current_watches' = 2,


### PR DESCRIPTION
reduces the error from 4 to 3.

By casting  `"emit_stacktraces": "true"` to boolean in the upstream test `rest-spec-tests/platinum/watcher/stats/10_basic.yml`, we'll eliminate another error case.