### PR TITLE
Document CommonQueryParameters

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -153634,8 +153634,10 @@
       },
       "properties": [
         {
+          "description": "When set to `true` Elasticsearch will include the full stack trace of errors\nwhen they occur.",
           "name": "error_trace",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -153645,6 +153647,7 @@
           }
         },
         {
+          "description": "Comma-separated list of filters in dot notation which reduce the response\nreturned by Elasticsearch.",
           "name": "filter_path",
           "required": false,
           "type": {
@@ -153671,8 +153674,10 @@
           }
         },
         {
+          "description": "When set to `true` will return statistics in a format suitable for humans.\nFor example `\"exists_time\": \"1h\"` for humans and\n`\"eixsts_time_in_millis\": 3600000` for computers. When disabled the human\nreadable values will be omitted. This makes sense for responses being consumed\nonly by machines.",
           "name": "human",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -153682,23 +153687,14 @@
           }
         },
         {
+          "description": "If set to `true` the returned JSON will be \"pretty-formatted\". Only use\nthis option for debugging only.",
           "name": "pretty",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "source_query_string",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
               "namespace": "internal"
             }
           }
@@ -153714,8 +153710,10 @@
       },
       "properties": [
         {
+          "description": "Specifies the format to return the columnar data in, can be set to\n`text`, `json`, `cbor`, `yaml`, or `smile`.",
           "name": "format",
           "required": false,
+          "serverDefault": "text",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -153725,6 +153723,7 @@
           }
         },
         {
+          "description": "List of columns to appear in the response. Supports simple wildcards.",
           "name": "h",
           "required": false,
           "type": {
@@ -153736,8 +153735,10 @@
           }
         },
         {
+          "description": "When set to `true` will output available columns. This option\ncan't be combined with any other query string option.",
           "name": "help",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -153747,8 +153748,10 @@
           }
         },
         {
+          "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
           "name": "local",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -153758,8 +153761,10 @@
           }
         },
         {
+          "description": "Period to wait for a connection to the master node.",
           "name": "master_timeout",
           "required": false,
+          "serverDefault": "30s",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -153769,6 +153774,7 @@
           }
         },
         {
+          "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
           "name": "s",
           "required": false,
           "type": {
@@ -153783,8 +153789,10 @@
           }
         },
         {
+          "description": "When set to `true` will enable verbose output.",
           "name": "v",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16059,7 +16059,6 @@ export interface SpecUtilsCommonQueryParameters {
   filter_path?: string | string[]
   human?: boolean
   pretty?: boolean
-  source_query_string?: string
 }
 
 export interface SpecUtilsCommonCatQueryParameters {

--- a/specification/_spec_utils/behaviors.ts
+++ b/specification/_spec_utils/behaviors.ts
@@ -55,11 +55,32 @@ export interface AdditionalProperty<TKey, TValue> {}
  * @behavior Defines a common set of query parameters all API's support that alter the overall response.
  */
 export interface CommonQueryParameters {
+  /**
+   * When set to `true` Elasticsearch will include the full stack trace of errors
+   * when they occur.
+   * @server_default false
+   */
   error_trace?: boolean
+  /**
+   * Comma-separated list of filters in dot notation which reduce the response
+   * returned by Elasticsearch.
+   */
   filter_path?: string | string[]
+  /**
+   * When set to `true` will return statistics in a format suitable for humans.
+   * For example `"exists_time": "1h"` for humans and
+   * `"eixsts_time_in_millis": 3600000` for computers. When disabled the human
+   * readable values will be omitted. This makes sense for responses being consumed
+   * only by machines.
+   * @server_default false
+   */
   human?: boolean
+  /**
+   * If set to `true` the returned JSON will be "pretty-formatted". Only use
+   * this option for debugging only.
+   * @server_default false
+   */
   pretty?: boolean
-  source_query_string?: string
 }
 
 /**
@@ -68,12 +89,45 @@ export interface CommonQueryParameters {
  * @behavior Defines a common set of query parameters all Cat API's support that alter the overall response.
  */
 export interface CommonCatQueryParameters {
+  /**
+   * Specifies the format to return the columnar data in, can be set to
+   * `text`, `json`, `cbor`, `yaml`, or `smile`.
+   * @server_default text
+   */
   format?: string
+  /**
+   * List of columns to appear in the response. Supports simple wildcards.
+   */
   h?: Names
+  /**
+   * When set to `true` will output available columns. This option
+   * can't be combined with any other query string option.
+   * @server_default false
+   */
   help?: boolean
+  /**
+   * If `true`, the request computes the list of selected nodes from the
+   * local cluster state. If `false` the list of selected nodes are computed
+   * from the cluster state of the master node. In both cases the coordinating
+   * node will send requests for further information to each selected node.
+   * @server_default false
+   */
   local?: boolean
+  /**
+   * Period to wait for a connection to the master node.
+   * @server_default 30s
+   */
   master_timeout?: Time
+  /**
+   * List of columns that determine how the table should be sorted.
+   * Sorting defaults to ascending and can be changed by setting `:asc`
+   * or `:desc` as a suffix to the column name.
+   */
   s?: string[]
+  /**
+   * When set to `true` will enable verbose output.
+   * @server_default false
+   */
   v?: boolean
 }
 


### PR DESCRIPTION
Documented all the parameters defined in `CommonQueryParameters` and `CommonCatQueryParameters`.

I also found `source_query_string` which isn't an Elasticsearch parameter but is instead likely inherited from NEST and would've been translated into `?source=...` as a means of smuggling small request bodies for GET into the query string. I've removed this parameter in this PR.