### PR TITLE
Mark 'keep_alive' for 'open_point_in_time' API as required

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -19396,7 +19396,7 @@
         {
           "description": "Specific the time to live for the point in time",
           "name": "keep_alive",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -677,7 +677,7 @@ export interface MtermvectorsTermVectorsResult {
 
 export interface OpenPointInTimeRequest extends RequestBase {
   index: Indices
-  keep_alive?: Time
+  keep_alive: Time
 }
 
 export interface OpenPointInTimeResponse {

--- a/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
+++ b/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
@@ -31,6 +31,6 @@ export interface Request extends RequestBase {
     index: Indices
   }
   query_parameters: {
-    keep_alive?: Time
+    keep_alive: Time
   }
 }


### PR DESCRIPTION
The `keep_alive` parameter isn't documented as required/options in the docs, however trying to use the API without it [always produces an error](https://github.com/elastic/elasticsearch/blob/26c86871fc091900952e88e252c36fbfedf8d5fa/server/src/main/java/org/elasticsearch/action/search/OpenPointInTimeRequest.java#L104). I'm not sure if there are other query parameters that are required, if not this may be the first of it's kind!

Corresponding PR to the other API spec: https://github.com/elastic/elasticsearch/pull/80449