### PR TITLE
Adds missing query parameters in ML flush jobs API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -117505,7 +117505,7 @@
         "kind": "properties",
         "properties": [
           {
-            "description": "Specifies to advance to a particular time value. Results are generated\nand the model is updated for data from the specified time interval.",
+            "description": "Refer to the description for the `advance_time` query parameter.",
             "name": "advance_time",
             "required": false,
             "type": {
@@ -117517,7 +117517,7 @@
             }
           },
           {
-            "description": "If true, calculates the interim results for the most recent bucket or all\nbuckets within the latency period.",
+            "description": "Refer to the description for the `calc_interim` query parameter.",
             "name": "calc_interim",
             "required": false,
             "type": {
@@ -117529,7 +117529,7 @@
             }
           },
           {
-            "description": "When used in conjunction with `calc_interim`, specifies the range of\nbuckets on which to calculate interim results.",
+            "description": "Refer to the description for the `end` query parameter.",
             "name": "end",
             "required": false,
             "type": {
@@ -117541,7 +117541,19 @@
             }
           },
           {
-            "description": "When used in conjunction with calc_interim, specifies the range of\nbuckets on which to calculate interim results.",
+            "description": "Refer to the description for the `skip_time` query parameter.",
+            "name": "skip_time",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "Refer to the description for the `start` query parameter.",
             "name": "start",
             "required": false,
             "type": {
@@ -117582,6 +117594,42 @@
       ],
       "query": [
         {
+          "description": "Specifies to advance to a particular time value. Results are generated\nand the model is updated for data from the specified time interval.",
+          "name": "advance_time",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "If true, calculates the interim results for the most recent bucket or all\nbuckets within the latency period.",
+          "name": "calc_interim",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "When used in conjunction with `calc_interim` and `start`, specifies the\nrange of buckets on which to calculate interim results.",
+          "name": "end",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "description": "Specifies to skip to a particular time value. Results are not generated\nand the model is not updated for data from the specified time interval.",
           "name": "skip_time",
           "required": false,
@@ -117590,6 +117638,18 @@
             "type": {
               "name": "string",
               "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "When used in conjunction with `calc_interim`, specifies the range of\nbuckets on which to calculate interim results.",
+          "name": "start",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateString",
+              "namespace": "_types"
             }
           }
         }
@@ -117611,6 +117671,7 @@
             }
           },
           {
+            "description": "Provides the timestamp (in milliseconds since the epoch) of the end of\nthe last bucket that was processed.",
             "name": "last_finalized_bucket_end",
             "required": false,
             "type": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1232,15 +1232,6 @@
         "interface definition ml.evaluate_data_frame:DataframeRegressionSummary / Property 'r_squared' / instance_of - Non-leaf type cannot be used here: 'ml.evaluate_data_frame:DataframeEvaluationValue'"
       ]
     },
-    "ml.flush_job": {
-      "request": [
-        "Request: missing json spec query parameter 'calc_interim'",
-        "Request: missing json spec query parameter 'start'",
-        "Request: missing json spec query parameter 'end'",
-        "Request: missing json spec query parameter 'advance_time'"
-      ],
-      "response": []
-    },
     "ml.forecast": {
       "request": [
         "Request: missing json spec query parameter 'duration'",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11909,11 +11909,16 @@ export interface MlExplainDataFrameAnalyticsResponse {
 
 export interface MlFlushJobRequest extends RequestBase {
   job_id: Id
+  advance_time?: DateString
+  calc_interim?: boolean
+  end?: DateString
   skip_time?: string
+  start?: DateString
   body?: {
     advance_time?: DateString
     calc_interim?: boolean
     end?: DateString
+    skip_time?: string
     start?: DateString
   }
 }

--- a/specification/ml/flush_job/MlFlushJobRequest.ts
+++ b/specification/ml/flush_job/MlFlushJobRequest.ts
@@ -45,13 +45,6 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
-     * Specifies to skip to a particular time value. Results are not generated
-     * and the model is not updated for data from the specified time interval.
-     */
-    skip_time?: string
-  }
-  body: {
-    /**
      * Specifies to advance to a particular time value. Results are generated
      * and the model is updated for data from the specified time interval.
      */
@@ -62,13 +55,40 @@ export interface Request extends RequestBase {
      */
     calc_interim?: boolean
     /**
-     * When used in conjunction with `calc_interim`, specifies the range of
-     * buckets on which to calculate interim results.
+     * When used in conjunction with `calc_interim` and `start`, specifies the
+     * range of buckets on which to calculate interim results.
      */
     end?: DateString
     /**
-     * When used in conjunction with calc_interim, specifies the range of
+     * Specifies to skip to a particular time value. Results are not generated
+     * and the model is not updated for data from the specified time interval.
+     */
+    skip_time?: string
+    /**
+     * When used in conjunction with `calc_interim`, specifies the range of
      * buckets on which to calculate interim results.
+     */
+    start?: DateString
+  }
+  body: {
+    /**
+     * Refer to the description for the `advance_time` query parameter.
+     */
+    advance_time?: DateString
+    /**
+     * Refer to the description for the `calc_interim` query parameter.
+     */
+    calc_interim?: boolean
+    /**
+     * Refer to the description for the `end` query parameter.
+     */
+    end?: DateString
+    /**
+     * Refer to the description for the `skip_time` query parameter.
+     */
+    skip_time?: string
+    /**
+     * Refer to the description for the `start` query parameter.
      */
     start?: DateString
   }

--- a/specification/ml/flush_job/MlFlushJobResponse.ts
+++ b/specification/ml/flush_job/MlFlushJobResponse.ts
@@ -22,6 +22,10 @@ import { integer } from '@_types/Numeric'
 export class Response {
   body: {
     flushed: boolean
+    /**
+     * Provides the timestamp (in milliseconds since the epoch) of the end of
+     * the last bucket that was processed.
+     */
     last_finalized_bucket_end?: integer
   }
 }


### PR DESCRIPTION
This PR updates the specification for the machine learning "flush jobs" API, since the parameters listed in the body of the API are also applicable as query parameters.