### PR TITLE
Adds missing query parameters for ML forecast API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -117637,7 +117637,7 @@
         "kind": "properties",
         "properties": [
           {
-            "description": "A period of time that indicates how far into the future to forecast. For\nexample, `30d` corresponds to 30 days. The forecast starts at the last\nrecord that was processed.",
+            "description": "Refer to the description for the `duration` query parameter.",
             "name": "duration",
             "required": false,
             "serverDefault": "1d",
@@ -117650,7 +117650,7 @@
             }
           },
           {
-            "description": "The period of time that forecast results are retained. After a forecast\nexpires, the results are deleted. If set to a value of 0, the forecast is\nnever automatically deleted.",
+            "description": "Refer to the description for the `expires_in` query parameter.",
             "name": "expires_in",
             "required": false,
             "serverDefault": "14d",
@@ -117663,7 +117663,7 @@
             }
           },
           {
-            "description": "The maximum memory the forecast can use. If the forecast needs to use\nmore than the provided amount, it will spool to disk. Default is 20mb,\nmaximum is 500mb and minimum is 1mb. If set to 40% or more of the job’s\nconfigured memory limit, it is automatically reduced to below that\namount.",
+            "description": "Refer to the description for the `max_model_memory` query parameter.",
             "name": "max_model_memory",
             "required": false,
             "serverDefault": "20mb",
@@ -117677,7 +117677,7 @@
           }
         ]
       },
-      "description": "Predicts the future behavior of a time series by using its historical\nbehavior.\nYou can create a forecast job based on an anomaly detection job to\nextrapolate future behavior. You can delete a forecast by using the Delete\nforecast API.",
+      "description": "Predicts the future behavior of a time series by using its historical\nbehavior.\n\nForecasts are not supported for jobs that perform population analysis; an\nerror occurs if you try to create a forecast for a job that has an\n`over_field_name` in its configuration.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -117691,7 +117691,7 @@
       },
       "path": [
         {
-          "description": "Identifier for the anomaly detection job.",
+          "description": "Identifier for the anomaly detection job. The job must be open when you\ncreate a forecast; otherwise, an error occurs.",
           "name": "job_id",
           "required": true,
           "type": {
@@ -117703,7 +117703,47 @@
           }
         }
       ],
-      "query": []
+      "query": [
+        {
+          "description": "A period of time that indicates how far into the future to forecast. For\nexample, `30d` corresponds to 30 days. The forecast starts at the last\nrecord that was processed.",
+          "name": "duration",
+          "required": false,
+          "serverDefault": "1d",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The period of time that forecast results are retained. After a forecast\nexpires, the results are deleted. If set to a value of 0, the forecast is\nnever automatically deleted.",
+          "name": "expires_in",
+          "required": false,
+          "serverDefault": "14d",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The maximum memory the forecast can use. If the forecast needs to use\nmore than the provided amount, it will spool to disk. Default is 20mb,\nmaximum is 500mb and minimum is 1mb. If set to 40% or more of the job’s\nconfigured memory limit, it is automatically reduced to below that\namount.",
+          "name": "max_model_memory",
+          "required": false,
+          "serverDefault": "20mb",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "body": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1243,9 +1243,6 @@
     },
     "ml.forecast": {
       "request": [
-        "Request: missing json spec query parameter 'duration'",
-        "Request: missing json spec query parameter 'expires_in'",
-        "Request: missing json spec query parameter 'max_model_memory'",
         "Request: should not have a body"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11925,6 +11925,9 @@ export interface MlFlushJobResponse {
 
 export interface MlForecastRequest extends RequestBase {
   job_id: Id
+  duration?: Time
+  expires_in?: Time
+  max_model_memory?: string
   body?: {
     duration?: Time
     expires_in?: Time

--- a/specification/ml/forecast/MlForecastJobRequest.ts
+++ b/specification/ml/forecast/MlForecastJobRequest.ts
@@ -24,11 +24,11 @@ import { Time } from '@_types/Time'
 /**
  * Predicts the future behavior of a time series by using its historical
  * behavior.
- * 
+ *
  * Forecasts are not supported for jobs that perform population analysis; an
  * error occurs if you try to create a forecast for a job that has an
  * `over_field_name` in its configuration.
- * 
+ *
  * @rest_spec_name ml.forecast
  * @since 6.1.0
  * @stability stable

--- a/specification/ml/forecast/MlForecastJobRequest.ts
+++ b/specification/ml/forecast/MlForecastJobRequest.ts
@@ -24,9 +24,11 @@ import { Time } from '@_types/Time'
 /**
  * Predicts the future behavior of a time series by using its historical
  * behavior.
- * You can create a forecast job based on an anomaly detection job to
- * extrapolate future behavior. You can delete a forecast by using the Delete
- * forecast API.
+ * 
+ * Forecasts are not supported for jobs that perform population analysis; an
+ * error occurs if you try to create a forecast for a job that has an
+ * `over_field_name` in its configuration.
+ * 
  * @rest_spec_name ml.forecast
  * @since 6.1.0
  * @stability stable
@@ -35,11 +37,12 @@ import { Time } from '@_types/Time'
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * Identifier for the anomaly detection job.
+     * Identifier for the anomaly detection job. The job must be open when you
+     * create a forecast; otherwise, an error occurs.
      */
     job_id: Id
   }
-  body: {
+  query_parameters: {
     /**
      * A period of time that indicates how far into the future to forecast. For
      * example, `30d` corresponds to 30 days. The forecast starts at the last
@@ -60,6 +63,23 @@ export interface Request extends RequestBase {
      * maximum is 500mb and minimum is 1mb. If set to 40% or more of the job’s
      * configured memory limit, it is automatically reduced to below that
      * amount.
+     * @server_default 20mb
+     */
+    max_model_memory?: string
+  }
+  body: {
+    /**
+     * Refer to the description for the `duration` query parameter.
+     * @server_default 1d
+     */
+    duration?: Time
+    /**
+     * Refer to the description for the `expires_in` query parameter.
+     * @server_default 14d
+     */
+    expires_in?: Time
+    /**
+     * Refer to the description for the `max_model_memory` query parameter.
      * @server_default 20mb
      */
     max_model_memory?: string


### PR DESCRIPTION
This PR updates the specification for the machine learning "forecast" API, since the parameters listed in the body of the API are also applicable as query parameters.