### PR TITLE
Add 'fleet.global_checkpoints' API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -2805,9 +2805,16 @@
       "description": "Returns the current global checkpoints for an index. This API is design for internal use by the fleet server project.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-global-checkpoints.html",
       "name": "fleet.global_checkpoints",
-      "request": null,
+      "request": {
+        "name": "Request",
+        "namespace": "fleet.global_checkpoints"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "Response",
+        "namespace": "fleet.global_checkpoints"
+      },
+      "since": "7.13.0",
       "stability": "stable",
       "urls": [
         {
@@ -87939,6 +87946,160 @@
       "name": {
         "name": "Response",
         "namespace": "features.reset_features"
+      }
+    },
+    {
+      "kind": "type_alias",
+      "name": {
+        "name": "Checkpoint",
+        "namespace": "fleet._types"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "long",
+          "namespace": "_types"
+        }
+      }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "no_body"
+      },
+      "description": "Returns the current global checkpoints for an index. This API is design for internal use by the fleet server project.",
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "request",
+      "name": {
+        "name": "Request",
+        "namespace": "fleet.global_checkpoints"
+      },
+      "path": [
+        {
+          "description": "A single index or index alias that resolves to a single index.",
+          "name": "index",
+          "required": true,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "IndexName",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "IndexAlias",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "union_of"
+          }
+        }
+      ],
+      "query": [
+        {
+          "description": "A boolean value which controls whether to wait (until the timeout) for the global checkpoints\nto advance past the provided `checkpoints`.",
+          "name": "wait_for_advance",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "A boolean value which controls whether to wait (until the timeout) for the target index to exist\nand all primary shards be active. Can only be true when `wait_for_advance` is true.",
+          "name": "wait_for_index",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "A comma separated list of previous global checkpoints. When used in combination with `wait_for_advance`,\nthe API will only return once the global checkpoints advances past the checkpoints. Providing an empty list\nwill cause Elasticsearch to immediately return the current global checkpoints.",
+          "name": "checkpoints",
+          "required": false,
+          "serverDefault": [],
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Checkpoint",
+                "namespace": "fleet._types"
+              }
+            }
+          }
+        },
+        {
+          "description": "Period to wait for a global checkpoints to advance past `checkpoints`.",
+          "name": "timeout",
+          "required": false,
+          "serverDefault": "30s",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "global_checkpoints",
+            "required": true,
+            "type": {
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "Checkpoint",
+                  "namespace": "fleet._types"
+                }
+              }
+            }
+          },
+          {
+            "name": "timed_out",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
+      },
+      "kind": "response",
+      "name": {
+        "name": "Response",
+        "namespace": "fleet.global_checkpoints"
       }
     },
     {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -642,7 +642,7 @@
     },
     "fleet.global_checkpoints": {
       "request": [
-        "Missing request & response"
+        "Request: should not have a body"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8598,6 +8598,21 @@ export interface FeaturesResetFeaturesResponse {
   features: FeaturesFeature[]
 }
 
+export type FleetCheckpoint = long
+
+export interface FleetGlobalCheckpointsRequest extends RequestBase {
+  index: IndexName | IndexAlias
+  wait_for_advance?: boolean
+  wait_for_index?: boolean
+  checkpoints?: FleetCheckpoint[]
+  timeout?: Time
+}
+
+export interface FleetGlobalCheckpointsResponse {
+  global_checkpoints: FleetCheckpoint[]
+  timed_out: boolean
+}
+
 export interface GraphConnection {
   doc_count: long
   source: long

--- a/specification/fleet/_types/Checkpoints.ts
+++ b/specification/fleet/_types/Checkpoints.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { long } from '@_types/Numeric'
+
+export type Checkpoint = long

--- a/specification/fleet/global_checkpoints/GlobalCheckpointsRequest.ts
+++ b/specification/fleet/global_checkpoints/GlobalCheckpointsRequest.ts
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { IndexName, IndexAlias } from '@_types/common'
+import { Time } from '@_types/Time'
+import { Checkpoint } from '../_types/Checkpoints'
+
+/**
+ * @rest_spec_name fleet.global_checkpoints
+ * @since 7.13.0
+ * @stability stable
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * A single index or index alias that resolves to a single index.
+     */
+    index: IndexName | IndexAlias
+  }
+  query_parameters: {
+    /**
+     * A boolean value which controls whether to wait (until the timeout) for the global checkpoints
+     * to advance past the provided `checkpoints`.
+     * @server_default false
+     */
+    wait_for_advance?: boolean
+    /**
+     * A boolean value which controls whether to wait (until the timeout) for the target index to exist
+     * and all primary shards be active. Can only be true when `wait_for_advance` is true.
+     * @server_default false
+     */
+    wait_for_index?: boolean
+    /**
+     * A comma separated list of previous global checkpoints. When used in combination with `wait_for_advance`,
+     * the API will only return once the global checkpoints advances past the checkpoints. Providing an empty list
+     * will cause Elasticsearch to immediately return the current global checkpoints.
+     * @server_default []
+     */
+    checkpoints?: Checkpoint[]
+    /**
+     * Period to wait for a global checkpoints to advance past `checkpoints`.
+     * @server_default 30s
+     */
+    timeout?: Time
+  }
+}

--- a/specification/fleet/global_checkpoints/GlobalCheckpointsResponse.ts
+++ b/specification/fleet/global_checkpoints/GlobalCheckpointsResponse.ts
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Checkpoint } from '../_types/Checkpoints'
+
+export class Response {
+  body: {
+    global_checkpoints: Checkpoint[]
+    timed_out: boolean
+  }
+}


### PR DESCRIPTION
Adds the `fleet.global_checkpoints` API which unfortunately doesn't have any recorded tests?

Request was built from the documentation, an example response for this API looks like:

```json
{"timed_out":false,"global_checkpoints":[2]}
```