### PR TITLE
Add 'fleet.search' and 'fleet.msearch' APIs

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -2829,9 +2829,16 @@
       "description": "Multi Search API where the search will only be executed after specified checkpoints are available due to a refresh. This API is designed for internal use by the fleet server project.",
       "docUrl": null,
       "name": "fleet.msearch",
-      "request": null,
+      "request": {
+        "name": "Request",
+        "namespace": "fleet.msearch"
+      },
       "requestBodyRequired": true,
-      "response": null,
+      "response": {
+        "name": "Response",
+        "namespace": "fleet.msearch"
+      },
+      "since": "7.16.0",
       "stability": "experimental",
       "urls": [
         {
@@ -2861,9 +2868,16 @@
       "description": "Search API where the search will only be executed after specified checkpoints are available due to a refresh. This API is designed for internal use by the fleet server project.",
       "docUrl": null,
       "name": "fleet.search",
-      "request": null,
+      "request": {
+        "name": "Request",
+        "namespace": "fleet.search"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "Response",
+        "namespace": "fleet.search"
+      },
+      "since": "7.16.0",
       "stability": "experimental",
       "urls": [
         {
@@ -87594,6 +87608,388 @@
       "name": {
         "name": "Response",
         "namespace": "features.reset_features"
+      }
+    },
+    {
+      "kind": "type_alias",
+      "name": {
+        "name": "Checkpoint",
+        "namespace": "fleet._types"
+      },
+      "type": {
+        "kind": "instance_of",
+        "type": {
+          "name": "long",
+          "namespace": "_types"
+        }
+      }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "codegenName": "searches",
+        "kind": "value",
+        "value": {
+          "kind": "array_of",
+          "value": {
+            "kind": "instance_of",
+            "type": {
+              "name": "RequestItem",
+              "namespace": "_global.msearch"
+            }
+          }
+        }
+      },
+      "description": "Multi Search API where the search will only be executed after specified checkpoints are available due to a refresh. This API is designed for internal use by the fleet server project.",
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "request",
+      "name": {
+        "name": "Request",
+        "namespace": "fleet.msearch"
+      },
+      "path": [
+        {
+          "description": "A single target to search. If the target is an index alias, it must resolve to a single index.",
+          "name": "index",
+          "required": false,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "IndexName",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "IndexAlias",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "union_of"
+          }
+        }
+      ],
+      "query": [
+        {
+          "description": "If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.",
+          "name": "allow_no_indices",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "If true, network roundtrips between the coordinating node and remote clusters are minimized for cross-cluster search requests.",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cross-cluster-search.html#ccs-network-delays",
+          "name": "ccs_minimize_roundtrips",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "Type of index that wildcard expressions can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.",
+          "name": "expand_wildcards",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ExpandWildcards",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "If true, concrete, expanded or aliased indices are ignored when frozen.",
+          "name": "ignore_throttled",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "If true, missing or closed indices are not included in the response.",
+          "name": "ignore_unavailable",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "Maximum number of concurrent searches the multi search API can execute.",
+          "name": "max_concurrent_searches",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Maximum number of concurrent shard requests that each sub-search request executes per node.",
+          "name": "max_concurrent_shard_requests",
+          "required": false,
+          "serverDefault": 5,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method i.e., if date filters are mandatory to match but the shard bounds and the query are disjoint.",
+          "name": "pre_filter_shard_size",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Indicates whether global term and document frequencies should be used when scoring returned documents.",
+          "name": "search_type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "SearchType",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "If true, hits.total are returned as an integer in the response. Defaults to false, which returns an object.",
+          "name": "rest_total_hits_as_int",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "Specifies whether aggregation and suggester names should be prefixed by their respective types in the response.",
+          "name": "typed_keys",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "If `true`, returns partial results if there are shard request timeouts or shard failures. If `false`,\nreturns an error with no partial results. Defaults to the configured cluster setting\n`search.default_allow_partial_results` which is `true` by default.",
+          "name": "allow_partial_search_results",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "A comma separated list of checkpoints. When configured, the search API will only be executed on\na shard after the relevant checkpoint has become visible for search. Defaults to an empty list\nwhich will cause Elasticsearch to immediately execute the search.",
+          "name": "wait_for_checkpoints",
+          "required": false,
+          "serverDefault": [],
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Checkpoint",
+                "namespace": "fleet._types"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
+      "generics": [
+        {
+          "name": "TDocument",
+          "namespace": "fleet.msearch"
+        }
+      ],
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TDocument",
+              "namespace": "fleet.msearch"
+            }
+          }
+        ],
+        "type": {
+          "name": "Response",
+          "namespace": "_global.msearch"
+        }
+      },
+      "kind": "response",
+      "name": {
+        "name": "Response",
+        "namespace": "fleet.msearch"
+      }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
+      "description": "Search API where the search will only be executed after specified checkpoints are available due to a refresh. This API is designed for internal use by the fleet server project.",
+      "inherits": {
+        "type": {
+          "name": "Request",
+          "namespace": "_global.search"
+        }
+      },
+      "kind": "request",
+      "name": {
+        "name": "Request",
+        "namespace": "fleet.search"
+      },
+      "path": [
+        {
+          "description": "A single index or index alias that resolves to a single index.",
+          "name": "index",
+          "required": true,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "IndexName",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "IndexAlias",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "union_of"
+          }
+        }
+      ],
+      "query": [
+        {
+          "description": "If `true`, returns partial results if there are shard request timeouts or shard failures. If `false`,\nreturns an error with no partial results. Defaults to the configured cluster setting\n`search.default_allow_partial_results` which is `true` by default.",
+          "name": "allow_partial_search_results",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "A comma separated list of checkpoints. When configured, the search API will only be executed on\na shard after the relevant checkpoint has become visible for search. Defaults to an empty list\nwhich will cause Elasticsearch to immediately execute the search.",
+          "name": "wait_for_checkpoints",
+          "required": false,
+          "serverDefault": [],
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Checkpoint",
+                "namespace": "fleet._types"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
+      "generics": [
+        {
+          "name": "TDocument",
+          "namespace": "fleet.search"
+        }
+      ],
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TDocument",
+              "namespace": "fleet.search"
+            }
+          }
+        ],
+        "type": {
+          "name": "Response",
+          "namespace": "_global.search"
+        }
+      },
+      "kind": "response",
+      "name": {
+        "name": "Response",
+        "namespace": "fleet.search"
       }
     },
     {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -647,13 +647,30 @@
     },
     "fleet.msearch": {
       "request": [
-        "Missing request & response"
+        "Request: query parameter 'allow_no_indices' does not exist in the json spec",
+        "Request: query parameter 'ccs_minimize_roundtrips' does not exist in the json spec",
+        "Request: query parameter 'expand_wildcards' does not exist in the json spec",
+        "Request: query parameter 'ignore_throttled' does not exist in the json spec",
+        "Request: query parameter 'ignore_unavailable' does not exist in the json spec",
+        "Request: query parameter 'max_concurrent_searches' does not exist in the json spec",
+        "Request: query parameter 'max_concurrent_shard_requests' does not exist in the json spec",
+        "Request: query parameter 'pre_filter_shard_size' does not exist in the json spec",
+        "Request: query parameter 'search_type' does not exist in the json spec",
+        "Request: query parameter 'rest_total_hits_as_int' does not exist in the json spec",
+        "Request: query parameter 'typed_keys' does not exist in the json spec",
+        "Request: query parameter 'allow_partial_search_results' does not exist in the json spec",
+        "Request: query parameter 'wait_for_checkpoints' does not exist in the json spec"
       ],
-      "response": []
+      "response": [
+        "type_alias definition _global.msearch:ResponseItem / union_of / instance_of / Generics / instance_of - No type definition for '_global.msearch:TDocument'"
+      ]
     },
     "fleet.search": {
       "request": [
-        "Missing request & response"
+        "Request: missing json spec query parameter 'wait_for_checkpoints_timeout'",
+        "request definition fleet.search:Request / Inherits - '_global.search:Request' is a request and must only be used in endpoints",
+        "request definition fleet.search:Request / path - Property 'index' is already defined in an ancestor class",
+        "request definition fleet.search:Request / query - Property 'allow_partial_search_results' is already defined in an ancestor class"
       ],
       "response": []
     },
@@ -1402,9 +1419,7 @@
         "Request: query parameter 'ignore_throttled' does not exist in the json spec",
         "Request: query parameter 'ignore_unavailable' does not exist in the json spec"
       ],
-      "response": [
-        "type_alias definition _global.msearch:ResponseItem / union_of / instance_of / Generics / instance_of - No type definition for '_global.msearch:TDocument'"
-      ]
+      "response": []
     },
     "nodes.clear_repositories_metering_archive": {
       "request": [
@@ -1526,7 +1541,9 @@
       "response": []
     },
     "search": {
-      "request": [],
+      "request": [
+        "Non-leaf type cannot be used here: '_global.search:Request'"
+      ],
       "response": [
         "Non-leaf type cannot be used here: '_global.search:Response'"
       ]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8632,6 +8632,38 @@ export interface FeaturesResetFeaturesResponse {
   features: FeaturesFeature[]
 }
 
+export type FleetCheckpoint = long
+
+export interface FleetMsearchRequest extends RequestBase {
+  index?: IndexName | IndexAlias
+  allow_no_indices?: boolean
+  ccs_minimize_roundtrips?: boolean
+  expand_wildcards?: ExpandWildcards
+  ignore_throttled?: boolean
+  ignore_unavailable?: boolean
+  max_concurrent_searches?: long
+  max_concurrent_shard_requests?: long
+  pre_filter_shard_size?: long
+  search_type?: SearchType
+  rest_total_hits_as_int?: boolean
+  typed_keys?: boolean
+  allow_partial_search_results?: boolean
+  wait_for_checkpoints?: FleetCheckpoint[]
+  body?: MsearchRequestItem[]
+}
+
+export interface FleetMsearchResponse<TDocument = unknown> extends MsearchResponse<TDocument> {
+}
+
+export interface FleetSearchRequest extends SearchRequest {
+  index: IndexName | IndexAlias
+  allow_partial_search_results?: boolean
+  wait_for_checkpoints?: FleetCheckpoint[]
+}
+
+export interface FleetSearchResponse<TDocument = unknown> extends SearchResponse<TDocument> {
+}
+
 export interface GraphConnection {
   doc_count: long
   source: long

--- a/specification/fleet/_types/Checkpoints.ts
+++ b/specification/fleet/_types/Checkpoints.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { long } from '@_types/Numeric'
+
+export type Checkpoint = long

--- a/specification/fleet/msearch/MSearchResponse.ts
+++ b/specification/fleet/msearch/MSearchResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Response as MsearchResponse } from '@global/msearch/MultiSearchResponse'
+
+export class Response<TDocument> extends MsearchResponse<TDocument> {}

--- a/specification/fleet/msearch/MsearchRequest.ts
+++ b/specification/fleet/msearch/MsearchRequest.ts
@@ -1,0 +1,107 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { RequestItem } from '@global/msearch/types'
+import { ExpandWildcards } from '@_types/common'
+import { IndexName, IndexAlias, SearchType } from '@_types/common'
+import { long } from '@_types/Numeric'
+import { Checkpoint } from '../_types/Checkpoints'
+
+/**
+ * @rest_spec_name fleet.msearch
+ * @since 7.16.0
+ * @stability experimental
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * A single target to search. If the target is an index alias, it must resolve to a single index.
+     */
+    index?: IndexName | IndexAlias
+  }
+  query_parameters: {
+    /**
+     * If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.
+     */
+    allow_no_indices?: boolean
+    /**
+     * If true, network roundtrips between the coordinating node and remote clusters are minimized for cross-cluster search requests.
+     * @server_default true
+     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cross-cluster-search.html#ccs-network-delays
+     */
+    ccs_minimize_roundtrips?: boolean
+    /**
+     * Type of index that wildcard expressions can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
+     */
+    expand_wildcards?: ExpandWildcards
+    /**
+     * If true, concrete, expanded or aliased indices are ignored when frozen.
+     * @server_default false
+     */
+    ignore_throttled?: boolean
+    /**
+     * If true, missing or closed indices are not included in the response.
+     * @server_default false
+     */
+    ignore_unavailable?: boolean
+    /**
+     * Maximum number of concurrent searches the multi search API can execute.
+     */
+    max_concurrent_searches?: long
+    /**
+     * Maximum number of concurrent shard requests that each sub-search request executes per node.
+     * @server_default 5
+     */
+    max_concurrent_shard_requests?: long
+    /**
+     * Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold. This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method i.e., if date filters are mandatory to match but the shard bounds and the query are disjoint.
+     */
+    pre_filter_shard_size?: long
+    /**
+     * Indicates whether global term and document frequencies should be used when scoring returned documents.
+     */
+    search_type?: SearchType
+    /**
+     * If true, hits.total are returned as an integer in the response. Defaults to false, which returns an object.
+     * @server_default false
+     */
+    rest_total_hits_as_int?: boolean
+    /**
+     * Specifies whether aggregation and suggester names should be prefixed by their respective types in the response.
+     */
+    typed_keys?: boolean
+    /**
+     * If `true`, returns partial results if there are shard request timeouts or shard failures. If `false`,
+     * returns an error with no partial results. Defaults to the configured cluster setting
+     * `search.default_allow_partial_results` which is `true` by default.
+     * @server_default true
+     */
+    allow_partial_search_results?: boolean
+    /**
+     * A comma separated list of checkpoints. When configured, the search API will only be executed on
+     * a shard after the relevant checkpoint has become visible for search. Defaults to an empty list
+     * which will cause Elasticsearch to immediately execute the search.
+     * @server_default []
+     */
+    wait_for_checkpoints?: Checkpoint[]
+  }
+  /** @codegen_name searches */
+  body?: Array<RequestItem>
+}

--- a/specification/fleet/search/SearchRequest.ts
+++ b/specification/fleet/search/SearchRequest.ts
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Request as SearchRequest } from '@global/search/SearchRequest'
+import { IndexName, IndexAlias } from '@_types/common'
+import { Checkpoint } from '../_types/Checkpoints'
+
+/**
+ * @rest_spec_name fleet.search
+ * @since 7.16.0
+ * @stability experimental
+ */
+export interface Request extends SearchRequest {
+  path_parts: {
+    /**
+     * A single index or index alias that resolves to a single index.
+     */
+    index: IndexName | IndexAlias
+  }
+  query_parameters: {
+    /**
+     * If `true`, returns partial results if there are shard request timeouts or shard failures. If `false`,
+     * returns an error with no partial results. Defaults to the configured cluster setting
+     * `search.default_allow_partial_results` which is `true` by default.
+     * @server_default true
+     */
+    allow_partial_search_results?: boolean
+    /**
+     * A comma separated list of checkpoints. When configured, the search API will only be executed on
+     * a shard after the relevant checkpoint has become visible for search. Defaults to an empty list
+     * which will cause Elasticsearch to immediately execute the search.
+     * @server_default []
+     */
+    wait_for_checkpoints?: Checkpoint[]
+  }
+}

--- a/specification/fleet/search/SearchResponse.ts
+++ b/specification/fleet/search/SearchResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Response as SearchResponse } from '@global/search/SearchResponse'
+
+export class Response<TDocument> extends SearchResponse<TDocument> {}


### PR DESCRIPTION
These APIs support all the parameters of `search` and `msearch` with the additional `wait_for_checkpoints` parameter.

Not sure how best to implement these without replication?