### PR TITLE
Updates ML get buckets API specification (#1020)

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -109496,25 +109496,25 @@
       },
       "properties": [
         {
-          "description": "The length of the bucket in seconds. This value matches the bucket_span that is specified in the job.",
+          "description": "A normalized score between 0-100, which is calculated for each bucket influencer. This score might be updated as\nnewer data is analyzed.",
+          "name": "anomaly_score",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The length of the bucket in seconds. This value matches the bucket span that is specified in the job.",
           "name": "bucket_span",
           "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "long",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "A normalized score between 0-100, which is based on the probability of the influencer in this bucket aggregated across detectors. Unlike initial_influencer_score, this value will be updated by a re-normalization process as new data is analyzed.",
-          "name": "influencer_score",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
               "namespace": "_types"
             }
           }
@@ -109532,20 +109532,8 @@
           }
         },
         {
-          "description": "The entity that influenced, contributed to, or was to blame for the anomaly.",
-          "name": "influencer_field_value",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "description": "A normalized score between 0-100, which is based on the probability of the influencer aggregated across detectors. This is the initial value that was calculated at the time the bucket was processed.",
-          "name": "initial_influencer_score",
+          "description": "The score between 0-100 for each bucket influencer. This score is the initial value that was calculated at the\ntime the bucket was processed.",
+          "name": "initial_anomaly_score",
           "required": true,
           "type": {
             "kind": "instance_of",
@@ -109580,7 +109568,7 @@
           }
         },
         {
-          "description": "The probability that the influencer has this behavior, in the range 0 to 1. This value can be held to a high precision of over 300 decimal places, so the influencer_score is provided as a human-readable and friendly interpretation of this.",
+          "description": "The probability that the bucket has this behavior, in the range 0 to 1. This value can be held to a high precision\nof over 300 decimal places, so the `anomaly_score` is provided as a human-readable and friendly interpretation of\nthis.",
           "name": "probability",
           "required": true,
           "type": {
@@ -109592,7 +109580,19 @@
           }
         },
         {
-          "description": "Internal. This value is always set to influencer.",
+          "description": "Internal.",
+          "name": "raw_anomaly_score",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Internal. This value is always set to `bucket_influencer`.",
           "name": "result_type",
           "required": true,
           "type": {
@@ -109614,17 +109614,6 @@
               "namespace": "_types"
             }
           }
-        },
-        {
-          "name": "foo",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
         }
       ]
     },
@@ -109636,6 +109625,7 @@
       },
       "properties": [
         {
+          "description": "The maximum anomaly score, between 0-100, for any of the bucket influencers. This is an overall, rate-limited\nscore for the job. All the anomaly records in the bucket contribute to this score. This value might be updated as\nnew data is analyzed.",
           "name": "anomaly_score",
           "required": true,
           "type": {
@@ -109661,6 +109651,7 @@
           }
         },
         {
+          "description": "The length of the bucket in seconds. This value matches the bucket span that is specified in the job.",
           "name": "bucket_span",
           "required": true,
           "type": {
@@ -109672,6 +109663,7 @@
           }
         },
         {
+          "description": "The number of input data records processed in this bucket.",
           "name": "event_count",
           "required": true,
           "type": {
@@ -109683,6 +109675,7 @@
           }
         },
         {
+          "description": "The maximum anomaly score for any of the bucket influencers. This is the initial value that was calculated at the\ntime the bucket was processed.",
           "name": "initial_anomaly_score",
           "required": true,
           "type": {
@@ -109694,6 +109687,7 @@
           }
         },
         {
+          "description": "If true, this is an interim result. In other words, the results are calculated based on partial input data.",
           "name": "is_interim",
           "required": true,
           "type": {
@@ -109705,6 +109699,7 @@
           }
         },
         {
+          "description": "Identifier for the anomaly detection job.",
           "name": "job_id",
           "required": true,
           "type": {
@@ -109716,20 +109711,7 @@
           }
         },
         {
-          "name": "partition_scores",
-          "required": false,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "PartitionScore",
-                "namespace": "ml._types"
-              }
-            }
-          }
-        },
-        {
+          "description": "The amount of time, in milliseconds, that it took to analyze the bucket contents and calculate results.",
           "name": "processing_time_ms",
           "required": true,
           "type": {
@@ -109741,6 +109723,7 @@
           }
         },
         {
+          "description": "Internal. This value is always set to bucket.",
           "name": "result_type",
           "required": true,
           "type": {
@@ -109752,6 +109735,7 @@
           }
         },
         {
+          "description": "The start time of the bucket. This timestamp uniquely identifies the bucket. Events that occur exactly at the\ntimestamp of the bucket are included in the results for the bucket.",
           "name": "timestamp",
           "required": true,
           "type": {
@@ -113957,6 +113941,147 @@
     {
       "kind": "interface",
       "name": {
+        "name": "Influencer",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "description": "The length of the bucket in seconds. This value matches the bucket span that is specified in the job.",
+          "name": "bucket_span",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "A normalized score between 0-100, which is based on the probability of the influencer in this bucket aggregated\nacross detectors. Unlike `initial_influencer_score`, this value is updated by a re-normalization process as new\ndata is analyzed.",
+          "name": "influencer_score",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The field name of the influencer.",
+          "name": "influencer_field_name",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Field",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The entity that influenced, contributed to, or was to blame for the anomaly.",
+          "name": "influencer_field_value",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "A normalized score between 0-100, which is based on the probability of the influencer aggregated across detectors.\nThis is the initial value that was calculated at the time the bucket was processed.",
+          "name": "initial_influencer_score",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "If true, this is an interim result. In other words, the results are calculated based on partial input data.",
+          "name": "is_interim",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "Identifier for the anomaly detection job.",
+          "name": "job_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The probability that the influencer has this behavior, in the range 0 to 1. This value can be held to a high\nprecision of over 300 decimal places, so the `influencer_score` is provided as a human-readable and friendly\ninterpretation of this value.",
+          "name": "probability",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Internal. This value is always set to `influencer`.",
+          "name": "result_type",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "The start time of the bucket for which these results were calculated.",
+          "name": "timestamp",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Additional influencer properties are added, depending on the fields being analyzed. For example, if it’s\nanalyzing `user_name` as an influencer, a field `user_name` is added to the result document. This\ninformation enables you to filter the anomaly results more easily.",
+          "name": "foo",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
         "name": "Job",
         "namespace": "ml._types"
       },
@@ -115503,70 +115628,6 @@
             "kind": "instance_of",
             "type": {
               "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "PartitionScore",
-        "namespace": "ml._types"
-      },
-      "properties": [
-        {
-          "name": "initial_record_score",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "partition_field_name",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Field",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "partition_field_value",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "probability",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "record_score",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
               "namespace": "_types"
             }
           }
@@ -118511,7 +118572,7 @@
         "kind": "properties",
         "properties": [
           {
-            "description": "Returns buckets with anomaly scores greater or equal than this value.",
+            "description": "Refer to the description for the `anomaly_score` query parameter.",
             "name": "anomaly_score",
             "required": false,
             "serverDefault": 0,
@@ -118524,7 +118585,7 @@
             }
           },
           {
-            "description": "If `true`, the buckets are sorted in descending order.",
+            "description": "Refer to the description for the `desc` query parameter.",
             "name": "desc",
             "required": false,
             "serverDefault": false,
@@ -118537,7 +118598,20 @@
             }
           },
           {
-            "description": "If `true`, the output excludes interim results.",
+            "description": "Refer to the description for the `end` query parameter.",
+            "name": "end",
+            "required": false,
+            "serverDefault": "-1",
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "DateString",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "description": "Refer to the description for the `exclude_interim` query parameter.",
             "name": "exclude_interim",
             "required": false,
             "serverDefault": false,
@@ -118550,7 +118624,7 @@
             }
           },
           {
-            "description": "If true, the output includes anomaly records.",
+            "description": "Refer to the description for the `expand` query parameter.",
             "name": "expand",
             "required": false,
             "serverDefault": false,
@@ -118563,7 +118637,18 @@
             }
           },
           {
-            "description": "Specifies the sort field for the requested buckets.",
+            "name": "page",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Page",
+                "namespace": "ml._types"
+              }
+            }
+          },
+          {
+            "description": "Refer to the desription for the `sort` query parameter.",
             "name": "sort",
             "required": false,
             "serverDefault": "timestamp",
@@ -118576,21 +118661,8 @@
             }
           },
           {
-            "description": "Returns buckets with timestamps after this time. `-1` means it is unset\nand results are not limited to specific timestamps.",
+            "description": "Refer to the description for the `start` query parameter.",
             "name": "start",
-            "required": false,
-            "serverDefault": "-1",
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "DateString",
-                "namespace": "_types"
-              }
-            }
-          },
-          {
-            "description": "Returns buckets with timestamps earlier than this time. `-1` means it is\nunset and results are not limited to specific timestamps.",
-            "name": "end",
             "required": false,
             "serverDefault": "-1",
             "type": {
@@ -118643,6 +118715,71 @@
       ],
       "query": [
         {
+          "description": "Returns buckets with anomaly scores greater or equal than this value.",
+          "name": "anomaly_score",
+          "required": false,
+          "serverDefault": 0,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "If `true`, the buckets are sorted in descending order.",
+          "name": "desc",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "Returns buckets with timestamps earlier than this time. `-1` means it is\nunset and results are not limited to specific timestamps.",
+          "name": "end",
+          "required": false,
+          "serverDefault": "-1",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "If `true`, the output excludes interim results.",
+          "name": "exclude_interim",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "If true, the output includes anomaly records.",
+          "name": "expand",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "description": "Skips the specified number of buckets.",
           "name": "from",
           "required": false,
@@ -118669,19 +118806,6 @@
           }
         },
         {
-          "description": "If `true`, the output excludes interim results.",
-          "name": "exclude_interim",
-          "required": false,
-          "serverDefault": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "description": "Specifies the sort field for the requested buckets.",
           "name": "sort",
           "required": false,
@@ -118695,34 +118819,8 @@
           }
         },
         {
-          "description": "If `true`, the buckets are sorted in descending order.",
-          "name": "desc",
-          "required": false,
-          "serverDefault": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "description": "Returns buckets with timestamps after this time. `-1` means it is unset\nand results are not limited to specific timestamps.",
           "name": "start",
-          "required": false,
-          "serverDefault": "-1",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "DateString",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Returns buckets with timestamps earlier than this time. `-1` means it is\nunset and results are not limited to specific timestamps.",
-          "name": "end",
           "required": false,
           "serverDefault": "-1",
           "type": {
@@ -119946,7 +120044,7 @@
               "value": {
                 "kind": "instance_of",
                 "type": {
-                  "name": "BucketInfluencer",
+                  "name": "Influencer",
                   "namespace": "ml._types"
                 }
               }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1318,13 +1318,6 @@
       ],
       "response": []
     },
-    "ml.get_buckets": {
-      "request": [
-        "Request: missing json spec query parameter 'expand'",
-        "Request: missing json spec query parameter 'anomaly_score'"
-      ],
-      "response": []
-    },
     "ml.get_calendar_events": {
       "request": [
         "Request: should not have a body"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10944,17 +10944,16 @@ export interface MlAnomalyCause {
 export type MlAppliesTo = 'actual' | 'typical' | 'diff_from_typical' | 'time'
 
 export interface MlBucketInfluencer {
+  anomaly_score: double
   bucket_span: long
-  influencer_score: double
   influencer_field_name: Field
-  influencer_field_value: string
-  initial_influencer_score: double
+  initial_anomaly_score: double
   is_interim: boolean
   job_id: Id
   probability: double
+  raw_anomaly_score: double
   result_type: string
   timestamp: Time
-  foo?: string
 }
 
 export interface MlBucketSummary {
@@ -10965,7 +10964,6 @@ export interface MlBucketSummary {
   initial_anomaly_score: double
   is_interim: boolean
   job_id: Id
-  partition_scores?: MlPartitionScore[]
   processing_time_ms: double
   result_type: string
   timestamp: Time
@@ -11434,6 +11432,20 @@ export interface MlInfluence {
   influencer_field_values: string[]
 }
 
+export interface MlInfluencer {
+  bucket_span: long
+  influencer_score: double
+  influencer_field_name: Field
+  influencer_field_value: string
+  initial_influencer_score: double
+  is_interim: boolean
+  job_id: Id
+  probability: double
+  result_type: string
+  timestamp: Time
+  foo?: string
+}
+
 export interface MlJob {
   allow_lazy_open: boolean
   analysis_config: MlAnalysisConfig
@@ -11600,14 +11612,6 @@ export interface MlOverallBucketJob {
 export interface MlPage {
   from?: integer
   size?: integer
-}
-
-export interface MlPartitionScore {
-  initial_record_score: double
-  partition_field_name: Field
-  partition_field_value: string
-  probability: double
-  record_score: double
 }
 
 export interface MlPerPartitionCategorization {
@@ -11967,21 +11971,24 @@ export interface MlForecastResponse extends AcknowledgedResponseBase {
 export interface MlGetBucketsRequest extends RequestBase {
   job_id: Id
   timestamp?: Timestamp
+  anomaly_score?: double
+  desc?: boolean
+  end?: DateString
+  exclude_interim?: boolean
+  expand?: boolean
   from?: integer
   size?: integer
-  exclude_interim?: boolean
   sort?: Field
-  desc?: boolean
   start?: DateString
-  end?: DateString
   body?: {
     anomaly_score?: double
     desc?: boolean
+    end?: DateString
     exclude_interim?: boolean
     expand?: boolean
+    page?: MlPage
     sort?: Field
     start?: DateString
-    end?: DateString
   }
 }
 
@@ -12117,7 +12124,7 @@ export interface MlGetInfluencersRequest extends RequestBase {
 
 export interface MlGetInfluencersResponse {
   count: long
-  influencers: MlBucketInfluencer[]
+  influencers: MlInfluencer[]
 }
 
 export interface MlGetJobStatsRequest extends RequestBase {

--- a/specification/ml/_types/Bucket.ts
+++ b/specification/ml/_types/Bucket.ts
@@ -22,41 +22,93 @@ import { double, long } from '@_types/Numeric'
 import { Time } from '@_types/Time'
 
 export class BucketSummary {
+  /**
+   * The maximum anomaly score, between 0-100, for any of the bucket influencers. This is an overall, rate-limited
+   * score for the job. All the anomaly records in the bucket contribute to this score. This value might be updated as
+   * new data is analyzed.
+   */
   anomaly_score: double
   bucket_influencers: BucketInfluencer[]
+  /**
+   * The length of the bucket in seconds. This value matches the bucket span that is specified in the job.
+   */
   bucket_span: Time
+  /**
+   * The number of input data records processed in this bucket.
+   */
   event_count: long
+  /**
+   * The maximum anomaly score for any of the bucket influencers. This is the initial value that was calculated at the
+   * time the bucket was processed.
+   */
   initial_anomaly_score: double
+  /**
+   * If true, this is an interim result. In other words, the results are calculated based on partial input data.
+   */
   is_interim: boolean
+  /**
+   * Identifier for the anomaly detection job.
+   */
   job_id: Id
-  partition_scores?: PartitionScore[]
+  /**
+   * The amount of time, in milliseconds, that it took to analyze the bucket contents and calculate results.
+   */
   processing_time_ms: double
+  /**
+   * Internal. This value is always set to bucket.
+   */
   result_type: string
+  /**
+   * The start time of the bucket. This timestamp uniquely identifies the bucket. Events that occur exactly at the
+   * timestamp of the bucket are included in the results for the bucket.
+   */
   timestamp: Time
 }
 
 export class BucketInfluencer {
-  /** The length of the bucket in seconds. This value matches the bucket_span that is specified in the job. */
+  /**
+   * A normalized score between 0-100, which is calculated for each bucket influencer. This score might be updated as
+   * newer data is analyzed.
+   */
+  anomaly_score: double
+  /**
+   * The length of the bucket in seconds. This value matches the bucket span that is specified in the job.
+   */
   bucket_span: long
-  /** A normalized score between 0-100, which is based on the probability of the influencer in this bucket aggregated across detectors. Unlike initial_influencer_score, this value will be updated by a re-normalization process as new data is analyzed. */
-  influencer_score: double
-  /** The field name of the influencer. */
+  /**
+   * The field name of the influencer.
+   */
   influencer_field_name: Field
-  /** The entity that influenced, contributed to, or was to blame for the anomaly. */
-  influencer_field_value: string
-  /** A normalized score between 0-100, which is based on the probability of the influencer aggregated across detectors. This is the initial value that was calculated at the time the bucket was processed. */
-  initial_influencer_score: double
-  /** If true, this is an interim result. In other words, the results are calculated based on partial input data. */
+  /**
+   * The score between 0-100 for each bucket influencer. This score is the initial value that was calculated at the
+   * time the bucket was processed. */
+  initial_anomaly_score: double
+  /**
+   * If true, this is an interim result. In other words, the results are calculated based on partial input data.
+   */
   is_interim: boolean
-  /** Identifier for the anomaly detection job. */
+  /**
+   * Identifier for the anomaly detection job.
+   */
   job_id: Id
-  /** The probability that the influencer has this behavior, in the range 0 to 1. This value can be held to a high precision of over 300 decimal places, so the influencer_score is provided as a human-readable and friendly interpretation of this. */
+  /**
+   * The probability that the bucket has this behavior, in the range 0 to 1. This value can be held to a high precision
+   * of over 300 decimal places, so the `anomaly_score` is provided as a human-readable and friendly interpretation of
+   * this.
+   */
   probability: double
-  /** Internal. This value is always set to influencer. */
+  /**
+   * Internal.
+   */
+  raw_anomaly_score: double
+  /**
+   * Internal. This value is always set to `bucket_influencer`.
+   */
   result_type: string
-  /** The start time of the bucket for which these results were calculated. */
+  /**
+   * The start time of the bucket for which these results were calculated.
+   */
   timestamp: Time
-  foo?: string // TODO ??? - the tests carry this prop but :shrug:
 }
 
 export class OverallBucket {
@@ -76,12 +128,4 @@ export class OverallBucket {
 export class OverallBucketJob {
   job_id: Id
   max_anomaly_score: double
-}
-
-export class PartitionScore {
-  initial_record_score: double
-  partition_field_name: Field
-  partition_field_value: string
-  probability: double
-  record_score: double
 }

--- a/specification/ml/_types/Influencer.ts
+++ b/specification/ml/_types/Influencer.ts
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { double, integer, long } from '@_types/Numeric'
+import { Field, Id } from '@_types/common'
+import { Time } from '@_types/Time'
+
+export class Influencer {
+  /**
+   * The length of the bucket in seconds. This value matches the bucket span that is specified in the job.
+   */
+  bucket_span: long
+  /**
+   * A normalized score between 0-100, which is based on the probability of the influencer in this bucket aggregated
+   * across detectors. Unlike `initial_influencer_score`, this value is updated by a re-normalization process as new
+   * data is analyzed.
+   */
+  influencer_score: double
+  /**
+   * The field name of the influencer.
+   */
+  influencer_field_name: Field
+  /**
+   * The entity that influenced, contributed to, or was to blame for the anomaly.
+   */
+  influencer_field_value: string
+  /**
+   * A normalized score between 0-100, which is based on the probability of the influencer aggregated across detectors.
+   * This is the initial value that was calculated at the time the bucket was processed.
+   */
+  initial_influencer_score: double
+  /**
+   * If true, this is an interim result. In other words, the results are calculated based on partial input data.
+   */
+  is_interim: boolean
+  /**
+   * Identifier for the anomaly detection job.
+   */
+  job_id: Id
+  /**
+   * The probability that the influencer has this behavior, in the range 0 to 1. This value can be held to a high
+   * precision of over 300 decimal places, so the `influencer_score` is provided as a human-readable and friendly
+   * interpretation of this value.
+   */
+  probability: double
+  /**
+   * Internal. This value is always set to `influencer`.
+   */
+  result_type: string
+  /**
+   * The start time of the bucket for which these results were calculated.
+   */
+  timestamp: Time
+  /**
+   * Additional influencer properties are added, depending on the fields being analyzed. For example, if it’s
+   * analyzing `user_name` as an influencer, a field `user_name` is added to the result document. This
+   * information enables you to filter the anomaly results more easily.
+   */
+  foo?: string // TODO ??? - the tests carry this prop but :shrug:
+}

--- a/specification/ml/get_buckets/MlGetBucketsRequest.ts
+++ b/specification/ml/get_buckets/MlGetBucketsRequest.ts
@@ -45,6 +45,32 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
+     * Returns buckets with anomaly scores greater or equal than this value.
+     * @server_default 0.0
+     */
+    anomaly_score?: double
+    /**
+     * If `true`, the buckets are sorted in descending order.
+     * @server_default false
+     */
+    desc?: boolean
+    /**
+     * Returns buckets with timestamps earlier than this time. `-1` means it is
+     * unset and results are not limited to specific timestamps.
+     * @server_default -1
+     */
+    end?: DateString
+    /**
+     *  If `true`, the output excludes interim results.
+     * @server_default false
+     */
+    exclude_interim?: boolean
+    /**
+     * If true, the output includes anomaly records.
+     * @server_default false
+     */
+    expand?: boolean
+    /**
      * Skips the specified number of buckets.
      * @server_default 0
      */
@@ -55,70 +81,53 @@ export interface Request extends RequestBase {
      */
     size?: integer
     /**
-     *  If `true`, the output excludes interim results.
-     * @server_default false
-     */
-    exclude_interim?: boolean
-    /**
      * Specifies the sort field for the requested buckets.
      * @server_default timestamp
      */
     sort?: Field
-    /**
-     * If `true`, the buckets are sorted in descending order.
-     * @server_default false
-     */
-    desc?: boolean
     /**
      * Returns buckets with timestamps after this time. `-1` means it is unset
      * and results are not limited to specific timestamps.
      * @server_default -1
      */
     start?: DateString
-    /**
-     * Returns buckets with timestamps earlier than this time. `-1` means it is
-     * unset and results are not limited to specific timestamps.
-     * @server_default -1
-     */
-    end?: DateString
   }
   body: {
     /**
-     * Returns buckets with anomaly scores greater or equal than this value.
+     * Refer to the description for the `anomaly_score` query parameter.
      * @server_default 0.0
      */
     anomaly_score?: double
     /**
-     *  If `true`, the buckets are sorted in descending order.
+     * Refer to the description for the `desc` query parameter.
      * @server_default false
      */
     desc?: boolean
     /**
-     * If `true`, the output excludes interim results.
+     * Refer to the description for the `end` query parameter.
+     * @server_default -1
+     */
+    end?: DateString
+    /**
+     * Refer to the description for the `exclude_interim` query parameter.
      * @server_default false
      */
     exclude_interim?: boolean
     /**
-     * If true, the output includes anomaly records.
+     * Refer to the description for the `expand` query parameter.
      * @server_default false
      */
     expand?: boolean
+    page?: Page
     /**
-     * Specifies the sort field for the requested buckets.
+     * Refer to the desription for the `sort` query parameter.
      * @server_default timestamp
      */
     sort?: Field
     /**
-     * Returns buckets with timestamps after this time. `-1` means it is unset
-     * and results are not limited to specific timestamps.
+     * Refer to the description for the `start` query parameter.
      * @server_default -1
      */
     start?: DateString
-    /**
-     * Returns buckets with timestamps earlier than this time. `-1` means it is
-     * unset and results are not limited to specific timestamps.
-     * @server_default -1
-     */
-    end?: DateString
   }
 }

--- a/specification/ml/get_influencers/MlGetInfluencersResponse.ts
+++ b/specification/ml/get_influencers/MlGetInfluencersResponse.ts
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-import { BucketInfluencer } from '@ml/_types/Bucket'
+import { Influencer } from '@ml/_types/Influencer'
 import { long } from '@_types/Numeric'
 
 export class Response {
   body: {
     count: long
     /** Array of influencer objects */
-    influencers: BucketInfluencer[]
+    influencers: Influencer[]
   }
 }


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-specification/pull/1020, which didn't backport automatically.