### PR TITLE
Adds spec for update datafeed API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -8090,9 +8090,21 @@
       "description": "Updates certain properties of a datafeed.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html",
       "name": "ml.update_datafeed",
-      "request": null,
+      "privileges": {
+        "cluster": [
+          "manage_ml"
+        ]
+      },
+      "request": {
+        "name": "Request",
+        "namespace": "ml.update_datafeed"
+      },
       "requestBodyRequired": true,
-      "response": null,
+      "response": {
+        "name": "Response",
+        "namespace": "ml.update_datafeed"
+      },
+      "since": "6.4.0",
       "stability": "stable",
       "urls": [
         {
@@ -124557,6 +124569,465 @@
       "name": {
         "name": "Response",
         "namespace": "ml.update_data_frame_analytics"
+      }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "description": "If set, the datafeed performs aggregation searches. Support for aggregations is limited and should be used only\nwith low cardinality data.",
+            "name": "aggregations",
+            "required": false,
+            "type": {
+              "key": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              },
+              "kind": "dictionary_of",
+              "singleKey": false,
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "AggregationContainer",
+                  "namespace": "_types.aggregations"
+                }
+              }
+            }
+          },
+          {
+            "description": "Datafeeds might search over long time periods, for several months or years. This search is split into time\nchunks in order to ensure the load on Elasticsearch is managed. Chunking configuration controls how the size of\nthese time chunks are calculated; it is an advanced configuration option.",
+            "name": "chunking_config",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "ChunkingConfig",
+                "namespace": "ml._types"
+              }
+            }
+          },
+          {
+            "description": "Specifies whether the datafeed checks for missing data and the size of the window. The datafeed can optionally\nsearch over indices that have already been read in an effort to determine whether any data has subsequently been\nadded to the index. If missing data is found, it is a good indication that the `query_delay` is set too low and\nthe data is being indexed after the datafeed has passed that moment in time. This check runs only on real-time\ndatafeeds.",
+            "name": "delayed_data_check_config",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "DelayedDataCheckConfig",
+                "namespace": "ml._types"
+              }
+            }
+          },
+          {
+            "description": "The interval at which scheduled queries are made while the datafeed runs in real time. The default value is\neither the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket\nspan. When `frequency` is shorter than the bucket span, interim results for the last (partial) bucket are\nwritten then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value\nmust be divisible by the interval of the date histogram aggregation.",
+            "name": "frequency",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Time",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "aliases": [
+              "indexes"
+            ],
+            "description": "An array of index names. Wildcards are supported. If any of the indices are in remote clusters, the machine\nlearning nodes must have the `remote_cluster_client` role.",
+            "name": "indices",
+            "required": false,
+            "type": {
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              }
+            }
+          },
+          {
+            "description": "Specifies index expansion options that are used during search.",
+            "name": "indices_options",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "DatafeedIndicesOptions",
+                "namespace": "ml._types"
+              }
+            }
+          },
+          {
+            "description": "If a real-time datafeed has never seen any data (including during any initial training period), it automatically\nstops and closes the associated job after this many real-time searches return no documents. In other words,\nit stops after `frequency` times `max_empty_searches` of real-time operation. If not set, a datafeed with no\nend time that sees no data remains started until it is explicitly stopped. By default, it is not set.",
+            "name": "max_empty_searches",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "description": "The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an\nElasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this\nobject is passed verbatim to Elasticsearch. Note that if you change the query, the analyzed data is also\nchanged. Therefore, the time required to learn might be long and the understandability of the results is\nunpredictable. If you want to make significant changes to the source data, it is recommended that you\nclone the job and datafeed and make the amendments in the clone. Let both run in parallel and close one\nwhen you are satisfied with the results of the job.",
+            "name": "query",
+            "required": false,
+            "serverDefault": "{\"match_all\": {\"boost\": 1}}",
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "QueryContainer",
+                "namespace": "_types.query_dsl"
+              }
+            }
+          },
+          {
+            "description": "The number of seconds behind real time that data is queried. For example, if data from 10:04 a.m. might\nnot be searchable in Elasticsearch until 10:06 a.m., set this property to 120 seconds. The default\nvalue is randomly selected between `60s` and `120s`. This randomness improves the query performance\nwhen there are multiple jobs running on the same node.",
+            "name": "query_delay",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Time",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "description": "Specifies runtime fields for the datafeed search.",
+            "name": "runtime_mappings",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "RuntimeFields",
+                "namespace": "_types.mapping"
+              }
+            }
+          },
+          {
+            "description": "Specifies scripts that evaluate custom expressions and returns script fields to the datafeed.\nThe detector configuration objects in a job can contain functions that use these script fields.",
+            "name": "script_fields",
+            "required": false,
+            "type": {
+              "key": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              },
+              "kind": "dictionary_of",
+              "singleKey": false,
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "ScriptField",
+                  "namespace": "_types"
+                }
+              }
+            }
+          },
+          {
+            "description": "The size parameter that is used in Elasticsearch searches when the datafeed does not use aggregations.\nThe maximum value is the value of `index.max_result_window`.",
+            "name": "scroll_size",
+            "required": false,
+            "serverDefault": 1000,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
+            }
+          }
+        ]
+      },
+      "description": "Updates the properties of a datafeed.\nYou must stop and start the datafeed for the changes to be applied.\nWhen Elasticsearch security features are enabled, your datafeed remembers which roles the user who updated it had at\nthe time of the update and runs the query using those same roles. If you provide secondary authorization headers,\nthose credentials are used instead.",
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "request",
+      "name": {
+        "name": "Request",
+        "namespace": "ml.update_datafeed"
+      },
+      "path": [
+        {
+          "description": "A numerical character string that uniquely identifies the datafeed.\nThis identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.\nIt must start and end with alphanumeric characters.",
+          "name": "datafeed_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "description": "If `true`, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the\n`_all` string or when no indices are specified.",
+          "name": "allow_no_indices",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "Type of index that wildcard patterns can match. If the request can target data streams, this argument determines\nwhether wildcard expressions match hidden data streams. Supports comma-separated values. Valid values are:\n\n* `all`: Match any data stream or index, including hidden ones.\n* `closed`: Match closed, non-hidden indices. Also matches any non-hidden data stream. Data streams cannot be closed.\n* `hidden`: Match hidden data streams and hidden indices. Must be combined with `open`, `closed`, or both.\n* `none`: Wildcard patterns are not accepted.\n* `open`: Match open, non-hidden indices. Also matches any non-hidden data stream.",
+          "name": "expand_wildcards",
+          "required": false,
+          "serverDefault": "open",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ExpandWildcards",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "deprecation": {
+            "description": "",
+            "version": "7.16.0"
+          },
+          "description": "If `true`, concrete, expanded or aliased indices are ignored when frozen.",
+          "name": "ignore_throttled",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "If `true`, unavailable indices (missing or closed) are ignored.",
+          "name": "ignore_unavailable",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "aggregations",
+            "required": true,
+            "type": {
+              "key": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              },
+              "kind": "dictionary_of",
+              "singleKey": false,
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "AggregationContainer",
+                  "namespace": "_types.aggregations"
+                }
+              }
+            }
+          },
+          {
+            "name": "chunking_config",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "ChunkingConfig",
+                "namespace": "ml._types"
+              }
+            }
+          },
+          {
+            "name": "delayed_data_check_config",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "DelayedDataCheckConfig",
+                "namespace": "ml._types"
+              }
+            }
+          },
+          {
+            "name": "datafeed_id",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Id",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "name": "frequency",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Time",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "name": "indices",
+            "required": true,
+            "type": {
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              }
+            }
+          },
+          {
+            "name": "job_id",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Id",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "name": "indices_options",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "DatafeedIndicesOptions",
+                "namespace": "ml._types"
+              }
+            }
+          },
+          {
+            "name": "max_empty_searches",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "name": "query",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "QueryContainer",
+                "namespace": "_types.query_dsl"
+              }
+            }
+          },
+          {
+            "name": "query_delay",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Time",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "name": "runtime_mappings",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "RuntimeFields",
+                "namespace": "_types.mapping"
+              }
+            }
+          },
+          {
+            "name": "script_fields",
+            "required": false,
+            "type": {
+              "key": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              },
+              "kind": "dictionary_of",
+              "singleKey": false,
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "ScriptField",
+                  "namespace": "_types"
+                }
+              }
+            }
+          },
+          {
+            "name": "scroll_size",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
+            }
+          }
+        ]
+      },
+      "kind": "response",
+      "name": {
+        "name": "Response",
+        "namespace": "ml.update_datafeed"
       }
     },
     {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1408,12 +1408,6 @@
       ],
       "response": []
     },
-    "ml.update_datafeed": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "ml.upgrade_job_snapshot": {
       "request": [
         "Request: should not have a body"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12686,6 +12686,46 @@ export interface MlUpdateDataFrameAnalyticsResponse {
   analyzed_fields?: MlDataframeAnalysisAnalyzedFields
 }
 
+export interface MlUpdateDatafeedRequest extends RequestBase {
+  datafeed_id: Id
+  allow_no_indices?: boolean
+  expand_wildcards?: ExpandWildcards
+  ignore_throttled?: boolean
+  ignore_unavailable?: boolean
+  body?: {
+    aggregations?: Record<string, AggregationsAggregationContainer>
+    chunking_config?: MlChunkingConfig
+    delayed_data_check_config?: MlDelayedDataCheckConfig
+    frequency?: Time
+    indices?: string[]
+    indexes?: string[]
+    indices_options?: MlDatafeedIndicesOptions
+    max_empty_searches?: integer
+    query?: QueryDslQueryContainer
+    query_delay?: Time
+    runtime_mappings?: MappingRuntimeFields
+    script_fields?: Record<string, ScriptField>
+    scroll_size?: integer
+  }
+}
+
+export interface MlUpdateDatafeedResponse {
+  aggregations: Record<string, AggregationsAggregationContainer>
+  chunking_config: MlChunkingConfig
+  delayed_data_check_config?: MlDelayedDataCheckConfig
+  datafeed_id: Id
+  frequency: Time
+  indices: string[]
+  job_id: Id
+  indices_options?: MlDatafeedIndicesOptions
+  max_empty_searches: integer
+  query: QueryDslQueryContainer
+  query_delay: Time
+  runtime_mappings?: MappingRuntimeFields
+  script_fields?: Record<string, ScriptField>
+  scroll_size: integer
+}
+
 export interface MlUpdateFilterRequest extends RequestBase {
   filter_id: Id
   body?: {

--- a/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
@@ -1,0 +1,165 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { ExpandWildcards, Id } from '@_types/common'
+import { Dictionary } from '@spec_utils/Dictionary'
+import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
+import {
+  ChunkingConfig,
+  DatafeedIndicesOptions,
+  DelayedDataCheckConfig
+} from '@ml/_types/Datafeed'
+import { Time } from '@_types/Time'
+import { integer } from '@_types/Numeric'
+import { QueryContainer } from '@_types/query_dsl/abstractions'
+import { RuntimeFields } from '@_types/mapping/RuntimeFields'
+import { ScriptField } from '@_types/Scripting'
+
+/**
+ * Updates the properties of a datafeed.
+ * You must stop and start the datafeed for the changes to be applied.
+ * When Elasticsearch security features are enabled, your datafeed remembers which roles the user who updated it had at
+ * the time of the update and runs the query using those same roles. If you provide secondary authorization headers,
+ * those credentials are used instead.
+ * @rest_spec_name ml.update_datafeed
+ * @since 6.4.0
+ * @stability stable
+ * @cluster_privileges manage_ml
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * A numerical character string that uniquely identifies the datafeed.
+     * This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
+     * It must start and end with alphanumeric characters.
+     */
+     datafeed_id: Id
+  }
+  query_parameters: {
+    /**
+     * If `true`, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the
+     * `_all` string or when no indices are specified.
+     * @server_default true
+     */
+    allow_no_indices?: boolean
+    /**
+     * Type of index that wildcard patterns can match. If the request can target data streams, this argument determines
+     * whether wildcard expressions match hidden data streams. Supports comma-separated values. Valid values are:
+     * 
+     * * `all`: Match any data stream or index, including hidden ones.
+     * * `closed`: Match closed, non-hidden indices. Also matches any non-hidden data stream. Data streams cannot be closed.
+     * * `hidden`: Match hidden data streams and hidden indices. Must be combined with `open`, `closed`, or both.
+     * * `none`: Wildcard patterns are not accepted.
+     * * `open`: Match open, non-hidden indices. Also matches any non-hidden data stream.
+     * @server_default open
+     */
+    expand_wildcards?: ExpandWildcards
+    /**
+     * If `true`, concrete, expanded or aliased indices are ignored when frozen.
+     * @server_default true
+     * @deprecated 7.16.0
+     */
+    ignore_throttled?: boolean
+    /**
+     * If `true`, unavailable indices (missing or closed) are ignored.
+     * @server_default false
+     */
+    ignore_unavailable?: boolean
+  }
+  body: {
+    /**
+     * If set, the datafeed performs aggregation searches. Support for aggregations is limited and should be used only
+     * with low cardinality data.
+     */
+    aggregations?: Dictionary<string, AggregationContainer>
+    /**
+     * Datafeeds might search over long time periods, for several months or years. This search is split into time
+     * chunks in order to ensure the load on Elasticsearch is managed. Chunking configuration controls how the size of
+     * these time chunks are calculated; it is an advanced configuration option.
+     */
+    chunking_config?: ChunkingConfig
+    /**
+     * Specifies whether the datafeed checks for missing data and the size of the window. The datafeed can optionally
+     * search over indices that have already been read in an effort to determine whether any data has subsequently been
+     * added to the index. If missing data is found, it is a good indication that the `query_delay` is set too low and
+     * the data is being indexed after the datafeed has passed that moment in time. This check runs only on real-time
+     * datafeeds.
+     */
+     delayed_data_check_config?: DelayedDataCheckConfig
+    /**
+     * The interval at which scheduled queries are made while the datafeed runs in real time. The default value is
+     * either the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket
+     * span. When `frequency` is shorter than the bucket span, interim results for the last (partial) bucket are
+     * written then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value
+     * must be divisible by the interval of the date histogram aggregation.
+     */
+     frequency?: Time
+    /**
+     * An array of index names. Wildcards are supported. If any of the indices are in remote clusters, the machine
+     * learning nodes must have the `remote_cluster_client` role.
+     * @aliases indexes
+     * */
+     indices?: string[]
+    /**
+     * Specifies index expansion options that are used during search.
+     */
+     indices_options?: DatafeedIndicesOptions
+    /**
+     * If a real-time datafeed has never seen any data (including during any initial training period), it automatically
+     * stops and closes the associated job after this many real-time searches return no documents. In other words,
+     * it stops after `frequency` times `max_empty_searches` of real-time operation. If not set, a datafeed with no
+     * end time that sees no data remains started until it is explicitly stopped. By default, it is not set.
+     */
+     max_empty_searches?: integer
+    /**
+     * The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an
+     * Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this
+     * object is passed verbatim to Elasticsearch. Note that if you change the query, the analyzed data is also
+     * changed. Therefore, the time required to learn might be long and the understandability of the results is
+     * unpredictable. If you want to make significant changes to the source data, it is recommended that you
+     * clone the job and datafeed and make the amendments in the clone. Let both run in parallel and close one
+     * when you are satisfied with the results of the job.
+     * @server_default {"match_all": {"boost": 1}}
+     */
+     query?: QueryContainer
+    /**
+     * The number of seconds behind real time that data is queried. For example, if data from 10:04 a.m. might
+     * not be searchable in Elasticsearch until 10:06 a.m., set this property to 120 seconds. The default
+     * value is randomly selected between `60s` and `120s`. This randomness improves the query performance
+     * when there are multiple jobs running on the same node.
+     */
+     query_delay?: Time
+    /**
+     * Specifies runtime fields for the datafeed search.
+     */
+     runtime_mappings?: RuntimeFields
+    /**
+     * Specifies scripts that evaluate custom expressions and returns script fields to the datafeed.
+     * The detector configuration objects in a job can contain functions that use these script fields.
+     */
+     script_fields?: Dictionary<string, ScriptField>
+    /**
+     * The size parameter that is used in Elasticsearch searches when the datafeed does not use aggregations.
+     * The maximum value is the value of `index.max_result_window`.
+     * @server_default 1000
+     */
+     scroll_size?: integer
+  }
+}

--- a/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
@@ -50,7 +50,7 @@ export interface Request extends RequestBase {
      * This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores.
      * It must start and end with alphanumeric characters.
      */
-     datafeed_id: Id
+    datafeed_id: Id
   }
   query_parameters: {
     /**
@@ -62,7 +62,7 @@ export interface Request extends RequestBase {
     /**
      * Type of index that wildcard patterns can match. If the request can target data streams, this argument determines
      * whether wildcard expressions match hidden data streams. Supports comma-separated values. Valid values are:
-     * 
+     *
      * * `all`: Match any data stream or index, including hidden ones.
      * * `closed`: Match closed, non-hidden indices. Also matches any non-hidden data stream. Data streams cannot be closed.
      * * `hidden`: Match hidden data streams and hidden indices. Must be combined with `open`, `closed`, or both.
@@ -102,7 +102,7 @@ export interface Request extends RequestBase {
      * the data is being indexed after the datafeed has passed that moment in time. This check runs only on real-time
      * datafeeds.
      */
-     delayed_data_check_config?: DelayedDataCheckConfig
+    delayed_data_check_config?: DelayedDataCheckConfig
     /**
      * The interval at which scheduled queries are made while the datafeed runs in real time. The default value is
      * either the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket
@@ -110,24 +110,24 @@ export interface Request extends RequestBase {
      * written then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value
      * must be divisible by the interval of the date histogram aggregation.
      */
-     frequency?: Time
+    frequency?: Time
     /**
      * An array of index names. Wildcards are supported. If any of the indices are in remote clusters, the machine
      * learning nodes must have the `remote_cluster_client` role.
      * @aliases indexes
      * */
-     indices?: string[]
+    indices?: string[]
     /**
      * Specifies index expansion options that are used during search.
      */
-     indices_options?: DatafeedIndicesOptions
+    indices_options?: DatafeedIndicesOptions
     /**
      * If a real-time datafeed has never seen any data (including during any initial training period), it automatically
      * stops and closes the associated job after this many real-time searches return no documents. In other words,
      * it stops after `frequency` times `max_empty_searches` of real-time operation. If not set, a datafeed with no
      * end time that sees no data remains started until it is explicitly stopped. By default, it is not set.
      */
-     max_empty_searches?: integer
+    max_empty_searches?: integer
     /**
      * The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an
      * Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this
@@ -138,28 +138,28 @@ export interface Request extends RequestBase {
      * when you are satisfied with the results of the job.
      * @server_default {"match_all": {"boost": 1}}
      */
-     query?: QueryContainer
+    query?: QueryContainer
     /**
      * The number of seconds behind real time that data is queried. For example, if data from 10:04 a.m. might
      * not be searchable in Elasticsearch until 10:06 a.m., set this property to 120 seconds. The default
      * value is randomly selected between `60s` and `120s`. This randomness improves the query performance
      * when there are multiple jobs running on the same node.
      */
-     query_delay?: Time
+    query_delay?: Time
     /**
      * Specifies runtime fields for the datafeed search.
      */
-     runtime_mappings?: RuntimeFields
+    runtime_mappings?: RuntimeFields
     /**
      * Specifies scripts that evaluate custom expressions and returns script fields to the datafeed.
      * The detector configuration objects in a job can contain functions that use these script fields.
      */
-     script_fields?: Dictionary<string, ScriptField>
+    script_fields?: Dictionary<string, ScriptField>
     /**
      * The size parameter that is used in Elasticsearch searches when the datafeed does not use aggregations.
      * The maximum value is the value of `index.max_result_window`.
      * @server_default 1000
      */
-     scroll_size?: integer
+    scroll_size?: integer
   }
 }

--- a/specification/ml/update_datafeed/MlUpdateDatafeedResponse.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedResponse.ts
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  ChunkingConfig,
+  DatafeedIndicesOptions,
+  DelayedDataCheckConfig
+} from '@ml/_types/Datafeed'
+import { Dictionary } from '@spec_utils/Dictionary'
+import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
+import { Id, Indices } from '@_types/common'
+import { RuntimeFields } from '@_types/mapping/RuntimeFields'
+import { integer } from '@_types/Numeric'
+import { QueryContainer } from '@_types/query_dsl/abstractions'
+import { ScriptField } from '@_types/Scripting'
+import { Time } from '@_types/Time'
+
+export class Response {
+  body: {
+    aggregations: Dictionary<string, AggregationContainer>
+    chunking_config: ChunkingConfig
+    delayed_data_check_config?: DelayedDataCheckConfig
+    datafeed_id: Id
+    frequency: Time
+    indices: string[]
+    job_id: Id
+    indices_options?: DatafeedIndicesOptions
+    max_empty_searches: integer
+    query: QueryContainer
+    query_delay: Time
+    runtime_mappings?: RuntimeFields
+    script_fields?: Dictionary<string, ScriptField>
+    scroll_size: integer
+  }
+}


### PR DESCRIPTION
[Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-update-datafeed.html) and a [rest-api-spec](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_datafeed.json) exist for the "update datafeed" API, but it was missing from these specifications.