### PR TITLE
Name unions

### DIFF
--- a/compiler/model/metamodel.ts
+++ b/compiler/model/metamodel.ts
@@ -160,6 +160,14 @@ export abstract class BaseType {
   kind: string
   /** Variant name for externally tagged variants */
   variantName?: string
+  /**
+   * Additional identifiers for use by code generators. Usage depends on the actual type:
+   * - on unions (modeled as alias(union_of)), these are identifiers for the union members
+   * - for additional properties, this is the name of the dict that holds these properties
+   * - for additional property, this is the name of the key and value fields that hold the
+   *   additional property
+   */
+  codegenNames?: string[]
 }
 
 export type Variants = ExternalTag | InternalTag | Container

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -653,7 +653,7 @@ export function hoistTypeAnnotations (type: model.TypeDefinition, jsDocs: JSDoc[
       assert(jsDocs,
         type.kind === 'type_alias' && type.type.kind === 'union_of' && type.type.items.length === type.codegenNames.length,
         '@codegen_names must have the number of items as the union definition'
-        )
+      )
     } else {
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on type ${type.name.name}`)
     }

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -651,7 +651,7 @@ export function hoistTypeAnnotations (type: model.TypeDefinition, jsDocs: JSDoc[
     } else if (tag === 'codegen_names') {
       type.codegenNames = value.split(',').map(v => v.trim())
       assert(jsDocs,
-        type.kind == 'type_alias' && type.type.kind == 'union_of' && type.type.items.length == type.codegenNames.length,
+        type.kind === 'type_alias' && type.type.kind === 'union_of' && type.type.items.length === type.codegenNames.length,
         '@codegen_names must have the number of items as the union definition'
         )
     } else {

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -650,6 +650,10 @@ export function hoistTypeAnnotations (type: model.TypeDefinition, jsDocs: JSDoc[
       type.docUrl = value
     } else if (tag === 'codegen_names') {
       type.codegenNames = value.split(',').map(v => v.trim())
+      assert(jsDocs,
+        type.kind == 'type_alias' && type.type.kind == 'union_of' && type.type.items.length == type.codegenNames.length,
+        '@codegen_names must have the number of items as the union definition'
+        )
     } else {
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on type ${type.name.name}`)
     }

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -627,7 +627,7 @@ export function hoistTypeAnnotations (type: model.TypeDefinition, jsDocs: JSDoc[
   // We want to enforce a single jsDoc block.
   assert(jsDocs, jsDocs.length < 2, 'Use a single multiline jsDoc block instead of multiple single line blocks')
 
-  const validTags = ['class_serializer', 'doc_url', 'behavior', 'variants', 'variant', 'shortcut_property']
+  const validTags = ['class_serializer', 'doc_url', 'behavior', 'variants', 'variant', 'shortcut_property', 'codegen_names']
   const tags = parseJsDocTags(jsDocs)
   if (jsDocs.length === 1) {
     const description = jsDocs[0].getDescription()
@@ -648,6 +648,8 @@ export function hoistTypeAnnotations (type: model.TypeDefinition, jsDocs: JSDoc[
     } else if (tag === 'doc_url') {
       assert(jsDocs, isValidUrl(value), '@doc_url is not a valid url')
       type.docUrl = value
+    } else if (tag === 'codegen_names') {
+      type.codegenNames = value.split(',').map(v => v.trim())
     } else {
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on type ${type.name.name}`)
     }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -13065,23 +13065,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GetSourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -14607,23 +14595,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GetSourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -15137,23 +15113,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GetSourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -15339,23 +15303,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GetSourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -15656,23 +15608,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GetSourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -16209,23 +16149,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GetSourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -16870,23 +16798,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GetSourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -17285,30 +17201,11 @@
             "name": "_source",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "boolean",
-                    "namespace": "internal"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Fields",
-                    "namespace": "_types"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "SourceFilter",
-                    "namespace": "_global.search._types"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "SourceConfig",
+                "namespace": "_global.search._types"
+              }
             }
           },
           {
@@ -17316,38 +17213,14 @@
             "name": "docvalue_fields",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "DocValueField",
-                    "namespace": "_global.search._types"
-                  }
-                },
-                {
-                  "kind": "array_of",
-                  "value": {
-                    "items": [
-                      {
-                        "kind": "instance_of",
-                        "type": {
-                          "name": "Field",
-                          "namespace": "_types"
-                        }
-                      },
-                      {
-                        "kind": "instance_of",
-                        "type": {
-                          "name": "DocValueField",
-                          "namespace": "_global.search._types"
-                        }
-                      }
-                    ],
-                    "kind": "union_of"
-                  }
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "DocValueField",
+                  "namespace": "_global.search._types"
                 }
-              ],
-              "kind": "union_of"
+              }
             }
           },
           {
@@ -17822,30 +17695,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "SourceFilter",
-                  "namespace": "_global.search._types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "SourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -18011,23 +17865,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GetSourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -18189,57 +18031,22 @@
           "name": "track_total_hits",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "integer",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "TrackHits",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
           "name": "suggest",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "SuggestContainer",
-                  "namespace": "_global.search._types"
-                }
-              },
-              {
-                "key": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                },
-                "kind": "dictionary_of",
-                "singleKey": false,
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "SuggestContainer",
-                    "namespace": "_global.search._types"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "Suggester",
+              "namespace": "_global.search._types"
+            }
           }
         }
       ]
@@ -19471,7 +19278,7 @@
         "properties": [
           {
             "name": "script",
-            "required": false,
+            "required": true,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -21761,23 +21568,11 @@
             "name": "track_total_hits",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "boolean",
-                    "namespace": "internal"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "integer",
-                    "namespace": "_types"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "TrackHits",
+                "namespace": "_global.search._types"
+              }
             }
           },
           {
@@ -21811,38 +21606,14 @@
             "name": "docvalue_fields",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "DocValueField",
-                    "namespace": "_global.search._types"
-                  }
-                },
-                {
-                  "kind": "array_of",
-                  "value": {
-                    "items": [
-                      {
-                        "kind": "instance_of",
-                        "type": {
-                          "name": "Field",
-                          "namespace": "_types"
-                        }
-                      },
-                      {
-                        "kind": "instance_of",
-                        "type": {
-                          "name": "DocValueField",
-                          "namespace": "_global.search._types"
-                        }
-                      }
-                    ],
-                    "kind": "union_of"
-                  }
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "DocValueField",
+                  "namespace": "_global.search._types"
                 }
-              ],
-              "kind": "union_of"
+              }
             }
           },
           {
@@ -21992,30 +21763,11 @@
             "name": "_source",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "boolean",
-                    "namespace": "internal"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Fields",
-                    "namespace": "_types"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "SourceFilter",
-                    "namespace": "_global.search._types"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "SourceConfig",
+                "namespace": "_global.search._types"
+              }
             }
           },
           {
@@ -22025,23 +21777,11 @@
             "type": {
               "kind": "array_of",
               "value": {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "Field",
-                      "namespace": "_types"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "DateField",
-                      "namespace": "_types"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+                "kind": "instance_of",
+                "type": {
+                  "name": "FieldAndFormat",
+                  "namespace": "_types.query_dsl"
+                }
               }
             }
           },
@@ -22049,34 +21789,11 @@
             "name": "suggest",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "SuggestContainer",
-                    "namespace": "_global.search._types"
-                  }
-                },
-                {
-                  "key": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  },
-                  "kind": "dictionary_of",
-                  "singleKey": false,
-                  "value": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SuggestContainer",
-                      "namespace": "_global.search._types"
-                    }
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "Suggester",
+                "namespace": "_global.search._types"
+              }
             }
           },
           {
@@ -22590,23 +22307,11 @@
           "name": "track_total_hits",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "integer",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "TrackHits",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -22662,23 +22367,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GetSourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -23619,6 +23312,24 @@
       }
     },
     {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "plain"
+        },
+        {
+          "name": "fvh"
+        },
+        {
+          "name": "unified"
+        }
+      ],
+      "name": {
+        "name": "BuiltinHighlighterType",
+        "namespace": "_global.search._types"
+      }
+    },
+    {
       "kind": "interface",
       "name": {
         "name": "Collector",
@@ -23673,6 +23384,74 @@
           }
         }
       ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "CompletionContext",
+        "namespace": "_global.search._types"
+      },
+      "properties": [
+        {
+          "name": "boost",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "context",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Context",
+              "namespace": "_global.search._types"
+            }
+          }
+        },
+        {
+          "name": "neighbours",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "GeoHashPrecision",
+                "namespace": "_types"
+              }
+            }
+          }
+        },
+        {
+          "name": "precision",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "GeoHashPrecision",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "prefix",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "shortcutProperty": "context"
     },
     {
       "generics": [
@@ -23840,8 +23619,8 @@
             "key": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Field",
+                "namespace": "_types"
               }
             },
             "kind": "dictionary_of",
@@ -23851,8 +23630,8 @@
                 {
                   "kind": "instance_of",
                   "type": {
-                    "name": "string",
-                    "namespace": "internal"
+                    "name": "CompletionContext",
+                    "namespace": "_global.search._types"
                   }
                 },
                 {
@@ -23860,24 +23639,7 @@
                   "value": {
                     "kind": "instance_of",
                     "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "GeoLocation",
-                    "namespace": "_types.query_dsl"
-                  }
-                },
-                {
-                  "kind": "array_of",
-                  "value": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SuggestContextQuery",
+                      "name": "CompletionContext",
                       "namespace": "_global.search._types"
                     }
                   }
@@ -23934,7 +23696,11 @@
       ]
     },
     {
-      "description": "Text that we want similar documents for or a lookup to a document's field for the text.",
+      "codegenNames": [
+        "category",
+        "location"
+      ],
+      "description": "Text or location that we want similar documents for or a lookup to a document's field for the text.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html#_document_input_parameters",
       "kind": "type_alias",
       "name": {
@@ -23954,7 +23720,7 @@
             "kind": "instance_of",
             "type": {
               "name": "GeoLocation",
-              "namespace": "_types.query_dsl"
+              "namespace": "_types"
             }
           }
         ],
@@ -24120,7 +23886,8 @@
             }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "field"
     },
     {
       "kind": "interface",
@@ -24312,49 +24079,6 @@
     {
       "kind": "interface",
       "name": {
-        "name": "FieldAndFormat",
-        "namespace": "_global.search._types"
-      },
-      "properties": [
-        {
-          "name": "field",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Field",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "format",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "include_unmapped",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        }
-      ],
-      "shortcutProperty": "field"
-    },
-    {
-      "kind": "interface",
-      "name": {
         "name": "FieldCollapse",
         "namespace": "_global.search._types"
       },
@@ -24470,8 +24194,130 @@
               "namespace": "_types.mapping"
             }
           }
+        },
+        {
+          "name": "numeric_type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "FieldSortNumericType",
+              "namespace": "_global.search._types"
+            }
+          }
+        },
+        {
+          "name": "format",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
         }
-      ]
+      ],
+      "shortcutProperty": "order"
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "long"
+        },
+        {
+          "name": "double"
+        },
+        {
+          "name": "date"
+        },
+        {
+          "name": "date_nanos"
+        }
+      ],
+      "name": {
+        "name": "FieldSortNumericType",
+        "namespace": "_global.search._types"
+      }
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "FieldSuggester",
+        "namespace": "_global.search._types"
+      },
+      "properties": [
+        {
+          "name": "completion",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "CompletionSuggester",
+              "namespace": "_global.search._types"
+            }
+          }
+        },
+        {
+          "name": "phrase",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "PhraseSuggester",
+              "namespace": "_global.search._types"
+            }
+          }
+        },
+        {
+          "name": "prefix",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "regex",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "term",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TermSuggester",
+              "namespace": "_global.search._types"
+            }
+          }
+        },
+        {
+          "name": "text",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "attachedBehaviors": [
@@ -24493,7 +24339,7 @@
                   "kind": "instance_of",
                   "type": {
                     "name": "GeoLocation",
-                    "namespace": "_types.query_dsl"
+                    "namespace": "_types"
                   }
                 },
                 {
@@ -24502,7 +24348,7 @@
                     "kind": "instance_of",
                     "type": {
                       "name": "GeoLocation",
-                      "namespace": "_types.query_dsl"
+                      "namespace": "_types"
                     }
                   }
                 }
@@ -24545,6 +24391,17 @@
           }
         },
         {
+          "name": "ignore_unmapped",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
           "name": "order",
           "required": false,
           "type": {
@@ -24567,6 +24424,36 @@
           }
         }
       ]
+    },
+    {
+      "codegenNames": [
+        "fetch",
+        "fields"
+      ],
+      "kind": "type_alias",
+      "name": {
+        "name": "GetSourceConfig",
+        "namespace": "_global.search._types"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "_types"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
     },
     {
       "kind": "interface",
@@ -25063,23 +24950,11 @@
           "name": "type",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "HighlighterType",
-                  "namespace": "_global.search._types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "HighlighterType",
+              "namespace": "_global.search._types"
+            }
           }
         }
       ]
@@ -25139,21 +25014,33 @@
       }
     },
     {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "plain"
-        },
-        {
-          "name": "fvh"
-        },
-        {
-          "name": "unified"
-        }
+      "codegenNames": [
+        "builtin",
+        "custom"
       ],
+      "kind": "type_alias",
       "name": {
         "name": "HighlighterType",
         "namespace": "_global.search._types"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "BuiltinHighlighterType",
+              "namespace": "_global.search._types"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        ],
+        "kind": "union_of"
       }
     },
     {
@@ -25550,7 +25437,7 @@
               "kind": "instance_of",
               "type": {
                 "name": "FieldAndFormat",
-                "namespace": "_global.search._types"
+                "namespace": "_types.query_dsl"
               }
             }
           }
@@ -25647,23 +25534,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "SourceFilter",
-                  "namespace": "_global.search._types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "SourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -25705,79 +25580,6 @@
     {
       "kind": "interface",
       "name": {
-        "name": "InnerHitsMetadata",
-        "namespace": "_global.search._types"
-      },
-      "properties": [
-        {
-          "name": "total",
-          "required": true,
-          "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "TotalHits",
-                  "namespace": "_global.search._types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "long",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
-        {
-          "name": "hits",
-          "required": true,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "generics": [
-                {
-                  "key": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  },
-                  "kind": "dictionary_of",
-                  "singleKey": false,
-                  "value": {
-                    "kind": "user_defined_value"
-                  }
-                }
-              ],
-              "kind": "instance_of",
-              "type": {
-                "name": "Hit",
-                "namespace": "_global.search._types"
-              }
-            }
-          }
-        },
-        {
-          "name": "max_score",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
         "name": "InnerHitsResult",
         "namespace": "_global.search._types"
       },
@@ -25786,9 +25588,14 @@
           "name": "hits",
           "required": true,
           "type": {
+            "generics": [
+              {
+                "kind": "user_defined_value"
+              }
+            ],
             "kind": "instance_of",
             "type": {
-              "name": "InnerHitsMetadata",
+              "name": "HitsMetadata",
               "namespace": "_global.search._types"
             }
           }
@@ -25925,6 +25732,17 @@
             "type": {
               "name": "integer",
               "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "nested",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "NestedSortValue",
+              "namespace": "_global.search._types"
             }
           }
         },
@@ -26700,17 +26518,6 @@
       },
       "properties": [
         {
-          "name": "mode",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "SortMode",
-              "namespace": "_global.search._types"
-            }
-          }
-        },
-        {
           "name": "order",
           "required": false,
           "type": {
@@ -26758,12 +26565,49 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "ScriptSortType",
+              "namespace": "_global.search._types"
+            }
+          }
+        },
+        {
+          "name": "mode",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "SortMode",
+              "namespace": "_global.search._types"
+            }
+          }
+        },
+        {
+          "name": "nested",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "NestedSortValue",
+              "namespace": "_global.search._types"
             }
           }
         }
       ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "string"
+        },
+        {
+          "name": "number"
+        }
+      ],
+      "name": {
+        "name": "ScriptSortType",
+        "namespace": "_global.search._types"
+      }
     },
     {
       "kind": "interface",
@@ -26947,6 +26791,10 @@
       }
     },
     {
+      "codegenNames": [
+        "field",
+        "options"
+      ],
       "kind": "type_alias",
       "name": {
         "name": "SortCombinations",
@@ -26964,14 +26812,7 @@
           {
             "kind": "instance_of",
             "type": {
-              "name": "SortContainer",
-              "namespace": "_global.search._types"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "SortOrder",
+              "name": "SortOptions",
               "namespace": "_global.search._types"
             }
           }
@@ -26980,8 +26821,32 @@
       }
     },
     {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "min"
+        },
+        {
+          "name": "max"
+        },
+        {
+          "name": "sum"
+        },
+        {
+          "name": "avg"
+        },
+        {
+          "name": "median"
+        }
+      ],
+      "name": {
+        "name": "SortMode",
+        "namespace": "_global.search._types"
+      }
+    },
+    {
       "attachedBehaviors": [
-        "AdditionalProperties"
+        "AdditionalProperty"
       ],
       "behaviors": [
         {
@@ -26994,34 +26859,23 @@
               }
             },
             {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "FieldSort",
-                    "namespace": "_global.search._types"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "SortOrder",
-                    "namespace": "_global.search._types"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "FieldSort",
+                "namespace": "_global.search._types"
+              }
             }
           ],
           "type": {
-            "name": "AdditionalProperties",
+            "name": "AdditionalProperty",
             "namespace": "_spec_utils"
           }
         }
       ],
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html",
       "kind": "interface",
       "name": {
-        "name": "SortContainer",
+        "name": "SortOptions",
         "namespace": "_global.search._types"
       },
       "properties": [
@@ -27069,30 +26923,9 @@
             }
           }
         }
-      ]
-    },
-    {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "min"
-        },
-        {
-          "name": "max"
-        },
-        {
-          "name": "sum"
-        },
-        {
-          "name": "avg"
-        },
-        {
-          "name": "median"
-        }
       ],
-      "name": {
-        "name": "SortMode",
-        "namespace": "_global.search._types"
+      "variants": {
+        "kind": "container"
       }
     },
     {
@@ -27103,10 +26936,6 @@
         },
         {
           "name": "desc"
-        },
-        {
-          "codegenName": "Document",
-          "name": "_doc"
         }
       ],
       "name": {
@@ -27158,6 +26987,37 @@
       }
     },
     {
+      "codegenNames": [
+        "fetch",
+        "filter"
+      ],
+      "description": "Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.",
+      "kind": "type_alias",
+      "name": {
+        "name": "SourceConfig",
+        "namespace": "_global.search._types"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "SourceFilter",
+              "namespace": "_global.search._types"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
       "kind": "interface",
       "name": {
         "name": "SourceFilter",
@@ -27165,6 +27025,9 @@
       },
       "properties": [
         {
+          "aliases": [
+            "exclude"
+          ],
           "name": "excludes",
           "required": false,
           "type": {
@@ -27176,6 +27039,9 @@
           }
         },
         {
+          "aliases": [
+            "include"
+          ],
           "name": "includes",
           "required": false,
           "type": {
@@ -27185,30 +27051,9 @@
               "namespace": "_types"
             }
           }
-        },
-        {
-          "name": "exclude",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Fields",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "include",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Fields",
-              "namespace": "_types"
-            }
-          }
         }
-      ]
+      ],
+      "shortcutProperty": "includes"
     },
     {
       "kind": "enum",
@@ -27328,178 +27173,6 @@
     {
       "kind": "interface",
       "name": {
-        "name": "SuggestContainer",
-        "namespace": "_global.search._types"
-      },
-      "properties": [
-        {
-          "name": "completion",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "CompletionSuggester",
-              "namespace": "_global.search._types"
-            }
-          }
-        },
-        {
-          "name": "phrase",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "PhraseSuggester",
-              "namespace": "_global.search._types"
-            }
-          }
-        },
-        {
-          "name": "prefix",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "regex",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "term",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "TermSuggester",
-              "namespace": "_global.search._types"
-            }
-          }
-        },
-        {
-          "name": "text",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        }
-      ],
-      "variants": {
-        "kind": "container"
-      }
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "SuggestContextQuery",
-        "namespace": "_global.search._types"
-      },
-      "properties": [
-        {
-          "name": "boost",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "context",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Context",
-              "namespace": "_global.search._types"
-            }
-          }
-        },
-        {
-          "name": "neighbours",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Distance",
-                    "namespace": "_types"
-                  }
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "integer",
-                    "namespace": "_types"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
-        {
-          "name": "precision",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Distance",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "integer",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
-        {
-          "name": "prefix",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
         "name": "SuggestFuzziness",
         "namespace": "_global.search._types"
       },
@@ -27562,6 +27235,11 @@
       ]
     },
     {
+      "codegenNames": [
+        "completion",
+        "phrase",
+        "term"
+      ],
       "generics": [
         {
           "name": "TDocument",
@@ -27623,6 +27301,54 @@
         "name": "SuggestSort",
         "namespace": "_global.search._types"
       }
+    },
+    {
+      "attachedBehaviors": [
+        "AdditionalProperties"
+      ],
+      "behaviors": [
+        {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "FieldSuggester",
+                "namespace": "_global.search._types"
+              }
+            }
+          ],
+          "type": {
+            "name": "AdditionalProperties",
+            "namespace": "_spec_utils"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "Suggester",
+        "namespace": "_global.search._types"
+      },
+      "properties": [
+        {
+          "description": "Global suggest text, to avoid repetition when the same text is used in several suggesters",
+          "name": "text",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "kind": "interface",
@@ -27901,6 +27627,37 @@
       "name": {
         "name": "TotalHitsRelation",
         "namespace": "_global.search._types"
+      }
+    },
+    {
+      "codegenNames": [
+        "enabled",
+        "count"
+      ],
+      "description": "Number of hits matching the query to count accurately. If true, the exact\nnumber of hits is returned at the cost of some performance. If false, the\nresponse does not include the total number of hits matching the query.\nDefaults to 10,000 hits.",
+      "kind": "type_alias",
+      "name": {
+        "name": "TrackHits",
+        "namespace": "_global.search._types"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        ],
+        "kind": "union_of"
       }
     },
     {
@@ -29679,23 +29436,11 @@
             "required": false,
             "serverDefault": "true",
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "boolean",
-                    "namespace": "internal"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "SourceFilter",
-                    "namespace": "_global.search._types"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "SourceConfig",
+                "namespace": "_global.search._types"
+              }
             }
           },
           {
@@ -29893,23 +29638,11 @@
           "required": false,
           "serverDefault": "true",
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GetSourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -30356,23 +30089,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GetSourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -30914,6 +30635,27 @@
       }
     },
     {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "painless"
+        },
+        {
+          "name": "expression"
+        },
+        {
+          "name": "mustache"
+        },
+        {
+          "name": "java"
+        }
+      ],
+      "name": {
+        "name": "BuiltinScriptLanguage",
+        "namespace": "_types"
+      }
+    },
+    {
       "kind": "interface",
       "name": {
         "name": "BulkIndexByScrollFailure",
@@ -31293,6 +31035,59 @@
       }
     },
     {
+      "kind": "interface",
+      "name": {
+        "name": "CoordsGeoBounds",
+        "namespace": "_types"
+      },
+      "properties": [
+        {
+          "name": "top",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "bottom",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "left",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "right",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-data-stream.html#indices-create-data-stream-api-path-params",
       "kind": "type_alias",
       "name": {
@@ -31335,49 +31130,6 @@
         ],
         "kind": "union_of"
       }
-    },
-    {
-      "description": "A reference to a date field with formatting instructions on how to return the date",
-      "kind": "interface",
-      "name": {
-        "name": "DateField",
-        "namespace": "_types"
-      },
-      "properties": [
-        {
-          "name": "field",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Field",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "format",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "include_unmapped",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
     },
     {
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/7.x/mapping-date-format.html",
@@ -31867,7 +31619,7 @@
         }
       ],
       "name": {
-        "name": "ExpandWildcardOptions",
+        "name": "ExpandWildcard",
         "namespace": "_types"
       }
     },
@@ -31882,7 +31634,7 @@
           {
             "kind": "instance_of",
             "type": {
-              "name": "ExpandWildcardOptions",
+              "name": "ExpandWildcard",
               "namespace": "_types"
             }
           },
@@ -31891,16 +31643,9 @@
             "value": {
               "kind": "instance_of",
               "type": {
-                "name": "ExpandWildcardOptions",
+                "name": "ExpandWildcard",
                 "namespace": "_types"
               }
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
             }
           }
         ],
@@ -31983,6 +31728,53 @@
           }
         }
       ]
+    },
+    {
+      "codegenNames": [
+        "long",
+        "double",
+        "string",
+        "boolean"
+      ],
+      "description": "A field value.",
+      "kind": "type_alias",
+      "name": {
+        "name": "FieldValue",
+        "namespace": "_types"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
     },
     {
       "kind": "interface",
@@ -32157,6 +31949,53 @@
       }
     },
     {
+      "codegenNames": [
+        "coords",
+        "tlbr",
+        "trbl",
+        "wkt"
+      ],
+      "description": "A geo bounding box. It can be represented in various ways:\n- as 4 top/bottom/left/right coordinates\n- as 2 top_left / bottom_right points\n- as 2 top_right / bottom_left points\n- as a WKT bounding box",
+      "kind": "type_alias",
+      "name": {
+        "name": "GeoBounds",
+        "namespace": "_types"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CoordsGeoBounds",
+              "namespace": "_types"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TopLeftBottomRightGeoBounds",
+              "namespace": "_types"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TopRightBottomLeftGeoBounds",
+              "namespace": "_types"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "WktGeoBounds",
+              "namespace": "_types"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
       "kind": "enum",
       "members": [
         {
@@ -32186,17 +32025,54 @@
       }
     },
     {
+      "kind": "interface",
+      "name": {
+        "name": "GeoHashLocation",
+        "namespace": "_types"
+      },
+      "properties": [
+        {
+          "name": "geohash",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "GeoHash",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "codegenNames": [
+        "geohash_length",
+        "distance"
+      ],
+      "description": "A precision that can be expressed as a geohash length between 1 and 12, or a distance measure like \"1km\", \"10m\".",
       "kind": "type_alias",
       "name": {
         "name": "GeoHashPrecision",
         "namespace": "_types"
       },
       "type": {
-        "kind": "instance_of",
-        "type": {
-          "name": "number",
-          "namespace": "internal"
-        }
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "number",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        ],
+        "kind": "union_of"
       }
     },
     {
@@ -32238,6 +32114,56 @@
           }
         }
       ]
+    },
+    {
+      "codegenNames": [
+        "latlon",
+        "geohash",
+        "coords",
+        "text"
+      ],
+      "description": "A latitude/longitude as a 2 dimensional point. It can be represented in various ways:\n- as a `{lat, long}` object\n- as a geo hash value\n- as a `[lon, lat]` array\n- as a string in `\"<lat>, <lon>\"` or WKT point formats",
+      "kind": "type_alias",
+      "name": {
+        "name": "GeoLocation",
+        "namespace": "_types"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "LatLonGeoLocation",
+              "namespace": "_types"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "GeoHashLocation",
+              "namespace": "_types"
+            }
+          },
+          {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "double",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
     },
     {
       "description": "A GeoJson shape, that can also use Elasticsearch's `envelope` extension.",
@@ -32423,24 +32349,6 @@
       "kind": "enum",
       "members": [
         {
-          "name": "nodes"
-        },
-        {
-          "name": "parents"
-        },
-        {
-          "name": "none"
-        }
-      ],
-      "name": {
-        "name": "GroupBy",
-        "namespace": "_types"
-      }
-    },
-    {
-      "kind": "enum",
-      "members": [
-        {
           "description": "All shards are assigned.",
           "name": "green"
         },
@@ -32613,32 +32521,6 @@
           }
         }
       }
-    },
-    {
-      "inherits": {
-        "type": {
-          "name": "ScriptBase",
-          "namespace": "_types"
-        }
-      },
-      "kind": "interface",
-      "name": {
-        "name": "IndexedScript",
-        "namespace": "_types"
-      },
-      "properties": [
-        {
-          "name": "id",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Id",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
     },
     {
       "kind": "interface",
@@ -32994,6 +32876,39 @@
       },
       "properties": [
         {
+          "name": "lang",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ScriptLanguage",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "options",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        },
+        {
           "name": "source",
           "required": true,
           "type": {
@@ -33004,7 +32919,8 @@
             }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "source"
     },
     {
       "kind": "type_alias",
@@ -33023,7 +32939,7 @@
     {
       "kind": "interface",
       "name": {
-        "name": "LatLon",
+        "name": "LatLonGeoLocation",
         "namespace": "_types"
       },
       "properties": [
@@ -34205,24 +34121,12 @@
           {
             "kind": "instance_of",
             "type": {
-              "name": "RefreshOptions",
+              "name": "RefreshValues",
               "namespace": "_types"
             }
           }
         ],
         "kind": "union_of"
-      }
-    },
-    {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "wait_for"
-        }
-      ],
-      "name": {
-        "name": "RefreshOptions",
-        "namespace": "_types"
       }
     },
     {
@@ -34299,6 +34203,24 @@
           }
         }
       ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "true"
+        },
+        {
+          "name": "false"
+        },
+        {
+          "name": "wait_for"
+        }
+      ],
+      "name": {
+        "name": "RefreshValues",
+        "namespace": "_types"
+      }
     },
     {
       "kind": "type_alias",
@@ -34471,47 +34393,10 @@
       }
     },
     {
-      "description": "A single value",
-      "kind": "type_alias",
-      "name": {
-        "name": "ScalarValue",
-        "namespace": "_types"
-      },
-      "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        ],
-        "kind": "union_of"
-      }
-    },
-    {
+      "codegenNames": [
+        "inline",
+        "stored"
+      ],
       "kind": "type_alias",
       "name": {
         "name": "Script",
@@ -34529,15 +34414,8 @@
           {
             "kind": "instance_of",
             "type": {
-              "name": "IndexedScript",
+              "name": "StoredScriptId",
               "namespace": "_types"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
             }
           }
         ],
@@ -34551,29 +34429,6 @@
         "namespace": "_types"
       },
       "properties": [
-        {
-          "name": "lang",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "ScriptLanguage",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
         {
           "name": "params",
           "required": false,
@@ -34626,24 +34481,34 @@
       ]
     },
     {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "painless"
-        },
-        {
-          "name": "expression"
-        },
-        {
-          "name": "mustache"
-        },
-        {
-          "name": "java"
-        }
+      "codegenNames": [
+        "builtin",
+        "custom"
       ],
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html",
+      "kind": "type_alias",
       "name": {
         "name": "ScriptLanguage",
         "namespace": "_types"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "BuiltinScriptLanguage",
+              "namespace": "_types"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        ],
+        "kind": "union_of"
       }
     },
     {
@@ -35233,24 +35098,6 @@
       }
     },
     {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "intersects"
-        },
-        {
-          "name": "disjoint"
-        },
-        {
-          "name": "within"
-        }
-      ],
-      "name": {
-        "name": "ShapeRelation",
-        "namespace": "_types"
-      }
-    },
-    {
       "kind": "interface",
       "name": {
         "name": "ShardFailure",
@@ -35402,33 +35249,6 @@
       ]
     },
     {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "Raw"
-        },
-        {
-          "name": "k"
-        },
-        {
-          "name": "m"
-        },
-        {
-          "name": "g"
-        },
-        {
-          "name": "t"
-        },
-        {
-          "name": "p"
-        }
-      ],
-      "name": {
-        "name": "Size",
-        "namespace": "_types"
-      }
-    },
-    {
       "kind": "interface",
       "name": {
         "name": "SlicedScroll",
@@ -35554,25 +35374,35 @@
       "properties": [
         {
           "name": "lang",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ScriptLanguage",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "options",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "ScriptLanguage",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
               }
-            ],
-            "kind": "union_of"
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
           }
         },
         {
@@ -35583,6 +35413,32 @@
             "type": {
               "name": "string",
               "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "ScriptBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "StoredScriptId",
+        "namespace": "_types"
+      },
+      "properties": [
+        {
+          "name": "id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
             }
           }
         }
@@ -35666,8 +35522,12 @@
       }
     },
     {
+      "codegenNames": [
+        "time",
+        "offset"
+      ],
       "description": "Whenever durations need to be specified, e.g. for a timeout parameter, the duration must specify the unit, like 2d for 2 days.",
-      "docUrl": "https://github.com/elastic/elasticsearch/blob/master/libs/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java\nhttps://github.com/elastic/elasticsearch/blob/master/libs/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java\nOnly support 0 and -1 but we have no way to encode these as constants at the moment",
+      "docUrl": "https://github.com/elastic/elasticsearch/blob/master/libs/core/src/main/java/org/elasticsearch/core/TimeValue.java",
       "kind": "type_alias",
       "name": {
         "name": "Time",
@@ -35771,6 +35631,68 @@
           "namespace": "internal"
         }
       }
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "TopLeftBottomRightGeoBounds",
+        "namespace": "_types"
+      },
+      "properties": [
+        {
+          "name": "top_left",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "GeoLocation",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "bottom_right",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "GeoLocation",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "TopRightBottomLeftGeoBounds",
+        "namespace": "_types"
+      },
+      "properties": [
+        {
+          "name": "top_right",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "GeoLocation",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "bottom_left",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "GeoLocation",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
     },
     {
       "kind": "interface",
@@ -36058,6 +35980,10 @@
       }
     },
     {
+      "codegenNames": [
+        "count",
+        "option"
+      ],
       "kind": "type_alias",
       "name": {
         "name": "WaitForActiveShards",
@@ -36176,6 +36102,26 @@
             "type": {
               "name": "long",
               "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "WktGeoBounds",
+        "namespace": "_types"
+      },
+      "properties": [
+        {
+          "name": "wkt",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
             }
           }
         }
@@ -38508,6 +38454,10 @@
       ]
     },
     {
+      "codegenNames": [
+        "keyed",
+        "array"
+      ],
       "description": "Aggregation buckets. By default they are returned as an array, but if the aggregation has keys configured for\nthe different buckets, the result is a dictionary.",
       "generics": [
         {
@@ -38552,6 +38502,116 @@
           }
         ],
         "kind": "union_of"
+      }
+    },
+    {
+      "codegenNames": [
+        "single",
+        "array",
+        "dict"
+      ],
+      "description": "Buckets path can be expressed in different ways, and an aggregation may accept some or all of these\nforms depending on its type. Please refer to each aggregation's documentation to know what buckets\npath forms they accept.",
+      "kind": "type_alias",
+      "name": {
+        "name": "BucketsPath",
+        "namespace": "_types.aggregations"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "aliases": [
+            "1s"
+          ],
+          "name": "second"
+        },
+        {
+          "aliases": [
+            "1m"
+          ],
+          "name": "minute"
+        },
+        {
+          "aliases": [
+            "1h"
+          ],
+          "name": "hour"
+        },
+        {
+          "aliases": [
+            "1d"
+          ],
+          "name": "day"
+        },
+        {
+          "aliases": [
+            "1w"
+          ],
+          "name": "week"
+        },
+        {
+          "aliases": [
+            "1M"
+          ],
+          "name": "month"
+        },
+        {
+          "aliases": [
+            "1q"
+          ],
+          "name": "quarter"
+        },
+        {
+          "aliases": [
+            "1Y"
+          ],
+          "name": "year"
+        }
+      ],
+      "name": {
+        "name": "CalendarInterval",
+        "namespace": "_types.aggregations"
       }
     },
     {
@@ -39118,23 +39178,11 @@
           "name": "calendar_interval",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateInterval",
-                  "namespace": "_types.aggregations"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Time",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "CalendarInterval",
+              "namespace": "_types.aggregations"
+            }
           }
         },
         {
@@ -39143,23 +39191,11 @@
           "type": {
             "generics": [
               {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "DateMath",
-                      "namespace": "_types"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "long",
-                      "namespace": "_types"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+                "kind": "instance_of",
+                "type": {
+                  "name": "FieldDateMath",
+                  "namespace": "_types.aggregations"
+                }
               }
             ],
             "kind": "instance_of",
@@ -39175,23 +39211,11 @@
           "type": {
             "generics": [
               {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "DateMath",
-                      "namespace": "_types"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "long",
-                      "namespace": "_types"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+                "kind": "instance_of",
+                "type": {
+                  "name": "FieldDateMath",
+                  "namespace": "_types.aggregations"
+                }
               }
             ],
             "kind": "instance_of",
@@ -39216,23 +39240,11 @@
           "name": "fixed_interval",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateInterval",
-                  "namespace": "_types.aggregations"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Time",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
           }
         },
         {
@@ -39250,23 +39262,11 @@
           "name": "interval",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateInterval",
-                  "namespace": "_types.aggregations"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Time",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
           }
         },
         {
@@ -39407,39 +39407,6 @@
       ]
     },
     {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "second"
-        },
-        {
-          "name": "minute"
-        },
-        {
-          "name": "hour"
-        },
-        {
-          "name": "day"
-        },
-        {
-          "name": "week"
-        },
-        {
-          "name": "month"
-        },
-        {
-          "name": "quarter"
-        },
-        {
-          "name": "year"
-        }
-      ],
-      "name": {
-        "name": "DateInterval",
-        "namespace": "_types.aggregations"
-      }
-    },
-    {
       "description": "Result of a `date_range` aggregation. Same format as a for a `range` aggregation: `from` and `to`\nin `buckets` are milliseconds since the Epoch, represented as a floating point number.",
       "inherits": {
         "type": {
@@ -39550,44 +39517,10 @@
           "name": "from",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateMath",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "float",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
-        {
-          "name": "from_as_string",
-          "required": false,
-          "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "to_as_string",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "FieldDateMath",
+              "namespace": "_types.aggregations"
             }
           }
         },
@@ -39606,33 +39539,10 @@
           "name": "to",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateMath",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "float",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
-        {
-          "name": "doc_count",
-          "required": false,
-          "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
-              "namespace": "_types"
+              "name": "FieldDateMath",
+              "namespace": "_types.aggregations"
             }
           }
         }
@@ -39840,6 +39750,40 @@
             "type": {
               "name": "float",
               "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "MovingAverageAggregationBase",
+          "namespace": "_types.aggregations"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "EwmaMovingAverageAggregation",
+        "namespace": "_types.aggregations"
+      },
+      "properties": [
+        {
+          "name": "model",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "ewma"
+          }
+        },
+        {
+          "name": "settings",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "EwmaModelSettings",
+              "namespace": "_types.aggregations"
             }
           }
         }
@@ -40158,6 +40102,37 @@
       ]
     },
     {
+      "codegenNames": [
+        "expr",
+        "value"
+      ],
+      "description": "A date range limit, represented either as a DateMath expression or a number expressed\naccording to the target field's precision.",
+      "kind": "type_alias",
+      "name": {
+        "name": "FieldDateMath",
+        "namespace": "_types.aggregations"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateMath",
+              "namespace": "_types"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
       "inherits": {
         "type": {
           "name": "SingleBucketAggregateBase",
@@ -40213,37 +40188,20 @@
           "name": "filters",
           "required": false,
           "type": {
-            "items": [
+            "generics": [
               {
-                "key": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                },
-                "kind": "dictionary_of",
-                "singleKey": false,
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "QueryContainer",
-                    "namespace": "_types.query_dsl"
-                  }
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "QueryContainer",
-                    "namespace": "_types.query_dsl"
-                  }
+                "kind": "instance_of",
+                "type": {
+                  "name": "QueryContainer",
+                  "namespace": "_types.query_dsl"
                 }
               }
             ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "Buckets",
+              "namespace": "_types.aggregations"
+            }
           }
         },
         {
@@ -40366,37 +40324,6 @@
       }
     },
     {
-      "kind": "interface",
-      "name": {
-        "name": "GeoBounds",
-        "namespace": "_types.aggregations"
-      },
-      "properties": [
-        {
-          "name": "bottom_right",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "LatLon",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "top_left",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "LatLon",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
-    },
-    {
       "inherits": {
         "type": {
           "name": "AggregateBase",
@@ -40416,7 +40343,7 @@
             "kind": "instance_of",
             "type": {
               "name": "GeoBounds",
-              "namespace": "_types.aggregations"
+              "namespace": "_types"
             }
           }
         }
@@ -40480,7 +40407,7 @@
             "kind": "instance_of",
             "type": {
               "name": "GeoLocation",
-              "namespace": "_types.query_dsl"
+              "namespace": "_types"
             }
           }
         }
@@ -40518,7 +40445,7 @@
             "kind": "instance_of",
             "type": {
               "name": "GeoLocation",
-              "namespace": "_types.query_dsl"
+              "namespace": "_types"
             }
           }
         }
@@ -40579,23 +40506,11 @@
           "name": "origin",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "GeoLocation",
-                  "namespace": "_types.query_dsl"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GeoLocation",
+              "namespace": "_types"
+            }
           }
         },
         {
@@ -40668,8 +40583,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "BoundingBox",
-              "namespace": "_types.query_dsl"
+              "name": "GeoBounds",
+              "namespace": "_types"
             }
           }
         },
@@ -40765,8 +40680,11 @@
           "name": "type",
           "required": true,
           "type": {
-            "kind": "literal_value",
-            "value": "Feature"
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
           }
         },
         {
@@ -40975,7 +40893,7 @@
             "kind": "instance_of",
             "type": {
               "name": "GeoBounds",
-              "namespace": "_types.aggregations"
+              "namespace": "_types"
             }
           }
         }
@@ -41390,6 +41308,40 @@
       ]
     },
     {
+      "inherits": {
+        "type": {
+          "name": "MovingAverageAggregationBase",
+          "namespace": "_types.aggregations"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "HoltMovingAverageAggregation",
+        "namespace": "_types.aggregations"
+      },
+      "properties": [
+        {
+          "name": "model",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "holt"
+          }
+        },
+        {
+          "name": "settings",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "HoltLinearModelSettings",
+              "namespace": "_types.aggregations"
+            }
+          }
+        }
+      ]
+    },
+    {
       "kind": "interface",
       "name": {
         "name": "HoltWintersModelSettings",
@@ -41465,6 +41417,40 @@
       ]
     },
     {
+      "inherits": {
+        "type": {
+          "name": "MovingAverageAggregationBase",
+          "namespace": "_types.aggregations"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "HoltWintersMovingAverageAggregation",
+        "namespace": "_types.aggregations"
+      },
+      "properties": [
+        {
+          "name": "model",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "holt_winters"
+          }
+        },
+        {
+          "name": "settings",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "HoltWintersModelSettings",
+              "namespace": "_types.aggregations"
+            }
+          }
+        }
+      ]
+    },
+    {
       "kind": "enum",
       "members": [
         {
@@ -41523,7 +41509,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "ScalarValue",
+              "name": "FieldValue",
               "namespace": "_types"
             }
           }
@@ -41729,7 +41715,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "ScalarValue",
+              "name": "FieldValue",
               "namespace": "_types"
             }
           }
@@ -41947,6 +41933,40 @@
           "kind": "union_of"
         }
       }
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "MovingAverageAggregationBase",
+          "namespace": "_types.aggregations"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "LinearMovingAverageAggregation",
+        "namespace": "_types.aggregations"
+      },
+      "properties": [
+        {
+          "name": "model",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "linear"
+          }
+        },
+        {
+          "name": "settings",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "EmptyObject",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
     },
     {
       "description": "Result of the `rare_terms` aggregation when the field is some kind of whole number like a integer, long, or a date.",
@@ -42643,6 +42663,57 @@
       }
     },
     {
+      "kind": "type_alias",
+      "name": {
+        "name": "MovingAverageAggregation",
+        "namespace": "_types.aggregations"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "LinearMovingAverageAggregation",
+              "namespace": "_types.aggregations"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "SimpleMovingAverageAggregation",
+              "namespace": "_types.aggregations"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "EwmaMovingAverageAggregation",
+              "namespace": "_types.aggregations"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "HoltMovingAverageAggregation",
+              "namespace": "_types.aggregations"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "HoltWintersMovingAverageAggregation",
+              "namespace": "_types.aggregations"
+            }
+          }
+        ],
+        "kind": "union_of"
+      },
+      "variants": {
+        "kind": "internal_tag",
+        "tag": "model"
+      }
+    },
+    {
       "inherits": {
         "type": {
           "name": "PipelineAggregationBase",
@@ -42651,7 +42722,7 @@
       },
       "kind": "interface",
       "name": {
-        "name": "MovingAverageAggregation",
+        "name": "MovingAverageAggregationBase",
         "namespace": "_types.aggregations"
       },
       "properties": [
@@ -42663,28 +42734,6 @@
             "type": {
               "name": "boolean",
               "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "model",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "MovingAverageModel",
-              "namespace": "_types.aggregations"
-            }
-          }
-        },
-        {
-          "name": "settings",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "MovingAverageSettings",
-              "namespace": "_types.aggregations"
             }
           }
         },
@@ -42711,63 +42760,6 @@
           }
         }
       ]
-    },
-    {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "linear"
-        },
-        {
-          "name": "simple"
-        },
-        {
-          "name": "ewma"
-        },
-        {
-          "name": "holt"
-        },
-        {
-          "name": "holt_winters"
-        }
-      ],
-      "name": {
-        "name": "MovingAverageModel",
-        "namespace": "_types.aggregations"
-      }
-    },
-    {
-      "kind": "type_alias",
-      "name": {
-        "name": "MovingAverageSettings",
-        "namespace": "_types.aggregations"
-      },
-      "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "EwmaModelSettings",
-              "namespace": "_types.aggregations"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "HoltLinearModelSettings",
-              "namespace": "_types.aggregations"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "HoltWintersModelSettings",
-              "namespace": "_types.aggregations"
-            }
-          }
-        ],
-        "kind": "union_of"
-      }
     },
     {
       "inherits": {
@@ -43323,6 +43315,39 @@
       ]
     },
     {
+      "codegenNames": [
+        "keyed",
+        "array"
+      ],
+      "kind": "type_alias",
+      "name": {
+        "name": "Percentiles",
+        "namespace": "_types.aggregations"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "KeyedPercentiles",
+              "namespace": "_types.aggregations"
+            }
+          },
+          {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "ArrayPercentilesItem",
+                "namespace": "_types.aggregations"
+              }
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
       "inherits": {
         "type": {
           "name": "AggregateBase",
@@ -43339,26 +43364,11 @@
           "name": "values",
           "required": true,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "KeyedPercentiles",
-                  "namespace": "_types.aggregations"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "ArrayPercentilesItem",
-                    "namespace": "_types.aggregations"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "Percentiles",
+              "namespace": "_types.aggregations"
+            }
           }
         }
       ]
@@ -43486,44 +43496,11 @@
           "name": "buckets_path",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                }
-              },
-              {
-                "key": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                },
-                "kind": "dictionary_of",
-                "singleKey": false,
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "BucketsPath",
+              "namespace": "_types.aggregations"
+            }
           }
         },
         {
@@ -43726,26 +43703,11 @@
           "name": "exclude",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "TermsExclude",
+              "namespace": "_types.aggregations"
+            }
           }
         },
         {
@@ -43763,33 +43725,11 @@
           "name": "include",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "TermsInclude",
-                  "namespace": "_types.aggregations"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "TermsInclude",
+              "namespace": "_types.aggregations"
+            }
           }
         },
         {
@@ -43895,7 +43835,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "DateInterval",
+              "name": "CalendarInterval",
               "namespace": "_types.aggregations"
             }
           }
@@ -44364,26 +44304,11 @@
           "name": "exclude",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "TermsExclude",
+              "namespace": "_types.aggregations"
+            }
           }
         },
         {
@@ -44603,26 +44528,11 @@
           "name": "exclude",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "TermsExclude",
+              "namespace": "_types.aggregations"
+            }
           }
         },
         {
@@ -44779,6 +44689,40 @@
             "kind": "instance_of",
             "type": {
               "name": "Fields",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "MovingAverageAggregationBase",
+          "namespace": "_types.aggregations"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "SimpleMovingAverageAggregation",
+        "namespace": "_types.aggregations"
+      },
+      "properties": [
+        {
+          "name": "model",
+          "required": true,
+          "type": {
+            "kind": "literal_value",
+            "value": "simple"
+          }
+        },
+        {
+          "name": "settings",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "EmptyObject",
               "namespace": "_types"
             }
           }
@@ -45892,26 +45836,11 @@
           "name": "exclude",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "TermsExclude",
+              "namespace": "_types.aggregations"
+            }
           }
         },
         {
@@ -45940,33 +45869,11 @@
           "name": "include",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "TermsInclude",
-                  "namespace": "_types.aggregations"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "TermsInclude",
+              "namespace": "_types.aggregations"
+            }
           }
         },
         {
@@ -46126,18 +46033,11 @@
       "type": {
         "items": [
           {
-            "kind": "instance_of",
-            "type": {
-              "name": "SortOrder",
-              "namespace": "_global.search._types"
-            }
-          },
-          {
             "key": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "internal"
+                "name": "Field",
+                "namespace": "_types"
               }
             },
             "kind": "dictionary_of",
@@ -46156,8 +46056,8 @@
               "key": {
                 "kind": "instance_of",
                 "type": {
-                  "name": "string",
-                  "namespace": "internal"
+                  "name": "Field",
+                  "namespace": "_types"
                 }
               },
               "kind": "dictionary_of",
@@ -46205,9 +46105,83 @@
       ]
     },
     {
-      "kind": "interface",
+      "codegenNames": [
+        "regexp",
+        "terms"
+      ],
+      "kind": "type_alias",
+      "name": {
+        "name": "TermsExclude",
+        "namespace": "_types.aggregations"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
+      "codegenNames": [
+        "regexp",
+        "terms",
+        "partition"
+      ],
+      "kind": "type_alias",
       "name": {
         "name": "TermsInclude",
+        "namespace": "_types.aggregations"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TermsPartition",
+              "namespace": "_types.aggregations"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "TermsPartition",
         "namespace": "_types.aggregations"
       },
       "properties": [
@@ -46414,30 +46388,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "SourceFilter",
-                  "namespace": "_global.search._types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "SourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -46503,7 +46458,7 @@
                 {
                   "kind": "instance_of",
                   "type": {
-                    "name": "ScalarValue",
+                    "name": "FieldValue",
                     "namespace": "_types"
                   }
                 },
@@ -46537,7 +46492,7 @@
                 {
                   "kind": "instance_of",
                   "type": {
-                    "name": "ScalarValue",
+                    "name": "FieldValue",
                     "namespace": "_types"
                   }
                 },
@@ -47265,9 +47220,59 @@
       ]
     },
     {
+      "codegenNames": [
+        "name",
+        "definition"
+      ],
       "kind": "type_alias",
       "name": {
         "name": "CharFilter",
+        "namespace": "_types.analysis"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CharFilterDefinition",
+              "namespace": "_types.analysis"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "CharFilterBase",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "version",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "type_alias",
+      "name": {
+        "name": "CharFilterDefinition",
         "namespace": "_types.analysis"
       },
       "type": {
@@ -47314,26 +47319,6 @@
         "kind": "internal_tag",
         "tag": "type"
       }
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "CharFilterBase",
-        "namespace": "_types.analysis"
-      },
-      "properties": [
-        {
-          "name": "version",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "VersionString",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
     },
     {
       "inherits": {
@@ -51703,9 +51688,59 @@
       }
     },
     {
+      "codegenNames": [
+        "name",
+        "definition"
+      ],
       "kind": "type_alias",
       "name": {
         "name": "TokenFilter",
+        "namespace": "_types.analysis"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TokenFilterDefinition",
+              "namespace": "_types.analysis"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "TokenFilterBase",
+        "namespace": "_types.analysis"
+      },
+      "properties": [
+        {
+          "name": "version",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "type_alias",
+      "name": {
+        "name": "TokenFilterDefinition",
         "namespace": "_types.analysis"
       },
       "type": {
@@ -52055,9 +52090,39 @@
       }
     },
     {
+      "codegenNames": [
+        "name",
+        "definition"
+      ],
+      "kind": "type_alias",
+      "name": {
+        "name": "Tokenizer",
+        "namespace": "_types.analysis"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TokenizerDefinition",
+              "namespace": "_types.analysis"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
       "kind": "interface",
       "name": {
-        "name": "TokenFilterBase",
+        "name": "TokenizerBase",
         "namespace": "_types.analysis"
       },
       "properties": [
@@ -52077,7 +52142,7 @@
     {
       "kind": "type_alias",
       "name": {
-        "name": "Tokenizer",
+        "name": "TokenizerDefinition",
         "namespace": "_types.analysis"
       },
       "type": {
@@ -52187,26 +52252,6 @@
         "kind": "internal_tag",
         "tag": "type"
       }
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "TokenizerBase",
-        "namespace": "_types.analysis"
-      },
-      "properties": [
-        {
-          "name": "version",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "VersionString",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
     },
     {
       "inherits": {
@@ -53857,6 +53902,32 @@
       ]
     },
     {
+      "kind": "type_alias",
+      "name": {
+        "name": "DynamicMapping",
+        "namespace": "_types.mapping"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "DynamicMappingValues",
+              "namespace": "_types.mapping"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
       "kind": "enum",
       "members": [
         {
@@ -53873,7 +53944,7 @@
         }
       ],
       "name": {
-        "name": "DynamicMapping",
+        "name": "DynamicMappingValues",
         "namespace": "_types.mapping"
       }
     },
@@ -54584,7 +54655,7 @@
             "kind": "instance_of",
             "type": {
               "name": "GeoLocation",
-              "namespace": "_types.query_dsl"
+              "namespace": "_types"
             }
           }
         },
@@ -55715,23 +55786,11 @@
           "name": "dynamic",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DynamicMapping",
-                  "namespace": "_types.mapping"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "DynamicMapping",
+              "namespace": "_types.mapping"
+            }
           }
         },
         {
@@ -56874,23 +56933,11 @@
           "name": "dynamic",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DynamicMapping",
-                  "namespace": "_types.mapping"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "DynamicMapping",
+              "namespace": "_types.mapping"
+            }
           }
         },
         {
@@ -57361,115 +57408,6 @@
       ]
     },
     {
-      "description": "A geo bounding box. The various coordinates can be mixed. When set, `wkt` takes precedence over all other fields.",
-      "kind": "interface",
-      "name": {
-        "name": "BoundingBox",
-        "namespace": "_types.query_dsl"
-      },
-      "properties": [
-        {
-          "name": "bottom_right",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "GeoLocation",
-              "namespace": "_types.query_dsl"
-            }
-          }
-        },
-        {
-          "name": "top_left",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "GeoLocation",
-              "namespace": "_types.query_dsl"
-            }
-          }
-        },
-        {
-          "name": "top_right",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "GeoLocation",
-              "namespace": "_types.query_dsl"
-            }
-          }
-        },
-        {
-          "name": "bottom_left",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "GeoLocation",
-              "namespace": "_types.query_dsl"
-            }
-          }
-        },
-        {
-          "name": "top",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "left",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "right",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "bottom",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "wkt",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
-    },
-    {
       "kind": "enum",
       "members": [
         {
@@ -57909,6 +57847,11 @@
       ]
     },
     {
+      "codegenNames": [
+        "date",
+        "numeric",
+        "geo"
+      ],
       "kind": "type_alias",
       "name": {
         "name": "DecayFunction",
@@ -58072,6 +58015,10 @@
       ]
     },
     {
+      "codegenNames": [
+        "geo",
+        "date"
+      ],
       "kind": "type_alias",
       "name": {
         "name": "DistanceFeatureQuery",
@@ -58180,6 +58127,52 @@
           }
         }
       ]
+    },
+    {
+      "description": "A reference to a field with formatting instructions on how to return the value",
+      "kind": "interface",
+      "name": {
+        "name": "FieldAndFormat",
+        "namespace": "_types.query_dsl"
+      },
+      "properties": [
+        {
+          "description": "Wildcard pattern. The request returns values for field names matching this pattern.",
+          "name": "field",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Field",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Format in which the values are returned.",
+          "name": "format",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "include_unmapped",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        }
+      ],
+      "shortcutProperty": "field"
     },
     {
       "kind": "interface",
@@ -58690,8 +58683,8 @@
             {
               "kind": "instance_of",
               "type": {
-                "name": "BoundingBox",
-                "namespace": "_types.query_dsl"
+                "name": "GeoBounds",
+                "namespace": "_types"
               }
             }
           ],
@@ -58754,43 +58747,6 @@
       ]
     },
     {
-      "description": "Represents a Latitude/Longitude and optional Z value as a 2 or 3 dimensional point",
-      "kind": "type_alias",
-      "name": {
-        "name": "GeoCoordinate",
-        "namespace": "_types.query_dsl"
-      },
-      "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          },
-          {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "double",
-                "namespace": "_types"
-              }
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "ThreeDimensionalPoint",
-              "namespace": "_types.query_dsl"
-            }
-          }
-        ],
-        "kind": "union_of"
-      }
-    },
-    {
       "attachedBehaviors": [
         "AdditionalProperty"
       ],
@@ -58810,7 +58766,7 @@
                   "kind": "instance_of",
                   "type": {
                     "name": "GeoLocation",
-                    "namespace": "_types.query_dsl"
+                    "namespace": "_types"
                   }
                 },
                 {
@@ -58853,8 +58809,8 @@
           {
             "kind": "instance_of",
             "type": {
-              "name": "GeoCoordinate",
-              "namespace": "_types.query_dsl"
+              "name": "GeoLocation",
+              "namespace": "_types"
             }
           },
           {
@@ -58895,7 +58851,7 @@
               "kind": "instance_of",
               "type": {
                 "name": "GeoLocation",
-                "namespace": "_types.query_dsl"
+                "namespace": "_types"
               }
             }
           ],
@@ -58970,43 +58926,6 @@
       }
     },
     {
-      "description": "Represents a Latitude/Longitude as a 2 dimensional point",
-      "kind": "type_alias",
-      "name": {
-        "name": "GeoLocation",
-        "namespace": "_types.query_dsl"
-      },
-      "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          },
-          {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "double",
-                "namespace": "_types"
-              }
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "TwoDimensionalPoint",
-              "namespace": "_types.query_dsl"
-            }
-          }
-        ],
-        "kind": "union_of"
-      }
-    },
-    {
       "kind": "interface",
       "name": {
         "name": "GeoPolygonPoints",
@@ -59022,7 +58941,7 @@
               "kind": "instance_of",
               "type": {
                 "name": "GeoLocation",
-                "namespace": "_types.query_dsl"
+                "namespace": "_types"
               }
             }
           }
@@ -60007,6 +59926,10 @@
       ]
     },
     {
+      "codegenNames": [
+        "text",
+        "document"
+      ],
       "description": "Text that we want similar documents for or a lookup to a document's field for the text.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html#_document_input_parameters",
       "kind": "type_alias",
@@ -61364,9 +61287,15 @@
       "kind": "enum",
       "members": [
         {
+          "aliases": [
+            "AND"
+          ],
           "name": "and"
         },
         {
+          "aliases": [
+            "OR"
+          ],
           "name": "or"
         }
       ],
@@ -62816,6 +62745,10 @@
       ]
     },
     {
+      "codegenNames": [
+        "date",
+        "number"
+      ],
       "kind": "type_alias",
       "name": {
         "name": "RangeQuery",
@@ -63279,17 +63212,6 @@
       },
       "properties": [
         {
-          "name": "ignore_unmapped",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
           "name": "indexed_shape",
           "required": false,
           "type": {
@@ -63306,7 +63228,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "ShapeRelation",
+              "name": "GeoShapeRelation",
               "namespace": "_types"
             }
           }
@@ -63363,7 +63285,19 @@
         "name": "ShapeQuery",
         "namespace": "_types.query_dsl"
       },
-      "properties": []
+      "properties": [
+        {
+          "name": "ignore_unmapped",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "kind": "enum",
@@ -63409,8 +63343,40 @@
         }
       ],
       "name": {
+        "name": "SimpleQueryStringFlag",
+        "namespace": "_types.query_dsl"
+      }
+    },
+    {
+      "codegenNames": [
+        "single",
+        "multiple"
+      ],
+      "description": "Query flags can be either a single flag or a combination of flags, e.g. `OR|AND|PREFIX`",
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/7.15/query-dsl-simple-query-string-query.html#supported-flags",
+      "kind": "type_alias",
+      "name": {
         "name": "SimpleQueryStringFlags",
         "namespace": "_types.query_dsl"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "SimpleQueryStringFlag",
+              "namespace": "_types.query_dsl"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        ],
+        "kind": "union_of"
       }
     },
     {
@@ -63491,23 +63457,11 @@
           "name": "flags",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "SimpleQueryStringFlags",
-                  "namespace": "_types.query_dsl"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "SimpleQueryStringFlags",
+              "namespace": "_types.query_dsl"
+            }
           }
         },
         {
@@ -64120,30 +64074,11 @@
           "name": "value",
           "required": true,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "float",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "FieldValue",
+              "namespace": "_types"
+            }
           }
         },
         {
@@ -64229,36 +64164,11 @@
               }
             },
             {
-              "items": [
-                {
-                  "kind": "array_of",
-                  "value": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                },
-                {
-                  "kind": "array_of",
-                  "value": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "long",
-                      "namespace": "_types"
-                    }
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "TermsLookup",
-                    "namespace": "_types.query_dsl"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "TermsQueryField",
+                "namespace": "_types.query_dsl"
+              }
             }
           ],
           "type": {
@@ -64279,6 +64189,39 @@
         "namespace": "_types.query_dsl"
       },
       "properties": []
+    },
+    {
+      "codegenNames": [
+        "value",
+        "lookup"
+      ],
+      "kind": "type_alias",
+      "name": {
+        "name": "TermsQueryField",
+        "namespace": "_types.query_dsl"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "FieldValue",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TermsLookup",
+              "namespace": "_types.query_dsl"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
     },
     {
       "inherits": {
@@ -64357,79 +64300,6 @@
         "name": "TextQueryType",
         "namespace": "_types.query_dsl"
       }
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "ThreeDimensionalPoint",
-        "namespace": "_types.query_dsl"
-      },
-      "properties": [
-        {
-          "name": "lat",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "lon",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "z",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "TwoDimensionalPoint",
-        "namespace": "_types.query_dsl"
-      },
-      "properties": [
-        {
-          "name": "lat",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "lon",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
-          }
-        }
-      ]
     },
     {
       "inherits": {
@@ -65183,23 +65053,11 @@
             "name": "track_total_hits",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "boolean",
-                    "namespace": "internal"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "integer",
-                    "namespace": "_types"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "TrackHits",
+                "namespace": "_global.search._types"
+              }
             }
           },
           {
@@ -65233,38 +65091,14 @@
             "name": "docvalue_fields",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "DocValueField",
-                    "namespace": "_global.search._types"
-                  }
-                },
-                {
-                  "kind": "array_of",
-                  "value": {
-                    "items": [
-                      {
-                        "kind": "instance_of",
-                        "type": {
-                          "name": "Field",
-                          "namespace": "_types"
-                        }
-                      },
-                      {
-                        "kind": "instance_of",
-                        "type": {
-                          "name": "DocValueField",
-                          "namespace": "_global.search._types"
-                        }
-                      }
-                    ],
-                    "kind": "union_of"
-                  }
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "DocValueField",
+                  "namespace": "_global.search._types"
                 }
-              ],
-              "kind": "union_of"
+              }
             }
           },
           {
@@ -65414,30 +65248,11 @@
             "name": "_source",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "boolean",
-                    "namespace": "internal"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Fields",
-                    "namespace": "_types"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "SourceFilter",
-                    "namespace": "_global.search._types"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "SourceConfig",
+                "namespace": "_global.search._types"
+              }
             }
           },
           {
@@ -65447,23 +65262,11 @@
             "type": {
               "kind": "array_of",
               "value": {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "Field",
-                      "namespace": "_types"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "DateField",
-                      "namespace": "_types"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+                "kind": "instance_of",
+                "type": {
+                  "name": "FieldAndFormat",
+                  "namespace": "_types.query_dsl"
+                }
               }
             }
           },
@@ -65471,34 +65274,11 @@
             "name": "suggest",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "SuggestContainer",
-                    "namespace": "_global.search._types"
-                  }
-                },
-                {
-                  "key": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  },
-                  "kind": "dictionary_of",
-                  "singleKey": false,
-                  "value": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SuggestContainer",
-                      "namespace": "_global.search._types"
-                    }
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "Suggester",
+                "namespace": "_global.search._types"
+              }
             }
           },
           {
@@ -66047,23 +65827,11 @@
           "name": "track_total_hits",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "integer",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "TrackHits",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -66118,23 +65886,11 @@
           "name": "_source",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Fields",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "GetSourceConfig",
+              "namespace": "_global.search._types"
+            }
           }
         },
         {
@@ -77005,23 +76761,11 @@
           "name": "size",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Size",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "boolean",
-                  "namespace": "internal"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "ThreadPoolSize",
+              "namespace": "cat.thread_pool"
+            }
           }
         }
       ]
@@ -77354,6 +77098,30 @@
           }
         }
       ]
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "k"
+        },
+        {
+          "name": "m"
+        },
+        {
+          "name": "g"
+        },
+        {
+          "name": "t"
+        },
+        {
+          "name": "p"
+        }
+      ],
+      "name": {
+        "name": "ThreadPoolSize",
+        "namespace": "cat.thread_pool"
+      }
     },
     {
       "attachedBehaviors": [
@@ -87568,23 +87336,11 @@
             "name": "size",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "uint",
-                    "namespace": "_types"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "float",
-                    "namespace": "_types"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "uint",
+                "namespace": "_types"
+              }
             }
           },
           {
@@ -87592,25 +87348,10 @@
             "name": "fields",
             "required": false,
             "type": {
-              "kind": "array_of",
-              "value": {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "Field",
-                      "namespace": "_types"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SearchFieldFormatted",
-                      "namespace": "eql.search"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "FieldAndFormat",
+                "namespace": "_types.query_dsl"
               }
             }
           },
@@ -87780,39 +87521,6 @@
         "name": "ResultPosition",
         "namespace": "eql.search"
       }
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "SearchFieldFormatted",
-        "namespace": "eql.search"
-      },
-      "properties": [
-        {
-          "description": "Wildcard pattern. The request returns values for field names matching this pattern.",
-          "name": "field",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Field",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Format in which the values are returned.",
-          "name": "format",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
     },
     {
       "kind": "interface",
@@ -88474,12 +88182,14 @@
       }
     },
     {
-      "kind": "interface",
+      "kind": "type_alias",
       "name": {
-        "name": "Action",
+        "name": "Actions",
         "namespace": "ilm._types"
       },
-      "properties": []
+      "type": {
+        "kind": "user_defined_value"
+      }
     },
     {
       "kind": "interface",
@@ -88492,37 +88202,11 @@
           "name": "actions",
           "required": false,
           "type": {
-            "items": [
-              {
-                "key": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                },
-                "kind": "dictionary_of",
-                "singleKey": false,
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Action",
-                    "namespace": "ilm._types"
-                  }
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "Actions",
+              "namespace": "ilm._types"
+            }
           }
         },
         {
@@ -88533,51 +88217,6 @@
             "type": {
               "name": "Time",
               "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "configurations",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "integer",
-                      "namespace": "_types"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
             }
           }
         }
@@ -91405,23 +91044,11 @@
           "name": "settings",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "IndexSettings",
-                  "namespace": "indices._types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "IndexStatePrefixedSettings",
-                  "namespace": "indices._types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexSettings",
+              "namespace": "indices._types"
+            }
           }
         },
         {
@@ -91432,26 +91059,6 @@
             "type": {
               "name": "DataStreamName",
               "namespace": "_types"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "IndexStatePrefixedSettings",
-        "namespace": "indices._types"
-      },
-      "properties": [
-        {
-          "name": "index",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "IndexSettings",
-              "namespace": "indices._types"
             }
           }
         }
@@ -92306,23 +91913,11 @@
             "type": {
               "kind": "array_of",
               "value": {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "CharFilter",
-                      "namespace": "_types.analysis"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+                "kind": "instance_of",
+                "type": {
+                  "name": "CharFilter",
+                  "namespace": "_types.analysis"
+                }
               }
             }
           },
@@ -92354,23 +91949,11 @@
             "type": {
               "kind": "array_of",
               "value": {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "TokenFilter",
-                      "namespace": "_types.analysis"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+                "kind": "instance_of",
+                "type": {
+                  "name": "TokenFilter",
+                  "namespace": "_types.analysis"
+                }
               }
             }
           },
@@ -92400,23 +91983,11 @@
             "name": "tokenizer",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Tokenizer",
-                    "namespace": "_types.analysis"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "Tokenizer",
+                "namespace": "_types.analysis"
+              }
             }
           }
         ]
@@ -96880,23 +96451,11 @@
             "name": "dynamic",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "boolean",
-                    "namespace": "internal"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "DynamicMapping",
-                    "namespace": "_types.mapping"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "DynamicMapping",
+                "namespace": "_types.mapping"
+              }
             }
           },
           {
@@ -98980,6 +98539,47 @@
       }
     },
     {
+      "codegenNames": [
+        "single",
+        "by_type"
+      ],
+      "kind": "type_alias",
+      "name": {
+        "name": "IndexRolloverMapping",
+        "namespace": "indices.rollover"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TypeMapping",
+              "namespace": "_types.mapping"
+            }
+          },
+          {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "TypeMapping",
+                "namespace": "_types.mapping"
+              }
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
@@ -99023,34 +98623,11 @@
             "name": "mappings",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "key": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  },
-                  "kind": "dictionary_of",
-                  "singleKey": false,
-                  "value": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "TypeMapping",
-                      "namespace": "_types.mapping"
-                    }
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "TypeMapping",
-                    "namespace": "_types.mapping"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "IndexRolloverMapping",
+                "namespace": "indices.rollover"
+              }
             }
           },
           {
@@ -103329,26 +102906,15 @@
           }
         },
         {
+          "description": "How to round the date when formatting the date into the index name. Valid values are:\n`y` (year), `M` (month), `w` (week), `d` (day), `h` (hour), `m` (minute) and `s` (second).\nSupports template snippets.",
           "name": "date_rounding",
           "required": true,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateRounding",
-                  "namespace": "ingest._types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
           }
         },
         {
@@ -103480,43 +103046,6 @@
           }
         }
       ]
-    },
-    {
-      "kind": "enum",
-      "members": [
-        {
-          "codegenName": "Second",
-          "name": "s"
-        },
-        {
-          "codegenName": "Minute",
-          "name": "m"
-        },
-        {
-          "codegenName": "Hour",
-          "name": "h"
-        },
-        {
-          "codegenName": "Day",
-          "name": "d"
-        },
-        {
-          "codegenName": "Week",
-          "name": "w"
-        },
-        {
-          "codegenName": "Month",
-          "name": "M"
-        },
-        {
-          "codegenName": "Year",
-          "name": "y"
-        }
-      ],
-      "name": {
-        "name": "DateRounding",
-        "namespace": "ingest._types"
-      }
     },
     {
       "inherits": {
@@ -107892,23 +107421,11 @@
           "name": "categorization_analyzer",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "CategorizationAnalyzer",
-                  "namespace": "ml._types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "CategorizationAnalyzer",
+              "namespace": "ml._types"
+            }
           }
         },
         {
@@ -108075,23 +107592,11 @@
           "name": "categorization_analyzer",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "CategorizationAnalyzer",
-                  "namespace": "ml._types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "CategorizationAnalyzer",
+              "namespace": "ml._types"
+            }
           }
         },
         {
@@ -109055,9 +108560,39 @@
       ]
     },
     {
-      "kind": "interface",
+      "codegenNames": [
+        "name",
+        "definition"
+      ],
+      "kind": "type_alias",
       "name": {
         "name": "CategorizationAnalyzer",
+        "namespace": "ml._types"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "CategorizationAnalyzerDefinition",
+              "namespace": "ml._types"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "CategorizationAnalyzerDefinition",
         "namespace": "ml._types"
       },
       "properties": [
@@ -109068,23 +108603,11 @@
           "type": {
             "kind": "array_of",
             "value": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "CharFilter",
-                    "namespace": "_types.analysis"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "CharFilter",
+                "namespace": "_types.analysis"
+              }
             }
           }
         },
@@ -109095,23 +108618,11 @@
           "type": {
             "kind": "array_of",
             "value": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "TokenFilter",
-                    "namespace": "_types.analysis"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "TokenFilter",
+                "namespace": "_types.analysis"
+              }
             }
           }
         },
@@ -109120,23 +108631,11 @@
           "name": "tokenizer",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Tokenizer",
-                  "namespace": "_types.analysis"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "Tokenizer",
+              "namespace": "_types.analysis"
+            }
           }
         }
       ]
@@ -109410,60 +108909,15 @@
       }
     },
     {
-      "kind": "interface",
+      "description": "Custom metadata about the job",
+      "kind": "type_alias",
       "name": {
         "name": "CustomSettings",
         "namespace": "ml._types"
       },
-      "properties": [
-        {
-          "name": "custom_urls",
-          "required": false,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "UrlConfig",
-                "namespace": "xpack.usage"
-              }
-            }
-          }
-        },
-        {
-          "name": "created_by",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "job_tags",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          }
-        }
-      ]
+      "type": {
+        "kind": "user_defined_value"
+      }
     },
     {
       "kind": "interface",
@@ -110608,38 +110062,9 @@
       ]
     },
     {
-      "kind": "type_alias",
-      "name": {
-        "name": "DataframeAnalysisAnalyzedFields",
-        "namespace": "ml._types"
-      },
-      "type": {
-        "items": [
-          {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "DataframeAnalysisAnalyzedFieldsIncludeExclude",
-              "namespace": "ml._types"
-            }
-          }
-        ],
-        "kind": "union_of"
-      }
-    },
-    {
       "kind": "interface",
       "name": {
-        "name": "DataframeAnalysisAnalyzedFieldsIncludeExclude",
+        "name": "DataframeAnalysisAnalyzedFields",
         "namespace": "ml._types"
       },
       "properties": [
@@ -110673,7 +110098,8 @@
             }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "includes"
     },
     {
       "inherits": {
@@ -129029,23 +128455,11 @@
           "name": "type",
           "required": true,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "NodeInfoSettingsHttpType",
-                  "namespace": "nodes.info"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "NodeInfoSettingsHttpType",
+              "namespace": "nodes.info"
+            }
           }
         },
         {
@@ -129125,7 +128539,8 @@
             }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "default"
     },
     {
       "kind": "interface",
@@ -129590,23 +129005,11 @@
           "name": "type",
           "required": true,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "NodeInfoSettingsTransportType",
-                  "namespace": "nodes.info"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "NodeInfoSettingsTransportType",
+              "namespace": "nodes.info"
+            }
           }
         },
         {
@@ -129671,7 +129074,8 @@
             }
           }
         }
-      ]
+      ],
+      "shortcutProperty": "default"
     },
     {
       "kind": "interface",
@@ -130618,7 +130022,7 @@
     {
       "kind": "interface",
       "name": {
-        "name": "NodeReloadException",
+        "name": "NodeReloadError",
         "namespace": "nodes.reload_secure_settings"
       },
       "properties": [
@@ -130639,54 +130043,42 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "NodeReloadExceptionCausedBy",
-              "namespace": "nodes.reload_secure_settings"
+              "name": "ErrorCause",
+              "namespace": "_types"
             }
           }
         }
       ]
     },
     {
-      "kind": "interface",
+      "codegenNames": [
+        "stats",
+        "error"
+      ],
+      "kind": "type_alias",
       "name": {
-        "name": "NodeReloadExceptionCausedBy",
+        "name": "NodeReloadResult",
         "namespace": "nodes.reload_secure_settings"
       },
-      "properties": [
-        {
-          "name": "type",
-          "required": true,
-          "type": {
+      "type": {
+        "items": [
+          {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "Stats",
+              "namespace": "nodes._types"
             }
-          }
-        },
-        {
-          "name": "reason",
-          "required": true,
-          "type": {
+          },
+          {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "caused_by",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "NodeReloadExceptionCausedBy",
+              "name": "NodeReloadError",
               "namespace": "nodes.reload_secure_settings"
             }
           }
-        }
-      ]
+        ],
+        "kind": "union_of"
+      }
     },
     {
       "attachedBehaviors": [
@@ -130778,23 +130170,11 @@
               "kind": "dictionary_of",
               "singleKey": false,
               "value": {
-                "items": [
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "Stats",
-                      "namespace": "nodes._types"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "NodeReloadException",
-                      "namespace": "nodes.reload_secure_settings"
-                    }
-                  }
-                ],
-                "kind": "union_of"
+                "kind": "instance_of",
+                "type": {
+                  "name": "NodeReloadResult",
+                  "namespace": "nodes.reload_secure_settings"
+                }
               }
             }
           }
@@ -133845,13 +133225,6 @@
                     "namespace": "internal"
                   }
                 }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "QueryContainer",
-                  "namespace": "_types.query_dsl"
-                }
               }
             ],
             "kind": "union_of"
@@ -136179,88 +135552,6 @@
       }
     },
     {
-      "kind": "interface",
-      "name": {
-        "name": "InlineRoleTemplate",
-        "namespace": "security.get_role"
-      },
-      "properties": [
-        {
-          "name": "template",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "InlineRoleTemplateSource",
-              "namespace": "security.get_role"
-            }
-          }
-        },
-        {
-          "name": "format",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "TemplateFormat",
-              "namespace": "security.get_role"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "InlineRoleTemplateSource",
-        "namespace": "security.get_role"
-      },
-      "properties": [
-        {
-          "name": "source",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "InvalidRoleTemplate",
-        "namespace": "security.get_role"
-      },
-      "properties": [
-        {
-          "name": "template",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "format",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "TemplateFormat",
-              "namespace": "security.get_role"
-            }
-          }
-        }
-      ]
-    },
-    {
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
@@ -136430,56 +135721,12 @@
       ]
     },
     {
-      "kind": "type_alias",
+      "kind": "interface",
       "name": {
         "name": "RoleTemplate",
         "namespace": "security.get_role"
       },
-      "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "InlineRoleTemplate",
-              "namespace": "security.get_role"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "StoredRoleTemplate",
-              "namespace": "security.get_role"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "InvalidRoleTemplate",
-              "namespace": "security.get_role"
-            }
-          }
-        ],
-        "kind": "union_of"
-      }
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "StoredRoleTemplate",
-        "namespace": "security.get_role"
-      },
       "properties": [
-        {
-          "name": "template",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "StoredRoleTemplateId",
-              "namespace": "security.get_role"
-            }
-          }
-        },
         {
           "name": "format",
           "required": false,
@@ -136490,24 +135737,15 @@
               "namespace": "security.get_role"
             }
           }
-        }
-      ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "StoredRoleTemplateId",
-        "namespace": "security.get_role"
-      },
-      "properties": [
+        },
         {
-          "name": "id",
+          "name": "template",
           "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "Script",
+              "namespace": "_types"
             }
           }
         }
@@ -143450,30 +142688,11 @@
             "name": "_source",
             "required": true,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "boolean",
-                    "namespace": "internal"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Fields",
-                    "namespace": "_types"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "SourceFilter",
-                    "namespace": "_global.search._types"
-                  }
-                }
-              ],
-              "kind": "union_of"
+              "kind": "instance_of",
+              "type": {
+                "name": "SourceConfig",
+                "namespace": "_global.search._types"
+              }
             }
           },
           {
@@ -143646,6 +142865,24 @@
       "name": {
         "name": "Response",
         "namespace": "ssl.certificates"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "nodes"
+        },
+        {
+          "name": "parents"
+        },
+        {
+          "name": "none"
+        }
+      ],
+      "name": {
+        "name": "GroupBy",
+        "namespace": "tasks._types"
       }
     },
     {
@@ -144492,7 +143729,7 @@
             "kind": "instance_of",
             "type": {
               "name": "GroupBy",
-              "namespace": "_types"
+              "namespace": "tasks._types"
             }
           }
         },
@@ -144593,37 +143830,22 @@
             "name": "tasks",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "key": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "string",
-                      "namespace": "internal"
-                    }
-                  },
-                  "kind": "dictionary_of",
-                  "singleKey": false,
-                  "value": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "Info",
-                      "namespace": "tasks._types"
-                    }
-                  }
-                },
-                {
-                  "kind": "array_of",
-                  "value": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "Info",
-                      "namespace": "tasks._types"
-                    }
-                  }
+              "key": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
                 }
-              ],
-              "kind": "union_of"
+              },
+              "kind": "dictionary_of",
+              "singleKey": false,
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "Info",
+                  "namespace": "tasks._types"
+                }
+              }
             }
           }
         ]
@@ -147881,26 +147103,14 @@
           "name": "at",
           "required": true,
           "type": {
-            "items": [
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "TimeOfDay",
-                  "namespace": "watcher._types"
-                }
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "TimeOfDay",
+                "namespace": "watcher._types"
               }
-            ],
-            "kind": "union_of"
+            }
           }
         }
       ]
@@ -148377,6 +147587,43 @@
             "type": {
               "name": "long",
               "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "HourAndMinute",
+        "namespace": "watcher._types"
+      },
+      "properties": [
+        {
+          "name": "hour",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
+            }
+          }
+        },
+        {
+          "name": "minute",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
             }
           }
         }
@@ -149637,46 +148884,22 @@
           "name": "scheduled_time",
           "required": true,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateString",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "DateString",
+              "namespace": "_types"
+            }
           }
         },
         {
           "name": "triggered_time",
           "required": false,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "DateString",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "DateString",
+              "namespace": "_types"
+            }
           }
         }
       ]
@@ -150312,41 +149535,34 @@
       ]
     },
     {
-      "kind": "interface",
+      "codegenNames": [
+        "text",
+        "hour_minute"
+      ],
+      "kind": "type_alias",
       "name": {
         "name": "TimeOfDay",
         "namespace": "watcher._types"
       },
-      "properties": [
-        {
-          "name": "hour",
-          "required": true,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "_types"
-              }
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "HourAndMinute",
+              "namespace": "watcher._types"
             }
           }
-        },
-        {
-          "name": "minute",
-          "required": true,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "integer",
-                "namespace": "_types"
-              }
-            }
-          }
-        }
-      ]
+        ],
+        "kind": "union_of"
+      }
     },
     {
       "kind": "interface",
@@ -153170,37 +152386,6 @@
       ]
     },
     {
-      "kind": "interface",
-      "name": {
-        "name": "BaseUrlConfig",
-        "namespace": "xpack.usage"
-      },
-      "properties": [
-        {
-          "name": "url_name",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        },
-        {
-          "name": "url_value",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        }
-      ]
-    },
-    {
       "inherits": {
         "type": {
           "name": "Base",
@@ -154052,26 +153237,47 @@
       ]
     },
     {
-      "inherits": {
-        "type": {
-          "name": "BaseUrlConfig",
-          "namespace": "xpack.usage"
+      "attachedBehaviors": [
+        "AdditionalProperties"
+      ],
+      "behaviors": [
+        {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "Job",
+                "namespace": "ml._types"
+              }
+            }
+          ],
+          "type": {
+            "name": "AdditionalProperties",
+            "namespace": "_spec_utils"
+          }
         }
-      },
+      ],
       "kind": "interface",
       "name": {
-        "name": "KibanaUrlConfig",
+        "name": "Jobs",
         "namespace": "xpack.usage"
       },
       "properties": [
         {
-          "name": "time_range",
+          "name": "_all",
           "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "AllJobs",
+              "namespace": "xpack.usage"
             }
           }
         }
@@ -154116,45 +153322,11 @@
           "name": "jobs",
           "required": true,
           "type": {
-            "items": [
-              {
-                "key": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                },
-                "kind": "dictionary_of",
-                "singleKey": false,
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "Job",
-                    "namespace": "ml._types"
-                  }
-                }
-              },
-              {
-                "key": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                },
-                "kind": "dictionary_of",
-                "singleKey": true,
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "AllJobs",
-                    "namespace": "xpack.usage"
-                  }
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "Jobs",
+              "namespace": "xpack.usage"
+            }
           }
         },
         {
@@ -155897,32 +155069,6 @@
           }
         }
       ]
-    },
-    {
-      "kind": "type_alias",
-      "name": {
-        "name": "UrlConfig",
-        "namespace": "xpack.usage"
-      },
-      "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "BaseUrlConfig",
-              "namespace": "xpack.usage"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "KibanaUrlConfig",
-              "namespace": "xpack.usage"
-            }
-          }
-        ],
-        "kind": "union_of"
-      }
     },
     {
       "inherits": {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -17217,8 +17217,8 @@
               "value": {
                 "kind": "instance_of",
                 "type": {
-                  "name": "DocValueField",
-                  "namespace": "_global.search._types"
+                  "name": "FieldAndFormat",
+                  "namespace": "_types.query_dsl"
                 }
               }
             }
@@ -21610,8 +21610,8 @@
               "value": {
                 "kind": "instance_of",
                 "type": {
-                  "name": "DocValueField",
-                  "namespace": "_global.search._types"
+                  "name": "FieldAndFormat",
+                  "namespace": "_types.query_dsl"
                 }
               }
             }
@@ -23318,6 +23318,7 @@
           "name": "plain"
         },
         {
+          "codegenName": "fast_vector",
           "name": "fvh"
         },
         {
@@ -23856,38 +23857,6 @@
           }
         }
       ]
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "DocValueField",
-        "namespace": "_global.search._types"
-      },
-      "properties": [
-        {
-          "name": "field",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Field",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "format",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          }
-        }
-      ],
-      "shortcutProperty": "field"
     },
     {
       "kind": "interface",
@@ -65095,8 +65064,8 @@
               "value": {
                 "kind": "instance_of",
                 "type": {
-                  "name": "DocValueField",
-                  "namespace": "_global.search._types"
+                  "name": "FieldAndFormat",
+                  "namespace": "_types.query_dsl"
                 }
               }
             }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -34073,29 +34073,21 @@
       ]
     },
     {
-      "kind": "type_alias",
+      "kind": "enum",
+      "members": [
+        {
+          "name": "true"
+        },
+        {
+          "name": "false"
+        },
+        {
+          "name": "wait_for"
+        }
+      ],
       "name": {
         "name": "Refresh",
         "namespace": "_types"
-      },
-      "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "RefreshValues",
-              "namespace": "_types"
-            }
-          }
-        ],
-        "kind": "union_of"
       }
     },
     {
@@ -34172,24 +34164,6 @@
           }
         }
       ]
-    },
-    {
-      "kind": "enum",
-      "members": [
-        {
-          "name": "true"
-        },
-        {
-          "name": "false"
-        },
-        {
-          "name": "wait_for"
-        }
-      ],
-      "name": {
-        "name": "RefreshValues",
-        "namespace": "_types"
-      }
     },
     {
       "kind": "type_alias",
@@ -53871,32 +53845,6 @@
       ]
     },
     {
-      "kind": "type_alias",
-      "name": {
-        "name": "DynamicMapping",
-        "namespace": "_types.mapping"
-      },
-      "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "DynamicMappingValues",
-              "namespace": "_types.mapping"
-            }
-          }
-        ],
-        "kind": "union_of"
-      }
-    },
-    {
       "kind": "enum",
       "members": [
         {
@@ -53913,7 +53861,7 @@
         }
       ],
       "name": {
-        "name": "DynamicMappingValues",
+        "name": "DynamicMapping",
         "namespace": "_types.mapping"
       }
     },

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1284,9 +1284,7 @@
       "request": [
         "Request: should not have a body"
       ],
-      "response": [
-        "type_alias definition xpack.usage:UrlConfig / union_of / instance_of - Non-leaf type cannot be used here: 'xpack.usage:BaseUrlConfig'"
-      ]
+      "response": []
     },
     "ml.get_records": {
       "request": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -484,7 +484,7 @@ export interface KnnSearchRequest extends RequestBase {
   routing?: Routing
   body?: {
     _source?: SearchSourceConfig
-    docvalue_fields?: (SearchDocValueField | Field)[]
+    docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
     stored_fields?: Fields
     fields?: Fields
     knn: KnnSearchQuery
@@ -1000,7 +1000,7 @@ export interface SearchRequest extends RequestBase {
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
     indices_boost?: Record<IndexName, double>[]
-    docvalue_fields?: (SearchDocValueField | Field)[]
+    docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
     min_score?: double
     post_filter?: QueryDslQueryContainer
     profile?: boolean
@@ -1161,11 +1161,6 @@ export interface SearchDirectGenerator {
   prefix_length?: integer
   size?: integer
   suggest_mode?: SuggestMode
-}
-
-export interface SearchDocValueField {
-  field: Field
-  format?: string
 }
 
 export interface SearchFetchProfile {
@@ -5694,7 +5689,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
     indices_boost?: Record<IndexName, double>[]
-    docvalue_fields?: (SearchDocValueField | Field)[]
+    docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
     min_score?: double
     post_filter?: QueryDslQueryContainer
     profile?: boolean

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -51,7 +51,7 @@ export interface BulkRequest<TSource = unknown> extends RequestBase {
   pipeline?: string
   refresh?: Refresh
   routing?: Routing
-  _source?: boolean | Fields
+  _source?: SearchGetSourceConfig
   _source_excludes?: Fields
   _source_includes?: Fields
   timeout?: Time
@@ -202,7 +202,7 @@ export interface DeleteByQueryRequest extends RequestBase {
   size?: long
   slices?: long
   sort?: string[]
-  _source?: boolean | Fields
+  _source?: SearchGetSourceConfig
   _source_excludes?: Fields
   _source_includes?: Fields
   stats?: string[]
@@ -259,7 +259,7 @@ export interface ExistsRequest extends RequestBase {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  _source?: boolean | Fields
+  _source?: SearchGetSourceConfig
   _source_excludes?: Fields
   _source_includes?: Fields
   stored_fields?: Fields
@@ -277,7 +277,7 @@ export interface ExistsSourceRequest extends RequestBase {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  _source?: boolean | Fields
+  _source?: SearchGetSourceConfig
   _source_excludes?: Fields
   _source_includes?: Fields
   version?: VersionNumber
@@ -308,7 +308,7 @@ export interface ExplainRequest extends RequestBase {
   lenient?: boolean
   preference?: string
   routing?: Routing
-  _source?: boolean | Fields
+  _source?: SearchGetSourceConfig
   _source_excludes?: Fields
   _source_includes?: Fields
   stored_fields?: Fields
@@ -363,7 +363,7 @@ export interface GetRequest extends RequestBase {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  _source?: boolean | Fields
+  _source?: SearchGetSourceConfig
   _source_excludes?: Fields
   _source_includes?: Fields
   stored_fields?: Fields
@@ -438,7 +438,7 @@ export interface GetSourceRequest {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  _source?: boolean | Fields
+  _source?: SearchGetSourceConfig
   _source_excludes?: Fields
   _source_includes?: Fields
   stored_fields?: Fields
@@ -483,8 +483,8 @@ export interface KnnSearchRequest extends RequestBase {
   index: Indices
   routing?: Routing
   body?: {
-    _source?: boolean | Fields | SearchSourceFilter
-    docvalue_fields?: SearchDocValueField | (Field | SearchDocValueField)[]
+    _source?: SearchSourceConfig
+    docvalue_fields?: (SearchDocValueField | Field)[]
     stored_fields?: Fields
     fields?: Fields
     knn: KnnSearchQuery
@@ -529,7 +529,7 @@ export interface MgetOperation {
   _id: MgetMultiGetId
   _index?: IndexName
   routing?: Routing
-  _source?: boolean | Fields | SearchSourceFilter
+  _source?: SearchSourceConfig
   stored_fields?: Fields
   _type?: Type
   version?: VersionNumber
@@ -542,7 +542,7 @@ export interface MgetRequest extends RequestBase {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  _source?: boolean | Fields
+  _source?: SearchGetSourceConfig
   _source_excludes?: Fields
   _source_includes?: Fields
   stored_fields?: Fields
@@ -563,8 +563,8 @@ export interface MsearchBody {
   from?: integer
   size?: integer
   pit?: SearchPointInTimeReference
-  track_total_hits?: boolean | integer
-  suggest?: SearchSuggestContainer | Record<string, SearchSuggestContainer>
+  track_total_hits?: SearchTrackHits
+  suggest?: SearchSuggester
 }
 
 export interface MsearchHeader {
@@ -695,7 +695,7 @@ export interface PutScriptRequest extends RequestBase {
   master_timeout?: Time
   timeout?: Time
   body?: {
-    script?: StoredScript
+    script: StoredScript
   }
 }
 
@@ -925,7 +925,7 @@ export interface ScriptsPainlessExecuteRequest extends RequestBase {
   body?: {
     context?: string
     context_setup?: ScriptsPainlessExecutePainlessContextSetup
-    script?: InlineScript
+    script?: InlineScript | string
   }
 }
 
@@ -978,12 +978,12 @@ export interface SearchRequest extends RequestBase {
   suggest_text?: string
   terminate_after?: long
   timeout?: Time
-  track_total_hits?: boolean | integer
+  track_total_hits?: SearchTrackHits
   track_scores?: boolean
   typed_keys?: boolean
   rest_total_hits_as_int?: boolean
   version?: boolean
-  _source?: boolean | Fields
+  _source?: SearchGetSourceConfig
   _source_excludes?: Fields
   _source_includes?: Fields
   seq_no_primary_term?: boolean
@@ -998,9 +998,9 @@ export interface SearchRequest extends RequestBase {
     explain?: boolean
     from?: integer
     highlight?: SearchHighlight
-    track_total_hits?: boolean | integer
+    track_total_hits?: SearchTrackHits
     indices_boost?: Record<IndexName, double>[]
-    docvalue_fields?: SearchDocValueField | (Field | SearchDocValueField)[]
+    docvalue_fields?: (SearchDocValueField | Field)[]
     min_score?: double
     post_filter?: QueryDslQueryContainer
     profile?: boolean
@@ -1011,9 +1011,9 @@ export interface SearchRequest extends RequestBase {
     size?: integer
     slice?: SlicedScroll
     sort?: SearchSort
-    _source?: boolean | Fields | SearchSourceFilter
-    fields?: (Field | DateField)[]
-    suggest?: SearchSuggestContainer | Record<string, SearchSuggestContainer>
+    _source?: SearchSourceConfig
+    fields?: (QueryDslFieldAndFormat | Field)[]
+    suggest?: SearchSuggester
     terminate_after?: long
     timeout?: string
     track_scores?: boolean
@@ -1109,11 +1109,21 @@ export interface SearchAggregationProfileDelegateDebugFilter {
 
 export type SearchBoundaryScanner = 'chars' | 'sentence' | 'word'
 
+export type SearchBuiltinHighlighterType = 'plain' | 'fvh' | 'unified'
+
 export interface SearchCollector {
   name: string
   reason: string
   time_in_nanos: long
   children?: SearchCollector[]
+}
+
+export interface SearchCompletionContext {
+  boost?: double
+  context: SearchContext
+  neighbours?: GeoHashPrecision[]
+  precision?: GeoHashPrecision
+  prefix?: boolean
 }
 
 export interface SearchCompletionSuggestOption<TDocument = unknown> {
@@ -1130,14 +1140,14 @@ export interface SearchCompletionSuggestOption<TDocument = unknown> {
 }
 
 export interface SearchCompletionSuggester extends SearchSuggesterBase {
-  contexts?: Record<string, string | string[] | QueryDslGeoLocation | SearchSuggestContextQuery[]>
+  contexts?: Record<Field, SearchCompletionContext | SearchContext | (SearchCompletionContext | SearchContext)[]>
   fuzzy?: SearchSuggestFuzziness
   prefix?: string
   regex?: string
   skip_duplicates?: boolean
 }
 
-export type SearchContext = string | QueryDslGeoLocation
+export type SearchContext = string | GeoLocation
 
 export interface SearchDirectGenerator {
   field: Field
@@ -1181,12 +1191,6 @@ export interface SearchFetchProfileDebug {
   fast_path?: integer
 }
 
-export interface SearchFieldAndFormat {
-  field: Field
-  format?: string
-  include_unmapped?: boolean
-}
-
 export interface SearchFieldCollapse {
   field: Field
   inner_hits?: SearchInnerHits | SearchInnerHits[]
@@ -1199,16 +1203,32 @@ export interface SearchFieldSort {
   nested?: SearchNestedSortValue
   order?: SearchSortOrder
   unmapped_type?: MappingFieldType
+  numeric_type?: SearchFieldSortNumericType
+  format?: string
+}
+
+export type SearchFieldSortNumericType = 'long' | 'double' | 'date' | 'date_nanos'
+
+export interface SearchFieldSuggester {
+  completion?: SearchCompletionSuggester
+  phrase?: SearchPhraseSuggester
+  prefix?: string
+  regex?: string
+  term?: SearchTermSuggester
+  text?: string
 }
 
 export interface SearchGeoDistanceSortKeys {
   mode?: SearchSortMode
   distance_type?: GeoDistanceType
+  ignore_unmapped?: boolean
   order?: SearchSortOrder
   unit?: DistanceUnit
 }
 export type SearchGeoDistanceSort = SearchGeoDistanceSortKeys
-  & { [property: string]: QueryDslGeoLocation | QueryDslGeoLocation[] | SearchSortMode | GeoDistanceType | SearchSortOrder | DistanceUnit }
+  & { [property: string]: GeoLocation | GeoLocation[] | SearchSortMode | GeoDistanceType | boolean | SearchSortOrder | DistanceUnit }
+
+export type SearchGetSourceConfig = boolean | Fields
 
 export interface SearchHighlight {
   fields: Record<Field, SearchHighlightField>
@@ -1254,7 +1274,7 @@ export interface SearchHighlightField {
   pre_tags?: string[]
   require_field_match?: boolean
   tags_schema?: SearchHighlighterTagsSchema
-  type?: SearchHighlighterType | string
+  type?: SearchHighlighterType
 }
 
 export type SearchHighlighterEncoder = 'default' | 'html'
@@ -1265,7 +1285,7 @@ export type SearchHighlighterOrder = 'score'
 
 export type SearchHighlighterTagsSchema = 'styled'
 
-export type SearchHighlighterType = 'plain' | 'fvh' | 'unified'
+export type SearchHighlighterType = SearchBuiltinHighlighterType | string
 
 export interface SearchHit<TDocument = unknown> {
   _index: IndexName
@@ -1300,7 +1320,7 @@ export interface SearchInnerHits {
   size?: integer
   from?: integer
   collapse?: SearchFieldCollapse
-  docvalue_fields?: (SearchFieldAndFormat | Field)[]
+  docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
   explain?: boolean
   highlight?: SearchHighlight
   ignore_unmapped?: boolean
@@ -1308,20 +1328,14 @@ export interface SearchInnerHits {
   seq_no_primary_term?: boolean
   fields?: Fields
   sort?: SearchSort
-  _source?: boolean | SearchSourceFilter
+  _source?: SearchSourceConfig
   stored_field?: Fields
   track_scores?: boolean
   version?: boolean
 }
 
-export interface SearchInnerHitsMetadata {
-  total: SearchTotalHits | long
-  hits: SearchHit<Record<string, any>>[]
-  max_score?: double
-}
-
 export interface SearchInnerHitsResult {
-  hits: SearchInnerHitsMetadata
+  hits: SearchHitsMetadata<any>
 }
 
 export interface SearchLaplaceSmoothingModel {
@@ -1343,6 +1357,7 @@ export interface SearchNestedIdentity {
 export interface SearchNestedSortValue {
   filter?: QueryDslQueryContainer
   max_children?: integer
+  nested?: SearchNestedSortValue
   path: Field
 }
 
@@ -1437,15 +1452,18 @@ export interface SearchRescoreQuery {
 export type SearchScoreMode = 'avg' | 'max' | 'min' | 'multiply' | 'total'
 
 export interface SearchScoreSort {
-  mode?: SearchSortMode
   order?: SearchSortOrder
 }
 
 export interface SearchScriptSort {
   order?: SearchSortOrder
   script: Script
-  type?: string
+  type?: SearchScriptSortType
+  mode?: SearchSortMode
+  nested?: SearchNestedSortValue
 }
+
+export type SearchScriptSortType = 'string' | 'number'
 
 export interface SearchSearchProfile {
   collector: SearchCollector[]
@@ -1468,27 +1486,29 @@ export interface SearchSmoothingModelContainer {
 
 export type SearchSort = SearchSortCombinations | SearchSortCombinations[]
 
-export type SearchSortCombinations = Field | SearchSortContainer | SearchSortOrder
+export type SearchSortCombinations = Field | SearchSortOptions
 
-export interface SearchSortContainerKeys {
+export type SearchSortMode = 'min' | 'max' | 'sum' | 'avg' | 'median'
+
+export interface SearchSortOptionsKeys {
   _score?: SearchScoreSort
   _doc?: SearchScoreSort
   _geo_distance?: SearchGeoDistanceSort
   _script?: SearchScriptSort
 }
-export type SearchSortContainer = SearchSortContainerKeys
+export type SearchSortOptions = SearchSortOptionsKeys
   & { [property: string]: SearchFieldSort | SearchSortOrder | SearchScoreSort | SearchGeoDistanceSort | SearchScriptSort }
 
-export type SearchSortMode = 'min' | 'max' | 'sum' | 'avg' | 'median'
-
-export type SearchSortOrder = 'asc' | 'desc' | '_doc'
+export type SearchSortOrder = 'asc' | 'desc'
 
 export type SearchSortResults = (long | double | string | null)[]
 
+export type SearchSourceConfig = boolean | SearchSourceFilter | Fields
+
 export interface SearchSourceFilter {
   excludes?: Fields
-  includes?: Fields
   exclude?: Fields
+  includes?: Fields
   include?: Fields
 }
 
@@ -1505,23 +1525,6 @@ export interface SearchSuggest<T = unknown> {
   text: string
 }
 
-export interface SearchSuggestContainer {
-  completion?: SearchCompletionSuggester
-  phrase?: SearchPhraseSuggester
-  prefix?: string
-  regex?: string
-  term?: SearchTermSuggester
-  text?: string
-}
-
-export interface SearchSuggestContextQuery {
-  boost?: double
-  context: SearchContext
-  neighbours?: Distance[] | integer[]
-  precision?: Distance | integer
-  prefix?: boolean
-}
-
 export interface SearchSuggestFuzziness {
   fuzziness: Fuzziness
   min_length: integer
@@ -1533,6 +1536,12 @@ export interface SearchSuggestFuzziness {
 export type SearchSuggestOption<TDocument = unknown> = SearchCompletionSuggestOption<TDocument> | SearchPhraseSuggestOption | SearchTermSuggestOption
 
 export type SearchSuggestSort = 'score' | 'frequency'
+
+export interface SearchSuggesterKeys {
+  text?: string
+}
+export type SearchSuggester = SearchSuggesterKeys
+  & { [property: string]: SearchFieldSuggester | string }
 
 export interface SearchSuggesterBase {
   field: Field
@@ -1567,6 +1576,8 @@ export interface SearchTotalHits {
 }
 
 export type SearchTotalHitsRelation = 'eq' | 'gte'
+
+export type SearchTrackHits = boolean | integer
 
 export interface SearchMvtRequest extends RequestBase {
   index: Indices
@@ -1752,7 +1763,7 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
   routing?: Routing
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
-  _source?: boolean | Fields
+  _source?: SearchGetSourceConfig
   _source_excludes?: Fields
   _source_includes?: Fields
   body?: {
@@ -1761,7 +1772,7 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
     doc_as_upsert?: boolean
     script?: Script
     scripted_upsert?: boolean
-    _source?: boolean | SearchSourceFilter
+    _source?: SearchSourceConfig
     upsert?: TDocument
   }
 }
@@ -1795,7 +1806,7 @@ export interface UpdateByQueryRequest extends RequestBase {
   size?: long
   slices?: long
   sort?: string[]
-  _source?: boolean | Fields
+  _source?: SearchGetSourceConfig
   _source_excludes?: Fields
   _source_includes?: Fields
   stats?: string[]
@@ -1861,6 +1872,8 @@ export interface AcknowledgedResponseBase {
 
 export type AggregateName = string
 
+export type BuiltinScriptLanguage = 'painless' | 'expression' | 'mustache' | 'java'
+
 export interface BulkIndexByScrollFailure {
   cause: ErrorCause
   id: Id
@@ -1905,15 +1918,16 @@ export interface CompletionStats {
 
 export type Conflicts = 'abort' | 'proceed'
 
+export interface CoordsGeoBounds {
+  top: double
+  bottom: double
+  left: double
+  right: double
+}
+
 export type DataStreamName = string
 
 export type DataStreamNames = DataStreamName | DataStreamName[]
-
-export interface DateField {
-  field: Field
-  format?: string
-  include_unmapped?: boolean
-}
 
 export type DateFormat = string
 
@@ -1972,9 +1986,9 @@ export interface ErrorResponseBase {
   status: integer
 }
 
-export type ExpandWildcardOptions = 'all' | 'open' | 'closed' | 'hidden' | 'none'
+export type ExpandWildcard = 'all' | 'open' | 'closed' | 'hidden' | 'none'
 
-export type ExpandWildcards = ExpandWildcardOptions | ExpandWildcardOptions[] | string
+export type ExpandWildcards = ExpandWildcard | ExpandWildcard[]
 
 export type Field = string
 
@@ -1987,6 +2001,8 @@ export interface FieldSizeUsage {
   size?: ByteSize
   size_in_bytes: long
 }
+
+export type FieldValue = long | double | string | boolean
 
 export interface FielddataStats {
   evictions?: long
@@ -2006,16 +2022,24 @@ export interface FlushStats {
 
 export type Fuzziness = string | integer
 
+export type GeoBounds = CoordsGeoBounds | TopLeftBottomRightGeoBounds | TopRightBottomLeftGeoBounds | WktGeoBounds
+
 export type GeoDistanceType = 'arc' | 'plane'
 
 export type GeoHash = string
 
-export type GeoHashPrecision = number
+export interface GeoHashLocation {
+  geohash: GeoHash
+}
+
+export type GeoHashPrecision = number | string
 
 export interface GeoLine {
   type: string
   coordinates: double[][]
 }
+
+export type GeoLocation = LatLonGeoLocation | GeoHashLocation | double[] | string
 
 export type GeoShape = any
 
@@ -2038,8 +2062,6 @@ export interface GetStats {
   total: long
 }
 
-export type GroupBy = 'nodes' | 'parents' | 'none'
-
 export type Health = 'green' | 'yellow' | 'red'
 
 export type Host = string
@@ -2057,10 +2079,6 @@ export type IndexName = string
 export type IndexPattern = string
 
 export type IndexPatterns = IndexPattern[]
-
-export interface IndexedScript extends ScriptBase {
-  id: Id
-}
 
 export interface IndexingStats {
   index_current: long
@@ -2097,12 +2115,14 @@ export type InlineGet<TDocument = unknown> = InlineGetKeys<TDocument>
   & { [property: string]: any }
 
 export interface InlineScript extends ScriptBase {
+  lang?: ScriptLanguage
+  options?: Record<string, string>
   source: string
 }
 
 export type Ip = string
 
-export interface LatLon {
+export interface LatLonGeoLocation {
   lat: double
   lon: double
 }
@@ -2224,9 +2244,7 @@ export interface RecoveryStats {
   throttle_time_in_millis: long
 }
 
-export type Refresh = boolean | RefreshOptions
-
-export type RefreshOptions = 'wait_for'
+export type Refresh = boolean | RefreshValues
 
 export interface RefreshStats {
   external_total: long
@@ -2236,6 +2254,8 @@ export interface RefreshStats {
   total_time?: string
   total_time_in_millis: long
 }
+
+export type RefreshValues = 'true' | 'false' | 'wait_for'
 
 export type RelationName = string
 
@@ -2259,12 +2279,9 @@ export interface Retries {
 
 export type Routing = string
 
-export type ScalarValue = long | double | string | boolean
-
-export type Script = InlineScript | IndexedScript | string
+export type Script = InlineScript | string | StoredScriptId
 
 export interface ScriptBase {
-  lang?: ScriptLanguage | string
   params?: Record<string, any>
 }
 
@@ -2273,7 +2290,7 @@ export interface ScriptField {
   ignore_failure?: boolean
 }
 
-export type ScriptLanguage = 'painless' | 'expression' | 'mustache' | 'java'
+export type ScriptLanguage = BuiltinScriptLanguage | string
 
 export interface ScriptTransform {
   lang: string
@@ -2337,8 +2354,6 @@ export type SequenceNumber = long
 
 export type Service = string
 
-export type ShapeRelation = 'intersects' | 'disjoint' | 'within'
-
 export interface ShardFailure {
   index?: IndexName
   node?: string
@@ -2359,8 +2374,6 @@ export interface ShardsOperationResponseBase {
   _shards: ShardStatistics
 }
 
-export type Size = 'Raw' | 'k' | 'm' | 'g' | 't' | 'p'
-
 export interface SlicedScroll {
   field?: Field
   id: integer
@@ -2377,8 +2390,13 @@ export interface StoreStats {
 }
 
 export interface StoredScript {
-  lang?: ScriptLanguage | string
+  lang: ScriptLanguage
+  options?: Record<string, string>
   source: string
+}
+
+export interface StoredScriptId extends ScriptBase {
+  id: Id
 }
 
 export type SuggestMode = 'missing' | 'popular' | 'always'
@@ -2398,6 +2416,16 @@ export type TimeUnit = 'nanos' | 'micros' | 'ms' | 's' | 'm' | 'h' | 'd'
 export type TimeZone = string
 
 export type Timestamp = string
+
+export interface TopLeftBottomRightGeoBounds {
+  top_left: GeoLocation
+  bottom_right: GeoLocation
+}
+
+export interface TopRightBottomLeftGeoBounds {
+  top_right: GeoLocation
+  bottom_left: GeoLocation
+}
 
 export interface Transform {
   [key: string]: never
@@ -2448,6 +2476,10 @@ export interface WarmerStats {
   total: long
   total_time?: string
   total_time_in_millis: long
+}
+
+export interface WktGeoBounds {
+  wkt: string
 }
 
 export interface WriteResponseBase {
@@ -2659,6 +2691,10 @@ export interface AggregationsBucketSortAggregation extends AggregationsAggregati
 
 export type AggregationsBuckets<TBucket = unknown> = Record<string, TBucket> | TBucket[]
 
+export type AggregationsBucketsPath = string | string[] | Record<string, string>
+
+export type AggregationsCalendarInterval = 'second' | '1s' | 'minute' | '1m' | 'hour' | '1h' | 'day' | '1d' | 'week' | '1w' | 'month' | '1M' | 'quarter' | '1q' | 'year' | '1Y'
+
 export interface AggregationsCardinalityAggregate extends AggregationsAggregateBase {
   value: long
 }
@@ -2731,13 +2767,13 @@ export interface AggregationsDateHistogramAggregate extends AggregationsMultiBuc
 }
 
 export interface AggregationsDateHistogramAggregation extends AggregationsBucketAggregationBase {
-  calendar_interval?: AggregationsDateInterval | Time
-  extended_bounds?: AggregationsExtendedBounds<DateMath | long>
-  hard_bounds?: AggregationsExtendedBounds<DateMath | long>
+  calendar_interval?: AggregationsCalendarInterval
+  extended_bounds?: AggregationsExtendedBounds<AggregationsFieldDateMath>
+  hard_bounds?: AggregationsExtendedBounds<AggregationsFieldDateMath>
   field?: Field
-  fixed_interval?: AggregationsDateInterval | Time
+  fixed_interval?: Time
   format?: string
-  interval?: AggregationsDateInterval | Time
+  interval?: Time
   min_doc_count?: integer
   missing?: DateString
   offset?: Time
@@ -2755,8 +2791,6 @@ export interface AggregationsDateHistogramBucketKeys extends AggregationsMultiBu
 export type AggregationsDateHistogramBucket = AggregationsDateHistogramBucketKeys
   & { [property: string]: AggregationsAggregate | string | EpochMillis | long }
 
-export type AggregationsDateInterval = 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year'
-
 export interface AggregationsDateRangeAggregate extends AggregationsRangeAggregate {
 }
 
@@ -2770,12 +2804,9 @@ export interface AggregationsDateRangeAggregation extends AggregationsBucketAggr
 }
 
 export interface AggregationsDateRangeExpression {
-  from?: DateMath | float
-  from_as_string?: string
-  to_as_string?: string
+  from?: AggregationsFieldDateMath
   key?: string
-  to?: DateMath | float
-  doc_count?: long
+  to?: AggregationsFieldDateMath
 }
 
 export interface AggregationsDerivativeAggregate extends AggregationsSingleMetricAggregateBase {
@@ -2806,6 +2837,11 @@ export type AggregationsDoubleTermsBucket = AggregationsDoubleTermsBucketKeys
 
 export interface AggregationsEwmaModelSettings {
   alpha?: float
+}
+
+export interface AggregationsEwmaMovingAverageAggregation extends AggregationsMovingAverageAggregationBase {
+  model: 'ewma'
+  settings: AggregationsEwmaModelSettings
 }
 
 export interface AggregationsExtendedBounds<T = unknown> {
@@ -2839,6 +2875,8 @@ export interface AggregationsExtendedStatsBucketAggregation extends Aggregations
   sigma?: double
 }
 
+export type AggregationsFieldDateMath = DateMath | double
+
 export interface AggregationsFilterAggregate extends AggregationsSingleBucketAggregateBase {
 }
 
@@ -2846,7 +2884,7 @@ export interface AggregationsFiltersAggregate extends AggregationsMultiBucketAgg
 }
 
 export interface AggregationsFiltersAggregation extends AggregationsBucketAggregationBase {
-  filters?: Record<string, QueryDslQueryContainer> | QueryDslQueryContainer[]
+  filters?: AggregationsBuckets<QueryDslQueryContainer>
   other_bucket?: boolean
   other_bucket_key?: string
   keyed?: boolean
@@ -2867,13 +2905,8 @@ export interface AggregationsFormattableMetricAggregation extends AggregationsMe
 
 export type AggregationsGapPolicy = 'skip' | 'insert_zeros'
 
-export interface AggregationsGeoBounds {
-  bottom_right: LatLon
-  top_left: LatLon
-}
-
 export interface AggregationsGeoBoundsAggregate extends AggregationsAggregateBase {
-  bounds: AggregationsGeoBounds
+  bounds: GeoBounds
 }
 
 export interface AggregationsGeoBoundsAggregation extends AggregationsMetricAggregationBase {
@@ -2882,12 +2915,12 @@ export interface AggregationsGeoBoundsAggregation extends AggregationsMetricAggr
 
 export interface AggregationsGeoCentroidAggregate extends AggregationsAggregateBase {
   count: long
-  location?: QueryDslGeoLocation
+  location?: GeoLocation
 }
 
 export interface AggregationsGeoCentroidAggregation extends AggregationsMetricAggregationBase {
   count?: long
-  location?: QueryDslGeoLocation
+  location?: GeoLocation
 }
 
 export interface AggregationsGeoDistanceAggregate extends AggregationsRangeAggregate {
@@ -2896,7 +2929,7 @@ export interface AggregationsGeoDistanceAggregate extends AggregationsRangeAggre
 export interface AggregationsGeoDistanceAggregation extends AggregationsBucketAggregationBase {
   distance_type?: GeoDistanceType
   field?: Field
-  origin?: QueryDslGeoLocation | string
+  origin?: GeoLocation
   ranges?: AggregationsAggregationRange[]
   unit?: DistanceUnit
 }
@@ -2905,7 +2938,7 @@ export interface AggregationsGeoHashGridAggregate extends AggregationsMultiBucke
 }
 
 export interface AggregationsGeoHashGridAggregation extends AggregationsBucketAggregationBase {
-  bounds?: QueryDslBoundingBox
+  bounds?: GeoBounds
   field?: Field
   precision?: GeoHashPrecision
   shard_size?: integer
@@ -2919,7 +2952,7 @@ export type AggregationsGeoHashGridBucket = AggregationsGeoHashGridBucketKeys
   & { [property: string]: AggregationsAggregate | GeoHash | long }
 
 export interface AggregationsGeoLineAggregate extends AggregationsAggregateBase {
-  type: 'Feature'
+  type: string
   geometry: GeoLine
 }
 
@@ -2947,7 +2980,7 @@ export interface AggregationsGeoTileGridAggregation extends AggregationsBucketAg
   precision?: GeoTilePrecision
   shard_size?: integer
   size?: integer
-  bounds?: AggregationsGeoBounds
+  bounds?: GeoBounds
 }
 
 export interface AggregationsGeoTileGridBucketKeys extends AggregationsMultiBucketBase {
@@ -3010,6 +3043,11 @@ export interface AggregationsHoltLinearModelSettings {
   beta?: float
 }
 
+export interface AggregationsHoltMovingAverageAggregation extends AggregationsMovingAverageAggregationBase {
+  model: 'holt'
+  settings: AggregationsHoltLinearModelSettings
+}
+
 export interface AggregationsHoltWintersModelSettings {
   alpha?: float
   beta?: float
@@ -3019,10 +3057,15 @@ export interface AggregationsHoltWintersModelSettings {
   type?: AggregationsHoltWintersType
 }
 
+export interface AggregationsHoltWintersMovingAverageAggregation extends AggregationsMovingAverageAggregationBase {
+  model: 'holt_winters'
+  settings: AggregationsHoltWintersModelSettings
+}
+
 export type AggregationsHoltWintersType = 'add' | 'mult'
 
 export interface AggregationsInferenceAggregateKeys extends AggregationsAggregateBase {
-  value?: ScalarValue
+  value?: FieldValue
   feature_importance?: AggregationsInferenceFeatureImportance[]
   top_classes?: AggregationsInferenceTopClassEntry[]
   warning?: string
@@ -3052,7 +3095,7 @@ export interface AggregationsInferenceFeatureImportance {
 }
 
 export interface AggregationsInferenceTopClassEntry {
-  class_name: ScalarValue
+  class_name: FieldValue
   class_probability: double
   class_score: double
 }
@@ -3079,6 +3122,11 @@ export type AggregationsIpRangeBucket = AggregationsIpRangeBucketKeys
   & { [property: string]: AggregationsAggregate | string | long }
 
 export type AggregationsKeyedPercentiles = Record<string, string | long | null>
+
+export interface AggregationsLinearMovingAverageAggregation extends AggregationsMovingAverageAggregationBase {
+  model: 'linear'
+  settings: EmptyObject
+}
 
 export interface AggregationsLongRareTermsAggregate extends AggregationsMultiBucketAggregateBase<AggregationsLongRareTermsBucket> {
 }
@@ -3172,17 +3220,13 @@ export interface AggregationsMissingAggregation extends AggregationsBucketAggreg
 
 export type AggregationsMissingOrder = 'first' | 'last' | 'default'
 
-export interface AggregationsMovingAverageAggregation extends AggregationsPipelineAggregationBase {
+export type AggregationsMovingAverageAggregation = AggregationsLinearMovingAverageAggregation | AggregationsSimpleMovingAverageAggregation | AggregationsEwmaMovingAverageAggregation | AggregationsHoltMovingAverageAggregation | AggregationsHoltWintersMovingAverageAggregation
+
+export interface AggregationsMovingAverageAggregationBase extends AggregationsPipelineAggregationBase {
   minimize?: boolean
-  model?: AggregationsMovingAverageModel
-  settings: AggregationsMovingAverageSettings
   predict?: integer
   window?: integer
 }
-
-export type AggregationsMovingAverageModel = 'linear' | 'simple' | 'ewma' | 'holt' | 'holt_winters'
-
-export type AggregationsMovingAverageSettings = AggregationsEwmaModelSettings | AggregationsHoltLinearModelSettings | AggregationsHoltWintersModelSettings
 
 export interface AggregationsMovingFunctionAggregation extends AggregationsPipelineAggregationBase {
   script?: string
@@ -3256,8 +3300,10 @@ export interface AggregationsPercentileRanksAggregation extends AggregationsForm
   tdigest?: AggregationsTDigest
 }
 
+export type AggregationsPercentiles = AggregationsKeyedPercentiles | AggregationsArrayPercentilesItem[]
+
 export interface AggregationsPercentilesAggregateBase extends AggregationsAggregateBase {
-  values: AggregationsKeyedPercentiles | AggregationsArrayPercentilesItem[]
+  values: AggregationsPercentiles
 }
 
 export interface AggregationsPercentilesAggregation extends AggregationsFormatMetricAggregationBase {
@@ -3275,7 +3321,7 @@ export interface AggregationsPercentilesBucketAggregation extends AggregationsPi
 }
 
 export interface AggregationsPipelineAggregationBase extends AggregationsAggregation {
-  buckets_path?: string | string[] | Record<string, string>
+  buckets_path?: AggregationsBucketsPath
   format?: string
   gap_policy?: AggregationsGapPolicy
 }
@@ -3301,9 +3347,9 @@ export type AggregationsRangeBucket = AggregationsRangeBucketKeys
   & { [property: string]: AggregationsAggregate | double | string | long }
 
 export interface AggregationsRareTermsAggregation extends AggregationsBucketAggregationBase {
-  exclude?: string | string[]
+  exclude?: AggregationsTermsExclude
   field?: Field
-  include?: string | string[] | AggregationsTermsInclude
+  include?: AggregationsTermsInclude
   max_doc_count?: long
   missing?: AggregationsMissing
   precision?: double
@@ -3316,7 +3362,7 @@ export interface AggregationsRateAggregate extends AggregationsAggregateBase {
 }
 
 export interface AggregationsRateAggregation extends AggregationsFormatMetricAggregationBase {
-  unit?: AggregationsDateInterval
+  unit?: AggregationsCalendarInterval
   mode?: AggregationsRateMode
 }
 
@@ -3385,7 +3431,7 @@ export type AggregationsSignificantStringTermsBucket = AggregationsSignificantSt
 export interface AggregationsSignificantTermsAggregation extends AggregationsBucketAggregationBase {
   background_filter?: QueryDslQueryContainer
   chi_square?: AggregationsChiSquareHeuristic
-  exclude?: string | string[]
+  exclude?: AggregationsTermsExclude
   execution_hint?: AggregationsTermsAggregationExecutionHint
   field?: Field
   gnd?: AggregationsGoogleNormalizedDistanceHeuristic
@@ -3407,7 +3453,7 @@ export interface AggregationsSignificantTermsBucketBase extends AggregationsMult
 export interface AggregationsSignificantTextAggregation extends AggregationsBucketAggregationBase {
   background_filter?: QueryDslQueryContainer
   chi_square?: AggregationsChiSquareHeuristic
-  exclude?: string | string[]
+  exclude?: AggregationsTermsExclude
   execution_hint?: AggregationsTermsAggregationExecutionHint
   field?: Field
   filter_duplicate_text?: boolean
@@ -3421,6 +3467,11 @@ export interface AggregationsSignificantTextAggregation extends AggregationsBuck
   shard_size?: integer
   size?: integer
   source_fields?: Fields
+}
+
+export interface AggregationsSimpleMovingAverageAggregation extends AggregationsMovingAverageAggregationBase {
+  model: 'simple'
+  settings: EmptyObject
 }
 
 export interface AggregationsSimpleValueAggregate extends AggregationsSingleMetricAggregateBase {
@@ -3547,10 +3598,10 @@ export interface AggregationsTermsAggregateBase<TBucket = unknown> extends Aggre
 
 export interface AggregationsTermsAggregation extends AggregationsBucketAggregationBase {
   collect_mode?: AggregationsTermsAggregationCollectMode
-  exclude?: string | string[]
+  exclude?: AggregationsTermsExclude
   execution_hint?: AggregationsTermsAggregationExecutionHint
   field?: Field
-  include?: string | string[] | AggregationsTermsInclude
+  include?: AggregationsTermsInclude
   min_doc_count?: integer
   missing?: AggregationsMissing
   missing_order?: AggregationsMissingOrder
@@ -3567,13 +3618,17 @@ export type AggregationsTermsAggregationCollectMode = 'depth_first' | 'breadth_f
 
 export type AggregationsTermsAggregationExecutionHint = 'map' | 'global_ordinals' | 'global_ordinals_hash' | 'global_ordinals_low_cardinality'
 
-export type AggregationsTermsAggregationOrder = SearchSortOrder | Record<string, SearchSortOrder> | Record<string, SearchSortOrder>[]
+export type AggregationsTermsAggregationOrder = Record<Field, SearchSortOrder> | Record<Field, SearchSortOrder>[]
 
 export interface AggregationsTermsBucketBase extends AggregationsMultiBucketBase {
   doc_count_error?: long
 }
 
-export interface AggregationsTermsInclude {
+export type AggregationsTermsExclude = string | string[]
+
+export type AggregationsTermsInclude = string | string[] | AggregationsTermsPartition
+
+export interface AggregationsTermsPartition {
   num_partitions: long
   partition: long
 }
@@ -3596,7 +3651,7 @@ export interface AggregationsTopHitsAggregation extends AggregationsMetricAggreg
   script_fields?: Record<string, ScriptField>
   size?: integer
   sort?: SearchSort
-  _source?: boolean | SearchSourceFilter | Fields
+  _source?: SearchSourceConfig
   stored_fields?: Fields
   track_scores?: boolean
   version?: boolean
@@ -3604,8 +3659,8 @@ export interface AggregationsTopHitsAggregation extends AggregationsMetricAggreg
 }
 
 export interface AggregationsTopMetrics {
-  sort: (ScalarValue | null)[]
-  metrics: Record<string, ScalarValue | null>
+  sort: (FieldValue | null)[]
+  metrics: Record<string, FieldValue | null>
 }
 
 export interface AggregationsTopMetricsAggregate extends AggregationsMultiBucketAggregateBase<AggregationsTopMetricsBucket> {
@@ -3688,11 +3743,13 @@ export interface AnalysisAsciiFoldingTokenFilter extends AnalysisTokenFilterBase
   preserve_original: boolean
 }
 
-export type AnalysisCharFilter = AnalysisHtmlStripCharFilter | AnalysisMappingCharFilter | AnalysisPatternReplaceCharFilter | AnalysisIcuNormalizationCharFilter | AnalysisKuromojiIterationMarkCharFilter
+export type AnalysisCharFilter = string | AnalysisCharFilterDefinition
 
 export interface AnalysisCharFilterBase {
   version?: VersionString
 }
+
+export type AnalysisCharFilterDefinition = AnalysisHtmlStripCharFilter | AnalysisMappingCharFilter | AnalysisPatternReplaceCharFilter | AnalysisIcuNormalizationCharFilter | AnalysisKuromojiIterationMarkCharFilter
 
 export interface AnalysisCharGroupTokenizer extends AnalysisTokenizerBase {
   type: 'char_group'
@@ -4217,17 +4274,21 @@ export interface AnalysisSynonymTokenFilter extends AnalysisTokenFilterBase {
 
 export type AnalysisTokenChar = 'letter' | 'digit' | 'whitespace' | 'punctuation' | 'symbol' | 'custom'
 
-export type AnalysisTokenFilter = AnalysisAsciiFoldingTokenFilter | AnalysisCommonGramsTokenFilter | AnalysisConditionTokenFilter | AnalysisDelimitedPayloadTokenFilter | AnalysisEdgeNGramTokenFilter | AnalysisElisionTokenFilter | AnalysisFingerprintTokenFilter | AnalysisHunspellTokenFilter | AnalysisHyphenationDecompounderTokenFilter | AnalysisKeepTypesTokenFilter | AnalysisKeepWordsTokenFilter | AnalysisKeywordMarkerTokenFilter | AnalysisKStemTokenFilter | AnalysisLengthTokenFilter | AnalysisLimitTokenCountTokenFilter | AnalysisLowercaseTokenFilter | AnalysisMultiplexerTokenFilter | AnalysisNGramTokenFilter | AnalysisNoriPartOfSpeechTokenFilter | AnalysisPatternCaptureTokenFilter | AnalysisPatternReplaceTokenFilter | AnalysisPorterStemTokenFilter | AnalysisPredicateTokenFilter | AnalysisRemoveDuplicatesTokenFilter | AnalysisReverseTokenFilter | AnalysisShingleTokenFilter | AnalysisSnowballTokenFilter | AnalysisStemmerOverrideTokenFilter | AnalysisStemmerTokenFilter | AnalysisStopTokenFilter | AnalysisSynonymGraphTokenFilter | AnalysisSynonymTokenFilter | AnalysisTrimTokenFilter | AnalysisTruncateTokenFilter | AnalysisUniqueTokenFilter | AnalysisUppercaseTokenFilter | AnalysisWordDelimiterGraphTokenFilter | AnalysisWordDelimiterTokenFilter | AnalysisKuromojiStemmerTokenFilter | AnalysisKuromojiReadingFormTokenFilter | AnalysisKuromojiPartOfSpeechTokenFilter | AnalysisIcuTokenizer | AnalysisIcuCollationTokenFilter | AnalysisIcuFoldingTokenFilter | AnalysisIcuNormalizationTokenFilter | AnalysisIcuTransformTokenFilter | AnalysisPhoneticTokenFilter | AnalysisDictionaryDecompounderTokenFilter
+export type AnalysisTokenFilter = string | AnalysisTokenFilterDefinition
 
 export interface AnalysisTokenFilterBase {
   version?: VersionString
 }
 
-export type AnalysisTokenizer = AnalysisCharGroupTokenizer | AnalysisEdgeNGramTokenizer | AnalysisKeywordTokenizer | AnalysisLetterTokenizer | AnalysisLowercaseTokenizer | AnalysisNGramTokenizer | AnalysisNoriTokenizer | AnalysisPathHierarchyTokenizer | AnalysisStandardTokenizer | AnalysisUaxEmailUrlTokenizer | AnalysisWhitespaceTokenizer | AnalysisKuromojiTokenizer | AnalysisPatternTokenizer | AnalysisIcuTokenizer
+export type AnalysisTokenFilterDefinition = AnalysisAsciiFoldingTokenFilter | AnalysisCommonGramsTokenFilter | AnalysisConditionTokenFilter | AnalysisDelimitedPayloadTokenFilter | AnalysisEdgeNGramTokenFilter | AnalysisElisionTokenFilter | AnalysisFingerprintTokenFilter | AnalysisHunspellTokenFilter | AnalysisHyphenationDecompounderTokenFilter | AnalysisKeepTypesTokenFilter | AnalysisKeepWordsTokenFilter | AnalysisKeywordMarkerTokenFilter | AnalysisKStemTokenFilter | AnalysisLengthTokenFilter | AnalysisLimitTokenCountTokenFilter | AnalysisLowercaseTokenFilter | AnalysisMultiplexerTokenFilter | AnalysisNGramTokenFilter | AnalysisNoriPartOfSpeechTokenFilter | AnalysisPatternCaptureTokenFilter | AnalysisPatternReplaceTokenFilter | AnalysisPorterStemTokenFilter | AnalysisPredicateTokenFilter | AnalysisRemoveDuplicatesTokenFilter | AnalysisReverseTokenFilter | AnalysisShingleTokenFilter | AnalysisSnowballTokenFilter | AnalysisStemmerOverrideTokenFilter | AnalysisStemmerTokenFilter | AnalysisStopTokenFilter | AnalysisSynonymGraphTokenFilter | AnalysisSynonymTokenFilter | AnalysisTrimTokenFilter | AnalysisTruncateTokenFilter | AnalysisUniqueTokenFilter | AnalysisUppercaseTokenFilter | AnalysisWordDelimiterGraphTokenFilter | AnalysisWordDelimiterTokenFilter | AnalysisKuromojiStemmerTokenFilter | AnalysisKuromojiReadingFormTokenFilter | AnalysisKuromojiPartOfSpeechTokenFilter | AnalysisIcuTokenizer | AnalysisIcuCollationTokenFilter | AnalysisIcuFoldingTokenFilter | AnalysisIcuNormalizationTokenFilter | AnalysisIcuTransformTokenFilter | AnalysisPhoneticTokenFilter | AnalysisDictionaryDecompounderTokenFilter
+
+export type AnalysisTokenizer = string | AnalysisTokenizerDefinition
 
 export interface AnalysisTokenizerBase {
   version?: VersionString
 }
+
+export type AnalysisTokenizerDefinition = AnalysisCharGroupTokenizer | AnalysisEdgeNGramTokenizer | AnalysisKeywordTokenizer | AnalysisLetterTokenizer | AnalysisLowercaseTokenizer | AnalysisNGramTokenizer | AnalysisNoriTokenizer | AnalysisPathHierarchyTokenizer | AnalysisStandardTokenizer | AnalysisUaxEmailUrlTokenizer | AnalysisWhitespaceTokenizer | AnalysisKuromojiTokenizer | AnalysisPatternTokenizer | AnalysisIcuTokenizer
 
 export interface AnalysisTrimTokenFilter extends AnalysisTokenFilterBase {
   type: 'trim'
@@ -4413,7 +4474,9 @@ export interface MappingDoubleRangeProperty extends MappingRangePropertyBase {
   type: 'double_range'
 }
 
-export type MappingDynamicMapping = 'strict' | 'runtime' | 'true' | 'false'
+export type MappingDynamicMapping = boolean | MappingDynamicMappingValues
+
+export type MappingDynamicMappingValues = 'strict' | 'runtime' | 'true' | 'false'
 
 export interface MappingDynamicTemplate {
   mapping?: MappingProperty
@@ -4483,7 +4546,7 @@ export type MappingGeoOrientation = 'right' | 'RIGHT' | 'counterclockwise' | 'cc
 export interface MappingGeoPointProperty extends MappingDocValuesPropertyBase {
   ignore_malformed?: boolean
   ignore_z_value?: boolean
-  null_value?: QueryDslGeoLocation
+  null_value?: GeoLocation
   type: 'geo_point'
 }
 
@@ -4609,7 +4672,7 @@ export interface MappingPropertyBase {
   name?: PropertyName
   properties?: Record<PropertyName, MappingProperty>
   ignore_above?: integer
-  dynamic?: boolean | MappingDynamicMapping
+  dynamic?: MappingDynamicMapping
   fields?: Record<PropertyName, MappingProperty>
 }
 
@@ -4740,7 +4803,7 @@ export interface MappingTokenCountProperty extends MappingDocValuesPropertyBase 
 export interface MappingTypeMapping {
   all_field?: MappingAllField
   date_detection?: boolean
-  dynamic?: boolean | MappingDynamicMapping
+  dynamic?: MappingDynamicMapping
   dynamic_date_formats?: string[]
   dynamic_templates?: Record<string, MappingDynamicTemplate> | Record<string, MappingDynamicTemplate>[]
   _field_names?: MappingFieldNamesField
@@ -4781,18 +4844,6 @@ export interface QueryDslBoostingQuery extends QueryDslQueryBase {
   negative_boost: double
   negative: QueryDslQueryContainer
   positive: QueryDslQueryContainer
-}
-
-export interface QueryDslBoundingBox {
-  bottom_right?: QueryDslGeoLocation
-  top_left?: QueryDslGeoLocation
-  top_right?: QueryDslGeoLocation
-  bottom_left?: QueryDslGeoLocation
-  top?: double
-  left?: double
-  right?: double
-  bottom?: double
-  wkt?: string
 }
 
 export type QueryDslChildScoreMode = 'none' | 'avg' | 'sum' | 'max' | 'min'
@@ -4872,6 +4923,12 @@ export interface QueryDslExistsQuery extends QueryDslQueryBase {
   field: Field
 }
 
+export interface QueryDslFieldAndFormat {
+  field: Field
+  format?: string
+  include_unmapped?: boolean
+}
+
 export interface QueryDslFieldLookup {
   id: Id
   index?: IndexName
@@ -4927,16 +4984,14 @@ export interface QueryDslGeoBoundingBoxQueryKeys extends QueryDslQueryBase {
   ignore_unmapped?: boolean
 }
 export type QueryDslGeoBoundingBoxQuery = QueryDslGeoBoundingBoxQueryKeys
-  & { [property: string]: QueryDslBoundingBox | QueryDslGeoExecution | QueryDslGeoValidationMethod | boolean | float | string }
-
-export type QueryDslGeoCoordinate = string | double[] | QueryDslThreeDimensionalPoint
+  & { [property: string]: GeoBounds | QueryDslGeoExecution | QueryDslGeoValidationMethod | boolean | float | string }
 
 export interface QueryDslGeoDecayFunctionKeys extends QueryDslDecayFunctionBase {
 }
 export type QueryDslGeoDecayFunction = QueryDslGeoDecayFunctionKeys
-  & { [property: string]: QueryDslDecayPlacement<QueryDslGeoLocation, Distance> | QueryDslMultiValueMode | QueryDslQueryContainer | double }
+  & { [property: string]: QueryDslDecayPlacement<GeoLocation, Distance> | QueryDslMultiValueMode | QueryDslQueryContainer | double }
 
-export interface QueryDslGeoDistanceFeatureQuery extends QueryDslDistanceFeatureQueryBase<QueryDslGeoCoordinate, Distance> {
+export interface QueryDslGeoDistanceFeatureQuery extends QueryDslDistanceFeatureQueryBase<GeoLocation, Distance> {
 }
 
 export interface QueryDslGeoDistanceQueryKeys extends QueryDslQueryBase {
@@ -4945,14 +5000,12 @@ export interface QueryDslGeoDistanceQueryKeys extends QueryDslQueryBase {
   validation_method?: QueryDslGeoValidationMethod
 }
 export type QueryDslGeoDistanceQuery = QueryDslGeoDistanceQueryKeys
-  & { [property: string]: QueryDslGeoLocation | Distance | GeoDistanceType | QueryDslGeoValidationMethod | float | string }
+  & { [property: string]: GeoLocation | Distance | GeoDistanceType | QueryDslGeoValidationMethod | float | string }
 
 export type QueryDslGeoExecution = 'memory' | 'indexed'
 
-export type QueryDslGeoLocation = string | double[] | QueryDslTwoDimensionalPoint
-
 export interface QueryDslGeoPolygonPoints {
-  points: QueryDslGeoLocation[]
+  points: GeoLocation[]
 }
 
 export interface QueryDslGeoPolygonQueryKeys extends QueryDslQueryBase {
@@ -5201,7 +5254,7 @@ export interface QueryDslNumericDecayFunctionKeys extends QueryDslDecayFunctionB
 export type QueryDslNumericDecayFunction = QueryDslNumericDecayFunctionKeys
   & { [property: string]: QueryDslDecayPlacement<double, double> | QueryDslMultiValueMode | QueryDslQueryContainer | double }
 
-export type QueryDslOperator = 'and' | 'or'
+export type QueryDslOperator = 'and' | 'AND' | 'or' | 'OR'
 
 export interface QueryDslParentIdQuery extends QueryDslQueryBase {
   id?: Id
@@ -5292,7 +5345,7 @@ export interface QueryDslQueryContainer {
   span_or?: QueryDslSpanOrQuery
   span_term?: Partial<Record<Field, QueryDslSpanTermQuery | string>>
   span_within?: QueryDslSpanWithinQuery
-  term?: Partial<Record<Field, QueryDslTermQuery | string | float | boolean>>
+  term?: Partial<Record<Field, QueryDslTermQuery | FieldValue>>
   terms?: QueryDslTermsQuery
   terms_set?: Partial<Record<Field, QueryDslTermsSetQuery>>
   wildcard?: Partial<Record<Field, QueryDslWildcardQuery | string>>
@@ -5397,18 +5450,20 @@ export interface QueryDslScriptScoreQuery extends QueryDslQueryBase {
 }
 
 export interface QueryDslShapeFieldQuery {
-  ignore_unmapped?: boolean
   indexed_shape?: QueryDslFieldLookup
-  relation?: ShapeRelation
+  relation?: GeoShapeRelation
   shape?: GeoShape
 }
 
 export interface QueryDslShapeQueryKeys extends QueryDslQueryBase {
+  ignore_unmapped?: boolean
 }
 export type QueryDslShapeQuery = QueryDslShapeQueryKeys
-  & { [property: string]: QueryDslShapeFieldQuery | float | string }
+  & { [property: string]: QueryDslShapeFieldQuery | boolean | float | string }
 
-export type QueryDslSimpleQueryStringFlags = 'NONE' | 'AND' | 'OR' | 'NOT' | 'PREFIX' | 'PHRASE' | 'PRECEDENCE' | 'ESCAPE' | 'WHITESPACE' | 'FUZZY' | 'NEAR' | 'SLOP' | 'ALL'
+export type QueryDslSimpleQueryStringFlag = 'NONE' | 'AND' | 'OR' | 'NOT' | 'PREFIX' | 'PHRASE' | 'PRECEDENCE' | 'ESCAPE' | 'WHITESPACE' | 'FUZZY' | 'NEAR' | 'SLOP' | 'ALL'
+
+export type QueryDslSimpleQueryStringFlags = QueryDslSimpleQueryStringFlag | string
 
 export interface QueryDslSimpleQueryStringQuery extends QueryDslQueryBase {
   analyzer?: string
@@ -5416,7 +5471,7 @@ export interface QueryDslSimpleQueryStringQuery extends QueryDslQueryBase {
   auto_generate_synonyms_phrase_query?: boolean
   default_operator?: QueryDslOperator
   fields?: Field[]
-  flags?: QueryDslSimpleQueryStringFlags | string
+  flags?: QueryDslSimpleQueryStringFlags
   fuzzy_max_expansions?: integer
   fuzzy_prefix_length?: integer
   fuzzy_transpositions?: boolean
@@ -5488,7 +5543,7 @@ export interface QueryDslSpanWithinQuery extends QueryDslQueryBase {
 }
 
 export interface QueryDslTermQuery extends QueryDslQueryBase {
-  value: string | float | boolean
+  value: FieldValue
   case_insensitive?: boolean
 }
 
@@ -5502,7 +5557,9 @@ export interface QueryDslTermsLookup {
 export interface QueryDslTermsQueryKeys extends QueryDslQueryBase {
 }
 export type QueryDslTermsQuery = QueryDslTermsQueryKeys
-  & { [property: string]: string[] | long[] | QueryDslTermsLookup | float | string }
+  & { [property: string]: QueryDslTermsQueryField | float | string }
+
+export type QueryDslTermsQueryField = FieldValue[] | QueryDslTermsLookup
 
 export interface QueryDslTermsSetQuery extends QueryDslQueryBase {
   minimum_should_match_field?: Field
@@ -5511,17 +5568,6 @@ export interface QueryDslTermsSetQuery extends QueryDslQueryBase {
 }
 
 export type QueryDslTextQueryType = 'best_fields' | 'most_fields' | 'cross_fields' | 'phrase' | 'phrase_prefix' | 'bool_prefix'
-
-export interface QueryDslThreeDimensionalPoint {
-  lat: double
-  lon: double
-  z?: double
-}
-
-export interface QueryDslTwoDimensionalPoint {
-  lat: double
-  lon: double
-}
 
 export interface QueryDslTypeQuery extends QueryDslQueryBase {
   value: string
@@ -5626,12 +5672,12 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
   suggest_text?: string
   terminate_after?: long
   timeout?: Time
-  track_total_hits?: boolean | integer
+  track_total_hits?: SearchTrackHits
   track_scores?: boolean
   typed_keys?: boolean
   rest_total_hits_as_int?: boolean
   version?: boolean
-  _source?: boolean | Fields
+  _source?: SearchGetSourceConfig
   _source_excludes?: Fields
   _source_includes?: Fields
   seq_no_primary_term?: boolean
@@ -5646,9 +5692,9 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
     explain?: boolean
     from?: integer
     highlight?: SearchHighlight
-    track_total_hits?: boolean | integer
+    track_total_hits?: SearchTrackHits
     indices_boost?: Record<IndexName, double>[]
-    docvalue_fields?: SearchDocValueField | (Field | SearchDocValueField)[]
+    docvalue_fields?: (SearchDocValueField | Field)[]
     min_score?: double
     post_filter?: QueryDslQueryContainer
     profile?: boolean
@@ -5659,9 +5705,9 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
     size?: integer
     slice?: SlicedScroll
     sort?: SearchSort
-    _source?: boolean | Fields | SearchSourceFilter
-    fields?: (Field | DateField)[]
-    suggest?: SearchSuggestContainer | Record<string, SearchSuggestContainer>
+    _source?: SearchSourceConfig
+    fields?: (QueryDslFieldAndFormat | Field)[]
+    suggest?: SearchSuggester
     terminate_after?: long
     timeout?: string
     track_scores?: boolean
@@ -7344,7 +7390,7 @@ export interface CatTemplatesTemplatesRecord {
 
 export interface CatThreadPoolRequest extends CatCatRequestBase {
   thread_pool_patterns?: Names
-  size?: Size | boolean
+  size?: CatThreadPoolThreadPoolSize
 }
 
 export type CatThreadPoolResponse = CatThreadPoolThreadPoolRecord[]
@@ -7391,6 +7437,8 @@ export interface CatThreadPoolThreadPoolRecord {
   keep_alive?: string
   ka?: string
 }
+
+export type CatThreadPoolThreadPoolSize = 'k' | 'm' | 'g' | 't' | 'p'
 
 export interface CatTransformsRequest extends CatCatRequestBase {
   transform_id?: Id
@@ -8563,8 +8611,8 @@ export interface EqlSearchRequest extends RequestBase {
     keep_alive?: Time
     keep_on_completion?: boolean
     wait_for_completion_timeout?: Time
-    size?: uint | float
-    fields?: (Field | EqlSearchSearchFieldFormatted)[]
+    size?: uint
+    fields?: QueryDslFieldAndFormat | Field
     result_position?: EqlSearchResultPosition
   }
 }
@@ -8573,11 +8621,6 @@ export interface EqlSearchResponse<TEvent = unknown> extends EqlEqlSearchRespons
 }
 
 export type EqlSearchResultPosition = 'tail' | 'head'
-
-export interface EqlSearchSearchFieldFormatted {
-  field: Field
-  format?: string
-}
 
 export interface FeaturesFeature {
   name: string
@@ -8664,14 +8707,11 @@ export interface GraphExploreResponse {
   vertices: GraphVertex[]
 }
 
-export interface IlmAction {
-  [key: string]: never
-}
+export type IlmActions = any
 
 export interface IlmPhase {
-  actions?: Record<string, IlmAction> | string[]
+  actions?: IlmActions
   min_age?: Time
-  configurations?: Record<string, Record<string, integer | string>>
 }
 
 export interface IlmPhases {
@@ -9020,12 +9060,8 @@ export interface IndicesIndexSettingsLifecycle {
 export interface IndicesIndexState {
   aliases?: Record<IndexName, IndicesAlias>
   mappings?: MappingTypeMapping
-  settings?: IndicesIndexSettings | IndicesIndexStatePrefixedSettings
+  settings?: IndicesIndexSettings
   data_stream?: DataStreamName
-}
-
-export interface IndicesIndexStatePrefixedSettings {
-  index: IndicesIndexSettings
 }
 
 export interface IndicesIndexVersioning {
@@ -9134,13 +9170,13 @@ export interface IndicesAnalyzeRequest extends RequestBase {
   body?: {
     analyzer?: string
     attributes?: string[]
-    char_filter?: (string | AnalysisCharFilter)[]
+    char_filter?: AnalysisCharFilter[]
     explain?: boolean
     field?: Field
-    filter?: (string | AnalysisTokenFilter)[]
+    filter?: AnalysisTokenFilter[]
     normalizer?: string
     text?: IndicesAnalyzeTextToAnalyze
-    tokenizer?: string | AnalysisTokenizer
+    tokenizer?: AnalysisTokenizer
   }
 }
 
@@ -9629,7 +9665,7 @@ export interface IndicesPutMappingRequest extends RequestBase {
   write_index_only?: boolean
   body?: {
     date_detection?: boolean
-    dynamic?: boolean | MappingDynamicMapping
+    dynamic?: MappingDynamicMapping
     dynamic_date_formats?: string[]
     dynamic_templates?: Record<string, MappingDynamicTemplate> | Record<string, MappingDynamicTemplate>[]
     _field_names?: MappingFieldNamesField
@@ -9844,6 +9880,8 @@ export interface IndicesResolveIndexResponse {
   data_streams: IndicesResolveIndexResolveIndexDataStreamsItem[]
 }
 
+export type IndicesRolloverIndexRolloverMapping = MappingTypeMapping | Record<string, MappingTypeMapping>
+
 export interface IndicesRolloverRequest extends RequestBase {
   alias: IndexAlias
   new_index?: IndexName
@@ -9855,7 +9893,7 @@ export interface IndicesRolloverRequest extends RequestBase {
   body?: {
     aliases?: Record<IndexName, IndicesAlias>
     conditions?: IndicesRolloverRolloverConditions
-    mappings?: Record<string, MappingTypeMapping> | MappingTypeMapping
+    mappings?: IndicesRolloverIndexRolloverMapping
     settings?: Record<string, any>
   }
 }
@@ -10311,7 +10349,7 @@ export interface IngestCsvProcessor extends IngestProcessorBase {
 
 export interface IngestDateIndexNameProcessor extends IngestProcessorBase {
   date_formats: string[]
-  date_rounding: string | IngestDateRounding
+  date_rounding: string
   field: Field
   index_name_format: string
   index_name_prefix: string
@@ -10326,8 +10364,6 @@ export interface IngestDateProcessor extends IngestProcessorBase {
   target_field?: Field
   timezone?: string
 }
-
-export type IngestDateRounding = 's' | 'm' | 'h' | 'd' | 'w' | 'M' | 'y'
 
 export interface IngestDissectProcessor extends IngestProcessorBase {
   append_separator: string
@@ -10837,7 +10873,7 @@ export interface MigrationDeprecationsResponse {
 
 export interface MlAnalysisConfig {
   bucket_span: TimeSpan
-  categorization_analyzer?: MlCategorizationAnalyzer | string
+  categorization_analyzer?: MlCategorizationAnalyzer
   categorization_field_name?: Field
   categorization_filters?: string[]
   detectors: MlDetector[]
@@ -10851,7 +10887,7 @@ export interface MlAnalysisConfig {
 
 export interface MlAnalysisConfigRead {
   bucket_span: TimeSpan
-  categorization_analyzer?: MlCategorizationAnalyzer | string
+  categorization_analyzer?: MlCategorizationAnalyzer
   categorization_field_name?: Field
   categorization_filters?: string[]
   detectors: MlDetector[]
@@ -10950,10 +10986,12 @@ export interface MlCalendarEvent {
   start_time: EpochMillis
 }
 
-export interface MlCategorizationAnalyzer {
-  char_filter?: (string | AnalysisCharFilter)[]
-  filter?: (string | AnalysisTokenFilter)[]
-  tokenizer?: string | AnalysisTokenizer
+export type MlCategorizationAnalyzer = string | MlCategorizationAnalyzerDefinition
+
+export interface MlCategorizationAnalyzerDefinition {
+  char_filter?: AnalysisCharFilter[]
+  filter?: AnalysisTokenFilter[]
+  tokenizer?: AnalysisTokenizer
 }
 
 export type MlCategorizationStatus = 'ok' | 'warn'
@@ -10984,11 +11022,7 @@ export type MlChunkingMode = 'auto' | 'manual' | 'off'
 
 export type MlConditionOperator = 'gt' | 'gte' | 'lt' | 'lte'
 
-export interface MlCustomSettings {
-  custom_urls?: XpackUsageUrlConfig[]
-  created_by?: string
-  job_tags?: Record<string, string>
-}
+export type MlCustomSettings = any
 
 export interface MlDataCounts {
   bucket_count: long
@@ -11104,9 +11138,7 @@ export interface MlDataframeAnalysis {
   training_percent?: Percentage
 }
 
-export type MlDataframeAnalysisAnalyzedFields = string[] | MlDataframeAnalysisAnalyzedFieldsIncludeExclude
-
-export interface MlDataframeAnalysisAnalyzedFieldsIncludeExclude {
+export interface MlDataframeAnalysisAnalyzedFields {
   includes: string[]
   excludes: string[]
 }
@@ -11209,7 +11241,7 @@ export interface MlDataframeAnalyticsSource {
   index: Indices
   query?: QueryDslQueryContainer
   runtime_mappings?: MappingRuntimeFields
-  _source?: MlDataframeAnalysisAnalyzedFields
+  _source?: MlDataframeAnalysisAnalyzedFields | string[]
 }
 
 export interface MlDataframeAnalyticsStatsContainer {
@@ -11258,7 +11290,7 @@ export interface MlDataframeAnalyticsSummary {
   description?: string
   model_memory_limit?: string
   max_num_threads?: integer
-  analyzed_fields?: MlDataframeAnalysisAnalyzedFields
+  analyzed_fields?: MlDataframeAnalysisAnalyzedFields | string[]
   allow_lazy_start?: boolean
   create_time?: long
   version?: VersionString
@@ -11901,7 +11933,7 @@ export interface MlExplainDataFrameAnalyticsRequest extends RequestBase {
     description?: string
     model_memory_limit?: string
     max_num_threads?: integer
-    analyzed_fields?: MlDataframeAnalysisAnalyzedFields
+    analyzed_fields?: MlDataframeAnalysisAnalyzedFields | string[]
     allow_lazy_start?: boolean
   }
 }
@@ -12303,7 +12335,7 @@ export interface MlPreviewDataFrameAnalyticsDataframePreviewConfig {
   analysis: MlDataframeAnalysisContainer
   model_memory_limit?: string
   max_num_threads?: integer
-  analyzed_fields?: MlDataframeAnalysisAnalyzedFields
+  analyzed_fields?: MlDataframeAnalysisAnalyzedFields | string[]
 }
 
 export interface MlPreviewDataFrameAnalyticsRequest extends RequestBase {
@@ -12358,7 +12390,7 @@ export interface MlPutDataFrameAnalyticsRequest extends RequestBase {
   body?: {
     allow_lazy_start?: boolean
     analysis: MlDataframeAnalysisContainer
-    analyzed_fields?: MlDataframeAnalysisAnalyzedFields
+    analyzed_fields?: MlDataframeAnalysisAnalyzedFields | string[]
     description?: string
     dest: MlDataframeAnalyticsDestination
     max_num_threads?: integer
@@ -12378,7 +12410,7 @@ export interface MlPutDataFrameAnalyticsResponse {
   allow_lazy_start: boolean
   max_num_threads: integer
   analysis: MlDataframeAnalysisContainer
-  analyzed_fields?: MlDataframeAnalysisAnalyzedFields
+  analyzed_fields?: MlDataframeAnalysisAnalyzedFields | string[]
 }
 
 export interface MlPutDatafeedRequest extends RequestBase {
@@ -12683,7 +12715,7 @@ export interface MlUpdateDataFrameAnalyticsResponse {
   allow_lazy_start: boolean
   max_num_threads: integer
   analysis: MlDataframeAnalysisContainer
-  analyzed_fields?: MlDataframeAnalysisAnalyzedFields
+  analyzed_fields?: MlDataframeAnalysisAnalyzedFields | string[]
 }
 
 export interface MlUpdateFilterRequest extends RequestBase {
@@ -13205,7 +13237,7 @@ export interface NodesInfoNodeInfoSettingsClusterElection {
 }
 
 export interface NodesInfoNodeInfoSettingsHttp {
-  type: string | NodesInfoNodeInfoSettingsHttpType
+  type: NodesInfoNodeInfoSettingsHttpType | string
   'type.default'?: string
   compression?: boolean | string
   port?: integer | string
@@ -13263,7 +13295,7 @@ export interface NodesInfoNodeInfoSettingsNode {
 }
 
 export interface NodesInfoNodeInfoSettingsTransport {
-  type: string | NodesInfoNodeInfoSettingsTransportType
+  type: NodesInfoNodeInfoSettingsTransportType | string
   'type.default'?: string
   features?: NodesInfoNodeInfoSettingsTransportFeatures
 }
@@ -13384,16 +13416,12 @@ export interface NodesInfoResponse extends NodesNodesResponseBase {
   nodes: Record<string, NodesInfoNodeInfo>
 }
 
-export interface NodesReloadSecureSettingsNodeReloadException {
+export interface NodesReloadSecureSettingsNodeReloadError {
   name: Name
-  reload_exception?: NodesReloadSecureSettingsNodeReloadExceptionCausedBy
+  reload_exception?: ErrorCause
 }
 
-export interface NodesReloadSecureSettingsNodeReloadExceptionCausedBy {
-  type: string
-  reason: string
-  caused_by?: NodesReloadSecureSettingsNodeReloadExceptionCausedBy
-}
+export type NodesReloadSecureSettingsNodeReloadResult = NodesStats | NodesReloadSecureSettingsNodeReloadError
 
 export interface NodesReloadSecureSettingsRequest extends RequestBase {
   node_id?: NodeIds
@@ -13405,7 +13433,7 @@ export interface NodesReloadSecureSettingsRequest extends RequestBase {
 
 export interface NodesReloadSecureSettingsResponse extends NodesNodesResponseBase {
   cluster_name: Name
-  nodes: Record<string, NodesStats | NodesReloadSecureSettingsNodeReloadException>
+  nodes: Record<string, NodesReloadSecureSettingsNodeReloadResult>
 }
 
 export interface NodesStatsRequest extends RequestBase {
@@ -13742,7 +13770,7 @@ export interface SecurityIndicesPrivileges {
   field_security?: SecurityFieldSecurity | SecurityFieldSecurity[]
   names: Indices
   privileges: SecurityIndexPrivilege[]
-  query?: string | string[] | QueryDslQueryContainer
+  query?: string | string[]
   allow_restricted_indices?: boolean
 }
 
@@ -14018,20 +14046,6 @@ export interface SecurityGetPrivilegesRequest extends RequestBase {
 export interface SecurityGetPrivilegesResponse extends DictionaryResponseBase<string, Record<string, SecurityPutPrivilegesActions>> {
 }
 
-export interface SecurityGetRoleInlineRoleTemplate {
-  template: SecurityGetRoleInlineRoleTemplateSource
-  format?: SecurityGetRoleTemplateFormat
-}
-
-export interface SecurityGetRoleInlineRoleTemplateSource {
-  source: string
-}
-
-export interface SecurityGetRoleInvalidRoleTemplate {
-  template: string
-  format?: SecurityGetRoleTemplateFormat
-}
-
 export interface SecurityGetRoleRequest extends RequestBase {
   name?: Name
 }
@@ -14049,15 +14063,9 @@ export interface SecurityGetRoleRole {
   role_templates?: SecurityGetRoleRoleTemplate[]
 }
 
-export type SecurityGetRoleRoleTemplate = SecurityGetRoleInlineRoleTemplate | SecurityGetRoleStoredRoleTemplate | SecurityGetRoleInvalidRoleTemplate
-
-export interface SecurityGetRoleStoredRoleTemplate {
-  template: SecurityGetRoleStoredRoleTemplateId
+export interface SecurityGetRoleRoleTemplate {
   format?: SecurityGetRoleTemplateFormat
-}
-
-export interface SecurityGetRoleStoredRoleTemplateId {
-  id: string
+  template: Script
 }
 
 export type SecurityGetRoleTemplateFormat = 'string' | 'json'
@@ -14864,7 +14872,7 @@ export interface SqlTranslateRequest extends RequestBase {
 
 export interface SqlTranslateResponse {
   size: long
-  _source: boolean | Fields | SearchSourceFilter
+  _source: SearchSourceConfig
   fields: Record<Field, string>[]
   sort: SearchSort
 }
@@ -14883,6 +14891,8 @@ export interface SslCertificatesRequest extends RequestBase {
 }
 
 export type SslCertificatesResponse = SslCertificatesCertificateInformation[]
+
+export type TasksGroupBy = 'nodes' | 'parents' | 'none'
 
 export interface TasksInfo {
   action: string
@@ -14966,7 +14976,7 @@ export interface TasksGetResponse {
 export interface TasksListRequest extends RequestBase {
   actions?: string | string[]
   detailed?: boolean
-  group_by?: GroupBy
+  group_by?: TasksGroupBy
   nodes?: string[]
   parent_task_id?: Id
   timeout?: Time
@@ -14976,7 +14986,7 @@ export interface TasksListRequest extends RequestBase {
 export interface TasksListResponse {
   node_failures?: ErrorCause[]
   nodes?: Record<string, TasksTaskExecutingNode>
-  tasks?: Record<string, TasksInfo> | TasksInfo[]
+  tasks?: Record<string, TasksInfo>
 }
 
 export interface TextStructureFindStructureFieldStat {
@@ -15352,7 +15362,7 @@ export type WatcherConnectionScheme = 'http' | 'https'
 export type WatcherCronExpression = string
 
 export interface WatcherDailySchedule {
-  at: string[] | WatcherTimeOfDay
+  at: WatcherTimeOfDay[]
 }
 
 export type WatcherDay = 'sunday' | 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday' | 'saturday'
@@ -15408,6 +15418,11 @@ export type WatcherExecutionStatus = 'awaits_execution' | 'checking' | 'executio
 export interface WatcherExecutionThreadPool {
   max_size: long
   queue_size: long
+}
+
+export interface WatcherHourAndMinute {
+  hour: integer[]
+  minute: integer[]
 }
 
 export interface WatcherHourlySchedule {
@@ -15568,8 +15583,8 @@ export interface WatcherScheduleContainer {
 }
 
 export interface WatcherScheduleTriggerEvent {
-  scheduled_time: DateString | string
-  triggered_time?: DateString | string
+  scheduled_time: DateString
+  triggered_time?: DateString
 }
 
 export interface WatcherScriptCondition {
@@ -15651,10 +15666,7 @@ export interface WatcherThrottleState {
   timestamp: DateString
 }
 
-export interface WatcherTimeOfDay {
-  hour: integer[]
-  minute: integer[]
-}
+export type WatcherTimeOfDay = string | WatcherHourAndMinute
 
 export interface WatcherTimeOfMonth {
   at: string[]
@@ -15981,11 +15993,6 @@ export interface XpackUsageBase {
   enabled: boolean
 }
 
-export interface XpackUsageBaseUrlConfig {
-  url_name: string
-  url_value: string
-}
-
 export interface XpackUsageCcr extends XpackUsageBase {
   auto_follow_patterns_count: integer
   follower_indices_count: integer
@@ -16098,13 +16105,15 @@ export interface XpackUsageIpFilter {
   transport: boolean
 }
 
-export interface XpackUsageKibanaUrlConfig extends XpackUsageBaseUrlConfig {
-  time_range?: string
+export interface XpackUsageJobsKeys {
+  _all?: XpackUsageAllJobs
 }
+export type XpackUsageJobs = XpackUsageJobsKeys
+  & { [property: string]: MlJob | XpackUsageAllJobs }
 
 export interface XpackUsageMachineLearning extends XpackUsageBase {
   datafeeds: Record<string, XpackUsageDatafeed>
-  jobs: Record<string, MlJob> | Partial<Record<string, XpackUsageAllJobs>>
+  jobs: XpackUsageJobs
   node_count: integer
   data_frame_analytics_jobs: XpackUsageMlDataFrameAnalyticsJobs
   inference: XpackUsageMlInference
@@ -16311,8 +16320,6 @@ export interface XpackUsageSsl {
   http: XpackUsageFeatureToggle
   transport: XpackUsageFeatureToggle
 }
-
-export type XpackUsageUrlConfig = XpackUsageBaseUrlConfig | XpackUsageKibanaUrlConfig
 
 export interface XpackUsageVector extends XpackUsageBase {
   dense_vector_dims_avg_count: integer

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2239,7 +2239,7 @@ export interface RecoveryStats {
   throttle_time_in_millis: long
 }
 
-export type Refresh = boolean | RefreshValues
+export type Refresh = boolean | 'true' | 'false' | 'wait_for'
 
 export interface RefreshStats {
   external_total: long
@@ -2249,8 +2249,6 @@ export interface RefreshStats {
   total_time?: string
   total_time_in_millis: long
 }
-
-export type RefreshValues = 'true' | 'false' | 'wait_for'
 
 export type RelationName = string
 
@@ -4469,9 +4467,7 @@ export interface MappingDoubleRangeProperty extends MappingRangePropertyBase {
   type: 'double_range'
 }
 
-export type MappingDynamicMapping = boolean | MappingDynamicMappingValues
-
-export type MappingDynamicMappingValues = 'strict' | 'runtime' | 'true' | 'false'
+export type MappingDynamicMapping = boolean | 'strict' | 'runtime' | 'true' | 'false'
 
 export interface MappingDynamicTemplate {
   mapping?: MappingProperty
@@ -8878,7 +8874,7 @@ export interface IndicesFielddataFrequencyFilter {
   min_segment_size: integer
 }
 
-export type IndicesIndexCheckOnStartup = 'false' | 'checksum' | 'true'
+export type IndicesIndexCheckOnStartup = boolean | 'false' | 'checksum' | 'true'
 
 export interface IndicesIndexRouting {
   allocation?: IndicesIndexRoutingAllocation

--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -28,6 +28,7 @@ import {
 } from '@_types/common'
 import { Time } from '@_types/Time'
 import { OperationContainer } from './types'
+import {GetSourceConfig} from "@global/search/_types/SourceFilter";
 
 /**
  * @rest_spec_name bulk
@@ -44,7 +45,7 @@ export interface Request<TSource> extends RequestBase {
     pipeline?: string
     refresh?: Refresh
     routing?: Routing
-    _source?: boolean | Fields
+    _source?: GetSourceConfig
     _source_excludes?: Fields
     _source_includes?: Fields
     timeout?: Time

--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -28,7 +28,7 @@ import {
 } from '@_types/common'
 import { Time } from '@_types/Time'
 import { OperationContainer } from './types'
-import {GetSourceConfig} from "@global/search/_types/SourceFilter";
+import { GetSourceConfig } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name bulk

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -32,6 +32,7 @@ import { long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { Time } from '@_types/Time'
+import {GetSourceConfig} from "@global/search/_types/SourceFilter";
 
 /**
  * @rest_spec_name delete_by_query
@@ -67,7 +68,7 @@ export interface Request extends RequestBase {
     size?: long
     slices?: long
     sort?: string[]
-    _source?: boolean | Fields
+    _source?: GetSourceConfig
     _source_excludes?: Fields
     _source_includes?: Fields
     stats?: string[]

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -32,7 +32,7 @@ import { long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { Time } from '@_types/Time'
-import {GetSourceConfig} from "@global/search/_types/SourceFilter";
+import { GetSourceConfig } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name delete_by_query

--- a/specification/_global/exists/DocumentExistsRequest.ts
+++ b/specification/_global/exists/DocumentExistsRequest.ts
@@ -26,7 +26,7 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
-import {GetSourceConfig} from "@global/search/_types/SourceFilter";
+import { GetSourceConfig } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name exists

--- a/specification/_global/exists/DocumentExistsRequest.ts
+++ b/specification/_global/exists/DocumentExistsRequest.ts
@@ -26,6 +26,7 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
+import {GetSourceConfig} from "@global/search/_types/SourceFilter";
 
 /**
  * @rest_spec_name exists
@@ -42,7 +43,7 @@ export interface Request extends RequestBase {
     realtime?: boolean
     refresh?: boolean
     routing?: Routing
-    _source?: boolean | Fields
+    _source?: GetSourceConfig
     _source_excludes?: Fields
     _source_includes?: Fields
     stored_fields?: Fields

--- a/specification/_global/exists_source/SourceExistsRequest.ts
+++ b/specification/_global/exists_source/SourceExistsRequest.ts
@@ -27,7 +27,7 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
-import {GetSourceConfig} from "@global/search/_types/SourceFilter";
+import { GetSourceConfig } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name exists_source

--- a/specification/_global/exists_source/SourceExistsRequest.ts
+++ b/specification/_global/exists_source/SourceExistsRequest.ts
@@ -27,6 +27,7 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
+import {GetSourceConfig} from "@global/search/_types/SourceFilter";
 
 /**
  * @rest_spec_name exists_source
@@ -44,7 +45,7 @@ export interface Request extends RequestBase {
     realtime?: boolean
     refresh?: boolean
     routing?: Routing
-    _source?: boolean | Fields
+    _source?: GetSourceConfig
     _source_excludes?: Fields
     _source_includes?: Fields
     version?: VersionNumber

--- a/specification/_global/explain/ExplainRequest.ts
+++ b/specification/_global/explain/ExplainRequest.ts
@@ -20,6 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { DefaultOperator, Fields, Id, IndexName, Routing } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
+import {GetSourceConfig} from "@global/search/_types/SourceFilter";
 
 /**
  * @rest_spec_name explain
@@ -39,7 +40,7 @@ export interface Request extends RequestBase {
     lenient?: boolean
     preference?: string
     routing?: Routing
-    _source?: boolean | Fields
+    _source?: GetSourceConfig
     _source_excludes?: Fields
     _source_includes?: Fields
     stored_fields?: Fields

--- a/specification/_global/explain/ExplainRequest.ts
+++ b/specification/_global/explain/ExplainRequest.ts
@@ -20,7 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { DefaultOperator, Fields, Id, IndexName, Routing } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
-import {GetSourceConfig} from "@global/search/_types/SourceFilter";
+import { GetSourceConfig } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name explain

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -26,6 +26,7 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
+import {GetSourceConfig} from "@global/search/_types/SourceFilter";
 
 /**
  * @rest_spec_name get
@@ -63,7 +64,7 @@ export interface Request extends RequestBase {
     /**
      * True or false to return the _source field or not, or a list of fields to return.
      */
-    _source?: boolean | Fields
+    _source?: GetSourceConfig
     /**
      * A comma-separated list of source fields to exclude in the response.
      */

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -26,7 +26,7 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
-import {GetSourceConfig} from "@global/search/_types/SourceFilter";
+import { GetSourceConfig } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name get

--- a/specification/_global/get_source/SourceRequest.ts
+++ b/specification/_global/get_source/SourceRequest.ts
@@ -26,7 +26,7 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
-import {GetSourceConfig} from "@global/search/_types/SourceFilter";
+import { GetSourceConfig } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name get_source

--- a/specification/_global/get_source/SourceRequest.ts
+++ b/specification/_global/get_source/SourceRequest.ts
@@ -26,6 +26,7 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
+import {GetSourceConfig} from "@global/search/_types/SourceFilter";
 
 /**
  * @rest_spec_name get_source
@@ -63,7 +64,7 @@ export interface Request {
     /**
      * True or false to return the _source field or not, or a list of fields to return.
      */
-    _source?: boolean | Fields
+    _source?: GetSourceConfig
     /**
      * A comma-separated list of source fields to exclude in the response.
      */

--- a/specification/_global/knn_search/KnnSearchRequest.ts
+++ b/specification/_global/knn_search/KnnSearchRequest.ts
@@ -20,7 +20,11 @@
 import { RequestBase } from '@_types/Base'
 import { Field, Fields, Indices, Routing } from '@_types/common'
 import { Query } from './_types/Knn'
-import {DocValueField, SourceConfig, SourceFilter} from '@global/search/_types/SourceFilter'
+import {
+  DocValueField,
+  SourceConfig,
+  SourceFilter
+} from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name knn_search

--- a/specification/_global/knn_search/KnnSearchRequest.ts
+++ b/specification/_global/knn_search/KnnSearchRequest.ts
@@ -18,13 +18,10 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Field, Fields, Indices, Routing } from '@_types/common'
+import { Fields, Indices, Routing } from '@_types/common'
 import { Query } from './_types/Knn'
-import {
-  DocValueField,
-  SourceConfig,
-  SourceFilter
-} from '@global/search/_types/SourceFilter'
+import { SourceConfig } from '@global/search/_types/SourceFilter'
+import { FieldAndFormat } from '@_types/query_dsl/abstractions'
 
 /**
  * @rest_spec_name knn_search
@@ -55,7 +52,7 @@ export interface Request extends RequestBase {
      * The request returns doc values for field names matching these patterns
      * in the hits.fields property of the response. Accepts wildcard (*) patterns.
      */
-    docvalue_fields?: DocValueField[]
+    docvalue_fields?: FieldAndFormat[]
     /**
      * List of stored fields to return as part of a hit. If no fields are specified,
      * no stored fields are included in the response. If this field is specified, the _source

--- a/specification/_global/knn_search/KnnSearchRequest.ts
+++ b/specification/_global/knn_search/KnnSearchRequest.ts
@@ -20,7 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { Field, Fields, Indices, Routing } from '@_types/common'
 import { Query } from './_types/Knn'
-import { DocValueField, SourceFilter } from '@global/search/_types/SourceFilter'
+import {DocValueField, SourceConfig, SourceFilter} from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name knn_search
@@ -46,12 +46,12 @@ export interface Request extends RequestBase {
      * Indicates which source fields are returned for matching documents. These
      * fields are returned in the hits._source property of the search response.
      */
-    _source?: boolean | Fields | SourceFilter
+    _source?: SourceConfig
     /**
      * The request returns doc values for field names matching these patterns
      * in the hits.fields property of the response. Accepts wildcard (*) patterns.
      */
-    docvalue_fields?: DocValueField | Array<Field | DocValueField>
+    docvalue_fields?: DocValueField[]
     /**
      * List of stored fields to return as part of a hit. If no fields are specified,
      * no stored fields are included in the response. If this field is specified, the _source

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -20,6 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { Fields, IndexName, Routing } from '@_types/common'
 import { MultiGetId, Operation } from './types'
+import {GetSourceConfig} from "@global/search/_types/SourceFilter";
 
 /**
  * @rest_spec_name mget
@@ -36,7 +37,7 @@ export interface Request extends RequestBase {
     realtime?: boolean // default: true
     refresh?: boolean // default: false
     routing?: Routing
-    _source?: boolean | Fields
+    _source?: GetSourceConfig
     _source_excludes?: Fields
     _source_includes?: Fields
     stored_fields?: Fields

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -20,7 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { Fields, IndexName, Routing } from '@_types/common'
 import { MultiGetId, Operation } from './types'
-import {GetSourceConfig} from "@global/search/_types/SourceFilter";
+import { GetSourceConfig } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name mget

--- a/specification/_global/mget/types.ts
+++ b/specification/_global/mget/types.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { SourceFilter } from '@global/search/_types/SourceFilter'
+import {SourceConfig, SourceFilter} from '@global/search/_types/SourceFilter'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import {
@@ -37,7 +37,7 @@ export class Operation {
   _id: MultiGetId
   _index?: IndexName
   routing?: Routing
-  _source?: boolean | Fields | SourceFilter
+  _source?: SourceConfig
   stored_fields?: Fields
   _type?: Type
   version?: VersionNumber

--- a/specification/_global/mget/types.ts
+++ b/specification/_global/mget/types.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import {SourceConfig, SourceFilter} from '@global/search/_types/SourceFilter'
+import { SourceConfig, SourceFilter } from '@global/search/_types/SourceFilter'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import {

--- a/specification/_global/mget/types.ts
+++ b/specification/_global/mget/types.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { SourceConfig, SourceFilter } from '@global/search/_types/SourceFilter'
+import { SourceConfig } from '@global/search/_types/SourceFilter'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import {

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -48,7 +48,7 @@ export class Body {
   size?: integer
   pit?: PointInTimeReference
   track_total_hits?: boolean | integer
-  suggest?: SuggestContainer | Dictionary<string, SuggestContainer>
+  suggest?: Dictionary<string, SuggestContainer>
 }
 
 export class SearchResult<TDocument> extends SearchResponse<TDocument> {

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -18,13 +18,14 @@
  */
 
 import { PointInTimeReference } from '@global/search/_types/PointInTimeReference'
-import { SuggestContainer } from '@global/search/_types/suggester'
+import { Suggester } from '@global/search/_types/suggester'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import { ExpandWildcards, Indices, SearchType } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Response as SearchResponse } from '@global/search/SearchResponse'
+import { TrackHits } from '@global/search/_types/hits'
 
 /**
  * Contains parameters used to limit or change the subsequent search body request.
@@ -47,8 +48,8 @@ export class Body {
   from?: integer
   size?: integer
   pit?: PointInTimeReference
-  track_total_hits?: boolean | integer
-  suggest?: Dictionary<string, SuggestContainer>
+  track_total_hits?: TrackHits
+  suggest?: Suggester
 }
 
 export class SearchResult<TDocument> extends SearchResponse<TDocument> {

--- a/specification/_global/put_script/PutScriptRequest.ts
+++ b/specification/_global/put_script/PutScriptRequest.ts
@@ -37,6 +37,6 @@ export interface Request extends RequestBase {
     timeout?: Time
   }
   body: {
-    script?: StoredScript
+    script: StoredScript
   }
 }

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -34,7 +34,7 @@ import {
 } from '@_types/common'
 import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { double, integer, long } from '@_types/Numeric'
-import {FieldAndFormat, QueryContainer} from '@_types/query_dsl/abstractions'
+import { FieldAndFormat, QueryContainer } from '@_types/query_dsl/abstractions'
 import { ScriptField } from '@_types/Scripting'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { Time } from '@_types/Time'
@@ -43,8 +43,14 @@ import { Highlight } from './_types/highlighting'
 import { PointInTimeReference } from './_types/PointInTimeReference'
 import { Rescore } from './_types/rescoring'
 import { Sort, SortResults } from './_types/sort'
-import {DocValueField, GetSourceConfig, SourceConfig, SourceFilter} from './_types/SourceFilter'
-import { SuggestContainer } from './_types/suggester'
+import {
+  DocValueField,
+  GetSourceConfig,
+  SourceConfig,
+  SourceFilter
+} from './_types/SourceFilter'
+import { Suggester } from './_types/suggester'
+import { TrackHits } from '@global/search/_types/hits'
 
 /**
  * @rest_spec_name search
@@ -92,7 +98,7 @@ export interface Request extends RequestBase {
     suggest_text?: string
     terminate_after?: long
     timeout?: Time
-    track_total_hits?: boolean | integer
+    track_total_hits?: TrackHits
     track_scores?: boolean
     typed_keys?: boolean
     rest_total_hits_as_int?: boolean
@@ -129,7 +135,7 @@ export interface Request extends RequestBase {
      * response does not include the total number of hits matching the query.
      * Defaults to 10,000 hits.
      */
-    track_total_hits?: boolean | integer
+    track_total_hits?: TrackHits
     /**
      * Boosts the _score of documents from specified indices.
      */
@@ -176,7 +182,7 @@ export interface Request extends RequestBase {
      * matching these patterns in the hits.fields property of the response.
      */
     fields?: Array<FieldAndFormat>
-    suggest?: Dictionary<string, SuggestContainer>
+    suggest?: Suggester
     /**
      * Maximum number of documents to collect for each shard. If a query reaches this
      * limit, Elasticsearch terminates the query early. Elasticsearch collects documents

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -43,12 +43,7 @@ import { Highlight } from './_types/highlighting'
 import { PointInTimeReference } from './_types/PointInTimeReference'
 import { Rescore } from './_types/rescoring'
 import { Sort, SortResults } from './_types/sort'
-import {
-  DocValueField,
-  GetSourceConfig,
-  SourceConfig,
-  SourceFilter
-} from './_types/SourceFilter'
+import { GetSourceConfig, SourceConfig } from './_types/SourceFilter'
 import { Suggester } from './_types/suggester'
 import { TrackHits } from '@global/search/_types/hits'
 
@@ -144,7 +139,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (*) patterns. The request returns doc values for field
      * names matching these patterns in the hits.fields property of the response.
      */
-    docvalue_fields?: DocValueField[]
+    docvalue_fields?: FieldAndFormat[]
     /**
      * Minimum _score for matching documents. Documents with a lower _score are
      * not included in the search results.

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -34,16 +34,16 @@ import {
 } from '@_types/common'
 import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { double, integer, long } from '@_types/Numeric'
-import { QueryContainer } from '@_types/query_dsl/abstractions'
+import {FieldAndFormat, QueryContainer} from '@_types/query_dsl/abstractions'
 import { ScriptField } from '@_types/Scripting'
 import { SlicedScroll } from '@_types/SlicedScroll'
-import { DateField, Time } from '@_types/Time'
+import { Time } from '@_types/Time'
 import { FieldCollapse } from './_types/FieldCollapse'
 import { Highlight } from './_types/highlighting'
 import { PointInTimeReference } from './_types/PointInTimeReference'
 import { Rescore } from './_types/rescoring'
 import { Sort, SortResults } from './_types/sort'
-import { DocValueField, SourceFilter } from './_types/SourceFilter'
+import {DocValueField, GetSourceConfig, SourceConfig, SourceFilter} from './_types/SourceFilter'
 import { SuggestContainer } from './_types/suggester'
 
 /**
@@ -97,7 +97,7 @@ export interface Request extends RequestBase {
     typed_keys?: boolean
     rest_total_hits_as_int?: boolean
     version?: boolean
-    _source?: boolean | Fields
+    _source?: GetSourceConfig
     _source_excludes?: Fields
     _source_includes?: Fields
     seq_no_primary_term?: boolean
@@ -138,7 +138,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (*) patterns. The request returns doc values for field
      * names matching these patterns in the hits.fields property of the response.
      */
-    docvalue_fields?: DocValueField | Array<Field | DocValueField>
+    docvalue_fields?: DocValueField[]
     /**
      * Minimum _score for matching documents. Documents with a lower _score are
      * not included in the search results.
@@ -170,13 +170,13 @@ export interface Request extends RequestBase {
      * Indicates which source fields are returned for matching documents. These
      * fields are returned in the hits._source property of the search response.
      */
-    _source?: boolean | Fields | SourceFilter
+    _source?: SourceConfig
     /**
      * Array of wildcard (*) patterns. The request returns values for field names
      * matching these patterns in the hits.fields property of the response.
      */
-    fields?: Array<Field | DateField>
-    suggest?: SuggestContainer | Dictionary<string, SuggestContainer>
+    fields?: Array<FieldAndFormat>
+    suggest?: Dictionary<string, SuggestContainer>
     /**
      * Maximum number of documents to collect for each shard. If a query reaches this
      * limit, Elasticsearch terminates the query early. Elasticsearch collects documents

--- a/specification/_global/search/_types/SourceFilter.ts
+++ b/specification/_global/search/_types/SourceFilter.ts
@@ -20,13 +20,26 @@
 
 import { Field, Fields } from '@_types/common'
 
+/**
+ * @shortcut_property includes
+ */
 export class SourceFilter {
+  /** @aliases exclude */
   excludes?: Fields
+  /** @aliases include */
   includes?: Fields
-  exclude?: Fields
-  include?: Fields
 }
 
+/**
+ * Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.
+ * @codegen_names fetch, filter
+ */
+export type SourceConfig = boolean | SourceFilter
+
+/** @codegen_names fetch, fields */
+export type GetSourceConfig = boolean | Fields
+
+/** @shortcut_property field */
 export class DocValueField {
   field: Field
   format?: string

--- a/specification/_global/search/_types/SourceFilter.ts
+++ b/specification/_global/search/_types/SourceFilter.ts
@@ -38,9 +38,3 @@ export type SourceConfig = boolean | SourceFilter
 
 /** @codegen_names fetch, fields */
 export type GetSourceConfig = boolean | Fields
-
-/** @shortcut_property field */
-export class DocValueField {
-  field: Field
-  format?: string
-}

--- a/specification/_global/search/_types/highlighting.ts
+++ b/specification/_global/search/_types/highlighting.ts
@@ -76,6 +76,7 @@ export type HighlighterType = BuiltinHighlighterType | string
 
 export enum BuiltinHighlighterType {
   plain = 0,
+  /** @codegen_name fast_vector */
   fvh = 1,
   unified = 2
 }

--- a/specification/_global/search/_types/highlighting.ts
+++ b/specification/_global/search/_types/highlighting.ts
@@ -71,7 +71,10 @@ export enum HighlighterTagsSchema {
   styled = 0
 }
 
-export enum HighlighterType {
+/** @codegen_names builtin, custom */
+export type HighlighterType = BuiltinHighlighterType | string
+
+export enum BuiltinHighlighterType {
   plain = 0,
   fvh = 1,
   unified = 2
@@ -99,5 +102,5 @@ export class HighlightField {
   pre_tags?: string[]
   require_field_match?: boolean
   tags_schema?: HighlighterTagsSchema
-  type?: HighlighterType | string
+  type?: HighlighterType
 }

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -35,7 +35,7 @@ import { ScriptField } from '@_types/Scripting'
 import { FieldCollapse } from './FieldCollapse'
 import { Highlight } from './highlighting'
 import { Sort, SortResults } from './sort'
-import { SourceConfig, SourceFilter } from './SourceFilter'
+import { SourceConfig } from './SourceFilter'
 import { FieldAndFormat } from '@_types/query_dsl/abstractions'
 
 export class Hit<TDocument> {

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -35,7 +35,8 @@ import { ScriptField } from '@_types/Scripting'
 import { FieldCollapse } from './FieldCollapse'
 import { Highlight } from './highlighting'
 import { Sort, SortResults } from './sort'
-import { SourceFilter } from './SourceFilter'
+import {SourceConfig, SourceFilter} from './SourceFilter'
+import {FieldAndFormat} from "@_types/query_dsl/abstractions";
 
 export class Hit<TDocument> {
   _index: IndexName
@@ -80,15 +81,8 @@ export class HitMetadata<TDocument> {
   _version: VersionNumber
 }
 
-export class InnerHitsMetadata {
-  total: TotalHits | long
-  hits: Hit<Dictionary<string, UserDefinedValue>>[]
-
-  max_score?: double
-}
-
 export class InnerHitsResult {
-  hits: InnerHitsMetadata
+  hits: HitsMetadata<UserDefinedValue>
 }
 
 export class NestedIdentity {
@@ -122,16 +116,9 @@ export class InnerHits {
   seq_no_primary_term?: boolean
   fields?: Fields
   sort?: Sort
-  _source?: boolean | SourceFilter
+  _source?: SourceConfig
   stored_field?: Fields
   /** @server_default false */
   track_scores?: boolean
   version?: boolean
-}
-
-/** @shortcut_property field */
-export class FieldAndFormat {
-  field: Field
-  format?: string
-  include_unmapped?: boolean
 }

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -35,8 +35,8 @@ import { ScriptField } from '@_types/Scripting'
 import { FieldCollapse } from './FieldCollapse'
 import { Highlight } from './highlighting'
 import { Sort, SortResults } from './sort'
-import {SourceConfig, SourceFilter} from './SourceFilter'
-import {FieldAndFormat} from "@_types/query_dsl/abstractions";
+import { SourceConfig, SourceFilter } from './SourceFilter'
+import { FieldAndFormat } from '@_types/query_dsl/abstractions'
 
 export class Hit<TDocument> {
   _index: IndexName
@@ -122,3 +122,13 @@ export class InnerHits {
   track_scores?: boolean
   version?: boolean
 }
+
+/**
+ * Number of hits matching the query to count accurately. If true, the exact
+ * number of hits is returned at the cost of some performance. If false, the
+ * response does not include the total number of hits matching the query.
+ * Defaults to 10,000 hits.
+ *
+ * @codegen_names enabled, count
+ */
+export type TrackHits = boolean | integer

--- a/specification/_global/search/_types/sort.ts
+++ b/specification/_global/search/_types/sort.ts
@@ -20,7 +20,7 @@
 import { AdditionalProperty } from '@spec_utils/behaviors'
 import { Missing } from '@_types/aggregations/AggregationContainer'
 import { Field } from '@_types/common'
-import {DistanceUnit, GeoDistanceType, GeoLocation} from '@_types/Geo'
+import { DistanceUnit, GeoDistanceType, GeoLocation } from '@_types/Geo'
 import { FieldType } from '@_types/mapping/Property'
 import { double, integer, long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
@@ -59,6 +59,7 @@ export class GeoDistanceSort
 {
   mode?: SortMode
   distance_type?: GeoDistanceType
+  ignore_unmapped?: boolean
   order?: SortOrder
   unit?: DistanceUnit
 }
@@ -80,8 +81,7 @@ export enum ScriptSortType {
  * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html
  * @variants container
  */
-export class SortOptions implements AdditionalProperty<Field, FieldSort>
-{
+export class SortOptions implements AdditionalProperty<Field, FieldSort> {
   _score?: ScoreSort
   _doc?: ScoreSort
   _geo_distance?: GeoDistanceSort
@@ -110,4 +110,3 @@ export enum SortOrder {
   asc = 0,
   desc = 1
 }
-

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -28,9 +28,8 @@ import {
   SuggestMode,
   Type
 } from '@_types/common'
-import { Distance } from '@_types/Geo'
+import {Distance, GeoLocation} from '@_types/Geo'
 import { double, float, integer, long } from '@_types/Numeric'
-import { GeoLocation } from '@_types/query_dsl/geo'
 
 export class Suggest<T> {
   length: integer
@@ -57,6 +56,7 @@ export class SuggesterBase {
   size?: integer
 }
 
+/** @codegen_names completion, phrase, term */
 export type SuggestOption<TDocument> =
   | CompletionSuggestOption<TDocument>
   | PhraseSuggestOption

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -28,8 +28,9 @@ import {
   SuggestMode,
   Type
 } from '@_types/common'
-import {Distance, GeoLocation} from '@_types/Geo'
+import { GeoHash, GeoHashPrecision, GeoLocation } from '@_types/Geo'
 import { double, float, integer, long } from '@_types/Numeric'
+import { AdditionalProperties } from '@spec_utils/behaviors'
 
 export class Suggest<T> {
   length: integer
@@ -38,10 +39,15 @@ export class Suggest<T> {
   text: string
 }
 
+export class Suggester implements AdditionalProperties<string, FieldSuggester> {
+  /** Global suggest text, to avoid repetition when the same text is used in several suggesters */
+  text?: string
+}
+
 /**
  * @variants container
  */
-export class SuggestContainer {
+export class FieldSuggester {
   completion?: CompletionSuggester
   phrase?: PhraseSuggester
   prefix?: string
@@ -90,10 +96,7 @@ export class TermSuggestOption {
 // completion suggester
 
 export class CompletionSuggester extends SuggesterBase {
-  contexts?: Dictionary<
-    string,
-    string | string[] | GeoLocation | SuggestContextQuery[]
-  >
+  contexts?: Dictionary<Field, CompletionContext | CompletionContext[]>
   fuzzy?: SuggestFuzziness
   prefix?: string
   regex?: string
@@ -111,17 +114,19 @@ export class SuggestFuzziness {
 // context suggester
 
 /**
- * Text that we want similar documents for or a lookup to a document's field for the text.
+ * Text or location that we want similar documents for or a lookup to a document's field for the text.
  * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html#_document_input_parameters
  *
+ * @codegen_names category, location
  */
 export type Context = string | GeoLocation
 
-export class SuggestContextQuery {
+/** @shortcut_property context */
+export class CompletionContext {
   boost?: double
   context: Context
-  neighbours?: Distance[] | integer[]
-  precision?: Distance | integer
+  neighbours?: GeoHashPrecision[]
+  precision?: GeoHashPrecision
   prefix?: boolean
 }
 

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -17,7 +17,10 @@
  * under the License.
  */
 
-import {GetSourceConfig, SourceConfig} from '@global/search/_types/SourceFilter'
+import {
+  GetSourceConfig,
+  SourceConfig
+} from '@global/search/_types/SourceFilter'
 import { RequestBase } from '@_types/Base'
 import {
   Fields,

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { SourceFilter } from '@global/search/_types/SourceFilter'
+import {GetSourceConfig, SourceConfig} from '@global/search/_types/SourceFilter'
 import { RequestBase } from '@_types/Base'
 import {
   Fields,
@@ -98,7 +98,7 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
      * list of the fields you want to retrieve.
      * @server_default true
      */
-    _source?: boolean | Fields
+    _source?: GetSourceConfig
     /**
      * Specify the source fields you want to exclude.
      */
@@ -139,7 +139,7 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
      * list of the fields you want to retrieve.
      * @server_default true
      */
-    _source?: boolean | SourceFilter
+    _source?: SourceConfig
     /**
      * If the document does not already exist, the contents of 'upsert' are inserted as a
      * new document. If the document exists, the 'script' is executed.

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -33,7 +33,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Script } from '@_types/Scripting'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { Time } from '@_types/Time'
-import {GetSourceConfig} from "@global/search/_types/SourceFilter";
+import { GetSourceConfig } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name update_by_query

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -33,6 +33,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Script } from '@_types/Scripting'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { Time } from '@_types/Time'
+import {GetSourceConfig} from "@global/search/_types/SourceFilter";
 
 /**
  * @rest_spec_name update_by_query
@@ -67,7 +68,7 @@ export interface Request extends RequestBase {
     size?: long
     slices?: long
     sort?: string[]
-    _source?: boolean | Fields
+    _source?: GetSourceConfig
     _source_excludes?: Fields
     _source_includes?: Fields
     stats?: string[]

--- a/specification/_types/Geo.ts
+++ b/specification/_types/Geo.ts
@@ -72,7 +72,12 @@ export enum GeoShapeRelation {
 }
 
 export type GeoTilePrecision = number
-export type GeoHashPrecision = number
+
+/**
+ * A precision that can be expressed as a geohash length between 1 and 12, or a distance measure like "1km", "10m".
+ * @codegen_names geohash_length, distance
+ */
+export type GeoHashPrecision = number | string
 export type GeoHash = string
 
 /** A map tile reference, represented as `{zoom}/{x}/{y}` */
@@ -93,7 +98,11 @@ export class LatLon {
  * @codegen_names latlon, geohash, coords, text
  */
 // ES: GeoUtils.parseGeoPoint()
-export type GeoLocation = LatLonGeoLocation | GeoHashLocation | double[] | string
+export type GeoLocation =
+  | LatLonGeoLocation
+  | GeoHashLocation
+  | double[]
+  | string
 
 export class LatLonGeoLocation {
   lat: double

--- a/specification/_types/Geo.ts
+++ b/specification/_types/Geo.ts
@@ -82,3 +82,60 @@ export class LatLon {
   lat: double
   lon: double
 }
+
+/**
+ * A latitude/longitude as a 2 dimensional point. It can be represented in various ways:
+ * - as a `{lat, long}` object
+ * - as a geo hash value
+ * - as a `[lon, lat]` array
+ * - as a string in `"<lat>, <lon>"` or WKT point formats
+ *
+ * @codegen_names latlon, geohash, coords, text
+ */
+// ES: GeoUtils.parseGeoPoint()
+export type GeoLocation = LatLonGeoLocation | GeoHashLocation | double[] | string
+
+export class LatLonGeoLocation {
+  lat: double
+  lon: double
+}
+
+export class GeoHashLocation {
+  geohash: GeoHash
+}
+
+/**
+ * A geo bounding box. It can be represented in various ways:
+ * - as 4 top/bottom/left/right coordinates
+ * - as 2 top_left / bottom_right points
+ * - as 2 top_right / bottom_left points
+ * - as a WKT bounding box
+ *
+ * @codegen_names coords, tlbr, trbl, wkt
+ */
+export type GeoBounds =
+  | CoordsGeoBounds
+  | TopLeftBottomRightGeoBounds
+  | TopRightBottomLeftGeoBounds
+  | WktGeoBounds
+
+export class WktGeoBounds {
+  wkt: string
+}
+
+export class CoordsGeoBounds {
+  top: double
+  bottom: double
+  left: double
+  right: double
+}
+
+export class TopLeftBottomRightGeoBounds {
+  top_left: GeoLocation
+  bottom_right: GeoLocation
+}
+
+export class TopRightBottomLeftGeoBounds {
+  top_right: GeoLocation
+  bottom_left: GeoLocation
+}

--- a/specification/_types/Scripting.ts
+++ b/specification/_types/Scripting.ts
@@ -25,9 +25,9 @@ import { Id } from './common'
  * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
  * @codegen_names builtin, custom
  */
-export type ScriptLanguage = BuiltinLanguage | string
+export type ScriptLanguage = BuiltinScriptLanguage | string
 
-export enum BuiltinLanguage {
+export enum BuiltinScriptLanguage {
   painless = 0,
   expression = 1,
   mustache = 2,

--- a/specification/_types/Scripting.ts
+++ b/specification/_types/Scripting.ts
@@ -21,8 +21,13 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Id } from './common'
 
-/** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html */
-export enum ScriptLanguage {
+/**
+ * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
+ * @codegen_names builtin, custom
+ */
+export type ScriptLanguage = BuiltinLanguage | string
+
+export enum BuiltinLanguage {
   painless = 0,
   expression = 1,
   mustache = 2,
@@ -30,25 +35,28 @@ export enum ScriptLanguage {
 }
 
 export class StoredScript {
-  lang?: ScriptLanguage | string
+  lang: ScriptLanguage
+  options?: Dictionary<string, string>
   source: string
 }
 
 export class ScriptBase {
-  lang?: ScriptLanguage | string
   params?: Dictionary<string, UserDefinedValue>
 }
 
+/** @shortcut_property source */
 export class InlineScript extends ScriptBase {
+  lang?: ScriptLanguage
+  options?: Dictionary<string, string>
   source: string
 }
 
-export class IndexedScript extends ScriptBase {
+export class StoredScriptId extends ScriptBase {
   id: Id
 }
 
-// 'string' is a shortcut for InlineScript.source
-export type Script = InlineScript | IndexedScript | string
+/** @codegen_names inline, stored */
+export type Script = InlineScript | StoredScriptId
 
 export class ScriptField {
   script: Script

--- a/specification/_types/Time.ts
+++ b/specification/_types/Time.ts
@@ -17,19 +17,11 @@
  * under the License.
  */
 
-import { Field } from './common'
-import { integer, long } from './Numeric'
+import {integer, long} from './Numeric'
 
 export class DateMathTimeParsed {
   factor: integer
   interval: DateMathTimeUnit
-}
-
-/** A reference to a date field with formatting instructions on how to return the date */
-export class DateField {
-  field: Field
-  format?: string
-  include_unmapped?: boolean
 }
 
 export type DateString = string
@@ -69,10 +61,9 @@ export enum DateMathTimeUnit {
 
 /**
  * Whenever durations need to be specified, e.g. for a timeout parameter, the duration must specify the unit, like 2d for 2 days.
- * @doc_url https://github.com/elastic/elasticsearch/blob/master/libs/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
- * https://github.com/elastic/elasticsearch/blob/master/libs/core/src/main/java/org/elasticsearch/common/unit/TimeValue.java
- * Only support 0 and -1 but we have no way to encode these as constants at the moment
+ * @doc_url https://github.com/elastic/elasticsearch/blob/master/libs/core/src/main/java/org/elasticsearch/core/TimeValue.java
  */
+//FIXME: need to distinguish durations (has to be a string), offsets (can be a string or number)
 export type Time = string | integer
 
 export enum TimeUnit {

--- a/specification/_types/Time.ts
+++ b/specification/_types/Time.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import {integer, long} from './Numeric'
+import { integer, long } from './Numeric'
 
 export class DateMathTimeParsed {
   factor: integer
@@ -62,6 +62,7 @@ export enum DateMathTimeUnit {
 /**
  * Whenever durations need to be specified, e.g. for a timeout parameter, the duration must specify the unit, like 2d for 2 days.
  * @doc_url https://github.com/elastic/elasticsearch/blob/master/libs/core/src/main/java/org/elasticsearch/core/TimeValue.java
+ * @codegen_names time, offset
  */
 //FIXME: need to distinguish durations (has to be a string), offsets (can be a string or number)
 export type Time = string | integer

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -21,8 +21,8 @@ import { HitsMetadata } from '@global/search/_types/hits'
 import { AdditionalProperties, AdditionalProperty } from '@spec_utils/behaviors'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { AggregateName, Field, ScalarValue } from '@_types/common'
-import {GeoBounds, GeoHash, GeoLine, GeoLocation, GeoTile} from '@_types/Geo'
+import { AggregateName, Field, FieldValue } from '@_types/common'
+import { GeoBounds, GeoHash, GeoLine, GeoLocation, GeoTile } from '@_types/Geo'
 import { double, integer, long } from '@_types/Numeric'
 import { DateMathTime, EpochMillis } from '@_types/Time'
 import { Void } from '@spec_utils/VoidValue'
@@ -600,14 +600,14 @@ export class InferenceAggregate
   extends AggregateBase
   implements AdditionalProperties<string, UserDefinedValue>
 {
-  value?: ScalarValue
+  value?: FieldValue
   feature_importance?: InferenceFeatureImportance[]
   top_classes?: InferenceTopClassEntry[]
   warning?: string
 }
 
 export class InferenceTopClassEntry {
-  class_name: ScalarValue
+  class_name: FieldValue
   class_probability: double
   class_score: double
 }
@@ -667,8 +667,8 @@ export class TopMetricsBucket extends MultiBucketBase {
 
 export class TopMetrics {
   // Always contains a single element since `top_metrics` only accepts a single sort field
-  sort: Array<ScalarValue | null>
-  metrics: Dictionary<string, ScalarValue | null>
+  sort: Array<FieldValue | null>
+  metrics: Dictionary<string, FieldValue | null>
 }
 
 /** @variant name=t_test */
@@ -726,6 +726,6 @@ export class ParentAggregateBucket extends MultiBucketBase {}
 
 /** @variant name=geo_line */
 export class GeoLineAggregate extends AggregateBase {
-  type: 'Feature'
+  type: string // should be "Feature"
   geometry: GeoLine
 }

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -22,9 +22,8 @@ import { AdditionalProperties, AdditionalProperty } from '@spec_utils/behaviors'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { AggregateName, Field, ScalarValue } from '@_types/common'
-import { GeoHash, GeoLine, GeoTile, LatLon } from '@_types/Geo'
+import {GeoBounds, GeoHash, GeoLine, GeoLocation, GeoTile} from '@_types/Geo'
 import { double, integer, long } from '@_types/Numeric'
-import { GeoLocation } from '@_types/query_dsl/geo'
 import { DateMathTime, EpochMillis } from '@_types/Time'
 import { Void } from '@spec_utils/VoidValue'
 
@@ -131,8 +130,11 @@ export class CardinalityAggregate extends AggregateBase {
 
 // ES: AbstractInternalHDRPercentiles, AbstractInternalTDigestPercentiles, InternalPercentilesBucket
 export class PercentilesAggregateBase extends AggregateBase {
-  values: KeyedPercentiles | Array<ArrayPercentilesItem>
+  values: Percentiles
 }
+
+/** @codegen_names keyed, array */
+type Percentiles = KeyedPercentiles | Array<ArrayPercentilesItem>
 
 // In keyed form, percentiles are represented as an object with 1 or 2 properties for each key:
 // <key_name>: double | null - always present (null means there were no values for this percentile)
@@ -287,11 +289,6 @@ export class GeoBoundsAggregate extends AggregateBase {
   bounds: GeoBounds
 }
 
-export class GeoBounds {
-  bottom_right: LatLon
-  top_left: LatLon
-}
-
 /** @variant name=geo_centroid */
 export class GeoCentroidAggregate extends AggregateBase {
   count: long
@@ -303,11 +300,13 @@ export class GeoCentroidAggregate extends AggregateBase {
 /**
  * Aggregation buckets. By default they are returned as an array, but if the aggregation has keys configured for
  * the different buckets, the result is a dictionary.
+ *
+ * @codegen_names keyed, array
  */
 // Note: not all aggregations support keys in their configuration, meaning they will never return the dictionary
 // variant. However we use this union for all aggregates to future-proof the spec if some key-less aggregations finally
 // add support for keys.
-type Buckets<TBucket> = Dictionary<string, TBucket> | Array<TBucket>
+export type Buckets<TBucket> = Dictionary<string, TBucket> | Array<TBucket>
 
 export class MultiBucketAggregateBase<TBucket> extends AggregateBase {
   buckets: Buckets<TBucket>

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -25,18 +25,17 @@ import {
   GeoDistanceType,
   DistanceUnit,
   GeoHashPrecision,
-  GeoTilePrecision, GeoLocation, GeoBounds
+  GeoTilePrecision,
+  GeoLocation,
+  GeoBounds
 } from '@_types/Geo'
 import { integer, float, long, double } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Script } from '@_types/Scripting'
 import { DateString, Time, DateMath } from '@_types/Time'
-import {Buckets } from './Aggregate'
+import { Buckets } from './Aggregate'
 import { Aggregation } from './Aggregation'
-import {
-  Missing,
-  MissingOrder
-} from './AggregationContainer'
+import { Missing, MissingOrder } from './AggregationContainer'
 
 /**
  * Base type for bucket aggregations. These aggregations also accept sub-aggregations.
@@ -88,13 +87,13 @@ export class CompositeAggregationSource {
 }
 
 export class DateHistogramAggregation extends BucketAggregationBase {
-  calendar_interval?: CalendarInterval
-  extended_bounds?: ExtendedBounds<DateMath | long>
-  hard_bounds?: ExtendedBounds<DateMath | long>
+  calendar_interval?: CalendarInterval // CalendarInterval is too restrictive here
+  extended_bounds?: ExtendedBounds<FieldDateMath>
+  hard_bounds?: ExtendedBounds<FieldDateMath>
   field?: Field
-  fixed_interval?: CalendarInterval | Time
+  fixed_interval?: Time // CalendarInterval is too restrictive here
   format?: string
-  interval?: CalendarInterval | Time
+  interval?: Time
   min_doc_count?: integer
   missing?: DateString
   offset?: Time
@@ -133,13 +132,19 @@ export class DateRangeAggregation extends BucketAggregationBase {
   keyed?: boolean
 }
 
+/**
+ * A date range limit, represented either as a DateMath expression or a number expressed
+ * according to the target field's precision.
+ *
+ * @codegen_names expr, value
+ */
+// ES: DateRangeAggregationBuilder.innerBuild()
+export type FieldDateMath = DateMath | double
+
 export class DateRangeExpression {
-  from?: DateMath | float
-  from_as_string?: string
-  to_as_string?: string
+  from?: FieldDateMath
   key?: string
-  to?: DateMath | float
-  doc_count?: long
+  to?: FieldDateMath
 }
 
 export class DiversifiedSamplerAggregation extends BucketAggregationBase {
@@ -166,7 +171,7 @@ export class FiltersAggregation extends BucketAggregationBase {
 export class GeoDistanceAggregation extends BucketAggregationBase {
   distance_type?: GeoDistanceType
   field?: Field
-  origin?: GeoLocation | string
+  origin?: GeoLocation
   ranges?: AggregationRange[]
   unit?: DistanceUnit
 }

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -25,17 +25,15 @@ import {
   GeoDistanceType,
   DistanceUnit,
   GeoHashPrecision,
-  GeoTilePrecision
+  GeoTilePrecision, GeoLocation, GeoBounds
 } from '@_types/Geo'
 import { integer, float, long, double } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
-import { GeoLocation, BoundingBox } from '@_types/query_dsl/geo'
 import { Script } from '@_types/Scripting'
 import { DateString, Time, DateMath } from '@_types/Time'
-import { GeoBounds } from './Aggregate'
+import {Buckets } from './Aggregate'
 import { Aggregation } from './Aggregation'
 import {
-  AggregationContainer,
   Missing,
   MissingOrder
 } from './AggregationContainer'
@@ -90,13 +88,13 @@ export class CompositeAggregationSource {
 }
 
 export class DateHistogramAggregation extends BucketAggregationBase {
-  calendar_interval?: DateInterval | Time
+  calendar_interval?: CalendarInterval
   extended_bounds?: ExtendedBounds<DateMath | long>
   hard_bounds?: ExtendedBounds<DateMath | long>
   field?: Field
-  fixed_interval?: DateInterval | Time
+  fixed_interval?: CalendarInterval | Time
   format?: string
-  interval?: DateInterval | Time
+  interval?: CalendarInterval | Time
   min_doc_count?: integer
   missing?: DateString
   offset?: Time
@@ -107,15 +105,23 @@ export class DateHistogramAggregation extends BucketAggregationBase {
   keyed?: boolean
 }
 
-export enum DateInterval {
-  second = 0,
-  minute = 1,
-  hour = 2,
-  day = 3,
-  week = 4,
-  month = 5,
-  quarter = 6,
-  year = 7
+export enum CalendarInterval {
+  /** @aliases 1s */
+  second,
+  /** @aliases 1m */
+  minute,
+  /** @aliases 1h */
+  hour,
+  /** @aliases 1d */
+  day,
+  /** @aliases 1w */
+  week,
+  /** @aliases 1M */
+  month,
+  /** @aliases 1q */
+  quarter,
+  /** @aliases 1Y */
+  year
 }
 
 export class DateRangeAggregation extends BucketAggregationBase {
@@ -151,7 +157,7 @@ export enum SamplerAggregationExecutionHint {
 }
 
 export class FiltersAggregation extends BucketAggregationBase {
-  filters?: Dictionary<string, QueryContainer> | QueryContainer[]
+  filters?: Buckets<QueryContainer>
   other_bucket?: boolean
   other_bucket_key?: string
   keyed?: boolean
@@ -166,7 +172,7 @@ export class GeoDistanceAggregation extends BucketAggregationBase {
 }
 
 export class GeoHashGridAggregation extends BucketAggregationBase {
-  bounds?: BoundingBox
+  bounds?: GeoBounds
   field?: Field
   precision?: GeoHashPrecision
   shard_size?: integer
@@ -254,9 +260,9 @@ export class AggregationRange {
 }
 
 export class RareTermsAggregation extends BucketAggregationBase {
-  exclude?: string | string[]
+  exclude?: TermsExclude
   field?: Field
-  include?: string | string[] | TermsInclude
+  include?: TermsInclude
   max_doc_count?: long
   missing?: Missing
   precision?: double
@@ -294,7 +300,7 @@ export class ScriptedHeuristic {
 export class SignificantTermsAggregation extends BucketAggregationBase {
   background_filter?: QueryContainer
   chi_square?: ChiSquareHeuristic
-  exclude?: string | string[]
+  exclude?: TermsExclude
   execution_hint?: TermsAggregationExecutionHint
   field?: Field
   gnd?: GoogleNormalizedDistanceHeuristic
@@ -311,7 +317,7 @@ export class SignificantTermsAggregation extends BucketAggregationBase {
 export class SignificantTextAggregation extends BucketAggregationBase {
   background_filter?: QueryContainer
   chi_square?: ChiSquareHeuristic
-  exclude?: string | string[]
+  exclude?: TermsExclude
   execution_hint?: TermsAggregationExecutionHint
   field?: Field
   filter_duplicate_text?: boolean
@@ -329,10 +335,10 @@ export class SignificantTextAggregation extends BucketAggregationBase {
 
 export class TermsAggregation extends BucketAggregationBase {
   collect_mode?: TermsAggregationCollectMode
-  exclude?: string | string[]
+  exclude?: TermsExclude
   execution_hint?: TermsAggregationExecutionHint
   field?: Field
-  include?: string | string[] | TermsInclude
+  include?: TermsInclude
   min_doc_count?: integer
   missing?: Missing
   missing_order?: MissingOrder
@@ -346,9 +352,8 @@ export class TermsAggregation extends BucketAggregationBase {
 }
 
 export type TermsAggregationOrder =
-  | SortOrder
-  | Dictionary<string, SortOrder>
-  | Dictionary<string, SortOrder>[]
+  | Dictionary<Field, SortOrder>
+  | Dictionary<Field, SortOrder>[]
 
 export enum TermsAggregationCollectMode {
   depth_first = 0,
@@ -362,7 +367,13 @@ export enum TermsAggregationExecutionHint {
   global_ordinals_low_cardinality = 3
 }
 
-export class TermsInclude {
+/** @codegen_names regexp, terms, partition */
+export type TermsInclude = string | string[] | TermsPartition
+
+/** @codegen_names regexp, terms */
+export type TermsExclude = string | string[]
+
+export class TermsPartition {
   num_partitions: long
   partition: long
 }

--- a/specification/_types/aggregations/metric.ts
+++ b/specification/_types/aggregations/metric.ts
@@ -19,17 +19,17 @@
 
 import { Highlight } from '@global/search/_types/highlighting'
 import { SortOrder, Sort } from '@global/search/_types/sort'
-import { SourceFilter } from '@global/search/_types/SourceFilter'
+import {SourceConfig, SourceFilter} from '@global/search/_types/SourceFilter'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Field, Fields } from '@_types/common'
 import { double, integer, long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
-import { GeoLocation } from '@_types/query_dsl/geo'
 import { Script, ScriptField } from '@_types/Scripting'
 import { Aggregation } from './Aggregation'
 import { Missing } from './AggregationContainer'
-import { DateInterval } from './bucket'
+import { CalendarInterval } from './bucket'
+import {GeoLocation} from "@_types/Geo";
 
 export class MetricAggregationBase {
   field?: Field
@@ -116,7 +116,7 @@ export class TDigest {
 }
 
 export class RateAggregation extends FormatMetricAggregationBase {
-  unit?: DateInterval
+  unit?: CalendarInterval
   mode?: RateMode
 }
 
@@ -167,7 +167,7 @@ export class TopHitsAggregation extends MetricAggregationBase {
   script_fields?: Dictionary<string, ScriptField>
   size?: integer
   sort?: Sort
-  _source?: boolean | SourceFilter | Fields
+  _source?: SourceConfig
   stored_fields?: Fields
   track_scores?: boolean
   version?: boolean

--- a/specification/_types/aggregations/metric.ts
+++ b/specification/_types/aggregations/metric.ts
@@ -19,7 +19,7 @@
 
 import { Highlight } from '@global/search/_types/highlighting'
 import { SortOrder, Sort } from '@global/search/_types/sort'
-import {SourceConfig, SourceFilter} from '@global/search/_types/SourceFilter'
+import { SourceConfig, SourceFilter } from '@global/search/_types/SourceFilter'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Field, Fields } from '@_types/common'
@@ -29,7 +29,7 @@ import { Script, ScriptField } from '@_types/Scripting'
 import { Aggregation } from './Aggregation'
 import { Missing } from './AggregationContainer'
 import { CalendarInterval } from './bucket'
-import {GeoLocation} from "@_types/Geo";
+import { GeoLocation } from '@_types/Geo'
 
 export class MetricAggregationBase {
   field?: Field

--- a/specification/_types/aggregations/metric.ts
+++ b/specification/_types/aggregations/metric.ts
@@ -19,7 +19,7 @@
 
 import { Highlight } from '@global/search/_types/highlighting'
 import { SortOrder, Sort } from '@global/search/_types/sort'
-import { SourceConfig, SourceFilter } from '@global/search/_types/SourceFilter'
+import { SourceConfig } from '@global/search/_types/SourceFilter'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Field, Fields } from '@_types/common'

--- a/specification/_types/aggregations/pipeline.ts
+++ b/specification/_types/aggregations/pipeline.ts
@@ -19,7 +19,7 @@
 
 import { Sort } from '@global/search/_types/sort'
 import { Dictionary } from '@spec_utils/Dictionary'
-import { Name, Field } from '@_types/common'
+import {Name, Field, EmptyObject} from '@_types/common'
 import { integer, double, float } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 import { Aggregation } from './Aggregation'
@@ -107,26 +107,44 @@ export class MaxBucketAggregation extends PipelineAggregationBase {}
 
 export class MinBucketAggregation extends PipelineAggregationBase {}
 
-export class MovingAverageAggregation extends PipelineAggregationBase {
+/** @variants internal tag=model */
+export type MovingAverageAggregation =
+  | LinearMovingAverageAggregation
+  | SimpleMovingAverageAggregation
+  | EwmaMovingAverageAggregation
+  | HoltMovingAverageAggregation
+  | HoltWintersMovingAverageAggregation
+
+export class MovingAverageAggregationBase extends PipelineAggregationBase {
   minimize?: boolean
-  model?: MovingAverageModel
-  settings: MovingAverageSettings
   predict?: integer
   window?: integer
 }
 
-export enum MovingAverageModel {
-  linear,
-  simple,
-  ewma,
-  holt,
-  holt_winters
+export class LinearMovingAverageAggregation extends MovingAverageAggregationBase {
+  model: 'linear'
+  settings: EmptyObject
 }
 
-export type MovingAverageSettings =
-  | EwmaModelSettings
-  | HoltLinearModelSettings
-  | HoltWintersModelSettings
+export class SimpleMovingAverageAggregation extends MovingAverageAggregationBase {
+  model: 'simple'
+  settings: EmptyObject
+}
+
+export class EwmaMovingAverageAggregation extends MovingAverageAggregationBase {
+  model: 'ewma'
+  settings: EwmaModelSettings
+}
+
+export class HoltMovingAverageAggregation extends MovingAverageAggregationBase {
+  model: 'holt'
+  settings: HoltLinearModelSettings
+}
+
+export class HoltWintersMovingAverageAggregation extends MovingAverageAggregationBase {
+  model: 'holt_winters'
+  settings: HoltWintersModelSettings
+}
 
 export class EwmaModelSettings {
   alpha?: float

--- a/specification/_types/aggregations/pipeline.ts
+++ b/specification/_types/aggregations/pipeline.ts
@@ -19,19 +19,24 @@
 
 import { Sort } from '@global/search/_types/sort'
 import { Dictionary } from '@spec_utils/Dictionary'
-import {Name, Field, EmptyObject} from '@_types/common'
+import { Name, Field, EmptyObject } from '@_types/common'
 import { integer, double, float } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 import { Aggregation } from './Aggregation'
 
 export class PipelineAggregationBase extends Aggregation {
-  // TODO: `buckets_path` chanegs based on the aggregation,
-  //       this property should be moved in the aggregations
-  //       that are extending this baseclass
-  buckets_path?: string | string[] | Dictionary<string, string>
+  buckets_path?: BucketsPath
   format?: string
   gap_policy?: GapPolicy
 }
+
+/**
+ * Buckets path can be expressed in different ways, and an aggregation may accept some or all of these
+ * forms depending on its type. Please refer to each aggregation's documentation to know what buckets
+ * path forms they accept.
+ * @codegen_names single, array, dict
+ */
+export type BucketsPath = string | string[] | Dictionary<string, string>
 
 export enum GapPolicy {
   skip = 0,

--- a/specification/_types/analysis/char_filters.ts
+++ b/specification/_types/analysis/char_filters.ts
@@ -25,8 +25,12 @@ export class CharFilterBase {
   version?: VersionString
 }
 
+/** @codegen_names name, definition */
+// ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
+export type CharFilter = string | CharFilterDefinition
+
 /** @variants internal tag='type' */
-export type CharFilter =
+export type CharFilterDefinition =
   | HtmlStripCharFilter
   | MappingCharFilter
   | PatternReplaceCharFilter

--- a/specification/_types/analysis/token_filters.ts
+++ b/specification/_types/analysis/token_filters.ts
@@ -337,8 +337,12 @@ export class UppercaseTokenFilter extends TokenFilterBase {
   type: 'uppercase'
 }
 
+/** @codegen_names name, definition */
+// ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
+export type TokenFilter = string | TokenFilterDefinition
+
 /** @variants internal tag='type' */
-export type TokenFilter =
+export type TokenFilterDefinition =
   | AsciiFoldingTokenFilter
   | CommonGramsTokenFilter
   | ConditionTokenFilter

--- a/specification/_types/analysis/tokenizers.ts
+++ b/specification/_types/analysis/tokenizers.ts
@@ -21,6 +21,7 @@ import { VersionString } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { IcuTokenizer } from './icu-plugin'
 import { KuromojiTokenizer } from './kuromoji-plugin'
+import { TokenFilterDefinition } from '@_types/analysis/token_filters'
 
 export class TokenizerBase {
   version?: VersionString
@@ -115,8 +116,12 @@ export class WhitespaceTokenizer extends TokenizerBase {
   max_token_length?: integer
 }
 
+/** @codegen_names name, definition */
+// ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
+export type Tokenizer = string | TokenizerDefinition
+
 /** @variants internal tag='type' */
-export type Tokenizer =
+export type TokenizerDefinition =
   | CharGroupTokenizer
   | EdgeNGramTokenizer
   | KeywordTokenizer

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -111,6 +111,7 @@ export type MultiTermQueryRewrite = string
 export type Field = string
 export type Fields = Field | Field[]
 
+/** @codegen_names count, option */
 export type WaitForActiveShards = integer | WaitForActiveShardOptions
 
 /**
@@ -238,9 +239,13 @@ export enum OpType {
   create = 1
 }
 
-export type Refresh = boolean | RefreshOptions
-export enum RefreshOptions {
-  wait_for = 1
+// ES uses a string but accepts a json boolean for strings
+export type Refresh = boolean | RefreshValues
+
+export enum RefreshValues {
+  true,
+  false,
+  wait_for
 }
 
 export enum SearchType {

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -22,8 +22,12 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { double, integer, long } from './Numeric'
 import { AdditionalProperties } from '@spec_utils/behaviors'
 
-/** A single value */
-export type ScalarValue = long | double | string | boolean
+/**
+ * A field value.
+ * @codegen_names long, double, string, boolean
+ */
+// FIXME: representation of geopoints and ip addresses?
+export type FieldValue = long | double | string | boolean
 
 export class UrlParameter {}
 
@@ -138,12 +142,6 @@ export class EmptyObject {}
  */
 export type MinimumShouldMatch = integer | string
 
-export enum ShapeRelation {
-  intersects = 0,
-  disjoint = 1,
-  within = 2
-}
-
 /**
  * Byte size units. These units use powers of 1024, so 1 kB means 1024 bytes.
  *
@@ -184,7 +182,7 @@ export class ElasticsearchUrlFormatter {}
 /**
  * Type of index that wildcard expressions can match.
  */
-export enum ExpandWildcardOptions {
+export enum ExpandWildcard {
   /** Match any data stream or index, including hidden ones. */
   all = 0,
   /** Match open, non-hidden indices. Also matches any non-hidden data stream. */
@@ -197,16 +195,7 @@ export enum ExpandWildcardOptions {
   none = 4
 }
 
-export type ExpandWildcards =
-  | ExpandWildcardOptions
-  | Array<ExpandWildcardOptions>
-  | string
-
-export enum GroupBy {
-  nodes = 0,
-  parents = 1,
-  none = 2
-}
+export type ExpandWildcards = ExpandWildcard | ExpandWildcard[]
 
 /**
  * Health status of the cluster, based on the state of its primary and replica shards.
@@ -253,15 +242,6 @@ export enum SearchType {
   query_then_fetch = 0,
   /** Documents are scored using global term and document frequencies across all shards. This is usually slower but more accurate. */
   dfs_query_then_fetch = 1
-}
-
-export enum Size {
-  Raw = 0,
-  k = 1,
-  m = 2,
-  g = 3,
-  t = 4,
-  p = 5
 }
 
 export enum SuggestMode {

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -228,10 +228,8 @@ export enum OpType {
   create = 1
 }
 
-// ES uses a string but accepts a json boolean for strings
-export type Refresh = boolean | RefreshValues
-
-export enum RefreshValues {
+// Note: ES also accepts plain booleans for true and false. The TS generator implements this leniency rule.
+export enum Refresh {
   true,
   false,
   wait_for

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -45,7 +45,7 @@ export class PropertyBase {
   name?: PropertyName
   properties?: Dictionary<PropertyName, Property>
   ignore_above?: integer
-  dynamic?: boolean | DynamicMapping
+  dynamic?: DynamicMapping
   fields?: Dictionary<PropertyName, Property>
 }
 

--- a/specification/_types/mapping/TypeMapping.ts
+++ b/specification/_types/mapping/TypeMapping.ts
@@ -34,7 +34,7 @@ import { RuntimeField } from './RuntimeFields'
 export class TypeMapping {
   all_field?: AllField
   date_detection?: boolean
-  dynamic?: boolean | DynamicMapping
+  dynamic?: DynamicMapping
   dynamic_date_formats?: string[]
   dynamic_templates?:
     | Dictionary<string, DynamicTemplate>

--- a/specification/_types/mapping/dynamic-template.ts
+++ b/specification/_types/mapping/dynamic-template.ts
@@ -34,9 +34,12 @@ export enum MatchType {
   regex = 1
 }
 
-export enum DynamicMapping {
-  strict = 0,
-  runtime = 1,
-  true = 2,
-  false = 3
+// ES uses a string but accepts a json boolean for strings
+export type DynamicMapping = boolean | DynamicMappingValues
+
+export enum DynamicMappingValues {
+  strict,
+  runtime,
+  true,
+  false
 }

--- a/specification/_types/mapping/dynamic-template.ts
+++ b/specification/_types/mapping/dynamic-template.ts
@@ -34,10 +34,7 @@ export enum MatchType {
   regex = 1
 }
 
-// ES uses a string but accepts a json boolean for strings
-export type DynamicMapping = boolean | DynamicMappingValues
-
-export enum DynamicMappingValues {
+export enum DynamicMapping {
   strict,
   runtime,
   true,

--- a/specification/_types/mapping/geo.ts
+++ b/specification/_types/mapping/geo.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { GeoLocation } from '@_types/query_dsl/geo'
 import { DocValuesPropertyBase } from './core'
+import {GeoLocation} from "@_types/Geo";
 
 export class GeoPointProperty extends DocValuesPropertyBase {
   ignore_malformed?: boolean

--- a/specification/_types/mapping/geo.ts
+++ b/specification/_types/mapping/geo.ts
@@ -18,7 +18,7 @@
  */
 
 import { DocValuesPropertyBase } from './core'
-import {GeoLocation} from "@_types/Geo";
+import { GeoLocation } from '@_types/Geo'
 
 export class GeoPointProperty extends DocValuesPropertyBase {
   ignore_malformed?: boolean

--- a/specification/_types/query_dsl/Operator.ts
+++ b/specification/_types/query_dsl/Operator.ts
@@ -20,6 +20,8 @@
 // Note: corresponding server enum is uppercase, but parsing is case-insensitive. Tests only use lower-case identifiers
 // so we only keep those.
 export enum Operator {
-  and = 0,
-  or = 1
+  /** @aliases AND */
+  and,
+  /** @aliases OR */
+  or
 }

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -17,10 +17,22 @@
  * under the License.
  */
 
-import {SingleKeyDictionary} from '@spec_utils/Dictionary'
-import {Field, Id, IndexName, MinimumShouldMatch, Routing} from '@_types/common'
-import {float} from '@_types/Numeric'
-import {BoolQuery, BoostingQuery, ConstantScoreQuery, DisMaxQuery, FunctionScoreQuery} from './compound'
+import { SingleKeyDictionary } from '@spec_utils/Dictionary'
+import {
+  Field,
+  Id,
+  IndexName,
+  MinimumShouldMatch,
+  Routing
+} from '@_types/common'
+import { float } from '@_types/Numeric'
+import {
+  BoolQuery,
+  BoostingQuery,
+  ConstantScoreQuery,
+  DisMaxQuery,
+  FunctionScoreQuery
+} from './compound'
 import {
   CommonTermsQuery,
   IntervalsQuery,
@@ -32,10 +44,20 @@ import {
   QueryStringQuery,
   SimpleQueryStringQuery
 } from './fulltext'
-import {GeoBoundingBoxQuery, GeoDistanceQuery, GeoPolygonQuery, GeoShapeQuery} from './geo'
-import {HasChildQuery, HasParentQuery, NestedQuery, ParentIdQuery} from './joining'
-import {MatchAllQuery} from './MatchAllQuery'
-import {MatchNoneQuery} from './MatchNoneQuery'
+import {
+  GeoBoundingBoxQuery,
+  GeoDistanceQuery,
+  GeoPolygonQuery,
+  GeoShapeQuery
+} from './geo'
+import {
+  HasChildQuery,
+  HasParentQuery,
+  NestedQuery,
+  ParentIdQuery
+} from './joining'
+import { MatchAllQuery } from './MatchAllQuery'
+import { MatchNoneQuery } from './MatchNoneQuery'
 import {
   SpanContainingQuery,
   SpanFieldMaskingQuery,
@@ -184,7 +206,13 @@ export enum CombinedFieldsZeroTerms {
  * @shortcut_property field
  */
 export class FieldAndFormat {
+  /**
+   * Wildcard pattern. The request returns values for field names matching this pattern.
+   */
   field: Field
+  /**
+   * Format in which the values are returned.
+   */
   format?: string
   include_unmapped?: boolean
 }

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -17,22 +17,10 @@
  * under the License.
  */
 
-import { SingleKeyDictionary } from '@spec_utils/Dictionary'
-import {
-  Field,
-  Id,
-  IndexName,
-  MinimumShouldMatch,
-  Routing
-} from '@_types/common'
-import { float, long } from '@_types/Numeric'
-import {
-  BoolQuery,
-  BoostingQuery,
-  ConstantScoreQuery,
-  DisMaxQuery,
-  FunctionScoreQuery
-} from './compound'
+import {SingleKeyDictionary} from '@spec_utils/Dictionary'
+import {Field, Id, IndexName, MinimumShouldMatch, Routing} from '@_types/common'
+import {float} from '@_types/Numeric'
+import {BoolQuery, BoostingQuery, ConstantScoreQuery, DisMaxQuery, FunctionScoreQuery} from './compound'
 import {
   CommonTermsQuery,
   IntervalsQuery,
@@ -44,20 +32,10 @@ import {
   QueryStringQuery,
   SimpleQueryStringQuery
 } from './fulltext'
-import {
-  GeoBoundingBoxQuery,
-  GeoDistanceQuery,
-  GeoPolygonQuery,
-  GeoShapeQuery
-} from './geo'
-import {
-  HasChildQuery,
-  HasParentQuery,
-  NestedQuery,
-  ParentIdQuery
-} from './joining'
-import { MatchAllQuery } from './MatchAllQuery'
-import { MatchNoneQuery } from './MatchNoneQuery'
+import {GeoBoundingBoxQuery, GeoDistanceQuery, GeoPolygonQuery, GeoShapeQuery} from './geo'
+import {HasChildQuery, HasParentQuery, NestedQuery, ParentIdQuery} from './joining'
+import {MatchAllQuery} from './MatchAllQuery'
+import {MatchNoneQuery} from './MatchNoneQuery'
 import {
   SpanContainingQuery,
   SpanFieldMaskingQuery,
@@ -199,4 +177,14 @@ export enum CombinedFieldsOperator {
 export enum CombinedFieldsZeroTerms {
   none,
   all
+}
+
+/**
+ * A reference to a field with formatting instructions on how to return the value
+ * @shortcut_property field
+ */
+export class FieldAndFormat {
+  field: Field
+  format?: string
+  include_unmapped?: boolean
 }

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -19,7 +19,7 @@
 
 import { AdditionalProperties, AdditionalProperty } from '@spec_utils/behaviors'
 import { Field, MinimumShouldMatch } from '@_types/common'
-import {Distance, GeoLocation} from '@_types/Geo'
+import { Distance, GeoLocation } from '@_types/Geo'
 import { double, float, long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 import { DateMath, Time } from '@_types/Time'

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -19,12 +19,11 @@
 
 import { AdditionalProperties, AdditionalProperty } from '@spec_utils/behaviors'
 import { Field, MinimumShouldMatch } from '@_types/common'
-import { Distance } from '@_types/Geo'
+import {Distance, GeoLocation} from '@_types/Geo'
 import { double, float, long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 import { DateMath, Time } from '@_types/Time'
 import { QueryBase, QueryContainer } from './abstractions'
-import { GeoLocation } from './geo'
 
 export class BoolQuery extends QueryBase {
   filter?: QueryContainer | QueryContainer[]
@@ -105,6 +104,8 @@ export class GeoDecayFunction
   extends DecayFunctionBase
   implements AdditionalProperty<Field, DecayPlacement<GeoLocation, Distance>> {}
 
+/** @codegen_names date, numeric, geo */
+// Note: deserialization depends on value types
 export type DecayFunction =
   | DateDecayFunction
   | NumericDecayFunction

--- a/specification/_types/query_dsl/fulltext.ts
+++ b/specification/_types/query_dsl/fulltext.ts
@@ -268,7 +268,14 @@ export class QueryStringQuery extends QueryBase {
   type?: TextQueryType
 }
 
-export enum SimpleQueryStringFlags {
+/**
+ * Query flags can be either a single flag or a combination of flags, e.g. `OR|AND|PREFIX`
+ * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/7.15/query-dsl-simple-query-string-query.html#supported-flags
+ * @codegen_names single, multiple
+ */
+export type SimpleQueryStringFlags = SimpleQueryStringFlag | string
+
+export enum SimpleQueryStringFlag {
   NONE = 1,
   AND = 2,
   OR = 4,
@@ -293,7 +300,7 @@ export class SimpleQueryStringQuery extends QueryBase {
   /** @server_default 'or' */
   default_operator?: Operator
   fields?: Field[]
-  flags?: SimpleQueryStringFlags | string
+  flags?: SimpleQueryStringFlags
   fuzzy_max_expansions?: integer
   fuzzy_prefix_length?: integer
   fuzzy_transpositions?: boolean

--- a/specification/_types/query_dsl/geo.ts
+++ b/specification/_types/query_dsl/geo.ts
@@ -19,10 +19,12 @@
 
 import { AdditionalProperty } from '@spec_utils/behaviors'
 import {
-  Distance, GeoBounds,
-  GeoDistanceType, GeoLocation,
+  Distance,
+  GeoBounds,
+  GeoDistanceType,
+  GeoLocation,
   GeoShape,
-  GeoShapeRelation,
+  GeoShapeRelation
 } from '@_types/Geo'
 import { FieldLookup, QueryBase } from './abstractions'
 import { Field } from '@_types/common'

--- a/specification/_types/query_dsl/geo.ts
+++ b/specification/_types/query_dsl/geo.ts
@@ -17,40 +17,19 @@
  * under the License.
  */
 
-import { AdditionalProperties, AdditionalProperty } from '@spec_utils/behaviors'
+import { AdditionalProperty } from '@spec_utils/behaviors'
 import {
-  Distance,
-  GeoDistanceType,
+  Distance, GeoBounds,
+  GeoDistanceType, GeoLocation,
   GeoShape,
   GeoShapeRelation,
-  LatLon
 } from '@_types/Geo'
-import { double } from '@_types/Numeric'
 import { FieldLookup, QueryBase } from './abstractions'
 import { Field } from '@_types/common'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-
-/**
- * A geo bounding box. The various coordinates can be mixed. When set, `wkt` takes precedence over all other fields.
- */
-export class BoundingBox {
-  bottom_right?: GeoLocation
-  top_left?: GeoLocation
-
-  top_right?: GeoLocation
-  bottom_left?: GeoLocation
-
-  top?: double
-  left?: double
-  right?: double
-  bottom?: double
-
-  wkt?: string
-}
 
 export class GeoBoundingBoxQuery
   extends QueryBase
-  implements AdditionalProperty<Field, BoundingBox>
+  implements AdditionalProperty<Field, GeoBounds>
 {
   /** @deprecated 7.14.0 */
   type?: GeoExecution
@@ -122,28 +101,6 @@ export enum TokenType {
   RParen = 3,
   Comma = 4
 }
-
-// TODO -- is duplicate with LatLon
-export class TwoDimensionalPoint {
-  lat: double
-  lon: double
-}
-
-export class ThreeDimensionalPoint {
-  lat: double
-  lon: double
-  z?: double
-}
-
-/**
- * Represents a Latitude/Longitude as a 2 dimensional point
- */
-export type GeoLocation = string | double[] | TwoDimensionalPoint
-
-/**
- * Represents a Latitude/Longitude and optional Z value as a 2 or 3 dimensional point
- */
-export type GeoCoordinate = string | double[] | ThreeDimensionalPoint
 
 export enum GeoValidationMethod {
   coerce = 0,

--- a/specification/_types/query_dsl/specialized.ts
+++ b/specification/_types/query_dsl/specialized.ts
@@ -32,12 +32,11 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
-import { Distance, GeoShape } from '@_types/Geo'
+import {Distance, GeoLocation, GeoShape} from '@_types/Geo'
 import { double, float, integer, long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 import { DateMath, Time } from '@_types/Time'
 import { FieldLookup, QueryBase, QueryContainer } from './abstractions'
-import { GeoCoordinate } from './geo'
 import { AdditionalProperty } from '@spec_utils/behaviors'
 
 export class DistanceFeatureQueryBase<TOrigin, TDistance> extends QueryBase {
@@ -47,7 +46,7 @@ export class DistanceFeatureQueryBase<TOrigin, TDistance> extends QueryBase {
 }
 
 export class GeoDistanceFeatureQuery extends DistanceFeatureQueryBase<
-  GeoCoordinate,
+  GeoLocation,
   Distance
 > {}
 
@@ -56,6 +55,8 @@ export class DateDistanceFeatureQuery extends DistanceFeatureQueryBase<
   Time
 > {}
 
+/** @codegen_names geo, date */
+// Note: deserialization depends on value types
 export type DistanceFeatureQuery =
   | GeoDistanceFeatureQuery
   | DateDistanceFeatureQuery

--- a/specification/_types/query_dsl/specialized.ts
+++ b/specification/_types/query_dsl/specialized.ts
@@ -27,12 +27,11 @@ import {
   IndexName,
   MinimumShouldMatch,
   Routing,
-  ShapeRelation,
   Type,
   VersionNumber,
   VersionType
 } from '@_types/common'
-import {Distance, GeoLocation, GeoShape} from '@_types/Geo'
+import { Distance, GeoLocation, GeoShape, GeoShapeRelation } from '@_types/Geo'
 import { double, float, integer, long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 import { DateMath, Time } from '@_types/Time'
@@ -106,7 +105,7 @@ export class LikeDocument {
 /**
  * Text that we want similar documents for or a lookup to a document's field for the text.
  * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html#_document_input_parameters
- *
+ * @codegen_names text, document
  */
 export type Like = string | LikeDocument
 
@@ -178,11 +177,13 @@ export class ScriptScoreQuery extends QueryBase {
 // holding also the query base fields (boost and _name)
 export class ShapeQuery
   extends QueryBase
-  implements AdditionalProperty<Field, ShapeFieldQuery> {}
+  implements AdditionalProperty<Field, ShapeFieldQuery>
+{
+  ignore_unmapped?: boolean
+}
 
 export class ShapeFieldQuery {
-  ignore_unmapped?: boolean
   indexed_shape?: FieldLookup
-  relation?: ShapeRelation
+  relation?: GeoShapeRelation
   shape?: GeoShape
 }

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -24,7 +24,8 @@ import {
   Ids,
   IndexName,
   MultiTermQueryRewrite,
-  Routing
+  Routing,
+  FieldValue
 } from '@_types/common'
 import { double, float, integer, long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
@@ -114,14 +115,19 @@ export class RegexpQuery extends QueryBase {
 
 /** @shortcut_property value */
 export class TermQuery extends QueryBase {
-  value: string | float | boolean
+  value: FieldValue
   /** @since 7.10.0 */
   case_insensitive?: boolean
 }
 
 export class TermsQuery
   extends QueryBase
-  implements AdditionalProperty<Field, string[] | long[] | TermsLookup> {}
+  implements AdditionalProperty<Field, TermsQueryField> {}
+
+/**
+ * @codegen_names value, lookup
+ */
+export type TermsQueryField = FieldValue[] | TermsLookup
 
 export class TermsLookup {
   index: IndexName

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -88,6 +88,8 @@ export class NumberRangeQuery extends RangeQueryBase {
   to?: double
 }
 
+/** @codegen_names date, number */
+// Note: deserialization depends on value types
 export type RangeQuery = DateRangeQuery | NumberRangeQuery
 
 export enum RangeRelation {

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -44,10 +44,8 @@ import { PointInTimeReference } from '@global/search/_types/PointInTimeReference
 import { Rescore } from '@global/search/_types/rescoring'
 import { Sort, SortResults } from '@global/search/_types/sort'
 import {
-  DocValueField,
   GetSourceConfig,
-  SourceConfig,
-  SourceFilter
+  SourceConfig
 } from '@global/search/_types/SourceFilter'
 import { Suggester } from '@global/search/_types/suggester'
 import { TrackHits } from '@global/search/_types/hits'
@@ -151,7 +149,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (*) patterns. The request returns doc values for field
      * names matching these patterns in the hits.fields property of the response.
      */
-    docvalue_fields?: DocValueField[]
+    docvalue_fields?: FieldAndFormat[]
     /**
      * Minimum _score for matching documents. Documents with a lower _score are
      * not included in the search results.

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -34,7 +34,7 @@ import {
 } from '@_types/common'
 import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { double, integer, long } from '@_types/Numeric'
-import {FieldAndFormat, QueryContainer} from '@_types/query_dsl/abstractions'
+import { FieldAndFormat, QueryContainer } from '@_types/query_dsl/abstractions'
 import { ScriptField } from '@_types/Scripting'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { Time } from '@_types/Time'
@@ -43,8 +43,14 @@ import { Highlight } from '@global/search/_types/highlighting'
 import { PointInTimeReference } from '@global/search/_types/PointInTimeReference'
 import { Rescore } from '@global/search/_types/rescoring'
 import { Sort, SortResults } from '@global/search/_types/sort'
-import {DocValueField, GetSourceConfig, SourceConfig, SourceFilter} from '@global/search/_types/SourceFilter'
-import { SuggestContainer } from '@global/search/_types/suggester'
+import {
+  DocValueField,
+  GetSourceConfig,
+  SourceConfig,
+  SourceFilter
+} from '@global/search/_types/SourceFilter'
+import { Suggester } from '@global/search/_types/suggester'
+import { TrackHits } from '@global/search/_types/hits'
 
 /**
  * @rest_spec_name async_search.submit
@@ -99,7 +105,7 @@ export interface Request extends RequestBase {
     suggest_text?: string
     terminate_after?: long
     timeout?: Time
-    track_total_hits?: boolean | integer
+    track_total_hits?: TrackHits
     track_scores?: boolean
     typed_keys?: boolean
     rest_total_hits_as_int?: boolean
@@ -136,7 +142,7 @@ export interface Request extends RequestBase {
      * response does not include the total number of hits matching the query.
      * Defaults to 10,000 hits.
      */
-    track_total_hits?: boolean | integer
+    track_total_hits?: TrackHits
     /**
      * Boosts the _score of documents from specified indices.
      */
@@ -183,7 +189,7 @@ export interface Request extends RequestBase {
      * matching these patterns in the hits.fields property of the response.
      */
     fields?: Array<FieldAndFormat>
-    suggest?: Dictionary<string, SuggestContainer>
+    suggest?: Suggester
     /**
      * Maximum number of documents to collect for each shard. If a query reaches this
      * limit, Elasticsearch terminates the query early. Elasticsearch collects documents

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -34,16 +34,16 @@ import {
 } from '@_types/common'
 import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { double, integer, long } from '@_types/Numeric'
-import { QueryContainer } from '@_types/query_dsl/abstractions'
+import {FieldAndFormat, QueryContainer} from '@_types/query_dsl/abstractions'
 import { ScriptField } from '@_types/Scripting'
 import { SlicedScroll } from '@_types/SlicedScroll'
-import { DateField, Time } from '@_types/Time'
+import { Time } from '@_types/Time'
 import { FieldCollapse } from '@global/search/_types/FieldCollapse'
 import { Highlight } from '@global/search/_types/highlighting'
 import { PointInTimeReference } from '@global/search/_types/PointInTimeReference'
 import { Rescore } from '@global/search/_types/rescoring'
 import { Sort, SortResults } from '@global/search/_types/sort'
-import { DocValueField, SourceFilter } from '@global/search/_types/SourceFilter'
+import {DocValueField, GetSourceConfig, SourceConfig, SourceFilter} from '@global/search/_types/SourceFilter'
 import { SuggestContainer } from '@global/search/_types/suggester'
 
 /**
@@ -104,7 +104,7 @@ export interface Request extends RequestBase {
     typed_keys?: boolean
     rest_total_hits_as_int?: boolean
     version?: boolean
-    _source?: boolean | Fields
+    _source?: GetSourceConfig
     _source_excludes?: Fields
     _source_includes?: Fields
     seq_no_primary_term?: boolean
@@ -145,7 +145,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (*) patterns. The request returns doc values for field
      * names matching these patterns in the hits.fields property of the response.
      */
-    docvalue_fields?: DocValueField | Array<Field | DocValueField>
+    docvalue_fields?: DocValueField[]
     /**
      * Minimum _score for matching documents. Documents with a lower _score are
      * not included in the search results.
@@ -177,13 +177,13 @@ export interface Request extends RequestBase {
      * Indicates which source fields are returned for matching documents. These
      * fields are returned in the hits._source property of the search response.
      */
-    _source?: boolean | Fields | SourceFilter
+    _source?: SourceConfig
     /**
      * Array of wildcard (*) patterns. The request returns values for field names
      * matching these patterns in the hits.fields property of the response.
      */
-    fields?: Array<Field | DateField>
-    suggest?: SuggestContainer | Dictionary<string, SuggestContainer>
+    fields?: Array<FieldAndFormat>
+    suggest?: Dictionary<string, SuggestContainer>
     /**
      * Maximum number of documents to collect for each shard. If a query reaches this
      * limit, Elasticsearch terminates the query early. Elasticsearch collects documents

--- a/specification/cat/thread_pool/CatThreadPoolRequest.ts
+++ b/specification/cat/thread_pool/CatThreadPoolRequest.ts
@@ -18,7 +18,8 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
-import { Names, Size } from '@_types/common'
+import { Names } from '@_types/common'
+import { ThreadPoolSize } from '@cat/thread_pool/types'
 
 /**
  * @rest_spec_name cat.thread_pool
@@ -30,6 +31,6 @@ export interface Request extends CatRequestBase {
     thread_pool_patterns?: Names
   }
   query_parameters: {
-    size?: Size | boolean
+    size?: ThreadPoolSize
   }
 }

--- a/specification/cat/thread_pool/types.ts
+++ b/specification/cat/thread_pool/types.ts
@@ -121,3 +121,11 @@ export class ThreadPoolRecord {
    */
   'keep_alive'?: string
 }
+
+export enum ThreadPoolSize {
+  k = 1,
+  m = 2,
+  g = 3,
+  t = 4,
+  p = 5
+}

--- a/specification/eql/search/EqlSearchRequest.ts
+++ b/specification/eql/search/EqlSearchRequest.ts
@@ -20,9 +20,9 @@
 import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, Field, IndexName } from '@_types/common'
 import { float, uint } from '@_types/Numeric'
-import { QueryContainer } from '@_types/query_dsl/abstractions'
+import { FieldAndFormat, QueryContainer } from '@_types/query_dsl/abstractions'
 import { Time } from '@_types/Time'
-import { ResultPosition, SearchFieldFormatted } from './types'
+import { ResultPosition } from './types'
 
 /**
  * @rest_spec_name eql.search
@@ -99,11 +99,11 @@ export interface Request extends RequestBase {
      * For basic queries, the maximum number of matching events to return. Defaults to 10
      * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-basic-syntax
      */
-    size?: uint | float
+    size?: uint // doc says "integer of float" but it's really an int
     /**
      * Array of wildcard (*) patterns. The response returns values for field names matching these patterns in the fields property of each hit.
      */
-    fields?: Array<Field | SearchFieldFormatted>
+    fields?: FieldAndFormat
     /**
      * @server_default tail
      */

--- a/specification/ilm/_types/Phase.ts
+++ b/specification/ilm/_types/Phase.ts
@@ -20,7 +20,7 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 import { integer } from '@_types/Numeric'
 import { Time } from '@_types/Time'
-import {UserDefinedValue} from "@spec_utils/UserDefinedValue";
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Phase {
   actions?: Actions

--- a/specification/ilm/_types/Phase.ts
+++ b/specification/ilm/_types/Phase.ts
@@ -20,11 +20,11 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 import { integer } from '@_types/Numeric'
 import { Time } from '@_types/Time'
+import {UserDefinedValue} from "@spec_utils/UserDefinedValue";
 
 export class Phase {
-  actions?: Dictionary<string, Action> | string[]
+  actions?: Actions
   min_age?: Time
-  configurations?: Dictionary<string, Dictionary<string, integer | string>>
 }
 
 export class Phases {
@@ -34,4 +34,6 @@ export class Phases {
   warm?: Phase
 }
 
-export class Action {}
+// TODO. This is a variants container.
+// See https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-actions
+export type Actions = UserDefinedValue

--- a/specification/indices/_types/IndexState.ts
+++ b/specification/indices/_types/IndexState.ts
@@ -26,10 +26,6 @@ import { IndexSettings } from './IndexSettings'
 export class IndexState {
   aliases?: Dictionary<IndexName, Alias>
   mappings?: TypeMapping
-  settings?: IndexSettings | IndexStatePrefixedSettings
+  settings?: IndexSettings
   data_stream?: DataStreamName
-}
-
-export class IndexStatePrefixedSettings {
-  index: IndexSettings
 }

--- a/specification/indices/analyze/IndicesAnalyzeRequest.ts
+++ b/specification/indices/analyze/IndicesAnalyzeRequest.ts
@@ -36,12 +36,12 @@ export interface Request extends RequestBase {
   body: {
     analyzer?: string
     attributes?: string[]
-    char_filter?: Array<string | CharFilter>
+    char_filter?: Array<CharFilter>
     explain?: boolean
     field?: Field
-    filter?: Array<string | TokenFilter>
+    filter?: Array<TokenFilter>
     normalizer?: string
     text?: TextToAnalyze
-    tokenizer?: string | Tokenizer
+    tokenizer?: Tokenizer
   }
 }

--- a/specification/indices/put_mapping/IndicesPutMappingRequest.ts
+++ b/specification/indices/put_mapping/IndicesPutMappingRequest.ts
@@ -60,7 +60,7 @@ export interface Request extends RequestBase {
     /**
      * Controls whether new fields are added dynamically.
      */
-    dynamic?: boolean | DynamicMapping
+    dynamic?: DynamicMapping
     /**
      * If date detection is enabled then new string fields are checked
      * against 'dynamic_date_formats' and if the value matches then

--- a/specification/indices/rollover/IndicesRolloverRequest.ts
+++ b/specification/indices/rollover/IndicesRolloverRequest.ts
@@ -24,7 +24,7 @@ import { RequestBase } from '@_types/Base'
 import { IndexAlias, IndexName, WaitForActiveShards } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { Time } from '@_types/Time'
-import { RolloverConditions } from './types'
+import {IndexRolloverMapping, RolloverConditions} from './types'
 
 /**
  * @rest_spec_name indices.rollover
@@ -46,7 +46,8 @@ export interface Request extends RequestBase {
   body: {
     aliases?: Dictionary<IndexName, Alias>
     conditions?: RolloverConditions
-    mappings?: Dictionary<string, TypeMapping> | TypeMapping
+    // Mappings is a dictionary if include_type_name is true, which is deprecated in 7.0 and removed in 8.0
+    mappings?: IndexRolloverMapping
     settings?: Dictionary<string, UserDefinedValue>
   }
 }

--- a/specification/indices/rollover/IndicesRolloverRequest.ts
+++ b/specification/indices/rollover/IndicesRolloverRequest.ts
@@ -24,7 +24,7 @@ import { RequestBase } from '@_types/Base'
 import { IndexAlias, IndexName, WaitForActiveShards } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { Time } from '@_types/Time'
-import {IndexRolloverMapping, RolloverConditions} from './types'
+import { IndexRolloverMapping, RolloverConditions } from './types'
 
 /**
  * @rest_spec_name indices.rollover

--- a/specification/indices/rollover/types.ts
+++ b/specification/indices/rollover/types.ts
@@ -20,8 +20,8 @@
 import { ByteSize } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { Time } from '@_types/Time'
-import {TypeMapping} from "@_types/mapping/TypeMapping";
-import {Dictionary} from "@spec_utils/Dictionary";
+import { TypeMapping } from '@_types/mapping/TypeMapping'
+import { Dictionary } from '@spec_utils/Dictionary'
 
 export class RolloverConditions {
   max_age?: Time

--- a/specification/indices/rollover/types.ts
+++ b/specification/indices/rollover/types.ts
@@ -20,6 +20,8 @@
 import { ByteSize } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { Time } from '@_types/Time'
+import {TypeMapping} from "@_types/mapping/TypeMapping";
+import {Dictionary} from "@spec_utils/Dictionary";
 
 export class RolloverConditions {
   max_age?: Time
@@ -27,3 +29,8 @@ export class RolloverConditions {
   max_size?: string
   max_primary_shard_size?: ByteSize
 }
+
+/**
+ * @codegen_names single, by_type
+ */
+export type IndexRolloverMapping = TypeMapping | Dictionary<string, TypeMapping>

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -160,26 +160,14 @@ export class CsvProcessor extends ProcessorBase {
   trim: boolean
 }
 
-export enum DateRounding {
-  /** @codegen_name Second */
-  s = 0,
-  /** @codegen_name Minute */
-  m = 1,
-  /** @codegen_name Hour */
-  h = 2,
-  /** @codegen_name Day */
-  d = 3,
-  /** @codegen_name Week */
-  w = 4,
-  /** @codegen_name Month */
-  M = 5,
-  /** @codegen_name Year */
-  y = 6
-}
-
 export class DateIndexNameProcessor extends ProcessorBase {
   date_formats: string[]
-  date_rounding: string | DateRounding
+  /**
+   * How to round the date when formatting the date into the index name. Valid values are:
+   * `y` (year), `M` (month), `w` (week), `d` (day), `h` (hour), `m` (minute) and `s` (second).
+   * Supports template snippets.
+   */
+  date_rounding: string
   field: Field
   index_name_format: string
   index_name_prefix: string

--- a/specification/ml/_types/Analysis.ts
+++ b/specification/ml/_types/Analysis.ts
@@ -22,7 +22,7 @@ import { long } from '@_types/Numeric'
 import { Time, TimeSpan } from '@_types/Time'
 import { Detector } from './Detector'
 import { CharFilter } from '@_types/analysis/char_filters'
-import { Tokenizer } from '@_types/analysis/tokenizers'
+import { Tokenizer, TokenizerDefinition } from '@_types/analysis/tokenizers'
 import { TokenFilter } from '@_types/analysis/token_filters'
 import { OverloadOf } from '@spec_utils/behaviors'
 
@@ -35,7 +35,7 @@ export class AnalysisConfig {
   /**
    * If `categorization_field_name` is specified, you can also define the analyzer that is used to interpret the categorization field. This property cannot be used at the same time as `categorization_filters`. The categorization analyzer specifies how the `categorization_field` is interpreted by the categorization process. The `categorization_analyzer` field can be specified either as a string or as an object. If it is a string, it must refer to a built-in analyzer or one added by another plugin.
    */
-  categorization_analyzer?: CategorizationAnalyzer | string
+  categorization_analyzer?: CategorizationAnalyzer
   /**
    * If this property is specified, the values of the specified field will be categorized. The resulting categories must be used in a detector by setting `by_field_name`, `over_field_name`, or `partition_field_name` to the keyword `mlcategory`.
    */
@@ -77,7 +77,7 @@ export class AnalysisConfig {
 
 export class AnalysisConfigRead implements OverloadOf<AnalysisConfig> {
   bucket_span: TimeSpan
-  categorization_analyzer?: CategorizationAnalyzer | string
+  categorization_analyzer?: CategorizationAnalyzer
   categorization_field_name?: Field
   categorization_filters?: string[]
   detectors: Detector[]
@@ -120,17 +120,20 @@ export class AnalysisMemoryLimit {
   model_memory_limit: string
 }
 
-export class CategorizationAnalyzer {
+/** @codegen_names name, definition */
+export type CategorizationAnalyzer = string | CategorizationAnalyzerDefinition
+
+export class CategorizationAnalyzerDefinition {
   /**
    * One or more character filters. In addition to the built-in character filters, other plugins can provide more character filters. If this property is not specified, no character filters are applied prior to categorization. If you are customizing some other aspect of the analyzer and you need to achieve the equivalent of `categorization_filters` (which are not permitted when some other aspect of the analyzer is customized), add them here as pattern replace character filters.
    */
-  char_filter?: Array<string | CharFilter>
+  char_filter?: Array<CharFilter>
   /**
    * One or more token filters. In addition to the built-in token filters, other plugins can provide more token filters. If this property is not specified, no token filters are applied prior to categorization.
    */
-  filter?: Array<string | TokenFilter>
+  filter?: Array<TokenFilter>
   /**
    * The name or definition of the tokenizer to use after character filters are applied. This property is compulsory if `categorization_analyzer` is specified as an object. Machine learning provides a tokenizer called `ml_standard` that tokenizes in a way that has been determined to produce good categorization results on a variety of log file formats for logs in English. If you want to use that tokenizer but change the character or token filters, specify "tokenizer": "ml_standard" in your `categorization_analyzer`. Additionally, the `ml_classic` tokenizer is available, which tokenizes in the same way as the non-customizable tokenizer in old versions of the product (before 6.2). `ml_classic` was the default categorization tokenizer in versions 6.2 to 7.13, so if you need categorization identical to the default for jobs created in these versions, specify "tokenizer": "ml_classic" in your `categorization_analyzer`.
    */
-  tokenizer?: string | Tokenizer
+  tokenizer?: Tokenizer
 }

--- a/specification/ml/_types/DataframeAnalytics.ts
+++ b/specification/ml/_types/DataframeAnalytics.ts
@@ -234,10 +234,8 @@ export class DataframeAnalysisClassification extends DataframeAnalysis {
   num_top_classes?: integer
 }
 
-export type DataframeAnalysisAnalyzedFields =
-  | string[]
-  | DataframeAnalysisAnalyzedFieldsIncludeExclude
-export class DataframeAnalysisAnalyzedFieldsIncludeExclude {
+/** @shortcut_property includes */
+export class DataframeAnalysisAnalyzedFields {
   /** An array of strings that defines the fields that will be excluded from the analysis. You do not need to add fields with unsupported data types to excludes, these fields are excluded from the analysis automatically. */
   includes: string[]
   /** An array of strings that defines the fields that will be included in the analysis. */

--- a/specification/ml/_types/Settings.ts
+++ b/specification/ml/_types/Settings.ts
@@ -17,11 +17,11 @@
  * under the License.
  */
 
-import { Dictionary } from '@spec_utils/Dictionary'
-import { UrlConfig } from '@xpack/usage/types'
+import {UserDefinedValue} from "@spec_utils/UserDefinedValue";
 
-export class CustomSettings {
-  custom_urls?: UrlConfig[]
-  created_by?: string
-  job_tags?: Dictionary<string, string>
-}
+/**
+ * Custom metadata about the job
+ */
+// Can be anything, see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html
+// Some settings are illustrated in https://www.elastic.co/guide/en/machine-learning/7.15/ml-configuring-url.html
+export type CustomSettings = UserDefinedValue

--- a/specification/ml/_types/Settings.ts
+++ b/specification/ml/_types/Settings.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import {UserDefinedValue} from "@spec_utils/UserDefinedValue";
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * Custom metadata about the job

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -172,12 +172,13 @@ export class NodeInfoClient {
 }
 
 export class NodeInfoSettingsHttp {
-  type: string | NodeInfoSettingsHttpType
+  type: NodeInfoSettingsHttpType
   'type.default'?: string // TODO this clashes with NodeInfoSettingsHttpType
   compression?: boolean | string
   port?: integer | string
 }
 
+/** @shortcut_property default */
 export class NodeInfoSettingsHttpType {
   default: string
 }
@@ -187,11 +188,12 @@ export class NodeInfoBootstrap {
 }
 
 export class NodeInfoSettingsTransport {
-  type: string | NodeInfoSettingsTransportType
+  type: NodeInfoSettingsTransportType
   'type.default'?: string // TODO this clashes with NodeInfoSettingsTransportType
   features?: NodeInfoSettingsTransportFeatures
 }
 
+/** @shortcut_property default */
 export class NodeInfoSettingsTransportType {
   default: string
 }

--- a/specification/nodes/reload_secure_settings/ReloadSecureSettingsResponse.ts
+++ b/specification/nodes/reload_secure_settings/ReloadSecureSettingsResponse.ts
@@ -21,7 +21,7 @@ import { Stats } from '@nodes/_types/Stats'
 import { NodesResponseBase } from '@nodes/_types/NodesResponseBase'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { Name } from '@_types/common'
-import { NodeReloadResult} from './types'
+import { NodeReloadResult } from './types'
 
 export class Response extends NodesResponseBase {
   body: {

--- a/specification/nodes/reload_secure_settings/ReloadSecureSettingsResponse.ts
+++ b/specification/nodes/reload_secure_settings/ReloadSecureSettingsResponse.ts
@@ -21,11 +21,11 @@ import { Stats } from '@nodes/_types/Stats'
 import { NodesResponseBase } from '@nodes/_types/NodesResponseBase'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { Name } from '@_types/common'
-import { NodeReloadException } from './types'
+import { NodeReloadResult} from './types'
 
 export class Response extends NodesResponseBase {
   body: {
     cluster_name: Name
-    nodes: Dictionary<string, Stats | NodeReloadException>
+    nodes: Dictionary<string, NodeReloadResult>
   }
 }

--- a/specification/nodes/reload_secure_settings/types.ts
+++ b/specification/nodes/reload_secure_settings/types.ts
@@ -18,14 +18,13 @@
  */
 
 import { Name } from '@_types/common'
+import {ErrorCause} from "@_types/Errors";
+import {Stats} from "@nodes/_types/Stats";
 
-export class NodeReloadException {
+export class NodeReloadError {
   name: Name
-  reload_exception?: NodeReloadExceptionCausedBy
+  reload_exception?: ErrorCause
 }
 
-export class NodeReloadExceptionCausedBy {
-  type: string
-  reason: string
-  caused_by?: NodeReloadExceptionCausedBy
-}
+/** @codegen_names stats, error */
+export type NodeReloadResult = Stats | NodeReloadError

--- a/specification/nodes/reload_secure_settings/types.ts
+++ b/specification/nodes/reload_secure_settings/types.ts
@@ -18,8 +18,8 @@
  */
 
 import { Name } from '@_types/common'
-import {ErrorCause} from "@_types/Errors";
-import {Stats} from "@nodes/_types/Stats";
+import { ErrorCause } from '@_types/Errors'
+import { Stats } from '@nodes/_types/Stats'
 
 export class NodeReloadError {
   name: Name

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -91,7 +91,7 @@ export class IndicesPrivileges {
   /**
    * A search query that defines the documents the owners of the role have read access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.
    */
-  query?: string | string[] | QueryContainer
+  query?: string | string[]
   /**
    * Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.
    * @server_default false

--- a/specification/security/_types/RoleMapping.ts
+++ b/specification/security/_types/RoleMapping.ts
@@ -21,6 +21,7 @@ import { RoleTemplate } from '@security/get_role/types'
 import { Metadata } from '@_types/common'
 import { RoleMappingRule } from './RoleMappingRule'
 
+// ES: ExpressionRoleMapping
 export class RoleMapping {
   enabled: boolean
   metadata: Metadata

--- a/specification/security/get_role/types.ts
+++ b/specification/security/get_role/types.ts
@@ -22,6 +22,7 @@ import {
   ApplicationPrivileges
 } from '@security/_types/Privileges'
 import { Metadata } from '@_types/common'
+import {Script} from "@_types/Scripting";
 
 export class Role {
   cluster: string[]
@@ -42,30 +43,8 @@ export enum TemplateFormat {
   json = 1
 }
 
-export class InlineRoleTemplate {
-  template: InlineRoleTemplateSource
+// ES: TemplateRoleName
+export class RoleTemplate {
   format?: TemplateFormat
+  template: Script
 }
-
-export class InlineRoleTemplateSource {
-  source: string
-}
-
-export class StoredRoleTemplate {
-  template: StoredRoleTemplateId
-  format?: TemplateFormat
-}
-
-export class StoredRoleTemplateId {
-  id: string
-}
-
-export class InvalidRoleTemplate {
-  template: string
-  format?: TemplateFormat
-}
-
-export type RoleTemplate =
-  | InlineRoleTemplate
-  | StoredRoleTemplate
-  | InvalidRoleTemplate

--- a/specification/security/get_role/types.ts
+++ b/specification/security/get_role/types.ts
@@ -22,7 +22,7 @@ import {
   ApplicationPrivileges
 } from '@security/_types/Privileges'
 import { Metadata } from '@_types/common'
-import {Script} from "@_types/Scripting";
+import { Script } from '@_types/Scripting'
 
 export class Role {
   cluster: string[]

--- a/specification/sql/translate/TranslateSqlResponse.ts
+++ b/specification/sql/translate/TranslateSqlResponse.ts
@@ -18,7 +18,7 @@
  */
 
 import { Sort } from '@global/search/_types/sort'
-import { SourceFilter } from '@global/search/_types/SourceFilter'
+import {SourceConfig, SourceFilter} from '@global/search/_types/SourceFilter'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { Field, Fields } from '@_types/common'
 import { long } from '@_types/Numeric'
@@ -26,7 +26,7 @@ import { long } from '@_types/Numeric'
 export class Response {
   body: {
     size: long
-    _source: boolean | Fields | SourceFilter
+    _source: SourceConfig
     fields: Array<Dictionary<Field, string>>
     sort: Sort
   }

--- a/specification/sql/translate/TranslateSqlResponse.ts
+++ b/specification/sql/translate/TranslateSqlResponse.ts
@@ -18,7 +18,7 @@
  */
 
 import { Sort } from '@global/search/_types/sort'
-import {SourceConfig, SourceFilter} from '@global/search/_types/SourceFilter'
+import { SourceConfig, SourceFilter } from '@global/search/_types/SourceFilter'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { Field, Fields } from '@_types/common'
 import { long } from '@_types/Numeric'

--- a/specification/sql/translate/TranslateSqlResponse.ts
+++ b/specification/sql/translate/TranslateSqlResponse.ts
@@ -18,7 +18,7 @@
  */
 
 import { Sort } from '@global/search/_types/sort'
-import { SourceConfig, SourceFilter } from '@global/search/_types/SourceFilter'
+import { SourceConfig } from '@global/search/_types/SourceFilter'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { Field, Fields } from '@_types/common'
 import { long } from '@_types/Numeric'

--- a/specification/tasks/_types/GroupBy.ts
+++ b/specification/tasks/_types/GroupBy.ts
@@ -17,16 +17,8 @@
  * under the License.
  */
 
-/**
- * Set of matching events or sequences to return.
- */
-export enum ResultPosition {
-  /**
-   * Return the most recent matches, similar to the Unix tail command.
-   */
-  tail = 0,
-  /**
-   * Return the earliest matches, similar to the Unix head command.
-   */
-  head = 1
+export enum GroupBy {
+  nodes = 0,
+  parents = 1,
+  none = 2
 }

--- a/specification/tasks/list/ListTasksRequest.ts
+++ b/specification/tasks/list/ListTasksRequest.ts
@@ -18,8 +18,9 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { GroupBy, Id } from '@_types/common'
+import { Id } from '@_types/common'
 import { Time } from '@_types/Time'
+import { GroupBy } from '@tasks/_types/GroupBy'
 
 /**
  * @rest_spec_name tasks.list

--- a/specification/tasks/list/ListTasksResponse.ts
+++ b/specification/tasks/list/ListTasksResponse.ts
@@ -26,6 +26,6 @@ export class Response {
   body: {
     node_failures?: ErrorCause[]
     nodes?: Dictionary<string, TaskExecutingNode>
-    tasks?: Dictionary<string, Info> | Array<Info>
+    tasks?: Dictionary<string, Info>
   }
 }

--- a/specification/watcher/_types/Schedule.ts
+++ b/specification/watcher/_types/Schedule.ts
@@ -31,7 +31,7 @@ export type CronExpression = string
 //export class CronExpression extends ScheduleBase {}
 
 export class DailySchedule {
-  at: string[] | TimeOfDay
+  at: TimeOfDay[]
 }
 
 export enum Day {
@@ -55,10 +55,15 @@ export class Interval {
 }
 
 export enum IntervalUnit {
+  /** @codegen_name second */
   s = 0,
+  /** @codegen_name minute */
   m = 1,
+  /** @codegen_name hour */
   h = 2,
+  /** @codegen_name day */
   d = 3,
+  /** @codegen_name week */
   w = 4
 }
 
@@ -91,11 +96,14 @@ export class ScheduleContainer {
 }
 
 export class ScheduleTriggerEvent {
-  scheduled_time: DateString | string
-  triggered_time?: DateString | string
+  scheduled_time: DateString
+  triggered_time?: DateString
 }
 
-export class TimeOfDay {
+/** @codegen_names text, hour_minute */
+export type TimeOfDay = string | HourAndMinute
+
+export class HourAndMinute {
   hour: integer[]
   minute: integer[]
 }

--- a/specification/xpack/usage/types.ts
+++ b/specification/xpack/usage/types.ts
@@ -23,6 +23,7 @@ import { Dictionary, SingleKeyDictionary } from '@spec_utils/Dictionary'
 import { ByteSize, EmptyObject, Field, Name } from '@_types/common'
 import { Job, JobStatistics } from '@ml/_types/Job'
 import { integer, long, uint, ulong } from '@_types/Numeric'
+import {AdditionalProperties} from "@spec_utils/behaviors";
 
 export class Base {
   available: boolean
@@ -37,17 +38,6 @@ export class Counter {
 export class FeatureToggle {
   enabled: boolean
 }
-
-export class BaseUrlConfig {
-  url_name: string
-  url_value: string
-}
-
-export class KibanaUrlConfig extends BaseUrlConfig {
-  time_range?: string
-}
-
-export type UrlConfig = BaseUrlConfig | KibanaUrlConfig
 
 export class AlertingExecution {
   actions: Dictionary<string, ExecutionAction>
@@ -331,16 +321,19 @@ export class AllJobs {
   forecasts: Dictionary<string, integer>
 }
 
+// The 'jobs' entry in MachineLearning can either contain a dictionary of
+// individual jobs or a single summary entry under the key '_all'.
+// The layout of the summary varies from that of the individual job,
+// and is specified in the 'AllJobs' class (defined above).
+export class Jobs implements AdditionalProperties<string, Job>{
+  _all?: AllJobs
+}
+
 export class MachineLearning extends Base {
   datafeeds: Dictionary<string, Datafeed>
   // TODO: xPack marks the entire Job definition as optional
   //       while the MlJob has many required properties.
-
-  // Assumption: the 'jobs' entry can either contain a dictionary of
-  // individual jobs or a single summary entry under the key '_all'.
-  // The layout of the summary varies from that of the individual job,
-  // and is specified in the 'AllJobs' class (defined above).
-  jobs: Dictionary<string, Job> | SingleKeyDictionary<string, AllJobs>
+  jobs: Jobs
   node_count: integer
   data_frame_analytics_jobs: MlDataFrameAnalyticsJobs
   inference: MlInference

--- a/specification/xpack/usage/types.ts
+++ b/specification/xpack/usage/types.ts
@@ -23,7 +23,7 @@ import { Dictionary, SingleKeyDictionary } from '@spec_utils/Dictionary'
 import { ByteSize, EmptyObject, Field, Name } from '@_types/common'
 import { Job, JobStatistics } from '@ml/_types/Job'
 import { integer, long, uint, ulong } from '@_types/Numeric'
-import {AdditionalProperties} from "@spec_utils/behaviors";
+import { AdditionalProperties } from '@spec_utils/behaviors'
 
 export class Base {
   available: boolean
@@ -325,7 +325,7 @@ export class AllJobs {
 // individual jobs or a single summary entry under the key '_all'.
 // The layout of the summary varies from that of the individual job,
 // and is specified in the 'AllJobs' class (defined above).
-export class Jobs implements AdditionalProperties<string, Job>{
+export class Jobs implements AdditionalProperties<string, Job> {
   _all?: AllJobs
 }
 

--- a/typescript-generator/index.ts
+++ b/typescript-generator/index.ts
@@ -418,7 +418,10 @@ function buildEnum (type: M.Enum): string {
     }
   }, new Array<string>())
 
-  return `export type ${createName(type.name)} = ${names.map(m => `'${m}'`).join(' | ')}\n`
+  // Also allow plain boolean values if the enum contains 'true' and 'false'
+  const boolean = (names.includes('true') && names.includes('false')) ? 'boolean | ' : ''
+
+  return `export type ${createName(type.name)} = ${boolean}${names.map(m => `'${m}'`).join(' | ')}\n`
 }
 
 function buildTypeAlias (type: M.TypeAlias): string {


### PR DESCRIPTION
Most strongly typed languages need each member of a union type to have an identifier. In Java we generate custom wrappers for unions, Rust needs names for enum variants (Rust unifies enums and tagged unions).

This PR updates the spec to change inline unions used in property declarations to a distinct type with a new `@codegen_names` (plural) annotation that names the union members.

```ts
class Foo {
  field: Bar | Baz
}
```
becomes
```ts
class Foo {
  field: SomeBarBaz
}

/** @codegen_names bar, baz */
type SomeBarBaz = Bar | Baz
```

Some inline unions are left in the spec, that represent the leniency rules that ES implements. These are notably `SomeType | SomeType[]` (read a single object as a 1-sized array) and strings that accept any primitive type.

These leniency rules are currently implemented in the Java generator and will later be formalized as new model validation rules that will report inline unions that require a separate type definition.

------

Along with refactoring enumerations to enum types, this PR also fixes a number of definitions that were ambiguous or actually wrong. API validation has been run on most of these changes to verify that there were no regressions.

Validation of the `search` API has 3 errors less, and the remaing ones are because of the use of numbers for ids (they're not quoted in the YAML tests) and experimental `bucket_correlation` and `bucket_count_ks_test` aggregations that have not been represented in the spec.
