### PR TITLE
Refactor and fix multi* APIs

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -16344,8 +16344,23 @@
     },
     {
       "body": {
-        "kind": "properties",
-        "properties": []
+        "kind": "value",
+        "value": {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "TDocument",
+                "namespace": "_global.get"
+              }
+            }
+          ],
+          "kind": "instance_of",
+          "type": {
+            "name": "GetResult",
+            "namespace": "_global.get"
+          }
+        }
       },
       "generics": [
         {
@@ -16353,21 +16368,6 @@
           "namespace": "_global.get"
         }
       ],
-      "inherits": {
-        "generics": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "TDocument",
-              "namespace": "_global.get"
-            }
-          }
-        ],
-        "type": {
-          "name": "GetResult",
-          "namespace": "_global.get"
-        }
-      },
       "kind": "response",
       "name": {
         "name": "Response",

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -18146,7 +18146,7 @@
       ],
       "kind": "interface",
       "name": {
-        "name": "MultisearchResponseBase",
+        "name": "MultisearchResult",
         "namespace": "_global.msearch"
       },
       "properties": [
@@ -18403,8 +18403,23 @@
     },
     {
       "body": {
-        "kind": "properties",
-        "properties": []
+        "kind": "value",
+        "value": {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "TDocument",
+                "namespace": "_global.msearch"
+              }
+            }
+          ],
+          "kind": "instance_of",
+          "type": {
+            "name": "MultisearchResult",
+            "namespace": "_global.msearch"
+          }
+        }
       },
       "generics": [
         {
@@ -18412,21 +18427,6 @@
           "namespace": "_global.msearch"
         }
       ],
-      "inherits": {
-        "generics": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "TDocument",
-              "namespace": "_global.msearch"
-            }
-          }
-        ],
-        "type": {
-          "name": "MultisearchResponseBase",
-          "namespace": "_global.msearch"
-        }
-      },
       "kind": "response",
       "name": {
         "name": "Response",
@@ -18617,8 +18617,23 @@
     },
     {
       "body": {
-        "kind": "properties",
-        "properties": []
+        "kind": "value",
+        "value": {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "TDocument",
+                "namespace": "_global.msearch_template"
+              }
+            }
+          ],
+          "kind": "instance_of",
+          "type": {
+            "name": "MultisearchResult",
+            "namespace": "_global.msearch"
+          }
+        }
       },
       "generics": [
         {
@@ -18626,21 +18641,6 @@
           "namespace": "_global.msearch_template"
         }
       ],
-      "inherits": {
-        "generics": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "TDocument",
-              "namespace": "_global.msearch_template"
-            }
-          }
-        ],
-        "type": {
-          "name": "MultisearchResponseBase",
-          "namespace": "_global.msearch"
-        }
-      },
       "kind": "response",
       "name": {
         "name": "Response",

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -13055,7 +13055,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GetSourceConfig",
+              "name": "SourceConfigParam",
               "namespace": "_global.search._types"
             }
           }
@@ -14585,7 +14585,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GetSourceConfig",
+              "name": "SourceConfigParam",
               "namespace": "_global.search._types"
             }
           }
@@ -15103,7 +15103,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GetSourceConfig",
+              "name": "SourceConfigParam",
               "namespace": "_global.search._types"
             }
           }
@@ -15293,7 +15293,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GetSourceConfig",
+              "name": "SourceConfigParam",
               "namespace": "_global.search._types"
             }
           }
@@ -15598,7 +15598,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GetSourceConfig",
+              "name": "SourceConfigParam",
               "namespace": "_global.search._types"
             }
           }
@@ -16035,6 +16035,142 @@
       }
     },
     {
+      "generics": [
+        {
+          "name": "TDocument",
+          "namespace": "_global.get"
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "GetResult",
+        "namespace": "_global.get"
+      },
+      "properties": [
+        {
+          "name": "_index",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "fields",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "user_defined_value"
+            }
+          }
+        },
+        {
+          "name": "found",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "_primary_term",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "_routing",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "_seq_no",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "SequenceNumber",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "_source",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TDocument",
+              "namespace": "_global.get"
+            }
+          }
+        },
+        {
+          "deprecation": {
+            "description": "",
+            "version": "7.0.0"
+          },
+          "name": "_type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Type",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "_version",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionNumber",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
@@ -16139,7 +16275,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GetSourceConfig",
+              "name": "SourceConfigParam",
               "namespace": "_global.search._types"
             }
           }
@@ -16209,129 +16345,7 @@
     {
       "body": {
         "kind": "properties",
-        "properties": [
-          {
-            "name": "_index",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexName",
-                "namespace": "_types"
-              }
-            }
-          },
-          {
-            "name": "fields",
-            "required": false,
-            "type": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "kind": "user_defined_value"
-              }
-            }
-          },
-          {
-            "name": "found",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "boolean",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "name": "_id",
-            "required": true,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Id",
-                "namespace": "_types"
-              }
-            }
-          },
-          {
-            "name": "_primary_term",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "long",
-                "namespace": "_types"
-              }
-            }
-          },
-          {
-            "name": "_routing",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            }
-          },
-          {
-            "name": "_seq_no",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "SequenceNumber",
-                "namespace": "_types"
-              }
-            }
-          },
-          {
-            "name": "_source",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "TDocument",
-                "namespace": "_global.get"
-              }
-            }
-          },
-          {
-            "deprecation": {
-              "description": "",
-              "version": "7.0.0"
-            },
-            "name": "_type",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "Type",
-                "namespace": "_types"
-              }
-            }
-          },
-          {
-            "name": "_version",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "VersionNumber",
-                "namespace": "_types"
-              }
-            }
-          }
-        ]
+        "properties": []
       },
       "generics": [
         {
@@ -16339,6 +16353,21 @@
           "namespace": "_global.get"
         }
       ],
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TDocument",
+              "namespace": "_global.get"
+            }
+          }
+        ],
+        "type": {
+          "name": "GetResult",
+          "namespace": "_global.get"
+        }
+      },
       "kind": "response",
       "name": {
         "name": "Response",
@@ -16788,7 +16817,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GetSourceConfig",
+              "name": "SourceConfigParam",
               "namespace": "_global.search._types"
             }
           }
@@ -17471,55 +17500,20 @@
       }
     },
     {
-      "generics": [
-        {
-          "name": "TDocument",
-          "namespace": "_global.mget"
-        }
-      ],
       "kind": "interface",
       "name": {
-        "name": "Hit",
+        "name": "MultiGetError",
         "namespace": "_global.mget"
       },
       "properties": [
         {
           "name": "error",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "ErrorCause",
               "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "fields",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "internal"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "user_defined_value"
-            }
-          }
-        },
-        {
-          "name": "found",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
             }
           }
         },
@@ -17546,50 +17540,10 @@
           }
         },
         {
-          "name": "_primary_term",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "_routing",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Routing",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "_seq_no",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "SequenceNumber",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "_source",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "TDocument",
-              "namespace": "_global.mget"
-            }
-          }
-        },
-        {
+          "deprecation": {
+            "description": "",
+            "version": "7.0.0"
+          },
           "name": "_type",
           "required": false,
           "type": {
@@ -17599,45 +17553,8 @@
               "namespace": "_types"
             }
           }
-        },
-        {
-          "name": "_version",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "VersionNumber",
-              "namespace": "_types"
-            }
-          }
         }
       ]
-    },
-    {
-      "kind": "type_alias",
-      "name": {
-        "name": "MultiGetId",
-        "namespace": "_global.mget"
-      },
-      "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "internal"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        ],
-        "kind": "union_of"
-      }
     },
     {
       "kind": "interface",
@@ -17652,8 +17569,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "MultiGetId",
-              "namespace": "_global.mget"
+              "name": "Id",
+              "namespace": "_types"
             }
           }
         },
@@ -17761,13 +17678,10 @@
             "name": "ids",
             "required": false,
             "type": {
-              "kind": "array_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "MultiGetId",
-                  "namespace": "_global.mget"
-                }
+              "kind": "instance_of",
+              "type": {
+                "name": "Ids",
+                "namespace": "_types"
               }
             }
           }
@@ -17855,7 +17769,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GetSourceConfig",
+              "name": "SourceConfigParam",
               "namespace": "_global.search._types"
             }
           }
@@ -17919,7 +17833,7 @@
                 ],
                 "kind": "instance_of",
                 "type": {
-                  "name": "Hit",
+                  "name": "ResponseItem",
                   "namespace": "_global.mget"
                 }
               }
@@ -17940,9 +17854,95 @@
       }
     },
     {
+      "codegenNames": [
+        "result",
+        "failure"
+      ],
+      "generics": [
+        {
+          "name": "TDocument",
+          "namespace": "_global.mget"
+        }
+      ],
+      "kind": "type_alias",
+      "name": {
+        "name": "ResponseItem",
+        "namespace": "_global.mget"
+      },
+      "type": {
+        "items": [
+          {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "TDocument",
+                  "namespace": "_global.mget"
+                }
+              }
+            ],
+            "kind": "instance_of",
+            "type": {
+              "name": "GetResult",
+              "namespace": "_global.get"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "MultiGetError",
+              "namespace": "_global.mget"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
+      "generics": [
+        {
+          "name": "TDocument",
+          "namespace": "_global.msearch"
+        }
+      ],
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TDocument",
+              "namespace": "_global.msearch"
+            }
+          }
+        ],
+        "type": {
+          "name": "Response",
+          "namespace": "_global.search"
+        }
+      },
       "kind": "interface",
       "name": {
-        "name": "Body",
+        "name": "MultiSearchResult",
+        "namespace": "_global.msearch"
+      },
+      "properties": [
+        {
+          "name": "status",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "MultisearchBody",
         "namespace": "_global.msearch"
       },
       "properties": [
@@ -18043,7 +18043,7 @@
       "description": "Contains parameters used to limit or change the subsequent search body request.",
       "kind": "interface",
       "name": {
-        "name": "Header",
+        "name": "MultisearchHeader",
         "namespace": "_global.msearch"
       },
       "properties": [
@@ -18138,6 +18138,55 @@
       ]
     },
     {
+      "generics": [
+        {
+          "name": "TDocument",
+          "namespace": "_global.msearch"
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "MultisearchResponseBase",
+        "namespace": "_global.msearch"
+      },
+      "properties": [
+        {
+          "name": "took",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "responses",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "generics": [
+                {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "TDocument",
+                    "namespace": "_global.msearch"
+                  }
+                }
+              ],
+              "kind": "instance_of",
+              "type": {
+                "name": "ResponseItem",
+                "namespace": "_global.msearch"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
       "attachedBehaviors": [
         "CommonQueryParameters"
       ],
@@ -18147,23 +18196,11 @@
         "value": {
           "kind": "array_of",
           "value": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Header",
-                  "namespace": "_global.msearch"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "Body",
-                  "namespace": "_global.msearch"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "RequestItem",
+              "namespace": "_global.msearch"
+            }
           }
         }
       },
@@ -18335,70 +18372,40 @@
       ]
     },
     {
-      "body": {
-        "kind": "properties",
-        "properties": [
+      "codegenNames": [
+        "header",
+        "body"
+      ],
+      "kind": "type_alias",
+      "name": {
+        "name": "RequestItem",
+        "namespace": "_global.msearch"
+      },
+      "type": {
+        "items": [
           {
-            "name": "took",
-            "required": true,
+            "kind": "instance_of",
             "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "long",
-                "namespace": "_types"
-              }
+              "name": "MultisearchHeader",
+              "namespace": "_global.msearch"
             }
           },
           {
-            "name": "responses",
-            "required": true,
+            "kind": "instance_of",
             "type": {
-              "kind": "array_of",
-              "value": {
-                "items": [
-                  {
-                    "generics": [
-                      {
-                        "kind": "instance_of",
-                        "type": {
-                          "name": "TDocument",
-                          "namespace": "_global.msearch"
-                        }
-                      }
-                    ],
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "SearchResult",
-                      "namespace": "_global.msearch"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "ErrorResponseBase",
-                      "namespace": "_types"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
+              "name": "MultisearchBody",
+              "namespace": "_global.msearch"
             }
           }
-        ]
-      },
-      "generics": [
-        {
-          "name": "TDocument",
-          "namespace": "_global.msearch"
-        }
-      ],
-      "kind": "response",
-      "name": {
-        "name": "Response",
-        "namespace": "_global.msearch"
+        ],
+        "kind": "union_of"
       }
     },
     {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
       "generics": [
         {
           "name": "TDocument",
@@ -18416,28 +18423,60 @@
           }
         ],
         "type": {
-          "name": "Response",
-          "namespace": "_global.search"
+          "name": "MultisearchResponseBase",
+          "namespace": "_global.msearch"
         }
       },
-      "kind": "interface",
+      "kind": "response",
       "name": {
-        "name": "SearchResult",
+        "name": "Response",
+        "namespace": "_global.msearch"
+      }
+    },
+    {
+      "codegenNames": [
+        "result",
+        "failure"
+      ],
+      "generics": [
+        {
+          "name": "TDocument",
+          "namespace": "_global.msearch"
+        }
+      ],
+      "kind": "type_alias",
+      "name": {
+        "name": "ResponseItem",
         "namespace": "_global.msearch"
       },
-      "properties": [
-        {
-          "name": "status",
-          "required": true,
-          "type": {
+      "type": {
+        "items": [
+          {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "TDocument",
+                  "namespace": "_global.msearch"
+                }
+              }
+            ],
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "MultiSearchResult",
+              "namespace": "_global.msearch"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "ErrorResponseBase",
               "namespace": "_types"
             }
           }
-        }
-      ]
+        ],
+        "kind": "union_of"
+      }
     },
     {
       "attachedBehaviors": [
@@ -18451,7 +18490,7 @@
           "value": {
             "kind": "instance_of",
             "type": {
-              "name": "TemplateItem",
+              "name": "RequestItem",
               "namespace": "_global.msearch_template"
             }
           }
@@ -18547,56 +18586,39 @@
       ]
     },
     {
-      "body": {
-        "kind": "properties",
-        "properties": [
+      "codegenNames": [
+        "header",
+        "body"
+      ],
+      "kind": "type_alias",
+      "name": {
+        "name": "RequestItem",
+        "namespace": "_global.msearch_template"
+      },
+      "type": {
+        "items": [
           {
-            "name": "responses",
-            "required": true,
+            "kind": "instance_of",
             "type": {
-              "kind": "array_of",
-              "value": {
-                "items": [
-                  {
-                    "generics": [
-                      {
-                        "kind": "instance_of",
-                        "type": {
-                          "name": "TDocument",
-                          "namespace": "_global.msearch_template"
-                        }
-                      }
-                    ],
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "Response",
-                      "namespace": "_global.search"
-                    }
-                  },
-                  {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "ErrorResponseBase",
-                      "namespace": "_types"
-                    }
-                  }
-                ],
-                "kind": "union_of"
-              }
+              "name": "MultisearchHeader",
+              "namespace": "_global.msearch"
             }
           },
           {
-            "name": "took",
-            "required": true,
+            "kind": "instance_of",
             "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "long",
-                "namespace": "_types"
-              }
+              "name": "TemplateConfig",
+              "namespace": "_global.msearch_template"
             }
           }
-        ]
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
+      "body": {
+        "kind": "properties",
+        "properties": []
       },
       "generics": [
         {
@@ -18604,6 +18626,21 @@
           "namespace": "_global.msearch_template"
         }
       ],
+      "inherits": {
+        "generics": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "TDocument",
+              "namespace": "_global.msearch_template"
+            }
+          }
+        ],
+        "type": {
+          "name": "MultisearchResponseBase",
+          "namespace": "_global.msearch"
+        }
+      },
       "kind": "response",
       "name": {
         "name": "Response",
@@ -18613,28 +18650,30 @@
     {
       "kind": "interface",
       "name": {
-        "name": "TemplateItem",
+        "name": "TemplateConfig",
         "namespace": "_global.msearch_template"
       },
       "properties": [
         {
+          "name": "explain",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "ID of the search template to use. If no source is specified,\nthis parameter is required.",
           "name": "id",
           "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "Id",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "index",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Indices",
               "namespace": "_types"
             }
           }
@@ -18658,6 +18697,19 @@
           }
         },
         {
+          "name": "profile",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "An inline search template. Supports the same parameters as the search API's\nrequest body. Also supports Mustache variables. If no id is specified, this\nparameter is required.",
           "name": "source",
           "required": false,
           "type": {
@@ -22357,7 +22409,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GetSourceConfig",
+              "name": "SourceConfigParam",
               "namespace": "_global.search._types"
             }
           }
@@ -24381,36 +24433,6 @@
           }
         }
       ]
-    },
-    {
-      "codegenNames": [
-        "fetch",
-        "fields"
-      ],
-      "kind": "type_alias",
-      "name": {
-        "name": "GetSourceConfig",
-        "namespace": "_global.search._types"
-      },
-      "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "internal"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "Fields",
-              "namespace": "_types"
-            }
-          }
-        ],
-        "kind": "union_of"
-      }
     },
     {
       "kind": "interface",
@@ -26968,6 +26990,37 @@
             "type": {
               "name": "SourceFilter",
               "namespace": "_global.search._types"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
+      "codegenNames": [
+        "fetch",
+        "fields"
+      ],
+      "description": "Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.\nUsed as a query parameter along with the `_source_includes` and `_source_excludes` parameters.",
+      "kind": "type_alias",
+      "name": {
+        "name": "SourceConfigParam",
+        "namespace": "_global.search._types"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "Fields",
+              "namespace": "_types"
             }
           }
         ],
@@ -29597,7 +29650,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GetSourceConfig",
+              "name": "SourceConfigParam",
               "namespace": "_global.search._types"
             }
           }
@@ -30048,7 +30101,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GetSourceConfig",
+              "name": "SourceConfigParam",
               "namespace": "_global.search._types"
             }
           }
@@ -65793,7 +65846,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "GetSourceConfig",
+              "name": "SourceConfigParam",
               "namespace": "_global.search._types"
             }
           }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -17922,7 +17922,7 @@
       },
       "kind": "interface",
       "name": {
-        "name": "MultiSearchResult",
+        "name": "MultiSearchItem",
         "namespace": "_global.msearch"
       },
       "properties": [
@@ -17934,6 +17934,55 @@
             "type": {
               "name": "integer",
               "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "generics": [
+        {
+          "name": "TDocument",
+          "namespace": "_global.msearch"
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "MultiSearchResult",
+        "namespace": "_global.msearch"
+      },
+      "properties": [
+        {
+          "name": "took",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "responses",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "generics": [
+                {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "TDocument",
+                    "namespace": "_global.msearch"
+                  }
+                }
+              ],
+              "kind": "instance_of",
+              "type": {
+                "name": "ResponseItem",
+                "namespace": "_global.msearch"
+              }
             }
           }
         }
@@ -18132,55 +18181,6 @@
             "type": {
               "name": "SearchType",
               "namespace": "_types"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "generics": [
-        {
-          "name": "TDocument",
-          "namespace": "_global.msearch"
-        }
-      ],
-      "kind": "interface",
-      "name": {
-        "name": "MultisearchResult",
-        "namespace": "_global.msearch"
-      },
-      "properties": [
-        {
-          "name": "took",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "responses",
-          "required": true,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "generics": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "TDocument",
-                    "namespace": "_global.msearch"
-                  }
-                }
-              ],
-              "kind": "instance_of",
-              "type": {
-                "name": "ResponseItem",
-                "namespace": "_global.msearch"
-              }
             }
           }
         }
@@ -18416,7 +18416,7 @@
           ],
           "kind": "instance_of",
           "type": {
-            "name": "MultisearchResult",
+            "name": "MultiSearchResult",
             "namespace": "_global.msearch"
           }
         }
@@ -18463,7 +18463,7 @@
             ],
             "kind": "instance_of",
             "type": {
-              "name": "MultiSearchResult",
+              "name": "MultiSearchItem",
               "namespace": "_global.msearch"
             }
           },
@@ -18630,7 +18630,7 @@
           ],
           "kind": "instance_of",
           "type": {
-            "name": "MultisearchResult",
+            "name": "MultiSearchResult",
             "namespace": "_global.msearch"
           }
         }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1138,6 +1138,12 @@
       ],
       "response": []
     },
+    "mget": {
+      "request": [],
+      "response": [
+        "type_alias definition _global.mget:ResponseItem / union_of / instance_of / Generics / instance_of - No type definition for '_global.mget:TDocument'"
+      ]
+    },
     "migration.deprecations": {
       "request": [
         "Request: should not have a body"
@@ -1413,12 +1419,8 @@
         "Request: query parameter 'ignore_throttled' does not exist in the json spec",
         "Request: query parameter 'ignore_unavailable' does not exist in the json spec"
       ],
-      "response": []
-    },
-    "msearch_template": {
-      "request": [],
       "response": [
-        "response definition _global.msearch_template:Response / body / Property 'responses' / array_of / union_of / instance_of - Non-leaf type cannot be used here: '_global.search:Response'"
+        "type_alias definition _global.msearch:ResponseItem / union_of / instance_of / Generics / instance_of - No type definition for '_global.msearch:TDocument'"
       ]
     },
     "nodes.clear_repositories_metering_archive": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -384,8 +384,7 @@ export interface GetRequest extends RequestBase {
   version_type?: VersionType
 }
 
-export interface GetResponse<TDocument = unknown> extends GetGetResult<TDocument> {
-}
+export type GetResponse<TDocument = unknown> = GetGetResult<TDocument>
 
 export interface GetScriptRequest extends RequestBase {
   id: Id

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -51,7 +51,7 @@ export interface BulkRequest<TSource = unknown> extends RequestBase {
   pipeline?: string
   refresh?: Refresh
   routing?: Routing
-  _source?: SearchGetSourceConfig
+  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   timeout?: Time
@@ -202,7 +202,7 @@ export interface DeleteByQueryRequest extends RequestBase {
   size?: long
   slices?: long
   sort?: string[]
-  _source?: SearchGetSourceConfig
+  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   stats?: string[]
@@ -259,7 +259,7 @@ export interface ExistsRequest extends RequestBase {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  _source?: SearchGetSourceConfig
+  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   stored_fields?: Fields
@@ -277,7 +277,7 @@ export interface ExistsSourceRequest extends RequestBase {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  _source?: SearchGetSourceConfig
+  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   version?: VersionNumber
@@ -308,7 +308,7 @@ export interface ExplainRequest extends RequestBase {
   lenient?: boolean
   preference?: string
   routing?: Routing
-  _source?: SearchGetSourceConfig
+  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   stored_fields?: Fields
@@ -356,22 +356,7 @@ export interface FieldCapsResponse {
   fields: Record<Field, Record<string, FieldCapsFieldCapability>>
 }
 
-export interface GetRequest extends RequestBase {
-  id: Id
-  index: IndexName
-  preference?: string
-  realtime?: boolean
-  refresh?: boolean
-  routing?: Routing
-  _source?: SearchGetSourceConfig
-  _source_excludes?: Fields
-  _source_includes?: Fields
-  stored_fields?: Fields
-  version?: VersionNumber
-  version_type?: VersionType
-}
-
-export interface GetResponse<TDocument = unknown> {
+export interface GetGetResult<TDocument = unknown> {
   _index: IndexName
   fields?: Record<string, any>
   found: boolean
@@ -382,6 +367,24 @@ export interface GetResponse<TDocument = unknown> {
   _source?: TDocument
   _type?: Type
   _version?: VersionNumber
+}
+
+export interface GetRequest extends RequestBase {
+  id: Id
+  index: IndexName
+  preference?: string
+  realtime?: boolean
+  refresh?: boolean
+  routing?: Routing
+  _source?: SearchSourceConfigParam
+  _source_excludes?: Fields
+  _source_includes?: Fields
+  stored_fields?: Fields
+  version?: VersionNumber
+  version_type?: VersionType
+}
+
+export interface GetResponse<TDocument = unknown> extends GetGetResult<TDocument> {
 }
 
 export interface GetScriptRequest extends RequestBase {
@@ -438,7 +441,7 @@ export interface GetSourceRequest {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  _source?: SearchGetSourceConfig
+  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   stored_fields?: Fields
@@ -509,24 +512,15 @@ export interface KnnSearchQuery {
 
 export type KnnSearchQueryVector = double[]
 
-export interface MgetHit<TDocument = unknown> {
-  error?: ErrorCause
-  fields?: Record<string, any>
-  found?: boolean
+export interface MgetMultiGetError {
+  error: ErrorCause
   _id: Id
   _index: IndexName
-  _primary_term?: long
-  _routing?: Routing
-  _seq_no?: SequenceNumber
-  _source?: TDocument
   _type?: Type
-  _version?: VersionNumber
 }
 
-export type MgetMultiGetId = string | integer
-
 export interface MgetOperation {
-  _id: MgetMultiGetId
+  _id: Id
   _index?: IndexName
   routing?: Routing
   _source?: SearchSourceConfig
@@ -542,21 +536,27 @@ export interface MgetRequest extends RequestBase {
   realtime?: boolean
   refresh?: boolean
   routing?: Routing
-  _source?: SearchGetSourceConfig
+  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   stored_fields?: Fields
   body?: {
     docs?: MgetOperation[]
-    ids?: MgetMultiGetId[]
+    ids?: Ids
   }
 }
 
 export interface MgetResponse<TDocument = unknown> {
-  docs: MgetHit<TDocument>[]
+  docs: MgetResponseItem<TDocument>[]
 }
 
-export interface MsearchBody {
+export type MgetResponseItem<TDocument = unknown> = GetGetResult<TDocument> | MgetMultiGetError
+
+export interface MsearchMultiSearchResult<TDocument = unknown> extends SearchResponse<TDocument> {
+  status: integer
+}
+
+export interface MsearchMultisearchBody {
   aggregations?: Record<string, AggregationsAggregationContainer>
   aggs?: Record<string, AggregationsAggregationContainer>
   query?: QueryDslQueryContainer
@@ -567,7 +567,7 @@ export interface MsearchBody {
   suggest?: SearchSuggester
 }
 
-export interface MsearchHeader {
+export interface MsearchMultisearchHeader {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
@@ -576,6 +576,11 @@ export interface MsearchHeader {
   request_cache?: boolean
   routing?: string
   search_type?: SearchType
+}
+
+export interface MsearchMultisearchResponseBase<TDocument = unknown> {
+  took: long
+  responses: MsearchResponseItem<TDocument>[]
 }
 
 export interface MsearchRequest extends RequestBase {
@@ -591,17 +596,15 @@ export interface MsearchRequest extends RequestBase {
   search_type?: SearchType
   rest_total_hits_as_int?: boolean
   typed_keys?: boolean
-  body?: (MsearchHeader | MsearchBody)[]
+  body?: MsearchRequestItem[]
 }
 
-export interface MsearchResponse<TDocument = unknown> {
-  took: long
-  responses: (MsearchSearchResult<TDocument> | ErrorResponseBase)[]
+export type MsearchRequestItem = MsearchMultisearchHeader | MsearchMultisearchBody
+
+export interface MsearchResponse<TDocument = unknown> extends MsearchMultisearchResponseBase<TDocument> {
 }
 
-export interface MsearchSearchResult<TDocument = unknown> extends SearchResponse<TDocument> {
-  status: integer
-}
+export type MsearchResponseItem<TDocument = unknown> = MsearchMultiSearchResult<TDocument> | ErrorResponseBase
 
 export interface MsearchTemplateRequest extends RequestBase {
   index?: Indices
@@ -610,18 +613,19 @@ export interface MsearchTemplateRequest extends RequestBase {
   search_type?: SearchType
   rest_total_hits_as_int?: boolean
   typed_keys?: boolean
-  body?: MsearchTemplateTemplateItem[]
+  body?: MsearchTemplateRequestItem[]
 }
 
-export interface MsearchTemplateResponse<TDocument = unknown> {
-  responses: (SearchResponse<TDocument> | ErrorResponseBase)[]
-  took: long
+export type MsearchTemplateRequestItem = MsearchMultisearchHeader | MsearchTemplateTemplateConfig
+
+export interface MsearchTemplateResponse<TDocument = unknown> extends MsearchMultisearchResponseBase<TDocument> {
 }
 
-export interface MsearchTemplateTemplateItem {
+export interface MsearchTemplateTemplateConfig {
+  explain?: boolean
   id?: Id
-  index?: Indices
   params?: Record<string, any>
+  profile?: boolean
   source?: string
 }
 
@@ -983,7 +987,7 @@ export interface SearchRequest extends RequestBase {
   typed_keys?: boolean
   rest_total_hits_as_int?: boolean
   version?: boolean
-  _source?: SearchGetSourceConfig
+  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   seq_no_primary_term?: boolean
@@ -1222,8 +1226,6 @@ export interface SearchGeoDistanceSortKeys {
 }
 export type SearchGeoDistanceSort = SearchGeoDistanceSortKeys
   & { [property: string]: GeoLocation | GeoLocation[] | SearchSortMode | GeoDistanceType | boolean | SearchSortOrder | DistanceUnit }
-
-export type SearchGetSourceConfig = boolean | Fields
 
 export interface SearchHighlight {
   fields: Record<Field, SearchHighlightField>
@@ -1500,6 +1502,8 @@ export type SearchSortResults = (long | double | string | null)[]
 
 export type SearchSourceConfig = boolean | SearchSourceFilter | Fields
 
+export type SearchSourceConfigParam = boolean | Fields
+
 export interface SearchSourceFilter {
   excludes?: Fields
   exclude?: Fields
@@ -1758,7 +1762,7 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
   routing?: Routing
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
-  _source?: SearchGetSourceConfig
+  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   body?: {
@@ -1801,7 +1805,7 @@ export interface UpdateByQueryRequest extends RequestBase {
   size?: long
   slices?: long
   sort?: string[]
-  _source?: SearchGetSourceConfig
+  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   stats?: string[]
@@ -5668,7 +5672,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
   typed_keys?: boolean
   rest_total_hits_as_int?: boolean
   version?: boolean
-  _source?: SearchGetSourceConfig
+  _source?: SearchSourceConfigParam
   _source_excludes?: Fields
   _source_includes?: Fields
   seq_no_primary_term?: boolean

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -577,7 +577,7 @@ export interface MsearchMultisearchHeader {
   search_type?: SearchType
 }
 
-export interface MsearchMultisearchResponseBase<TDocument = unknown> {
+export interface MsearchMultisearchResult<TDocument = unknown> {
   took: long
   responses: MsearchResponseItem<TDocument>[]
 }
@@ -600,8 +600,7 @@ export interface MsearchRequest extends RequestBase {
 
 export type MsearchRequestItem = MsearchMultisearchHeader | MsearchMultisearchBody
 
-export interface MsearchResponse<TDocument = unknown> extends MsearchMultisearchResponseBase<TDocument> {
-}
+export type MsearchResponse<TDocument = unknown> = MsearchMultisearchResult<TDocument>
 
 export type MsearchResponseItem<TDocument = unknown> = MsearchMultiSearchResult<TDocument> | ErrorResponseBase
 
@@ -617,8 +616,7 @@ export interface MsearchTemplateRequest extends RequestBase {
 
 export type MsearchTemplateRequestItem = MsearchMultisearchHeader | MsearchTemplateTemplateConfig
 
-export interface MsearchTemplateResponse<TDocument = unknown> extends MsearchMultisearchResponseBase<TDocument> {
-}
+export type MsearchTemplateResponse<TDocument = unknown> = MsearchMultisearchResult<TDocument>
 
 export interface MsearchTemplateTemplateConfig {
   explain?: boolean

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -551,8 +551,13 @@ export interface MgetResponse<TDocument = unknown> {
 
 export type MgetResponseItem<TDocument = unknown> = GetGetResult<TDocument> | MgetMultiGetError
 
-export interface MsearchMultiSearchResult<TDocument = unknown> extends SearchResponse<TDocument> {
+export interface MsearchMultiSearchItem<TDocument = unknown> extends SearchResponse<TDocument> {
   status: integer
+}
+
+export interface MsearchMultiSearchResult<TDocument = unknown> {
+  took: long
+  responses: MsearchResponseItem<TDocument>[]
 }
 
 export interface MsearchMultisearchBody {
@@ -577,11 +582,6 @@ export interface MsearchMultisearchHeader {
   search_type?: SearchType
 }
 
-export interface MsearchMultisearchResult<TDocument = unknown> {
-  took: long
-  responses: MsearchResponseItem<TDocument>[]
-}
-
 export interface MsearchRequest extends RequestBase {
   index?: Indices
   allow_no_indices?: boolean
@@ -600,9 +600,9 @@ export interface MsearchRequest extends RequestBase {
 
 export type MsearchRequestItem = MsearchMultisearchHeader | MsearchMultisearchBody
 
-export type MsearchResponse<TDocument = unknown> = MsearchMultisearchResult<TDocument>
+export type MsearchResponse<TDocument = unknown> = MsearchMultiSearchResult<TDocument>
 
-export type MsearchResponseItem<TDocument = unknown> = MsearchMultiSearchResult<TDocument> | ErrorResponseBase
+export type MsearchResponseItem<TDocument = unknown> = MsearchMultiSearchItem<TDocument> | ErrorResponseBase
 
 export interface MsearchTemplateRequest extends RequestBase {
   index?: Indices
@@ -616,7 +616,7 @@ export interface MsearchTemplateRequest extends RequestBase {
 
 export type MsearchTemplateRequestItem = MsearchMultisearchHeader | MsearchTemplateTemplateConfig
 
-export type MsearchTemplateResponse<TDocument = unknown> = MsearchMultisearchResult<TDocument>
+export type MsearchTemplateResponse<TDocument = unknown> = MsearchMultiSearchResult<TDocument>
 
 export interface MsearchTemplateTemplateConfig {
   explain?: boolean

--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -28,7 +28,7 @@ import {
 } from '@_types/common'
 import { Time } from '@_types/Time'
 import { OperationContainer } from './types'
-import { GetSourceConfig } from '@global/search/_types/SourceFilter'
+import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name bulk
@@ -45,7 +45,7 @@ export interface Request<TSource> extends RequestBase {
     pipeline?: string
     refresh?: Refresh
     routing?: Routing
-    _source?: GetSourceConfig
+    _source?: SourceConfigParam
     _source_excludes?: Fields
     _source_includes?: Fields
     timeout?: Time

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -32,7 +32,7 @@ import { long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { Time } from '@_types/Time'
-import { GetSourceConfig } from '@global/search/_types/SourceFilter'
+import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name delete_by_query
@@ -68,7 +68,7 @@ export interface Request extends RequestBase {
     size?: long
     slices?: long
     sort?: string[]
-    _source?: GetSourceConfig
+    _source?: SourceConfigParam
     _source_excludes?: Fields
     _source_includes?: Fields
     stats?: string[]

--- a/specification/_global/exists/DocumentExistsRequest.ts
+++ b/specification/_global/exists/DocumentExistsRequest.ts
@@ -26,7 +26,7 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
-import { GetSourceConfig } from '@global/search/_types/SourceFilter'
+import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name exists
@@ -43,7 +43,7 @@ export interface Request extends RequestBase {
     realtime?: boolean
     refresh?: boolean
     routing?: Routing
-    _source?: GetSourceConfig
+    _source?: SourceConfigParam
     _source_excludes?: Fields
     _source_includes?: Fields
     stored_fields?: Fields

--- a/specification/_global/exists_source/SourceExistsRequest.ts
+++ b/specification/_global/exists_source/SourceExistsRequest.ts
@@ -27,7 +27,7 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
-import { GetSourceConfig } from '@global/search/_types/SourceFilter'
+import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name exists_source
@@ -45,7 +45,7 @@ export interface Request extends RequestBase {
     realtime?: boolean
     refresh?: boolean
     routing?: Routing
-    _source?: GetSourceConfig
+    _source?: SourceConfigParam
     _source_excludes?: Fields
     _source_includes?: Fields
     version?: VersionNumber

--- a/specification/_global/explain/ExplainRequest.ts
+++ b/specification/_global/explain/ExplainRequest.ts
@@ -20,7 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { DefaultOperator, Fields, Id, IndexName, Routing } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
-import { GetSourceConfig } from '@global/search/_types/SourceFilter'
+import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name explain
@@ -40,7 +40,7 @@ export interface Request extends RequestBase {
     lenient?: boolean
     preference?: string
     routing?: Routing
-    _source?: GetSourceConfig
+    _source?: SourceConfigParam
     _source_excludes?: Fields
     _source_includes?: Fields
     stored_fields?: Fields

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -26,7 +26,7 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
-import { GetSourceConfig } from '@global/search/_types/SourceFilter'
+import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name get
@@ -64,7 +64,7 @@ export interface Request extends RequestBase {
     /**
      * True or false to return the _source field or not, or a list of fields to return.
      */
-    _source?: GetSourceConfig
+    _source?: SourceConfigParam
     /**
      * A comma-separated list of source fields to exclude in the response.
      */

--- a/specification/_global/get/GetResponse.ts
+++ b/specification/_global/get/GetResponse.ts
@@ -19,6 +19,6 @@
 
 import { GetResult } from '@global/get/types'
 
-export class Response<TDocument> extends GetResult<TDocument> {
-  body: {}
+export class Response<TDocument> {
+  body: GetResult<TDocument>
 }

--- a/specification/_global/get/GetResponse.ts
+++ b/specification/_global/get/GetResponse.ts
@@ -17,29 +17,8 @@
  * under the License.
  */
 
-import { Dictionary } from '@spec_utils/Dictionary'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import {
-  Id,
-  IndexName,
-  SequenceNumber,
-  Type,
-  VersionNumber
-} from '@_types/common'
-import { long } from '@_types/Numeric'
+import { GetResult } from '@global/get/types'
 
-export class Response<TDocument> {
-  body: {
-    _index: IndexName
-    fields?: Dictionary<string, UserDefinedValue>
-    found: boolean
-    _id: Id
-    _primary_term?: long
-    _routing?: string
-    _seq_no?: SequenceNumber
-    _source?: TDocument
-    /** @deprecated 7.0.0 */
-    _type?: Type
-    _version?: VersionNumber
-  }
+export class Response<TDocument> extends GetResult<TDocument> {
+  body: {}
 }

--- a/specification/_global/get/types.ts
+++ b/specification/_global/get/types.ts
@@ -17,6 +17,27 @@
  * under the License.
  */
 
-import { MultisearchResponseBase } from '@global/msearch/types'
+import {
+  Id,
+  IndexName,
+  SequenceNumber,
+  Type,
+  VersionNumber
+} from '@_types/common'
+import { Dictionary } from '@spec_utils/Dictionary'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { long } from '@_types/Numeric'
 
-export class Response<TDocument> extends MultisearchResponseBase<TDocument> {}
+export class GetResult<TDocument> {
+  _index: IndexName
+  fields?: Dictionary<string, UserDefinedValue>
+  found: boolean
+  _id: Id
+  _primary_term?: long
+  _routing?: string
+  _seq_no?: SequenceNumber
+  _source?: TDocument
+  /** @deprecated 7.0.0 */
+  _type?: Type
+  _version?: VersionNumber
+}

--- a/specification/_global/get_source/SourceRequest.ts
+++ b/specification/_global/get_source/SourceRequest.ts
@@ -26,7 +26,7 @@ import {
   VersionNumber,
   VersionType
 } from '@_types/common'
-import { GetSourceConfig } from '@global/search/_types/SourceFilter'
+import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name get_source
@@ -64,7 +64,7 @@ export interface Request {
     /**
      * True or false to return the _source field or not, or a list of fields to return.
      */
-    _source?: GetSourceConfig
+    _source?: SourceConfigParam
     /**
      * A comma-separated list of source fields to exclude in the response.
      */

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -18,9 +18,9 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Fields, IndexName, Routing } from '@_types/common'
-import { MultiGetId, Operation } from './types'
-import { GetSourceConfig } from '@global/search/_types/SourceFilter'
+import { Fields, Ids, IndexName, Routing } from '@_types/common'
+import { Operation } from './types'
+import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name mget
@@ -37,13 +37,13 @@ export interface Request extends RequestBase {
     realtime?: boolean // default: true
     refresh?: boolean // default: false
     routing?: Routing
-    _source?: GetSourceConfig
+    _source?: SourceConfigParam
     _source_excludes?: Fields
     _source_includes?: Fields
     stored_fields?: Fields
   }
   body: {
     docs?: Operation[]
-    ids?: MultiGetId[]
+    ids?: Ids
   }
 }

--- a/specification/_global/mget/MultiGetResponse.ts
+++ b/specification/_global/mget/MultiGetResponse.ts
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-import { Hit } from './types'
+import { ResponseItem } from './types'
 
 export class Response<TDocument> {
   body: {
-    docs: Hit<TDocument>[]
+    docs: ResponseItem<TDocument>[]
   }
 }

--- a/specification/_global/mget/types.ts
+++ b/specification/_global/mget/types.ts
@@ -18,23 +18,20 @@
  */
 
 import { SourceConfig } from '@global/search/_types/SourceFilter'
-import { Dictionary } from '@spec_utils/Dictionary'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import {
   Fields,
   Id,
   IndexName,
   Routing,
-  SequenceNumber,
   Type,
   VersionNumber,
   VersionType
 } from '@_types/common'
 import { ErrorCause } from '@_types/Errors'
-import { integer, long } from '@_types/Numeric'
+import { GetResult } from '@global/get/types'
 
 export class Operation {
-  _id: MultiGetId
+  _id: Id
   _index?: IndexName
   routing?: Routing
   _source?: SourceConfig
@@ -44,18 +41,15 @@ export class Operation {
   version_type?: VersionType
 }
 
-export type MultiGetId = string | integer
+/**
+ * @codegen_names result, failure
+ */
+export type ResponseItem<TDocument> = GetResult<TDocument> | MultiGetError
 
-export class Hit<TDocument> {
-  error?: ErrorCause
-  fields?: Dictionary<string, UserDefinedValue>
-  found?: boolean
+export class MultiGetError {
+  error: ErrorCause
   _id: Id
   _index: IndexName
-  _primary_term?: long
-  _routing?: Routing
-  _seq_no?: SequenceNumber
-  _source?: TDocument
+  /** @deprecated 7.0.0 */
   _type?: Type
-  _version?: VersionNumber
 }

--- a/specification/_global/msearch/MultiSearchRequest.ts
+++ b/specification/_global/msearch/MultiSearchRequest.ts
@@ -20,7 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, Indices, SearchType } from '@_types/common'
 import { long } from '@_types/Numeric'
-import { Body, Header } from './types'
+import { MultisearchBody, MultisearchHeader, RequestItem } from './types'
 
 /**
  * @rest_spec_name msearch
@@ -87,5 +87,5 @@ export interface Request extends RequestBase {
     typed_keys?: boolean
   }
   /** @codegen_name searches */
-  body?: Array<Header | Body>
+  body?: Array<RequestItem>
 }

--- a/specification/_global/msearch/MultiSearchResponse.ts
+++ b/specification/_global/msearch/MultiSearchResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { MultisearchResult } from '@global/msearch/types'
+import { MultiSearchResult } from '@global/msearch/types'
 
 export class Response<TDocument> {
-  body: MultisearchResult<TDocument>
+  body: MultiSearchResult<TDocument>
 }

--- a/specification/_global/msearch/MultiSearchResponse.ts
+++ b/specification/_global/msearch/MultiSearchResponse.ts
@@ -17,6 +17,8 @@
  * under the License.
  */
 
-import { MultisearchResponseBase } from '@global/msearch/types'
+import { MultisearchResult } from '@global/msearch/types'
 
-export class Response<TDocument> extends MultisearchResponseBase<TDocument> {}
+export class Response<TDocument> {
+  body: MultisearchResult<TDocument>
+}

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -22,15 +22,21 @@ import { Suggester } from '@global/search/_types/suggester'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import { ExpandWildcards, Indices, SearchType } from '@_types/common'
-import { integer } from '@_types/Numeric'
+import { integer, long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Response as SearchResponse } from '@global/search/SearchResponse'
 import { TrackHits } from '@global/search/_types/hits'
+import { ErrorResponseBase } from '@_types/Base'
+
+/**
+ * @codegen_names header, body
+ */
+export type RequestItem = MultisearchHeader | MultisearchBody
 
 /**
  * Contains parameters used to limit or change the subsequent search body request.
  */
-export class Header {
+export class MultisearchHeader {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
@@ -41,7 +47,7 @@ export class Header {
   search_type?: SearchType
 }
 
-export class Body {
+export class MultisearchBody {
   /** @aliases aggs */
   aggregations?: Dictionary<string, AggregationContainer>
   query?: QueryContainer
@@ -52,6 +58,16 @@ export class Body {
   suggest?: Suggester
 }
 
-export class SearchResult<TDocument> extends SearchResponse<TDocument> {
+export class MultisearchResponseBase<TDocument> {
+  took: long
+  responses: Array<ResponseItem<TDocument>>
+}
+
+/** @codegen_names result, failure */
+export type ResponseItem<TDocument> =
+  | MultiSearchResult<TDocument>
+  | ErrorResponseBase
+
+export class MultiSearchResult<TDocument> extends SearchResponse<TDocument> {
   status: integer
 }

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -58,7 +58,7 @@ export class MultisearchBody {
   suggest?: Suggester
 }
 
-export class MultisearchResponseBase<TDocument> {
+export class MultisearchResult<TDocument> {
   took: long
   responses: Array<ResponseItem<TDocument>>
 }

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -58,16 +58,16 @@ export class MultisearchBody {
   suggest?: Suggester
 }
 
-export class MultisearchResult<TDocument> {
+export class MultiSearchResult<TDocument> {
   took: long
   responses: Array<ResponseItem<TDocument>>
 }
 
 /** @codegen_names result, failure */
 export type ResponseItem<TDocument> =
-  | MultiSearchResult<TDocument>
+  | MultiSearchItem<TDocument>
   | ErrorResponseBase
 
-export class MultiSearchResult<TDocument> extends SearchResponse<TDocument> {
+export class MultiSearchItem<TDocument> extends SearchResponse<TDocument> {
   status: integer
 }

--- a/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
@@ -20,7 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { Indices, SearchType } from '@_types/common'
 import { long } from '@_types/Numeric'
-import { TemplateItem } from './types'
+import { RequestItem } from './types'
 
 /**
  * @rest_spec_name msearch_template
@@ -40,5 +40,5 @@ export interface Request extends RequestBase {
     typed_keys?: boolean
   }
   /** @codegen_name search_templates */
-  body: Array<TemplateItem>
+  body: Array<RequestItem>
 }

--- a/specification/_global/msearch_template/MultiSearchTemplateResponse.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateResponse.ts
@@ -17,13 +17,6 @@
  * under the License.
  */
 
-import { Response as SearchResponse } from '@global/search/SearchResponse'
-import { ErrorResponseBase } from '@_types/Base'
-import { long } from '@_types/Numeric'
+import { MultisearchResponseBase } from '@global/msearch/types'
 
-export class Response<TDocument> {
-  body: {
-    responses: Array<SearchResponse<TDocument> | ErrorResponseBase>
-    took: long
-  }
-}
+export class Response<TDocument> extends MultisearchResponseBase<TDocument> {}

--- a/specification/_global/msearch_template/MultiSearchTemplateResponse.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { MultisearchResult } from '@global/msearch/types'
+import { MultiSearchResult } from '@global/msearch/types'
 
 export class Response<TDocument> {
-  body: MultisearchResult<TDocument>
+  body: MultiSearchResult<TDocument>
 }

--- a/specification/_global/msearch_template/MultiSearchTemplateResponse.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateResponse.ts
@@ -17,6 +17,8 @@
  * under the License.
  */
 
-import { MultisearchResponseBase } from '@global/msearch/types'
+import { MultisearchResult } from '@global/msearch/types'
 
-export class Response<TDocument> extends MultisearchResponseBase<TDocument> {}
+export class Response<TDocument> {
+  body: MultisearchResult<TDocument>
+}

--- a/specification/_global/msearch_template/types.ts
+++ b/specification/_global/msearch_template/types.ts
@@ -19,11 +19,27 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { Id, Indices } from '@_types/common'
+import { Id } from '@_types/common'
+import { MultisearchHeader } from '@global/msearch/types'
 
-export class TemplateItem {
+/** @codegen_names header, body */
+export type RequestItem = MultisearchHeader | TemplateConfig
+
+export class TemplateConfig {
+  /** @server_default false */
+  explain?: boolean
+  /**
+   * ID of the search template to use. If no source is specified,
+   * this parameter is required.
+   */
   id?: Id
-  index?: Indices
   params?: Dictionary<string, UserDefinedValue>
+  /** @server_default false */
+  profile?: boolean
+  /**
+   * An inline search template. Supports the same parameters as the search API's
+   * request body. Also supports Mustache variables. If no id is specified, this
+   * parameter is required.
+   */
   source?: string
 }

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -43,7 +43,7 @@ import { Highlight } from './_types/highlighting'
 import { PointInTimeReference } from './_types/PointInTimeReference'
 import { Rescore } from './_types/rescoring'
 import { Sort, SortResults } from './_types/sort'
-import { GetSourceConfig, SourceConfig } from './_types/SourceFilter'
+import { SourceConfigParam, SourceConfig } from './_types/SourceFilter'
 import { Suggester } from './_types/suggester'
 import { TrackHits } from '@global/search/_types/hits'
 
@@ -98,7 +98,7 @@ export interface Request extends RequestBase {
     typed_keys?: boolean
     rest_total_hits_as_int?: boolean
     version?: boolean
-    _source?: GetSourceConfig
+    _source?: SourceConfigParam
     _source_excludes?: Fields
     _source_includes?: Fields
     seq_no_primary_term?: boolean

--- a/specification/_global/search/_types/SourceFilter.ts
+++ b/specification/_global/search/_types/SourceFilter.ts
@@ -36,5 +36,10 @@ export class SourceFilter {
  */
 export type SourceConfig = boolean | SourceFilter
 
-/** @codegen_names fetch, fields */
-export type GetSourceConfig = boolean | Fields
+/**
+ * Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.
+ * Used as a query parameter along with the `_source_includes` and `_source_excludes` parameters.
+ *
+ * @codegen_names fetch, fields
+ */
+export type SourceConfigParam = boolean | Fields

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import {
-  GetSourceConfig,
+  SourceConfigParam,
   SourceConfig
 } from '@global/search/_types/SourceFilter'
 import { RequestBase } from '@_types/Base'
@@ -101,7 +101,7 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
      * list of the fields you want to retrieve.
      * @server_default true
      */
-    _source?: GetSourceConfig
+    _source?: SourceConfigParam
     /**
      * Specify the source fields you want to exclude.
      */

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -33,7 +33,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Script } from '@_types/Scripting'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { Time } from '@_types/Time'
-import { GetSourceConfig } from '@global/search/_types/SourceFilter'
+import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name update_by_query
@@ -68,7 +68,7 @@ export interface Request extends RequestBase {
     size?: long
     slices?: long
     sort?: string[]
-    _source?: GetSourceConfig
+    _source?: SourceConfigParam
     _source_excludes?: Fields
     _source_includes?: Fields
     stats?: string[]

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -44,7 +44,7 @@ import { PointInTimeReference } from '@global/search/_types/PointInTimeReference
 import { Rescore } from '@global/search/_types/rescoring'
 import { Sort, SortResults } from '@global/search/_types/sort'
 import {
-  GetSourceConfig,
+  SourceConfigParam,
   SourceConfig
 } from '@global/search/_types/SourceFilter'
 import { Suggester } from '@global/search/_types/suggester'
@@ -108,7 +108,7 @@ export interface Request extends RequestBase {
     typed_keys?: boolean
     rest_total_hits_as_int?: boolean
     version?: boolean
-    _source?: GetSourceConfig
+    _source?: SourceConfigParam
     _source_excludes?: Fields
     _source_includes?: Fields
     seq_no_primary_term?: boolean


### PR DESCRIPTION
Refactor and fix the `Multi{Search|Get|TemplateSearch}` APIs:
* fix some definitions that were not correct
* introduce unions to distiguish the header and body parts of ndjson requests
* reuse types between APIs when possible.
