### PR TITLE
Generate Id as string|number in TypeScript

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2063,7 +2063,7 @@ export type Host = string
 
 export type HttpHeaders = Record<string, string | string[]>
 
-export type Id = string
+export type Id = string | number
 
 export type Ids = Id | Id[]
 

--- a/typescript-generator/index.ts
+++ b/typescript-generator/index.ts
@@ -425,6 +425,10 @@ function buildEnum (type: M.Enum): string {
 }
 
 function buildTypeAlias (type: M.TypeAlias): string {
+  // A lot of yaml tests use numbers for document ids, even if it really should be a string
+  if (type.name.name === 'Id' && type.name.namespace === '_types') {
+    return 'export type Id = string | number\n'
+  }
   const openGenerics = type.generics?.map(t => t.name) ?? []
   return `export type ${createName(type.name)}${buildGenerics(type.generics)} = ${buildValue(type.type, openGenerics)}\n`
 }


### PR DESCRIPTION
This PR updates the TypeScript generator to produce `type Id = string | number`. Although document ids are strings, a lot of yaml tests use numbers as test document identifiers, which yaml returns as... well... numbers, and cause a number of API validations to fail.

With this change numbers are accepted for document id, which allows many more validation tests to pass. 
