### PR TITLE
Add missing request body detail for ML get APIs

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -114937,7 +114937,48 @@
         "CommonQueryParameters"
       ],
       "body": {
-        "kind": "no_body"
+        "kind": "properties",
+        "properties": [
+          {
+            "description": "Refer to the description for the `allow_no_match` query parameter.",
+            "name": "allow_no_match",
+            "required": false,
+            "serverDefault": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "Refer to the descriptiion for the `force` query parameter.",
+            "name": "force",
+            "required": false,
+            "serverDefault": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "Refer to the description for the `timeout` query parameter.",
+            "name": "timeout",
+            "required": false,
+            "serverDefault": "30m",
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Time",
+                "namespace": "_types"
+              }
+            }
+          }
+        ]
       },
       "description": "Closes one or more anomaly detection jobs.\nA job can be opened and closed multiple times throughout its lifecycle. A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results.\nWhen you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data.\nIf you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request.\nWhen a datafeed that has a specified end date stops, it automatically closes its associated job.",
       "inherits": {
@@ -120188,7 +120229,7 @@
         "kind": "properties",
         "properties": [
           {
-            "description": "Controls the time to wait until a job has opened.",
+            "description": "Refer to the description for the `timeout` query parameter.",
             "name": "timeout",
             "required": false,
             "serverDefault": "30m",
@@ -120228,7 +120269,21 @@
           }
         }
       ],
-      "query": []
+      "query": [
+        {
+          "description": "Controls the time to wait until a job has opened.",
+          "name": "timeout",
+          "required": false,
+          "serverDefault": "30m",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
     },
     {
       "body": {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -119100,7 +119100,108 @@
         "CommonQueryParameters"
       ],
       "body": {
-        "kind": "no_body"
+        "kind": "properties",
+        "properties": [
+          {
+            "description": "Refer to the description for the `allow_no_match` query parameter.",
+            "name": "allow_no_match",
+            "required": false,
+            "serverDefault": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "Refer to the description for the `bucket_span` query parameter.",
+            "name": "bucket_span",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Time",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "description": "Refer to the description for the `end` query parameter.",
+            "name": "end",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Time",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "description": "Refer to the description for the `exclude_interim` query parameter.",
+            "name": "exclude_interim",
+            "required": false,
+            "serverDefault": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "Refer to the description for the `overall_score` query parameter.",
+            "name": "overall_score",
+            "required": false,
+            "type": {
+              "items": [
+                {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "double",
+                    "namespace": "_types"
+                  }
+                },
+                {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "string",
+                    "namespace": "internal"
+                  }
+                }
+              ],
+              "kind": "union_of"
+            }
+          },
+          {
+            "description": "Refer to the description for the `start` query parameter.",
+            "name": "start",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Time",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "description": "Refer to the description for the `top_n` query parameter.",
+            "name": "top_n",
+            "required": false,
+            "serverDefault": 1,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
+            }
+          }
+        ]
       },
       "description": "Retrieves overall bucket results that summarize the bucket results of\nmultiple anomaly detection jobs.\n\nThe `overall_score` is calculated by combining the scores of all the\nbuckets within the overall bucket span. First, the maximum\n`anomaly_score` per anomaly detection job in the overall bucket is\ncalculated. Then the `top_n` of those scores are averaged to result in\nthe `overall_score`. This means that you can fine-tune the\n`overall_score` so that it is more or less sensitive to the number of\njobs that detect an anomaly at the same time. For example, if you set\n`top_n` to `1`, the `overall_score` is the maximum bucket score in the\noverall bucket. Alternatively, if you set `top_n` to the number of jobs,\nthe `overall_score` is high only when all jobs detect anomalies in that\noverall bucket. If you set the `bucket_span` parameter (to a value\ngreater than its default), the `overall_score` is the maximum\n`overall_score` of the overall buckets that have a span equal to the\njobs' largest bucket span.",
       "inherits": {
@@ -119276,7 +119377,7 @@
         "kind": "properties",
         "properties": [
           {
-            "description": "If true, the results are sorted in descending order.",
+            "description": "Refer to the description for the `desc` query parameter.",
             "name": "desc",
             "required": false,
             "serverDefault": false,
@@ -119289,7 +119390,20 @@
             }
           },
           {
-            "description": "If true, the output excludes interim results.",
+            "description": "Refer to the description for the `end` query parameter.",
+            "name": "end",
+            "required": false,
+            "serverDefault": "-1",
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "DateString",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
+            "description": "Refer to the description for the `exclude_interim` query parameter.",
             "name": "exclude_interim",
             "required": false,
             "serverDefault": false,
@@ -119313,7 +119427,7 @@
             }
           },
           {
-            "description": "Returns records with anomaly scores greater or equal than this value.",
+            "description": "Refer to the description for the `record_score` query parameter.",
             "name": "record_score",
             "required": false,
             "serverDefault": 0,
@@ -119326,7 +119440,7 @@
             }
           },
           {
-            "description": "Specifies the sort field for the requested records.",
+            "description": "Refer to the description for the `sort` query parameter.",
             "name": "sort",
             "required": false,
             "serverDefault": "record_score",
@@ -119339,21 +119453,8 @@
             }
           },
           {
-            "description": "Returns records with timestamps earlier than this time. The default value\nmeans results are not limited to specific timestamps.",
+            "description": "Refer to the description for the `start` query parameter.",
             "name": "start",
-            "required": false,
-            "serverDefault": "-1",
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "DateString",
-                "namespace": "_types"
-              }
-            }
-          },
-          {
-            "description": "Returns records with timestamps earlier than this time. The default value\nmeans results are not limited to specific timestamps.",
-            "name": "end",
             "required": false,
             "serverDefault": "-1",
             "type": {
@@ -119394,6 +119495,32 @@
       ],
       "query": [
         {
+          "description": "If true, the results are sorted in descending order.",
+          "name": "desc",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "Returns records with timestamps earlier than this time. The default value\nmeans results are not limited to specific timestamps.",
+          "name": "end",
+          "required": false,
+          "serverDefault": "-1",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "description": "If `true`, the output excludes interim results.",
           "name": "exclude_interim",
           "required": false,
@@ -119420,6 +119547,19 @@
           }
         },
         {
+          "description": "Returns records with anomaly scores greater or equal than this value.",
+          "name": "record_score",
+          "required": false,
+          "serverDefault": 0,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "description": "Specifies the maximum number of records to obtain.",
           "name": "size",
           "required": false,
@@ -119433,21 +119573,21 @@
           }
         },
         {
-          "description": "Returns records with timestamps after this time. The default value means\nresults are not limited to specific timestamps.",
-          "name": "start",
+          "description": "Specifies the sort field for the requested records.",
+          "name": "sort",
           "required": false,
-          "serverDefault": "-1",
+          "serverDefault": "record_score",
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "DateString",
+              "name": "Field",
               "namespace": "_types"
             }
           }
         },
         {
-          "description": "Returns records with timestamps earlier than this time. The default value\nmeans results are not limited to specific timestamps.",
-          "name": "end",
+          "description": "Returns records with timestamps after this time. The default value means\nresults are not limited to specific timestamps.",
+          "name": "start",
           "required": false,
           "serverDefault": "-1",
           "type": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1286,14 +1286,6 @@
       ],
       "response": []
     },
-    "ml.get_records": {
-      "request": [
-        "Request: missing json spec query parameter 'record_score'",
-        "Request: missing json spec query parameter 'sort'",
-        "Request: missing json spec query parameter 'desc'"
-      ],
-      "response": []
-    },
     "ml.get_trained_models": {
       "request": [
         "Request: missing json spec query parameter 'include_model_definition'",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11698,6 +11698,11 @@ export interface MlCloseJobRequest extends RequestBase {
   allow_no_match?: boolean
   force?: boolean
   timeout?: Time
+  body?: {
+    allow_no_match?: boolean
+    force?: boolean
+    timeout?: Time
+  }
 }
 
 export interface MlCloseJobResponse {
@@ -12291,6 +12296,7 @@ export interface MlInfoResponse {
 
 export interface MlOpenJobRequest extends RequestBase {
   job_id: Id
+  timeout?: Time
   body?: {
     timeout?: Time
   }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12181,6 +12181,15 @@ export interface MlGetOverallBucketsRequest extends RequestBase {
   overall_score?: double | string
   start?: Time
   top_n?: integer
+  body?: {
+    allow_no_match?: boolean
+    bucket_span?: Time
+    end?: Time
+    exclude_interim?: boolean
+    overall_score?: double | string
+    start?: Time
+    top_n?: integer
+  }
 }
 
 export interface MlGetOverallBucketsResponse {
@@ -12190,19 +12199,22 @@ export interface MlGetOverallBucketsResponse {
 
 export interface MlGetRecordsRequest extends RequestBase {
   job_id: Id
+  desc?: boolean
+  end?: DateString
   exclude_interim?: boolean
   from?: integer
+  record_score?: double
   size?: integer
+  sort?: Field
   start?: DateString
-  end?: DateString
   body?: {
     desc?: boolean
+    end?: DateString
     exclude_interim?: boolean
     page?: MlPage
     record_score?: double
     sort?: Field
     start?: DateString
-    end?: DateString
   }
 }
 

--- a/specification/ml/close_job/MlCloseJobRequest.ts
+++ b/specification/ml/close_job/MlCloseJobRequest.ts
@@ -57,4 +57,20 @@ export interface Request extends RequestBase {
      * @server_default 30m */
     timeout?: Time
   }
+  body: {
+    /**
+     * Refer to the description for the `allow_no_match` query parameter.
+     * @server_default true
+     */
+    allow_no_match?: boolean
+    /**
+     * Refer to the descriptiion for the `force` query parameter.
+     * @server_default false
+     */
+    force?: boolean
+    /**
+     * Refer to the description for the `timeout` query parameter.
+     * @server_default 30m */
+    timeout?: Time
+  }
 }

--- a/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
+++ b/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { Page } from '@ml/_types/Page'
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
@@ -48,6 +49,15 @@ export interface Request extends RequestBase {
      */
     size?: integer
     /** Specifies to get events with timestamps after this time. */
+    start?: string
+  }
+  body: {
+    /** Refer to the description for the `end` query parameter. */
+    end?: DateString
+    /** Refer to the description for the `job_id` query parameter. */
+    job_id?: Id
+    page?: Page
+    /** Refer to the description for the `start` query parameter. */
     start?: string
   }
 }

--- a/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
+++ b/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { Page } from '@ml/_types/Page'
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
@@ -49,15 +48,6 @@ export interface Request extends RequestBase {
      */
     size?: integer
     /** Specifies to get events with timestamps after this time. */
-    start?: string
-  }
-  body: {
-    /** Refer to the description for the `end` query parameter. */
-    end?: DateString
-    /** Refer to the description for the `job_id` query parameter. */
-    job_id?: Id
-    page?: Page
-    /** Refer to the description for the `start` query parameter. */
     start?: string
   }
 }

--- a/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
+++ b/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
@@ -125,11 +125,11 @@ export interface Request extends RequestBase {
      * Refer to the description for the `exclude_interim` query parameter.
      * @server_default false
      */
-     exclude_interim?: boolean
+    exclude_interim?: boolean
     /**
      * Refer to the description for the `overall_score` query parameter.
      */
-     overall_score?: double | string
+    overall_score?: double | string
     /**
      * Refer to the description for the `start` query parameter.
      */

--- a/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
+++ b/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
@@ -107,4 +107,37 @@ export interface Request extends RequestBase {
      */
     top_n?: integer
   }
+  body: {
+    /**
+     * Refer to the description for the `allow_no_match` query parameter.
+     * @server_default true
+     */
+    allow_no_match?: boolean
+    /**
+     * Refer to the description for the `bucket_span` query parameter.
+     */
+    bucket_span?: Time
+    /**
+     * Refer to the description for the `end` query parameter.
+     */
+    end?: Time
+    /**
+     * Refer to the description for the `exclude_interim` query parameter.
+     * @server_default false
+     */
+     exclude_interim?: boolean
+    /**
+     * Refer to the description for the `overall_score` query parameter.
+     */
+     overall_score?: double | string
+    /**
+     * Refer to the description for the `start` query parameter.
+     */
+    start?: Time
+    /**
+     * Refer to the description for the `top_n` query parameter.
+     * @server_default 1
+     */
+    top_n?: integer
+  }
 }

--- a/specification/ml/get_records/MlGetAnomalyRecordsRequest.ts
+++ b/specification/ml/get_records/MlGetAnomalyRecordsRequest.ts
@@ -49,6 +49,17 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
+     * If true, the results are sorted in descending order.
+     * @server_default false
+     */
+     desc?: boolean    
+    /**
+     * Returns records with timestamps earlier than this time. The default value
+     * means results are not limited to specific timestamps.
+     * @server_default -1
+     */
+    end?: DateString
+    /**
      * If `true`, the output excludes interim results.
      * @server_default false
      */
@@ -59,56 +70,58 @@ export interface Request extends RequestBase {
      */
     from?: integer
     /**
+     * Returns records with anomaly scores greater or equal than this value.
+     * @server_default 0.0
+     */
+    record_score?: double
+    /**
      * Specifies the maximum number of records to obtain.
      * @server_default 100
      */
     size?: integer
+    /**
+     * Specifies the sort field for the requested records.
+     * @server_default record_score
+     */
+     sort?: Field
     /**
      * Returns records with timestamps after this time. The default value means
      * results are not limited to specific timestamps.
      * @server_default -1
      */
     start?: DateString
-    /**
-     * Returns records with timestamps earlier than this time. The default value
-     * means results are not limited to specific timestamps.
-     * @server_default -1
-     */
-    end?: DateString
   }
   body: {
     /**
-     * If true, the results are sorted in descending order.
+     * Refer to the description for the `desc` query parameter.
      * @server_default false
      */
     desc?: boolean
     /**
-     * If true, the output excludes interim results.
+     * Refer to the description for the `end` query parameter.
+     * @server_default -1
+     */
+     end?: DateString
+    /**
+     * Refer to the description for the `exclude_interim` query parameter.
      * @server_default false
      */
     exclude_interim?: boolean
     page?: Page
     /**
-     * Returns records with anomaly scores greater or equal than this value.
+     * Refer to the description for the `record_score` query parameter.
      * @server_default 0.0
      */
-    record_score?: double
+     record_score?: double
     /**
-     * Specifies the sort field for the requested records.
+     * Refer to the description for the `sort` query parameter.
      * @server_default record_score
      */
     sort?: Field
     /**
-     * Returns records with timestamps earlier than this time. The default value
-     * means results are not limited to specific timestamps.
+     * Refer to the description for the `start` query parameter.
      * @server_default -1
      */
     start?: DateString
-    /**
-     * Returns records with timestamps earlier than this time. The default value
-     * means results are not limited to specific timestamps.
-     * @server_default -1
-     */
-    end?: DateString
   }
 }

--- a/specification/ml/get_records/MlGetAnomalyRecordsRequest.ts
+++ b/specification/ml/get_records/MlGetAnomalyRecordsRequest.ts
@@ -52,7 +52,7 @@ export interface Request extends RequestBase {
      * If true, the results are sorted in descending order.
      * @server_default false
      */
-     desc?: boolean    
+    desc?: boolean
     /**
      * Returns records with timestamps earlier than this time. The default value
      * means results are not limited to specific timestamps.
@@ -83,7 +83,7 @@ export interface Request extends RequestBase {
      * Specifies the sort field for the requested records.
      * @server_default record_score
      */
-     sort?: Field
+    sort?: Field
     /**
      * Returns records with timestamps after this time. The default value means
      * results are not limited to specific timestamps.
@@ -101,7 +101,7 @@ export interface Request extends RequestBase {
      * Refer to the description for the `end` query parameter.
      * @server_default -1
      */
-     end?: DateString
+    end?: DateString
     /**
      * Refer to the description for the `exclude_interim` query parameter.
      * @server_default false
@@ -112,7 +112,7 @@ export interface Request extends RequestBase {
      * Refer to the description for the `record_score` query parameter.
      * @server_default 0.0
      */
-     record_score?: double
+    record_score?: double
     /**
      * Refer to the description for the `sort` query parameter.
      * @server_default record_score

--- a/specification/ml/open_job/MlOpenJobRequest.ts
+++ b/specification/ml/open_job/MlOpenJobRequest.ts
@@ -42,9 +42,16 @@ export interface Request extends RequestBase {
      */
     job_id: Id
   }
-  body: {
+  query_parameters: {
     /**
      * Controls the time to wait until a job has opened.
+     * @server_default 30m
+     */
+    timeout?: Time
+  }
+  body: {
+    /**
+     * Refer to the description for the `timeout` query parameter.
      * @server_default 30m
      */
     timeout?: Time


### PR DESCRIPTION
This PR adds missing details for the ML get calendar events, get overall buckets, and get records API.