### PR TITLE
Add query parameters for revert model API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -121642,9 +121642,10 @@
       ],
       "query": [
         {
-          "description": "Ignore if the source indices expressions resolves to no concrete indices (default: true)",
+          "description": "If true, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the `_all`\nstring or when no indices are specified.",
           "name": "allow_no_indices",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -121654,9 +121655,10 @@
           }
         },
         {
-          "description": "Whether source index expressions should get expanded to open or closed indices (default: open)",
+          "description": "Type of index that wildcard patterns can match. If the request can target data streams, this argument determines\nwhether wildcard expressions match hidden data streams. Supports comma-separated values.",
           "name": "expand_wildcards",
           "required": false,
+          "serverDefault": "open",
           "type": {
             "kind": "instance_of",
             "type": {
@@ -121666,9 +121668,14 @@
           }
         },
         {
-          "description": "Ignore indices that are marked as throttled (default: true)",
+          "deprecation": {
+            "description": "",
+            "version": "7.16.0"
+          },
+          "description": "If true, concrete, expanded, or aliased indices are ignored when frozen.",
           "name": "ignore_throttled",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -121678,9 +121685,10 @@
           }
         },
         {
-          "description": "Ignore unavailable indexes (default: false)",
+          "description": "If true, unavailable indices (missing or closed) are ignored.",
           "name": "ignore_unavailable",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -123376,7 +123384,7 @@
         "kind": "properties",
         "properties": [
           {
-            "description": "If true, deletes the results in the time period between the latest\nresults and the time of the reverted snapshot. It also resets the model\nto accept records for this time period. If you choose not to delete\nintervening results when reverting a snapshot, the job will not accept\ninput data that is older than the current time. If you want to resend\ndata, then delete the intervening results.",
+            "description": "Refer to the description for the `delete_intervening_results` query parameter.",
             "name": "delete_intervening_results",
             "required": false,
             "serverDefault": false,
@@ -123428,7 +123436,21 @@
           }
         }
       ],
-      "query": []
+      "query": [
+        {
+          "description": "If true, deletes the results in the time period between the latest\nresults and the time of the reverted snapshot. It also resets the model\nto accept records for this time period. If you choose not to delete\nintervening results when reverting a snapshot, the job will not accept\ninput data that is older than the current time. If you want to resend\ndata, then delete the intervening results.",
+          "name": "delete_intervening_results",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
     },
     {
       "body": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1359,12 +1359,6 @@
       ],
       "response": []
     },
-    "ml.revert_model_snapshot": {
-      "request": [
-        "Request: missing json spec query parameter 'delete_intervening_results'"
-      ],
-      "response": []
-    },
     "ml.set_upgrade_mode": {
       "request": [
         "Request: should not have a body"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12641,6 +12641,7 @@ export interface MlResetJobResponse extends AcknowledgedResponseBase {
 export interface MlRevertModelSnapshotRequest extends RequestBase {
   job_id: Id
   snapshot_id: Id
+  delete_intervening_results?: boolean
   body?: {
     delete_intervening_results?: boolean
   }

--- a/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
@@ -59,9 +59,28 @@ export interface Request extends RequestBase {
     datafeed_id: Id
   }
   query_parameters: {
+    /**
+     * If true, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the `_all`
+     * string or when no indices are specified.
+     * @server_default true
+     */
     allow_no_indices?: boolean
+    /**
+     * Type of index that wildcard patterns can match. If the request can target data streams, this argument determines
+     * whether wildcard expressions match hidden data streams. Supports comma-separated values.
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards
+    /**
+     * If true, concrete, expanded, or aliased indices are ignored when frozen.
+     * @server_default true
+     * @deprecated 7.16.0
+     */
     ignore_throttled?: boolean
+    /**
+     * If true, unavailable indices (missing or closed) are ignored.
+     * @server_default false
+     */
     ignore_unavailable?: boolean
   }
   body: {

--- a/specification/ml/revert_model_snapshot/MlRevertModelSnapshotRequest.ts
+++ b/specification/ml/revert_model_snapshot/MlRevertModelSnapshotRequest.ts
@@ -47,7 +47,7 @@ export interface Request extends RequestBase {
      */
     snapshot_id: Id
   }
-  body: {
+  query_parameters: {
     /**
      * If true, deletes the results in the time period between the latest
      * results and the time of the reverted snapshot. It also resets the model
@@ -55,6 +55,13 @@ export interface Request extends RequestBase {
      * intervening results when reverting a snapshot, the job will not accept
      * input data that is older than the current time. If you want to resend
      * data, then delete the intervening results.
+     * @server_default false
+     */
+    delete_intervening_results?: boolean
+  }
+  body: {
+    /**
+     * Refer to the description for the `delete_intervening_results` query parameter.
      * @server_default false
      */
     delete_intervening_results?: boolean


### PR DESCRIPTION
This PR adds missing query parameters for the ML revert model snapshot API and missing descriptions for the create datafeeds API.
