### PR TITLE
Add missing TermVectorOption enum member

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -56551,6 +56551,9 @@
         },
         {
           "name": "with_positions_offsets_payloads"
+        },
+        {
+          "name": "with_positions_payloads"
         }
       ],
       "name": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4756,7 +4756,7 @@ export interface MappingSuggestContext {
   precision?: integer | string
 }
 
-export type MappingTermVectorOption = 'no' | 'yes' | 'with_offsets' | 'with_positions' | 'with_positions_offsets' | 'with_positions_offsets_payloads'
+export type MappingTermVectorOption = 'no' | 'yes' | 'with_offsets' | 'with_positions' | 'with_positions_offsets' | 'with_positions_offsets_payloads' | 'with_positions_payloads'
 
 export interface MappingTextIndexPrefixes {
   max_chars: integer

--- a/specification/_types/mapping/TermVectorOption.ts
+++ b/specification/_types/mapping/TermVectorOption.ts
@@ -18,10 +18,11 @@
  */
 
 export enum TermVectorOption {
-  no = 0,
-  yes = 1,
-  with_offsets = 2,
-  with_positions = 3,
-  with_positions_offsets = 4,
-  with_positions_offsets_payloads = 5
+  no,
+  yes,
+  with_offsets,
+  with_positions,
+  with_positions_offsets,
+  with_positions_offsets_payloads,
+  with_positions_payloads
 }


### PR DESCRIPTION
Adds `with_positions_payloads` to `TermVectorOption`.

Reported by @sothawo in https://github.com/elastic/elasticsearch-java/issues/48