### PR TITLE
Adds ML put model definition part API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -7681,9 +7681,21 @@
       "description": "Creates part of a trained model definition",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-model-definition-part.html",
       "name": "ml.put_trained_model_definition_part",
-      "request": null,
+      "privileges": {
+        "cluster": [
+          "manage_ml"
+        ]
+      },
+      "request": {
+        "name": "Request",
+        "namespace": "ml.put_trained_model_definition_part"
+      },
       "requestBodyRequired": true,
-      "response": null,
+      "response": {
+        "name": "Response",
+        "namespace": "ml.put_trained_model_definition_part"
+      },
+      "since": "8.0.0",
       "stability": "experimental",
       "urls": [
         {
@@ -123442,6 +123454,108 @@
       "name": {
         "name": "Response",
         "namespace": "ml.put_trained_model_alias"
+      }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "description": "The definition part for the model. Must be a base64 encoded string.",
+            "name": "definition",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "The total uncompressed definition length in bytes. Not base64 encoded.",
+            "name": "total_definition_length",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "number",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "The total number of parts that will be uploaded. Must be greater than 0.",
+            "name": "total_parts",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "number",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
+      },
+      "description": "Creates part of a trained model definition.",
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "request",
+      "name": {
+        "name": "Request",
+        "namespace": "ml.put_trained_model_definition_part"
+      },
+      "path": [
+        {
+          "description": "The unique identifier of the trained model.",
+          "name": "model_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The definition part number. When the definition is loaded for inference the definition parts are streamed in the\norder of their part number. The first part must be `0` and the final part must be `total_parts - 1`.",
+          "name": "part",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "query": []
+    },
+    {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "response",
+      "name": {
+        "name": "Response",
+        "namespace": "ml.put_trained_model_definition_part"
       }
     },
     {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1346,12 +1346,6 @@
       ],
       "response": []
     },
-    "ml.put_trained_model_definition_part": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "ml.put_trained_model_vocabulary": {
       "request": [
         "Missing request & response"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12635,6 +12635,19 @@ export interface MlPutTrainedModelAliasRequest extends RequestBase {
 export interface MlPutTrainedModelAliasResponse extends AcknowledgedResponseBase {
 }
 
+export interface MlPutTrainedModelDefinitionPartRequest extends RequestBase {
+  model_id: Id
+  part: integer
+  body?: {
+    definition: string
+    total_definition_length: number
+    total_parts: number
+  }
+}
+
+export interface MlPutTrainedModelDefinitionPartResponse extends AcknowledgedResponseBase {
+}
+
 export interface MlResetJobRequest extends RequestBase {
   job_id: Id
   wait_for_completion?: boolean

--- a/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartRequest.ts
+++ b/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartRequest.ts
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { integer } from '@_types/Numeric'
+import { Id } from '@_types/common'
+
+/**
+ * Creates part of a trained model definition.
+ * @rest_spec_name ml.put_trained_model_definition_part
+ * @since 8.0.0
+ * @stability experimental
+ * @cluster_privileges manage_ml
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the trained model.
+     */
+    model_id: Id
+    /**
+     * The definition part number. When the definition is loaded for inference the definition parts are streamed in the
+     * order of their part number. The first part must be `0` and the final part must be `total_parts - 1`.
+     */
+    part: integer
+  }
+  body: {
+    /**
+     * The definition part for the model. Must be a base64 encoded string.
+     */
+    definition: string
+    /**
+     * The total uncompressed definition length in bytes. Not base64 encoded.
+     */
+    total_definition_length: number
+    /**
+     * The total number of parts that will be uploaded. Must be greater than 0.
+     */
+    total_parts: number
+  }
+}

--- a/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartResponse.ts
+++ b/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response extends AcknowledgedResponseBase {}


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/76987

This PR adds a specification for the ML [create trained model definition part API](https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-model-definition-part.html) per https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_trained_model_definition_part.json