### PR TITLE
Adds ML put trained model vocabulary API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -7717,9 +7717,21 @@
       "description": "Creates a trained model vocabulary",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-model-vocabulary.html",
       "name": "ml.put_trained_model_vocabulary",
-      "request": null,
+      "privileges": {
+        "cluster": [
+          "manage_ml"
+        ]
+      },
+      "request": {
+        "name": "Request",
+        "namespace": "ml.put_trained_model_vocabulary"
+      },
       "requestBodyRequired": true,
-      "response": null,
+      "response": {
+        "name": "Response",
+        "namespace": "ml.put_trained_model_vocabulary"
+      },
+      "since": "8.0.0",
       "stability": "experimental",
       "urls": [
         {
@@ -123556,6 +123568,75 @@
       "name": {
         "name": "Response",
         "namespace": "ml.put_trained_model_definition_part"
+      }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "description": "The model vocabulary, which must not be empty.",
+            "name": "vocabulary",
+            "required": true,
+            "type": {
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "description": "Creates a trained model vocabulary.\nThis API is supported only for natural language processing (NLP) models.\nThe vocabulary is stored in the index as described in `inference_config.*.vocabulary` of the trained model definition.",
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "request",
+      "name": {
+        "name": "Request",
+        "namespace": "ml.put_trained_model_vocabulary"
+      },
+      "path": [
+        {
+          "description": "The unique identifier of the trained model.",
+          "name": "model_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "query": []
+    },
+    {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
+      "inherits": {
+        "type": {
+          "name": "AcknowledgedResponseBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "response",
+      "name": {
+        "name": "Response",
+        "namespace": "ml.put_trained_model_vocabulary"
       }
     },
     {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1346,12 +1346,6 @@
       ],
       "response": []
     },
-    "ml.put_trained_model_vocabulary": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "ml.reset_job": {
       "request": [
         "Request: should not have a body"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12648,6 +12648,16 @@ export interface MlPutTrainedModelDefinitionPartRequest extends RequestBase {
 export interface MlPutTrainedModelDefinitionPartResponse extends AcknowledgedResponseBase {
 }
 
+export interface MlPutTrainedModelVocabularyRequest extends RequestBase {
+  model_id: Id
+  body?: {
+    vocabulary: string[]
+  }
+}
+
+export interface MlPutTrainedModelVocabularyResponse extends AcknowledgedResponseBase {
+}
+
 export interface MlResetJobRequest extends RequestBase {
   job_id: Id
   wait_for_completion?: boolean

--- a/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
+++ b/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+
+/**
+ * Creates a trained model vocabulary.
+ * This API is supported only for natural language processing (NLP) models.
+ * The vocabulary is stored in the index as described in `inference_config.*.vocabulary` of the trained model definition.
+ * @rest_spec_name ml.put_trained_model_vocabulary
+ * @since 8.0.0
+ * @stability experimental
+ * @cluster_privileges manage_ml
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the trained model.
+     */
+    model_id: Id
+  }
+  body: {
+    /**
+     * The model vocabulary, which must not be empty.
+     */
+    vocabulary: string[]
+  }
+}

--- a/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyResponse.ts
+++ b/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response extends AcknowledgedResponseBase {}


### PR DESCRIPTION
Relates to [elastic/elasticsearch#76987](https://github.com/elastic/elasticsearch/pull/77387)

This PR adds a specification for the ML [create trained model vocabulary API](https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-model-vocabulary.html) per https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/ml.put_trained_model_vocabulary.json