### PR TITLE
Adds ML infer trained model deployment API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -115202,8 +115202,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "number",
-              "namespace": "internal"
+              "name": "integer",
+              "namespace": "_types"
             }
           }
         },
@@ -115213,8 +115213,8 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "number",
-              "namespace": "internal"
+              "name": "integer",
+              "namespace": "_types"
             }
           }
         }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -120491,10 +120491,21 @@
             "type": {
               "kind": "array_of",
               "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "internal"
+                "key": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "string",
+                    "namespace": "internal"
+                  }
+                },
+                "kind": "dictionary_of",
+                "singleKey": true,
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "string",
+                    "namespace": "internal"
+                  }
                 }
               }
             }

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -7129,9 +7129,16 @@
       "description": "Evaluate a trained model.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model-deployment.html",
       "name": "ml.infer_trained_model_deployment",
-      "request": null,
+      "request": {
+        "name": "Request",
+        "namespace": "ml.infer_trained_model_deployment"
+      },
       "requestBodyRequired": true,
-      "response": null,
+      "response": {
+        "name": "Response",
+        "namespace": "ml.infer_trained_model_deployment"
+      },
+      "since": "8.0.0",
       "stability": "experimental",
       "urls": [
         {
@@ -115152,6 +115159,70 @@
     {
       "kind": "interface",
       "name": {
+        "name": "TrainedModelEntities",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "class_name",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "class_probability",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "entity",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "start_pos",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "number",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "end_pos",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "number",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
         "name": "TrainedModelInferenceStats",
         "namespace": "ml._types"
       },
@@ -120362,6 +120433,123 @@
       "name": {
         "name": "Response",
         "namespace": "ml.get_trained_models_stats"
+      }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "description": "An array of objects to pass to the model for inference. The objects should contain a field matching your\nconfigured trained model input. Typically, the field name is `text_field`. Currently, only a single value is allowed.",
+            "name": "docs",
+            "required": true,
+            "type": {
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "internal"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "description": "Evaluates a trained model.",
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "request",
+      "name": {
+        "name": "Request",
+        "namespace": "ml.infer_trained_model_deployment"
+      },
+      "path": [
+        {
+          "description": "The unique identifier of the trained model.",
+          "name": "model_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "description": "Controls the amount of time to wait for inference results.",
+          "name": "timeout",
+          "required": false,
+          "serverDefault": "10s",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "description": "If the model is trained for named entity recognition (NER) tasks, the response contains the recognized entities.",
+            "name": "entities",
+            "required": false,
+            "type": {
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "TrainedModelEntities",
+                  "namespace": "ml._types"
+                }
+              }
+            }
+          },
+          {
+            "description": "If the model is trained for a text classification task, the response is a predicted label.\nFor named entity recognition (NER) tasks, the response contains the annotated text output.",
+            "name": "predicted_value",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "If the model is trained for a text classification task, the response is a confidence score.",
+            "name": "prediction_probability",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "double",
+                "namespace": "_types"
+              }
+            }
+          }
+        ]
+      },
+      "kind": "response",
+      "name": {
+        "name": "Response",
+        "namespace": "ml.infer_trained_model_deployment"
       }
     },
     {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -114466,6 +114466,32 @@
       ]
     },
     {
+      "kind": "type_alias",
+      "name": {
+        "name": "PredictedValue",
+        "namespace": "ml._types"
+      },
+      "type": {
+        "items": [
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        ],
+        "kind": "union_of"
+      }
+    },
+    {
       "kind": "enum",
       "members": [
         {
@@ -120499,7 +120525,7 @@
                   }
                 },
                 "kind": "dictionary_of",
-                "singleKey": true,
+                "singleKey": false,
                 "value": {
                   "kind": "instance_of",
                   "type": {
@@ -120590,26 +120616,14 @@
             "name": "predicted_value",
             "required": false,
             "type": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "string",
-                    "namespace": "internal"
-                  }
-                },
-                {
-                  "kind": "array_of",
-                  "value": {
-                    "kind": "instance_of",
-                    "type": {
-                      "name": "double",
-                      "namespace": "_types"
-                    }
-                  }
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "PredictedValue",
+                  "namespace": "ml._types"
                 }
-              ],
-              "kind": "union_of"
+              }
             }
           },
           {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -114592,6 +114592,48 @@
     {
       "kind": "interface",
       "name": {
+        "name": "TopClassEntry",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "class_name",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "class_probability",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "class_score",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
         "name": "TotalFeatureImportance",
         "namespace": "ml._types"
       },
@@ -120521,8 +120563,47 @@
             }
           },
           {
-            "description": "If the model is trained for a text classification task, the response is a predicted label.\nFor named entity recognition (NER) tasks, the response contains the annotated text output.",
+            "description": "Indicates whether the input text was truncated to meet the model's maximum sequence length limit. This property\nis present only when it is true.",
+            "name": "is_truncated",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "internal"
+              }
+            }
+          },
+          {
+            "description": "If the model is trained for a text classification or zero shot classification task, the response is the\npredicted class.\nFor named entity recognition (NER) tasks, it contains the annotated text output.\nFor fill mask tasks, it contains the top prediction for replacing the mask token.\nFor text embedding tasks, it contains the raw numerical text embedding values.",
             "name": "predicted_value",
+            "required": false,
+            "type": {
+              "items": [
+                {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "string",
+                    "namespace": "internal"
+                  }
+                },
+                {
+                  "kind": "array_of",
+                  "value": {
+                    "kind": "instance_of",
+                    "type": {
+                      "name": "double",
+                      "namespace": "_types"
+                    }
+                  }
+                }
+              ],
+              "kind": "union_of"
+            }
+          },
+          {
+            "description": "For fill mask tasks, the response contains the input text sequence with the mask token replaced by the predicted\nvalue.",
+            "name": "predicted_value_sequence",
             "required": false,
             "type": {
               "kind": "instance_of",
@@ -120533,7 +120614,7 @@
             }
           },
           {
-            "description": "If the model is trained for a text classification task, the response is a confidence score.",
+            "description": "Specifies a confidence score for the predicted value.",
             "name": "prediction_probability",
             "required": false,
             "type": {
@@ -120541,6 +120622,33 @@
               "type": {
                 "name": "double",
                 "namespace": "_types"
+              }
+            }
+          },
+          {
+            "description": "For fill mask, text classification, and zero shot classification tasks, the response contains a list of top\nclass entries.",
+            "name": "top_classes",
+            "required": true,
+            "type": {
+              "kind": "array_of",
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "TopClassEntry",
+                  "namespace": "ml._types"
+                }
+              }
+            }
+          },
+          {
+            "description": "If the request failed, the response contains the reason for the failure.",
+            "name": "warning",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
               }
             }
           }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1301,12 +1301,6 @@
       ],
       "response": []
     },
-    "ml.infer_trained_model_deployment": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "ml.info": {
       "request": [
         "Request: should not have a body"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11636,6 +11636,12 @@ export interface MlTimingStats {
   iteration_time?: integer
 }
 
+export interface MlTopClassEntry {
+  class_name: string
+  class_probability: double
+  class_score: double
+}
+
 export interface MlTotalFeatureImportance {
   feature_name: Name
   importance: MlTotalFeatureImportanceStatistics[]
@@ -12302,8 +12308,12 @@ export interface MlInferTrainedModelDeploymentRequest extends RequestBase {
 
 export interface MlInferTrainedModelDeploymentResponse {
   entities?: MlTrainedModelEntities[]
-  predicted_value?: string
+  is_truncated?: boolean
+  predicted_value?: string | double[]
+  predicted_value_sequence?: string
   prediction_probability?: double
+  top_classes: MlTopClassEntry[]
+  warning?: string
 }
 
 export interface MlInfoAnomalyDetectors {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11621,6 +11621,8 @@ export interface MlPerPartitionCategorization {
   stop_on_warn?: boolean
 }
 
+export type MlPredictedValue = string | double
+
 export type MlRoutingState = 'failed' | 'started' | 'starting' | 'stopped' | 'stopping'
 
 export type MlRuleAction = 'skip_result' | 'skip_model_update'
@@ -12302,14 +12304,14 @@ export interface MlInferTrainedModelDeploymentRequest extends RequestBase {
   model_id: Id
   timeout?: Time
   body?: {
-    docs: Partial<Record<string, string>>[]
+    docs: Record<string, string>[]
   }
 }
 
 export interface MlInferTrainedModelDeploymentResponse {
   entities?: MlTrainedModelEntities[]
   is_truncated?: boolean
-  predicted_value?: string | double[]
+  predicted_value?: MlPredictedValue[]
   predicted_value_sequence?: string
   prediction_probability?: double
   top_classes: MlTopClassEntry[]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11703,8 +11703,8 @@ export interface MlTrainedModelEntities {
   class_name: string
   class_probability: double
   entity: string
-  start_pos: number
-  end_pos: number
+  start_pos: integer
+  end_pos: integer
 }
 
 export interface MlTrainedModelInferenceStats {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12302,7 +12302,7 @@ export interface MlInferTrainedModelDeploymentRequest extends RequestBase {
   model_id: Id
   timeout?: Time
   body?: {
-    docs: string[]
+    docs: Partial<Record<string, string>>[]
   }
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11699,6 +11699,14 @@ export interface MlTrainedModelConfigMetadata {
   total_feature_importance?: MlTotalFeatureImportance[]
 }
 
+export interface MlTrainedModelEntities {
+  class_name: string
+  class_probability: double
+  entity: string
+  start_pos: number
+  end_pos: number
+}
+
 export interface MlTrainedModelInferenceStats {
   failure_count: long
   inference_count: long
@@ -12282,6 +12290,20 @@ export interface MlGetTrainedModelsStatsRequest extends RequestBase {
 export interface MlGetTrainedModelsStatsResponse {
   count: integer
   trained_model_stats: MlTrainedModelStats[]
+}
+
+export interface MlInferTrainedModelDeploymentRequest extends RequestBase {
+  model_id: Id
+  timeout?: Time
+  body?: {
+    docs: string[]
+  }
+}
+
+export interface MlInferTrainedModelDeploymentResponse {
+  entities?: MlTrainedModelEntities[]
+  predicted_value?: string
+  prediction_probability?: double
 }
 
 export interface MlInfoAnomalyDetectors {

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -247,3 +247,5 @@ export class TopClassEntry {
   class_probability: double
   class_score: double
 }
+
+export type PredictedValue = string | double

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -239,6 +239,6 @@ export class TrainedModelEntities {
   class_name: string
   class_probability: double
   entity: string
-  start_pos: number
-  end_pos: number
+  start_pos: integer
+  end_pos: integer
 }

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -235,3 +235,10 @@ export class TrainedModelAllocation {
   start_time: DateString
   task_parameters: TrainedModelAllocationTaskParameters
 }
+export class TrainedModelEntities {
+  class_name: string
+  class_probability: double
+  entity: string
+  start_pos: number
+  end_pos: number
+}

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -242,3 +242,8 @@ export class TrainedModelEntities {
   start_pos: integer
   end_pos: integer
 }
+export class TopClassEntry {
+  class_name: string
+  class_probability: double
+  class_score: double
+}

--- a/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentRequest.ts
+++ b/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentRequest.ts
@@ -20,7 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 import { Time } from '@_types/Time'
-import { SingleKeyDictionary } from '@spec_utils/Dictionary'
+import { Dictionary } from '@spec_utils/Dictionary'
 
 /**
  * Evaluates a trained model.
@@ -47,6 +47,6 @@ export interface Request extends RequestBase {
      * An array of objects to pass to the model for inference. The objects should contain a field matching your
      * configured trained model input. Typically, the field name is `text_field`. Currently, only a single value is allowed.
      */
-    docs: SingleKeyDictionary<string, string>[]
+    docs: Dictionary<string, string>[]
   }
 }

--- a/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentRequest.ts
+++ b/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentRequest.ts
@@ -20,6 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 import { Time } from '@_types/Time'
+import { SingleKeyDictionary } from '@spec_utils/Dictionary'
 
 /**
  * Evaluates a trained model.
@@ -46,6 +47,6 @@ export interface Request extends RequestBase {
      * An array of objects to pass to the model for inference. The objects should contain a field matching your
      * configured trained model input. Typically, the field name is `text_field`. Currently, only a single value is allowed.
      */
-    docs: string[]
+    docs: SingleKeyDictionary<string, string>[]
   }
 }

--- a/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentRequest.ts
+++ b/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentRequest.ts
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+import { Time } from '@_types/Time'
+
+/**
+ * Evaluates a trained model.
+ * @rest_spec_name ml.infer_trained_model_deployment
+ * @since 8.0.0
+ * @stability experimental
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the trained model.
+     */
+    model_id: Id
+  }
+  query_parameters: {
+    /**
+     * Controls the amount of time to wait for inference results.
+     * @server_default 10s
+     */
+    timeout?: Time
+  }
+  body: {
+    /**
+     * An array of objects to pass to the model for inference. The objects should contain a field matching your
+     * configured trained model input. Typically, the field name is `text_field`. Currently, only a single value is allowed.
+     */
+    docs: string[]
+  }
+}

--- a/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentResponse.ts
+++ b/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentResponse.ts
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { double } from '@_types/Numeric'
+import { TrainedModelEntities } from '@ml/_types/TrainedModel'
+
+export class Response {
+  body: {
+    /**
+     * If the model is trained for named entity recognition (NER) tasks, the response contains the recognized entities.
+     */
+    entities?: TrainedModelEntities[]
+    /**
+     * If the model is trained for a text classification task, the response is a predicted label.
+     * For named entity recognition (NER) tasks, the response contains the annotated text output.
+     */
+    predicted_value?: string
+    /**
+     * If the model is trained for a text classification task, the response is a confidence score.
+     */
+    prediction_probability?: double
+  }
+}

--- a/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentResponse.ts
+++ b/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentResponse.ts
@@ -18,7 +18,7 @@
  */
 
 import { double } from '@_types/Numeric'
-import { TrainedModelEntities } from '@ml/_types/TrainedModel'
+import { TopClassEntry, TrainedModelEntities } from '@ml/_types/TrainedModel'
 
 export class Response {
   body: {
@@ -27,17 +27,35 @@ export class Response {
      */
     entities?: TrainedModelEntities[]
     /**
-     * If the model is trained for a text classification task, the response is a predicted label.
-     * For named entity recognition (NER) tasks, the response contains the annotated text output.
+     * Indicates whether the input text was truncated to meet the model's maximum sequence length limit. This property
+     * is present only when it is true.
      */
-    predicted_value?: string
+    is_truncated?: boolean
     /**
-     * If the model is trained for a text classification task, the response is a confidence score.
+     * If the model is trained for a text classification or zero shot classification task, the response is the
+     * predicted class.
+     * For named entity recognition (NER) tasks, it contains the annotated text output.
+     * For fill mask tasks, it contains the top prediction for replacing the mask token.
+     * For text embedding tasks, it contains the raw numerical text embedding values.
+     */
+    predicted_value?: string | double[]
+    /**
+     * For fill mask tasks, the response contains the input text sequence with the mask token replaced by the predicted
+     * value.
+     */
+    predicted_value_sequence?: string
+    /**
+     * Specifies a confidence score for the predicted value.
      */
     prediction_probability?: double
-      /**
-       * Indicates whether the input text was truncated to meet the model's maximum sequence length limit. This property is present only when it is true.
-       */
-      is_truncated?: boolean
+    /**
+     * For fill mask, text classification, and zero shot classification tasks, the response contains a list of top
+     * class entries.
+     */
+    top_classes: TopClassEntry[]
+    /**
+     * If the request failed, the response contains the reason for the failure.
+     */
+    warning?: string
   }
 }

--- a/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentResponse.ts
+++ b/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentResponse.ts
@@ -36,7 +36,7 @@ export class Response {
      */
     prediction_probability?: double
       /**
-       * True if the input text was truncated to meet the model's maximum sequence length limit. is_truncated is present only when it is true.
+       * Indicates whether the input text was truncated to meet the model's maximum sequence length limit. This property is present only when it is true.
        */
       is_truncated?: boolean
   }

--- a/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentResponse.ts
+++ b/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentResponse.ts
@@ -35,5 +35,9 @@ export class Response {
      * If the model is trained for a text classification task, the response is a confidence score.
      */
     prediction_probability?: double
+      /**
+       * True if the input text was truncated to meet the model's maximum sequence length limit. is_truncated is present only when it is true.
+       */
+      is_truncated?: boolean
   }
 }

--- a/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentResponse.ts
+++ b/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentResponse.ts
@@ -18,7 +18,11 @@
  */
 
 import { double } from '@_types/Numeric'
-import { TopClassEntry, TrainedModelEntities } from '@ml/_types/TrainedModel'
+import {
+  PredictedValue,
+  TopClassEntry,
+  TrainedModelEntities
+} from '@ml/_types/TrainedModel'
 
 export class Response {
   body: {
@@ -38,7 +42,7 @@ export class Response {
      * For fill mask tasks, it contains the top prediction for replacing the mask token.
      * For text embedding tasks, it contains the raw numerical text embedding values.
      */
-    predicted_value?: string | double[]
+    predicted_value?: PredictedValue[]
     /**
      * For fill mask tasks, the response contains the input text sequence with the mask token replaced by the predicted
      * value.


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/73660

This PR adds a specification for the ML [infer trained model deployment API](https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model-deployment.html) per https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/ml.infer_trained_model_deployment.json

NOTE: I have omitted the security details for now, since they're missing from the documentation but we'll want to fix that in both places.