### PR TITLE
Adds ML start and stop trained model deployment specifications

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -124730,7 +124730,19 @@
     {
       "body": {
         "kind": "properties",
-        "properties": []
+        "properties": [
+          {
+            "name": "stopped",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "internal"
+              }
+            }
+          }
+        ]
       },
       "kind": "response",
       "name": {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -7934,9 +7934,21 @@
       "description": "Start a trained model deployment.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trained-model-deployment.html",
       "name": "ml.start_trained_model_deployment",
-      "request": null,
+      "privileges": {
+        "cluster": [
+          "manage_ml"
+        ]
+      },
+      "request": {
+        "name": "Request",
+        "namespace": "ml.start_trained_model_deployment"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "Response",
+        "namespace": "ml.start_trained_model_deployment"
+      },
+      "since": "8.0.0",
       "stability": "experimental",
       "urls": [
         {
@@ -8030,9 +8042,21 @@
       "description": "Stop a trained model deployment.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-trained-model-deployment.html",
       "name": "ml.stop_trained_model_deployment",
-      "request": null,
+      "privileges": {
+        "cluster": [
+          "manage_ml"
+        ]
+      },
+      "request": {
+        "name": "Request",
+        "namespace": "ml.stop_trained_model_deployment"
+      },
       "requestBodyRequired": false,
-      "response": null,
+      "response": {
+        "name": "Response",
+        "namespace": "ml.stop_trained_model_deployment"
+      },
+      "since": "8.0.0",
       "stability": "experimental",
       "urls": [
         {
@@ -112014,6 +112038,27 @@
       ]
     },
     {
+      "kind": "enum",
+      "members": [
+        {
+          "description": "The trained model is started on at least one node.",
+          "name": "started"
+        },
+        {
+          "description": "Trained model deployment is starting but it is not yet deployed on any nodes.",
+          "name": "starting"
+        },
+        {
+          "description": "Trained model deployment has started on all valid nodes.",
+          "name": "fully_allocated"
+        }
+      ],
+      "name": {
+        "name": "DeploymentState",
+        "namespace": "ml._types"
+      }
+    },
+    {
       "kind": "interface",
       "name": {
         "name": "DetectionRule",
@@ -114643,6 +114688,124 @@
             "kind": "instance_of",
             "type": {
               "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "TrainedModelAllocation",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "allocation_state",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DeploymentState",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "routing_table",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "TrainedModelAllocationRoutingTable",
+                "namespace": "ml._types"
+              }
+            }
+          }
+        },
+        {
+          "name": "start_time",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DateString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "task_parameters",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TrainedModelAllocationTaskParameters",
+              "namespace": "ml._types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "TrainedModelAllocationRoutingTable",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "reason",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "name": "routing_state",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "TrainedModelAllocationTaskParameters",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "model_bytes",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "model_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
               "namespace": "_types"
             }
           }
@@ -124104,6 +124267,130 @@
       "body": {
         "kind": "no_body"
       },
+      "description": "Starts a trained model deployment, which allocates the model to every machine learning node.",
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "request",
+      "name": {
+        "name": "Request",
+        "namespace": "ml.start_trained_model_deployment"
+      },
+      "path": [
+        {
+          "description": "The unique identifier of the trained model. Currently, only PyTorch models are supported.",
+          "name": "model_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "description": "Specifies the number of threads that are used by the inference process. If you increase this value, inference\nspeed generally increases. However, the actual number of threads is limited by the number of available CPU\ncores.",
+          "name": "inference_threads",
+          "required": false,
+          "serverDefault": 1,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Specifies the number of threads that are used when sending inference requests to the model. If you increase this value,\nthroughput generally increases.",
+          "name": "model_threads",
+          "required": false,
+          "serverDefault": 1,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Specifies the number of inference requests that are allowed in the queue. After the number of requests exceeds\nthis value, new requests are rejected with a 429 error.",
+          "name": "queue_capacity",
+          "required": false,
+          "serverDefault": 1024,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Specifies the amount of time to wait for the model to deploy.",
+          "name": "timeout",
+          "required": false,
+          "serverDefault": "20s",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Time",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Specifies the allocation status to wait for before returning.",
+          "name": "wait_for",
+          "required": false,
+          "serverDefault": "started",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DeploymentState",
+              "namespace": "ml._types"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "body": {
+        "kind": "properties",
+        "properties": [
+          {
+            "name": "allocation",
+            "required": true,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "TrainedModelAllocation",
+                "namespace": "ml._types"
+              }
+            }
+          }
+        ]
+      },
+      "kind": "response",
+      "name": {
+        "name": "Response",
+        "namespace": "ml.start_trained_model_deployment"
+      }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "no_body"
+      },
       "description": "Stops one or more data frame analytics jobs.\nA data frame analytics job can be started and stopped multiple times\nthroughout its lifecycle.",
       "inherits": {
         "type": {
@@ -124332,6 +124619,79 @@
       "name": {
         "name": "Response",
         "namespace": "ml.stop_datafeed"
+      }
+    },
+    {
+      "attachedBehaviors": [
+        "CommonQueryParameters"
+      ],
+      "body": {
+        "kind": "no_body"
+      },
+      "description": "Stops a trained model deployment.",
+      "inherits": {
+        "type": {
+          "name": "RequestBase",
+          "namespace": "_types"
+        }
+      },
+      "kind": "request",
+      "name": {
+        "name": "Request",
+        "namespace": "ml.stop_trained_model_deployment"
+      },
+      "path": [
+        {
+          "description": "The unique identifier of the trained model.",
+          "name": "model_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "query": [
+        {
+          "description": "Specifies what to do when the request: contains wildcard expressions and there are no deployments that match;\ncontains the  `_all` string or no identifiers and there are no matches; or contains wildcard expressions and\nthere are only partial matches. By default, it returns an empty array when there are no matches and the subset of results when there are partial matches.\nIf `false`, the request returns a 404 status code when there are no matches or only partial matches.",
+          "name": "allow_no_match",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        },
+        {
+          "description": "Forcefully stops the deployment, even if it is used by ingest pipelines. You can't use these pipelines until you\nrestart the model deployment.",
+          "name": "force",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "internal"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "body": {
+        "kind": "properties",
+        "properties": []
+      },
+      "kind": "response",
+      "name": {
+        "name": "Response",
+        "namespace": "ml.stop_trained_model_deployment"
       }
     },
     {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -114471,6 +114471,35 @@
       "kind": "enum",
       "members": [
         {
+          "description": "The allocation attempt failed.",
+          "name": "failed"
+        },
+        {
+          "description": "The trained model is allocated and ready to accept inference requests.",
+          "name": "started"
+        },
+        {
+          "description": "The trained model is attempting to allocate on this node; inference requests are not yet accepted.",
+          "name": "starting"
+        },
+        {
+          "description": "The trained model is fully deallocated from this node.",
+          "name": "stopped"
+        },
+        {
+          "description": "The trained model is being deallocated from this node.",
+          "name": "stopping"
+        }
+      ],
+      "name": {
+        "name": "RoutingState",
+        "namespace": "ml._types"
+      }
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
           "description": "The result will not be created. Unless you also specify `skip_model_update`, the model will be updated as usual with the corresponding series value.",
           "name": "skip_result"
         },
@@ -114702,6 +114731,7 @@
       },
       "properties": [
         {
+          "description": "The overall allocation state.",
           "name": "allocation_state",
           "required": true,
           "type": {
@@ -114713,10 +114743,19 @@
           }
         },
         {
+          "description": "The allocation state for each node.",
           "name": "routing_table",
           "required": true,
           "type": {
-            "kind": "array_of",
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "internal"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
             "value": {
               "kind": "instance_of",
               "type": {
@@ -114727,6 +114766,7 @@
           }
         },
         {
+          "description": "The timestamp when the deployment started.",
           "name": "start_time",
           "required": true,
           "type": {
@@ -114758,6 +114798,7 @@
       },
       "properties": [
         {
+          "description": "The reason for the current state. It is usually populated only when the\n`routing_state` is `failed`.",
           "name": "reason",
           "required": true,
           "type": {
@@ -114769,13 +114810,14 @@
           }
         },
         {
+          "description": "The current routing state.",
           "name": "routing_state",
           "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "internal"
+              "name": "RoutingState",
+              "namespace": "ml._types"
             }
           }
         }
@@ -114789,6 +114831,7 @@
       },
       "properties": [
         {
+          "description": "The size of the trained model in bytes.",
           "name": "model_bytes",
           "required": true,
           "type": {
@@ -114800,6 +114843,7 @@
           }
         },
         {
+          "description": "The unique identifier for the trained model.",
           "name": "model_id",
           "required": true,
           "type": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1360,19 +1360,16 @@
     },
     "ml.start_trained_model_deployment": {
       "request": [
-        "Missing request & response"
+        "Request: query parameter 'inference_threads' does not exist in the json spec",
+        "Request: query parameter 'model_threads' does not exist in the json spec",
+        "Request: query parameter 'queue_capacity' does not exist in the json spec",
+        "Request: should not have a body"
       ],
       "response": []
     },
     "ml.stop_datafeed": {
       "request": [
         "Request: missing json spec query parameter 'allow_no_datafeeds'"
-      ],
-      "response": []
-    },
-    "ml.stop_trained_model_deployment": {
-      "request": [
-        "Missing request & response"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11622,6 +11622,8 @@ export interface MlPerPartitionCategorization {
   stop_on_warn?: boolean
 }
 
+export type MlRoutingState = 'failed' | 'started' | 'starting' | 'stopped' | 'stopping'
+
 export type MlRuleAction = 'skip_result' | 'skip_model_update'
 
 export interface MlRuleCondition {
@@ -11654,14 +11656,14 @@ export interface MlTotalFeatureImportanceStatistics {
 
 export interface MlTrainedModelAllocation {
   allocation_state: MlDeploymentState
-  routing_table: MlTrainedModelAllocationRoutingTable[]
+  routing_table: Record<string, MlTrainedModelAllocationRoutingTable>
   start_time: DateString
   task_parameters: MlTrainedModelAllocationTaskParameters
 }
 
 export interface MlTrainedModelAllocationRoutingTable {
   reason: string
-  routing_state: string
+  routing_state: MlRoutingState
 }
 
 export interface MlTrainedModelAllocationTaskParameters {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12781,6 +12781,7 @@ export interface MlStopTrainedModelDeploymentRequest extends RequestBase {
 }
 
 export interface MlStopTrainedModelDeploymentResponse {
+  stopped: boolean
 }
 
 export interface MlUpdateDataFrameAnalyticsRequest extends RequestBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11359,6 +11359,8 @@ export interface MlDelayedDataCheckConfig {
   enabled: boolean
 }
 
+export type MlDeploymentState = 'started' | 'starting' | 'fully_allocated'
+
 export interface MlDetectionRule {
   actions?: MlRuleAction[]
   conditions?: MlRuleCondition[]
@@ -11648,6 +11650,23 @@ export interface MlTotalFeatureImportanceStatistics {
   mean_magnitude: double
   max: integer
   min: integer
+}
+
+export interface MlTrainedModelAllocation {
+  allocation_state: MlDeploymentState
+  routing_table: MlTrainedModelAllocationRoutingTable[]
+  start_time: DateString
+  task_parameters: MlTrainedModelAllocationTaskParameters
+}
+
+export interface MlTrainedModelAllocationRoutingTable {
+  reason: string
+  routing_state: string
+}
+
+export interface MlTrainedModelAllocationTaskParameters {
+  model_bytes: integer
+  model_id: Id
 }
 
 export interface MlTrainedModelConfig {
@@ -12713,6 +12732,19 @@ export interface MlStartDatafeedResponse {
   started: boolean
 }
 
+export interface MlStartTrainedModelDeploymentRequest extends RequestBase {
+  model_id: Id
+  inference_threads?: integer
+  model_threads?: integer
+  queue_capacity?: integer
+  timeout?: Time
+  wait_for?: MlDeploymentState
+}
+
+export interface MlStartTrainedModelDeploymentResponse {
+  allocation: MlTrainedModelAllocation
+}
+
 export interface MlStopDataFrameAnalyticsRequest extends RequestBase {
   id: Id
   allow_no_match?: boolean
@@ -12738,6 +12770,15 @@ export interface MlStopDatafeedRequest extends RequestBase {
 
 export interface MlStopDatafeedResponse {
   stopped: boolean
+}
+
+export interface MlStopTrainedModelDeploymentRequest extends RequestBase {
+  model_id: Id
+  allow_no_match?: boolean
+  force?: boolean
+}
+
+export interface MlStopTrainedModelDeploymentResponse {
 }
 
 export interface MlUpdateDataFrameAnalyticsRequest extends RequestBase {

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -175,18 +175,64 @@ export enum DeploymentState {
 }
 
 export class TrainedModelAllocationTaskParameters {
+  /**
+   * The size of the trained model in bytes.
+   */
   model_bytes: integer
+  /**
+   * The unique identifier for the trained model.
+   */
   model_id: Id
 }
 
+export enum RoutingState {
+  /**
+   * The allocation attempt failed.
+   */
+  failed = 0,
+  /**
+   * The trained model is allocated and ready to accept inference requests.
+   */
+  started = 1,
+  /**
+   * The trained model is attempting to allocate on this node; inference requests are not yet accepted.
+   */
+  starting = 2,
+  /**
+   * The trained model is fully deallocated from this node.
+   */
+  stopped = 3,
+  /**
+   * The trained model is being deallocated from this node.
+   */
+  stopping = 4
+}
+
+
 export class TrainedModelAllocationRoutingTable {
+  /**
+   * The reason for the current state. It is usually populated only when the
+   * `routing_state` is `failed`.
+   */
   reason: string
-  routing_state: string
+  /**
+   * The current routing state.
+   */
+  routing_state: RoutingState
 }
 
 export class TrainedModelAllocation {
+  /**
+   * The overall allocation state.
+   */
   allocation_state: DeploymentState
-  routing_table: TrainedModelAllocationRoutingTable[]
+  /**
+   * The allocation state for each node.
+   */
+  routing_table: Dictionary<string,TrainedModelAllocationRoutingTable>
+  /**
+   * The timestamp when the deployment started.
+   */
   start_time: DateString
   task_parameters: TrainedModelAllocationTaskParameters
 }

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -23,6 +23,7 @@ import { InferenceConfigContainer } from '@_types/aggregations/pipeline'
 import { Field, Id, Name, VersionString } from '@_types/common'
 import { double, integer, long } from '@_types/Numeric'
 import { Time } from '@_types/Time'
+import { DateString } from '@_types/Time'
 
 export class TrainedModelStats {
   /** The unique identifier of the trained model. */
@@ -156,4 +157,36 @@ export enum TrainedModelType {
    * Currently only NLP models are supported.
    */
   pytorch
+}
+
+export enum DeploymentState {
+  /**
+   * The trained model is started on at least one node.
+   */
+  started = 0,
+  /**
+   * Trained model deployment is starting but it is not yet deployed on any nodes.
+   */
+  starting = 1,
+  /**
+   * Trained model deployment has started on all valid nodes.
+   */
+  fully_allocated = 3
+}
+
+export class TrainedModelAllocationTaskParameters {
+  model_bytes: integer
+  model_id: Id
+}
+
+export class TrainedModelAllocationRoutingTable {
+  reason: string
+  routing_state: string
+}
+
+export class TrainedModelAllocation {
+  allocation_state: DeploymentState
+  routing_table: TrainedModelAllocationRoutingTable[]
+  start_time: DateString
+  task_parameters: TrainedModelAllocationTaskParameters
 }

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -208,7 +208,6 @@ export enum RoutingState {
   stopping = 4
 }
 
-
 export class TrainedModelAllocationRoutingTable {
   /**
    * The reason for the current state. It is usually populated only when the
@@ -229,7 +228,7 @@ export class TrainedModelAllocation {
   /**
    * The allocation state for each node.
    */
-  routing_table: Dictionary<string,TrainedModelAllocationRoutingTable>
+  routing_table: Dictionary<string, TrainedModelAllocationRoutingTable>
   /**
    * The timestamp when the deployment started.
    */

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+import { integer } from '@_types/Numeric'
+import { Time } from '@_types/Time'
+import { DeploymentState } from '../_types/TrainedModel'
+
+/**
+ * Starts a trained model deployment, which allocates the model to every machine learning node.
+ * @rest_spec_name ml.start_trained_model_deployment
+ * @since 8.0.0
+ * @stability experimental
+ * @cluster_privileges manage_ml
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the trained model. Currently, only PyTorch models are supported.
+     */
+    model_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the number of threads that are used by the inference process. If you increase this value, inference
+     * speed generally increases. However, the actual number of threads is limited by the number of available CPU
+     * cores.
+     * @server_default 1
+     */
+    inference_threads?: integer
+    /**
+     * Specifies the number of threads that are used when sending inference requests to the model. If you increase this value,
+     * throughput generally increases.
+     * @server_default 1
+     */
+    model_threads?: integer
+    /**
+     * Specifies the number of inference requests that are allowed in the queue. After the number of requests exceeds
+     * this value, new requests are rejected with a 429 error.
+     * @server_default 1024
+     */
+    queue_capacity?: integer
+    /**
+     * Specifies the amount of time to wait for the model to deploy.
+     * @server_default 20s
+     */
+    timeout?: Time
+    /**
+     * Specifies the allocation status to wait for before returning.
+     * @server_default started
+     */
+    wait_for?: DeploymentState
+  }
+}

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentResponse.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentResponse.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TrainedModelAllocation } from '../_types/TrainedModel'
+
+export class Response {
+  body: {
+    allocation: TrainedModelAllocation
+  }
+}

--- a/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentRequest.ts
+++ b/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentRequest.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+/*
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { InferenceConfigContainer } from '@_types/aggregations/pipeline'
+import { Definition, Input } from './types'
+import { TrainedModelType } from '../_types/TrainedModel'
+*/
+/**
+ * Stops a trained model deployment.
+ * @rest_spec_name ml.stop_trained_model_deployment
+ * @since 8.0.0
+ * @stability experimental
+ * @cluster_privileges manage_ml
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the trained model.
+     */
+    model_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies what to do when the request: contains wildcard expressions and there are no deployments that match;
+     * contains the  `_all` string or no identifiers and there are no matches; or contains wildcard expressions and
+     * there are only partial matches. By default, it returns an empty array when there are no matches and the subset of results when there are partial matches.
+     * If `false`, the request returns a 404 status code when there are no matches or only partial matches.
+     * @server_default true
+     */
+    allow_no_match?: boolean
+    /**
+     * Forcefully stops the deployment, even if it is used by ingest pipelines. You can't use these pipelines until you
+     * restart the model deployment.
+     * @server_default false
+     */
+    force?: boolean
+  }
+}

--- a/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentResponse.ts
+++ b/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class Response {
+  body: {}
+}

--- a/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentResponse.ts
+++ b/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentResponse.ts
@@ -18,5 +18,5 @@
  */
 
 export class Response {
-  body: {}
+  body: { stopped: boolean }
 }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/73660

Adds specifications for the [start trained model deployment API](https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trained-model-deployment.html) and [stop trained model deployment APII](https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-trained-model-deployment.html) based on the documentation and specs ([ml.stop_trained_model_deployment.json](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/ml.stop_trained_model_deployment.json), [ml.start_trained_model_deployment](https://github.com/elastic/elasticsearch/blob/master/rest-api-spec/src/main/resources/rest-api-spec/api/ml.start_trained_model_deployment.json))
