### PR TITLE
Add spec source location to type definitions

### DIFF
--- a/compiler/model/build-model.ts
+++ b/compiler/model/build-model.ts
@@ -52,7 +52,7 @@ import {
   parseVariantsTag,
   verifyUniqueness,
   parseJsDocTags,
-  deepEqual
+  deepEqual, sourceLocation
 } from './utils'
 
 const specsFolder = join(__dirname, '..', '..', 'specification')
@@ -188,6 +188,7 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
     const namespace = getNameSpace(declaration)
     if (name === 'Request') {
       type = {
+        specLocation: sourceLocation(declaration),
         kind: 'request',
         name: { name, namespace },
         path: new Array<model.Property>(),
@@ -305,6 +306,7 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
       }
     } else {
       type = {
+        specLocation: sourceLocation(declaration),
         kind: 'response',
         name: { name, namespace: getNameSpace(declaration) },
         body: { kind: 'no_body' }
@@ -386,6 +388,7 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
   // Every other class or interface will be handled here
   } else {
     const type: model.Interface = {
+      specLocation: sourceLocation(declaration),
       kind: 'interface',
       name: { name, namespace: getNameSpace(declaration) },
       properties: new Array<model.Property>()

--- a/compiler/model/build-model.ts
+++ b/compiler/model/build-model.ts
@@ -52,7 +52,8 @@ import {
   parseVariantsTag,
   verifyUniqueness,
   parseJsDocTags,
-  deepEqual, sourceLocation
+  deepEqual,
+  sourceLocation
 } from './utils'
 
 const specsFolder = join(__dirname, '..', '..', 'specification')

--- a/compiler/model/metamodel.ts
+++ b/compiler/model/metamodel.ts
@@ -41,7 +41,8 @@ export class TypeName {
  */
 export class SourceLocation {
   path: string
-  line: number
+  startLine: number
+  endLine: number
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/compiler/model/metamodel.ts
+++ b/compiler/model/metamodel.ts
@@ -36,6 +36,14 @@ export class TypeName {
   name: string
 }
 
+/**
+ * Location of an item. The path is relative to the "specification" directory, e.g "_types/common.ts"
+ */
+export class SourceLocation {
+  path: string
+  line: number
+}
+
 // ------------------------------------------------------------------------------------------------
 // Value types
 
@@ -168,6 +176,8 @@ export abstract class BaseType {
    *   additional property
    */
   codegenNames?: string[]
+  /** Location in the API spec where this type is defined */
+  specLocation: SourceLocation
 }
 
 export type Variants = ExternalTag | InternalTag | Container

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -37,7 +37,7 @@ import semver from 'semver'
 import chalk from 'chalk'
 import * as model from './metamodel'
 import { EOL } from 'os'
-import { dirname, sep } from 'path'
+import {dirname, join, sep} from 'path'
 
 /**
  * Behaviors that the compiler recognized
@@ -412,6 +412,7 @@ export function modelGenerics (node: TypeParameterDeclaration): string {
  */
 export function modelEnumDeclaration (declaration: EnumDeclaration): model.Enum {
   return {
+    specLocation: sourceLocation(declaration),
     name: {
       name: declaration.getName(),
       namespace: getNameSpace(declaration)
@@ -447,6 +448,7 @@ export function modelTypeAlias (declaration: TypeAliasDeclaration): model.TypeAl
 
   const alias = modelType(type)
   const typeAlias: model.TypeAlias = {
+    specLocation: sourceLocation(declaration),
     name: {
       name: declaration.getName(),
       namespace: getNameSpace(declaration)
@@ -1176,5 +1178,15 @@ export function deepEqual (a: any, b: any): boolean {
     return true
   } catch (err) {
     return false
+  }
+}
+
+const basePath = join(__dirname, "..", "..", "specification") + "/"
+
+export function sourceLocation(node: Node): model.SourceLocation {
+  const sourceFile = node.getSourceFile()
+  return {
+    path: sourceFile.getFilePath().replace(basePath, ""),
+    line: sourceFile.getLineAndColumnAtPos(node.getPos()).line
   }
 }

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -1185,8 +1185,10 @@ const basePath = join(__dirname, '..', '..', 'specification') + '/'
 
 export function sourceLocation (node: Node): model.SourceLocation {
   const sourceFile = node.getSourceFile()
+  //const pos = sourceFile.getLineAndColumnAtPos(node.getPos())
   return {
     path: sourceFile.getFilePath().replace(basePath, ''),
-    line: sourceFile.getLineAndColumnAtPos(node.getPos()).line
+    startLine: node.getStartLineNumber(true),
+    endLine: node.getEndLineNumber()
   }
 }

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -1185,7 +1185,6 @@ const basePath = join(__dirname, '..', '..', 'specification') + '/'
 
 export function sourceLocation (node: Node): model.SourceLocation {
   const sourceFile = node.getSourceFile()
-  //const pos = sourceFile.getLineAndColumnAtPos(node.getPos())
   return {
     path: sourceFile.getFilePath().replace(basePath, ''),
     startLine: node.getStartLineNumber(true),

--- a/compiler/model/utils.ts
+++ b/compiler/model/utils.ts
@@ -37,7 +37,7 @@ import semver from 'semver'
 import chalk from 'chalk'
 import * as model from './metamodel'
 import { EOL } from 'os'
-import {dirname, join, sep} from 'path'
+import { dirname, join, sep } from 'path'
 
 /**
  * Behaviors that the compiler recognized
@@ -1181,12 +1181,12 @@ export function deepEqual (a: any, b: any): boolean {
   }
 }
 
-const basePath = join(__dirname, "..", "..", "specification") + "/"
+const basePath = join(__dirname, '..', '..', 'specification') + '/'
 
-export function sourceLocation(node: Node): model.SourceLocation {
+export function sourceLocation (node: Node): model.SourceLocation {
   const sourceFile = node.getSourceFile()
   return {
-    path: sourceFile.getFilePath().replace(basePath, ""),
+    path: sourceFile.getFilePath().replace(basePath, ''),
     line: sourceFile.getLineAndColumnAtPos(node.getPos()).line
   }
 }

--- a/compiler/steps/validate-model.ts
+++ b/compiler/steps/validate-model.ts
@@ -166,7 +166,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
       name: typeName,
       properties: [],
       // arbitrary location, it's not written to schema.json
-      specLocation: { path: '', line: -1 }
+      specLocation: { path: '', startLine: -1, endLine: -1 }
     })
   }
 

--- a/compiler/steps/validate-model.ts
+++ b/compiler/steps/validate-model.ts
@@ -164,7 +164,9 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     typeDefByName.set(fqn(typeName), {
       kind: 'interface',
       name: typeName,
-      properties: []
+      properties: [],
+      // arbitrary location, it's not written to schema.json
+      specLocation: {path: "", line: -1}
     })
   }
 

--- a/compiler/steps/validate-model.ts
+++ b/compiler/steps/validate-model.ts
@@ -166,7 +166,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
       name: typeName,
       properties: [],
       // arbitrary location, it's not written to schema.json
-      specLocation: {path: "", line: -1}
+      specLocation: { path: '', line: -1 }
     })
   }
 


### PR DESCRIPTION
Adds spec source location to type definitions in `schema.json`, containing path and line number. The path is relative to the `specification` directory, e.g.

```json
"specLocation": {
  "path": "_types/query_dsl/compound.ts",
  "startLine": 131,
  "endLine": 137
}
```