### PR TITLE
Remove NESTism documents property

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -1,6 +1,6 @@
 {
   "_info": {
-    "hash": "21676f5",
+    "hash": "5c1dbdf51",
     "license": {
       "name": "Apache 2.0",
       "url": "https://github.com/elastic/elasticsearch-specification/blob/master/LICENSE"
@@ -22638,20 +22638,6 @@
               "type": {
                 "name": "ClusterStatistics",
                 "namespace": "_types"
-              }
-            }
-          },
-          {
-            "name": "documents",
-            "required": false,
-            "type": {
-              "kind": "array_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "TDocument",
-                  "namespace": "_global.search"
-                }
               }
             }
           },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1034,7 +1034,6 @@ export interface SearchResponse<TDocument = unknown> {
   hits: SearchHitsMetadata<TDocument>
   aggregations?: Record<AggregateName, AggregationsAggregate>
   _clusters?: ClusterStatistics
-  documents?: TDocument[]
   fields?: Record<string, any>
   max_score?: double
   num_reduce_phases?: long

--- a/specification/_global/search/SearchResponse.ts
+++ b/specification/_global/search/SearchResponse.ts
@@ -33,10 +33,8 @@ export class Response<TDocument> {
     timed_out: boolean
     _shards: ShardStatistics
     hits: HitsMetadata<TDocument>
-
     aggregations?: Dictionary<AggregateName, Aggregate>
     _clusters?: ClusterStatistics
-    documents?: TDocument[]
     fields?: Dictionary<string, UserDefinedValue>
     max_score?: double
     num_reduce_phases?: long


### PR DESCRIPTION
Remove a property which is a carry over from a NEST shortcut to the hits. This is not on the response.