### PR TITLE
Adds descriptions to delete transform API

### DIFF
--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -145898,7 +145898,7 @@
       ],
       "query": [
         {
-          "description": "If this value is false, the transform must be stopped before it can be deleted. If true, the transform is \ndeleted regardless of its current state.",
+          "description": "If this value is false, the transform must be stopped before it can be deleted. If true, the transform is\ndeleted regardless of its current state.",
           "name": "force",
           "required": false,
           "serverDefault": false,

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -11998,6 +11998,11 @@
       "description": "Deletes an existing transform.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-transform.html",
       "name": "transform.delete_transform",
+      "privileges": {
+        "cluster": [
+          "manage_transform"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "transform.delete_transform"
@@ -145865,7 +145870,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Deletes an existing transform.",
+      "description": "Deletes a transform.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -145879,13 +145884,13 @@
       },
       "path": [
         {
-          "description": "The id of the transform to delete",
+          "description": "Identifier for the transform. This identifier can contain lowercase alphanumeric characters (a-z and 0-9),\nhyphens, and underscores. It has a 64 character limit and must start and end with alphanumeric characters.",
           "name": "transform_id",
           "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "Name",
+              "name": "Id",
               "namespace": "_types"
             }
           }
@@ -145893,9 +145898,10 @@
       ],
       "query": [
         {
-          "description": "When `true`, the transform is deleted regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be deleted.",
+          "description": "If this value is false, the transform must be stopped before it can be deleted. If true, the transform is \ndeleted regardless of its current state.",
           "name": "force",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/schema/schema.json
+++ b/output/schema/schema.json
@@ -145884,7 +145884,7 @@
       },
       "path": [
         {
-          "description": "Identifier for the transform. This identifier can contain lowercase alphanumeric characters (a-z and 0-9),\nhyphens, and underscores. It has a 64 character limit and must start and end with alphanumeric characters.",
+          "description": "Identifier for the transform.",
           "name": "transform_id",
           "required": true,
           "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15181,7 +15181,7 @@ export interface TransformTimeSync {
 }
 
 export interface TransformDeleteTransformRequest extends RequestBase {
-  transform_id: Name
+  transform_id: Id
   force?: boolean
 }
 

--- a/specification/transform/delete_transform/DeleteTransformRequest.ts
+++ b/specification/transform/delete_transform/DeleteTransformRequest.ts
@@ -18,18 +18,29 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Name } from '@_types/common'
+import { Id } from '@_types/common'
 
 /**
+ * Deletes a transform.
  * @rest_spec_name transform.delete_transform
  * @since 7.5.0
  * @stability stable
+ * @cluster_privileges manage_transform
  */
 export interface Request extends RequestBase {
   path_parts: {
-    transform_id: Name
+    /**
+     * Identifier for the transform. This identifier can contain lowercase alphanumeric characters (a-z and 0-9),
+     * hyphens, and underscores. It has a 64 character limit and must start and end with alphanumeric characters.
+     */
+    transform_id: Id
   }
   query_parameters: {
+    /**
+     * If this value is false, the transform must be stopped before it can be deleted. If true, the transform is
+     * deleted regardless of its current state.
+     * @server_default false
+     */
     force?: boolean
   }
 }

--- a/specification/transform/delete_transform/DeleteTransformRequest.ts
+++ b/specification/transform/delete_transform/DeleteTransformRequest.ts
@@ -30,8 +30,7 @@ import { Id } from '@_types/common'
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * Identifier for the transform. This identifier can contain lowercase alphanumeric characters (a-z and 0-9),
-     * hyphens, and underscores. It has a 64 character limit and must start and end with alphanumeric characters.
+     * Identifier for the transform.
      */
     transform_id: Id
   }


### PR DESCRIPTION
This PR adds descriptions to the delete transform specification from the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-transform.html)