### PR TITLE
Adds descriptions for start and stop transform APIs

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15383,7 +15383,7 @@ export interface TransformPutTransformResponse extends AcknowledgedResponseBase 
 }
 
 export interface TransformStartTransformRequest extends RequestBase {
-  transform_id: Name
+  transform_id: Id
   timeout?: Time
 }
 

--- a/specification/transform/start_transform/StartTransformRequest.ts
+++ b/specification/transform/start_transform/StartTransformRequest.ts
@@ -54,6 +54,7 @@ export interface Request extends RequestBase {
   query_parameters: {
     /**
      * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
      */
     timeout?: Time
   }

--- a/specification/transform/start_transform/StartTransformRequest.ts
+++ b/specification/transform/start_transform/StartTransformRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Time } from '@_types/Time'
 
 /**
- * Starts one or more transforms.
+ * Starts a transform.
  *
  * When you start a transform, it creates the destination index if it does not already exist. The `number_of_shards` is
  * set to `1` and the `auto_expand_replicas` is set to `0-1`. If it is a pivot transform, it deduces the mapping

--- a/specification/transform/start_transform/StartTransformRequest.ts
+++ b/specification/transform/start_transform/StartTransformRequest.ts
@@ -18,19 +18,43 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Name } from '@_types/common'
+import { Id } from '@_types/common'
 import { Time } from '@_types/Time'
 
 /**
+ * Starts one or more transforms.
+ *
+ * When you start a transform, it creates the destination index if it does not already exist. The `number_of_shards` is
+ * set to `1` and the `auto_expand_replicas` is set to `0-1`. If it is a pivot transform, it deduces the mapping
+ * definitions for the destination index from the source indices and the transform aggregations. If fields in the
+ * destination index are derived from scripts (as in the case of `scripted_metric` or `bucket_script` aggregations),
+ * the transform uses dynamic mappings unless an index template exists. If it is a latest transform, it does not deduce
+ * mapping definitions; it uses dynamic mappings. To use explicit mappings, create the destination index before you
+ * start the transform. Alternatively, you can create an index template, though it does not affect the deduced mappings
+ * in a pivot transform.
+ *
+ * When the transform starts, a series of validations occur to ensure its success. If you deferred validation when you
+ * created the transform, they occur when you start the transform—​with the exception of privilege checks. When
+ * Elasticsearch security features are enabled, the transform remembers which roles the user that created it had at the
+ * time of creation and uses those same roles. If those roles do not have the required privileges on the source and
+ * destination indices, the transform fails when it attempts unauthorized operations.
  * @rest_spec_name transform.start_transform
  * @since 7.5.0
  * @stability stable
+ * @cluster_privileges manage_transform
+ * @index_privileges read, view_index_metadata
  */
 export interface Request extends RequestBase {
   path_parts: {
-    transform_id: Name
+    /**
+     * Identifier for the transform.
+     */
+    transform_id: Id
   }
   query_parameters: {
+    /**
+     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     */
     timeout?: Time
   }
 }

--- a/specification/transform/stop_transform/StopTransformRequest.ts
+++ b/specification/transform/stop_transform/StopTransformRequest.ts
@@ -22,19 +22,55 @@ import { Name } from '@_types/common'
 import { Time } from '@_types/Time'
 
 /**
+ * Stops one or more transforms.
  * @rest_spec_name transform.stop_transform
  * @since 7.5.0
  * @stability stable
+ * @cluster_privileges manage_transform
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier for the transform. To stop multiple transforms, use a comma-separated list or a wildcard expression.
+     * To stop all transforms, use `_all` or `*` as the identifier.
+     */
     transform_id: Name
   }
   query_parameters: {
+    /**
+     * Specifies what to do when the request: contains wildcard expressions and there are no transforms that match;
+     * contains the `_all` string or no identifiers and there are no matches; contains wildcard expressions and there
+     * are only partial matches.
+     *
+     * If it is true, the API returns a successful acknowledgement message when there are no matches. When there are
+     * only partial matches, the API stops the appropriate transforms.
+     *
+     * If it is false, the request returns a 404 status code when there are no matches or only partial matches.
+     * @server_default true
+     */
     allow_no_match?: boolean
+    /**
+     * If it is true, the API forcefully stops the transforms.
+     * @server_default false
+     */
     force?: boolean
+    /**
+     * Period to wait for a response when `wait_for_completion` is `true`. If no response is received before the
+     * timeout expires, the request returns a timeout exception. However, the request continues processing and
+     * eventually moves the transform to a STOPPED state.
+     * @server_default 30s */
     timeout?: Time
+    /**
+     * If it is true, the transform does not completely stop until the current checkpoint is completed. If it is false,
+     * the transform stops as soon as possible.
+     * @server_default false
+     */
     wait_for_checkpoint?: boolean
+    /**
+     * If it is true, the API blocks until the indexer state completely stops. If it is false, the API returns
+     * immediately and the indexer is stopped asynchronously in the background.
+     * @server_default false
+     */
     wait_for_completion?: boolean
   }
 }


### PR DESCRIPTION
Adds descriptions for the [start transform](https://www.elastic.co/guide/en/elasticsearch/reference/master/start-transform.html) and [stop transform](https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-transform.html) APIs.