### PR TITLE
[7.16] Adds missing ML API intros 

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12073,8 +12073,8 @@ export interface MlGetCategoriesRequest extends RequestBase {
   job_id: Id
   category_id?: CategoryId
   from?: integer
-  size?: integer
   partition_field_value?: string
+  size?: integer
   body?: {
     page?: MlPage
   }

--- a/specification/ml/delete_data_frame_analytics/MlDeleteDataFrameAnalyticsRequest.ts
+++ b/specification/ml/delete_data_frame_analytics/MlDeleteDataFrameAnalyticsRequest.ts
@@ -22,9 +22,11 @@ import { Id } from '@_types/common'
 import { Time } from '@_types/Time'
 
 /**
+ * Deletes a data frame analytics job.
  * @rest_spec_name ml.delete_data_frame_analytics
  * @since 7.3.0
  * @stability stable
+ * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ml/delete_job/MlDeleteJobRequest.ts
+++ b/specification/ml/delete_job/MlDeleteJobRequest.ts
@@ -21,7 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes an existing anomaly detection job.
+ * Deletes an anomaly detection job.
+ *
  * All job configuration, model state and results are deleted.
  * It is not currently possible to delete multiple jobs using wildcards or a
  * comma separated list. If you delete a job that has a datafeed, the request

--- a/specification/ml/get_categories/MlGetCategoriesRequest.ts
+++ b/specification/ml/get_categories/MlGetCategoriesRequest.ts
@@ -23,6 +23,7 @@ import { CategoryId, Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
+ * Retrieves anomaly detection job results for one or more categories.
  * @rest_spec_name ml.get_categories
  * @since 5.4.0
  * @stability stable
@@ -50,14 +51,14 @@ export interface Request extends RequestBase {
      */
     from?: integer
     /**
+     * Only return categories for the specified partition.
+     */
+    partition_field_value?: string
+    /**
      * Specifies the maximum number of categories to obtain.
      * @server_default 100
      */
     size?: integer
-    /**
-     * Only return categories for the specified partition.
-     */
-    partition_field_value?: string
   }
   body: {
     page?: Page

--- a/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
@@ -24,8 +24,7 @@ import { Id } from '@_types/common'
 import { Definition, Input } from './types'
 
 /**
- * The create trained model API enables you to supply a trained model that is
- * not created by data frame analytics.
+ * Enables you to supply a trained model that is not created by data frame analytics.
  * @rest_spec_name ml.put_trained_model
  * @since 7.10.0
  * @stability stable

--- a/specification/ml/reset_job/MlResetJobRequest.ts
+++ b/specification/ml/reset_job/MlResetJobRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Resets an existing anomaly detection job.
+ * Resets an anomaly detection job.
  * All model state and results are deleted. The job is ready to start over as if
  * it had just been created.
  * It is not currently possible to reset multiple jobs using wildcards or a


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-specification/pull/1084