### PR TITLE
Remove source parameters from update_by_query/delete_by_query

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -547,7 +547,10 @@
     },
     "delete_by_query": {
       "request": [
-        "Request: query parameter 'size' does not exist in the json spec"
+        "Request: query parameter 'size' does not exist in the json spec",
+        "Request: missing json spec query parameter '_source'",
+        "Request: missing json spec query parameter '_source_excludes'",
+        "Request: missing json spec query parameter '_source_includes'"
       ],
       "response": []
     },
@@ -1973,7 +1976,10 @@
       "request": [
         "Request: query parameter 'size' does not exist in the json spec",
         "Request: missing json spec query parameter 'q'",
-        "Request: missing json spec query parameter 'max_docs'"
+        "Request: missing json spec query parameter 'max_docs'",
+        "Request: missing json spec query parameter '_source'",
+        "Request: missing json spec query parameter '_source_excludes'",
+        "Request: missing json spec query parameter '_source_includes'"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -202,9 +202,6 @@ export interface DeleteByQueryRequest extends RequestBase {
   size?: long
   slices?: long
   sort?: string[]
-  _source?: SearchSourceConfigParam
-  _source_excludes?: Fields
-  _source_includes?: Fields
   stats?: string[]
   terminate_after?: long
   timeout?: Time
@@ -1739,9 +1736,6 @@ export interface UpdateByQueryRequest extends RequestBase {
   size?: long
   slices?: long
   sort?: string[]
-  _source?: SearchSourceConfigParam
-  _source_excludes?: Fields
-  _source_includes?: Fields
   stats?: string[]
   terminate_after?: long
   timeout?: Time

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 import {
   Conflicts,
   ExpandWildcards,
-  Fields,
   Indices,
   Routing,
   SearchType,
@@ -31,7 +30,6 @@ import { long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { Time } from '@_types/Time'
-import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 import { Operator } from '@_types/query_dsl/Operator'
 
 /**
@@ -68,9 +66,6 @@ export interface Request extends RequestBase {
     size?: long
     slices?: long
     sort?: string[]
-    _source?: SourceConfigParam
-    _source_excludes?: Fields
-    _source_includes?: Fields
     stats?: string[]
     terminate_after?: long
     timeout?: Time

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 import {
   Conflicts,
   ExpandWildcards,
-  Fields,
   Indices,
   Routing,
   SearchType,
@@ -32,7 +31,6 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Script } from '@_types/Scripting'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { Time } from '@_types/Time'
-import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 import { Operator } from '@_types/query_dsl/Operator'
 
 /**
@@ -68,9 +66,6 @@ export interface Request extends RequestBase {
     size?: long
     slices?: long
     sort?: string[]
-    _source?: SourceConfigParam
-    _source_excludes?: Fields
-    _source_includes?: Fields
     stats?: string[]
     terminate_after?: long
     timeout?: Time


### PR DESCRIPTION
Follows from https://github.com/elastic/elasticsearch/pull/81131, these parameters were always no-ops as both `update_by_query` and `delete_by_query` don't return source information.