### PR TITLE
Adds missing timeout parameter to transform APIs

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15254,6 +15254,7 @@ export interface TransformTimeSync {
 export interface TransformDeleteTransformRequest extends RequestBase {
   transform_id: Id
   force?: boolean
+  timeout?: Time
 }
 
 export interface TransformDeleteTransformResponse extends AcknowledgedResponseBase {
@@ -15338,6 +15339,7 @@ export interface TransformGetTransformStatsTransformStats {
 
 export interface TransformPreviewTransformRequest extends RequestBase {
   transform_id?: Id
+  timeout?: Time
   body?: {
     dest?: ReindexDestination
     description?: string
@@ -15359,6 +15361,7 @@ export interface TransformPreviewTransformResponse<TTransform = unknown> {
 export interface TransformPutTransformRequest extends RequestBase {
   transform_id: Id
   defer_validation?: boolean
+  timeout?: Time
   body?: {
     dest: ReindexDestination
     description?: string
@@ -15399,6 +15402,7 @@ export interface TransformStopTransformResponse extends AcknowledgedResponseBase
 export interface TransformUpdateTransformRequest extends RequestBase {
   transform_id: Id
   defer_validation?: boolean
+  timeout?: Time
   body?: {
     dest?: ReindexDestination
     description?: string

--- a/specification/_json_spec/transform.delete_transform.json
+++ b/specification/_json_spec/transform.delete_transform.json
@@ -29,10 +29,10 @@
         "required": false,
         "description": "When `true`, the transform is deleted regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be deleted."
       },
-      "timeout":{
-        "type":"time",
-        "required":false,
-        "description":"Controls the time to wait for the transform deletion"
+      "timeout": {
+        "type": "time",
+        "required": false,
+        "description": "Controls the time to wait for the transform deletion"
       }
     }
   }

--- a/specification/_json_spec/transform.delete_transform.json
+++ b/specification/_json_spec/transform.delete_transform.json
@@ -28,6 +28,11 @@
         "type": "boolean",
         "required": false,
         "description": "When `true`, the transform is deleted regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be deleted."
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the transform deletion"
       }
     }
   }

--- a/specification/_json_spec/transform.preview_transform.json
+++ b/specification/_json_spec/transform.preview_transform.json
@@ -28,11 +28,11 @@
         }
       ]
     },
-    "params":{
-      "timeout":{
-        "type":"time",
-        "required":false,
-        "description":"Controls the time to wait for the preview"
+    "params": {
+      "timeout": {
+        "type": "time",
+        "required": false,
+        "description": "Controls the time to wait for the preview"
       }
     },
     "body": {

--- a/specification/_json_spec/transform.preview_transform.json
+++ b/specification/_json_spec/transform.preview_transform.json
@@ -28,6 +28,13 @@
         }
       ]
     },
+    "params":{
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the preview"
+      }
+    },
     "body": {
       "description": "The definition for the transform to preview",
       "required": false

--- a/specification/_json_spec/transform.put_transform.json
+++ b/specification/_json_spec/transform.put_transform.json
@@ -30,10 +30,10 @@
         "required": false,
         "description": "If validations should be deferred until transform starts, defaults to false."
       },
-      "timeout":{
-        "type":"time",
-        "required":false,
-        "description":"Controls the time to wait for the transform to start"
+      "timeout": {
+        "type": "time",
+        "required": false,
+        "description": "Controls the time to wait for the transform to start"
       }
     },
     "body": {

--- a/specification/_json_spec/transform.put_transform.json
+++ b/specification/_json_spec/transform.put_transform.json
@@ -29,6 +29,11 @@
         "type": "boolean",
         "required": false,
         "description": "If validations should be deferred until transform starts, defaults to false."
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the transform to start"
       }
     },
     "body": {

--- a/specification/_json_spec/transform.reset_transform.json
+++ b/specification/_json_spec/transform.reset_transform.json
@@ -28,6 +28,11 @@
         "type": "boolean",
         "required": false,
         "description": "When `true`, the transform is reset regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be reset."
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the transform to reset"
       }
     }
   }

--- a/specification/_json_spec/transform.reset_transform.json
+++ b/specification/_json_spec/transform.reset_transform.json
@@ -29,10 +29,10 @@
         "required": false,
         "description": "When `true`, the transform is reset regardless of its current state. The default value is `false`, meaning that the transform must be `stopped` before it can be reset."
       },
-      "timeout":{
-        "type":"time",
-        "required":false,
-        "description":"Controls the time to wait for the transform to reset"
+      "timeout": {
+        "type": "time",
+        "required": false,
+        "description": "Controls the time to wait for the transform to reset"
       }
     }
   }

--- a/specification/_json_spec/transform.update_transform.json
+++ b/specification/_json_spec/transform.update_transform.json
@@ -31,10 +31,11 @@
         "required": false,
         "description": "If validations should be deferred until transform starts, defaults to false."
       },
-      "timeout":{
-        "type":"time",
-        "required":false,
-        "description":"Controls the time to wait for the update"
+      "timeout": {
+        "type": "time",
+        "required": false,
+        "description": "Controls the time to wait for the update"
+      }
     },
     "body": {
       "description": "The update transform definition",

--- a/specification/_json_spec/transform.update_transform.json
+++ b/specification/_json_spec/transform.update_transform.json
@@ -30,7 +30,11 @@
         "type": "boolean",
         "required": false,
         "description": "If validations should be deferred until transform starts, defaults to false."
-      }
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the update"
     },
     "body": {
       "description": "The update transform definition",

--- a/specification/_json_spec/transform.upgrade_transforms.json
+++ b/specification/_json_spec/transform.upgrade_transforms.json
@@ -24,10 +24,10 @@
         "required": false,
         "description": "Whether to only check for updates but don't execute"
       },
-      "timeout":{
-        "type":"time",
-        "required":false,
-        "description":"Controls the time to wait for the upgrade"
+      "timeout": {
+        "type": "time",
+        "required": false,
+        "description": "Controls the time to wait for the upgrade"
       }
     }
   }

--- a/specification/_json_spec/transform.upgrade_transforms.json
+++ b/specification/_json_spec/transform.upgrade_transforms.json
@@ -23,6 +23,11 @@
         "type": "boolean",
         "required": false,
         "description": "Whether to only check for updates but don't execute"
+      },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the upgrade"
       }
     }
   }

--- a/specification/transform/delete_transform/DeleteTransformRequest.ts
+++ b/specification/transform/delete_transform/DeleteTransformRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Time } from '@_types/Time'
 
 /**
  * Deletes a transform.
@@ -41,5 +42,10 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     force?: boolean
+    /**
+     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
+     timeout?: Time
   }
 }

--- a/specification/transform/delete_transform/DeleteTransformRequest.ts
+++ b/specification/transform/delete_transform/DeleteTransformRequest.ts
@@ -46,6 +46,6 @@ export interface Request extends RequestBase {
      * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
-     timeout?: Time
+    timeout?: Time
   }
 }

--- a/specification/transform/preview_transform/PreviewTransformRequest.ts
+++ b/specification/transform/preview_transform/PreviewTransformRequest.ts
@@ -38,6 +38,13 @@ export interface Request extends RequestBase {
   path_parts: {
     transform_id?: Id
   }
+  query_parameters: {
+    /**
+     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
+    timeout?: Time
+  }
   body: {
     /** The destination for the transform. */
     dest?: Destination

--- a/specification/transform/put_transform/PutTransformRequest.ts
+++ b/specification/transform/put_transform/PutTransformRequest.ts
@@ -76,6 +76,11 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     defer_validation?: boolean
+    /**
+     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
+    timeout?: Time
   }
   body: {
     /** The destination for the transform. */

--- a/specification/transform/update_transform/UpdateTransformRequest.ts
+++ b/specification/transform/update_transform/UpdateTransformRequest.ts
@@ -40,6 +40,11 @@ export interface Request extends RequestBase {
   query_parameters: {
     /** When true, deferrable validations are not run. This behavior may be desired if the source index does not exist until after the transform is created. */
     defer_validation?: boolean
+   /**
+     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
+    timeout?: Time
   }
   body: {
     /** The destination for the transform. */

--- a/specification/transform/update_transform/UpdateTransformRequest.ts
+++ b/specification/transform/update_transform/UpdateTransformRequest.ts
@@ -40,7 +40,7 @@ export interface Request extends RequestBase {
   query_parameters: {
     /** When true, deferrable validations are not run. This behavior may be desired if the source index does not exist until after the transform is created. */
     defer_validation?: boolean
-   /**
+    /**
      * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */


### PR DESCRIPTION
This PR must be merged after https://github.com/elastic/elasticsearch/pull/81129

It adds the missing timeout query parameters to the transform API specifications.