### PR TITLE
Switch to using concrete types for ml.put_trained_model_definition_part

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12688,8 +12688,8 @@ export interface MlPutTrainedModelDefinitionPartRequest extends RequestBase {
   part: integer
   body?: {
     definition: string
-    total_definition_length: number
-    total_parts: number
+    total_definition_length: long
+    total_parts: integer
   }
 }
 

--- a/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartRequest.ts
+++ b/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { integer } from '@_types/Numeric'
+import { integer, long } from '@_types/Numeric'
 import { Id } from '@_types/common'
 
 /**
@@ -48,10 +48,10 @@ export interface Request extends RequestBase {
     /**
      * The total uncompressed definition length in bytes. Not base64 encoded.
      */
-    total_definition_length: number
+    total_definition_length: long
     /**
      * The total number of parts that will be uploaded. Must be greater than 0.
      */
-    total_parts: number
+    total_parts: integer
   }
 }


### PR DESCRIPTION
`number` converts to `float` in Python which isn't correct, should be an integer/long.