### PR TITLE
Adds upgrade transform specification

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1933,7 +1933,7 @@
     },
     "transform.upgrade_transforms": {
       "request": [
-        "Missing request & response"
+        "Request: should not have a body"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15379,6 +15379,17 @@ export interface TransformUpdateTransformResponse {
   version: VersionString
 }
 
+export interface TransformUpgradeTransformsRequest extends RequestBase {
+  dry_run?: boolean
+  timeout?: Time
+}
+
+export interface TransformUpgradeTransformsResponse {
+  needs_update: integer
+  no_action: integer
+  updated: integer
+}
+
 export interface WatcherAcknowledgeState {
   state: WatcherAcknowledgementOptions
   timestamp: DateString

--- a/specification/transform/upgrade_transforms/UpgradeTransformsRequest.ts
+++ b/specification/transform/upgrade_transforms/UpgradeTransformsRequest.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Time } from '@_types/Time'
+
+/**
+ * Upgrades all transforms.
+ * This API identifies transforms that have a legacy configuration format and upgrades them to the latest version. It
+ * also cleans up the internal data structures that store the transform state and checkpoints. The upgrade does not
+ * affect the source and destination indices. The upgrade also does not affect the roles that transforms use when
+ * Elasticsearch security features are enabled; the role used to read source data and write to the destination index
+ * remains unchanged.
+ * @rest_spec_name transform.upgrade_transforms
+ * @since 7.16.0
+ * @stability stable
+ * @cluster_privileges manage_transform
+ */
+export interface Request extends RequestBase {
+  query_parameters: {
+    /**
+     * When true, the request checks for updates but does not run them.
+     * @server_default false
+     */
+    dry_run?: boolean
+    /**
+     * Period to wait for a response. If no response is received before the timeout expires, the request fails and
+     * returns an error.
+     * @server_default 30s
+     */
+    timeout?: Time
+  }
+}

--- a/specification/transform/upgrade_transforms/UpgradeTransformsResponse.ts
+++ b/specification/transform/upgrade_transforms/UpgradeTransformsResponse.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { integer } from '@_types/Numeric'
+/*
+import { long } from '@_types/Numeric'
+import { Transform } from '@_types/Transform'
+*/
+export class Response {
+  body: {
+    /** The number of transforms that need to be upgraded. */
+    needs_update: integer
+    /** The number of transforms that don’t require upgrading. */
+    no_action: integer
+    /** The number of transforms that have been upgraded. */
+    updated: integer
+  }
+}


### PR DESCRIPTION
Adds a specification for the [upgrade transforms API](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/upgrade-transforms.html)
