### PR TITLE
HitsMetadata.total is not present if track_total_hits == false

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1266,7 +1266,7 @@ export interface SearchHit<TDocument = unknown> {
 }
 
 export interface SearchHitsMetadata<T = unknown> {
-  total: SearchTotalHits | long
+  total?: SearchTotalHits | long
   hits: SearchHit<T>[]
   max_score?: double | null
 }

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -60,7 +60,8 @@ export class Hit<TDocument> {
 }
 
 export class HitsMetadata<T> {
-  total: TotalHits | long
+  /** Total hit count information, present only if `track_total_hits` wasn't `false` in the search request. */
+  total?: TotalHits | long
   hits: Hit<T>[]
 
   max_score?: double | null


### PR DESCRIPTION
`HitsMetadata.total` should be optional. Reported in https://github.com/elastic/elasticsearch-java/issues/56