### PR TITLE
Add 'encoded' property to SecurityCreateApiKeyResponse

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14228,6 +14228,7 @@ export interface SecurityCreateApiKeyResponse {
   expiration?: long
   id: Id
   name: Name
+  encoded: string
 }
 
 export interface SecurityCreateApiKeyRoleDescriptor {

--- a/specification/security/create_api_key/SecurityCreateApiKeyResponse.ts
+++ b/specification/security/create_api_key/SecurityCreateApiKeyResponse.ts
@@ -21,5 +21,29 @@ import { Id, Name } from '@_types/common'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  body: { api_key: string; expiration?: long; id: Id; name: Name }
+  body: {
+    /**
+     * Generated API key.
+     */
+    api_key: string
+    /**
+     * Expiration in milliseconds for the API key.
+     */
+    expiration?: long
+    /**
+     * Unique ID for this API key.
+     */
+    id: Id
+    /**
+     * Specifies the name for this API key.
+     */
+    name: Name
+    /**
+     * API key credentials which is the base64-encoding of
+     * the UTF-8 representation of `id` and `api_key` joined
+     * by a colon (`:`).
+     * @since 7.16.0
+     */
+    encoded: string
+  }
 }


### PR DESCRIPTION
There are NEST tests that don't have this property and thus fail, but those will require an update.