### PR TITLE
[8.0] HitsMetadata.total is not present if track_total_hits == false

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1266,7 +1266,7 @@ export interface SearchHit<TDocument = unknown> {
 }
 
 export interface SearchHitsMetadata<T = unknown> {
-  total: SearchTotalHits | long
+  total?: SearchTotalHits | long
   hits: SearchHit<T>[]
   max_score?: double
 }

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -62,7 +62,8 @@ export class Hit<TDocument> {
 }
 
 export class HitsMetadata<T> {
-  total: TotalHits | long
+  /** Total hit count information, present only if `track_total_hits` wasn't `false` in the search request. */
+  total?: TotalHits | long
   hits: Hit<T>[]
 
   max_score?: double


### PR DESCRIPTION
<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make generate-spec`
- Make sure your code follows the lint rules, you can fix them by running `npm run lint:fix --prefix specification`
- Sign the CLA https://www.elastic.co/contributor-agreement/

Happy coding!

-->
