### PR TITLE
Model prune default

### DIFF
--- a/specification/ml/_types/Analysis.ts
+++ b/specification/ml/_types/Analysis.ts
@@ -58,7 +58,8 @@ export class AnalysisConfig {
    */
   latency?: Time
   /**
-   * Advanced configuration option. Affects the pruning of models that have not been updated for the given time duration. The value must be set to a multiple of the `bucket_span`. If set too low, important information may be removed from the model. Typically, set to `30d` or longer. If not set, model pruning only occurs if the model memory status reaches the soft limit or the hard limit.
+   * Advanced configuration option. Affects the pruning of models that have not been updated for the given time duration. The value must be set to a multiple of the `bucket_span`. If set too low, important information may be removed from the model.
+   * @server_default 30d
    */
   model_prune_window?: Time
   /**

--- a/specification/ml/_types/Analysis.ts
+++ b/specification/ml/_types/Analysis.ts
@@ -58,8 +58,7 @@ export class AnalysisConfig {
    */
   latency?: Time
   /**
-   * Advanced configuration option. Affects the pruning of models that have not been updated for the given time duration. The value must be set to a multiple of the `bucket_span`. If set too low, important information may be removed from the model.
-   * @server_default 30d
+   * Advanced configuration option. Affects the pruning of models that have not been updated for the given time duration. The value must be set to a multiple of the `bucket_span`. If set too low, important information may be removed from the model. For jobs created in 8.1 and later, the default value is the greater of `30d` or 20 times `bucket_span`.
    */
   model_prune_window?: Time
   /**


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/81377, which sets a default value for the model_prune_window setting in 8.1 and later releases.