### PR TITLE
Add missing "wrapper" query type

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -32,7 +32,8 @@
         "Request: query parameter 'min_compatible_shard_node' does not exist in the json spec",
         "Request: query parameter 'pre_filter_shard_size' does not exist in the json spec",
         "Request: query parameter 'scroll' does not exist in the json spec",
-        "Request: query parameter 'rest_total_hits_as_int' does not exist in the json spec"
+        "Request: query parameter 'rest_total_hits_as_int' does not exist in the json spec",
+        "interface definition _types.query_dsl:QueryContainer - Variant bool must be optional"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5312,6 +5312,7 @@ export interface QueryDslQueryContainer {
   terms?: QueryDslTermsQuery
   terms_set?: Partial<Record<Field, QueryDslTermsSetQuery>>
   wildcard?: Partial<Record<Field, QueryDslWildcardQuery | string>>
+  wrapper: QueryDslWrapperQuery
   type?: QueryDslTypeQuery
 }
 
@@ -5541,6 +5542,10 @@ export interface QueryDslWildcardQuery extends QueryDslQueryBase {
   rewrite?: MultiTermQueryRewrite
   value?: string
   wildcard?: string
+}
+
+export interface QueryDslWrapperQuery extends QueryDslQueryBase {
+  query: string
 }
 
 export type QueryDslZeroTermsQuery = 'all' | 'none'

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -151,6 +151,7 @@ export class QueryContainer {
   terms?: TermsQuery
   terms_set?: SingleKeyDictionary<Field, TermsSetQuery>
   wildcard?: SingleKeyDictionary<Field, WildcardQuery>
+  wrapper: WrapperQuery
 
   /**
    * @deprecated 7.0.0 https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html
@@ -189,6 +190,11 @@ export class CombinedFieldsQuery extends QueryBase {
 
   /** @server_default none */
   zero_terms_query?: CombinedFieldsZeroTerms
+}
+
+export class WrapperQuery extends QueryBase {
+  /** A base64 encoded query. The binary data format can be any of JSON, YAML, CBOR or SMILE encodings */
+  query: string
 }
 
 export enum CombinedFieldsOperator {


### PR DESCRIPTION
The "wrapper" query type is missing in `QueryContainer`.

Reported in https://github.com/elastic/elasticsearch-java/issues/67