### PR TITLE
query.wrapper should be optional

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -32,8 +32,7 @@
         "Request: query parameter 'min_compatible_shard_node' does not exist in the json spec",
         "Request: query parameter 'pre_filter_shard_size' does not exist in the json spec",
         "Request: query parameter 'scroll' does not exist in the json spec",
-        "Request: query parameter 'rest_total_hits_as_int' does not exist in the json spec",
-        "interface definition _types.query_dsl:QueryContainer - Variant bool must be optional"
+        "Request: query parameter 'rest_total_hits_as_int' does not exist in the json spec"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5312,7 +5312,7 @@ export interface QueryDslQueryContainer {
   terms?: QueryDslTermsQuery
   terms_set?: Partial<Record<Field, QueryDslTermsSetQuery>>
   wildcard?: Partial<Record<Field, QueryDslWildcardQuery | string>>
-  wrapper: QueryDslWrapperQuery
+  wrapper?: QueryDslWrapperQuery
   type?: QueryDslTypeQuery
 }
 

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -151,7 +151,7 @@ export class QueryContainer {
   terms?: TermsQuery
   terms_set?: SingleKeyDictionary<Field, TermsSetQuery>
   wildcard?: SingleKeyDictionary<Field, WildcardQuery>
-  wrapper: WrapperQuery
+  wrapper?: WrapperQuery
 
   /**
    * @deprecated 7.0.0 https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html


### PR DESCRIPTION
As titled.

Follow-up of #1132 