### PR TITLE
Validate ilm.delete_lifecycle

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -687,6 +687,8 @@
     },
     "ilm.delete_lifecycle": {
       "request": [
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
+        "Request: query parameter 'timeout' does not exist in the json spec",
         "Request: should not have a body"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8706,6 +8706,8 @@ export interface IlmPolicy {
 
 export interface IlmDeleteLifecycleRequest extends RequestBase {
   policy: Name
+  master_timeout?: Time
+  timeout?: Time
 }
 
 export interface IlmDeleteLifecycleResponse extends AcknowledgedResponseBase {

--- a/specification/ilm/delete_lifecycle/DeleteLifecycleRequest.ts
+++ b/specification/ilm/delete_lifecycle/DeleteLifecycleRequest.ts
@@ -19,15 +19,34 @@
 
 import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
+import { Time } from '@_types/Time'
 
 /**
+ * Deletes the specified lifecycle policy definition. You cannot delete policies that are currently in use. If the policy is being used to manage any indices, the request fails and returns an error.
+ *
  * @rest_spec_name ilm.delete_lifecycle
  * @since 6.6.0
  * @stability stable
+ * @cluster_privileges manage_ilm
  */
 export interface Request extends RequestBase {
   path_parts: {
-    /** @codegen_name name */
+    /**
+     * Identifier for the policy.
+     * @codegen_name name
+     */
     policy: Name
+  }
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
+    master_timeout?: Time
+    /**
+     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
+    timeout?: Time
   }
 }


### PR DESCRIPTION
added more descriptions and fixed upstream tests in https://github.com/elastic/clients-flight-recorder/pull/839