### PR TITLE
Check nodejs version before running the compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ spec-dangling-types:	## Generate the dangling types rreport
 	@npm run generate-dangling --prefix compiler
 
 setup:	## Install dependencies for contrib target
+	@node compiler/check-node.js
 	@make clean-dep
 	@npm install --prefix compiler
 	@npm install --prefix typescript-generator

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Once the installation is completed, install Node.js with `nvm`:
 
 ```sh
 # this command will install the version configured in .nvmrc
-nvm use
+nvm install
 ```
 
 ## How to generate the JSON representation

--- a/compiler/check-node.js
+++ b/compiler/check-node.js
@@ -17,17 +17,10 @@
  * under the License.
  */
 
-import { readFileSync } from 'fs'
-import { join } from 'path'
-import Compiler from './compiler'
-import validateRestSpec from './steps/validate-rest-spec'
-import addInfo from './steps/add-info'
-import addDescription from './steps/add-description'
-import validateModel from './steps/validate-model'
-import addContentType from './steps/add-content-type'
-import readDefinitionValidation from './steps/read-definition-validation'
+const { readFileSync } = require('fs')
+const { join } = require('path')
 
-const nvmrc = readFileSync(join(__dirname, '..', '..', '.nvmrc'), 'utf8')
+const nvmrc = readFileSync(join(__dirname, '..', '.nvmrc'), 'utf8')
 const nodejsMajor = process.version.split('.').shift()?.slice(1)
 const nvmMajor = nvmrc.trim().split('.').shift()
 
@@ -35,22 +28,3 @@ if (nodejsMajor !== nvmMajor) {
   console.error(`Bad nodejs major version, you are using ${nodejsMajor}, while ${nvmMajor} should be used. Run 'nvm install' to fix this.`)
   process.exit(1)
 }
-
-const compiler = new Compiler()
-
-compiler
-  .generateModel()
-  .step(addInfo)
-  .step(addContentType)
-  .step(readDefinitionValidation)
-  .step(validateRestSpec)
-  .step(addDescription)
-  .step(validateModel)
-  .write()
-  .then(() => {
-    console.log('Done')
-  })
-  .catch(err => {
-    console.error(err)
-    process.exit(1)
-  })

--- a/compiler/src/index.ts
+++ b/compiler/src/index.ts
@@ -28,8 +28,8 @@ import addContentType from './steps/add-content-type'
 import readDefinitionValidation from './steps/read-definition-validation'
 
 const nvmrc = readFileSync(join(__dirname, '..', '..', '.nvmrc'), 'utf8')
-const nodejsMajor = process.version.split('.').shift()?.slice(1)
-const nvmMajor = nvmrc.trim().split('.').shift()
+const nodejsMajor = process.version.split('.').shift()?.slice(1) ?? ''
+const nvmMajor = nvmrc.trim().split('.').shift() ?? ''
 
 if (nodejsMajor !== nvmMajor) {
   console.error(`Bad nodejs major version, you are using ${nodejsMajor}, while ${nvmMajor} should be used. Run 'nvm install' to fix this.`)


### PR DESCRIPTION
With this change, the compiler will ensure that you are running it with the nodejs version configured in `.nvmrc`.
The `make setup` target will perform the same check as well.

Closes: #1011