### PR TITLE
Suggest the correct API name if the input is wrong

### DIFF
--- a/compiler/package-lock.json
+++ b/compiler/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",
+        "fastest-levenshtein": "^1.0.12",
         "ora": "^5.4.1",
         "safe-stable-stringify": "^2.3.1",
         "semver": "^7.3.5",
@@ -1623,6 +1624,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -4951,6 +4957,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
     },
     "fastq": {
       "version": "1.13.0",

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
+    "fastest-levenshtein": "^1.0.12",
     "ora": "^5.4.1",
     "safe-stable-stringify": "^2.3.1",
     "semver": "^7.3.5",

--- a/compiler/run-validations.js
+++ b/compiler/run-validations.js
@@ -28,6 +28,7 @@ try {
 
 const ora = require('ora')
 const { readFile, writeFile } = require('fs/promises')
+const { closest } = require('fastest-levenshtein')
 
 // enable subprocess colors
 process.env.COLOR = true
@@ -43,6 +44,10 @@ const uploadRecordingsPath = path.join(__dirname, '..', '..', 'clients-flight-re
 const tsValidationPath = path.join(__dirname, '..', '..', 'clients-flight-recorder', 'scripts', 'types-validator')
 const DAY = 1000 * 60 * 60 * 24
 
+const apis = require('../output/schema/schema.json')
+  .endpoints
+  .map(endpoint => endpoint.name)
+
 async function run () {
   spinner.text = 'Checking requirements'
 
@@ -53,6 +58,11 @@ async function run () {
 
   if (typeof argv.api !== 'string') {
     spinner.fail('You must specify the api, for example: \'make validate-request api=index type=request stack-version=8.1.0-SNAPSHOT\'')
+    process.exit(1)
+  }
+
+  if (!apis.includes(argv.api)) {
+    spinner.fail(`The api '${argv.api}' does not exists, did you mean '${closest(argv.api, apis)}'?`)
     process.exit(1)
   }
 

--- a/compiler/run-validations.js
+++ b/compiler/run-validations.js
@@ -19,16 +19,19 @@
 
 /* global $ argv, path, cd, nothrow */
 
+let ora
+let closest
 try {
   require('zx/globals')
+  ora = require('ora')
+  const fl = require('fastest-levenshtein')
+  closest = fl.closest
 } catch (err) {
   console.log('It looks like you didn\'t install the project dependencies, please run \'make setup\'')
   process.exit(1)
 }
 
-const ora = require('ora')
 const { readFile, writeFile } = require('fs/promises')
-const { closest } = require('fastest-levenshtein')
 
 // enable subprocess colors
 process.env.COLOR = true

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -35,6 +35,7 @@ import {
   Node,
   Project
 } from 'ts-morph'
+import { closest } from 'fastest-levenshtein'
 import semver from 'semver'
 import chalk from 'chalk'
 import * as model from './metamodel'
@@ -566,7 +567,7 @@ export function hoistRequestAnnotations (
     `Request ${request.name.name} does not declare the @rest_spec_name to link back to`)
 
   const endpoint = mappings[apiName]
-  assert(jsDocs, endpoint != null, `${apiName} is not represented in the spec as a json file`)
+  assert(jsDocs, endpoint != null, `The api '${apiName}' does not exists, did you mean '${closest(apiName, Object.keys(mappings))}'?`)
 
   endpoint.request = request.name
   endpoint.response = response


### PR DESCRIPTION
As titled.

Example:
```sh
▶ make validate stack-version=8.1.0-SNAPSHOT type=response api=indices.get_mappings
✖ The api 'indices.get_mappings' does not exists, did you mean 'indices.get_mapping'?
```

This check will be performed by both the compiler and validator.