### PR TITLE
Validate both request and response at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,11 @@ git clone https://github.com/elastic/elasticsearch-specification.git
 git clone https://github.com/elastic/clients-flight-recorder.git
 
 cd elasticsearch-specification
-# this will validate the xpack.info request type agains the 8.1.0 stack version
+# this will validate the xpack.info request type against the 8.1.0 stack version
 make validate api=xpack.info type=request stack-version=8.1.0-SNAPSHOT
+
+# this will validate the xpack.info request and response types against the 8.1.0 stack version
+make validate api=xpack.info stack-version=8.1.0-SNAPSHOT
 ```
 
 The last command above will install all the dependencies and run, download


### PR DESCRIPTION
If you want to validate both requests and response types at the same time, omit the `type` argument in the make command, for example:

```sh
# this will validate the request
make validate stack-version=8.1.0-SNAPSHOT api=indices.create type=request

# this will validate the response
make validate stack-version=8.1.0-SNAPSHOT api=indices.create type=response

# this will validate both request and response
make validate stack-version=8.1.0-SNAPSHOT api=indices.create

```