### PR TITLE
Add IndexSettings.time_series field

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9144,6 +9144,7 @@ export interface IndicesIndexSettings {
   analysis?: IndicesIndexSettingsAnalysis
   'index.analysis'?: IndicesIndexSettingsAnalysis
   settings?: IndicesIndexSettings
+  time_series?: IndicesIndexSettingsTimeSeries
 }
 
 export interface IndicesIndexSettingsAnalysis {
@@ -9156,6 +9157,11 @@ export interface IndicesIndexSettingsAnalysis {
 
 export interface IndicesIndexSettingsLifecycle {
   name: Name
+}
+
+export interface IndicesIndexSettingsTimeSeries {
+  end_time?: DateString
+  start_time?: DateString
 }
 
 export interface IndicesIndexState {

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -282,6 +282,10 @@ export class IndexSettings {
    */
   analysis?: IndexSettingsAnalysis
   settings?: IndexSettings
+  /**
+   * @stability experimental
+   */
+  time_series?: IndexSettingsTimeSeries
 }
 
 export class IndexSettingBlocks {
@@ -313,4 +317,9 @@ export class IndexSettingsAnalysis {
   filter?: Dictionary<string, TokenFilter>
   normalizer?: Dictionary<string, Normalizer>
   tokenizer?: Dictionary<string, Tokenizer>
+}
+
+export class IndexSettingsTimeSeries {
+  end_time?: DateString
+  start_time?: DateString
 }


### PR DESCRIPTION
Only applies to 8.1.0 I believe? The [PR adding it](https://github.com/elastic/elasticsearch/pull/78291) is marked as 8.0.0 but the YAML tests say 8.1.0.