### PR TITLE
Fix regression in aggregation changes

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3572,7 +3572,7 @@ export interface AggregationsStringStatsAggregate extends AggregationsAggregateB
   max_length: integer | null
   avg_length: double | null
   entropy: double | null
-  distribution?: string | null
+  distribution?: Record<string, double> | null
   min_length_as_string?: string
   max_length_as_string?: string
   avg_length_as_string?: string

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -645,7 +645,7 @@ export class StringStatsAggregate extends AggregateBase {
   max_length: integer | null
   avg_length: double | null
   entropy: double | null
-  distribution?: string | null
+  distribution?: Dictionary<string, double> | null
   min_length_as_string?: string
   max_length_as_string?: string
   avg_length_as_string?: string


### PR DESCRIPTION
As discussed with @swallez last week. It appears that a mistake slipped into a prior PR which changed the `distribution` field in `StringStatsAggregate` to a `string` from a `Dictionary<string, double>`. This PR reverts this as .NET client tests are failing due to the currently generated type using a string for the property.

@swallez Not sure if we want this backported back to 7.x branches?