### PR TITLE
Change timestamps defined as integer to long

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2295,7 +2295,7 @@ export interface SegmentsStats {
   index_writer_memory?: ByteSize
   index_writer_max_memory_in_bytes?: integer
   index_writer_memory_in_bytes: integer
-  max_unsafe_auto_id_timestamp: integer
+  max_unsafe_auto_id_timestamp: long
   memory?: ByteSize
   memory_in_bytes: integer
   norms_memory?: ByteSize
@@ -9419,7 +9419,7 @@ export interface IndicesDataStreamsStatsDataStreamsStatsItem {
   data_stream: Name
   store_size?: ByteSize
   store_size_bytes: integer
-  maximum_timestamp: integer
+  maximum_timestamp: long
 }
 
 export interface IndicesDataStreamsStatsRequest extends RequestBase {
@@ -11700,7 +11700,7 @@ export interface MlModelSnapshot {
   retain: boolean
   snapshot_doc_count: long
   snapshot_id: Id
-  timestamp: integer
+  timestamp: long
 }
 
 export interface MlOutlierDetectionParameters {
@@ -12514,7 +12514,7 @@ export interface MlPostDataRequest<TData = unknown> extends RequestBase {
 
 export interface MlPostDataResponse {
   bucket_count: long
-  earliest_record_timestamp: integer
+  earliest_record_timestamp: long
   empty_bucket_count: long
   input_bytes: long
   input_field_count: long
@@ -12522,7 +12522,7 @@ export interface MlPostDataResponse {
   invalid_date_count: long
   job_id: Id
   last_data_time: integer
-  latest_record_timestamp: integer
+  latest_record_timestamp: long
   missing_field_count: long
   out_of_order_timestamp_count: long
   processed_field_count: long

--- a/specification/_types/Stats.ts
+++ b/specification/_types/Stats.ts
@@ -208,7 +208,7 @@ export class SegmentsStats {
   index_writer_memory?: ByteSize
   index_writer_max_memory_in_bytes?: integer
   index_writer_memory_in_bytes: integer
-  max_unsafe_auto_id_timestamp: integer
+  max_unsafe_auto_id_timestamp: long
   memory?: ByteSize
   memory_in_bytes: integer
   norms_memory?: ByteSize

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsResponse.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsResponse.ts
@@ -18,7 +18,7 @@
  */
 
 import { ByteSize, Name } from '@_types/common'
-import { integer } from '@_types/Numeric'
+import { integer, long } from '@_types/Numeric'
 import { ShardStatistics } from '@_types/Stats'
 
 export class Response {
@@ -37,5 +37,5 @@ export class DataStreamsStatsItem {
   data_stream: Name
   store_size?: ByteSize
   store_size_bytes: integer
-  maximum_timestamp: integer
+  maximum_timestamp: long
 }

--- a/specification/ml/_types/Model.ts
+++ b/specification/ml/_types/Model.ts
@@ -41,7 +41,7 @@ export class ModelSnapshot {
   /** A numerical character string that uniquely identifies the model snapshot. */
   snapshot_id: Id
   /** The creation timestamp for the snapshot. */
-  timestamp: integer
+  timestamp: long
 }
 
 export class ModelSizeStats {

--- a/specification/ml/post_data/MlPostJobDataResponse.ts
+++ b/specification/ml/post_data/MlPostJobDataResponse.ts
@@ -23,7 +23,7 @@ import { integer, long } from '@_types/Numeric'
 export class Response {
   body: {
     bucket_count: long
-    earliest_record_timestamp: integer
+    earliest_record_timestamp: long
     empty_bucket_count: long
     input_bytes: long
     input_field_count: long
@@ -31,7 +31,7 @@ export class Response {
     invalid_date_count: long
     job_id: Id
     last_data_time: integer
-    latest_record_timestamp: integer
+    latest_record_timestamp: long
     missing_field_count: long
     out_of_order_timestamp_count: long
     processed_field_count: long


### PR DESCRIPTION
Integers are not large enough to hold timestamps. This caused a failure in the Java client (see https://github.com/elastic/elasticsearch-java/issues/88).

This PR fixes fields declared as `*_timestamp: integer` (which includes the one that caused the original issue).
