### PR TITLE
Address some of the Top 20 APIs

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -2026,7 +2026,9 @@
       "request": [
         "Request: should not have a body"
       ],
-      "response": []
+      "response": [
+        "interface definition transform._types:SyncContainer - Property time is a single-variant and must be required"
+      ]
     },
     "transform.get_transform_stats": {
       "request": [
@@ -2036,7 +2038,6 @@
     },
     "transform.preview_transform": {
       "request": [
-        "interface definition transform._types:SyncContainer - Property time is a single-variant and must be required",
         "interface definition transform._types:RetentionPolicyContainer - Property time is a single-variant and must be required"
       ],
       "response": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2405,10 +2405,6 @@ export interface TopRightBottomLeftGeoBounds {
   bottom_left: GeoLocation
 }
 
-export interface Transform {
-  [key: string]: never
-}
-
 export interface TransformContainer {
   chain?: ChainTransform
   script?: ScriptTransform
@@ -9033,8 +9029,8 @@ export interface IndicesIndexSettings {
   'index.uuid'?: Uuid
   version?: IndicesIndexVersioning
   'index.version'?: IndicesIndexVersioning
-  verified_before_close?: boolean | string
-  'index.verified_before_close'?: boolean | string
+  verified_before_close?: boolean
+  'index.verified_before_close'?: boolean
   format?: string | integer
   'index.format'?: string | integer
   max_slices_per_scroll?: integer
@@ -9043,8 +9039,8 @@ export interface IndicesIndexSettings {
   'index.translog.durability'?: string
   'translog.flush_threshold_size'?: string
   'index.translog.flush_threshold_size'?: string
-  'query_string.lenient'?: boolean | string
-  'index.query_string.lenient'?: boolean | string
+  'query_string.lenient'?: boolean
+  'index.query_string.lenient'?: boolean
   priority?: integer | string
   'index.priority'?: integer | string
   top_metrics_max_size?: integer
@@ -11093,18 +11089,19 @@ export type MlCustomSettings = any
 
 export interface MlDataCounts {
   bucket_count: long
-  earliest_record_timestamp: long
+  earliest_record_timestamp?: long
   empty_bucket_count: long
   input_bytes: long
   input_field_count: long
   input_record_count: long
   invalid_date_count: long
   job_id: Id
-  last_data_time: long
-  latest_empty_bucket_timestamp: long
-  latest_record_timestamp: long
-  latest_sparse_bucket_timestamp: long
-  latest_bucket_timestamp: long
+  last_data_time?: long
+  latest_empty_bucket_timestamp?: long
+  latest_record_timestamp?: long
+  latest_sparse_bucket_timestamp?: long
+  latest_bucket_timestamp?: long
+  log_time?: long
   missing_field_count: long
   out_of_order_timestamp_count: long
   processed_field_count: long
@@ -11157,14 +11154,20 @@ export interface MlDatafeedConfig {
   scroll_size?: integer
 }
 
+export interface MlDatafeedRunningState {
+  real_time_configured: boolean
+  real_time_running: boolean
+}
+
 export type MlDatafeedState = 'started' | 'stopped' | 'starting' | 'stopping'
 
 export interface MlDatafeedStats {
-  assignment_explanation: string
+  assignment_explanation?: string
   datafeed_id: Id
-  node: MlDiscoveryNode
+  node?: MlDiscoveryNode
   state: MlDatafeedState
   timing_stats: MlDatafeedTimingStats
+  running_state?: MlDatafeedRunningState
 }
 
 export interface MlDatafeedTimingStats {
@@ -11173,7 +11176,7 @@ export interface MlDatafeedTimingStats {
   job_id: Id
   search_count: long
   total_search_time_ms: double
-  average_search_time_per_bucket_ms: number
+  average_search_time_per_bucket_ms?: number
 }
 
 export interface MlDataframeAnalysis {
@@ -11515,9 +11518,9 @@ export interface MlJob {
   allow_lazy_open: boolean
   analysis_config: MlAnalysisConfig
   analysis_limits?: MlAnalysisLimits
-  background_persist_interval: Time
+  background_persist_interval?: Time
   blocked?: MlJobBlocked
-  create_time: integer
+  create_time?: integer
   custom_settings?: MlCustomSettings
   daily_model_snapshot_retention_after_days?: long
   data_description: MlDataDescription
@@ -11527,8 +11530,8 @@ export interface MlJob {
   finished_time?: integer
   groups?: string[]
   job_id: Id
-  job_type: string
-  job_version: VersionString
+  job_type?: string
+  job_version?: VersionString
   model_plot_config?: MlModelPlotConfig
   model_snapshot_id?: Id
   model_snapshot_retention_days: long
@@ -11583,12 +11586,12 @@ export interface MlJobStatistics {
 }
 
 export interface MlJobStats {
-  assignment_explanation: string
+  assignment_explanation?: string
   data_counts: MlDataCounts
   forecasts_stats: MlJobForecastStatistics
   job_id: string
   model_size_stats: MlModelSizeStats
-  node: MlDiscoveryNode
+  node?: MlDiscoveryNode
   open_time?: DateString
   state: MlJobState
   timing_stats: MlJobTimingStats
@@ -11596,14 +11599,14 @@ export interface MlJobStats {
 }
 
 export interface MlJobTimingStats {
-  average_bucket_processing_time_ms: double
+  average_bucket_processing_time_ms?: double
   bucket_count: long
-  exponential_average_bucket_processing_time_ms: double
+  exponential_average_bucket_processing_time_ms?: double
   exponential_average_bucket_processing_time_per_hour_ms: double
   job_id: Id
   total_bucket_processing_time_ms: double
-  maximum_bucket_processing_time_ms: double
-  minimum_bucket_processing_time_ms: double
+  maximum_bucket_processing_time_ms?: double
+  minimum_bucket_processing_time_ms?: double
 }
 
 export type MlMemoryStatus = 'ok' | 'soft_limit' | 'hard_limit'
@@ -15403,6 +15406,12 @@ export interface TransformSettings {
   max_page_search_size?: integer
 }
 
+export interface TransformSource {
+  index: Indices
+  query?: QueryDslQueryContainer
+  runtime_mappings?: MappingRuntimeFields
+}
+
 export interface TransformSyncContainer {
   time?: TransformTimeSync
 }
@@ -15431,7 +15440,22 @@ export interface TransformGetTransformRequest extends RequestBase {
 
 export interface TransformGetTransformResponse {
   count: long
-  transforms: Transform[]
+  transforms: TransformGetTransformTransformSummary[]
+}
+
+export interface TransformGetTransformTransformSummary {
+  dest: ReindexDestination
+  description?: string
+  frequency?: Time
+  id: Id
+  pivot?: TransformPivot
+  settings?: TransformSettings
+  source: TransformSource
+  sync?: TransformSyncContainer
+  create_time?: EpochMillis
+  version?: VersionString
+  latest?: TransformLatest
+  _meta?: Metadata
 }
 
 export interface TransformGetTransformStatsCheckpointStats {

--- a/specification/_global/msearch/MultiSearchRequest.ts
+++ b/specification/_global/msearch/MultiSearchRequest.ts
@@ -20,12 +20,13 @@
 import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, Indices, SearchType, Types } from '@_types/common'
 import { long } from '@_types/Numeric'
-import { MultisearchBody, MultisearchHeader, RequestItem } from './types'
+import { RequestItem } from './types'
 
 /**
  * @rest_spec_name msearch
  * @since 1.3.0
  * @stability stable
+ * @index_privileges read
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
@@ -23,10 +23,11 @@ import { long } from '@_types/Numeric'
 import { RequestItem } from './types'
 
 /**
+ * Runs multiple [templated searches](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html#run-multiple-templated-searches) with a single request.
  * @rest_spec_name msearch_template
  * @since 5.0.0
- *
  * @stability stable
+ * @index_privileges read
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -237,7 +237,7 @@ export class IndexSettings {
   /**
    * @aliases index.verified_before_close
    */
-  verified_before_close?: boolean | string // TODO should be bool only
+  verified_before_close?: boolean
   /**
    * @aliases index.format
    */
@@ -257,7 +257,7 @@ export class IndexSettings {
   /**
    * @aliases index.query_string.lenient
    */
-  'query_string.lenient'?: boolean | string // TODO: should be bool only
+  'query_string.lenient'?: boolean
   /**
    * @aliases index.priority
    */

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -118,18 +118,19 @@ export class DelayedDataCheckConfig {
 
 // Identical to WatcherState, but kept separate as they're different enums in ES
 export enum DatafeedState {
-  started = 0,
-  stopped = 1,
-  starting = 2,
-  stopping = 3
+  started,
+  stopped,
+  starting,
+  stopping
 }
 
 export class DatafeedStats {
-  assignment_explanation: string
+  assignment_explanation?: string
   datafeed_id: Id
-  node: DiscoveryNode
+  node?: DiscoveryNode
   state: DatafeedState
   timing_stats: DatafeedTimingStats
+  running_state?: DatafeedRunningState
 }
 
 export class DatafeedTimingStats {
@@ -138,13 +139,18 @@ export class DatafeedTimingStats {
   job_id: Id
   search_count: long
   total_search_time_ms: double
-  average_search_time_per_bucket_ms: number
+  average_search_time_per_bucket_ms?: number
+}
+
+export class DatafeedRunningState {
+  real_time_configured: boolean
+  real_time_running: boolean
 }
 
 export enum ChunkingMode {
-  auto = 0,
-  manual = 1,
-  off = 2
+  auto,
+  manual,
+  off
 }
 
 export class ChunkingConfig {
@@ -154,6 +160,7 @@ export class ChunkingConfig {
   mode: ChunkingMode
   /**
    * The time span that each search will be querying. This setting is only applicable when the `mode` is set to `manual`.
-   * @server_default 3h */
+   * @server_default 3h
+   */
   time_span?: Time
 }

--- a/specification/ml/_types/Job.ts
+++ b/specification/ml/_types/Job.ts
@@ -47,9 +47,9 @@ export class Job {
   allow_lazy_open: boolean
   analysis_config: AnalysisConfig
   analysis_limits?: AnalysisLimits
-  background_persist_interval: Time
+  background_persist_interval?: Time
   blocked?: JobBlocked
-  create_time: integer
+  create_time?: integer
   custom_settings?: CustomSettings
   daily_model_snapshot_retention_after_days?: long
   data_description: DataDescription
@@ -59,8 +59,8 @@ export class Job {
   finished_time?: integer
   groups?: string[]
   job_id: Id
-  job_type: string
-  job_version: VersionString
+  job_type?: string
+  job_version?: VersionString
   model_plot_config?: ModelPlotConfig
   model_snapshot_id?: Id
   model_snapshot_retention_days: long
@@ -89,12 +89,12 @@ export class JobConfig {
   results_retention_days?: long
 }
 export class JobStats {
-  assignment_explanation: string
+  assignment_explanation?: string
   data_counts: DataCounts
   forecasts_stats: JobForecastStatistics
   job_id: string
   model_size_stats: ModelSizeStats
-  node: DiscoveryNode
+  node?: DiscoveryNode
   open_time?: DateString
   state: JobState
   timing_stats: JobTimingStats
@@ -102,14 +102,14 @@ export class JobStats {
 }
 
 export class JobTimingStats {
-  average_bucket_processing_time_ms: double
+  average_bucket_processing_time_ms?: double
   bucket_count: long
-  exponential_average_bucket_processing_time_ms: double
+  exponential_average_bucket_processing_time_ms?: double
   exponential_average_bucket_processing_time_per_hour_ms: double
   job_id: Id
   total_bucket_processing_time_ms: double
-  maximum_bucket_processing_time_ms: double
-  minimum_bucket_processing_time_ms: double
+  maximum_bucket_processing_time_ms?: double
+  minimum_bucket_processing_time_ms?: double
 }
 
 export class JobForecastStatistics {
@@ -123,18 +123,19 @@ export class JobForecastStatistics {
 
 export class DataCounts {
   bucket_count: long
-  earliest_record_timestamp: long
+  earliest_record_timestamp?: long
   empty_bucket_count: long
   input_bytes: long
   input_field_count: long
   input_record_count: long
   invalid_date_count: long
   job_id: Id
-  last_data_time: long
-  latest_empty_bucket_timestamp: long
-  latest_record_timestamp: long
-  latest_sparse_bucket_timestamp: long
-  latest_bucket_timestamp: long
+  last_data_time?: long
+  latest_empty_bucket_timestamp?: long
+  latest_record_timestamp?: long
+  latest_sparse_bucket_timestamp?: long
+  latest_bucket_timestamp?: long
+  log_time?: long
   missing_field_count: long
   out_of_order_timestamp_count: long
   processed_field_count: long

--- a/specification/nodes/hot_threads/NodesHotThreadsRequest.ts
+++ b/specification/nodes/hot_threads/NodesHotThreadsRequest.ts
@@ -23,9 +23,12 @@ import { long } from '@_types/Numeric'
 import { Time } from '@_types/Time'
 
 /**
+ * This API yields a breakdown of the hot threads on each selected node in the cluster.
+ * The output is plain text with a breakdown of each node’s top hot threads.
  * @rest_spec_name nodes.hot_threads
  * @since 0.0.0
  * @stability stable
+ * @cluster_privileges monitor,manage
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/transform/get_transform/GetTransformResponse.ts
+++ b/specification/transform/get_transform/GetTransformResponse.ts
@@ -18,8 +18,8 @@
  */
 
 import { long } from '@_types/Numeric'
-import { Transform } from '@_types/Transform'
+import { TransformSummary } from './types'
 
 export class Response {
-  body: { count: long; transforms: Transform[] }
+  body: { count: long; transforms: TransformSummary[] }
 }

--- a/specification/transform/get_transform/types.ts
+++ b/specification/transform/get_transform/types.ts
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Destination } from '@global/reindex/types'
+import {
+  Latest,
+  Pivot,
+  Settings,
+  Source,
+  SyncContainer
+} from '@transform/_types/Transform'
+import { Id, Metadata, VersionString } from '@_types/common'
+import { EpochMillis, Time } from '@_types/Time'
+
+export class TransformSummary {
+  /** The destination for the transform. */
+  dest: Destination
+  /** Free text description of the transform. */
+  description?: string
+  frequency?: Time
+  id: Id
+  /** The pivot method transforms the data by aggregating and grouping it. */
+  pivot?: Pivot
+  /** Defines optional transform settings. */
+  settings?: Settings
+  /** The source of the data for the transform. */
+  source: Source
+  /**  Defines the properties transforms require to run continuously. */
+  sync?: SyncContainer
+  create_time?: EpochMillis
+  version?: VersionString
+  latest?: Latest
+  _meta?: Metadata
+}


### PR DESCRIPTION
Backport #1235 to 7.17.

These changes, even if they introduce breaking changes, have to be backported as they're fixing errors in the spec that will cause strongly types clients (like Java) to fail.