### PR TITLE
Improve eql.search

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8662,7 +8662,7 @@ export interface EqlGetStatusResponse {
 }
 
 export interface EqlSearchRequest extends RequestBase {
-  index: IndexName
+  index: Indices
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
@@ -8681,8 +8681,9 @@ export interface EqlSearchRequest extends RequestBase {
     keep_on_completion?: boolean
     wait_for_completion_timeout?: Time
     size?: uint
-    fields?: QueryDslFieldAndFormat | Field
+    fields?: QueryDslFieldAndFormat | Field | (QueryDslFieldAndFormat | Field)[]
     result_position?: EqlSearchResultPosition
+    runtime_mappings?: MappingRuntimeFields
   }
 }
 

--- a/specification/eql/search/EqlSearchRequest.ts
+++ b/specification/eql/search/EqlSearchRequest.ts
@@ -18,8 +18,9 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { ExpandWildcards, Field, IndexName } from '@_types/common'
-import { float, uint } from '@_types/Numeric'
+import { ExpandWildcards, Field, IndexName, Indices } from '@_types/common'
+import { RuntimeFields } from '@_types/mapping/RuntimeFields'
+import { uint } from '@_types/Numeric'
 import { FieldAndFormat, QueryContainer } from '@_types/query_dsl/abstractions'
 import { Time } from '@_types/Time'
 import { ResultPosition } from './types'
@@ -31,7 +32,7 @@ import { ResultPosition } from './types'
  */
 export interface Request extends RequestBase {
   path_parts: {
-    index: IndexName
+    index: Indices
   }
   query_parameters: {
     /**
@@ -103,10 +104,12 @@ export interface Request extends RequestBase {
     /**
      * Array of wildcard (*) patterns. The response returns values for field names matching these patterns in the fields property of each hit.
      */
-    fields?: FieldAndFormat
+    fields?: FieldAndFormat | FieldAndFormat[]
     /**
      * @server_default tail
      */
     result_position?: ResultPosition
+    /** @since 8.0.0 */
+    runtime_mappings?: RuntimeFields
   }
 }


### PR DESCRIPTION
fixed 13 tests, still two failing though.

```
make validate stack-version=8.0.0-SNAPSHOT api=eql.search
- Validating endpoints
⚠ It looks like eql.search request has some errors, take a look at the workbench.
/Users/pkrauss/github.com/clients-flight-recorder/scripts/types-validator/workbench

scripts/types-validator/workbench/0407f84ece889d72be16d0133bbad50a.test-d.ts:15:6
Property 'type' is missing in type '{ script: string; }' but required in type 'MappingRuntimeField'.

scripts/types-validator/workbench/09192327dc9f866660e042f1f72f1742.test-d.ts:15:6
Property 'type' is missing in type '{ script: string; type: string; }[]' but required in type 'MappingRuntimeField'.

✖ 24 out of 26 test request cases are passing.
✔ 26 out of 26 test response cases are passing.
```