### PR TITLE
Fix some unlabelled unions

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15450,7 +15450,7 @@ export type TasksTaskInfos = TasksTaskInfo[] | Record<string, TasksParentTaskInf
 export interface TasksTaskListResponseBase {
   node_failures?: ErrorCause[]
   task_failures?: TaskFailure[]
-  nodes?: Record<NodeId, TasksNodeTasks>
+  nodes?: Record<string, TasksNodeTasks>
   tasks?: TasksTaskInfos
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1054,7 +1054,7 @@ export interface SearchAggregationProfile {
   description: string
   time_in_nanos: long
   type: string
-  debug?: SearchAggregationProfileDebug | SearchAggregationProfileDelegateDebug
+  debug?: SearchAggregationProfileDebug
   children?: SearchAggregationProfile[]
 }
 
@@ -1067,7 +1067,7 @@ export interface SearchAggregationProfileDebug {
   result_strategy?: string
   has_filter?: boolean
   delegate?: string
-  delegate_debug?: SearchAggregationProfileDelegateDebug
+  delegate_debug?: SearchAggregationProfileDebug
   chars_fetched?: integer
   extract_count?: integer
   extract_ns?: integer
@@ -1081,9 +1081,6 @@ export interface SearchAggregationProfileDebug {
   numeric_collectors_used?: integer
   empty_collectors_used?: integer
   deferred_aggregators?: string[]
-}
-
-export interface SearchAggregationProfileDelegateDebug {
   segments_with_doc_count_field?: integer
   segments_with_deleted_docs?: integer
   filters?: SearchAggregationProfileDelegateDebugFilter[]
@@ -2143,7 +2140,7 @@ export interface NodeShard {
   allocation_id?: Record<string, Id>
   recovery_source?: Record<string, Id>
   unassigned_info?: ClusterAllocationExplainUnassignedInformation
-  relocating_node?: null
+  relocating_node?: NodeId | null
 }
 
 export interface NodeStatistics {
@@ -2718,18 +2715,14 @@ export interface AggregationsCategorizeTextAggregation extends AggregationsAggre
   max_matched_tokens?: integer
   similarity_threshold?: integer
   categorization_filters?: string[]
-  categorization_analyzer?: string | AggregationsCategorizeTextAnalyzer
+  categorization_analyzer?: AggregationsCategorizeTextAnalyzer
   shard_size?: integer
   size?: integer
   min_doc_count?: integer
   shard_min_doc_count?: integer
 }
 
-export interface AggregationsCategorizeTextAnalyzer {
-  char_filter?: string[]
-  tokenizer?: string
-  filter?: string[]
-}
+export type AggregationsCategorizeTextAnalyzer = string | AggregationsCustomCategorizeTextAnalyzer
 
 export interface AggregationsChiSquareHeuristic {
   background_is_superset: boolean
@@ -2785,6 +2778,12 @@ export interface AggregationsCumulativeCardinalityAggregation extends Aggregatio
 }
 
 export interface AggregationsCumulativeSumAggregation extends AggregationsPipelineAggregationBase {
+}
+
+export interface AggregationsCustomCategorizeTextAnalyzer {
+  char_filter?: string[]
+  tokenizer?: string
+  filter?: string[]
 }
 
 export interface AggregationsDateHistogramAggregate extends AggregationsMultiBucketAggregateBase<AggregationsDateHistogramBucket> {
@@ -15451,7 +15450,7 @@ export type TasksTaskInfos = TasksTaskInfo[] | Record<string, TasksParentTaskInf
 export interface TasksTaskListResponseBase {
   node_failures?: ErrorCause[]
   task_failures?: TaskFailure[]
-  nodes?: Record<string, TasksNodeTasks>
+  nodes?: Record<NodeId, TasksNodeTasks>
   tasks?: TasksTaskInfos
 }
 

--- a/specification/_global/search/_types/profile.ts
+++ b/specification/_global/search/_types/profile.ts
@@ -34,6 +34,7 @@ export class AggregationBreakdown {
   reduce_count: long
 }
 
+// This is a Map<String, Object> in ES. Below are the known fields.
 export class AggregationProfileDebug {
   segments_with_multi_valued_ords?: integer
   collection_strategy?: string
@@ -43,7 +44,7 @@ export class AggregationProfileDebug {
   result_strategy?: string
   has_filter?: boolean
   delegate?: string
-  delegate_debug?: AggregationProfileDelegateDebug
+  delegate_debug?: AggregationProfileDebug
   chars_fetched?: integer
   extract_count?: integer
   extract_ns?: integer
@@ -57,9 +58,6 @@ export class AggregationProfileDebug {
   numeric_collectors_used?: integer
   empty_collectors_used?: integer
   deferred_aggregators?: string[]
-}
-
-export class AggregationProfileDelegateDebug {
   segments_with_doc_count_field?: integer
   segments_with_deleted_docs?: integer
   filters?: AggregationProfileDelegateDebugFilter[]
@@ -78,7 +76,7 @@ export class AggregationProfile {
   description: string
   time_in_nanos: long
   type: string
-  debug?: AggregationProfileDebug | AggregationProfileDelegateDebug
+  debug?: AggregationProfileDebug
   children?: AggregationProfile[]
 }
 

--- a/specification/_types/Node.ts
+++ b/specification/_types/Node.ts
@@ -22,7 +22,7 @@ import { ShardRoutingState } from '@indices/stats/types'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { ErrorCause } from '@_types/Errors'
 import { integer } from '@_types/Numeric'
-import { Id, IndexName, Name, NodeName } from './common'
+import { Id, IndexName, Name, NodeId, NodeName } from './common'
 import { TransportAddress } from './Networking'
 
 export class NodeStatistics {
@@ -58,7 +58,7 @@ export class NodeShard {
   allocation_id?: Dictionary<string, Id>
   recovery_source?: Dictionary<string, Id>
   unassigned_info?: UnassignedInformation
-  relocating_node?: null
+  relocating_node?: NodeId | null
 }
 
 /**

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -438,7 +438,7 @@ export class CategorizeTextAggregation extends Aggregation {
    * The syntax is very similar to that used to define the analyzer in the [Analyze endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-analyze.html). This property
    * cannot be used at the same time as categorization_filters.
    */
-  categorization_analyzer?: string | CategorizeTextAnalyzer
+  categorization_analyzer?: CategorizeTextAnalyzer
   /**
    * The number of categorization buckets to return from each shard before merging all the results.
    */
@@ -458,7 +458,12 @@ export class CategorizeTextAggregation extends Aggregation {
   shard_min_doc_count?: integer
 }
 
-export class CategorizeTextAnalyzer {
+/**
+ * @codegen_names builtin, custom
+ */
+export type CategorizeTextAnalyzer = string | CustomCategorizeTextAnalyzer
+
+export class CustomCategorizeTextAnalyzer {
   char_filter?: string[]
   tokenizer?: string
   filter?: string[]


### PR DESCRIPTION
Fixes some union types that had a missing `@codegen_names`, and also a property that only had a `null` type.

`AggregationProfileDebug` and `AggregationProfileDelegateDebug` have been merged into a single type. On the server side it's a `Map<String, Object>` and there's no strong indication that these are really two different types. Avoiding the union also simplifies the type definition.