### PR TITLE
Adds deduce_mappings transform setting

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15607,6 +15607,7 @@ export interface TransformRetentionPolicyContainer {
 export interface TransformSettings {
   align_checkpoints?: boolean
   dates_as_epoch_millis?: boolean
+  deduce_mappings?: boolean
   docs_per_second?: float
   max_page_search_size?: integer
 }

--- a/specification/transform/_types/Transform.ts
+++ b/specification/transform/_types/Transform.ts
@@ -114,6 +114,11 @@ export class Settings {
    */
   dates_as_epoch_millis?: boolean
   /**
+   * Specifies whether the transform should deduce the destination index mappings from the transform configuration.
+   * @server_default true
+   */
+  deduce_mappings?: boolean
+  /**
    * Specifies a limit on the number of input documents per second. This setting throttles the transform by adding a
    * wait time between search requests. The default value is null, which disables throttling.
    */


### PR DESCRIPTION
Adds new deduce_mappings setting to the types in Transform.ts

Relates to https://github.com/elastic/elasticsearch/pull/82256