### PR TITLE
Add an optional key field to RangeBucket

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3376,6 +3376,7 @@ export interface AggregationsRangeBucketKeys extends AggregationsMultiBucketBase
   to?: double
   from_as_string?: string
   to_as_string?: string
+  key?: string
 }
 export type AggregationsRangeBucket = AggregationsRangeBucketKeys
   & { [property: string]: AggregationsAggregate | double | string | long }

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -515,6 +515,8 @@ export class RangeBucket extends MultiBucketBase {
   to?: double
   from_as_string?: string
   to_as_string?: string
+  /** The bucket key. Present if the aggregation is _not_ keyed */
+  key?: string
 }
 
 /**


### PR DESCRIPTION
The `key` field is missing on `RangeBucket`. Found in https://github.com/elastic/elasticsearch-java/issues/107
