### PR TITLE
Align Datafeed+Job classes with read/write

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1353,7 +1353,6 @@
       "request": [
         "Request: missing json spec query parameter 'ignore_unavailable'",
         "Request: missing json spec query parameter 'allow_no_indices'",
-        "Request: missing json spec query parameter 'ignore_throttled'",
         "Request: missing json spec query parameter 'expand_wildcards'"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11237,7 +11237,7 @@ export interface MigrationDeprecationsResponse {
 }
 
 export interface MlAnalysisConfig {
-  bucket_span: TimeSpan
+  bucket_span?: TimeSpan
   categorization_analyzer?: MlCategorizationAnalyzer
   categorization_field_name?: Field
   categorization_filters?: string[]
@@ -11266,7 +11266,7 @@ export interface MlAnalysisConfigRead {
 
 export interface MlAnalysisLimits {
   categorization_examples_limit?: long
-  model_memory_limit?: string
+  model_memory_limit?: ByteSize
 }
 
 export interface MlAnalysisMemoryLimit {
@@ -11418,25 +11418,6 @@ export interface MlDataDescription {
   field_delimiter?: string
 }
 
-export interface MlDatafeed {
-  aggregations?: Record<string, AggregationsAggregationContainer>
-  aggs?: Record<string, AggregationsAggregationContainer>
-  chunking_config?: MlChunkingConfig
-  datafeed_id: Id
-  frequency?: Timestamp
-  indices: string[]
-  indexes?: string[]
-  job_id: Id
-  max_empty_searches?: integer
-  query: QueryDslQueryContainer
-  query_delay?: Timestamp
-  script_fields?: Record<string, ScriptField>
-  scroll_size?: integer
-  delayed_data_check_config: MlDelayedDataCheckConfig
-  runtime_mappings?: MappingRuntimeFields
-  indices_options?: IndicesOptions
-}
-
 export interface MlDatafeedConfig {
   aggregations?: Record<string, AggregationsAggregationContainer>
   aggs?: Record<string, AggregationsAggregationContainer>
@@ -11444,10 +11425,29 @@ export interface MlDatafeedConfig {
   datafeed_id?: Id
   delayed_data_check_config?: MlDelayedDataCheckConfig
   frequency?: Timestamp
-  indexes?: string[]
-  indices: string[]
+  indexes?: Indices
+  indices?: Indices
   indices_options?: IndicesOptions
   job_id?: Id
+  max_empty_searches?: integer
+  query?: QueryDslQueryContainer
+  query_delay?: Timestamp
+  runtime_mappings?: MappingRuntimeFields
+  script_fields?: Record<string, ScriptField>
+  scroll_size?: integer
+}
+
+export interface MlDatafeedConfigRead {
+  aggregations?: Record<string, AggregationsAggregationContainer>
+  aggs?: Record<string, AggregationsAggregationContainer>
+  chunking_config?: MlChunkingConfig
+  datafeed_id: Id
+  delayed_data_check_config?: MlDelayedDataCheckConfig
+  frequency?: Timestamp
+  indexes?: Indices
+  indices: Indices
+  indices_options?: IndicesOptions
+  job_id: Id
   max_empty_searches?: integer
   query: QueryDslQueryContainer
   query_delay?: Timestamp
@@ -11741,21 +11741,23 @@ export interface MlDetectionRule {
 export interface MlDetector {
   by_field_name?: Field
   custom_rules?: MlDetectionRule[]
+  description?: string
   detector_description?: string
   detector_index?: integer
   exclude_frequent?: MlExcludeFrequent
   field_name?: Field
-  function: string
+  function?: string
   over_field_name?: Field
   partition_field_name?: Field
   use_null?: boolean
 }
 
 export interface MlDetectorRead {
-  by_field_name?: Field
-  custom_rules?: MlDetectionRule[]
-  detector_description?: string
-  detector_index?: integer
+  by_field_name: Field
+  custom_rules: MlDetectionRule[]
+  description?: string
+  detector_description: string
+  detector_index: integer
   exclude_frequent?: MlExcludeFrequent
   field_name?: Field
   function: string
@@ -11834,39 +11836,6 @@ export interface MlInfluencer {
 }
 
 export interface MlJob {
-  allow_lazy_open: boolean
-  analysis_config: MlAnalysisConfig
-  analysis_limits?: MlAnalysisLimits
-  background_persist_interval?: Time
-  blocked?: MlJobBlocked
-  create_time?: integer
-  custom_settings?: MlCustomSettings
-  daily_model_snapshot_retention_after_days?: long
-  data_description: MlDataDescription
-  datafeed_config?: MlDatafeed
-  deleting?: boolean
-  description?: string
-  finished_time?: integer
-  groups?: string[]
-  job_id: Id
-  job_type?: string
-  job_version?: VersionString
-  model_plot_config?: MlModelPlotConfig
-  model_snapshot_id?: Id
-  model_snapshot_retention_days: long
-  renormalization_window_days?: long
-  results_index_name: IndexName
-  results_retention_days?: long
-}
-
-export interface MlJobBlocked {
-  reason: MlJobBlockedReason
-  task_id?: TaskId
-}
-
-export type MlJobBlockedReason = 'delete' | 'reset' | 'revert'
-
-export interface MlJobConfig {
   allow_lazy_open?: boolean
   analysis_config: MlAnalysisConfig
   analysis_limits?: MlAnalysisLimits
@@ -11886,6 +11855,13 @@ export interface MlJobConfig {
   results_retention_days?: long
 }
 
+export interface MlJobBlocked {
+  reason: MlJobBlockedReason
+  task_id?: TaskId
+}
+
+export type MlJobBlockedReason = 'delete' | 'reset' | 'revert'
+
 export interface MlJobForecastStatistics {
   memory_bytes?: MlJobStatistics
   processing_time_ms?: MlJobStatistics
@@ -11893,6 +11869,32 @@ export interface MlJobForecastStatistics {
   status?: Record<string, long>
   total: long
   forecasted_jobs: integer
+}
+
+export interface MlJobRead {
+  allow_lazy_open: boolean
+  analysis_config: MlAnalysisConfig
+  analysis_limits?: MlAnalysisLimits
+  background_persist_interval?: Time
+  blocked?: MlJobBlocked
+  create_time?: integer
+  custom_settings?: MlCustomSettings
+  daily_model_snapshot_retention_after_days?: long
+  data_description: MlDataDescription
+  datafeed_config?: MlDatafeedConfig
+  deleting?: boolean
+  description?: string
+  finished_time?: integer
+  groups?: string[]
+  job_id: Id
+  job_type?: string
+  job_version?: VersionString
+  model_plot_config?: MlModelPlotConfig
+  model_snapshot_id?: Id
+  model_snapshot_retention_days: long
+  renormalization_window_days?: long
+  results_index_name: IndexName
+  results_retention_days?: long
 }
 
 export type MlJobState = 'closing' | 'closed' | 'opened' | 'failed' | 'opening'
@@ -12583,7 +12585,7 @@ export interface MlGetDatafeedsRequest extends RequestBase {
 
 export interface MlGetDatafeedsResponse {
   count: long
-  datafeeds: MlDatafeed[]
+  datafeeds: MlDatafeedConfigRead[]
 }
 
 export interface MlGetFiltersRequest extends RequestBase {
@@ -12635,7 +12637,7 @@ export interface MlGetJobsRequest extends RequestBase {
 
 export interface MlGetJobsResponse {
   count: long
-  jobs: MlJob[]
+  jobs: MlJobRead[]
 }
 
 export interface MlGetModelSnapshotsRequest extends RequestBase {
@@ -12867,7 +12869,7 @@ export interface MlPreviewDatafeedRequest extends RequestBase {
   datafeed_id?: Id
   body?: {
     datafeed_config?: MlDatafeedConfig
-    job_config?: MlJobConfig
+    job_config?: MlJob
   }
 }
 
@@ -12938,6 +12940,7 @@ export interface MlPutDatafeedRequest extends RequestBase {
   ignore_unavailable?: boolean
   body?: {
     aggregations?: Record<string, AggregationsAggregationContainer>
+    aggs?: Record<string, AggregationsAggregationContainer>
     chunking_config?: MlChunkingConfig
     delayed_data_check_config?: MlDelayedDataCheckConfig
     frequency?: Time
@@ -12955,22 +12958,7 @@ export interface MlPutDatafeedRequest extends RequestBase {
   }
 }
 
-export interface MlPutDatafeedResponse {
-  aggregations: Record<string, AggregationsAggregationContainer>
-  chunking_config: MlChunkingConfig
-  delayed_data_check_config?: MlDelayedDataCheckConfig
-  datafeed_id: Id
-  frequency: Time
-  indices: string[]
-  job_id: Id
-  indices_options?: IndicesOptions
-  max_empty_searches: integer
-  query: QueryDslQueryContainer
-  query_delay: Time
-  runtime_mappings?: MappingRuntimeFields
-  script_fields?: Record<string, ScriptField>
-  scroll_size: integer
-}
+export type MlPutDatafeedResponse = MlDatafeedConfigRead
 
 export interface MlPutFilterRequest extends RequestBase {
   filter_id: Id
@@ -12988,17 +12976,19 @@ export interface MlPutFilterResponse {
 
 export interface MlPutJobRequest extends RequestBase {
   job_id: Id
+  ignore_throttled?: boolean
   body?: {
     allow_lazy_open?: boolean
     analysis_config: MlAnalysisConfig
     analysis_limits?: MlAnalysisLimits
-    background_persist_interval: Time
+    background_persist_interval?: Time
     custom_settings?: MlCustomSettings
     daily_model_snapshot_retention_after_days?: long
     data_description: MlDataDescription
     datafeed_config?: MlDatafeedConfig
     description?: string
     groups?: string[]
+    job_id?: Id
     model_plot_config?: MlModelPlotConfig
     model_snapshot_retention_days?: long
     renormalization_window_days?: long
@@ -13012,11 +13002,11 @@ export interface MlPutJobResponse {
   analysis_config: MlAnalysisConfigRead
   analysis_limits: MlAnalysisLimits
   background_persist_interval?: Time
-  create_time: DateString
+  create_time: EpochMillis
   custom_settings?: MlCustomSettings
   daily_model_snapshot_retention_after_days: long
   data_description: MlDataDescription
-  datafeed_config?: MlDatafeed
+  datafeed_config?: MlDatafeedConfigRead
   description?: string
   groups?: string[]
   job_id: Id
@@ -13353,6 +13343,7 @@ export interface MlUpdateJobRequest extends RequestBase {
     model_plot_config?: MlModelPlotConfig
     daily_model_snapshot_retention_after_days?: long
     model_snapshot_retention_days?: long
+    model_prune_window?: Time
     renormalization_window_days?: long
     results_retention_days?: long
     groups?: string[]
@@ -13371,7 +13362,7 @@ export interface MlUpdateJobResponse {
   custom_settings?: Record<string, string>
   daily_model_snapshot_retention_after_days: long
   data_description: MlDataDescription
-  datafeed_config?: MlDatafeed
+  datafeed_config?: MlDatafeedConfigRead
   description?: string
   groups?: string[]
   job_id: Id

--- a/specification/ml/_types/Analysis.ts
+++ b/specification/ml/_types/Analysis.ts
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-import { Field } from '@_types/common'
+import { ByteSize, Field } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { Time, TimeSpan } from '@_types/Time'
 import { Detector, DetectorRead } from './Detector'
 import { CharFilter } from '@_types/analysis/char_filters'
-import { Tokenizer, TokenizerDefinition } from '@_types/analysis/tokenizers'
+import { Tokenizer } from '@_types/analysis/tokenizers'
 import { TokenFilter } from '@_types/analysis/token_filters'
 import { OverloadOf } from '@spec_utils/behaviors'
 
@@ -32,7 +32,7 @@ export class AnalysisConfig {
 whole number of buckets in one day. If the anomaly detection job uses a datafeed with aggregations, this value must also be divisible by the interval of the date histogram aggregation.
    * * @server_default 5m
    */
-  bucket_span: TimeSpan
+  bucket_span?: TimeSpan
   /**
    * If `categorization_field_name` is specified, you can also define the analyzer that is used to interpret the categorization field. This property cannot be used at the same time as `categorization_filters`. The categorization analyzer specifies how the `categorization_field` is interpreted by the categorization process. The `categorization_analyzer` field can be specified either as a string or as an object. If it is a string, it must refer to a built-in analyzer or one added by another plugin.
    */
@@ -111,7 +111,7 @@ export class AnalysisLimits {
    * The approximate maximum amount of memory resources that are required for analytical processing. Once this limit is approached, data pruning becomes more aggressive. Upon exceeding this limit, new entities are not modeled. If the `xpack.ml.max_model_memory_limit` setting has a value greater than 0 and less than 1024mb, that value is used instead of the default. The default value is relatively small to ensure that high resource usage is a conscious decision. If you have jobs that are expected to analyze high cardinality fields, you will likely need to use a higher value. If you specify a number instead of a string, the units are assumed to be MiB. Specifying a string is recommended for clarity. If you specify a byte size unit of `b` or `kb` and the number does not equate to a discrete number of megabytes, it is rounded down to the closest MiB. The minimum valid value is 1 MiB. If you specify a value less than 1 MiB, an error occurs. If you specify a value for the `xpack.ml.max_model_memory_limit` setting, an error occurs when you try to create jobs that have `model_memory_limit` values greater than that setting value.
    * @server_default 1024mb
    */
-  model_memory_limit?: string
+  model_memory_limit?: ByteSize
 }
 
 export class AnalysisMemoryLimit {

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -17,34 +17,16 @@
  * under the License.
  */
 
+import { OverloadOf } from '@spec_utils/behaviors'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
-import { ExpandWildcards, Id, Indices, IndicesOptions } from '@_types/common'
+import { Id, IndexName, Indices, IndicesOptions } from '@_types/common'
 import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { double, integer, long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { ScriptField } from '@_types/Scripting'
 import { Time, Timestamp } from '@_types/Time'
 import { DiscoveryNode } from './DiscoveryNode'
-
-export class Datafeed {
-  /** @aliases aggs */
-  aggregations?: Dictionary<string, AggregationContainer>
-  chunking_config?: ChunkingConfig
-  datafeed_id: Id
-  frequency?: Timestamp
-  indices: string[]
-  indexes?: string[]
-  job_id: Id
-  max_empty_searches?: integer
-  query: QueryContainer
-  query_delay?: Timestamp
-  script_fields?: Dictionary<string, ScriptField>
-  scroll_size?: integer
-  delayed_data_check_config: DelayedDataCheckConfig
-  runtime_mappings?: RuntimeFields
-  indices_options?: IndicesOptions
-}
 
 export class DatafeedConfig {
   /**
@@ -68,15 +50,21 @@ export class DatafeedConfig {
    * The interval at which scheduled queries are made while the datafeed runs in real time. The default value is either the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket span. For example: `150s`. When `frequency` is shorter than the bucket span, interim results for the last (partial) bucket are written then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value must be divisible by the interval of the date histogram aggregation.
    */
   frequency?: Timestamp
-  indexes?: string[]
+  /**
+   * Use `indices` instead.
+   */
+  indexes?: Indices
   /**
    * An array of index names. Wildcards are supported. If any indices are in remote clusters, the machine learning nodes must have the `remote_cluster_client` role.
    */
-  indices: string[]
+  indices?: Indices
   /**
    * Specifies index expansion options that are used during search.
    */
   indices_options?: IndicesOptions
+  /**
+   * The identifier for the anomaly detection job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters.
+   */
   job_id?: Id
   /**
    * If a real-time datafeed has never seen any data (including during any initial training period) then it will automatically stop itself and close its associated job after this many real-time searches that return no documents. In other words, it will stop after `frequency` times `max_empty_searches` of real-time operation. If not set then a datafeed with no end time that sees no data will remain started until it is explicitly stopped.
@@ -85,7 +73,7 @@ export class DatafeedConfig {
   /**
    * The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch.
    */
-  query: QueryContainer
+  query?: QueryContainer
   /**
    * The number of seconds behind real time that data is queried. For example, if data from 10:04 a.m. might not be searchable in Elasticsearch until 10:06 a.m., set this property to 120 seconds. The default value is randomly selected between `60s` and `120s`. This randomness improves the query performance when there are multiple jobs running on the same node.
    */
@@ -102,6 +90,25 @@ export class DatafeedConfig {
    * The size parameter that is used in Elasticsearch searches when the datafeed does not use aggregations. The maximum value is the value of `index.max_result_window`, which is 10,000 by default.
    * @server_default 1000
    */
+  scroll_size?: integer
+}
+
+export class DatafeedConfigRead implements OverloadOf<DatafeedConfig> {
+  /** @aliases aggs */
+  aggregations?: Dictionary<string, AggregationContainer>
+  chunking_config?: ChunkingConfig
+  datafeed_id: Id
+  delayed_data_check_config?: DelayedDataCheckConfig
+  frequency?: Timestamp
+  indexes?: Indices /** TODO: Remove but defined as alias above? */
+  indices: Indices /** TODO: Change to IndexName[] */
+  indices_options?: IndicesOptions
+  job_id: Id
+  max_empty_searches?: integer
+  query: QueryContainer
+  query_delay?: Timestamp
+  runtime_mappings?: RuntimeFields
+  script_fields?: Dictionary<string, ScriptField>
   scroll_size?: integer
 }
 

--- a/specification/ml/_types/Detector.ts
+++ b/specification/ml/_types/Detector.ts
@@ -34,11 +34,63 @@ export class Detector {
   /**
    * A description of the detector.
    */
+  description?: string
+  /**
+   * A description of the detector.
+   */
   detector_description?: string
   /**
    * A unique identifier for the detector. This identifier is based on the order of the detectors in the `analysis_config`, starting at zero. If you specify a value for this property, it is ignored.
    */
   detector_index?: integer
+  /**
+   * If set, frequent entities are excluded from influencing the anomaly results. Entities can be considered frequent over time or frequent in a population. If you are working with both over and by fields, you can set `exclude_frequent` to `all` for both fields, or to `by` or `over` for those specific fields.
+   */
+  exclude_frequent?: ExcludeFrequent
+  /**
+   * The field that the detector uses in the function. If you use an event rate function such as count or rare, do not specify this field. The `field_name` cannot contain double quotes or backslashes.
+   */
+  field_name?: Field
+  /**
+   * The analysis function that is used. For example, `count`, `rare`, `mean`, `min`, `max`, or `sum`.
+   */
+  function?: string
+  /**
+   * The field used to split the data. In particular, this property is used for analyzing the splits with respect to the history of all splits. It is used for finding unusual values in the population of all splits.
+   */
+  over_field_name?: Field
+  /**
+   * The field used to segment the analysis. When you use this property, you have completely independent baselines for each value of this field.
+   */
+  partition_field_name?: Field
+  /**
+   * Defines whether a new series is used as the null series when there is no value for the by or partition fields.
+   * @server_default false
+   */
+  use_null?: boolean
+}
+
+export class DetectorRead implements OverloadOf<Detector> {
+  /**
+   * The field used to split the data. In particular, this property is used for analyzing the splits with respect to their own history. It is used for finding unusual values in the context of the split.
+   */
+  by_field_name: Field
+  /**
+   * Custom rules enable you to customize the way detectors operate. For example, a rule may dictate conditions under which results should be skipped. Kibana refers to custom rules as job rules.
+   */
+  custom_rules: DetectionRule[]
+  /**
+   * A description of the detector.
+   */
+  description?: string
+  /**
+   * A description of the detector.
+   */
+  detector_description: string
+  /**
+   * A unique identifier for the detector. This identifier is based on the order of the detectors in the `analysis_config`, starting at zero. If you specify a value for this property, it is ignored.
+   */
+  detector_index: integer
   /**
    * If set, frequent entities are excluded from influencing the anomaly results. Entities can be considered frequent over time or frequent in a population. If you are working with both over and by fields, you can set `exclude_frequent` to `all` for both fields, or to `by` or `over` for those specific fields.
    */
@@ -63,19 +115,6 @@ export class Detector {
    * Defines whether a new series is used as the null series when there is no value for the by or partition fields.
    * @server_default false
    */
-  use_null?: boolean
-}
-
-export class DetectorRead implements OverloadOf<Detector> {
-  by_field_name?: Field
-  custom_rules?: DetectionRule[]
-  detector_description?: string
-  detector_index?: integer
-  exclude_frequent?: ExcludeFrequent
-  field_name?: Field
-  function: string
-  over_field_name?: Field
-  partition_field_name?: Field
   use_null?: boolean
 }
 

--- a/specification/ml/_types/Job.ts
+++ b/specification/ml/_types/Job.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { OverloadOf } from '@spec_utils/behaviors'
 import { AnalysisConfig, AnalysisLimits } from '@ml/_types/Analysis'
 import { ModelPlotConfig } from '@ml/_types/ModelPlot'
 import { Dictionary } from '@spec_utils/Dictionary'
@@ -26,7 +27,7 @@ import { double, integer, long } from '@_types/Numeric'
 import { DateString, Time } from '@_types/Time'
 import { DiscoveryNode } from './DiscoveryNode'
 import { ModelSizeStats } from './Model'
-import { Datafeed, DatafeedConfig } from '@ml/_types/Datafeed'
+import { DatafeedConfig, DatafeedConfigRead } from '@ml/_types/Datafeed'
 
 export enum JobState {
   closing = 0,
@@ -44,32 +45,6 @@ export class JobStatistics {
 }
 
 export class Job {
-  allow_lazy_open: boolean
-  analysis_config: AnalysisConfig
-  analysis_limits?: AnalysisLimits
-  background_persist_interval?: Time
-  blocked?: JobBlocked
-  create_time?: integer
-  custom_settings?: CustomSettings
-  daily_model_snapshot_retention_after_days?: long
-  data_description: DataDescription
-  datafeed_config?: Datafeed
-  deleting?: boolean
-  description?: string
-  finished_time?: integer
-  groups?: string[]
-  job_id: Id
-  job_type?: string
-  job_version?: VersionString
-  model_plot_config?: ModelPlotConfig
-  model_snapshot_id?: Id
-  model_snapshot_retention_days: long
-  renormalization_window_days?: long
-  results_index_name: IndexName
-  results_retention_days?: long
-}
-
-export class JobConfig {
   allow_lazy_open?: boolean
   analysis_config: AnalysisConfig
   analysis_limits?: AnalysisLimits
@@ -88,6 +63,32 @@ export class JobConfig {
   results_index_name?: IndexName
   results_retention_days?: long
 }
+export class JobRead implements OverloadOf<Job> {
+  allow_lazy_open: boolean
+  analysis_config: AnalysisConfig
+  analysis_limits?: AnalysisLimits
+  background_persist_interval?: Time
+  blocked?: JobBlocked
+  create_time?: integer
+  custom_settings?: CustomSettings
+  daily_model_snapshot_retention_after_days?: long
+  data_description: DataDescription
+  datafeed_config?: DatafeedConfig /** TODO: Make DatafeedConfigRead */
+  deleting?: boolean
+  description?: string
+  finished_time?: integer
+  groups?: string[]
+  job_id: Id
+  job_type?: string
+  job_version?: VersionString
+  model_plot_config?: ModelPlotConfig
+  model_snapshot_id?: Id
+  model_snapshot_retention_days: long
+  renormalization_window_days?: long
+  results_index_name: IndexName
+  results_retention_days?: long
+}
+
 export class JobStats {
   assignment_explanation?: string
   data_counts: DataCounts

--- a/specification/ml/get_datafeeds/MlGetDatafeedsResponse.ts
+++ b/specification/ml/get_datafeeds/MlGetDatafeedsResponse.ts
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-import { Datafeed } from '@ml/_types/Datafeed'
+import { DatafeedConfigRead } from '@ml/_types/Datafeed'
 import { long } from '@_types/Numeric'
 
 export class Response {
   body: {
     count: long
-    datafeeds: Datafeed[]
+    datafeeds: DatafeedConfigRead[]
   }
 }

--- a/specification/ml/get_jobs/MlGetJobsResponse.ts
+++ b/specification/ml/get_jobs/MlGetJobsResponse.ts
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-import { Job } from '@ml/_types/Job'
+import { JobRead } from '@ml/_types/Job'
 import { long } from '@_types/Numeric'
 
 export class Response {
   body: {
     count: long
-    jobs: Job[]
+    jobs: JobRead[]
   }
 }

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
@@ -20,7 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 import { DatafeedConfig } from '@ml/_types/Datafeed'
-import { JobConfig } from '@ml/_types/Job'
+import { Job } from '@ml/_types/Job'
 
 /**
  * Previews a datafeed.
@@ -59,6 +59,6 @@ export interface Request extends RequestBase {
      * supply this `job_config` object. If you include both a `job_id` and a `job_config`, the latter information is
      * used. You cannot specify a `job_config` object unless you also supply a `datafeed_config` object.
      */
-    job_config?: JobConfig
+    job_config?: Job
   }
 }

--- a/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
@@ -88,6 +88,7 @@ export interface Request extends RequestBase {
   body: {
     /** If set, the datafeed performs aggregation searches.
      * Support for aggregations is limited and should be used only with low cardinality data.
+     * @aliases aggs
      */
     aggregations?: Dictionary<string, AggregationContainer>
     /**

--- a/specification/ml/put_datafeed/MlPutDatafeedResponse.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedResponse.ts
@@ -17,31 +17,8 @@
  * under the License.
  */
 
-import { ChunkingConfig, DelayedDataCheckConfig } from '@ml/_types/Datafeed'
-import { Dictionary } from '@spec_utils/Dictionary'
-import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
-import { Id, Indices, IndicesOptions } from '@_types/common'
-import { RuntimeFields } from '@_types/mapping/RuntimeFields'
-import { integer } from '@_types/Numeric'
-import { QueryContainer } from '@_types/query_dsl/abstractions'
-import { ScriptField } from '@_types/Scripting'
-import { Time } from '@_types/Time'
+import { DatafeedConfigRead } from '@ml/_types/Datafeed'
 
 export class Response {
-  body: {
-    aggregations: Dictionary<string, AggregationContainer>
-    chunking_config: ChunkingConfig
-    delayed_data_check_config?: DelayedDataCheckConfig
-    datafeed_id: Id
-    frequency: Time
-    indices: string[]
-    job_id: Id
-    indices_options?: IndicesOptions
-    max_empty_searches: integer
-    query: QueryContainer
-    query_delay: Time
-    runtime_mappings?: RuntimeFields
-    script_fields?: Dictionary<string, ScriptField>
-    scroll_size: integer
-  }
+  body: DatafeedConfigRead
 }

--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -42,6 +42,10 @@ export interface Request extends RequestBase {
      */
     job_id: Id
   }
+  query_parameters: {
+    /** @deprecated 7.16.0 */
+    ignore_throttled?: boolean
+  }
   body: {
     /**
      * Advanced configuration option. Specifies whether this job can open when there is insufficient machine learning node capacity for it to be immediately assigned to a node. By default, if a machine learning node with capacity to run the job cannot immediately be found, the open anomaly detection jobs API returns an error. However, this is also subject to the cluster-wide `xpack.ml.max_lazy_ml_nodes` setting. If this option is set to true, the open anomaly detection jobs API does not return an error and the job waits in the opening state until sufficient machine learning node capacity is available.
@@ -59,7 +63,7 @@ export interface Request extends RequestBase {
     /**
      * Advanced configuration option. The time between each periodic persistence of the model. The default value is a randomized value between 3 to 4 hours, which avoids all jobs persisting at exactly the same time. The smallest allowed value is 1 hour. For very large models (several GB), persistence could take 10-20 minutes, so do not set the `background_persist_interval` value too low.
      */
-    background_persist_interval: Time
+    background_persist_interval?: Time
     /**
      *  Advanced configuration option. Contains custom meta data about the job.
      */
@@ -85,6 +89,10 @@ export interface Request extends RequestBase {
      * A list of job groups. A job can belong to no groups or many.
      */
     groups?: string[]
+    /**
+     * The identifier for the anomaly detection job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters.
+     */
+    job_id?: Id
     /**
      * This advanced configuration option stores model information along with the results. It provides a more detailed view into anomaly detection. If you enable model plot it can add considerable overhead to the performance of the system; it is not feasible for jobs with many entities. Model plot provides a simplified and indicative view of the model and its bounds. It does not display complex features such as multivariate correlations or multimodal data. As such, anomalies may occasionally be reported which cannot be seen in the model plot. Model plot config can be configured when the job is created or updated later. It must be disabled if performance issues are experienced.
      */

--- a/specification/ml/put_job/MlPutJobResponse.ts
+++ b/specification/ml/put_job/MlPutJobResponse.ts
@@ -23,8 +23,8 @@ import { ModelPlotConfig } from '@ml/_types/ModelPlot'
 import { CustomSettings } from '@ml/_types/Settings'
 import { Id } from '@_types/common'
 import { long } from '@_types/Numeric'
-import { DateString, Time } from '@_types/Time'
-import { Datafeed } from '@ml/_types/Datafeed'
+import { EpochMillis, Time } from '@_types/Time'
+import { DatafeedConfigRead } from '@ml/_types/Datafeed'
 
 export class Response {
   body: {
@@ -32,11 +32,11 @@ export class Response {
     analysis_config: AnalysisConfigRead
     analysis_limits: AnalysisLimits
     background_persist_interval?: Time
-    create_time: DateString
+    create_time: EpochMillis
     custom_settings?: CustomSettings
     daily_model_snapshot_retention_after_days: long
     data_description: DataDescription
-    datafeed_config?: Datafeed
+    datafeed_config?: DatafeedConfigRead
     description?: string
     groups?: string[]
     job_id: Id

--- a/specification/ml/update_job/MlUpdateJobRequest.ts
+++ b/specification/ml/update_job/MlUpdateJobRequest.ts
@@ -108,6 +108,15 @@ export interface Request extends RequestBase {
      */
     model_snapshot_retention_days?: long
     /**
+     * Advanced configuration option. Affects the pruning of models that have
+     * not been updated for the given time duration. The value must be set to a
+     * multiple of the bucket_span. If set too low, important information may be
+     * removed from the model. Typically, set to 30d or longer. If not set, model
+     * pruning only occurs if the model memory status reaches the soft limit or
+     * the hard limit.
+     */
+    model_prune_window?: Time
+    /**
      * Advanced configuration option. The period over which adjustments to the
      * score are applied, as new data is seen.
      */

--- a/specification/ml/update_job/MlUpdateJobResponse.ts
+++ b/specification/ml/update_job/MlUpdateJobResponse.ts
@@ -18,7 +18,7 @@
  */
 
 import { AnalysisConfigRead, AnalysisLimits } from '@ml/_types/Analysis'
-import { Datafeed } from '@ml/_types/Datafeed'
+import { DatafeedConfigRead } from '@ml/_types/Datafeed'
 import { DataDescription } from '@ml/_types/Job'
 import { ModelPlotConfig } from '@ml/_types/ModelPlot'
 import { Dictionary } from '@spec_utils/Dictionary'
@@ -37,7 +37,7 @@ export class Response {
     custom_settings?: Dictionary<string, string>
     daily_model_snapshot_retention_after_days: long
     data_description: DataDescription
-    datafeed_config?: Datafeed
+    datafeed_config?: DatafeedConfigRead
     description?: string
     groups?: string[]
     job_id: Id


### PR DESCRIPTION
```
$ make validate stack-version=8.1.0-SNAPSHOT api=ml.put_job
- Validating endpoints
⚠ It looks like ml.put_job request has some errors, take a look at the workbench.
/home/sethmlarson/clients-flight-recorder/scripts/types-validator/workbench

scripts/types-validator/workbench/f580409745707de8240570793edf99f1.test-d.ts:7:59
Argument of type '{ allow_lazy_open: false; analysis_config: { bucket_span: string; detectors: { by_field_name: string; custom_rules: { actions: "skip_result"[]; conditions: ({ applies_to: "actual"; operator: "lt"; value: number; } | { ...; })[]; scope: { ...; }; }[]; ... 4 more ...; partition_field_name: string; }[]; influencers: ne...' is not assignable to parameter of type 'ErrorResponseBase | MlPutJobResponse'.
  Property 'daily_model_snapshot_retention_after_days' is missing in type '{ allow_lazy_open: false; analysis_config: { bucket_span: string; detectors: { by_field_name: string; custom_rules: { actions: "skip_result"[]; conditions: ({ applies_to: "actual"; operator: "lt"; value: number; } | { ...; })[]; scope: { ...; }; }[]; ... 4 more ...; partition_field_name: string; }[]; influencers: ne...' but required in type 'MlPutJobResponse'.

✔ 226 out of 226 test request cases are passing.
✖ 225 out of 226 test response cases are passing.

$ make validate stack-version=8.1.0-SNAPSHOT api=ml.get_datafeeds
- Validating endpoints
✔ ml.get_datafeeds request has been successfully validated!

✔ 20 out of 20 test request cases are passing.
✔ 20 out of 20 test response cases are passing.

$ make validate stack-version=8.1.0-SNAPSHOT api=ml.put_datafeed
- Validating endpoints
✔ ml.put_datafeed request has been successfully validated!

✔ 71 out of 71 test request cases are passing.
✔ 71 out of 71 test response cases are passing.

make validate stack-version=8.1.0-SNAPSHOT api=ml.update_job
- Validating endpoints
✔ ml.update_job request has been successfully validated!

✔ 5 out of 5 test request cases are passing.
✔ 5 out of 5 test response cases are passing.

$ make validate stack-version=8.1.0-SNAPSHOT api=ml.get_jobs
- Validating endpoints
✔ ml.get_jobs request has been successfully validated!

✔ 31 out of 31 test request cases are passing.
✔ 31 out of 31 test response cases are passing.
```