### PR TITLE
Fix suggest results that are a typed-key union type

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -17,7 +17,9 @@
         "type_alias definition _types.aggregations:Buckets / union_of / array_of / instance_of - No type definition for '_types.aggregations:TBucket'",
         "type_alias definition _spec_utils:Void / instance_of - No type definition for 'internal:void'",
         "type_alias definition _types.aggregations:Aggregate / instance_of - Non-leaf type cannot be used here: '_types.aggregations:RangeAggregate'",
-        "type_alias definition _global.search._types:SuggestOption / union_of / instance_of / Generics / instance_of - No type definition for '_global.search._types:TDocument'"
+        "type_alias definition _global.search._types:Suggest - A tagged union should not have generic parameters",
+        "type_alias definition _global.search._types:Suggest / instance_of / Generics / instance_of - No type definition for '_global.search._types:TDocument'",
+        "type_alias definition _global.search._types:Suggest - Expected 1 generic parameters but got 0"
       ]
     },
     "async_search.status": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1111,6 +1111,10 @@ export interface SearchCompletionContext {
   prefix?: boolean
 }
 
+export interface SearchCompletionSuggest<TDocument = unknown> extends SearchSuggestBase {
+  options: SearchCompletionSuggestOption<TDocument>[]
+}
+
 export interface SearchCompletionSuggestOption<TDocument = unknown> {
   collate_match?: boolean
   contexts?: Record<string, SearchContext[]>
@@ -1118,8 +1122,8 @@ export interface SearchCompletionSuggestOption<TDocument = unknown> {
   _id: string
   _index: IndexName
   _routing?: Routing
-  _score: double
-  _source: TDocument
+  _score?: double
+  _source?: TDocument
   text: string
 }
 
@@ -1310,6 +1314,10 @@ export interface SearchNestedIdentity {
   _nested?: SearchNestedIdentity
 }
 
+export interface SearchPhraseSuggest extends SearchSuggestBase {
+  options: SearchPhraseSuggestOption
+}
+
 export interface SearchPhraseSuggestCollate {
   params?: Record<string, any>
   prune?: boolean
@@ -1436,10 +1444,11 @@ export interface SearchStupidBackoffSmoothingModel {
   discount: double
 }
 
-export interface SearchSuggest<T = unknown> {
+export type SearchSuggest<TDocument = unknown> = SearchCompletionSuggest<TDocument> | SearchPhraseSuggest | SearchTermSuggest
+
+export interface SearchSuggestBase {
   length: integer
   offset: integer
-  options: SearchSuggestOption<T>[]
   text: string
 }
 
@@ -1450,8 +1459,6 @@ export interface SearchSuggestFuzziness {
   transpositions: boolean
   unicode_aware: boolean
 }
-
-export type SearchSuggestOption<TDocument = unknown> = SearchCompletionSuggestOption<TDocument> | SearchPhraseSuggestOption | SearchTermSuggestOption
 
 export type SearchSuggestSort = 'score' | 'frequency'
 
@@ -1467,9 +1474,13 @@ export interface SearchSuggesterBase {
   size?: integer
 }
 
+export interface SearchTermSuggest extends SearchSuggestBase {
+  options: SearchTermSuggestOption
+}
+
 export interface SearchTermSuggestOption {
   text: string
-  freq?: long
+  freq: long
   score: double
 }
 

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -31,11 +31,65 @@ import { GeoHash, GeoHashPrecision, GeoLocation } from '@_types/Geo'
 import { double, float, integer, long } from '@_types/Numeric'
 import { AdditionalProperties } from '@spec_utils/behaviors'
 
-export class Suggest<T> {
+/**
+ * @variants external
+ */
+export type Suggest<TDocument> =
+  | CompletionSuggest<TDocument>
+  | PhraseSuggest
+  | TermSuggest
+
+export class SuggestBase {
   length: integer
   offset: integer
-  options: SuggestOption<T>[]
   text: string
+}
+
+/**
+ * @variant name=completion
+ */
+export class CompletionSuggest<TDocument> extends SuggestBase {
+  options: CompletionSuggestOption<TDocument>[]
+}
+
+/**
+ * @variant name=phrase
+ */
+export class PhraseSuggest extends SuggestBase {
+  options: PhraseSuggestOption
+}
+
+/**
+ * @variant name=term
+ */
+export class TermSuggest extends SuggestBase {
+  options: TermSuggestOption
+}
+
+// In the ES code a nested Hit object is expanded inline. Not all Hit fields have been
+// added below as many do not make sense in the context of a suggestion.
+export class CompletionSuggestOption<TDocument> {
+  collate_match?: boolean
+  contexts?: Dictionary<string, Context[]>
+  fields?: Dictionary<string, UserDefinedValue>
+  _id: string
+  _index: IndexName
+  _routing?: Routing
+  _score?: double
+  _source?: TDocument
+  text: string
+}
+
+export class PhraseSuggestOption {
+  text: string
+  highlighted: string
+  score: double
+}
+
+export class TermSuggestOption {
+  text: string
+  freq: long
+  score: double
 }
 
 export class Suggester implements AdditionalProperties<string, FieldSuggester> {
@@ -59,36 +113,6 @@ export class SuggesterBase {
   field: Field
   analyzer?: string
   size?: integer
-}
-
-/** @codegen_names completion, phrase, term */
-export type SuggestOption<TDocument> =
-  | CompletionSuggestOption<TDocument>
-  | PhraseSuggestOption
-  | TermSuggestOption
-
-export class CompletionSuggestOption<TDocument> {
-  collate_match?: boolean
-  contexts?: Dictionary<string, Context[]>
-  fields?: Dictionary<string, UserDefinedValue>
-  _id: string
-  _index: IndexName
-  _routing?: Routing
-  _score: double
-  _source: TDocument
-  text: string
-}
-
-export class PhraseSuggestOption {
-  text: string
-  highlighted: string
-  score: double
-}
-
-export class TermSuggestOption {
-  text: string
-  freq?: long
-  score: double
 }
 
 // completion suggester


### PR DESCRIPTION
This PR fixes the defintion of suggest results. They are a typed-keys union type (i.e. externally tagged), used in `SearchResponse` as follows:

```ts
suggest?: Dictionary<SuggestionName, Suggest<TDocument>[]>
```

To correctly capture the typed-key nature of this type, `Suggest` has to be the union type, even if the difference only happens in the nested `options` field.

This was found in https://github.com/elastic/elasticsearch-java/issues/57 that is fixed by this change.

Unfortunately this PR adds 2 validation errors: `expectAssignable` doesn't seem to be able to correctly resolve the union member when the discriminating field is in the nested `options` field.

```
scripts/types-validator/workbench/702f290e18c3cd5fbc1ce1a3b0304f29.test-d.ts:32:12
Type '{ freq: number; score: number; text: string; }' is not assignable to type 'SearchCompletionSuggestOption<unknown>'.
  Object literal may only specify known properties, and '"freq"' does not exist in type 'SearchCompletionSuggestOption<unknown>'.

scripts/types-validator/workbench/702f290e18c3cd5fbc1ce1a3b0304f29.test-d.ts:44:12
Type '{ freq: number; score: number; text: string; }' is not assignable to type 'SearchCompletionSuggestOption<unknown>'.
  Object literal may only specify known properties, and '"freq"' does not exist in type 'SearchCompletionSuggestOption<unknown>'.
```