### PR TITLE
Update cat datafeeds specification

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -179,12 +179,12 @@
     },
     "cat.ml_datafeeds": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
         "Request: should not have a body",
+        "request definition cat.ml_datafeeds:Request / query - Property 'format' is already defined in an ancestor class",
+        "request definition cat.ml_datafeeds:Request / query - Property 'h' is already defined in an ancestor class",
+        "request definition cat.ml_datafeeds:Request / query - Property 'help' is already defined in an ancestor class",
+        "request definition cat.ml_datafeeds:Request / query - Property 's' is already defined in an ancestor class",
+        "request definition cat.ml_datafeeds:Request / query - Property 'v' is already defined in an ancestor class",
         "request definition cat.ml_datafeeds:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5865,6 +5865,10 @@ export type CatCatAnonalyDetectorColumn = 'assignment_explanation' | 'ae' | 'buc
 
 export type CatCatAnonalyDetectorColumns = CatCatAnonalyDetectorColumn | CatCatAnonalyDetectorColumn[]
 
+export type CatCatDatafeedColumn = 'ae' | 'assignment_explanation' | 'bc' | 'buckets.count' | 'bucketsCount' | 'id' | 'na' | 'node.address' | 'nodeAddress' | 'ne' | 'node.ephemeral_id' | 'nodeEphemeralId' | 'ni' | 'node.id' | 'nodeId' | 'nn' | 'node.name' | 'nodeName' | 'sba' | 'search.bucket_avg' | 'searchBucketAvg' | 'sc' | 'search.count' | 'searchCount' | 'seah' | 'search.exp_avg_hour' | 'searchExpAvgHour' | 'st' | 'search.time' | 'searchTime' | 's' | 'state'
+
+export type CatCatDatafeedColumns = CatCatDatafeedColumn | CatCatDatafeedColumn[]
+
 export interface CatCatRequestBase extends RequestBase, SpecUtilsCommonCatQueryParameters {
 }
 
@@ -6435,7 +6439,12 @@ export interface CatMlDatafeedsDatafeedsRecord {
 export interface CatMlDatafeedsRequest extends CatCatRequestBase {
   datafeed_id?: Id
   allow_no_match?: boolean
+  format?: string
+  h?: CatCatDatafeedColumns
+  help?: boolean
+  s?: CatCatDatafeedColumns
   time?: TimeUnit
+  v?: boolean
 }
 
 export type CatMlDatafeedsResponse = CatMlDatafeedsDatafeedsRecord[]

--- a/specification/cat/_types/CatBase.ts
+++ b/specification/cat/_types/CatBase.ts
@@ -403,28 +403,70 @@ export type CatAnonalyDetectorColumns =
   | CatAnonalyDetectorColumn
   | CatAnonalyDetectorColumn[]
 export enum CatDatafeedColumn {
-  /** @aliases assignment_explanation */
+  /**
+   * For started datafeeds only, contains messages relating to the selection of
+   * a node.
+   * @aliases assignment_explanation
+   */
   ae = 0,
-  /** @aliases buckets.count, bucketsCount */
+  /**
+   * The number of buckets processed.
+   * @aliases buckets.count, bucketsCount
+   */
   bc = 1,
+  /** A numerical character string that uniquely identifies the datafeed. */
   id = 2,
-  /** @aliases node.address, nodeAddress */
-  na = 3
-  /** @aliases node.ephemeral_id, nodeEphemeralId */
-  ne = 4
-  /** @aliases node.id, nodeId */
-  ni = 5
-  /** @aliases node.name, nodeName */
-  nn = 6
-  /** @aliases search.bucket_avg, searchBucketAvg */
-  sba = 7
-  /** @aliases search.count, searchCount */
-  sc = 8
-  /** @aliases search.exp_avg_hour, searchExpAvgHour */
-  seah = 9
-  /** @aliases search.time, searchTime */
-  st = 10
-  /** @aliases state */
+  /**
+   * For started datafeeds only, the network address of the node where the
+   * datafeed is started.
+   * @aliases node.address, nodeAddress
+   */
+  na = 3,
+  /**
+   * For started datafeeds only, the ephemeral ID of the node where the
+   * datafeed is started.
+   * @aliases node.ephemeral_id, nodeEphemeralId
+   */
+  ne = 4,
+  /**
+   * For started datafeeds only, the unique identifier of the node where the
+   * datafeed is started.
+   * @aliases node.id, nodeId
+   */
+  ni = 5,
+  /**
+   * For started datafeeds only, the name of the node where the datafeed is
+   * started.
+   * @aliases node.name, nodeName
+   */
+  nn = 6,
+  /**
+   * The average search time per bucket, in milliseconds.
+   * @aliases search.bucket_avg, searchBucketAvg
+   */
+  sba = 7,
+  /**
+   * The number of searches run by the datafeed.
+   * @aliases search.count, searchCount */
+  sc = 8,
+  /**
+   * The exponential average search time per hour, in milliseconds.
+   * @aliases search.exp_avg_hour, searchExpAvgHour
+   */
+  seah = 9,
+  /**
+   * The total time the datafeed spent searching, in milliseconds.
+   * @aliases search.time, searchTime */
+  st = 10,
+  /**
+   * The status of the datafeed: `starting`, `started`, `stopping`, or `stopped`.
+   * If `starting`, the datafeed has been requested to start but has not yet
+   * started. If `started`, the datafeed is actively receiving data. If
+   * `stopping`, the datafeed has been requested to stop gracefully and is
+   * completing its final action. If `stopped`, the datafeed is stopped and will
+   * not receive data until it is re-started.
+   * @aliases state
+   */
   s = 11
 }
 

--- a/specification/cat/_types/CatBase.ts
+++ b/specification/cat/_types/CatBase.ts
@@ -402,3 +402,30 @@ export enum CatAnonalyDetectorColumn {
 export type CatAnonalyDetectorColumns =
   | CatAnonalyDetectorColumn
   | CatAnonalyDetectorColumn[]
+export enum CatDatafeedColumn {
+  /** @aliases assignment_explanation */
+  ae = 0,
+  /** @aliases buckets.count, bucketsCount */
+  bc = 1,
+  id = 2,
+  /** @aliases node.address, nodeAddress */
+  na = 3
+  /** @aliases node.ephemeral_id, nodeEphemeralId */
+  ne = 4
+  /** @aliases node.id, nodeId */
+  ni = 5
+  /** @aliases node.name, nodeName */
+  nn = 6
+  /** @aliases search.bucket_avg, searchBucketAvg */
+  sba = 7
+  /** @aliases search.count, searchCount */
+  sc = 8
+  /** @aliases search.exp_avg_hour, searchExpAvgHour */
+  seah = 9
+  /** @aliases search.time, searchTime */
+  st = 10
+  /** @aliases state */
+  s = 11
+}
+
+export type CatDatafeedColumns = CatDatafeedColumn | CatDatafeedColumn[]

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { CatRequestBase } from '@cat/_types/CatBase'
+import { CatRequestBase, CatDatafeedColumns } from '@cat/_types/CatBase'
 import { Id } from '@_types/common'
 import { TimeUnit } from '@_types/Time'
 
@@ -35,9 +35,7 @@ import { TimeUnit } from '@_types/Time'
 export interface Request extends CatRequestBase {
   path_parts: {
     /**
-     * A numerical character string that uniquely identifies the datafeed. This identifier can contain lowercase
-     * alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric
-     * characters.
+     * A numerical character string that uniquely identifies the datafeed.
      */
     datafeed_id?: Id
   }
@@ -55,9 +53,27 @@ export interface Request extends CatRequestBase {
      * @server_default true
      */
     allow_no_match?: boolean
+    /** Short version of the HTTP accept header. Valid values include JSON, YAML, for example. */
+    format?: string
+    /**
+     * Comma-separated list of column names to display.
+     * @server_default bc,id,sc,s
+     */
+    h?: CatDatafeedColumns
+    /** If `true`, the response includes help information.
+     * @server_default false
+     */
+    help?: boolean
+    /** Comma-separated list of column names or column aliases used to sort the response. */
+    s?: CatDatafeedColumns
     /**
      * The unit used to display time values.
      */
     time?: TimeUnit
+    /**
+     * If `true`, the response includes column headings.
+     * @server_default false
+     */
+    v?: boolean
   }
 }


### PR DESCRIPTION
Adds missing fields for the [cat datafeeds API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-datafeeds.html). 