### PR TITLE
Add `codegen_names` to time series settings time fields

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1854,6 +1854,8 @@ export type DateMath = string
 
 export type DateMathTime = string
 
+export type DateOrEpochMillis = DateString | EpochMillis
+
 export type DateString = string
 
 export interface DictionaryResponseBase<TKey = unknown, TValue = unknown> {
@@ -9240,8 +9242,8 @@ export interface IndicesIndexSettingsLifecycle {
 }
 
 export interface IndicesIndexSettingsTimeSeries {
-  end_time?: DateString | EpochMillis
-  start_time?: DateString | EpochMillis
+  end_time?: DateOrEpochMillis
+  start_time?: DateOrEpochMillis
 }
 
 export interface IndicesIndexState {

--- a/specification/_types/Time.ts
+++ b/specification/_types/Time.ts
@@ -32,6 +32,9 @@ export type DateMath = string
 export type DateMathExpression = string
 export type DateMathTime = string
 
+/** @codegen_names date, millis */
+export type DateOrEpochMillis = DateString | EpochMillis
+
 export type TimeZone = string
 
 /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/7.x/mapping-date-format.html */

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -32,7 +32,7 @@ import {
   VersionString
 } from '@_types/common'
 import { integer } from '@_types/Numeric'
-import { DateString, EpochMillis, Time } from '@_types/Time'
+import { DateOrEpochMillis, DateString, Time } from '@_types/Time'
 import { Tokenizer } from '@_types/analysis/tokenizers'
 import {
   IndexSegmentSort,
@@ -334,8 +334,8 @@ export class IndexSettingsAnalysis {
 }
 
 export class IndexSettingsTimeSeries {
-  end_time?: DateString | EpochMillis
-  start_time?: DateString | EpochMillis
+  end_time?: DateOrEpochMillis
+  start_time?: DateOrEpochMillis
 }
 
 export class Merge {


### PR DESCRIPTION
Refactor times series settings to add `@codegen_name` needed by the Java code generator.

Follow-up to #1229 that is 8.1 only