### PR TITLE
Add UpdateAction for bulk requests

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -45,7 +45,7 @@ export interface BulkOperationContainer {
 
 export type BulkOperationType = 'index' | 'create' | 'update' | 'delete'
 
-export interface BulkRequest extends RequestBase {
+export interface BulkRequest<TDocument = unknown, TPartialDocument = unknown> extends RequestBase {
   index?: IndexName
   pipeline?: string
   refresh?: Refresh
@@ -56,7 +56,7 @@ export interface BulkRequest extends RequestBase {
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
   require_alias?: boolean
-  body?: (BulkOperationContainer | BulkUpdateAction<any, any> | any)[]
+  body?: (BulkOperationContainer | BulkUpdateAction<TDocument, TPartialDocument> | TDocument)[]
 }
 
 export interface BulkResponse {
@@ -13204,12 +13204,12 @@ export interface MlValidateDetectorRequest extends RequestBase {
 export interface MlValidateDetectorResponse extends AcknowledgedResponseBase {
 }
 
-export interface MonitoringBulkRequest<TSource = unknown> extends RequestBase {
+export interface MonitoringBulkRequest<TDocument = unknown, TPartialDocument = unknown> extends RequestBase {
   type?: string
   system_id: string
   system_api_version: string
   interval: TimeSpan
-  body?: (BulkOperationContainer | BulkUpdateAction<any, any> | any)[]
+  body?: (BulkOperationContainer | BulkUpdateAction<TDocument, TPartialDocument> | TDocument)[]
 }
 
 export interface MonitoringBulkResponse {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -45,7 +45,7 @@ export interface BulkOperationContainer {
 
 export type BulkOperationType = 'index' | 'create' | 'update' | 'delete'
 
-export interface BulkRequest<TSource = unknown> extends RequestBase {
+export interface BulkRequest extends RequestBase {
   index?: IndexName
   pipeline?: string
   refresh?: Refresh
@@ -56,7 +56,7 @@ export interface BulkRequest<TSource = unknown> extends RequestBase {
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
   require_alias?: boolean
-  body?: (BulkOperationContainer | TSource)[]
+  body?: (BulkOperationContainer | BulkUpdateAction<any, any> | any)[]
 }
 
 export interface BulkResponse {
@@ -78,6 +78,16 @@ export interface BulkResponseItem {
   _version?: VersionNumber
   forced_refresh?: boolean
   get?: InlineGet<Record<string, any>>
+}
+
+export interface BulkUpdateAction<TDocument = unknown, TPartialDocument = unknown> {
+  detect_noop?: boolean
+  doc?: TPartialDocument
+  doc_as_upsert?: boolean
+  script?: Script
+  scripted_upsert?: boolean
+  _source?: SearchSourceConfig
+  upsert?: TDocument
 }
 
 export interface BulkUpdateOperation extends BulkOperationBase {
@@ -13199,7 +13209,7 @@ export interface MonitoringBulkRequest<TSource = unknown> extends RequestBase {
   system_id: string
   system_api_version: string
   interval: TimeSpan
-  body?: (BulkOperationContainer | TSource)[]
+  body?: (BulkOperationContainer | BulkUpdateAction<any, any> | any)[]
 }
 
 export interface MonitoringBulkResponse {

--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -26,8 +26,9 @@ import {
   WaitForActiveShards
 } from '@_types/common'
 import { Time } from '@_types/Time'
-import { OperationContainer } from './types'
+import { OperationContainer, UpdateAction } from './types'
 import { SourceConfigParam } from '@global/search/_types/SourceFilter'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * @rest_spec_name bulk
@@ -36,7 +37,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
  * @doc_id docs-bulk
  *
  */
-export interface Request<TSource> extends RequestBase {
+export interface Request extends RequestBase {
   path_parts: {
     index?: IndexName
   }
@@ -52,5 +53,15 @@ export interface Request<TSource> extends RequestBase {
     require_alias?: boolean
   }
   /** @codegen_name operations */
-  body?: Array<OperationContainer | TSource>
+  // This declaration captures action_and_meta_data (OperationContainer) and the two kinds of sources
+  // that can follow: an update action for update operations and anything for index or create operations.
+  // Document types are set to "UserDefinedValue" rather than being a generic parameter on Request since
+  // bulk operations can target any index and the document type of operations can be widely different.
+  //
+  // /!\ must be kept in sync with MonitoringBulkRequest
+  body?: Array<
+    | OperationContainer
+    | UpdateAction<UserDefinedValue, UserDefinedValue>
+    | UserDefinedValue
+  >
 }

--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -28,7 +28,6 @@ import {
 import { Time } from '@_types/Time'
 import { OperationContainer, UpdateAction } from './types'
 import { SourceConfigParam } from '@global/search/_types/SourceFilter'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * @rest_spec_name bulk
@@ -37,7 +36,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * @doc_id docs-bulk
  *
  */
-export interface Request extends RequestBase {
+export interface Request<TDocument, TPartialDocument> extends RequestBase {
   path_parts: {
     index?: IndexName
   }
@@ -55,13 +54,9 @@ export interface Request extends RequestBase {
   /** @codegen_name operations */
   // This declaration captures action_and_meta_data (OperationContainer) and the two kinds of sources
   // that can follow: an update action for update operations and anything for index or create operations.
-  // Document types are set to "UserDefinedValue" rather than being a generic parameter on Request since
-  // bulk operations can target any index and the document type of operations can be widely different.
   //
-  // /!\ must be kept in sync with MonitoringBulkRequest
+  // /!\ must be kept in sync with BulkMonitoringRequest
   body?: Array<
-    | OperationContainer
-    | UpdateAction<UserDefinedValue, UserDefinedValue>
-    | UserDefinedValue
+    OperationContainer | UpdateAction<TDocument, TPartialDocument> | TDocument
   >
 }

--- a/specification/_global/bulk/types.ts
+++ b/specification/_global/bulk/types.ts
@@ -31,6 +31,8 @@ import {
 import { ErrorCause } from '@_types/Errors'
 import { integer, long } from '@_types/Numeric'
 import { ShardStatistics } from '@_types/Stats'
+import { Script } from '@_types/Scripting'
+import { SourceConfig } from '@global/search/_types/SourceFilter'
 
 export class ResponseItem {
   _id?: string | null
@@ -86,4 +88,42 @@ export class OperationContainer {
   create?: CreateOperation
   update?: UpdateOperation
   delete?: DeleteOperation
+}
+
+export class UpdateAction<TDocument, TPartialDocument> {
+  /**
+   * Set to false to disable setting 'result' in the response
+   * to 'noop' if no change to the document occurred.
+   * @server_default true
+   */
+  detect_noop?: boolean
+  /**
+   * A partial update to an existing document.
+   */
+  doc?: TPartialDocument
+  /**
+   * Set to true to use the contents of 'doc' as the value of 'upsert'
+   * @server_default false
+   */
+  doc_as_upsert?: boolean
+  /**
+   * Script to execute to update the document.
+   */
+  script?: Script
+  /**
+   * Set to true to execute the script whether or not the document exists.
+   * @server_default false
+   */
+  scripted_upsert?: boolean
+  /**
+   * Set to false to disable source retrieval. You can also specify a comma-separated
+   * list of the fields you want to retrieve.
+   * @server_default true
+   */
+  _source?: SourceConfig
+  /**
+   * If the document does not already exist, the contents of 'upsert' are inserted as a
+   * new document. If the document exists, the 'script' is executed.
+   */
+  upsert?: TDocument
 }

--- a/specification/monitoring/bulk/BulkMonitoringRequest.ts
+++ b/specification/monitoring/bulk/BulkMonitoringRequest.ts
@@ -19,7 +19,8 @@
 
 import { RequestBase } from '@_types/Base'
 import { TimeSpan } from '@_types/Time'
-import { OperationContainer } from '@global/bulk/types'
+import { OperationContainer, UpdateAction } from '@global/bulk/types'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * @rest_spec_name monitoring.bulk
@@ -53,5 +54,10 @@ export interface Request<TSource> extends RequestBase {
 
   /** @codegen_name operations */
   // MonitoringBulkRequest accepts a body request that has the same format as the BulkRequest
-  body?: Array<OperationContainer | TSource>
+  // See BulkRequest for additional notes.
+  body?: Array<
+    | OperationContainer
+    | UpdateAction<UserDefinedValue, UserDefinedValue>
+    | UserDefinedValue
+  >
 }

--- a/specification/monitoring/bulk/BulkMonitoringRequest.ts
+++ b/specification/monitoring/bulk/BulkMonitoringRequest.ts
@@ -20,14 +20,13 @@
 import { RequestBase } from '@_types/Base'
 import { TimeSpan } from '@_types/Time'
 import { OperationContainer, UpdateAction } from '@global/bulk/types'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * @rest_spec_name monitoring.bulk
  * @since 6.3.0
  * @stability stable
  */
-export interface Request<TSource> extends RequestBase {
+export interface Request<TDocument, TPartialDocument> extends RequestBase {
   path_parts: {
     /**
      * @deprecated 7.0.0
@@ -53,11 +52,9 @@ export interface Request<TSource> extends RequestBase {
   }
 
   /** @codegen_name operations */
-  // MonitoringBulkRequest accepts a body request that has the same format as the BulkRequest
+  // BulkMonitoringRequest accepts a body request that has the same format as the BulkRequest
   // See BulkRequest for additional notes.
   body?: Array<
-    | OperationContainer
-    | UpdateAction<UserDefinedValue, UserDefinedValue>
-    | UserDefinedValue
+    OperationContainer | UpdateAction<TDocument, TPartialDocument> | TDocument
   >
 }


### PR DESCRIPTION
Adds a formal definition for the "document" part of the `update` bulk operation, similar to a regular document update request.

This also removes the generic parameter of the top-level `BulkRequest` (they're kept in invididual operations), considering that operations of a bulk request can have widely different unrelated types. The generic parameters are kept though in individual operation definitions.

Reported in https://github.com/elastic/elasticsearch-java/issues/81
