### PR TITLE
Changes back indices.create:alias to a simple dictionary

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9473,7 +9473,7 @@ export interface IndicesCreateRequest extends RequestBase {
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
   body?: {
-    aliases?: Record<Name, IndicesAlias> | Record<Name, IndicesAlias>[]
+    aliases?: Record<Name, IndicesAlias>
     mappings?: MappingTypeMapping
     settings?: IndicesIndexSettings
   }

--- a/specification/indices/create/IndicesCreateRequest.ts
+++ b/specification/indices/create/IndicesCreateRequest.ts
@@ -42,7 +42,7 @@ export interface Request extends RequestBase {
   }
   body: {
     /* Aliases for the index. */
-    aliases?: Dictionary<Name, Alias> | Dictionary<Name, Alias>[]
+    aliases?: Dictionary<Name, Alias>
     /**
      * Mapping for fields in the index. If specified, this mapping can include:
      * - Field names


### PR DESCRIPTION
Follow-up to #1276 - reverts `indices.create:alias` to be a simple dictionary as it doesn't accept an array value.
