### PR TITLE
Make MultiSearchItem.status optional

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -553,7 +553,7 @@ export interface MgetResponse<TDocument = unknown> {
 export type MgetResponseItem<TDocument = unknown> = GetGetResult<TDocument> | MgetMultiGetError
 
 export interface MsearchMultiSearchItem<TDocument = unknown> extends SearchResponse<TDocument> {
-  status: integer
+  status?: integer
 }
 
 export interface MsearchMultiSearchResult<TDocument = unknown> {

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -69,5 +69,6 @@ export type ResponseItem<TDocument> =
   | ErrorResponseBase
 
 export class MultiSearchItem<TDocument> extends SearchResponse<TDocument> {
-  status: integer
+  // Not returned in MultiSearchTemplateResponse
+  status?: integer
 }


### PR DESCRIPTION
The `MultiSearchItem.status` property is always returned in multisearch responses but is missing from multisearch-template responses.

This should be considered as an inconsistency/bug in the ES API, and this PR fixes it by making `status` optional rather than creating a separate type for multisearch-template responses.

Reported in https://github.com/elastic/elasticsearch-java/issues/110