### PR TITLE
Adds cat data frame analytics API spec

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -166,13 +166,12 @@
     },
     "cat.ml_data_frame_analytics": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'time'",
-        "Request: missing json spec query parameter 'v'",
         "Request: should not have a body",
+        "request definition cat.ml_data_frame_analytics:Request / query - Property 'format' is already defined in an ancestor class",
+        "request definition cat.ml_data_frame_analytics:Request / query - Property 'h' is already defined in an ancestor class",
+        "request definition cat.ml_data_frame_analytics:Request / query - Property 'help' is already defined in an ancestor class",
+        "request definition cat.ml_data_frame_analytics:Request / query - Property 's' is already defined in an ancestor class",
+        "request definition cat.ml_data_frame_analytics:Request / query - Property 'v' is already defined in an ancestor class",
         "request definition cat.ml_data_frame_analytics:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -166,12 +166,12 @@
     },
     "cat.ml_data_frame_analytics": {
       "request": [
+        "Request: missing json spec query parameter 'format'",
+        "Request: missing json spec query parameter 'help'",
+        "Request: missing json spec query parameter 'v'",
         "Request: should not have a body",
-        "request definition cat.ml_data_frame_analytics:Request / query - Property 'format' is already defined in an ancestor class",
         "request definition cat.ml_data_frame_analytics:Request / query - Property 'h' is already defined in an ancestor class",
-        "request definition cat.ml_data_frame_analytics:Request / query - Property 'help' is already defined in an ancestor class",
         "request definition cat.ml_data_frame_analytics:Request / query - Property 's' is already defined in an ancestor class",
-        "request definition cat.ml_data_frame_analytics:Request / query - Property 'v' is already defined in an ancestor class",
         "request definition cat.ml_data_frame_analytics:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6393,12 +6393,9 @@ export interface CatMlDataFrameAnalyticsRequest extends CatCatRequestBase {
   id?: Id
   allow_no_match?: boolean
   bytes?: Bytes
-  format?: string
   h?: CatCatDfaColumns
-  help?: boolean
   s?: CatCatDfaColumns
   time?: Time
-  v?: boolean
 }
 
 export type CatMlDataFrameAnalyticsResponse = CatMlDataFrameAnalyticsDataFrameAnalyticsRecord[]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5861,6 +5861,10 @@ export interface AutoscalingPutAutoscalingPolicyRequest extends RequestBase {
 export interface AutoscalingPutAutoscalingPolicyResponse extends AcknowledgedResponseBase {
 }
 
+export type CatCatDfaColumn = 'assignment_explanation' | 'ae' | 'create_time' | 'ct' | 'createTime' | 'description' | 'd' | 'dest_index' | 'di' | 'destIndex' | 'failure_reason' | 'fr' | 'failureReason' | 'id' | 'model_memory_limit' | 'mml' | 'modelMemoryLimit' | 'node.address' | 'na' | 'nodeAddress' | 'node.ephemeral_id' | 'ne' | 'nodeEphemeralId' | 'node.id' | 'ni' | 'nodeId' | 'node.name' | 'nn' | 'nodeName' | 'progress' | 'p' | 'source_index' | 'si' | 'sourceIndex' | 'state' | 's' | 'type' | 't' | 'version' | 'v'
+
+export type CatCatDfaColumns = CatCatDfaColumn | CatCatDfaColumn[]
+
 export interface CatCatRequestBase extends RequestBase, SpecUtilsCommonCatQueryParameters {
 }
 
@@ -6389,6 +6393,12 @@ export interface CatMlDataFrameAnalyticsRequest extends CatCatRequestBase {
   id?: Id
   allow_no_match?: boolean
   bytes?: Bytes
+  format?: string
+  h?: CatCatDfaColumns
+  help?: boolean
+  s?: CatCatDfaColumns
+  time?: Time
+  v?: boolean
 }
 
 export type CatMlDataFrameAnalyticsResponse = CatMlDataFrameAnalyticsDataFrameAnalyticsRecord[]

--- a/specification/cat/_types/CatBase.ts
+++ b/specification/cat/_types/CatBase.ts
@@ -34,85 +34,85 @@ export enum CatDfaColumn {
    * Contains messages relating to the selection of a node.
    * @aliases ae
    */
-  assignment_explanation = 0,
+  assignment_explanation,
   /**
    * The time when the data frame analytics job was created.
    * @aliases ct, createTime
    */
-  create_time = 1,
+  create_time,
   /**
    * A description of a job.
    * @aliases d
    */
-  description = 2,
+  description,
   /**
    * Name of the destination index.
    * @aliases di, destIndex
    */
-  dest_index = 3,
+  dest_index,
   /**
    * Contains messages about the reason why a data frame analytics job failed.
    * @aliases fr, failureReason
    */
-  failure_reason = 4,
+  failure_reason,
   /**
    * Identifier for the data frame analytics job.
    */
-  id = 5,
+  id,
   /**
    * The approximate maximum amount of memory resources that are permitted for
    * the data frame analytics job.
    * @aliases mml, modelMemoryLimit
    */
-  model_memory_limit = 6,
+  model_memory_limit,
   /**
    * The network address of the node that the data frame analytics job is
    * assigned to.
    * @aliases na, nodeAddress
    */
-  'node.address' = 7,
+  'node.address',
   /**
    * The ephemeral ID of the node that the data frame analytics job is assigned
    * to.
    * @aliases ne, nodeEphemeralId
    */
-  'node.ephemeral_id' = 8,
+  'node.ephemeral_id',
   /**
    * The unique identifier of the node that the data frame analytics job is
    * assigned to.
    * @aliases ni, nodeId
    */
-  'node.id' = 9,
+  'node.id',
   /**
    * The name of the node that the data frame analytics job is assigned to.
    * @aliases nn, nodeName
    */
-  'node.name' = 10,
+  'node.name',
   /**
    * The progress report of the data frame analytics job by phase.
    * @aliases p
    */
-  progress = 11,
+  progress,
   /**
    * Name of the source index.
    * @aliases si, sourceIndex
    */
-  source_index = 12,
+  source_index,
   /**
    * Current state of the data frame analytics job.
    * @aliases s
    */
-  state = 13,
+  state,
   /**
    * The type of analysis that the data frame analytics job performs.
    * @aliases t
    */
-  type = 14,
+  type,
   /**
    * The Elasticsearch version number in which the data frame analytics job was
    * created.
    * @aliases v
    */
-  version = 15
+  version
 }
 export type CatDfaColumns = CatDfaColumn | CatDfaColumn[]

--- a/specification/cat/_types/CatBase.ts
+++ b/specification/cat/_types/CatBase.ts
@@ -64,55 +64,55 @@ export enum CatDfaColumn {
    * the data frame analytics job.
    * @aliases mml, modelMemoryLimit
    */
-  model_memory_limit = 5,
+  model_memory_limit = 6,
   /**
    * The network address of the node that the data frame analytics job is
    * assigned to.
    * @aliases na, nodeAddress
    */
-  'node.address' = 6,
+  'node.address' = 7,
   /**
    * The ephemeral ID of the node that the data frame analytics job is assigned
    * to.
    * @aliases ne, nodeEphemeralId
    */
-  'node.ephemeral_id' = 7,
+  'node.ephemeral_id' = 8,
   /**
    * The unique identifier of the node that the data frame analytics job is
    * assigned to.
    * @aliases ni, nodeId
    */
-  'node.id' = 8,
+  'node.id' = 9,
   /**
    * The name of the node that the data frame analytics job is assigned to.
    * @aliases nn, nodeName
    */
-  'node.name' = 9,
+  'node.name' = 10,
   /**
    * The progress report of the data frame analytics job by phase.
    * @aliases p
    */
-  progress = 10,
+  progress = 11,
   /**
    * Name of the source index.
    * @aliases si, sourceIndex
    */
-  source_index = 11,
+  source_index = 12,
   /**
    * Current state of the data frame analytics job.
    * @aliases s
    */
-  state = 12,
+  state = 13,
   /**
    * The type of analysis that the data frame analytics job performs.
    * @aliases t
    */
-  type = 13,
+  type = 14,
   /**
    * The Elasticsearch version number in which the data frame analytics job was
    * created.
    * @aliases v
    */
-  version = 14
+  version = 15
 }
 export type CatDfaColumns = CatDfaColumn | CatDfaColumn[]

--- a/specification/cat/_types/CatBase.ts
+++ b/specification/cat/_types/CatBase.ts
@@ -28,3 +28,91 @@ import { RequestBase } from '@_types/Base'
 export class CatRequestBase
   extends RequestBase
   implements CommonCatQueryParameters {}
+
+export enum CatDfaColumn {
+  /**
+   * Contains messages relating to the selection of a node.
+   * @aliases ae
+   */
+  assignment_explanation = 0,
+  /**
+   * The time when the data frame analytics job was created.
+   * @aliases ct, createTime
+   */
+  create_time = 1,
+  /**
+   * A description of a job.
+   * @aliases d
+   */
+  description = 2,
+  /**
+   * Name of the destination index.
+   * @aliases di, destIndex
+   */
+  dest_index = 3,
+  /**
+   * Contains messages about the reason why a data frame analytics job failed.
+   * @aliases fr, failureReason
+   */
+  failure_reason = 4,
+  /**
+   * Identifier for the data frame analytics job.
+   */
+  id = 5,
+  /**
+   * The approximate maximum amount of memory resources that are permitted for
+   * the data frame analytics job.
+   * @aliases mml, modelMemoryLimit
+   */
+  model_memory_limit = 5,
+  /**
+   * The network address of the node that the data frame analytics job is
+   * assigned to.
+   * @aliases na, nodeAddress
+   */
+  'node.address' = 6,
+  /**
+   * The ephemeral ID of the node that the data frame analytics job is assigned
+   * to.
+   * @aliases ne, nodeEphemeralId
+   */
+  'node.ephemeral_id' = 7,
+  /**
+   * The unique identifier of the node that the data frame analytics job is
+   * assigned to.
+   * @aliases ni, nodeId
+   */
+  'node.id' = 8,
+  /**
+   * The name of the node that the data frame analytics job is assigned to.
+   * @aliases nn, nodeName
+   */
+  'node.name' = 9,
+  /**
+   * The progress report of the data frame analytics job by phase.
+   * @aliases p
+   */
+  progress = 10,
+  /**
+   * Name of the source index.
+   * @aliases si, sourceIndex
+   */
+  source_index = 11,
+  /**
+   * Current state of the data frame analytics job.
+   * @aliases s
+   */
+  state = 12,
+  /**
+   * The type of analysis that the data frame analytics job performs.
+   * @aliases t
+   */
+  type = 13,
+  /**
+   * The Elasticsearch version number in which the data frame analytics job was
+   * created.
+   * @aliases v
+   */
+  version = 14
+}
+export type CatDfaColumns = CatDfaColumn | CatDfaColumn[]

--- a/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
+++ b/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
@@ -17,8 +17,9 @@
  * under the License.
  */
 
-import { CatRequestBase } from '@cat/_types/CatBase'
+import { CatRequestBase, CatDfaColumns } from '@cat/_types/CatBase'
 import { Bytes, Id } from '@_types/common'
+import { Time } from '@_types/Time'
 
 /**
  * @rest_spec_name cat.ml_data_frame_analytics
@@ -33,5 +34,33 @@ export interface Request extends CatRequestBase {
   query_parameters: {
     allow_no_match?: boolean
     bytes?: Bytes
+    /**
+     * Short version of the HTTP accept header. Valid values include JSON, YAML,
+     * etc.
+     */
+    format?: string
+    /**
+     * Comma-separated list of column names to display.
+     * @server_default create_time,id,state,type
+     */
+    h?: CatDfaColumns
+    /**
+     * If `true`, the response includes help information.
+     * @server_default false
+     */
+    help?: boolean
+    /** Comma-separated list of column names or column aliases used to sort the
+     * response.
+     */
+    s?: CatDfaColumns
+    /**
+     * Unit used to display time values.
+     */
+    time?: Time
+    /**
+     * If `true`, the response includes column headings.
+     * @server_default false
+     */
+    v?: boolean
   }
 }

--- a/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
+++ b/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
@@ -35,20 +35,10 @@ export interface Request extends CatRequestBase {
     allow_no_match?: boolean
     bytes?: Bytes
     /**
-     * Short version of the HTTP accept header. Valid values include JSON, YAML,
-     * etc.
-     */
-    format?: string
-    /**
      * Comma-separated list of column names to display.
      * @server_default create_time,id,state,type
      */
     h?: CatDfaColumns
-    /**
-     * If `true`, the response includes help information.
-     * @server_default false
-     */
-    help?: boolean
     /** Comma-separated list of column names or column aliases used to sort the
      * response.
      */
@@ -57,10 +47,5 @@ export interface Request extends CatRequestBase {
      * Unit used to display time values.
      */
     time?: Time
-    /**
-     * If `true`, the response includes column headings.
-     * @server_default false
-     */
-    v?: boolean
   }
 }


### PR DESCRIPTION
## Overview

This PR adds missing fields to the [cat data frame analytics API](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-dfanalytics.html). 