### PR TITLE
Make snapshot info in CreateSnapshotResponse optional

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15419,7 +15419,7 @@ export interface SnapshotCreateRequest extends RequestBase {
 
 export interface SnapshotCreateResponse {
   accepted?: boolean
-  snapshot: SnapshotSnapshotInfo
+  snapshot?: SnapshotSnapshotInfo
 }
 
 export interface SnapshotCreateRepositoryRequest extends RequestBase {

--- a/specification/snapshot/create/SnapshotCreateResponse.ts
+++ b/specification/snapshot/create/SnapshotCreateResponse.ts
@@ -21,8 +21,14 @@ import { SnapshotInfo } from '@snapshot/_types/SnapshotInfo'
 
 export class Response {
   body: {
-    /** @since 7.15.0 */
+    /**
+     * Equals `true` if the snapshot was accepted. Present when the request had `wait_for_completion` set to `false`
+     * @since 7.15.0
+     */
     accepted?: boolean
-    snapshot: SnapshotInfo
+    /**
+     * Snapshot information. Present when the request had `wait_for_completion` set to `true`
+     */
+    snapshot?: SnapshotInfo
   }
 }


### PR DESCRIPTION
Snapshot info is only present if `wait_for_completion` was set to `true`.

Found in https://github.com/elastic/elasticsearch-java/issues/132
