### PR TITLE
Fixes TopHitsAggregate which are a simple aggregate (no buckets)

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3724,7 +3724,8 @@ export interface AggregationsTopMetrics {
   metrics: Record<string, FieldValue | null>
 }
 
-export interface AggregationsTopMetricsAggregate extends AggregationsMultiBucketAggregateBase<AggregationsTopMetricsBucket> {
+export interface AggregationsTopMetricsAggregate extends AggregationsAggregateBase {
+  top: AggregationsTopMetrics[]
 }
 
 export interface AggregationsTopMetricsAggregation extends AggregationsMetricAggregationBase {
@@ -3732,12 +3733,6 @@ export interface AggregationsTopMetricsAggregation extends AggregationsMetricAgg
   size?: integer
   sort?: Sort
 }
-
-export interface AggregationsTopMetricsBucketKeys extends AggregationsMultiBucketBase {
-  top: AggregationsTopMetrics[]
-}
-export type AggregationsTopMetricsBucket = AggregationsTopMetricsBucketKeys
-  & { [property: string]: AggregationsAggregate | AggregationsTopMetrics[] | long }
 
 export interface AggregationsTopMetricsValue {
   field: Field

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -672,9 +672,7 @@ export class BoxPlotAggregate extends AggregateBase {
 }
 
 /** @variant name=top_metrics */
-export class TopMetricsAggregate extends MultiBucketAggregateBase<TopMetricsBucket> {}
-
-export class TopMetricsBucket extends MultiBucketBase {
+export class TopMetricsAggregate extends AggregateBase {
   top: TopMetrics[]
 }
 


### PR DESCRIPTION
The top hits aggregation returns a simple result, with no buckets

Reported in https://github.com/elastic/elasticsearch-java/issues/123 ([see also doc](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/search-aggregations-metrics-top-metrics.html))