### PR TITLE
Add missing fields to SearchTemplateResponse

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1598,10 +1598,20 @@ export interface SearchTemplateRequest extends RequestBase {
 }
 
 export interface SearchTemplateResponse<TDocument = unknown> {
-  _shards: ShardStatistics
+  took: long
   timed_out: boolean
-  took: integer
+  _shards: ShardStatistics
   hits: SearchHitsMetadata<TDocument>
+  aggregations?: Record<AggregateName, AggregationsAggregate>
+  _clusters?: ClusterStatistics
+  fields?: Record<string, any>
+  max_score?: double
+  num_reduce_phases?: long
+  profile?: SearchProfile
+  pit_id?: Id
+  _scroll_id?: ScrollId
+  suggest?: Record<SuggestionName, SearchSuggest<TDocument>[]>
+  terminated_early?: boolean
 }
 
 export interface TermsEnumRequest extends RequestBase {

--- a/specification/_global/search/SearchResponse.ts
+++ b/specification/_global/search/SearchResponse.ts
@@ -29,6 +29,7 @@ import { Suggest } from './_types/suggester'
 
 export class Response<TDocument> {
   body: {
+    // Has to be kept in sync with SearchTemplateResponse
     took: long
     timed_out: boolean
     _shards: ShardStatistics

--- a/specification/_global/search_template/SearchTemplateResponse.ts
+++ b/specification/_global/search_template/SearchTemplateResponse.ts
@@ -18,14 +18,31 @@
  */
 
 import { HitsMetadata } from '@global/search/_types/hits'
-import { integer } from '@_types/Numeric'
-import { ShardStatistics } from '@_types/Stats'
+import { double, integer, long } from '@_types/Numeric'
+import { ClusterStatistics, ShardStatistics } from '@_types/Stats'
+import { Dictionary } from '@spec_utils/Dictionary'
+import { AggregateName, Id, ScrollId, SuggestionName } from '@_types/common'
+import { Aggregate } from '@_types/aggregations/Aggregate'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { Profile } from '@global/search/_types/profile'
+import { Suggest } from '@global/search/_types/suggester'
 
 export class Response<TDocument> {
   body: {
-    _shards: ShardStatistics
+    // Has to be kept in sync with SearchResponse
+    took: long
     timed_out: boolean
-    took: integer
+    _shards: ShardStatistics
     hits: HitsMetadata<TDocument>
+    aggregations?: Dictionary<AggregateName, Aggregate>
+    _clusters?: ClusterStatistics
+    fields?: Dictionary<string, UserDefinedValue>
+    max_score?: double
+    num_reduce_phases?: long
+    profile?: Profile
+    pit_id?: Id
+    _scroll_id?: ScrollId
+    suggest?: Dictionary<SuggestionName, Suggest<TDocument>[]>
+    terminated_early?: boolean
   }
 }


### PR DESCRIPTION
Add missing fields to `SearchTemplateResponse` so that it has the same fields as `SearchResponse`.

Reported in https://github.com/elastic/elasticsearch-java/issues/89 and [the docs says](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html#run-templated-search) _"The response uses the same properties as the search API's response"_. 