### PR TITLE
[Backport 7.17] Add admonition to cat ML specifications

### DIFF
--- a/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
+++ b/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
@@ -21,6 +21,12 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { Bytes, Id } from '@_types/common'
 
 /**
+ * Returns configuration and usage information about data frame analytics jobs.
+ *
+ * IMPORTANT: cat APIs are only intended for human consumption using the Kibana
+ * console or command line. They are not intended for use by applications. For
+ * application consumption, use the get data frame analytics jobs statistics API.
+ *
  * @rest_spec_name cat.ml_data_frame_analytics
  * @since 7.7.0
  * @stability stable

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -22,6 +22,15 @@ import { Id } from '@_types/common'
 import { TimeUnit } from '@_types/Time'
 
 /**
+ * Returns configuration and usage information about datafeeds.
+ * This API returns a maximum of 10,000 datafeeds.
+ * If the Elasticsearch security features are enabled, you must have `monitor_ml`,
+ * `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.
+ *
+ * IMPORTANT: cat APIs are only intended for human consumption using the Kibana
+ * console or command line. They are not intended for use by applications. For
+ * application consumption, use the get datafeed statistics API.
+ *
  * @rest_spec_name cat.ml_datafeeds
  * @since 7.7.0
  * @stability stable

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -22,6 +22,15 @@ import { Bytes, Id } from '@_types/common'
 import { TimeUnit } from '@_types/Time'
 
 /**
+ * Returns configuration and usage information for anomaly detection jobs.
+ * This API returns a maximum of 10,000 jobs.
+ * If the Elasticsearch security features are enabled, you must have `monitor_ml`,
+ * `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.
+ *
+ * IMPORTANT: cat APIs are only intended for human consumption using the Kibana
+ * console or command line. They are not intended for use by applications. For
+ * application consumption, use the get anomaly detection job statistics API.
+ *
  * @rest_spec_name cat.ml_jobs
  * @since 7.7.0
  * @stability stable

--- a/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
+++ b/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
@@ -22,6 +22,12 @@ import { Bytes, Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
+ * Returns configuration and usage information about inference trained models.
+ *
+ * IMPORTANT: cat APIs are only intended for human consumption using the Kibana
+ * console or command line. They are not intended for use by applications. For
+ * application consumption, use the get trained models statistics API.
+ *
  * @rest_spec_name cat.ml_trained_models
  * @since 7.7.0
  * @stability stable

--- a/specification/cat/transforms/CatTransformsRequest.ts
+++ b/specification/cat/transforms/CatTransformsRequest.ts
@@ -22,6 +22,12 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
+ * Returns configuration and usage information about transforms.
+ *
+ * IMPORTANT: cat APIs are only intended for human consumption using the Kibana
+ * console or command line. They are not intended for use by applications. For
+ * application consumption, use the get transform statistics API.
+ *
  * @rest_spec_name cat.transforms
  * @since 7.7.0
  * @stability stable


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-specification/pull/1337