### PR TITLE
Verify that the TS view is valid

### DIFF
--- a/.github/workflows/output-check.yml
+++ b/.github/workflows/output-check.yml
@@ -25,6 +25,10 @@ jobs:
         npm run generate-schema --prefix compiler
         npm run start --prefix typescript-generator
 
+    - name: Validate TS output
+      run: |
+        npm run validate-ts-view --prefix compiler
+
     - name: Check freshness
       run: |
         if [ -n "$(git status --porcelain)" ]; then echo Error: changes found after running the generation; git diff; git status; exit 1; fi

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -11,6 +11,7 @@
     "generate-schema": "ts-node src/index.ts",
     "compile:specification": "tsc --project ../specification/tsconfig.json --noEmit",
     "build": "rm -rf lib && tsc",
+    "validate-ts-view": "tsc --noEmit ../output/typescript/types.ts",
     "generate-dangling": "ts-node src dangling-types-report.ts"
   },
   "author": "Elastic",

--- a/compiler/run-validations.js
+++ b/compiler/run-validations.js
@@ -152,6 +152,15 @@ async function run () {
     }
   }
 
+  {
+    spinner.text = 'Validating typescript view'
+    const Process = await nothrow($`npm run validate-ts-view --prefix ${compilerPath}`)
+    if (Process.exitCode !== 0) {
+      spinner.fail(removeHeader(Process.toString()))
+      process.exit(1)
+    }
+  }
+
   spinner.text = 'Running validations'
 
   const branchName = argv['stack-version'].startsWith('7.') ? '7.x' : 'master'

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -191,13 +191,7 @@
     },
     "cat.ml_jobs": {
       "request": [
-        "Request: should not have a body",
-        "request definition cat.ml_jobs:Request / query - Property 'format' is already defined in an ancestor class",
-        "request definition cat.ml_jobs:Request / query - Property 'h' is already defined in an ancestor class",
-        "request definition cat.ml_jobs:Request / query - Property 'help' is already defined in an ancestor class",
-        "request definition cat.ml_jobs:Request / query - Property 's' is already defined in an ancestor class",
-        "request definition cat.ml_jobs:Request / query - Property 'v' is already defined in an ancestor class",
-        "request definition cat.ml_jobs:Request / body - A request with inherited properties must have a PropertyBody"
+        "Request: should not have a body"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6629,7 +6629,7 @@ export interface CatMlJobsJobsRecord {
   bucketsTimeExpAvgHour?: string
 }
 
-export interface CatMlJobsRequest extends CatCatRequestBase {
+export interface CatMlJobsRequest extends RequestBase {
   job_id?: Id
   allow_no_match?: boolean
   bytes?: Bytes

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5872,8 +5872,6 @@ export type CatCatAnonalyDetectorColumns = CatCatAnomalyDetectorColumn | CatCatA
 
 export type CatCatDatafeedColumn = 'ae' | 'assignment_explanation' | 'bc' | 'buckets.count' | 'bucketsCount' | 'id' | 'na' | 'node.address' | 'nodeAddress' | 'ne' | 'node.ephemeral_id' | 'nodeEphemeralId' | 'ni' | 'node.id' | 'nodeId' | 'nn' | 'node.name' | 'nodeName' | 'sba' | 'search.bucket_avg' | 'searchBucketAvg' | 'sc' | 'search.count' | 'searchCount' | 'seah' | 'search.exp_avg_hour' | 'searchExpAvgHour' | 'st' | 'search.time' | 'searchTime' | 's' | 'state'
 
-export type CatCatDatafeedColumns = CatCatDatafeedColumn | CatCatDatafeedColumn[]
-
 export interface CatCatRequestBase extends RequestBase, SpecUtilsCommonCatQueryParameters {
 }
 
@@ -6445,9 +6443,9 @@ export interface CatMlDatafeedsRequest extends CatCatRequestBase {
   datafeed_id?: Id
   allow_no_match?: boolean
   format?: string
-  h?: CatCatDatafeedColumns
+  h?: CatCatDatafeedColumn[]
   help?: boolean
-  s?: CatCatDatafeedColumns
+  s?: CatCatDatafeedColumn[]
   time?: TimeUnit
   v?: boolean
 }

--- a/specification/cat/_types/CatBase.ts
+++ b/specification/cat/_types/CatBase.ts
@@ -469,5 +469,3 @@ export enum CatDatafeedColumn {
    */
   s = 11
 }
-
-export type CatDatafeedColumns = CatDatafeedColumn | CatDatafeedColumn[]

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { CatRequestBase, CatDatafeedColumns } from '@cat/_types/CatBase'
+import { CatRequestBase, CatDatafeedColumn } from '@cat/_types/CatBase'
 import { Id } from '@_types/common'
 import { TimeUnit } from '@_types/Time'
 
@@ -62,15 +62,15 @@ export interface Request extends CatRequestBase {
     format?: string
     /**
      * Comma-separated list of column names to display.
-     * @server_default bc,id,sc,s
+     * @server_default ['bc', 'id', 'sc', 's']
      */
-    h?: CatDatafeedColumns
+    h?: CatDatafeedColumn[]
     /** If `true`, the response includes help information.
      * @server_default false
      */
     help?: boolean
     /** Comma-separated list of column names or column aliases used to sort the response. */
-    s?: CatDatafeedColumns
+    s?: CatDatafeedColumn[]
     /**
      * The unit used to display time values.
      */

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -17,7 +17,8 @@
  * under the License.
  */
 
-import { CatRequestBase, CatAnonalyDetectorColumns } from '@cat/_types/CatBase'
+import { CatAnonalyDetectorColumns } from '@cat/_types/CatBase'
+import { RequestBase } from '@_types/Base'
 import { Bytes, Id } from '@_types/common'
 import { TimeUnit } from '@_types/Time'
 
@@ -37,7 +38,7 @@ import { TimeUnit } from '@_types/Time'
  * @cluster_privileges monitor_ml
  * @doc_id cat-anomaly-detectors
  */
-export interface Request extends CatRequestBase {
+export interface Request extends RequestBase {
   path_parts: {
     /**
      * Identifier for the anomaly detection job.


### PR DESCRIPTION
It can happen that the specification does not catch an invalid `extends` or `implements`, especially if we are using behaviors.
This additional check will add an additional safeguard for those cases.