### PR TITLE
Fix security apis

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14432,7 +14432,7 @@ export interface SecurityIndicesPrivileges {
   field_security?: SecurityFieldSecurity | SecurityFieldSecurity[]
   names: Indices
   privileges: SecurityIndexPrivilege[]
-  query?: QueryDslQueryContainer
+  query?: string[] | QueryDslQueryContainer
   allow_restricted_indices?: boolean
 }
 
@@ -14611,7 +14611,7 @@ export interface SecurityDeletePrivilegesFoundStatus {
 
 export interface SecurityDeletePrivilegesRequest extends RequestBase {
   application: Name
-  name: Name
+  name: Names
   refresh?: Refresh
 }
 

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -92,7 +92,7 @@ export class IndicesPrivileges {
   /**
    * A search query that defines the documents the owners of the role have read access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.
    */
-  query?: QueryContainer
+  query?: string[] | QueryContainer
   /**
    * Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.
    * @server_default false

--- a/specification/security/delete_privileges/SecurityDeletePrivilegesRequest.ts
+++ b/specification/security/delete_privileges/SecurityDeletePrivilegesRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Name, Refresh } from '@_types/common'
+import { Name, Names, Refresh } from '@_types/common'
 
 /**
  * @rest_spec_name security.delete_privileges
@@ -28,7 +28,7 @@ import { Name, Refresh } from '@_types/common'
 export interface Request extends RequestBase {
   path_parts: {
     application: Name
-    name: Name
+    name: Names
   }
   query_parameters: {
     refresh?: Refresh


### PR DESCRIPTION
As titled.

The APIs that are still failing should be fixed once https://github.com/elastic/clients-flight-recorder/pull/941 is merged.