### PR TITLE
Run validate-pr action only if the pr is not from a fork

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   validate-pr:
     name: build
+    if: github.repository_owner == 'elastic' # this action will fail if executed from a fork
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
As titled. Otherwise the action will fail due to permissions.