### PR TITLE
Store hash and branch in a separate file to quickly resolve conflicts

### DIFF
--- a/compiler/src/steps/add-info.ts
+++ b/compiler/src/steps/add-info.ts
@@ -20,7 +20,7 @@
 import * as model from '../model/metamodel'
 import { JsonSpec } from '../model/json-spec'
 import { execSync } from 'child_process'
-import { readFileSync } from 'fs'
+import { readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 
 /**
@@ -43,13 +43,16 @@ export default async function addInfo (model: model.Model, jsonSpec: Map<string,
         url: 'https://github.com/elastic/elasticsearch-specification/blob/master/LICENSE'
       }
     }
-  } else {
-    const current: model.Model = JSON.parse(
-      readFileSync(join(__dirname, '..', '..', '..', 'output', 'schema', 'schema.json'), 'utf8')
+    writeFileSync(
+      join(__dirname, '..', '..', '..', 'output', 'schema', 'hash.txt'),
+      `${execSync('git rev-parse --short HEAD').toString().trim()}\n${branch}`,
+      'utf8'
     )
+  } else {
+    const [hash, branch] = readFileSync(join(__dirname, '..', '..', '..', 'output', 'schema', 'hash.txt'), 'utf8').split('\n').filter(Boolean)
     model._info = {
-      version: current._info!.version, // eslint-disable-line
-      hash: current._info!.hash, // eslint-disable-line
+      version: branch,
+      hash,
       title: 'Elasticsearch Request & Response Specification',
       license: {
         name: 'Apache 2.0',

--- a/output/schema/hash.txt
+++ b/output/schema/hash.txt
@@ -1,0 +1,2 @@
+ec381cd
+main


### PR DESCRIPTION
Currently, if there is a conflict while merging the base branch with your current working branch, you can't quickly solve it by running `make generate` because the compiler needs to parse the `schema.json`.
This pr adds a `hash.txt` which contains the git hash and branch name that can be easily fixed in case of conflicts.