### PR TITLE
Add @deprecated to indices.exists_type

### DIFF
--- a/specification/indices/exists_type/IndicesExistsTypeRequest.ts
+++ b/specification/indices/exists_type/IndicesExistsTypeRequest.ts
@@ -24,6 +24,7 @@ import { ExpandWildcards, Indices, Types } from '@_types/common'
  * @rest_spec_name indices.exists_type
  * @since 0.0.0
  * @stability stable
+ * @deprecated 7.0.0
  */
 export interface Request extends RequestBase {
   path_parts: {


### PR DESCRIPTION
This PR adds the @deprecated property to the
[type exists API](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/indices-types-exists.html). The API is removed in 8.0 per https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-types-exists.html

