### PR TITLE
Fix ml.get_datafeed_stats add missing optional search_interval property

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11459,6 +11459,7 @@ export interface MlDatafeedConfig {
 export interface MlDatafeedRunningState {
   real_time_configured: boolean
   real_time_running: boolean
+  search_interval?: MlRunningStateSearchInterval
 }
 
 export type MlDatafeedState = 'started' | 'stopped' | 'starting' | 'stopping'
@@ -12016,6 +12017,11 @@ export interface MlRuleCondition {
   applies_to: MlAppliesTo
   operator: MlConditionOperator
   value: double
+}
+
+export interface MlRunningStateSearchInterval {
+  end_ms: long
+  start_ms: long
 }
 
 export interface MlTimingStats {

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -147,6 +147,12 @@ export class DatafeedTimingStats {
 export class DatafeedRunningState {
   real_time_configured: boolean
   real_time_running: boolean
+  search_interval?: RunningStateSearchInterval
+}
+
+export class RunningStateSearchInterval {
+  end_ms: long
+  start_ms: long
 }
 
 export enum ChunkingMode {


### PR DESCRIPTION
As titled.
