### PR TITLE
Remove generic on async search status response

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5727,7 +5727,7 @@ export interface AsyncSearchStatusRequest extends RequestBase {
   id: Id
 }
 
-export interface AsyncSearchStatusResponse<TDocument = unknown> extends AsyncSearchAsyncSearchResponseBase {
+export interface AsyncSearchStatusResponse extends AsyncSearchAsyncSearchResponseBase {
   _shards: ShardStatistics
   completion_status: integer
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5729,7 +5729,7 @@ export interface AsyncSearchStatusRequest extends RequestBase {
 
 export interface AsyncSearchStatusResponse extends AsyncSearchAsyncSearchResponseBase {
   _shards: ShardStatistics
-  completion_status: integer
+  completion_status?: integer
 }
 
 export interface AsyncSearchSubmitRequest extends RequestBase {

--- a/specification/async_search/status/AsyncSearchStatusResponse.ts
+++ b/specification/async_search/status/AsyncSearchStatusResponse.ts
@@ -21,7 +21,7 @@ import { AsyncSearchResponseBase } from '@async_search/_types/AsyncSearchRespons
 import { integer } from '@_types/Numeric'
 import { ShardStatistics } from '@_types/Stats'
 
-export class Response<TDocument> extends AsyncSearchResponseBase {
+export class Response extends AsyncSearchResponseBase {
   body: {
     _shards: ShardStatistics
     completion_status: integer

--- a/specification/async_search/status/AsyncSearchStatusResponse.ts
+++ b/specification/async_search/status/AsyncSearchStatusResponse.ts
@@ -24,6 +24,6 @@ import { ShardStatistics } from '@_types/Stats'
 export class Response extends AsyncSearchResponseBase {
   body: {
     _shards: ShardStatistics
-    completion_status: integer
+    completion_status?: integer
   }
 }


### PR DESCRIPTION
As titled, this removes the generic type on the status response for async search which is not used in the body. 

Also, `completion_status` should be optional as it's only returned for non-running searches.

@swallez Should we backport to 7.17?