### PR TITLE
Rename internal namespace

### DIFF
--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -82,7 +82,7 @@ export function modelType (node: Node): model.ValueOf {
         kind: 'instance_of',
         type: {
           name: 'boolean',
-          namespace: 'internal'
+          namespace: '_primitive'
         }
       }
       return type
@@ -93,7 +93,7 @@ export function modelType (node: Node): model.ValueOf {
         kind: 'instance_of',
         type: {
           name: 'string',
-          namespace: 'internal'
+          namespace: '_primitive'
         }
       }
       return type
@@ -104,7 +104,7 @@ export function modelType (node: Node): model.ValueOf {
         kind: 'instance_of',
         type: {
           name: 'number',
-          namespace: 'internal'
+          namespace: '_primitive'
         }
       }
       return type
@@ -115,7 +115,7 @@ export function modelType (node: Node): model.ValueOf {
         kind: 'instance_of',
         type: {
           name: 'null',
-          namespace: 'internal'
+          namespace: '_primitive'
         }
       }
       return type
@@ -126,7 +126,7 @@ export function modelType (node: Node): model.ValueOf {
         kind: 'instance_of',
         type: {
           name: 'void',
-          namespace: 'internal'
+          namespace: '_primitive'
         }
       }
       return type
@@ -139,7 +139,7 @@ export function modelType (node: Node): model.ValueOf {
         kind: 'instance_of',
         type: {
           name: 'object',
-          namespace: 'internal'
+          namespace: '_primitive'
         }
       }
       return type
@@ -258,7 +258,7 @@ export function modelType (node: Node): model.ValueOf {
             kind: 'instance_of',
             type: {
               name: 'binary',
-              namespace: 'internal'
+              namespace: '_primitive'
             }
           }
           return type
@@ -837,7 +837,7 @@ export function isKnownBehavior (node: HeritageClause | ExpressionWithTypeArgume
 
 /**
  * Given a Node, it returns its namespace computed from the symbol declarations.
- * If it can't compute it, defaults to `internal`.
+ * If it can't compute it, defaults to `_primitive`.
  */
 export function getNameSpace (node: Node): string {
   // if the node we are checking is a TypeReferenceNode,
@@ -848,7 +848,7 @@ export function getNameSpace (node: Node): string {
     if (Node.isIdentifier(identifier)) {
       const name = identifier.compilerNode.escapedText as string
       // the Array object is defined by TypeScript
-      if (name === 'Array') return 'internal'
+      if (name === 'Array') return '_primitive'
       const definition = identifier.getDefinitions()[0]
       assert(identifier, definition != null, 'Cannot find codegen_name')
       return cleanPath(definition.getSourceFile().getFilePath())
@@ -864,7 +864,7 @@ export function getNameSpace (node: Node): string {
 
   const declaration = node.getType().getSymbol()?.getDeclarations()[0]
   if (declaration == null) {
-    return 'internal'
+    return '_primitive'
   }
 
   return cleanPath(declaration.getSourceFile().getFilePath())
@@ -873,7 +873,7 @@ export function getNameSpace (node: Node): string {
     path = dirname(path)
       .replace(/.*[/\\]specification[/\\]?/, '')
       .replace(/[/\\]/g, '.')
-    if (path === '') path = 'internal'
+    if (path === '') path = '_primitive'
     return path
   }
 }

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -82,7 +82,7 @@ export function modelType (node: Node): model.ValueOf {
         kind: 'instance_of',
         type: {
           name: 'boolean',
-          namespace: '_primitive'
+          namespace: '_builtins'
         }
       }
       return type
@@ -93,7 +93,7 @@ export function modelType (node: Node): model.ValueOf {
         kind: 'instance_of',
         type: {
           name: 'string',
-          namespace: '_primitive'
+          namespace: '_builtins'
         }
       }
       return type
@@ -104,7 +104,7 @@ export function modelType (node: Node): model.ValueOf {
         kind: 'instance_of',
         type: {
           name: 'number',
-          namespace: '_primitive'
+          namespace: '_builtins'
         }
       }
       return type
@@ -115,7 +115,7 @@ export function modelType (node: Node): model.ValueOf {
         kind: 'instance_of',
         type: {
           name: 'null',
-          namespace: '_primitive'
+          namespace: '_builtins'
         }
       }
       return type
@@ -126,7 +126,7 @@ export function modelType (node: Node): model.ValueOf {
         kind: 'instance_of',
         type: {
           name: 'void',
-          namespace: '_primitive'
+          namespace: '_builtins'
         }
       }
       return type
@@ -139,7 +139,7 @@ export function modelType (node: Node): model.ValueOf {
         kind: 'instance_of',
         type: {
           name: 'object',
-          namespace: '_primitive'
+          namespace: '_builtins'
         }
       }
       return type
@@ -258,7 +258,7 @@ export function modelType (node: Node): model.ValueOf {
             kind: 'instance_of',
             type: {
               name: 'binary',
-              namespace: '_primitive'
+              namespace: '_builtins'
             }
           }
           return type
@@ -837,7 +837,7 @@ export function isKnownBehavior (node: HeritageClause | ExpressionWithTypeArgume
 
 /**
  * Given a Node, it returns its namespace computed from the symbol declarations.
- * If it can't compute it, defaults to `_primitive`.
+ * If it can't compute it, defaults to `_builtins`.
  */
 export function getNameSpace (node: Node): string {
   // if the node we are checking is a TypeReferenceNode,
@@ -848,7 +848,7 @@ export function getNameSpace (node: Node): string {
     if (Node.isIdentifier(identifier)) {
       const name = identifier.compilerNode.escapedText as string
       // the Array object is defined by TypeScript
-      if (name === 'Array') return '_primitive'
+      if (name === 'Array') return '_builtins'
       const definition = identifier.getDefinitions()[0]
       assert(identifier, definition != null, 'Cannot find codegen_name')
       return cleanPath(definition.getSourceFile().getFilePath())
@@ -864,7 +864,7 @@ export function getNameSpace (node: Node): string {
 
   const declaration = node.getType().getSymbol()?.getDeclarations()[0]
   if (declaration == null) {
-    return '_primitive'
+    return '_builtins'
   }
 
   return cleanPath(declaration.getSourceFile().getFilePath())
@@ -873,7 +873,7 @@ export function getNameSpace (node: Node): string {
     path = dirname(path)
       .replace(/.*[/\\]specification[/\\]?/, '')
       .replace(/[/\\]/g, '.')
-    if (path === '') path = '_primitive'
+    if (path === '') path = '_builtins'
     return path
   }
 }

--- a/compiler/src/steps/read-definition-validation.ts
+++ b/compiler/src/steps/read-definition-validation.ts
@@ -77,7 +77,7 @@ export default async function readDefinitionValidation (model: model.Model, json
     const readTypeInstance = unwrap(readType)
     const typeInstance = unwrap(type)
     if (readTypeInstance == null || typeInstance == null) return false
-    if (readTypeInstance.type.namespace !== 'internal') {
+    if (readTypeInstance.type.namespace !== '_primitive') {
       const definition = model.types.find(t => t.name.namespace === readTypeInstance.type.namespace && t.name.name === readTypeInstance.type.name)
       return definition?.kind === 'interface' && (definition.behaviors?.some(overloaded) ?? false)
     }

--- a/compiler/src/steps/read-definition-validation.ts
+++ b/compiler/src/steps/read-definition-validation.ts
@@ -77,7 +77,7 @@ export default async function readDefinitionValidation (model: model.Model, json
     const readTypeInstance = unwrap(readType)
     const typeInstance = unwrap(type)
     if (readTypeInstance == null || typeInstance == null) return false
-    if (readTypeInstance.type.namespace !== '_primitive') {
+    if (readTypeInstance.type.namespace !== '_builtins') {
       const definition = model.types.find(t => t.name.namespace === readTypeInstance.type.namespace && t.name.name === readTypeInstance.type.name)
       return definition?.kind === 'interface' && (definition.behaviors?.some(overloaded) ?? false)
     }

--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -158,7 +158,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     'string', 'boolean', 'number', 'null'
   ]) {
     const typeName = {
-      namespace: '_primitive',
+      namespace: '_builtins',
       name: name
     }
     typeDefByName.set(fqn(typeName), {
@@ -739,7 +739,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
 
       switch (fqName) {
         // Base type also used as property, no polymorphic usage
-        case '_primitive:ErrorCause':
+        case '_builtins:ErrorCause':
         case 'x_pack.enrich:EnrichPolicy':
         case 'x_pack.info.x_pack_usage:XPackUsage':
         case 'x_pack.info.x_pack_usage:SecurityFeatureToggle':
@@ -825,7 +825,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
   }
 
   function typeDefJsonEvents (events: Set<JsonEvent>, typeDef: model.TypeDefinition): void {
-    if (typeDef.name.namespace === '_primitive') {
+    if (typeDef.name.namespace === '_builtins') {
       switch (typeDef.name.name) {
         case 'string':
           validateEvent(events, JsonEvent.string)

--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -158,7 +158,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     'string', 'boolean', 'number', 'null'
   ]) {
     const typeName = {
-      namespace: 'internal',
+      namespace: '_primitive',
       name: name
     }
     typeDefByName.set(fqn(typeName), {
@@ -739,7 +739,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
 
       switch (fqName) {
         // Base type also used as property, no polymorphic usage
-        case 'internal:ErrorCause':
+        case '_primitive:ErrorCause':
         case 'x_pack.enrich:EnrichPolicy':
         case 'x_pack.info.x_pack_usage:XPackUsage':
         case 'x_pack.info.x_pack_usage:SecurityFeatureToggle':
@@ -825,7 +825,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
   }
 
   function typeDefJsonEvents (events: Set<JsonEvent>, typeDef: model.TypeDefinition): void {
-    if (typeDef.name.namespace === 'internal') {
+    if (typeDef.name.namespace === '_primitive') {
       switch (typeDef.name.name) {
         case 'string':
           validateEvent(events, JsonEvent.string)

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -39,7 +39,7 @@
         "type_alias definition _types.aggregations:Aggregate / instance_of - Non-leaf type cannot be used here: '_types.aggregations:ExtendedStatsAggregate'",
         "type_alias definition _types.aggregations:Buckets / union_of / dictionary_of / instance_of - No type definition for '_types.aggregations:TBucket'",
         "type_alias definition _types.aggregations:Buckets / union_of / array_of / instance_of - No type definition for '_types.aggregations:TBucket'",
-        "type_alias definition _spec_utils:Void / instance_of - No type definition for 'internal:void'",
+        "type_alias definition _spec_utils:Void / instance_of - No type definition for '_primitive:void'",
         "type_alias definition _types.aggregations:Aggregate / instance_of - Non-leaf type cannot be used here: '_types.aggregations:RangeAggregate'",
         "type_alias definition _global.search._types:Suggest - A tagged union should not have generic parameters",
         "type_alias definition _global.search._types:Suggest / instance_of / Generics / instance_of - No type definition for '_global.search._types:TDocument'",
@@ -1562,7 +1562,7 @@
         "Request: missing json spec query parameter 'track_total_hits'"
       ],
       "response": [
-        "type_alias definition _types:MapboxVectorTiles / instance_of - No type definition for 'internal:binary'"
+        "type_alias definition _types:MapboxVectorTiles / instance_of - No type definition for '_primitive:binary'"
       ]
     },
     "search_shards": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -39,7 +39,7 @@
         "type_alias definition _types.aggregations:Aggregate / instance_of - Non-leaf type cannot be used here: '_types.aggregations:ExtendedStatsAggregate'",
         "type_alias definition _types.aggregations:Buckets / union_of / dictionary_of / instance_of - No type definition for '_types.aggregations:TBucket'",
         "type_alias definition _types.aggregations:Buckets / union_of / array_of / instance_of - No type definition for '_types.aggregations:TBucket'",
-        "type_alias definition _spec_utils:Void / instance_of - No type definition for '_primitive:void'",
+        "type_alias definition _spec_utils:Void / instance_of - No type definition for '_builtins:void'",
         "type_alias definition _types.aggregations:Aggregate / instance_of - Non-leaf type cannot be used here: '_types.aggregations:RangeAggregate'",
         "type_alias definition _global.search._types:Suggest - A tagged union should not have generic parameters",
         "type_alias definition _global.search._types:Suggest / instance_of / Generics / instance_of - No type definition for '_global.search._types:TDocument'",
@@ -1562,7 +1562,7 @@
         "Request: missing json spec query parameter 'track_total_hits'"
       ],
       "response": [
-        "type_alias definition _types:MapboxVectorTiles / instance_of - No type definition for '_primitive:binary'"
+        "type_alias definition _types:MapboxVectorTiles / instance_of - No type definition for '_builtins:binary'"
       ]
     },
     "search_shards": {

--- a/typescript-generator/src/client.ts
+++ b/typescript-generator/src/client.ts
@@ -399,7 +399,7 @@ export {
   }
 
   function createName (type: M.TypeName): string {
-    if (type.namespace === '_primitive') return type.name
+    if (type.namespace === '_builtins') return type.name
     const namespace = strip(type.namespace).replace(/_([a-z])/g, k => k[1].toUpperCase())
     return `${namespace.split('.').map(TitleCase).join('')}${type.name}`
 

--- a/typescript-generator/src/client.ts
+++ b/typescript-generator/src/client.ts
@@ -399,7 +399,7 @@ export {
   }
 
   function createName (type: M.TypeName): string {
-    if (type.namespace === 'internal') return type.name
+    if (type.namespace === '_primitive') return type.name
     const namespace = strip(type.namespace).replace(/_([a-z])/g, k => k[1].toUpperCase())
     return `${namespace.split('.').map(TitleCase).join('')}${type.name}`
 

--- a/typescript-generator/src/index.ts
+++ b/typescript-generator/src/index.ts
@@ -115,7 +115,7 @@ function buildValue (type: M.ValueOf, openGenerics?: string[], origin?: M.TypeNa
         }
       }
 
-      if (type.type.name === 'binary' && type.type.namespace === '_primitive') {
+      if (type.type.name === 'binary' && type.type.namespace === '_builtins') {
         return 'ArrayBuffer'
       }
 
@@ -435,7 +435,7 @@ function buildTypeAlias (type: M.TypeAlias): string {
 }
 
 function createName (type: M.TypeName): string {
-  if (type.namespace === '_primitive') return type.name
+  if (type.namespace === '_builtins') return type.name
   const namespace = strip(type.namespace).replace(/_([a-z])/g, k => k[1].toUpperCase())
   return `${namespace.split('.').map(TitleCase).join('')}${type.name}`
 

--- a/typescript-generator/src/index.ts
+++ b/typescript-generator/src/index.ts
@@ -115,7 +115,7 @@ function buildValue (type: M.ValueOf, openGenerics?: string[], origin?: M.TypeNa
         }
       }
 
-      if (type.type.name === 'binary' && type.type.namespace === 'internal') {
+      if (type.type.name === 'binary' && type.type.namespace === '_primitive') {
         return 'ArrayBuffer'
       }
 
@@ -435,7 +435,7 @@ function buildTypeAlias (type: M.TypeAlias): string {
 }
 
 function createName (type: M.TypeName): string {
-  if (type.namespace === 'internal') return type.name
+  if (type.namespace === '_primitive') return type.name
   const namespace = strip(type.namespace).replace(/_([a-z])/g, k => k[1].toUpperCase())
   return `${namespace.split('.').map(TitleCase).join('')}${type.name}`
 


### PR DESCRIPTION
In light of the new Elasticsearch’s `internal` namespace, we must rename our `internal` namespace.
Given that our namespace was holding primitive values, I propose to rename it to `_primitive`.

Related: https://github.com/elastic/elasticsearch-specification/pull/1417