### PR TITLE
Fix indices.field_usage_stats

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9812,7 +9812,7 @@ export interface IndicesFieldUsageStatsInvertedIndex {
 }
 
 export interface IndicesFieldUsageStatsRequest extends RequestBase {
-  index?: Indices
+  index: Indices
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean

--- a/specification/indices/field_usage_stats/IndicesFieldUsageStatsRequest.ts
+++ b/specification/indices/field_usage_stats/IndicesFieldUsageStatsRequest.ts
@@ -37,7 +37,7 @@ export interface Request extends RequestBase {
     /**
      * Comma-separated list or wildcard expression of index names used to limit the request.
      */
-    index?: Indices
+    index: Indices
   }
   query_parameters: {
     /**


### PR DESCRIPTION
The [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/field-usage-stats.html) says it's optional, but the [rest-api-spec](https://github.com/elastic/elasticsearch/blob/e851efbaa1d0048909a96bdb942d6a2ebb462504/rest-api-spec/src/main/resources/rest-api-spec/api/indices.field_usage_stats.json#L15-L29) allows only url templates with the index defined.