### PR TITLE
Fix indices.delete_index_template Request

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -893,8 +893,6 @@
     },
     "indices.delete_index_template": {
       "request": [
-        "Request: missing json spec query parameter 'timeout'",
-        "Request: missing json spec query parameter 'master_timeout'",
         "Request: should not have a body"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9716,7 +9716,9 @@ export interface IndicesDeleteDataStreamResponse extends AcknowledgedResponseBas
 }
 
 export interface IndicesDeleteIndexTemplateRequest extends RequestBase {
-  name: Name
+  name: Names
+  master_timeout?: Time
+  timeout?: Time
 }
 
 export interface IndicesDeleteIndexTemplateResponse extends AcknowledgedResponseBase {

--- a/specification/indices/delete_index_template/IndicesDeleteIndexTemplateRequest.ts
+++ b/specification/indices/delete_index_template/IndicesDeleteIndexTemplateRequest.ts
@@ -18,15 +18,35 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Name } from '@_types/common'
+import { Names } from '@_types/common'
+import { Time } from '@_types/Time'
 
 /**
+ * The provided <index-template> may contain multiple template names separated by a comma. If multiple template
+ * names are specified then there is no wildcard support and the provided names should match completely with
+ * existing templates.
  * @rest_spec_name indices.delete_index_template
  * @since 7.8.0
  * @stability stable
+ * @cluster_privileges manage_index_templates,manage
  */
 export interface Request extends RequestBase {
   path_parts: {
-    name: Name
+    /**
+     * Comma-separated list of index template names used to limit the request. Wildcard (*) expressions are supported.
+     */
+    name: Names
+  }
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
+    master_timeout?: Time
+    /**
+     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
+    timeout?: Time
   }
 }


### PR DESCRIPTION
Name can be a list (csv) of indices, change the type to `Names` which includes the type `Name` but also `Name[]` making this change not breaking but additive.