### PR TITLE
Fix indices.simulate_template

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9360,6 +9360,28 @@ export interface IndicesIndexState {
   data_stream?: DataStreamName
 }
 
+export interface IndicesIndexTemplate {
+  index_patterns: Names
+  composed_of: Name[]
+  template?: IndicesIndexTemplateSummary
+  version?: VersionNumber
+  priority?: long
+  _meta?: Metadata
+  allow_auto_create?: boolean
+  data_stream?: IndicesIndexTemplateDataStreamConfiguration
+}
+
+export interface IndicesIndexTemplateDataStreamConfiguration {
+  hidden?: boolean
+  allow_custom_routing?: boolean
+}
+
+export interface IndicesIndexTemplateSummary {
+  aliases?: Record<IndexName, IndicesAlias>
+  mappings?: MappingTypeMapping
+  settings?: IndicesIndexSettings
+}
+
 export interface IndicesIndexVersioning {
   created: VersionString
   created_string?: VersionString
@@ -9922,26 +9944,9 @@ export interface IndicesGetFieldMappingTypeFieldMappings {
   mappings: Partial<Record<Field, MappingFieldMapping>>
 }
 
-export interface IndicesGetIndexTemplateIndexTemplate {
-  index_patterns: Name[]
-  composed_of: Name[]
-  template?: IndicesGetIndexTemplateIndexTemplateSummary
-  version?: VersionNumber
-  priority?: long
-  _meta?: Metadata
-  allow_auto_create?: boolean
-  data_stream?: Record<string, any>
-}
-
 export interface IndicesGetIndexTemplateIndexTemplateItem {
   name: Name
-  index_template: IndicesGetIndexTemplateIndexTemplate
-}
-
-export interface IndicesGetIndexTemplateIndexTemplateSummary {
-  aliases?: Record<IndexName, IndicesAlias>
-  mappings?: MappingTypeMapping
-  settings?: Record<string, any>
+  index_template: IndicesIndexTemplate
 }
 
 export interface IndicesGetIndexTemplateRequest extends RequestBase {
@@ -10450,18 +10455,18 @@ export interface IndicesSimulateTemplateRequest extends RequestBase {
   name?: Name
   create?: boolean
   master_timeout?: Time
-  body?: IndicesGetIndexTemplateIndexTemplate
+  body?: IndicesIndexTemplate
 }
 
 export interface IndicesSimulateTemplateResponse {
+  overlapping?: IndicesSimulateTemplateOverlapping[]
   template: IndicesSimulateTemplateTemplate
 }
 
 export interface IndicesSimulateTemplateTemplate {
   aliases: Record<IndexName, IndicesAlias>
   mappings: MappingTypeMapping
-  settings: Record<string, any>
-  overlapping: IndicesSimulateTemplateOverlapping[]
+  settings: IndicesIndexSettings
 }
 
 export interface IndicesSplitRequest extends RequestBase {

--- a/specification/indices/_types/IndexTemplate.ts
+++ b/specification/indices/_types/IndexTemplate.ts
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Dictionary } from '@spec_utils/Dictionary'
+import { IndexName, Metadata, Name, Names, VersionNumber } from '@_types/common'
+import { TypeMapping } from '@_types/mapping/TypeMapping'
+import { long } from '@_types/Numeric'
+import { Alias } from './Alias'
+import { IndexSettings } from './IndexSettings'
+
+export class IndexTemplate {
+  index_patterns: Names
+  composed_of: Name[]
+  template?: IndexTemplateSummary
+  version?: VersionNumber
+  priority?: long
+  /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
+  _meta?: Metadata
+  allow_auto_create?: boolean
+  data_stream?: IndexTemplateDataStreamConfiguration
+}
+
+export class IndexTemplateDataStreamConfiguration {
+  /**
+   * If true, the data stream is hidden.
+   * @server_default false
+   */
+  hidden?: boolean
+  /**
+   * If true, the data stream supports custom routing.
+   * @server_default false
+   */
+  allow_custom_routing?: boolean
+}
+
+export class IndexTemplateSummary {
+  aliases?: Dictionary<IndexName, Alias>
+  mappings?: TypeMapping
+  settings?: IndexSettings
+}

--- a/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
+++ b/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
@@ -22,9 +22,11 @@ import { Name } from '@_types/common'
 import { Time } from '@_types/Time'
 
 /**
+ * Returns information about one or more index templates.
  * @rest_spec_name indices.get_index_template
  * @since 7.9.0
  * @stability stable
+ * @cluster_privileges manage_index_templates,manage
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_index_template/IndicesGetIndexTemplateResponse.ts
+++ b/specification/indices/get_index_template/IndicesGetIndexTemplateResponse.ts
@@ -17,12 +17,8 @@
  * under the License.
  */
 
-import { Alias } from '@indices/_types/Alias'
-import { Dictionary } from '@spec_utils/Dictionary'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { IndexName, Metadata, Name, VersionNumber } from '@_types/common'
-import { TypeMapping } from '@_types/mapping/TypeMapping'
-import { long } from '@_types/Numeric'
+import { IndexTemplate } from '@indices/_types/IndexTemplate'
+import { Name } from '@_types/common'
 
 export class Response {
   body: {
@@ -33,22 +29,4 @@ export class Response {
 export class IndexTemplateItem {
   name: Name
   index_template: IndexTemplate
-}
-
-export class IndexTemplate {
-  index_patterns: Name[]
-  composed_of: Name[]
-  template?: IndexTemplateSummary
-  version?: VersionNumber
-  priority?: long
-  /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
-  _meta?: Metadata
-  allow_auto_create?: boolean
-  data_stream?: Dictionary<string, UserDefinedValue>
-}
-
-export class IndexTemplateSummary {
-  aliases?: Dictionary<IndexName, Alias>
-  mappings?: TypeMapping
-  settings?: Dictionary<string, UserDefinedValue>
 }

--- a/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
+++ b/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
@@ -17,19 +17,24 @@
  * under the License.
  */
 
-import { IndexTemplate } from '@indices/get_index_template/IndicesGetIndexTemplateResponse'
+import { IndexTemplate } from '@indices/_types/IndexTemplate'
 import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 import { Time } from '@_types/Time'
 
 /**
+ * Returns the index configuration that would be applied by a particular index template.
  * @rest_spec_name indices.simulate_template
  * @since 0.0.0
  * @stability stable
+ * @cluster_privileges manage_index_templates,manage
  */
 export interface Request extends RequestBase {
   path_parts: {
-    /** Name of the index template to simulate. To test a template configuration before you add it to the cluster, omit this parameter and specify the template configuration in the request body. */
+    /**
+     * Name of the index template to simulate. To test a template configuration before you add it to the cluster, omit
+     * this parameter and specify the template configuration in the request body.
+     */
     name?: Name
   }
   query_parameters: {

--- a/specification/indices/simulate_template/IndicesSimulateTemplateResponse.ts
+++ b/specification/indices/simulate_template/IndicesSimulateTemplateResponse.ts
@@ -18,13 +18,14 @@
  */
 
 import { Alias } from '@indices/_types/Alias'
+import { IndexSettings } from '@indices/_types/IndexSettings'
 import { Dictionary } from '@spec_utils/Dictionary'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { IndexName, Name } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 
 export class Response {
   body: {
+    overlapping?: Overlapping[]
     template: Template
   }
 }
@@ -32,8 +33,7 @@ export class Response {
 export class Template {
   aliases: Dictionary<IndexName, Alias>
   mappings: TypeMapping
-  settings: Dictionary<string, UserDefinedValue>
-  overlapping: Overlapping[]
+  settings: IndexSettings
 }
 
 export class Overlapping {


### PR DESCRIPTION
* removed three instances of `UserDefinedValue` in favour of once the correct [data_stream def](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-simulate-template.html#simulate-template-api-request-body) and twice for `IndexSettings`.
* moved shared type `IndexTemplate` into `indices._types`