### PR TITLE
Fix ml.delete_calendar_job Request

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12306,7 +12306,7 @@ export interface MlDeleteCalendarEventResponse extends AcknowledgedResponseBase 
 
 export interface MlDeleteCalendarJobRequest extends RequestBase {
   calendar_id: Id
-  job_id: Id
+  job_id: Ids
 }
 
 export interface MlDeleteCalendarJobResponse {

--- a/specification/ml/delete_calendar_job/MlDeleteCalendarJobRequest.ts
+++ b/specification/ml/delete_calendar_job/MlDeleteCalendarJobRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
+import { Id, Ids } from '@_types/common'
 
 /**
  * Deletes anomaly detection jobs from a calendar.
@@ -30,9 +30,14 @@ import { Id } from '@_types/common'
  */
 export interface Request extends RequestBase {
   path_parts: {
-    /** A string that uniquely identifies a calendar. */
+    /**
+     * A string that uniquely identifies a calendar.
+     */
     calendar_id: Id
-    /** An identifier for the anomaly detection jobs. It can be a job identifier, a group name, or a comma-separated list of jobs or groups. */
-    job_id: Id
+    /**
+     * An identifier for the anomaly detection jobs. It can be a job identifier, a group name, or a
+     * comma-separated list of jobs or groups.
+     */
+    job_id: Ids
   }
 }


### PR DESCRIPTION
Changed `Id` to `Ids` which is a superset of `Id`. The API accepts a string or a list of strings which is reflected in `Ids`.