### PR TITLE
Fix ml.get_filters Request

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12686,7 +12686,7 @@ export interface MlGetDatafeedsResponse {
 }
 
 export interface MlGetFiltersRequest extends RequestBase {
-  filter_id?: Id
+  filter_id?: Ids
   from?: integer
   size?: integer
 }

--- a/specification/ml/_types/Filter.ts
+++ b/specification/ml/_types/Filter.ts
@@ -20,8 +20,11 @@
 import { Id } from '@_types/common'
 
 export class Filter {
+  /** A description of the filter. */
   description?: string
+  /** A string that uniquely identifies a filter. */
   filter_id: Id
+  /** An array of strings which is the filter item list. */
   items: string[]
 }
 
@@ -38,6 +41,6 @@ export class FilterRef {
 }
 
 export enum FilterType {
-  include = 0,
-  exclude = 1
+  include,
+  exclude
 }

--- a/specification/ml/get_filters/MlGetFiltersRequest.ts
+++ b/specification/ml/get_filters/MlGetFiltersRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
+import { Ids } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
@@ -34,7 +34,7 @@ export interface Request extends RequestBase {
     /**
      * A string that uniquely identifies a filter.
      */
-    filter_id?: Id
+    filter_id?: Ids
   }
   query_parameters: {
     /**


### PR DESCRIPTION
The API accepts an one or a list of unique identifiers, the PR changes the type from `Id` to `Ids` to address this.