### PR TITLE
Fix ml.get_trained_models_stats Request

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12828,7 +12828,7 @@ export interface MlGetTrainedModelsResponse {
 }
 
 export interface MlGetTrainedModelsStatsRequest extends RequestBase {
-  model_id?: Id
+  model_id?: Ids
   allow_no_match?: boolean
   from?: integer
   size?: integer

--- a/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsRequest.ts
+++ b/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsRequest.ts
@@ -18,11 +18,12 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
+import { Ids } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Retrieves usage information for trained models.
+ * Retrieves usage information for trained models. You can get usage information for multiple trained
+ * models in a single API request by using a comma-separated list of model IDs or a wildcard expression.
  * @rest_spec_name ml.get_trained_models_stats
  * @since 7.10.0
  * @stability stable
@@ -34,7 +35,7 @@ export interface Request extends RequestBase {
      * The unique identifier of the trained model or a model alias. It can be a
      * comma-separated list or a wildcard expression.
      */
-    model_id?: Id
+    model_id?: Ids
   }
   query_parameters: {
     /**


### PR DESCRIPTION
changed `Id` to `Ids` to unblock to list of identifiers use case.