### PR TITLE
Remove _nodes property that exists in parent class

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13999,7 +13999,6 @@ export interface NodesClearRepositoriesMeteringArchiveRequest extends RequestBas
 }
 
 export interface NodesClearRepositoriesMeteringArchiveResponse extends NodesNodesResponseBase {
-  _nodes: NodeStatistics
   cluster_name: Name
   nodes: Record<string, NodesRepositoryMeteringInformation>
 }
@@ -14009,7 +14008,6 @@ export interface NodesGetRepositoriesMeteringInfoRequest extends RequestBase {
 }
 
 export interface NodesGetRepositoriesMeteringInfoResponse extends NodesNodesResponseBase {
-  _nodes: NodeStatistics
   cluster_name: Name
   nodes: Record<string, NodesRepositoryMeteringInformation>
 }

--- a/specification/nodes/clear_repositories_metering_archive/ClearRepositoriesMeteringArchiveResponse.ts
+++ b/specification/nodes/clear_repositories_metering_archive/ClearRepositoriesMeteringArchiveResponse.ts
@@ -26,10 +26,6 @@ import { NodeStatistics } from '@_types/Node'
 export class Response extends NodesResponseBase {
   body: {
     /**
-     * Contains statistics about the number of nodes selected by the request.
-     */
-    _nodes: NodeStatistics
-    /**
      * Name of the cluster. Based on the [Cluster name setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster-name).
      */
     cluster_name: Name

--- a/specification/nodes/get_repositories_metering_info/GetRepositoriesMeteringInfoResponse.ts
+++ b/specification/nodes/get_repositories_metering_info/GetRepositoriesMeteringInfoResponse.ts
@@ -26,10 +26,6 @@ import { NodeStatistics } from '@_types/Node'
 export class Response extends NodesResponseBase {
   body: {
     /**
-     * Contains statistics about the number of nodes selected by the request.
-     */
-    _nodes: NodeStatistics
-    /**
      * Name of the cluster. Based on the [Cluster name setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster-name).
      */
     cluster_name: Name


### PR DESCRIPTION
`_node: NodeStatistics` is defined in the parent class `NodesResponseBase` and causes a conflict.