### PR TITLE
Extract Search response body to its own type

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1559,7 +1559,7 @@
     "search": {
       "request": [],
       "response": [
-        "Non-leaf type cannot be used here: '_global.search:Response'"
+        "response definition _global.search:Response / body / instance_of - Non-leaf type cannot be used here: '_global.search:ResponseBody'"
       ]
     },
     "search_mvt": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -552,7 +552,7 @@ export interface MgetResponse<TDocument = unknown> {
 
 export type MgetResponseItem<TDocument = unknown> = GetGetResult<TDocument> | MgetMultiGetError
 
-export interface MsearchMultiSearchItem<TDocument = unknown> extends SearchResponse<TDocument> {
+export interface MsearchMultiSearchItem<TDocument = unknown> extends SearchResponseBody<TDocument> {
   status?: integer
 }
 
@@ -944,7 +944,7 @@ export interface ScrollRequest extends RequestBase {
   }
 }
 
-export interface ScrollResponse<TDocument = unknown> extends SearchResponse<TDocument> {
+export interface ScrollResponse<TDocument = unknown> extends SearchResponseBody<TDocument> {
 }
 
 export interface SearchRequest extends RequestBase {
@@ -1027,7 +1027,9 @@ export interface SearchRequest extends RequestBase {
   }
 }
 
-export interface SearchResponse<TDocument = unknown> {
+export type SearchResponse<TDocument = unknown> = SearchResponseBody<TDocument>
+
+export interface SearchResponseBody<TDocument = unknown> {
   took: long
   timed_out: boolean
   _shards: ShardStatistics

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -24,7 +24,7 @@ import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import { ExpandWildcards, Indices, SearchType } from '@_types/common'
 import { integer, long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
-import { Response as SearchResponse } from '@global/search/SearchResponse'
+import { ResponseBody as SearchResponse } from '@global/search/SearchResponse'
 import { TrackHits } from '@global/search/_types/hits'
 import { ErrorResponseBase } from '@_types/Base'
 

--- a/specification/_global/scroll/ScrollResponse.ts
+++ b/specification/_global/scroll/ScrollResponse.ts
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-import { Response as SearchResponse } from '@global/search/SearchResponse'
+import { ResponseBody as SearchResponse } from '@global/search/SearchResponse'
 
 export class Response<TDocument> extends SearchResponse<TDocument> {}

--- a/specification/_global/search/SearchResponse.ts
+++ b/specification/_global/search/SearchResponse.ts
@@ -31,21 +31,23 @@ import { Suggest } from './_types/suggester'
 // - search
 // - fleet.search
 export class Response<TDocument> {
-  body: {
-    // Has to be kept in sync with SearchTemplateResponse
-    took: long
-    timed_out: boolean
-    _shards: ShardStatistics
-    hits: HitsMetadata<TDocument>
-    aggregations?: Dictionary<AggregateName, Aggregate>
-    _clusters?: ClusterStatistics
-    fields?: Dictionary<string, UserDefinedValue>
-    max_score?: double
-    num_reduce_phases?: long
-    profile?: Profile
-    pit_id?: Id
-    _scroll_id?: ScrollId
-    suggest?: Dictionary<SuggestionName, Suggest<TDocument>[]>
-    terminated_early?: boolean
-  }
+  body: ResponseBody<TDocument>
+}
+
+export class ResponseBody<TDocument> {
+  // Has to be kept in sync with SearchTemplateResponse
+  took: long
+  timed_out: boolean
+  _shards: ShardStatistics
+  hits: HitsMetadata<TDocument>
+  aggregations?: Dictionary<AggregateName, Aggregate>
+  _clusters?: ClusterStatistics
+  fields?: Dictionary<string, UserDefinedValue>
+  max_score?: double
+  num_reduce_phases?: long
+  profile?: Profile
+  pit_id?: Id
+  _scroll_id?: ScrollId
+  suggest?: Dictionary<SuggestionName, Suggest<TDocument>[]>
+  terminated_early?: boolean
 }


### PR DESCRIPTION
Used in `ScrollResponse` and as base for `MultiSearchItem`.