### PR TITLE
Backport 1476 to 7.17

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1596,7 +1596,7 @@
     "search": {
       "request": [],
       "response": [
-        "Non-leaf type cannot be used here: '_global.search:Response'"
+        "response definition _global.search:Response / body / instance_of - Non-leaf type cannot be used here: '_global.search:ResponseBody'"
       ]
     },
     "search_mvt": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -536,7 +536,7 @@ export interface MgetResponse<TDocument = unknown> {
 
 export type MgetResponseItem<TDocument = unknown> = GetGetResult<TDocument> | MgetMultiGetError
 
-export interface MsearchMultiSearchItem<TDocument = unknown> extends SearchResponse<TDocument> {
+export interface MsearchMultiSearchItem<TDocument = unknown> extends SearchResponseBody<TDocument> {
   status?: integer
 }
 
@@ -931,7 +931,7 @@ export interface ScrollRequest extends RequestBase {
   }
 }
 
-export interface ScrollResponse<TDocument = unknown> extends SearchResponse<TDocument> {
+export interface ScrollResponse<TDocument = unknown> extends SearchResponseBody<TDocument> {
 }
 
 export interface SearchRequest extends RequestBase {
@@ -1015,7 +1015,9 @@ export interface SearchRequest extends RequestBase {
   }
 }
 
-export interface SearchResponse<TDocument = unknown> {
+export type SearchResponse<TDocument = unknown> = SearchResponseBody<TDocument>
+
+export interface SearchResponseBody<TDocument = unknown> {
   took: long
   timed_out: boolean
   _shards: ShardStatistics

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1024,7 +1024,6 @@ export interface SearchResponseBody<TDocument = unknown> {
   hits: SearchHitsMetadata<TDocument>
   aggregations?: Record<AggregateName, AggregationsAggregate>
   _clusters?: ClusterStatistics
-  documents?: TDocument[]
   fields?: Record<string, any>
   max_score?: double
   num_reduce_phases?: long

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -24,7 +24,7 @@ import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import { ExpandWildcards, Indices, SearchType } from '@_types/common'
 import { integer, long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
-import { Response as SearchResponse } from '@global/search/SearchResponse'
+import { ResponseBody as SearchResponse } from '@global/search/SearchResponse'
 import { TrackHits } from '@global/search/_types/hits'
 import { ErrorResponseBase } from '@_types/Base'
 

--- a/specification/_global/scroll/ScrollResponse.ts
+++ b/specification/_global/scroll/ScrollResponse.ts
@@ -17,6 +17,6 @@
  * under the License.
  */
 
-import { Response as SearchResponse } from '@global/search/SearchResponse'
+import { ResponseBody as SearchResponse } from '@global/search/SearchResponse'
 
 export class Response<TDocument> extends SearchResponse<TDocument> {}

--- a/specification/_global/search/SearchResponse.ts
+++ b/specification/_global/search/SearchResponse.ts
@@ -28,23 +28,23 @@ import { Profile } from './_types/profile'
 import { Suggest } from './_types/suggester'
 
 export class Response<TDocument> {
-  body: {
-    // Has to be kept in sync with SearchTemplateResponse
-    took: long
-    timed_out: boolean
-    _shards: ShardStatistics
-    hits: HitsMetadata<TDocument>
+  body: ResponseBody<TDocument>
+}
 
-    aggregations?: Dictionary<AggregateName, Aggregate>
-    _clusters?: ClusterStatistics
-    documents?: TDocument[]
-    fields?: Dictionary<string, UserDefinedValue>
-    max_score?: double
-    num_reduce_phases?: long
-    profile?: Profile
-    pit_id?: Id
-    _scroll_id?: ScrollId
-    suggest?: Dictionary<SuggestionName, Suggest<TDocument>[]>
-    terminated_early?: boolean
-  }
+export class ResponseBody<TDocument> {
+  // Has to be kept in sync with SearchTemplateResponse
+  took: long
+  timed_out: boolean
+  _shards: ShardStatistics
+  hits: HitsMetadata<TDocument>
+  aggregations?: Dictionary<AggregateName, Aggregate>
+  _clusters?: ClusterStatistics
+  fields?: Dictionary<string, UserDefinedValue>
+  max_score?: double
+  num_reduce_phases?: long
+  profile?: Profile
+  pit_id?: Id
+  _scroll_id?: ScrollId
+  suggest?: Dictionary<SuggestionName, Suggest<TDocument>[]>
+  terminated_early?: boolean
 }


### PR DESCRIPTION
Backport 7.17 of #1476 

Remove nestsism of `documents` in `SearchResponse`
