### PR TITLE
Replace or remove more doc URLs

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -374,4 +374,4 @@ field-and-document-access-control,https://www.elastic.co/guide/en/elasticsearch/
 run-as-privilege,https://www.elastic.co/guide/en/elasticsearch/reference/master/run-as-privilege.html
 sql-rest-filtering,https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-rest-filtering.html
 sql-rest-format,https://www.elastic.co/guide/en/elasticsearch/reference/master/sql-rest-format.html
-cron-expressions,https://www.elastic.co/guide/en/elasticsearch/reference/master/cron-expressions.html
+cron-expressions,https://www.elastic.co/guide/en/elasticsearch/reference/master/api-conventions.html#api-cron-expressions

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -79,7 +79,7 @@ export enum ClusterPrivilege {
 export class IndicesPrivileges {
   /**
    * The document fields that the owners of the role have read access to.
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/field-and-document-access-control.html
+   * @doc_id field-and-document-access-control
    */
   field_security?: FieldSecurity | FieldSecurity[]
   /**

--- a/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
+++ b/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
@@ -39,7 +39,7 @@ export interface Request extends RequestBase {
     name?: Name
     /**
      *  An array of role descriptors for this API key. This parameter is optional. When it is not specified or is an empty array, then the API key will have a point in time snapshot of permissions of the authenticated user. If you supply role descriptors then the resultant permissions would be an intersection of API keys permissions and authenticated user’s permissions thereby limiting the access scope for API keys. The structure of role descriptor is the same as the request for create role API. For more details, see create or update roles API.
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html
+     * @doc_id security-api-put-role
      */
     role_descriptors?: Dictionary<string, RoleDescriptor>
     /**

--- a/specification/security/get_role/SecurityGetRoleRequest.ts
+++ b/specification/security/get_role/SecurityGetRoleRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Names } from '@_types/common'
 
 /**
- * The role management APIs are generally the preferred way to manage roles, rather than using [file-based role management](https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-file).
+ * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
  * The get roles API cannot retrieve roles that are defined in roles files.
  * @rest_spec_name security.get_role
  * @since 0.0.0

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -29,7 +29,7 @@ import { RequestBase } from '@_types/Base'
 import { Metadata, Name, Refresh } from '@_types/common'
 
 /**
- * The role management APIs are generally the preferred way to manage roles, rather than using [file-based role management](https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html#roles-management-file).
+ * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
  * The create or update roles API cannot update roles that are defined in roles files.
  * @rest_spec_name security.put_role
  * @since 0.0.0
@@ -69,7 +69,7 @@ export interface Request extends RequestBase {
     metadata?: Metadata
     /**
      * A list of users that the owners of this role can impersonate.
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/run-as-privilege.html
+     * @doc_id run-as-privilege
      */
     run_as?: string[]
     /**

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -42,7 +42,7 @@ export interface Request extends RequestBase {
      * @server_default 0
      */
     from?: integer
-    /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html */
+    /** @doc_id sort-search-results */
     sort?: Sort
     /**
      * The number of hits to return. By default, you cannot page through more

--- a/specification/snapshot/_types/SnapshotShardsStatsStage.ts
+++ b/specification/snapshot/_types/SnapshotShardsStatsStage.ts
@@ -17,9 +17,6 @@
  * under the License.
  */
 
-/**
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/get-snapshot-status-api.html
- */
 export enum ShardsStatsStage {
   /** Number of shards in the snapshot that were successfully stored in the repository. */
   DONE = 0,

--- a/specification/sql/query/QuerySqlRequest.ts
+++ b/specification/sql/query/QuerySqlRequest.ts
@@ -33,7 +33,7 @@ import { Time } from '@_types/Time'
 export interface Request extends RequestBase {
   query_parameters: {
     /**
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-rest-format.html#sql-rest-format
+     * @doc_id sql-rest-format
      */
     format?: string
   }
@@ -51,7 +51,7 @@ export interface Request extends RequestBase {
     fetch_size?: integer
     /**
      * Optional Elasticsearch query DSL for additional filtering.
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-rest-filtering.html
+     * @doc_id sql-rest-filtering
      * @server_default none
      */
     filter?: QueryContainer

--- a/specification/watcher/_types/Action.ts
+++ b/specification/watcher/_types/Action.ts
@@ -63,7 +63,7 @@ export enum ActionType {
 
 export enum ActionExecutionMode {
   /**
-   * The action execution is simulated. Each action type defines its own simulation operation mode. For example, the [email action](https://www.elastic.co/guide/en/elasticsearch/reference/current/actions-email.html) creates the email that would have been sent but does not actually send it. In this mode, the action might be throttled if the current state of the watch indicates it should be.
+   * The action execution is simulated. Each action type defines its own simulation operation mode. For example, the email action creates the email that would have been sent but does not actually send it. In this mode, the action might be throttled if the current state of the watch indicates it should be.
    */
   simulate,
   /**

--- a/specification/watcher/execute_watch/WatcherExecuteWatchRequest.ts
+++ b/specification/watcher/execute_watch/WatcherExecuteWatchRequest.ts
@@ -49,7 +49,7 @@ export interface Request extends RequestBase {
   }
   body: {
     /**
-     * Determines how to handle the watch actions as part of the watch execution. See [Action execution modes](https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html#watcher-api-execute-watch-action-mode) for more information.
+     * Determines how to handle the watch actions as part of the watch execution.
      */
     action_modes?: Dictionary<string, ActionExecutionMode>
     /**
@@ -72,7 +72,7 @@ export interface Request extends RequestBase {
      */
     trigger_data?: ScheduleTriggerEvent
     /**
-     * When present, this [watch](https://www.elastic.co/guide/en/elasticsearch/reference/current/how-watcher-works.html#watch-definition) is used instead of the one specified in the request. This watch is not persisted to the index and record_execution cannot be set.
+     * When present, this watch is used instead of the one specified in the request. This watch is not persisted to the index and record_execution cannot be set.
      * @server_default null
      */
     watch?: Watch


### PR DESCRIPTION
This PR updates a dead link in the table of documentation URLs. It also replaces a handful of @doc_url values with appropriate @doc_id values. In some cases where the @doc_url wasn't necessary, it's been removed.