### PR TITLE
Fields in FieldCapabilities is required

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -346,7 +346,7 @@ export interface FieldCapsRequest extends RequestBase {
   index?: Indices
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
-  fields?: Fields
+  fields: Fields
   ignore_unavailable?: boolean
   include_unmapped?: boolean
   filters?: string

--- a/specification/_global/field_caps/FieldCapabilitiesRequest.ts
+++ b/specification/_global/field_caps/FieldCapabilitiesRequest.ts
@@ -54,7 +54,7 @@ export interface Request extends RequestBase {
     /**
      * Comma-separated list of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.
      */
-    fields?: Fields
+    fields: Fields
     /**
      * If `true`, missing or closed indices are not included in the response.
      * @server_default false


### PR DESCRIPTION
The `fields` property in `FieldCapabilitiesRequest` is required (see [API doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-field-caps.html#search-field-caps-api-query-params)).

Having it optional leads to all properties to be optional, causing the generation of a shortcut method in the Java client that always fails (reported in https://github.com/elastic/elasticsearch-java/issues/145).