### PR TITLE
Reindex source and dest fields are required

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -827,11 +827,11 @@ export interface ReindexRequest extends RequestBase {
   require_alias?: boolean
   body?: {
     conflicts?: Conflicts
-    dest?: ReindexDestination
+    dest: ReindexDestination
     max_docs?: long
     script?: Script
     size?: long
-    source?: ReindexSource
+    source: ReindexSource
   }
 }
 

--- a/specification/_global/reindex/ReindexRequest.ts
+++ b/specification/_global/reindex/ReindexRequest.ts
@@ -42,10 +42,10 @@ export interface Request extends RequestBase {
   }
   body: {
     conflicts?: Conflicts
-    dest?: Destination
+    dest: Destination
     max_docs?: long
     script?: Script
     size?: long
-    source?: Source
+    source: Source
   }
 }


### PR DESCRIPTION
The `source` and `dest` properties in `ReindexRequest` are required.

Having them optional leads to all properties to be optional, causing the generation of a shortcut method in the Java client that always fails (reported in https://github.com/elastic/elasticsearch-java/issues/145).