### PR TITLE
[8.0] Replace more hard-coded doc URLs with @doc_id #1523

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -390,3 +390,7 @@ document-input-parameters,https://www.elastic.co/guide/en/elasticsearch/referenc
 data-stream-path-param,https://www.elastic.co/guide/en/elasticsearch/reference/8.0/indices-create-data-stream.html#indices-create-data-stream-api-path-params
 byte-units,https://www.elastic.co/guide/en/elasticsearch/reference/8.0/api-conventions.html#byte-units
 node-roles,https://www.elastic.co/guide/en/elasticsearch/reference/8.0/modules-node.html#node-roles
+cluster-name,https://www.elastic.co/guide/en/elasticsearch/reference/8.0/important-settings.html#cluster-name
+cluster-nodes,https://www.elastic.co/guide/en/elasticsearch/reference/8.0/cluster.html#cluster-nodes
+sort-tiebreaker,https://www.elastic.co/guide/en/elasticsearch/reference/8.0/eql.html#eql-search-specify-a-sort-tiebreaker
+eql-basic-syntax,https://www.elastic.co/guide/en/elasticsearch/reference/8.0/eql-syntax.html#eql-basic-syntax

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -137,8 +137,7 @@ export class SuggestFuzziness {
 
 /**
  * Text or location that we want similar documents for or a lookup to a document's field for the text.
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html#_document_input_parameters
- *
+ * @doc_id document-input-parameters
  * @codegen_names category, location
  */
 export type Context = string | GeoLocation

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -176,7 +176,7 @@ export interface Request extends RequestBase {
      */
     size?: integer
     slice?: SlicedScroll
-    /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html */
+    /** @doc_id sort-search-results */
     sort?: Sort
     /**
      * Indicates which source fields are returned for matching documents. These

--- a/specification/ccr/put_auto_follow_pattern/PutAutoFollowPatternRequest.ts
+++ b/specification/ccr/put_auto_follow_pattern/PutAutoFollowPatternRequest.ts
@@ -40,7 +40,7 @@ export interface Request extends RequestBase {
   body: {
     /**
      * The remote cluster containing the leader indices to match against.
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-remote-clusters.html
+     * @doc_id modules-remote-clusters
      */
     remote_cluster: string
     /**

--- a/specification/cluster/put_component_template/ClusterPutComponentTemplateRequest.ts
+++ b/specification/cluster/put_component_template/ClusterPutComponentTemplateRequest.ts
@@ -48,7 +48,7 @@ export interface Request extends RequestBase {
     mappings?: TypeMapping
     settings?: IndexSettings
     version?: VersionNumber
-    /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
+    /** @doc_id mapping-meta-field */
     _meta?: Metadata
   }
 }

--- a/specification/cluster/stats/ClusterStatsResponse.ts
+++ b/specification/cluster/stats/ClusterStatsResponse.ts
@@ -26,7 +26,7 @@ export class Response extends NodesResponseBase {
   body: {
     /**
      * Name of the cluster, based on the Cluster name setting setting.
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#cluster-name
+     * @doc_id cluster-name
      */
     cluster_name: Name
     /**
@@ -39,7 +39,7 @@ export class Response extends NodesResponseBase {
     indices: ClusterIndices
     /**
      * Contains statistics about nodes selected by the request’s node filters.
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes
+     * @doc_id cluster-nodes
      */
     nodes: ClusterNodes
     /**

--- a/specification/eql/_types/EqlSearchResponseBase.ts
+++ b/specification/eql/_types/EqlSearchResponseBase.ts
@@ -21,9 +21,6 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { EqlHits } from './EqlHits'
 
-/**
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html#eql-search-api-response-body
- */
 export class EqlSearchResponseBase<TEvent> {
   /**
    *  Identifier for the search.

--- a/specification/eql/search/EqlSearchRequest.ts
+++ b/specification/eql/search/EqlSearchRequest.ts
@@ -66,7 +66,7 @@ export interface Request extends RequestBase {
   body: {
     /**
      * EQL query you wish to run.
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html
+     * @doc_id eql-syntax
      */
     query: string
     case_sensitive?: boolean
@@ -77,7 +77,7 @@ export interface Request extends RequestBase {
     event_category_field?: Field
     /**
      * Field used to sort hits with the same timestamp in ascending order
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html#eql-search-specify-a-sort-tiebreaker
+     * @doc_id sort-tiebreaker
      */
     tiebreaker_field?: Field
     /**
@@ -98,7 +98,7 @@ export interface Request extends RequestBase {
     wait_for_completion_timeout?: Time
     /**
      * For basic queries, the maximum number of matching events to return. Defaults to 10
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-basic-syntax
+     * @doc_id eql-basic-syntax
      */
     size?: uint // doc says "integer of float" but it's really an int
     /**

--- a/specification/fleet/msearch/MultiSearchRequest.ts
+++ b/specification/fleet/msearch/MultiSearchRequest.ts
@@ -53,7 +53,7 @@ export interface Request extends RequestBase {
     /**
      * If true, network roundtrips between the coordinating node and remote clusters are minimized for cross-cluster search requests.
      * @server_default true
-     * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cross-cluster-search.html#ccs-network-delays
+     * @doc_id ccs-network-delays
      */
     ccs_minimize_roundtrips?: boolean
     /**

--- a/specification/fleet/search/SearchRequest.ts
+++ b/specification/fleet/search/SearchRequest.ts
@@ -187,7 +187,7 @@ export interface Request extends RequestBase {
      */
     size?: integer
     slice?: SlicedScroll
-    /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html */
+    /** @doc_id sort-search-results */
     sort?: Sort
     /**
      * Indicates which source fields are returned for matching documents. These

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
@@ -49,7 +49,7 @@ export interface Request extends RequestBase {
     data_stream?: DataStream
     priority?: integer
     version?: VersionNumber
-    /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
+    /** @doc_id mapping-meta-field */
     _meta?: Metadata
   }
   query_parameters: {

--- a/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
+++ b/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
@@ -65,7 +65,7 @@ export interface Request extends RequestBase {
     data_stream?: DataStream
     priority?: integer
     version?: VersionNumber
-    /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
+    /** @doc_id mapping-meta-field */
     _meta?: Metadata
   }
 }


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-specification/pull/1523