### PR TITLE
[8.1] Replace hard-coded doc URLs with @doc_id #1530

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -340,7 +340,6 @@ query-dsl,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/query-dsl.
 common-options,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/common-options.html
 indices-create-data-stream,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/indices-create-data-stream.html
 mapping-date-format,https://www.elastic.co/guide/en/elasticsearch/reference/7.x/mapping-date-format.html
-////
 query-dsl-minimum-should-match,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/query-dsl-minimum-should-match.html
 query-dsl-multi-term-rewrite,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/query-dsl-multi-term-rewrite.html
 modules-node,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/modules-node.html
@@ -395,3 +394,8 @@ cluster-name,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/importa
 cluster-nodes,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/cluster.html#cluster-nodes
 sort-tiebreaker,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/eql.html#eql-search-specify-a-sort-tiebreaker
 eql-basic-syntax,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/eql-syntax.html#eql-basic-syntax
+time-value,https://github.com/elastic/elasticsearch/blob/8.1/libs/core/src/main/java/org/elasticsearch/core/TimeValue.java
+supported-flags,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/query-dsl-simple-query-string-query.html#supported-flags
+eql-sequences,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/eql-syntax.html#eql-sequences
+index-modules-settings,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/index-modules.html#index-modules-settings
+templating-role-query,https://www.elastic.co/guide/en/elasticsearch/reference/8.1/field-and-document-access-control.html#templating-role-query

--- a/specification/_global/rank_eval/types.ts
+++ b/specification/_global/rank_eval/types.ts
@@ -41,7 +41,7 @@ export class RankEvalMetricRatingTreshold extends RankEvalMetricBase {
 
 /**
  * Precision at K (P@k)
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#k-precision
+ * @doc_id k-precision
  */
 export class RankEvalMetricPrecision extends RankEvalMetricRatingTreshold {
   /**
@@ -53,19 +53,19 @@ export class RankEvalMetricPrecision extends RankEvalMetricRatingTreshold {
 
 /**
  * Recall at K (R@k)
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#k-recall
+ * @doc_id k-recall
  */
 export class RankEvalMetricRecall extends RankEvalMetricRatingTreshold {}
 
 /**
  * Mean Reciprocal Rank
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#_mean_reciprocal_rank
+ * @doc_id mean-reciprocal
  */
 export class RankEvalMetricMeanReciprocalRank extends RankEvalMetricRatingTreshold {}
 
 /**
  * Discounted cumulative gain (DCG)
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#_discounted_cumulative_gain_dcg
+ * @doc_id dcg
  */
 export class RankEvalMetricDiscountedCumulativeGain extends RankEvalMetricBase {
   /**
@@ -78,7 +78,7 @@ export class RankEvalMetricDiscountedCumulativeGain extends RankEvalMetricBase {
 
 /**
  * Expected Reciprocal Rank (ERR)
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#_expected_reciprocal_rank_err
+ * @doc_id expected-reciprocal
  */
 export class RankEvalMetricExpectedReciprocalRank extends RankEvalMetricBase {
   /**

--- a/specification/_types/Scripting.ts
+++ b/specification/_types/Scripting.ts
@@ -22,7 +22,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Id } from './common'
 
 /**
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
+ * @doc_id modules-scripting
  * @open_enum
  */
 export enum ScriptLanguage {

--- a/specification/_types/Time.ts
+++ b/specification/_types/Time.ts
@@ -37,7 +37,7 @@ export type DateOrEpochMillis = DateString | EpochMillis
 
 export type TimeZone = string
 
-/** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/7.x/mapping-date-format.html */
+/** @doc_id mapping-date-format */
 export type DateFormat = string
 
 export enum DateMathOperation {
@@ -64,7 +64,7 @@ export enum DateMathTimeUnit {
 
 /**
  * Whenever durations need to be specified, e.g. for a timeout parameter, the duration must specify the unit, like 2d for 2 days.
- * @doc_url https://github.com/elastic/elasticsearch/blob/master/libs/core/src/main/java/org/elasticsearch/core/TimeValue.java
+ * @doc_id time-value
  * @codegen_names time, offset
  */
 //FIXME: need to distinguish durations (has to be a string), offsets (can be a string or number)

--- a/specification/_types/aggregations/AggregationContainer.ts
+++ b/specification/_types/aggregations/AggregationContainer.ts
@@ -125,18 +125,18 @@ export class AggregationContainer {
   bucket_selector?: BucketSelectorAggregation
   bucket_sort?: BucketSortAggregation
   /**
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-count-ks-test-aggregation.html
+   * @doc_id search-aggregations-bucket-count-ks-test-aggregation
    * @stability experimental
    */
   bucket_count_ks_test?: BucketKsAggregation
   /**
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-correlation-aggregation.html
+   * @doc_id search-aggregations-bucket-correlation-aggregation
    * @stability experimental
    */
   bucket_correlation?: BucketCorrelationAggregation
   cardinality?: CardinalityAggregation
   /**
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-categorize-text-aggregation.html
+   * @doc_id search-aggregations-bucket-categorize-text-aggregation
    * @stability experimental
    */
   categorize_text?: CategorizeTextAggregation

--- a/specification/_types/analysis/normalizers.ts
+++ b/specification/_types/analysis/normalizers.ts
@@ -19,7 +19,7 @@
 
 /**
  * @variants internal tag='type'
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-normalizers.html
+ * @doc_id analysis-normalizers
  */
 export type Normalizer = LowercaseNormalizer | CustomNormalizer
 

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -70,15 +70,15 @@ export type Service = string
 
 export type PipelineName = string
 
-/** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#modules-node */
+/** @doc_id modules-node */
 export type NodeName = string
 
-/** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-data-stream.html#indices-create-data-stream-api-path-params */
+/** @doc_id data-stream-path-param  */
 export type DataStreamName = string
 
 export type DataStreamNames = DataStreamName | DataStreamName[]
 
-/** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#byte-units */
+/** @doc_id byte-units */
 export type ByteSize = long | string
 
 export type Metadata = Dictionary<string, UserDefinedValue>
@@ -105,7 +105,7 @@ export type PropertyName = string
 export type RelationName = string
 export type TaskId = string | integer
 export type Fuzziness = string | integer
-/** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-term-rewrite.html */
+/** @doc_id query-dsl-multi-term-rewrite */
 export type MultiTermQueryRewrite = string
 
 /** Path to field or array of paths. Some API's support wildcards in the path to select multiple fields.  */
@@ -135,14 +135,14 @@ export class EmptyObject {}
 
 /**
  * The minimum number of terms that should match as integer, percentage or range
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html
+ * @doc_id query-dsl-minimum-should-match
  */
 export type MinimumShouldMatch = integer | string
 
 /**
  * Byte size units. These units use powers of 1024, so 1 kB means 1024 bytes.
  *
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#byte-units
+ * @doc_id byte-units
  */
 export enum Bytes {
   /** @codegen_name bytes */

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -41,7 +41,7 @@ import {
 
 export class PropertyBase {
   local_metadata?: Metadata
-  /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
+  /** @doc_id mapping-meta-field */
   meta?: Dictionary<string, string>
   name?: PropertyName
   properties?: Dictionary<PropertyName, Property>

--- a/specification/_types/mapping/TypeMapping.ts
+++ b/specification/_types/mapping/TypeMapping.ts
@@ -41,7 +41,7 @@ export class TypeMapping {
     | Dictionary<string, DynamicTemplate>[]
   _field_names?: FieldNamesField
   index_field?: IndexField
-  /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
+  /** @doc_id mapping-meta-field */
   _meta?: Metadata
   numeric_detection?: boolean
   properties?: Dictionary<PropertyName, Property>

--- a/specification/_types/mapping/geo.ts
+++ b/specification/_types/mapping/geo.ts
@@ -38,7 +38,7 @@ export enum GeoOrientation {
  * The `geo_shape` data type facilitates the indexing of and searching with arbitrary geo shapes such as rectangles
  * and polygons.
  *
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-shape.html
+ * @doc_id geo-shape
  */
 export class GeoShapeProperty extends DocValuesPropertyBase {
   coerce?: boolean
@@ -70,7 +70,7 @@ export class PointProperty extends DocValuesPropertyBase {
  * The `shape` data type facilitates the indexing of and searching with arbitrary `x, y` cartesian shapes such as
  * rectangles and polygons.
  *
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/shape.html
+ * @doc_id shape
  */
 export class ShapeProperty extends DocValuesPropertyBase {
   coerce?: boolean

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -96,7 +96,7 @@ import {
 
 /**
  * @variants container
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+ * @doc_id query-dsl
  */
 export class QueryContainer {
   bool?: BoolQuery

--- a/specification/_types/query_dsl/fulltext.ts
+++ b/specification/_types/query_dsl/fulltext.ts
@@ -270,7 +270,7 @@ export class QueryStringQuery extends QueryBase {
 
 /**
  * Query flags can be either a single flag or a combination of flags, e.g. `OR|AND|PREFIX`
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/7.15/query-dsl-simple-query-string-query.html#supported-flags
+ * @doc_id supported-flags
  * @codegen_names single, multiple
  */
 export type SimpleQueryStringFlags = SimpleQueryStringFlag | string

--- a/specification/_types/query_dsl/specialized.ts
+++ b/specification/_types/query_dsl/specialized.ts
@@ -102,7 +102,7 @@ export class LikeDocument {
 
 /**
  * Text that we want similar documents for or a lookup to a document's field for the text.
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html#_document_input_parameters
+ * @doc_id document-input-parameters
  * @codegen_names text, document
  */
 export type Like = string | LikeDocument

--- a/specification/_types/sort.ts
+++ b/specification/_types/sort.ts
@@ -78,7 +78,7 @@ export enum ScriptSortType {
 }
 
 /**
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html
+ * @doc_id sort-search-results
  * @variants container
  */
 export class SortOptions implements AdditionalProperty<Field, FieldSort> {

--- a/specification/cluster/_types/ComponentTemplate.ts
+++ b/specification/cluster/_types/ComponentTemplate.ts
@@ -31,12 +31,12 @@ export class ComponentTemplate {
 export class ComponentTemplateNode {
   template: ComponentTemplateSummary
   version?: VersionNumber
-  /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
+  /** @doc_id mapping-meta-field */
   _meta?: Metadata
 }
 
 export class ComponentTemplateSummary {
-  /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
+  /** @doc_id mapping-meta-field */
   _meta?: Metadata
   version?: VersionNumber
   settings: Dictionary<IndexName, IndexSettings>

--- a/specification/cluster/allocation_explain/types.ts
+++ b/specification/cluster/allocation_explain/types.ts
@@ -125,7 +125,7 @@ export class UnassignedInformation {
 }
 
 /**
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-shards.html#cat-shards-query-params
+ * @doc_id cat-shards
  */
 export enum UnassignedInformationReason {
   INDEX_CREATED = 0,

--- a/specification/cluster/reroute/types.ts
+++ b/specification/cluster/reroute/types.ts
@@ -67,7 +67,7 @@ export class CommandMoveAction {
 }
 
 /**
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-cluster.html
+ * @doc_id modules-cluster
  */
 export class CommandAllocateReplicaAction {
   index: IndexName

--- a/specification/cluster/stats/types.ts
+++ b/specification/cluster/stats/types.ts
@@ -68,7 +68,7 @@ export class ClusterIndices {
   docs: DocStats
   /**
    * Contains statistics about the field data cache of selected nodes.
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-fielddata.html
+   * @doc_id modules-fielddata
    */
   fielddata: FielddataStats
   /** Contains statistics about the query cache of selected nodes. */
@@ -81,12 +81,12 @@ export class ClusterIndices {
   store: StoreStats
   /**
    * Contains statistics about field mappings in selected nodes.
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
+   * @doc_id mapping
    */
   mappings: FieldTypesMappings
   /**
    * Contains statistics about analyzers and analyzer components used in selected nodes.
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/analyzer-anatomy.html
+   * @doc_id analyzer-anatomy
    */
   analysis: CharFilterTypes
   versions?: IndicesVersions[]
@@ -195,7 +195,7 @@ export class ClusterNodes {
   count: ClusterNodeCount
   /**
    * Contains statistics about the discovery types used by selected nodes.
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-hosts-providers.html
+   * @doc_id modules-discovery-hosts-providers
    */
   discovery_types: Dictionary<string, integer>
   /** Contains statistics about file stores by selected nodes. */

--- a/specification/eql/_types/EqlHits.ts
+++ b/specification/eql/_types/EqlHits.ts
@@ -33,7 +33,7 @@ export class EqlHits<TEvent> {
   events?: HitsEvent<TEvent>[]
   /**
    * Contains event sequences matching the query. Each object represents a matching sequence. This parameter is only returned for EQL queries containing a sequence.
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-sequences
+   * @doc_id eql-sequences
    */
   sequences?: HitsSequence<TEvent>[]
 }
@@ -53,7 +53,7 @@ export class HitsSequence<TEvent> {
   events: HitsEvent<TEvent>[]
   /**
    * Shared field values used to constrain matches in the sequence. These are defined using the by keyword in the EQL query syntax.
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-sequences
+   * @doc_id eql-sequences
    */
   join_keys: UserDefinedValue[]
 }

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -40,7 +40,7 @@ export class DataStream {
   system?: boolean
   status: HealthStatus
   ilm_policy?: Name
-  /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
+  /** @doc_id mapping-meta-field */
   _meta?: Metadata
   allow_custom_routing?: boolean
 }

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -54,7 +54,7 @@ export class RetentionLease {
 }
 
 /**
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-modules.html#index-modules-settings
+ * @doc_id index-modules-settings
  */
 export class IndexSettings {
   index?: IndexSettings

--- a/specification/indices/_types/IndexTemplate.ts
+++ b/specification/indices/_types/IndexTemplate.ts
@@ -30,7 +30,7 @@ export class IndexTemplate {
   template?: IndexTemplateSummary
   version?: VersionNumber
   priority?: long
-  /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */
+  /** @doc_id mapping-meta-field */
   _meta?: Metadata
   allow_auto_create?: boolean
   data_stream?: IndexTemplateDataStreamConfiguration

--- a/specification/nodes/_types/NodesResponseBase.ts
+++ b/specification/nodes/_types/NodesResponseBase.ts
@@ -22,7 +22,7 @@ import { NodeStatistics } from '../../_types/Node'
 export class NodesResponseBase {
   /**
    * Contains statistics about the number of nodes selected by the request’s node filters.
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster.html#cluster-nodes
+   * @doc_id cluster-nodes
    * @codegen_name node_stats
    */
   _nodes?: NodeStatistics

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -49,7 +49,7 @@ export class NodeInfo {
   thread_pool?: Dictionary<string, NodeThreadPoolInfo>
   /**
    * Total heap allowed to be used to hold recently indexed documents before they must be written to disk. This size is a shared pool across all shards on this node, and is controlled by Indexing Buffer settings.
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/master/indexing-buffer.html
+   * @doc_id indexing-buffer
    */
   total_indexing_buffer?: long
   /** Same as total_indexing_buffer, but expressed in bytes. */

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -109,7 +109,7 @@ export class RoleTemplateQueryContainer {
    * Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based
    * templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.
    *
-   * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/field-and-document-access-control.html#templating-role-query
+   * @doc_id templating-role-query
    */
   template?: RoleTemplateScript
 }

--- a/specification/watcher/_types/Schedule.ts
+++ b/specification/watcher/_types/Schedule.ts
@@ -25,7 +25,7 @@ import { DateString, Time } from '@_types/Time'
 // export class ScheduleBase {}
 
 /**
- * @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/cron-expressions.html
+ * @doc_id cron-expressions
  */
 export type CronExpression = string
 //export class CronExpression extends ScheduleBase {}


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-specification/pull/1530