### PR TITLE
[ML] update put trained model vocab spec to allow merges

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13292,6 +13292,7 @@ export interface MlPutTrainedModelVocabularyRequest extends RequestBase {
   model_id: Id
   body?: {
     vocabulary: string[]
+    merges?: string[]
   }
 }
 

--- a/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
+++ b/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
@@ -44,6 +44,7 @@ export interface Request extends RequestBase {
 
     /**
      * The optional model merges if required by the tokenizer.
+     * @since 8.2.0
      */
     merges?: string[]
   }

--- a/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
+++ b/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
@@ -41,5 +41,10 @@ export interface Request extends RequestBase {
      * The model vocabulary, which must not be empty.
      */
     vocabulary: string[]
+
+    /**
+     * The optional model merges if required by the tokenizer.
+     */
+    merges?: string[]
   }
 }


### PR DESCRIPTION
With https://github.com/elastic/elasticsearch/pull/84777, the put trained model vocab can now accept an optional `merges` field that is a string array. This field is required for `roberta` tokenizers, but not for `mpnet` or `bert`.