### PR TITLE
Rollback #1468

### DIFF
--- a/specification/_global/bulk/BulkResponse.ts
+++ b/specification/_global/bulk/BulkResponse.ts
@@ -22,12 +22,10 @@ import { OperationType, ResponseItem } from './types'
 import { SingleKeyDictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  '200': {
-    body: {
-      errors: boolean
-      items: SingleKeyDictionary<OperationType, ResponseItem>[]
-      took: long
-      ingest_took?: long
-    }
+  body: {
+    errors: boolean
+    items: SingleKeyDictionary<OperationType, ResponseItem>[]
+    took: long
+    ingest_took?: long
   }
 }

--- a/specification/_global/clear_scroll/ClearScrollResponse.ts
+++ b/specification/_global/clear_scroll/ClearScrollResponse.ts
@@ -20,10 +20,8 @@
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      succeeded: boolean
-      num_freed: integer
-    }
+  body: {
+    succeeded: boolean
+    num_freed: integer
   }
 }

--- a/specification/_global/close_point_in_time/ClosePointInTimeResponse.ts
+++ b/specification/_global/close_point_in_time/ClosePointInTimeResponse.ts
@@ -20,7 +20,5 @@
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: { succeeded: boolean; num_freed: integer }
-  }
+  body: { succeeded: boolean; num_freed: integer }
 }

--- a/specification/_global/count/CountResponse.ts
+++ b/specification/_global/count/CountResponse.ts
@@ -21,7 +21,5 @@ import { long } from '@_types/Numeric'
 import { ShardStatistics } from '@_types/Stats'
 
 export class Response {
-  '200': {
-    body: { count: long; _shards: ShardStatistics }
-  }
+  body: { count: long; _shards: ShardStatistics }
 }

--- a/specification/_global/create/CreateResponse.ts
+++ b/specification/_global/create/CreateResponse.ts
@@ -20,7 +20,5 @@
 import { WriteResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: WriteResponseBase
-  }
+  body: WriteResponseBase
 }

--- a/specification/_global/delete/DeleteResponse.ts
+++ b/specification/_global/delete/DeleteResponse.ts
@@ -20,7 +20,5 @@
 import { WriteResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: WriteResponseBase
-  }
+  body: WriteResponseBase
 }

--- a/specification/_global/delete_by_query/DeleteByQueryResponse.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryResponse.ts
@@ -23,22 +23,20 @@ import { float, integer, long } from '@_types/Numeric'
 import { Retries } from '@_types/Retries'
 
 export class Response {
-  '200': {
-    body: {
-      batches?: long
-      deleted?: long
-      failures?: BulkIndexByScrollFailure[]
-      noops?: long
-      requests_per_second?: float
-      retries?: Retries
-      slice_id?: integer
-      task?: TaskId
-      throttled_millis?: long
-      throttled_until_millis?: long
-      timed_out?: boolean
-      took?: long
-      total?: long
-      version_conflicts?: long
-    }
+  body: {
+    batches?: long
+    deleted?: long
+    failures?: BulkIndexByScrollFailure[]
+    noops?: long
+    requests_per_second?: float
+    retries?: Retries
+    slice_id?: integer
+    task?: TaskId
+    throttled_millis?: long
+    throttled_until_millis?: long
+    timed_out?: boolean
+    took?: long
+    total?: long
+    version_conflicts?: long
   }
 }

--- a/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleResponse.ts
+++ b/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleResponse.ts
@@ -20,7 +20,5 @@
 import { Response as ListTasksResponse } from '@tasks/list/ListTasksResponse'
 
 export class Response {
-  '200': {
-    body: ListTasksResponse
-  }
+  body: ListTasksResponse
 }

--- a/specification/_global/delete_script/DeleteScriptResponse.ts
+++ b/specification/_global/delete_script/DeleteScriptResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/_global/exists/DocumentExistsResponse.ts
+++ b/specification/_global/exists/DocumentExistsResponse.ts
@@ -20,7 +20,5 @@
 import { Void } from '@spec_utils/VoidValue'
 
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/_global/exists_source/SourceExistsResponse.ts
+++ b/specification/_global/exists_source/SourceExistsResponse.ts
@@ -20,7 +20,5 @@
 import { Void } from '@spec_utils/VoidValue'
 
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/_global/explain/ExplainResponse.ts
+++ b/specification/_global/explain/ExplainResponse.ts
@@ -21,13 +21,11 @@ import { Id, IndexName, InlineGet } from '@_types/common'
 import { ExplanationDetail } from './types'
 
 export class Response<TDocument> {
-  '200': {
-    body: {
-      _index: IndexName
-      _id: Id
-      matched: boolean
-      explanation?: ExplanationDetail
-      get?: InlineGet<TDocument>
-    }
+  body: {
+    _index: IndexName
+    _id: Id
+    matched: boolean
+    explanation?: ExplanationDetail
+    get?: InlineGet<TDocument>
   }
 }

--- a/specification/_global/field_caps/FieldCapabilitiesResponse.ts
+++ b/specification/_global/field_caps/FieldCapabilitiesResponse.ts
@@ -28,10 +28,8 @@ import { FieldCapability } from './types'
  * For example, `keyword`, `constant_keyword` and `wildcard` field types are all described as the `keyword` type family.
  */
 export class Response {
-  '200': {
-    body: {
-      indices: Indices
-      fields: Dictionary<Field, Dictionary<string, FieldCapability>>
-    }
+  body: {
+    indices: Indices
+    fields: Dictionary<Field, Dictionary<string, FieldCapability>>
   }
 }

--- a/specification/_global/get/GetResponse.ts
+++ b/specification/_global/get/GetResponse.ts
@@ -20,7 +20,5 @@
 import { GetResult } from '@global/get/types'
 
 export class Response<TDocument> {
-  '200': {
-    body: GetResult<TDocument>
-  }
+  body: GetResult<TDocument>
 }

--- a/specification/_global/get_script/GetScriptResponse.ts
+++ b/specification/_global/get_script/GetScriptResponse.ts
@@ -21,11 +21,9 @@ import { Id } from '@_types/common'
 import { StoredScript } from '@_types/Scripting'
 
 export class Response {
-  '200': {
-    body: {
-      _id: Id
-      found: boolean
-      script?: StoredScript
-    }
+  body: {
+    _id: Id
+    found: boolean
+    script?: StoredScript
   }
 }

--- a/specification/_global/get_script_context/GetScriptContextResponse.ts
+++ b/specification/_global/get_script_context/GetScriptContextResponse.ts
@@ -20,9 +20,7 @@
 import { Context } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      contexts: Context[]
-    }
+  body: {
+    contexts: Context[]
   }
 }

--- a/specification/_global/get_script_languages/GetScriptLanguagesResponse.ts
+++ b/specification/_global/get_script_languages/GetScriptLanguagesResponse.ts
@@ -20,10 +20,8 @@
 import { LanguageContext } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      language_contexts: LanguageContext[]
-      types_allowed: string[]
-    }
+  body: {
+    language_contexts: LanguageContext[]
+    types_allowed: string[]
   }
 }

--- a/specification/_global/get_source/SourceResponse.ts
+++ b/specification/_global/get_source/SourceResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response<TDocument> {
-  '200': {
-    body: TDocument
-  }
+  body: TDocument
 }

--- a/specification/_global/index/IndexResponse.ts
+++ b/specification/_global/index/IndexResponse.ts
@@ -20,7 +20,5 @@
 import { WriteResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: WriteResponseBase
-  }
+  body: WriteResponseBase
 }

--- a/specification/_global/info/RootNodeInfoResponse.ts
+++ b/specification/_global/info/RootNodeInfoResponse.ts
@@ -21,13 +21,11 @@ import { ElasticsearchVersionInfo } from '@_types/Base'
 import { Name, Uuid } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      cluster_name: Name
-      cluster_uuid: Uuid
-      name: Name
-      tagline: string
-      version: ElasticsearchVersionInfo
-    }
+  body: {
+    cluster_name: Name
+    cluster_uuid: Uuid
+    name: Name
+    tagline: string
+    version: ElasticsearchVersionInfo
   }
 }

--- a/specification/_global/knn_search/KnnSearchResponse.ts
+++ b/specification/_global/knn_search/KnnSearchResponse.ts
@@ -24,33 +24,31 @@ import { ShardStatistics } from '@_types/Stats'
 import { HitsMetadata } from '@global/search/_types/hits'
 
 export class Response<TDocument> {
-  '200': {
-    body: {
-      /** Milliseconds it took Elasticsearch to execute the request. */
-      took: long
-      /**
-       * If true, the request timed out before completion;
-       * returned results may be partial or empty.
-       */
-      timed_out: boolean
-      /**
-       * Contains a count of shards used for the request.
-       */
-      _shards: ShardStatistics
-      /**
-       * Contains returned documents and metadata.
-       */
-      hits: HitsMetadata<TDocument>
-      /**
-       * Contains field values for the documents. These fields
-       * must be specified in the request using the `fields` parameter.
-       */
-      fields?: Dictionary<string, UserDefinedValue>
-      /**
-       * Highest returned document score. This value is null for requests
-       * that do not sort by score.
-       */
-      max_score?: double
-    }
+  body: {
+    /** Milliseconds it took Elasticsearch to execute the request. */
+    took: long
+    /**
+     * If true, the request timed out before completion;
+     * returned results may be partial or empty.
+     */
+    timed_out: boolean
+    /**
+     * Contains a count of shards used for the request.
+     */
+    _shards: ShardStatistics
+    /**
+     * Contains returned documents and metadata.
+     */
+    hits: HitsMetadata<TDocument>
+    /**
+     * Contains field values for the documents. These fields
+     * must be specified in the request using the `fields` parameter.
+     */
+    fields?: Dictionary<string, UserDefinedValue>
+    /**
+     * Highest returned document score. This value is null for requests
+     * that do not sort by score.
+     */
+    max_score?: double
   }
 }

--- a/specification/_global/mget/MultiGetResponse.ts
+++ b/specification/_global/mget/MultiGetResponse.ts
@@ -20,9 +20,7 @@
 import { ResponseItem } from './types'
 
 export class Response<TDocument> {
-  '200': {
-    body: {
-      docs: ResponseItem<TDocument>[]
-    }
+  body: {
+    docs: ResponseItem<TDocument>[]
   }
 }

--- a/specification/_global/msearch/MultiSearchResponse.ts
+++ b/specification/_global/msearch/MultiSearchResponse.ts
@@ -23,7 +23,5 @@ import { MultiSearchResult } from '@global/msearch/types'
 // - msearch
 // - fleet.msearch
 export class Response<TDocument> {
-  '200': {
-    body: MultiSearchResult<TDocument>
-  }
+  body: MultiSearchResult<TDocument>
 }

--- a/specification/_global/msearch_template/MultiSearchTemplateResponse.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateResponse.ts
@@ -20,7 +20,5 @@
 import { MultiSearchResult } from '@global/msearch/types'
 
 export class Response<TDocument> {
-  '200': {
-    body: MultiSearchResult<TDocument>
-  }
+  body: MultiSearchResult<TDocument>
 }

--- a/specification/_global/mtermvectors/MultiTermVectorsResponse.ts
+++ b/specification/_global/mtermvectors/MultiTermVectorsResponse.ts
@@ -20,7 +20,5 @@
 import { TermVectorsResult } from './types'
 
 export class Response {
-  '200': {
-    body: { docs: TermVectorsResult[] }
-  }
+  body: { docs: TermVectorsResult[] }
 }

--- a/specification/_global/open_point_in_time/OpenPointInTimeResponse.ts
+++ b/specification/_global/open_point_in_time/OpenPointInTimeResponse.ts
@@ -20,7 +20,5 @@
 import { Id } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: { id: Id }
-  }
+  body: { id: Id }
 }

--- a/specification/_global/ping/PingResponse.ts
+++ b/specification/_global/ping/PingResponse.ts
@@ -20,7 +20,5 @@
 import { Void } from '@spec_utils/VoidValue'
 
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/_global/put_script/PutScriptResponse.ts
+++ b/specification/_global/put_script/PutScriptResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/_global/rank_eval/RankEvalResponse.ts
+++ b/specification/_global/rank_eval/RankEvalResponse.ts
@@ -24,13 +24,11 @@ import { double } from '@_types/Numeric'
 import { RankEvalMetricDetail } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      /** The overall evaluation quality calculated by the defined metric */
-      metric_score: double
-      /** The details section contains one entry for every query in the original requests section, keyed by the search request id */
-      details: Dictionary<Id, RankEvalMetricDetail>
-      failures: Dictionary<string, UserDefinedValue> // TODO -- incomplete tests
-    }
+  body: {
+    /** The overall evaluation quality calculated by the defined metric */
+    metric_score: double
+    /** The details section contains one entry for every query in the original requests section, keyed by the search request id */
+    details: Dictionary<Id, RankEvalMetricDetail>
+    failures: Dictionary<string, UserDefinedValue> // TODO -- incomplete tests
   }
 }

--- a/specification/_global/reindex/ReindexResponse.ts
+++ b/specification/_global/reindex/ReindexResponse.ts
@@ -24,24 +24,22 @@ import { Retries } from '@_types/Retries'
 import { EpochMillis, Time } from '@_types/Time'
 
 export class Response {
-  '200': {
-    body: {
-      batches?: long
-      created?: long
-      deleted?: long
-      failures?: BulkIndexByScrollFailure[]
-      noops?: long
-      retries?: Retries
-      requests_per_second?: long
-      slice_id?: integer
-      task?: TaskId
-      throttled_millis?: EpochMillis
-      throttled_until_millis?: EpochMillis
-      timed_out?: boolean
-      took?: Time
-      total?: long
-      updated?: long
-      version_conflicts?: long
-    }
+  body: {
+    batches?: long
+    created?: long
+    deleted?: long
+    failures?: BulkIndexByScrollFailure[]
+    noops?: long
+    retries?: Retries
+    requests_per_second?: long
+    slice_id?: integer
+    task?: TaskId
+    throttled_millis?: EpochMillis
+    throttled_until_millis?: EpochMillis
+    timed_out?: boolean
+    took?: Time
+    total?: long
+    updated?: long
+    version_conflicts?: long
   }
 }

--- a/specification/_global/reindex_rethrottle/ReindexRethrottleResponse.ts
+++ b/specification/_global/reindex_rethrottle/ReindexRethrottleResponse.ts
@@ -21,7 +21,5 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { ReindexNode } from './types'
 
 export class Response {
-  '200': {
-    body: { nodes: Dictionary<string, ReindexNode> }
-  }
+  body: { nodes: Dictionary<string, ReindexNode> }
 }

--- a/specification/_global/render_search_template/RenderSearchTemplateResponse.ts
+++ b/specification/_global/render_search_template/RenderSearchTemplateResponse.ts
@@ -21,7 +21,5 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
-  '200': {
-    body: { template_output: Dictionary<string, UserDefinedValue> }
-  }
+  body: { template_output: Dictionary<string, UserDefinedValue> }
 }

--- a/specification/_global/scripts_painless_execute/ExecutePainlessScriptResponse.ts
+++ b/specification/_global/scripts_painless_execute/ExecutePainlessScriptResponse.ts
@@ -18,9 +18,7 @@
  */
 
 export class Response<TResult> {
-  '200': {
-    body: {
-      result: TResult
-    }
+  body: {
+    result: TResult
   }
 }

--- a/specification/_global/scroll/ScrollResponse.ts
+++ b/specification/_global/scroll/ScrollResponse.ts
@@ -20,7 +20,5 @@
 import { ResponseBody } from '@global/search/SearchResponse'
 
 export class Response<TDocument> {
-  '200': {
-    body: ResponseBody<TDocument>
-  }
+  body: ResponseBody<TDocument>
 }

--- a/specification/_global/search/SearchResponse.ts
+++ b/specification/_global/search/SearchResponse.ts
@@ -32,9 +32,7 @@ import { Suggest } from './_types/suggester'
 // - fleet.search
 // - scroll
 export class Response<TDocument> {
-  '200': {
-    body: ResponseBody<TDocument>
-  }
+  body: ResponseBody<TDocument>
 }
 
 export class ResponseBody<TDocument> {

--- a/specification/_global/search_mvt/SearchMvtResponse.ts
+++ b/specification/_global/search_mvt/SearchMvtResponse.ts
@@ -20,7 +20,5 @@
 import { MapboxVectorTiles } from '@_types/Binary'
 
 export class Response {
-  '200': {
-    body: MapboxVectorTiles
-  }
+  body: MapboxVectorTiles
 }

--- a/specification/_global/search_shards/SearchShardsResponse.ts
+++ b/specification/_global/search_shards/SearchShardsResponse.ts
@@ -23,12 +23,10 @@ import { NodeAttributes, NodeShard } from '@_types/Node'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 
 export class Response {
-  '200': {
-    body: {
-      nodes: Dictionary<string, NodeAttributes>
-      shards: NodeShard[][]
-      indices: Dictionary<IndexName, ShardStoreIndex>
-    }
+  body: {
+    nodes: Dictionary<string, NodeAttributes>
+    shards: NodeShard[][]
+    indices: Dictionary<IndexName, ShardStoreIndex>
   }
 }
 

--- a/specification/_global/search_template/SearchTemplateResponse.ts
+++ b/specification/_global/search_template/SearchTemplateResponse.ts
@@ -28,23 +28,21 @@ import { Profile } from '@global/search/_types/profile'
 import { Suggest } from '@global/search/_types/suggester'
 
 export class Response<TDocument> {
-  '200': {
-    body: {
-      // Has to be kept in sync with SearchResponse
-      took: long
-      timed_out: boolean
-      _shards: ShardStatistics
-      hits: HitsMetadata<TDocument>
-      aggregations?: Dictionary<AggregateName, Aggregate>
-      _clusters?: ClusterStatistics
-      fields?: Dictionary<string, UserDefinedValue>
-      max_score?: double
-      num_reduce_phases?: long
-      profile?: Profile
-      pit_id?: Id
-      _scroll_id?: ScrollId
-      suggest?: Dictionary<SuggestionName, Suggest<TDocument>[]>
-      terminated_early?: boolean
-    }
+  body: {
+    // Has to be kept in sync with SearchResponse
+    took: long
+    timed_out: boolean
+    _shards: ShardStatistics
+    hits: HitsMetadata<TDocument>
+    aggregations?: Dictionary<AggregateName, Aggregate>
+    _clusters?: ClusterStatistics
+    fields?: Dictionary<string, UserDefinedValue>
+    max_score?: double
+    num_reduce_phases?: long
+    profile?: Profile
+    pit_id?: Id
+    _scroll_id?: ScrollId
+    suggest?: Dictionary<SuggestionName, Suggest<TDocument>[]>
+    terminated_early?: boolean
   }
 }

--- a/specification/_global/terms_enum/TermsEnumResponse.ts
+++ b/specification/_global/terms_enum/TermsEnumResponse.ts
@@ -20,11 +20,9 @@
 import { ShardStatistics } from '@_types/Stats'
 
 export class Response {
-  '200': {
-    body: {
-      _shards: ShardStatistics
-      terms: string[]
-      complete: boolean
-    }
+  body: {
+    _shards: ShardStatistics
+    terms: string[]
+    complete: boolean
   }
 }

--- a/specification/_global/termvectors/TermVectorsResponse.ts
+++ b/specification/_global/termvectors/TermVectorsResponse.ts
@@ -23,14 +23,12 @@ import { long } from '@_types/Numeric'
 import { TermVector } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      found: boolean
-      _id: Id
-      _index: IndexName
-      term_vectors?: Dictionary<Field, TermVector>
-      took: long
-      _version: VersionNumber
-    }
+  body: {
+    found: boolean
+    _id: Id
+    _index: IndexName
+    term_vectors?: Dictionary<Field, TermVector>
+    took: long
+    _version: VersionNumber
   }
 }

--- a/specification/_global/update/UpdateResponse.ts
+++ b/specification/_global/update/UpdateResponse.ts
@@ -25,7 +25,5 @@ export class UpdateWriteResponseBase<TDocument> extends WriteResponseBase {
 }
 
 export class Response<TDocument> {
-  '200': {
-    body: UpdateWriteResponseBase<TDocument>
-  }
+  body: UpdateWriteResponseBase<TDocument>
 }

--- a/specification/_global/update_by_query/UpdateByQueryResponse.ts
+++ b/specification/_global/update_by_query/UpdateByQueryResponse.ts
@@ -23,22 +23,20 @@ import { float, long, ulong } from '@_types/Numeric'
 import { Retries } from '@_types/Retries'
 
 export class Response {
-  '200': {
-    body: {
-      batches?: long
-      failures?: BulkIndexByScrollFailure[]
-      noops?: long
-      deleted?: long
-      requests_per_second?: float
-      retries?: Retries
-      task?: TaskId
-      timed_out?: boolean
-      took?: long
-      total?: long
-      updated?: long
-      version_conflicts?: long
-      throttled_millis?: ulong
-      throttled_until_millis?: ulong
-    }
+  body: {
+    batches?: long
+    failures?: BulkIndexByScrollFailure[]
+    noops?: long
+    deleted?: long
+    requests_per_second?: float
+    retries?: Retries
+    task?: TaskId
+    timed_out?: boolean
+    took?: long
+    total?: long
+    updated?: long
+    version_conflicts?: long
+    throttled_millis?: ulong
+    throttled_until_millis?: ulong
   }
 }

--- a/specification/_global/update_by_query_rethrottle/UpdateByQueryRethrottleResponse.ts
+++ b/specification/_global/update_by_query_rethrottle/UpdateByQueryRethrottleResponse.ts
@@ -21,7 +21,5 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { UpdateByQueryRethrottleNode } from './UpdateByQueryRethrottleNode'
 
 export class Response {
-  '200': {
-    body: { nodes: Dictionary<string, UpdateByQueryRethrottleNode> }
-  }
+  body: { nodes: Dictionary<string, UpdateByQueryRethrottleNode> }
 }

--- a/specification/async_search/delete/AsyncSearchDeleteResponse.ts
+++ b/specification/async_search/delete/AsyncSearchDeleteResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/async_search/status/AsyncSearchStatusResponse.ts
+++ b/specification/async_search/status/AsyncSearchStatusResponse.ts
@@ -26,7 +26,5 @@ export class StatusResponseBase extends AsyncSearchResponseBase {
   completion_status?: integer
 }
 export class Response {
-  '200': {
-    body: StatusResponseBase
-  }
+  body: StatusResponseBase
 }

--- a/specification/autoscaling/delete_autoscaling_policy/DeleteAutoscalingPolicyResponse.ts
+++ b/specification/autoscaling/delete_autoscaling_policy/DeleteAutoscalingPolicyResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/autoscaling/get_autoscaling_capacity/GetAutoscalingCapacityResponse.ts
+++ b/specification/autoscaling/get_autoscaling_capacity/GetAutoscalingCapacityResponse.ts
@@ -23,10 +23,8 @@ import { NodeName } from '@_types/common'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
-  '200': {
-    body: {
-      policies: Dictionary<string, AutoscalingDeciders>
-    }
+  body: {
+    policies: Dictionary<string, AutoscalingDeciders>
   }
 }
 

--- a/specification/autoscaling/get_autoscaling_policy/GetAutoscalingPolicyResponse.ts
+++ b/specification/autoscaling/get_autoscaling_policy/GetAutoscalingPolicyResponse.ts
@@ -20,7 +20,5 @@
 import { AutoscalingPolicy } from '@autoscaling/_types/AutoscalingPolicy'
 
 export class Response {
-  '200': {
-    body: AutoscalingPolicy
-  }
+  body: AutoscalingPolicy
 }

--- a/specification/autoscaling/put_autoscaling_policy/PutAutoscalingPolicyResponse.ts
+++ b/specification/autoscaling/put_autoscaling_policy/PutAutoscalingPolicyResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/cat/aliases/CatAliasesResponse.ts
+++ b/specification/cat/aliases/CatAliasesResponse.ts
@@ -20,7 +20,5 @@
 import { AliasesRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<AliasesRecord>
-  }
+  body: Array<AliasesRecord>
 }

--- a/specification/cat/allocation/CatAllocationResponse.ts
+++ b/specification/cat/allocation/CatAllocationResponse.ts
@@ -20,7 +20,5 @@
 import { AllocationRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<AllocationRecord>
-  }
+  body: Array<AllocationRecord>
 }

--- a/specification/cat/count/CatCountResponse.ts
+++ b/specification/cat/count/CatCountResponse.ts
@@ -20,7 +20,5 @@
 import { CountRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<CountRecord>
-  }
+  body: Array<CountRecord>
 }

--- a/specification/cat/fielddata/CatFielddataResponse.ts
+++ b/specification/cat/fielddata/CatFielddataResponse.ts
@@ -20,7 +20,5 @@
 import { FielddataRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<FielddataRecord>
-  }
+  body: Array<FielddataRecord>
 }

--- a/specification/cat/health/CatHealthResponse.ts
+++ b/specification/cat/health/CatHealthResponse.ts
@@ -20,7 +20,5 @@
 import { HealthRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<HealthRecord>
-  }
+  body: Array<HealthRecord>
 }

--- a/specification/cat/help/CatHelpResponse.ts
+++ b/specification/cat/help/CatHelpResponse.ts
@@ -20,7 +20,5 @@
 import { HelpRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<HelpRecord>
-  }
+  body: Array<HelpRecord>
 }

--- a/specification/cat/indices/CatIndicesResponse.ts
+++ b/specification/cat/indices/CatIndicesResponse.ts
@@ -20,7 +20,5 @@
 import { IndicesRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<IndicesRecord>
-  }
+  body: Array<IndicesRecord>
 }

--- a/specification/cat/master/CatMasterResponse.ts
+++ b/specification/cat/master/CatMasterResponse.ts
@@ -20,7 +20,5 @@
 import { MasterRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<MasterRecord>
-  }
+  body: Array<MasterRecord>
 }

--- a/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsResponse.ts
+++ b/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsResponse.ts
@@ -20,7 +20,5 @@
 import { DataFrameAnalyticsRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<DataFrameAnalyticsRecord>
-  }
+  body: Array<DataFrameAnalyticsRecord>
 }

--- a/specification/cat/ml_datafeeds/CatDatafeedsResponse.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsResponse.ts
@@ -20,7 +20,5 @@
 import { DatafeedsRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<DatafeedsRecord>
-  }
+  body: Array<DatafeedsRecord>
 }

--- a/specification/cat/ml_jobs/CatJobsResponse.ts
+++ b/specification/cat/ml_jobs/CatJobsResponse.ts
@@ -20,7 +20,5 @@
 import { JobsRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<JobsRecord>
-  }
+  body: Array<JobsRecord>
 }

--- a/specification/cat/ml_trained_models/CatTrainedModelsResponse.ts
+++ b/specification/cat/ml_trained_models/CatTrainedModelsResponse.ts
@@ -20,7 +20,5 @@
 import { TrainedModelsRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<TrainedModelsRecord>
-  }
+  body: Array<TrainedModelsRecord>
 }

--- a/specification/cat/nodeattrs/CatNodeAttributesResponse.ts
+++ b/specification/cat/nodeattrs/CatNodeAttributesResponse.ts
@@ -20,7 +20,5 @@
 import { NodeAttributesRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<NodeAttributesRecord>
-  }
+  body: Array<NodeAttributesRecord>
 }

--- a/specification/cat/nodes/CatNodesResponse.ts
+++ b/specification/cat/nodes/CatNodesResponse.ts
@@ -20,7 +20,5 @@
 import { NodesRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<NodesRecord>
-  }
+  body: Array<NodesRecord>
 }

--- a/specification/cat/pending_tasks/CatPendingTasksResponse.ts
+++ b/specification/cat/pending_tasks/CatPendingTasksResponse.ts
@@ -20,7 +20,5 @@
 import { PendingTasksRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<PendingTasksRecord>
-  }
+  body: Array<PendingTasksRecord>
 }

--- a/specification/cat/plugins/CatPluginsResponse.ts
+++ b/specification/cat/plugins/CatPluginsResponse.ts
@@ -20,7 +20,5 @@
 import { PluginsRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<PluginsRecord>
-  }
+  body: Array<PluginsRecord>
 }

--- a/specification/cat/recovery/CatRecoveryResponse.ts
+++ b/specification/cat/recovery/CatRecoveryResponse.ts
@@ -20,7 +20,5 @@
 import { RecoveryRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<RecoveryRecord>
-  }
+  body: Array<RecoveryRecord>
 }

--- a/specification/cat/repositories/CatRepositoriesResponse.ts
+++ b/specification/cat/repositories/CatRepositoriesResponse.ts
@@ -20,7 +20,5 @@
 import { RepositoriesRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<RepositoriesRecord>
-  }
+  body: Array<RepositoriesRecord>
 }

--- a/specification/cat/segments/CatSegmentsResponse.ts
+++ b/specification/cat/segments/CatSegmentsResponse.ts
@@ -20,7 +20,5 @@
 import { SegmentsRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<SegmentsRecord>
-  }
+  body: Array<SegmentsRecord>
 }

--- a/specification/cat/shards/CatShardsResponse.ts
+++ b/specification/cat/shards/CatShardsResponse.ts
@@ -20,7 +20,5 @@
 import { ShardsRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<ShardsRecord>
-  }
+  body: Array<ShardsRecord>
 }

--- a/specification/cat/snapshots/CatSnapshotsResponse.ts
+++ b/specification/cat/snapshots/CatSnapshotsResponse.ts
@@ -20,7 +20,5 @@
 import { SnapshotsRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<SnapshotsRecord>
-  }
+  body: Array<SnapshotsRecord>
 }

--- a/specification/cat/tasks/CatTasksResponse.ts
+++ b/specification/cat/tasks/CatTasksResponse.ts
@@ -20,7 +20,5 @@
 import { TasksRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<TasksRecord>
-  }
+  body: Array<TasksRecord>
 }

--- a/specification/cat/templates/CatTemplatesResponse.ts
+++ b/specification/cat/templates/CatTemplatesResponse.ts
@@ -20,7 +20,5 @@
 import { TemplatesRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<TemplatesRecord>
-  }
+  body: Array<TemplatesRecord>
 }

--- a/specification/cat/thread_pool/CatThreadPoolResponse.ts
+++ b/specification/cat/thread_pool/CatThreadPoolResponse.ts
@@ -20,7 +20,5 @@
 import { ThreadPoolRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<ThreadPoolRecord>
-  }
+  body: Array<ThreadPoolRecord>
 }

--- a/specification/cat/transforms/CatTransformsResponse.ts
+++ b/specification/cat/transforms/CatTransformsResponse.ts
@@ -20,7 +20,5 @@
 import { TransformsRecord } from './types'
 
 export class Response {
-  '200': {
-    body: Array<TransformsRecord>
-  }
+  body: Array<TransformsRecord>
 }

--- a/specification/ccr/delete_auto_follow_pattern/DeleteAutoFollowPatternResponse.ts
+++ b/specification/ccr/delete_auto_follow_pattern/DeleteAutoFollowPatternResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ccr/follow/CreateFollowIndexResponse.ts
+++ b/specification/ccr/follow/CreateFollowIndexResponse.ts
@@ -18,11 +18,9 @@
  */
 
 export class Response {
-  '200': {
-    body: {
-      follow_index_created: boolean
-      follow_index_shards_acked: boolean
-      index_following_started: boolean
-    }
+  body: {
+    follow_index_created: boolean
+    follow_index_shards_acked: boolean
+    index_following_started: boolean
   }
 }

--- a/specification/ccr/follow_info/FollowInfoResponse.ts
+++ b/specification/ccr/follow_info/FollowInfoResponse.ts
@@ -20,7 +20,5 @@
 import { FollowerIndex } from './types'
 
 export class Response {
-  '200': {
-    body: { follower_indices: FollowerIndex[] }
-  }
+  body: { follower_indices: FollowerIndex[] }
 }

--- a/specification/ccr/follow_stats/FollowIndexStatsResponse.ts
+++ b/specification/ccr/follow_stats/FollowIndexStatsResponse.ts
@@ -20,7 +20,5 @@
 import { FollowIndexStats } from '@ccr/_types/FollowIndexStats'
 
 export class Response {
-  '200': {
-    body: { indices: FollowIndexStats[] }
-  }
+  body: { indices: FollowIndexStats[] }
 }

--- a/specification/ccr/forget_follower/ForgetFollowerIndexResponse.ts
+++ b/specification/ccr/forget_follower/ForgetFollowerIndexResponse.ts
@@ -20,7 +20,5 @@
 import { ShardStatistics } from '@_types/Stats'
 
 export class Response {
-  '200': {
-    body: { _shards: ShardStatistics }
-  }
+  body: { _shards: ShardStatistics }
 }

--- a/specification/ccr/get_auto_follow_pattern/GetAutoFollowPatternResponse.ts
+++ b/specification/ccr/get_auto_follow_pattern/GetAutoFollowPatternResponse.ts
@@ -20,7 +20,5 @@
 import { AutoFollowPattern } from './types'
 
 export class Response {
-  '200': {
-    body: { patterns: AutoFollowPattern[] }
-  }
+  body: { patterns: AutoFollowPattern[] }
 }

--- a/specification/ccr/pause_auto_follow_pattern/PauseAutoFollowPatternResponse.ts
+++ b/specification/ccr/pause_auto_follow_pattern/PauseAutoFollowPatternResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ccr/pause_follow/PauseFollowIndexResponse.ts
+++ b/specification/ccr/pause_follow/PauseFollowIndexResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ccr/put_auto_follow_pattern/PutAutoFollowPatternResponse.ts
+++ b/specification/ccr/put_auto_follow_pattern/PutAutoFollowPatternResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ccr/resume_auto_follow_pattern/ResumeAutoFollowPatternResponse.ts
+++ b/specification/ccr/resume_auto_follow_pattern/ResumeAutoFollowPatternResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ccr/resume_follow/ResumeFollowIndexResponse.ts
+++ b/specification/ccr/resume_follow/ResumeFollowIndexResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ccr/stats/CcrStatsResponse.ts
+++ b/specification/ccr/stats/CcrStatsResponse.ts
@@ -20,10 +20,8 @@
 import { AutoFollowStats, FollowStats } from './types.ts'
 
 export class Response {
-  '200': {
-    body: {
-      auto_follow_stats: AutoFollowStats
-      follow_stats: FollowStats
-    }
+  body: {
+    auto_follow_stats: AutoFollowStats
+    follow_stats: FollowStats
   }
 }

--- a/specification/ccr/unfollow/UnfollowIndexResponse.ts
+++ b/specification/ccr/unfollow/UnfollowIndexResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/cluster/allocation_explain/ClusterAllocationExplainResponse.ts
+++ b/specification/cluster/allocation_explain/ClusterAllocationExplainResponse.ts
@@ -29,34 +29,32 @@ import {
 } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      allocate_explanation?: string
-      allocation_delay?: string
-      allocation_delay_in_millis?: long
-      can_allocate?: Decision
-      can_move_to_other_node?: Decision
-      can_rebalance_cluster?: Decision
-      can_rebalance_cluster_decisions?: AllocationDecision[]
-      can_rebalance_to_other_node?: Decision
-      can_remain_decisions?: AllocationDecision[]
-      can_remain_on_current_node?: Decision
-      cluster_info?: ClusterInfo
-      configured_delay?: string
-      configured_delay_in_millis?: long
-      current_node?: CurrentNode
-      current_state: string
-      index: IndexName
-      move_explanation?: string
-      node_allocation_decisions?: NodeAllocationExplanation[]
-      primary: boolean
-      rebalance_explanation?: string
-      remaining_delay?: string
-      remaining_delay_in_millis?: long
-      shard: integer
-      unassigned_info?: UnassignedInformation
-      /** @since 7.14.0 */
-      note?: string
-    }
+  body: {
+    allocate_explanation?: string
+    allocation_delay?: string
+    allocation_delay_in_millis?: long
+    can_allocate?: Decision
+    can_move_to_other_node?: Decision
+    can_rebalance_cluster?: Decision
+    can_rebalance_cluster_decisions?: AllocationDecision[]
+    can_rebalance_to_other_node?: Decision
+    can_remain_decisions?: AllocationDecision[]
+    can_remain_on_current_node?: Decision
+    cluster_info?: ClusterInfo
+    configured_delay?: string
+    configured_delay_in_millis?: long
+    current_node?: CurrentNode
+    current_state: string
+    index: IndexName
+    move_explanation?: string
+    node_allocation_decisions?: NodeAllocationExplanation[]
+    primary: boolean
+    rebalance_explanation?: string
+    remaining_delay?: string
+    remaining_delay_in_millis?: long
+    shard: integer
+    unassigned_info?: UnassignedInformation
+    /** @since 7.14.0 */
+    note?: string
   }
 }

--- a/specification/cluster/delete_component_template/ClusterDeleteComponentTemplateResponse.ts
+++ b/specification/cluster/delete_component_template/ClusterDeleteComponentTemplateResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/cluster/delete_voting_config_exclusions/ClusterDeleteVotingConfigExclusionsResponse.ts
+++ b/specification/cluster/delete_voting_config_exclusions/ClusterDeleteVotingConfigExclusionsResponse.ts
@@ -20,7 +20,5 @@
 import { Void } from '@spec_utils/VoidValue'
 
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/cluster/exists_component_template/ClusterComponentTemplateExistsResponse.ts
+++ b/specification/cluster/exists_component_template/ClusterComponentTemplateExistsResponse.ts
@@ -20,7 +20,5 @@
 import { Void } from '@spec_utils/VoidValue'
 
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/cluster/get_component_template/ClusterGetComponentTemplateResponse.ts
+++ b/specification/cluster/get_component_template/ClusterGetComponentTemplateResponse.ts
@@ -20,7 +20,5 @@
 import { ComponentTemplate } from '@cluster/_types/ComponentTemplate'
 
 export class Response {
-  '200': {
-    body: { component_templates: ComponentTemplate[] }
-  }
+  body: { component_templates: ComponentTemplate[] }
 }

--- a/specification/cluster/get_settings/ClusterGetSettingsResponse.ts
+++ b/specification/cluster/get_settings/ClusterGetSettingsResponse.ts
@@ -21,11 +21,9 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
-  '200': {
-    body: {
-      persistent: Dictionary<string, UserDefinedValue>
-      transient: Dictionary<string, UserDefinedValue>
-      defaults?: Dictionary<string, UserDefinedValue>
-    }
+  body: {
+    persistent: Dictionary<string, UserDefinedValue>
+    transient: Dictionary<string, UserDefinedValue>
+    defaults?: Dictionary<string, UserDefinedValue>
   }
 }

--- a/specification/cluster/health/ClusterHealthResponse.ts
+++ b/specification/cluster/health/ClusterHealthResponse.ts
@@ -27,38 +27,36 @@ import { IndexHealthStats } from './types'
  * @doc_id cluster-health
  */
 export class Response {
-  '200': {
-    body: {
-      /** The number of active primary shards. */
-      active_primary_shards: integer
-      /** The total number of active primary and replica shards. */
-      active_shards: integer
-      /** The ratio of active shards in the cluster expressed as a percentage. */
-      active_shards_percent_as_number: Percentage
-      /** The name of the cluster. */
-      cluster_name: Name
-      /** The number of shards whose allocation has been delayed by the timeout settings. */
-      delayed_unassigned_shards: integer
-      indices?: Dictionary<IndexName, IndexHealthStats>
-      /** The number of shards that are under initialization. */
-      initializing_shards: integer
-      /** The number of nodes that are dedicated data nodes. */
-      number_of_data_nodes: integer
-      /** The number of unfinished fetches. */
-      number_of_in_flight_fetch: integer
-      /** The number of nodes within the cluster. */
-      number_of_nodes: integer
-      /** The number of cluster-level changes that have not yet been executed. */
-      number_of_pending_tasks: integer
-      /** The number of shards that are under relocation. */
-      relocating_shards: integer
-      status: HealthStatus
-      /** The time expressed in milliseconds since the earliest initiated task is waiting for being performed. */
-      task_max_waiting_in_queue_millis: EpochMillis
-      /** If false the response returned within the period of time that is specified by the timeout parameter (30s by default) */
-      timed_out: boolean
-      /** The number of shards that are not allocated. */
-      unassigned_shards: integer
-    }
+  body: {
+    /** The number of active primary shards. */
+    active_primary_shards: integer
+    /** The total number of active primary and replica shards. */
+    active_shards: integer
+    /** The ratio of active shards in the cluster expressed as a percentage. */
+    active_shards_percent_as_number: Percentage
+    /** The name of the cluster. */
+    cluster_name: Name
+    /** The number of shards whose allocation has been delayed by the timeout settings. */
+    delayed_unassigned_shards: integer
+    indices?: Dictionary<IndexName, IndexHealthStats>
+    /** The number of shards that are under initialization. */
+    initializing_shards: integer
+    /** The number of nodes that are dedicated data nodes. */
+    number_of_data_nodes: integer
+    /** The number of unfinished fetches. */
+    number_of_in_flight_fetch: integer
+    /** The number of nodes within the cluster. */
+    number_of_nodes: integer
+    /** The number of cluster-level changes that have not yet been executed. */
+    number_of_pending_tasks: integer
+    /** The number of shards that are under relocation. */
+    relocating_shards: integer
+    status: HealthStatus
+    /** The time expressed in milliseconds since the earliest initiated task is waiting for being performed. */
+    task_max_waiting_in_queue_millis: EpochMillis
+    /** If false the response returned within the period of time that is specified by the timeout parameter (30s by default) */
+    timed_out: boolean
+    /** The number of shards that are not allocated. */
+    unassigned_shards: integer
   }
 }

--- a/specification/cluster/pending_tasks/ClusterPendingTasksResponse.ts
+++ b/specification/cluster/pending_tasks/ClusterPendingTasksResponse.ts
@@ -20,7 +20,5 @@
 import { PendingTask } from './types'
 
 export class Response {
-  '200': {
-    body: { tasks: PendingTask[] }
-  }
+  body: { tasks: PendingTask[] }
 }

--- a/specification/cluster/post_voting_config_exclusions/ClusterPostVotingConfigExclusionsResponse.ts
+++ b/specification/cluster/post_voting_config_exclusions/ClusterPostVotingConfigExclusionsResponse.ts
@@ -20,7 +20,5 @@
 import { Void } from '@spec_utils/VoidValue'
 
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/cluster/put_component_template/ClusterPutComponentTemplateResponse.ts
+++ b/specification/cluster/put_component_template/ClusterPutComponentTemplateResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/cluster/put_settings/ClusterPutSettingsResponse.ts
+++ b/specification/cluster/put_settings/ClusterPutSettingsResponse.ts
@@ -21,11 +21,9 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      persistent: Dictionary<string, UserDefinedValue>
-      transient: Dictionary<string, UserDefinedValue>
-    }
+  body: {
+    acknowledged: boolean
+    persistent: Dictionary<string, UserDefinedValue>
+    transient: Dictionary<string, UserDefinedValue>
   }
 }

--- a/specification/cluster/remote_info/ClusterRemoteInfoResponse.ts
+++ b/specification/cluster/remote_info/ClusterRemoteInfoResponse.ts
@@ -22,9 +22,7 @@ import { integer, long } from '@_types/Numeric'
 import { Time } from '@_types/Time'
 
 export class Response {
-  '200': {
-    body: Dictionary<string, ClusterRemoteInfo>
-  }
+  body: Dictionary<string, ClusterRemoteInfo>
 }
 
 /** @variants internal tag='mode' */

--- a/specification/cluster/reroute/ClusterRerouteResponse.ts
+++ b/specification/cluster/reroute/ClusterRerouteResponse.ts
@@ -21,16 +21,14 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RerouteExplanation } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      explanations?: RerouteExplanation[]
-      /**
-       * There aren't any guarantees on the output/structure of the raw cluster state.
-       * Here you will find the internal representation of the cluster, which can
-       * differ from the external representation.
-       */
-      state: UserDefinedValue
-    }
+  body: {
+    acknowledged: boolean
+    explanations?: RerouteExplanation[]
+    /**
+     * There aren't any guarantees on the output/structure of the raw cluster state.
+     * Here you will find the internal representation of the cluster, which can
+     * differ from the external representation.
+     */
+    state: UserDefinedValue
   }
 }

--- a/specification/cluster/state/ClusterStateResponse.ts
+++ b/specification/cluster/state/ClusterStateResponse.ts
@@ -25,7 +25,5 @@ export class Response {
    * Here you will find the internal representation of the cluster, which can
    * differ from the external representation.
    */
-  '200': {
-    body: UserDefinedValue
-  }
+  body: UserDefinedValue
 }

--- a/specification/cluster/stats/ClusterStatsResponse.ts
+++ b/specification/cluster/stats/ClusterStatsResponse.ts
@@ -53,7 +53,5 @@ export class StatsResponseBase extends NodesResponseBase {
 }
 
 export class Response {
-  '200': {
-    body: StatsResponseBase
-  }
+  body: StatsResponseBase
 }

--- a/specification/dangling_indices/delete_dangling_index/DeleteDanglingIndexResponse.ts
+++ b/specification/dangling_indices/delete_dangling_index/DeleteDanglingIndexResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/dangling_indices/import_dangling_index/ImportDanglingIndexResponse.ts
+++ b/specification/dangling_indices/import_dangling_index/ImportDanglingIndexResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/dangling_indices/list_dangling_indices/ListDanglingIndicesResponse.ts
+++ b/specification/dangling_indices/list_dangling_indices/ListDanglingIndicesResponse.ts
@@ -21,10 +21,8 @@ import { Ids } from '@_types/common'
 import { EpochMillis } from '@_types/Time'
 
 export class Response {
-  '200': {
-    body: {
-      dangling_indices: DanglingIndex[]
-    }
+  body: {
+    dangling_indices: DanglingIndex[]
   }
 }
 

--- a/specification/enrich/delete_policy/DeleteEnrichPolicyResponse.ts
+++ b/specification/enrich/delete_policy/DeleteEnrichPolicyResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/enrich/execute_policy/ExecuteEnrichPolicyResponse.ts
+++ b/specification/enrich/execute_policy/ExecuteEnrichPolicyResponse.ts
@@ -21,10 +21,8 @@ import { TaskId } from '@_types/common'
 import { ExecuteEnrichPolicyStatus } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      status: ExecuteEnrichPolicyStatus
-      task_id?: TaskId
-    }
+  body: {
+    status: ExecuteEnrichPolicyStatus
+    task_id?: TaskId
   }
 }

--- a/specification/enrich/get_policy/GetEnrichPolicyResponse.ts
+++ b/specification/enrich/get_policy/GetEnrichPolicyResponse.ts
@@ -20,7 +20,5 @@
 import { Summary } from '@enrich/_types/Policy'
 
 export class Response {
-  '200': {
-    body: { policies: Summary[] }
-  }
+  body: { policies: Summary[] }
 }

--- a/specification/enrich/put_policy/PutEnrichPolicyResponse.ts
+++ b/specification/enrich/put_policy/PutEnrichPolicyResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/enrich/stats/EnrichStatsResponse.ts
+++ b/specification/enrich/stats/EnrichStatsResponse.ts
@@ -20,12 +20,10 @@
 import { ExecutingPolicy, CoordinatorStats, CacheStats } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      coordinator_stats: CoordinatorStats[]
-      executing_policies: ExecutingPolicy[]
-      /** @since 7.16.0 */
-      cache_stats?: CacheStats[]
-    }
+  body: {
+    coordinator_stats: CoordinatorStats[]
+    executing_policies: ExecutingPolicy[]
+    /** @since 7.16.0 */
+    cache_stats?: CacheStats[]
   }
 }

--- a/specification/eql/delete/EqlDeleteResponse.ts
+++ b/specification/eql/delete/EqlDeleteResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/eql/get_status/EqlGetStatusResponse.ts
+++ b/specification/eql/get_status/EqlGetStatusResponse.ts
@@ -22,32 +22,30 @@ import { integer } from '@_types/Numeric'
 import { EpochMillis } from '@_types/Time'
 
 export class Response {
-  '200': {
-    body: {
-      /**
-       * Identifier for the search.
-       */
-      id: Id
-      /**
-       * If true, the search request is still executing. If false, the search is completed.
-       */
-      is_partial: boolean
-      /**
-       * If true, the response does not contain complete search results. This could be because either the search is still running (is_running status is false), or because it is already completed (is_running status is true) and results are partial due to failures or timeouts.
-       */
-      is_running: boolean
-      /**
-       * For a running search shows a timestamp when the eql search started, in milliseconds since the Unix epoch.
-       */
-      start_time_in_millis?: EpochMillis
-      /**
-       * Shows a timestamp when the eql search will be expired, in milliseconds since the Unix epoch. When this time is reached, the search and its results are deleted, even if the search is still ongoing.
-       */
-      expiration_time_in_millis?: EpochMillis
-      /**
-       * For a completed search shows the http status code of the completed search.
-       */
-      completion_status?: integer
-    }
+  body: {
+    /**
+     * Identifier for the search.
+     */
+    id: Id
+    /**
+     * If true, the search request is still executing. If false, the search is completed.
+     */
+    is_partial: boolean
+    /**
+     * If true, the response does not contain complete search results. This could be because either the search is still running (is_running status is false), or because it is already completed (is_running status is true) and results are partial due to failures or timeouts.
+     */
+    is_running: boolean
+    /**
+     * For a running search shows a timestamp when the eql search started, in milliseconds since the Unix epoch.
+     */
+    start_time_in_millis?: EpochMillis
+    /**
+     * Shows a timestamp when the eql search will be expired, in milliseconds since the Unix epoch. When this time is reached, the search and its results are deleted, even if the search is still ongoing.
+     */
+    expiration_time_in_millis?: EpochMillis
+    /**
+     * For a completed search shows the http status code of the completed search.
+     */
+    completion_status?: integer
   }
 }

--- a/specification/features/get_features/GetFeaturesResponse.ts
+++ b/specification/features/get_features/GetFeaturesResponse.ts
@@ -20,9 +20,7 @@
 import { Feature } from '../_types/Feature'
 
 export class Response {
-  '200': {
-    body: {
-      features: Feature[]
-    }
+  body: {
+    features: Feature[]
   }
 }

--- a/specification/features/reset_features/ResetFeaturesResponse.ts
+++ b/specification/features/reset_features/ResetFeaturesResponse.ts
@@ -20,9 +20,7 @@
 import { Feature } from '../_types/Feature'
 
 export class Response {
-  '200': {
-    body: {
-      features: Feature[]
-    }
+  body: {
+    features: Feature[]
   }
 }

--- a/specification/fleet/global_checkpoints/GlobalCheckpointsResponse.ts
+++ b/specification/fleet/global_checkpoints/GlobalCheckpointsResponse.ts
@@ -20,10 +20,8 @@
 import { Checkpoint } from '../_types/Checkpoints'
 
 export class Response {
-  '200': {
-    body: {
-      global_checkpoints: Checkpoint[]
-      timed_out: boolean
-    }
+  body: {
+    global_checkpoints: Checkpoint[]
+    timed_out: boolean
   }
 }

--- a/specification/fleet/msearch/MultiSearchResponse.ts
+++ b/specification/fleet/msearch/MultiSearchResponse.ts
@@ -23,9 +23,7 @@ import { ResponseItem } from '_global/msearch/types'
 // - msearch
 // - fleet.msearch
 export class Response<TDocument> {
-  '200': {
-    body: {
-      docs: ResponseItem<TDocument>[]
-    }
+  body: {
+    docs: ResponseItem<TDocument>[]
   }
 }

--- a/specification/fleet/search/SearchResponse.ts
+++ b/specification/fleet/search/SearchResponse.ts
@@ -31,22 +31,20 @@ import { ClusterStatistics, ShardStatistics } from '@_types/Stats'
 // - search
 // - fleet.search
 export class Response<TDocument> {
-  '200': {
-    body: {
-      took: long
-      timed_out: boolean
-      _shards: ShardStatistics
-      hits: HitsMetadata<TDocument>
-      aggregations?: Dictionary<AggregateName, Aggregate>
-      _clusters?: ClusterStatistics
-      fields?: Dictionary<string, UserDefinedValue>
-      max_score?: double
-      num_reduce_phases?: long
-      profile?: Profile
-      pit_id?: Id
-      _scroll_id?: ScrollId
-      suggest?: Dictionary<SuggestionName, Suggest<TDocument>[]>
-      terminated_early?: boolean
-    }
+  body: {
+    took: long
+    timed_out: boolean
+    _shards: ShardStatistics
+    hits: HitsMetadata<TDocument>
+    aggregations?: Dictionary<AggregateName, Aggregate>
+    _clusters?: ClusterStatistics
+    fields?: Dictionary<string, UserDefinedValue>
+    max_score?: double
+    num_reduce_phases?: long
+    profile?: Profile
+    pit_id?: Id
+    _scroll_id?: ScrollId
+    suggest?: Dictionary<SuggestionName, Suggest<TDocument>[]>
+    terminated_early?: boolean
   }
 }

--- a/specification/graph/explore/GraphExploreResponse.ts
+++ b/specification/graph/explore/GraphExploreResponse.ts
@@ -23,13 +23,11 @@ import { long } from '@_types/Numeric'
 import { Connection } from '../_types/Connection'
 
 export class Response {
-  '200': {
-    body: {
-      connections: Connection[]
-      failures: ShardFailure[]
-      timed_out: boolean
-      took: long
-      vertices: Vertex[]
-    }
+  body: {
+    connections: Connection[]
+    failures: ShardFailure[]
+    timed_out: boolean
+    took: long
+    vertices: Vertex[]
   }
 }

--- a/specification/ilm/delete_lifecycle/DeleteLifecycleResponse.ts
+++ b/specification/ilm/delete_lifecycle/DeleteLifecycleResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ilm/explain_lifecycle/ExplainLifecycleResponse.ts
+++ b/specification/ilm/explain_lifecycle/ExplainLifecycleResponse.ts
@@ -22,9 +22,7 @@ import { IndexName } from '@_types/common'
 import { LifecycleExplain } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      indices: Dictionary<IndexName, LifecycleExplain>
-    }
+  body: {
+    indices: Dictionary<IndexName, LifecycleExplain>
   }
 }

--- a/specification/ilm/get_lifecycle/GetLifecycleResponse.ts
+++ b/specification/ilm/get_lifecycle/GetLifecycleResponse.ts
@@ -21,7 +21,5 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Lifecycle } from './types'
 
 export class Response {
-  '200': {
-    body: Dictionary<string, Lifecycle>
-  }
+  body: Dictionary<string, Lifecycle>
 }

--- a/specification/ilm/get_status/GetIlmStatusResponse.ts
+++ b/specification/ilm/get_status/GetIlmStatusResponse.ts
@@ -20,7 +20,5 @@
 import { LifecycleOperationMode } from '@_types/Lifecycle'
 
 export class Response {
-  '200': {
-    body: { operation_mode: LifecycleOperationMode }
-  }
+  body: { operation_mode: LifecycleOperationMode }
 }

--- a/specification/ilm/migrate_to_data_tiers/Response.ts
+++ b/specification/ilm/migrate_to_data_tiers/Response.ts
@@ -20,15 +20,13 @@
 import { Indices } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      dry_run: boolean
-      removed_legacy_template: string
-      migrated_ilm_policies: string[]
-      migrated_indices: Indices
-      migrated_legacy_templates: string[]
-      migrated_composable_templates: string[]
-      migrated_component_templates: string[]
-    }
+  body: {
+    dry_run: boolean
+    removed_legacy_template: string
+    migrated_ilm_policies: string[]
+    migrated_indices: Indices
+    migrated_legacy_templates: string[]
+    migrated_composable_templates: string[]
+    migrated_component_templates: string[]
   }
 }

--- a/specification/ilm/move_to_step/MoveToStepResponse.ts
+++ b/specification/ilm/move_to_step/MoveToStepResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ilm/put_lifecycle/PutLifecycleResponse.ts
+++ b/specification/ilm/put_lifecycle/PutLifecycleResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ilm/remove_policy/RemovePolicyResponse.ts
+++ b/specification/ilm/remove_policy/RemovePolicyResponse.ts
@@ -20,10 +20,8 @@
 import { IndexName } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      failed_indexes: IndexName[]
-      has_failures: boolean
-    }
+  body: {
+    failed_indexes: IndexName[]
+    has_failures: boolean
   }
 }

--- a/specification/ilm/retry/RetryIlmResponse.ts
+++ b/specification/ilm/retry/RetryIlmResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ilm/start/StartIlmResponse.ts
+++ b/specification/ilm/start/StartIlmResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ilm/stop/StopIlmResponse.ts
+++ b/specification/ilm/stop/StopIlmResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/indices/add_block/IndicesAddBlockResponse.ts
+++ b/specification/indices/add_block/IndicesAddBlockResponse.ts
@@ -20,12 +20,10 @@
 import { IndexName } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      shards_acknowledged: boolean
-      indices: IndicesBlockStatus[]
-    }
+  body: {
+    acknowledged: boolean
+    shards_acknowledged: boolean
+    indices: IndicesBlockStatus[]
   }
 }
 

--- a/specification/indices/analyze/IndicesAnalyzeResponse.ts
+++ b/specification/indices/analyze/IndicesAnalyzeResponse.ts
@@ -20,10 +20,8 @@
 import { AnalyzeDetail, AnalyzeToken } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      detail?: AnalyzeDetail
-      tokens?: AnalyzeToken[]
-    }
+  body: {
+    detail?: AnalyzeDetail
+    tokens?: AnalyzeToken[]
   }
 }

--- a/specification/indices/clear_cache/IndicesClearCacheResponse.ts
+++ b/specification/indices/clear_cache/IndicesClearCacheResponse.ts
@@ -20,7 +20,5 @@
 import { ShardsOperationResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: ShardsOperationResponseBase
-  }
+  body: ShardsOperationResponseBase
 }

--- a/specification/indices/clone/IndicesCloneResponse.ts
+++ b/specification/indices/clone/IndicesCloneResponse.ts
@@ -20,11 +20,9 @@
 import { IndexName } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      index: IndexName
-      shards_acknowledged: boolean
-    }
+  body: {
+    acknowledged: boolean
+    index: IndexName
+    shards_acknowledged: boolean
   }
 }

--- a/specification/indices/close/CloseIndexResponse.ts
+++ b/specification/indices/close/CloseIndexResponse.ts
@@ -22,12 +22,10 @@ import { IndexName } from '@_types/common'
 import { ShardFailure } from '@_types/Errors'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      indices: Dictionary<IndexName, CloseIndexResult>
-      shards_acknowledged: boolean
-    }
+  body: {
+    acknowledged: boolean
+    indices: Dictionary<IndexName, CloseIndexResult>
+    shards_acknowledged: boolean
   }
 }
 

--- a/specification/indices/create/IndicesCreateResponse.ts
+++ b/specification/indices/create/IndicesCreateResponse.ts
@@ -20,11 +20,9 @@
 import { IndexName } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      index: IndexName
-      shards_acknowledged: boolean
-      acknowledged?: boolean
-    }
+  body: {
+    index: IndexName
+    shards_acknowledged: boolean
+    acknowledged?: boolean
   }
 }

--- a/specification/indices/create_data_stream/IndicesCreateDataStreamResponse.ts
+++ b/specification/indices/create_data_stream/IndicesCreateDataStreamResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsResponse.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsResponse.ts
@@ -22,15 +22,13 @@ import { integer, long } from '@_types/Numeric'
 import { ShardStatistics } from '@_types/Stats'
 
 export class Response {
-  '200': {
-    body: {
-      _shards: ShardStatistics
-      backing_indices: integer
-      data_stream_count: integer
-      total_store_sizes?: ByteSize
-      total_store_size_bytes: integer
-      data_streams: DataStreamsStatsItem[]
-    }
+  body: {
+    _shards: ShardStatistics
+    backing_indices: integer
+    data_stream_count: integer
+    total_store_sizes?: ByteSize
+    total_store_size_bytes: integer
+    data_streams: DataStreamsStatsItem[]
   }
 }
 

--- a/specification/indices/delete/IndicesDeleteResponse.ts
+++ b/specification/indices/delete/IndicesDeleteResponse.ts
@@ -20,7 +20,5 @@
 import { IndicesResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: IndicesResponseBase
-  }
+  body: IndicesResponseBase
 }

--- a/specification/indices/delete_alias/IndicesDeleteAliasResponse.ts
+++ b/specification/indices/delete_alias/IndicesDeleteAliasResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/indices/delete_data_stream/IndicesDeleteDataStreamResponse.ts
+++ b/specification/indices/delete_data_stream/IndicesDeleteDataStreamResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/indices/delete_index_template/IndicesDeleteIndexTemplateResponse.ts
+++ b/specification/indices/delete_index_template/IndicesDeleteIndexTemplateResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/indices/delete_template/IndicesDeleteTemplateResponse.ts
+++ b/specification/indices/delete_template/IndicesDeleteTemplateResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/indices/disk_usage/IndicesDiskUsageResponse.ts
+++ b/specification/indices/disk_usage/IndicesDiskUsageResponse.ts
@@ -20,7 +20,5 @@
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
-  '200': {
-    body: UserDefinedValue
-  }
+  body: UserDefinedValue
 }

--- a/specification/indices/exists/IndicesExistsResponse.ts
+++ b/specification/indices/exists/IndicesExistsResponse.ts
@@ -20,7 +20,5 @@
 import { Void } from '@spec_utils/VoidValue'
 
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/indices/exists_alias/IndicesExistsAliasResponse.ts
+++ b/specification/indices/exists_alias/IndicesExistsAliasResponse.ts
@@ -20,7 +20,5 @@
 import { Void } from '@spec_utils/VoidValue'
 
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/indices/exists_index_template/IndicesExistsIndexTemplateResponse.ts
+++ b/specification/indices/exists_index_template/IndicesExistsIndexTemplateResponse.ts
@@ -25,7 +25,5 @@ import { Void } from '@spec_utils/VoidValue'
  * 404: Indicates one or more specified index templates do not exist.
  */
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/indices/exists_template/IndicesExistsTemplateResponse.ts
+++ b/specification/indices/exists_template/IndicesExistsTemplateResponse.ts
@@ -20,7 +20,5 @@
 import { Void } from '@spec_utils/VoidValue'
 
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/indices/field_usage_stats/IndicesFieldUsageStatsResponse.ts
+++ b/specification/indices/field_usage_stats/IndicesFieldUsageStatsResponse.ts
@@ -26,9 +26,7 @@ import { ShardStatistics } from '@_types/Stats'
 import { EpochMillis } from '@_types/Time'
 
 export class Response {
-  '200': {
-    body: FieldsUsageBody
-  }
+  body: FieldsUsageBody
 }
 
 export class FieldsUsageBody

--- a/specification/indices/flush/IndicesFlushResponse.ts
+++ b/specification/indices/flush/IndicesFlushResponse.ts
@@ -20,7 +20,5 @@
 import { ShardsOperationResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: ShardsOperationResponseBase
-  }
+  body: ShardsOperationResponseBase
 }

--- a/specification/indices/forcemerge/IndicesForceMergeResponse.ts
+++ b/specification/indices/forcemerge/IndicesForceMergeResponse.ts
@@ -20,7 +20,5 @@
 import { ShardsOperationResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: ShardsOperationResponseBase
-  }
+  body: ShardsOperationResponseBase
 }

--- a/specification/indices/get/IndicesGetResponse.ts
+++ b/specification/indices/get/IndicesGetResponse.ts
@@ -22,7 +22,5 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { IndexName } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: Dictionary<IndexName, IndexState>
-  }
+  body: Dictionary<IndexName, IndexState>
 }

--- a/specification/indices/get_alias/IndicesGetAliasResponse.ts
+++ b/specification/indices/get_alias/IndicesGetAliasResponse.ts
@@ -22,9 +22,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { IndexName } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: Dictionary<IndexName, IndexAliases>
-  }
+  body: Dictionary<IndexName, IndexAliases>
 }
 
 export class IndexAliases {

--- a/specification/indices/get_data_stream/IndicesGetDataStreamResponse.ts
+++ b/specification/indices/get_data_stream/IndicesGetDataStreamResponse.ts
@@ -20,7 +20,5 @@
 import { DataStream } from '@indices/_types/DataStream'
 
 export class Response {
-  '200': {
-    body: { data_streams: DataStream[] }
-  }
+  body: { data_streams: DataStream[] }
 }

--- a/specification/indices/get_field_mapping/IndicesGetFieldMappingResponse.ts
+++ b/specification/indices/get_field_mapping/IndicesGetFieldMappingResponse.ts
@@ -22,7 +22,5 @@ import { IndexName } from '@_types/common'
 import { TypeFieldMappings } from './types'
 
 export class Response {
-  '200': {
-    body: Dictionary<IndexName, TypeFieldMappings>
-  }
+  body: Dictionary<IndexName, TypeFieldMappings>
 }

--- a/specification/indices/get_index_template/IndicesGetIndexTemplateResponse.ts
+++ b/specification/indices/get_index_template/IndicesGetIndexTemplateResponse.ts
@@ -21,10 +21,8 @@ import { IndexTemplate } from '@indices/_types/IndexTemplate'
 import { Name } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      index_templates: IndexTemplateItem[]
-    }
+  body: {
+    index_templates: IndexTemplateItem[]
   }
 }
 

--- a/specification/indices/get_mapping/IndicesGetMappingResponse.ts
+++ b/specification/indices/get_mapping/IndicesGetMappingResponse.ts
@@ -22,9 +22,7 @@ import { IndexName } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 
 export class Response {
-  '200': {
-    body: Dictionary<IndexName, IndexMappingRecord>
-  }
+  body: Dictionary<IndexName, IndexMappingRecord>
 }
 
 export class IndexMappingRecord {

--- a/specification/indices/get_settings/IndicesGetSettingsResponse.ts
+++ b/specification/indices/get_settings/IndicesGetSettingsResponse.ts
@@ -22,7 +22,5 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { IndexName } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: Dictionary<IndexName, IndexState>
-  }
+  body: Dictionary<IndexName, IndexState>
 }

--- a/specification/indices/get_template/IndicesGetTemplateResponse.ts
+++ b/specification/indices/get_template/IndicesGetTemplateResponse.ts
@@ -21,7 +21,5 @@ import { TemplateMapping } from '@indices/_types/TemplateMapping'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  '200': {
-    body: Dictionary<string, TemplateMapping>
-  }
+  body: Dictionary<string, TemplateMapping>
 }

--- a/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamResponse.ts
+++ b/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/indices/open/IndicesOpenResponse.ts
+++ b/specification/indices/open/IndicesOpenResponse.ts
@@ -18,10 +18,8 @@
  */
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      shards_acknowledged: boolean
-    }
+  body: {
+    acknowledged: boolean
+    shards_acknowledged: boolean
   }
 }

--- a/specification/indices/promote_data_stream/IndicesPromoteDataStreamResponse.ts
+++ b/specification/indices/promote_data_stream/IndicesPromoteDataStreamResponse.ts
@@ -20,7 +20,5 @@
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
-  '200': {
-    body: UserDefinedValue
-  }
+  body: UserDefinedValue
 }

--- a/specification/indices/put_alias/IndicesPutAliasResponse.ts
+++ b/specification/indices/put_alias/IndicesPutAliasResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateResponse.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/indices/put_mapping/IndicesPutMappingResponse.ts
+++ b/specification/indices/put_mapping/IndicesPutMappingResponse.ts
@@ -20,7 +20,5 @@
 import { IndicesResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: IndicesResponseBase
-  }
+  body: IndicesResponseBase
 }

--- a/specification/indices/put_settings/IndicesPutSettingsResponse.ts
+++ b/specification/indices/put_settings/IndicesPutSettingsResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/indices/put_template/IndicesPutTemplateResponse.ts
+++ b/specification/indices/put_template/IndicesPutTemplateResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/indices/recovery/IndicesRecoveryResponse.ts
+++ b/specification/indices/recovery/IndicesRecoveryResponse.ts
@@ -22,7 +22,5 @@ import { IndexName } from '@_types/common'
 import { RecoveryStatus } from './types'
 
 export class Response {
-  '200': {
-    body: Dictionary<IndexName, RecoveryStatus>
-  }
+  body: Dictionary<IndexName, RecoveryStatus>
 }

--- a/specification/indices/refresh/IndicesRefreshResponse.ts
+++ b/specification/indices/refresh/IndicesRefreshResponse.ts
@@ -20,7 +20,5 @@
 import { ShardsOperationResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: ShardsOperationResponseBase
-  }
+  body: ShardsOperationResponseBase
 }

--- a/specification/indices/reload_search_analyzers/ReloadSearchAnalyzersResponse.ts
+++ b/specification/indices/reload_search_analyzers/ReloadSearchAnalyzersResponse.ts
@@ -21,7 +21,5 @@ import { ShardStatistics } from '@_types/Stats'
 import { ReloadDetails } from './types'
 
 export class Response {
-  '200': {
-    body: { reload_details: ReloadDetails[]; _shards: ShardStatistics }
-  }
+  body: { reload_details: ReloadDetails[]; _shards: ShardStatistics }
 }

--- a/specification/indices/resolve_index/ResolveIndexResponse.ts
+++ b/specification/indices/resolve_index/ResolveIndexResponse.ts
@@ -20,12 +20,10 @@
 import { DataStreamName, Field, Indices, Name } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      indices: ResolveIndexItem[]
-      aliases: ResolveIndexAliasItem[]
-      data_streams: ResolveIndexDataStreamsItem[]
-    }
+  body: {
+    indices: ResolveIndexItem[]
+    aliases: ResolveIndexAliasItem[]
+    data_streams: ResolveIndexDataStreamsItem[]
   }
 }
 

--- a/specification/indices/rollover/IndicesRolloverResponse.ts
+++ b/specification/indices/rollover/IndicesRolloverResponse.ts
@@ -20,15 +20,13 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      conditions: Dictionary<string, boolean>
-      dry_run: boolean
-      new_index: string
-      old_index: string
-      rolled_over: boolean
-      shards_acknowledged: boolean
-    }
+  body: {
+    acknowledged: boolean
+    conditions: Dictionary<string, boolean>
+    dry_run: boolean
+    new_index: string
+    old_index: string
+    rolled_over: boolean
+    shards_acknowledged: boolean
   }
 }

--- a/specification/indices/segments/IndicesSegmentsResponse.ts
+++ b/specification/indices/segments/IndicesSegmentsResponse.ts
@@ -22,10 +22,8 @@ import { ShardStatistics } from '@_types/Stats'
 import { IndexSegment } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      indices: Dictionary<string, IndexSegment>
-      _shards: ShardStatistics
-    }
+  body: {
+    indices: Dictionary<string, IndexSegment>
+    _shards: ShardStatistics
   }
 }

--- a/specification/indices/shard_stores/IndicesShardStoresResponse.ts
+++ b/specification/indices/shard_stores/IndicesShardStoresResponse.ts
@@ -22,7 +22,5 @@ import { IndexName } from '@_types/common'
 import { IndicesShardStores } from './types'
 
 export class Response {
-  '200': {
-    body: { indices: Dictionary<IndexName, IndicesShardStores> }
-  }
+  body: { indices: Dictionary<IndexName, IndicesShardStores> }
 }

--- a/specification/indices/shrink/IndicesShrinkResponse.ts
+++ b/specification/indices/shrink/IndicesShrinkResponse.ts
@@ -20,11 +20,9 @@
 import { IndexName } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      shards_acknowledged: boolean
-      index: IndexName
-    }
+  body: {
+    acknowledged: boolean
+    shards_acknowledged: boolean
+    index: IndexName
   }
 }

--- a/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateResponse.ts
+++ b/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: {}
-  }
+  body: {}
 }

--- a/specification/indices/simulate_template/IndicesSimulateTemplateResponse.ts
+++ b/specification/indices/simulate_template/IndicesSimulateTemplateResponse.ts
@@ -24,11 +24,9 @@ import { IndexName, Name } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 
 export class Response {
-  '200': {
-    body: {
-      overlapping?: Overlapping[]
-      template: Template
-    }
+  body: {
+    overlapping?: Overlapping[]
+    template: Template
   }
 }
 

--- a/specification/indices/split/IndicesSplitResponse.ts
+++ b/specification/indices/split/IndicesSplitResponse.ts
@@ -20,11 +20,9 @@
 import { IndexName } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      shards_acknowledged: boolean
-      index: IndexName
-    }
+  body: {
+    acknowledged: boolean
+    shards_acknowledged: boolean
+    index: IndexName
   }
 }

--- a/specification/indices/stats/IndicesStatsResponse.ts
+++ b/specification/indices/stats/IndicesStatsResponse.ts
@@ -22,11 +22,9 @@ import { ShardStatistics } from '@_types/Stats'
 import { IndicesStats } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      indices?: Dictionary<string, IndicesStats>
-      _shards: ShardStatistics
-      _all: IndicesStats
-    }
+  body: {
+    indices?: Dictionary<string, IndicesStats>
+    _shards: ShardStatistics
+    _all: IndicesStats
   }
 }

--- a/specification/indices/unfreeze/IndicesUnfreezeResponse.ts
+++ b/specification/indices/unfreeze/IndicesUnfreezeResponse.ts
@@ -18,10 +18,8 @@
  */
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      shards_acknowledged: boolean
-    }
+  body: {
+    acknowledged: boolean
+    shards_acknowledged: boolean
   }
 }

--- a/specification/indices/update_aliases/IndicesUpdateAliasesResponse.ts
+++ b/specification/indices/update_aliases/IndicesUpdateAliasesResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/indices/validate_query/IndicesValidateQueryResponse.ts
+++ b/specification/indices/validate_query/IndicesValidateQueryResponse.ts
@@ -21,13 +21,11 @@ import { IndexName } from '@_types/common'
 import { ShardStatistics } from '@_types/Stats'
 
 export class Response {
-  '200': {
-    body: {
-      explanations?: IndicesValidationExplanation[]
-      _shards?: ShardStatistics
-      valid: boolean
-      error?: string
-    }
+  body: {
+    explanations?: IndicesValidationExplanation[]
+    _shards?: ShardStatistics
+    valid: boolean
+    error?: string
   }
 }
 

--- a/specification/ingest/delete_pipeline/DeletePipelineResponse.ts
+++ b/specification/ingest/delete_pipeline/DeletePipelineResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ingest/geo_ip_stats/IngestGeoIpStatsResponse.ts
+++ b/specification/ingest/geo_ip_stats/IngestGeoIpStatsResponse.ts
@@ -22,12 +22,10 @@ import { Id } from '@_types/common'
 import { GeoIpDownloadStatistics, GeoIpNodeDatabases } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      /** Download statistics for all GeoIP2 databases. */
-      stats: GeoIpDownloadStatistics
-      /** Downloaded GeoIP2 databases for each node. */
-      nodes: Dictionary<Id, GeoIpNodeDatabases>
-    }
+  body: {
+    /** Download statistics for all GeoIP2 databases. */
+    stats: GeoIpDownloadStatistics
+    /** Downloaded GeoIP2 databases for each node. */
+    nodes: Dictionary<Id, GeoIpNodeDatabases>
   }
 }

--- a/specification/ingest/get_pipeline/GetPipelineResponse.ts
+++ b/specification/ingest/get_pipeline/GetPipelineResponse.ts
@@ -21,7 +21,5 @@ import { Pipeline } from '@ingest/_types/Pipeline'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  '200': {
-    body: Dictionary<string, Pipeline>
-  }
+  body: Dictionary<string, Pipeline>
 }

--- a/specification/ingest/processor_grok/GrokProcessorPatternsResponse.ts
+++ b/specification/ingest/processor_grok/GrokProcessorPatternsResponse.ts
@@ -20,7 +20,5 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  '200': {
-    body: { patterns: Dictionary<string, string> }
-  }
+  body: { patterns: Dictionary<string, string> }
 }

--- a/specification/ingest/put_pipeline/PutPipelineResponse.ts
+++ b/specification/ingest/put_pipeline/PutPipelineResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ingest/simulate/SimulatePipelineResponse.ts
+++ b/specification/ingest/simulate/SimulatePipelineResponse.ts
@@ -20,7 +20,5 @@
 import { PipelineSimulation } from './types'
 
 export class Response {
-  '200': {
-    body: { docs: PipelineSimulation[] }
-  }
+  body: { docs: PipelineSimulation[] }
 }

--- a/specification/license/delete/DeleteLicenseResponse.ts
+++ b/specification/license/delete/DeleteLicenseResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/license/get/GetLicenseResponse.ts
+++ b/specification/license/get/GetLicenseResponse.ts
@@ -20,7 +20,5 @@
 import { LicenseInformation } from './types'
 
 export class Response {
-  '200': {
-    body: { license: LicenseInformation }
-  }
+  body: { license: LicenseInformation }
 }

--- a/specification/license/get_basic_status/GetBasicLicenseStatusResponse.ts
+++ b/specification/license/get_basic_status/GetBasicLicenseStatusResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { eligible_to_start_basic: boolean }
-  }
+  body: { eligible_to_start_basic: boolean }
 }

--- a/specification/license/get_trial_status/GetTrialLicenseStatusResponse.ts
+++ b/specification/license/get_trial_status/GetTrialLicenseStatusResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { eligible_to_start_trial: boolean }
-  }
+  body: { eligible_to_start_trial: boolean }
 }

--- a/specification/license/post/PostLicenseResponse.ts
+++ b/specification/license/post/PostLicenseResponse.ts
@@ -21,11 +21,9 @@ import { LicenseStatus } from '@license/_types/License'
 import { Acknowledgement } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledge?: Acknowledgement
-      acknowledged: boolean
-      license_status: LicenseStatus
-    }
+  body: {
+    acknowledge?: Acknowledgement
+    acknowledged: boolean
+    license_status: LicenseStatus
   }
 }

--- a/specification/license/post_start_basic/StartBasicLicenseResponse.ts
+++ b/specification/license/post_start_basic/StartBasicLicenseResponse.ts
@@ -21,13 +21,11 @@ import { LicenseType } from '@license/_types/License'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      basic_was_started: boolean
-      error_message?: string
-      type?: LicenseType
-      acknowledge?: Dictionary<string, string | string[]>
-    }
+  body: {
+    acknowledged: boolean
+    basic_was_started: boolean
+    error_message?: string
+    type?: LicenseType
+    acknowledge?: Dictionary<string, string | string[]>
   }
 }

--- a/specification/license/post_start_trial/StartTrialLicenseResponse.ts
+++ b/specification/license/post_start_trial/StartTrialLicenseResponse.ts
@@ -20,12 +20,10 @@
 import { LicenseType } from '@license/_types/License'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      error_message?: string
-      trial_was_started: boolean
-      type?: LicenseType
-    }
+  body: {
+    acknowledged: boolean
+    error_message?: string
+    trial_was_started: boolean
+    type?: LicenseType
   }
 }

--- a/specification/logstash/delete_pipeline/LogstashDeletePipelineResponse.ts
+++ b/specification/logstash/delete_pipeline/LogstashDeletePipelineResponse.ts
@@ -20,7 +20,5 @@
 import { Void } from '@spec_utils/VoidValue'
 
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/logstash/get_pipeline/LogstashGetPipelineResponse.ts
+++ b/specification/logstash/get_pipeline/LogstashGetPipelineResponse.ts
@@ -22,7 +22,5 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Id } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: Dictionary<Id, Pipeline>
-  }
+  body: Dictionary<Id, Pipeline>
 }

--- a/specification/logstash/put_pipeline/LogstashPutPipelineResponse.ts
+++ b/specification/logstash/put_pipeline/LogstashPutPipelineResponse.ts
@@ -20,7 +20,5 @@
 import { Void } from '@spec_utils/VoidValue'
 
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/migration/deprecations/DeprecationInfoResponse.ts
+++ b/specification/migration/deprecations/DeprecationInfoResponse.ts
@@ -21,12 +21,10 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Deprecation } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      cluster_settings: Deprecation[]
-      index_settings: Dictionary<string, Deprecation[]>
-      node_settings: Deprecation[]
-      ml_settings: Deprecation[]
-    }
+  body: {
+    cluster_settings: Deprecation[]
+    index_settings: Dictionary<string, Deprecation[]>
+    node_settings: Deprecation[]
+    ml_settings: Deprecation[]
   }
 }

--- a/specification/migration/get_feature_upgrade_status/GetFeatureUpgradeStatusResponse.ts
+++ b/specification/migration/get_feature_upgrade_status/GetFeatureUpgradeStatusResponse.ts
@@ -21,11 +21,9 @@ import { IndexName, Indices, VersionString } from '@_types/common'
 import { ErrorCause } from '@_types/Errors'
 
 export class Response {
-  '200': {
-    body: {
-      features: MigrationFeature[]
-      migration_status: MigrationStatus
-    }
+  body: {
+    features: MigrationFeature[]
+    migration_status: MigrationStatus
   }
 }
 

--- a/specification/migration/post_feature_upgrade/PostFeatureUpgradeResponse.ts
+++ b/specification/migration/post_feature_upgrade/PostFeatureUpgradeResponse.ts
@@ -18,11 +18,9 @@
  */
 
 export class Response {
-  '200': {
-    body: {
-      accepted: boolean
-      features: MigrationFeature[]
-    }
+  body: {
+    accepted: boolean
+    features: MigrationFeature[]
   }
 }
 

--- a/specification/ml/close_job/MlCloseJobResponse.ts
+++ b/specification/ml/close_job/MlCloseJobResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { closed: boolean }
-  }
+  body: { closed: boolean }
 }

--- a/specification/ml/delete_calendar/MlDeleteCalendarResponse.ts
+++ b/specification/ml/delete_calendar/MlDeleteCalendarResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/delete_calendar_event/MlDeleteCalendarEventResponse.ts
+++ b/specification/ml/delete_calendar_event/MlDeleteCalendarEventResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/delete_calendar_job/MlDeleteCalendarJobResponse.ts
+++ b/specification/ml/delete_calendar_job/MlDeleteCalendarJobResponse.ts
@@ -20,14 +20,12 @@
 import { Id, Ids } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      /** A string that uniquely identifies a calendar. */
-      calendar_id: Id
-      /** A description of the calendar. */
-      description?: string
-      /** A list of anomaly detection job identifiers or group names. */
-      job_ids: Ids
-    }
+  body: {
+    /** A string that uniquely identifies a calendar. */
+    calendar_id: Id
+    /** A description of the calendar. */
+    description?: string
+    /** A list of anomaly detection job identifiers or group names. */
+    job_ids: Ids
   }
 }

--- a/specification/ml/delete_data_frame_analytics/MlDeleteDataFrameAnalyticsResponse.ts
+++ b/specification/ml/delete_data_frame_analytics/MlDeleteDataFrameAnalyticsResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/delete_datafeed/MlDeleteDatafeedResponse.ts
+++ b/specification/ml/delete_datafeed/MlDeleteDatafeedResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/delete_expired_data/MlDeleteExpiredDataResponse.ts
+++ b/specification/ml/delete_expired_data/MlDeleteExpiredDataResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { deleted: boolean }
-  }
+  body: { deleted: boolean }
 }

--- a/specification/ml/delete_filter/MlDeleteFilterResponse.ts
+++ b/specification/ml/delete_filter/MlDeleteFilterResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/delete_forecast/MlDeleteForecastResponse.ts
+++ b/specification/ml/delete_forecast/MlDeleteForecastResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/delete_job/MlDeleteJobResponse.ts
+++ b/specification/ml/delete_job/MlDeleteJobResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/delete_model_snapshot/MlDeleteModelSnapshotResponse.ts
+++ b/specification/ml/delete_model_snapshot/MlDeleteModelSnapshotResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/delete_trained_model/MlDeleteTrainedModelResponse.ts
+++ b/specification/ml/delete_trained_model/MlDeleteTrainedModelResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/delete_trained_model_alias/MlDeleteTrainedModelAliasResponse.ts
+++ b/specification/ml/delete_trained_model_alias/MlDeleteTrainedModelAliasResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/estimate_model_memory/MlEstimateModelMemoryResponse.ts
+++ b/specification/ml/estimate_model_memory/MlEstimateModelMemoryResponse.ts
@@ -18,9 +18,7 @@
  */
 
 export class Response {
-  '200': {
-    body: {
-      model_memory_estimate: string
-    }
+  body: {
+    model_memory_estimate: string
   }
 }

--- a/specification/ml/evaluate_data_frame/MlEvaluateDataFrameResponse.ts
+++ b/specification/ml/evaluate_data_frame/MlEvaluateDataFrameResponse.ts
@@ -25,11 +25,9 @@ import {
 
 /** @variants container */
 export class Response {
-  '200': {
-    body: {
-      classification?: DataframeClassificationSummary
-      outlier_detection?: DataframeOutlierDetectionSummary
-      regression?: DataframeRegressionSummary
-    }
+  body: {
+    classification?: DataframeClassificationSummary
+    outlier_detection?: DataframeOutlierDetectionSummary
+    regression?: DataframeRegressionSummary
   }
 }

--- a/specification/ml/explain_data_frame_analytics/MlExplainDataFrameAnalyticsResponse.ts
+++ b/specification/ml/explain_data_frame_analytics/MlExplainDataFrameAnalyticsResponse.ts
@@ -23,12 +23,10 @@ import {
 } from '@ml/_types/DataframeAnalytics'
 
 export class Response {
-  '200': {
-    body: {
-      /** An array of objects that explain selection for each field, sorted by the field names. */
-      field_selection: DataframeAnalyticsFieldSelection[]
-      /** An array of objects that explain selection for each field, sorted by the field names. */
-      memory_estimation: DataframeAnalyticsMemoryEstimation
-    }
+  body: {
+    /** An array of objects that explain selection for each field, sorted by the field names. */
+    field_selection: DataframeAnalyticsFieldSelection[]
+    /** An array of objects that explain selection for each field, sorted by the field names. */
+    memory_estimation: DataframeAnalyticsMemoryEstimation
   }
 }

--- a/specification/ml/flush_job/MlFlushJobResponse.ts
+++ b/specification/ml/flush_job/MlFlushJobResponse.ts
@@ -20,14 +20,12 @@
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      flushed: boolean
-      /**
-       * Provides the timestamp (in milliseconds since the epoch) of the end of
-       * the last bucket that was processed.
-       */
-      last_finalized_bucket_end?: integer
-    }
+  body: {
+    flushed: boolean
+    /**
+     * Provides the timestamp (in milliseconds since the epoch) of the end of
+     * the last bucket that was processed.
+     */
+    last_finalized_bucket_end?: integer
   }
 }

--- a/specification/ml/forecast/MlForecastJobResponse.ts
+++ b/specification/ml/forecast/MlForecastJobResponse.ts
@@ -20,10 +20,8 @@
 import { Id } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      forecast_id: Id
-    }
+  body: {
+    acknowledged: boolean
+    forecast_id: Id
   }
 }

--- a/specification/ml/get_buckets/MlGetBucketsResponse.ts
+++ b/specification/ml/get_buckets/MlGetBucketsResponse.ts
@@ -21,10 +21,8 @@ import { BucketSummary } from '@ml/_types/Bucket'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      buckets: BucketSummary[]
-      count: long
-    }
+  body: {
+    buckets: BucketSummary[]
+    count: long
   }
 }

--- a/specification/ml/get_calendar_events/MlGetCalendarEventsResponse.ts
+++ b/specification/ml/get_calendar_events/MlGetCalendarEventsResponse.ts
@@ -21,10 +21,8 @@ import { CalendarEvent } from '@ml/_types/CalendarEvent'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: long
-      events: CalendarEvent[]
-    }
+  body: {
+    count: long
+    events: CalendarEvent[]
   }
 }

--- a/specification/ml/get_calendars/MlGetCalendarsResponse.ts
+++ b/specification/ml/get_calendars/MlGetCalendarsResponse.ts
@@ -21,7 +21,5 @@ import { long } from '@_types/Numeric'
 import { Calendar } from './types'
 
 export class Response {
-  '200': {
-    body: { calendars: Calendar[]; count: long }
-  }
+  body: { calendars: Calendar[]; count: long }
 }

--- a/specification/ml/get_categories/MlGetCategoriesResponse.ts
+++ b/specification/ml/get_categories/MlGetCategoriesResponse.ts
@@ -21,10 +21,8 @@ import { Category } from '@ml/_types/Category'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      categories: Category[]
-      count: long
-    }
+  body: {
+    categories: Category[]
+    count: long
   }
 }

--- a/specification/ml/get_data_frame_analytics/MlGetDataFrameAnalyticsResponse.ts
+++ b/specification/ml/get_data_frame_analytics/MlGetDataFrameAnalyticsResponse.ts
@@ -21,11 +21,9 @@ import { DataframeAnalyticsSummary } from '@ml/_types/DataframeAnalytics'
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: integer
-      /** An array of data frame analytics job resources, which are sorted by the id value in ascending order. */
-      data_frame_analytics: DataframeAnalyticsSummary[]
-    }
+  body: {
+    count: integer
+    /** An array of data frame analytics job resources, which are sorted by the id value in ascending order. */
+    data_frame_analytics: DataframeAnalyticsSummary[]
   }
 }

--- a/specification/ml/get_data_frame_analytics_stats/MlGetDataFrameAnalyticsStatsResponse.ts
+++ b/specification/ml/get_data_frame_analytics_stats/MlGetDataFrameAnalyticsStatsResponse.ts
@@ -22,11 +22,9 @@ import { DataframeState } from '@ml/_types/Dataframe'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: long
-      /** An array of objects that contain usage information for data frame analytics jobs, which are sorted by the id value in ascending order. */
-      data_frame_analytics: DataframeAnalytics[]
-    }
+  body: {
+    count: long
+    /** An array of objects that contain usage information for data frame analytics jobs, which are sorted by the id value in ascending order. */
+    data_frame_analytics: DataframeAnalytics[]
   }
 }

--- a/specification/ml/get_datafeed_stats/MlGetDatafeedStatsResponse.ts
+++ b/specification/ml/get_datafeed_stats/MlGetDatafeedStatsResponse.ts
@@ -21,10 +21,8 @@ import { DatafeedStats } from '@ml/_types/Datafeed'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: long
-      datafeeds: DatafeedStats[]
-    }
+  body: {
+    count: long
+    datafeeds: DatafeedStats[]
   }
 }

--- a/specification/ml/get_datafeeds/MlGetDatafeedsResponse.ts
+++ b/specification/ml/get_datafeeds/MlGetDatafeedsResponse.ts
@@ -21,10 +21,8 @@ import { Datafeed } from '@ml/_types/Datafeed'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: long
-      datafeeds: Datafeed[]
-    }
+  body: {
+    count: long
+    datafeeds: Datafeed[]
   }
 }

--- a/specification/ml/get_filters/MlGetFiltersResponse.ts
+++ b/specification/ml/get_filters/MlGetFiltersResponse.ts
@@ -21,10 +21,8 @@ import { Filter } from '@ml/_types/Filter'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: long
-      filters: Filter[]
-    }
+  body: {
+    count: long
+    filters: Filter[]
   }
 }

--- a/specification/ml/get_influencers/MlGetInfluencersResponse.ts
+++ b/specification/ml/get_influencers/MlGetInfluencersResponse.ts
@@ -21,11 +21,9 @@ import { Influencer } from '@ml/_types/Influencer'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: long
-      /** Array of influencer objects */
-      influencers: Influencer[]
-    }
+  body: {
+    count: long
+    /** Array of influencer objects */
+    influencers: Influencer[]
   }
 }

--- a/specification/ml/get_job_stats/MlGetJobStatsResponse.ts
+++ b/specification/ml/get_job_stats/MlGetJobStatsResponse.ts
@@ -21,10 +21,8 @@ import { JobStats } from '@ml/_types/Job'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: long
-      jobs: JobStats[]
-    }
+  body: {
+    count: long
+    jobs: JobStats[]
   }
 }

--- a/specification/ml/get_jobs/MlGetJobsResponse.ts
+++ b/specification/ml/get_jobs/MlGetJobsResponse.ts
@@ -21,10 +21,8 @@ import { Job } from '@ml/_types/Job'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: long
-      jobs: Job[]
-    }
+  body: {
+    count: long
+    jobs: Job[]
   }
 }

--- a/specification/ml/get_model_snapshots/MlGetModelSnapshotsResponse.ts
+++ b/specification/ml/get_model_snapshots/MlGetModelSnapshotsResponse.ts
@@ -21,10 +21,8 @@ import { ModelSnapshot } from '@ml/_types/Model'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: long
-      model_snapshots: ModelSnapshot[]
-    }
+  body: {
+    count: long
+    model_snapshots: ModelSnapshot[]
   }
 }

--- a/specification/ml/get_overall_buckets/MlGetOverallBucketsResponse.ts
+++ b/specification/ml/get_overall_buckets/MlGetOverallBucketsResponse.ts
@@ -21,11 +21,9 @@ import { OverallBucket } from '@ml/_types/Bucket'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: long
-      /** Array of overall bucket objects */
-      overall_buckets: OverallBucket[]
-    }
+  body: {
+    count: long
+    /** Array of overall bucket objects */
+    overall_buckets: OverallBucket[]
   }
 }

--- a/specification/ml/get_records/MlGetAnomalyRecordsResponse.ts
+++ b/specification/ml/get_records/MlGetAnomalyRecordsResponse.ts
@@ -21,10 +21,8 @@ import { Anomaly } from '@ml/_types/Anomaly'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: long
-      records: Anomaly[]
-    }
+  body: {
+    count: long
+    records: Anomaly[]
   }
 }

--- a/specification/ml/get_trained_models/MlGetTrainedModelResponse.ts
+++ b/specification/ml/get_trained_models/MlGetTrainedModelResponse.ts
@@ -26,11 +26,9 @@ import { integer } from '@_types/Numeric'
  * 404 (Missing resources) - If allow_no_match is false, this code indicates that there are no resources that match the request or only partial matches for the request.
  */
 export class Response {
-  '200': {
-    body: {
-      count: integer
-      /** An array of trained model resources, which are sorted by the model_id value in ascending order. */
-      trained_model_configs: TrainedModelConfig[]
-    }
+  body: {
+    count: integer
+    /** An array of trained model resources, which are sorted by the model_id value in ascending order. */
+    trained_model_configs: TrainedModelConfig[]
   }
 }

--- a/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsResponse.ts
+++ b/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsResponse.ts
@@ -24,12 +24,10 @@ import { integer } from '@_types/Numeric'
  * 404 (Missing resources) If allow_no_match is false, this code indicates that there are no resources that match the request or only partial matches for the request.
  */
 export class Response {
-  '200': {
-    body: {
-      /** The total number of trained model statistics that matched the requested ID patterns. Could be higher than the number of items in the trained_model_stats array as the size of the array is restricted by the supplied size parameter. */
-      count: integer
-      /** An array of trained model statistics, which are sorted by the model_id value in ascending order. */
-      trained_model_stats: TrainedModelStats[]
-    }
+  body: {
+    /** The total number of trained model statistics that matched the requested ID patterns. Could be higher than the number of items in the trained_model_stats array as the size of the array is restricted by the supplied size parameter. */
+    count: integer
+    /** An array of trained model statistics, which are sorted by the model_id value in ascending order. */
+    trained_model_stats: TrainedModelStats[]
   }
 }

--- a/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentResponse.ts
+++ b/specification/ml/infer_trained_model_deployment/MlInferTrainedModelDeploymentResponse.ts
@@ -25,43 +25,41 @@ import {
 } from '@ml/_types/TrainedModel'
 
 export class Response {
-  '200': {
-    body: {
-      /**
-       * If the model is trained for named entity recognition (NER) tasks, the response contains the recognized entities.
-       */
-      entities?: TrainedModelEntities[]
-      /**
-       * Indicates whether the input text was truncated to meet the model's maximum sequence length limit. This property
-       * is present only when it is true.
-       */
-      is_truncated?: boolean
-      /**
-       * If the model is trained for a text classification or zero shot classification task, the response is the
-       * predicted class.
-       * For named entity recognition (NER) tasks, it contains the annotated text output.
-       * For fill mask tasks, it contains the top prediction for replacing the mask token.
-       * For text embedding tasks, it contains the raw numerical text embedding values.
-       */
-      predicted_value?: PredictedValue[]
-      /**
-       * For fill mask tasks, the response contains the input text sequence with the mask token replaced by the predicted
-       * value.
-       */
-      predicted_value_sequence?: string
-      /**
-       * Specifies a confidence score for the predicted value.
-       */
-      prediction_probability?: double
-      /**
-       * For fill mask, text classification, and zero shot classification tasks, the response contains a list of top
-       * class entries.
-       */
-      top_classes: TopClassEntry[]
-      /**
-       * If the request failed, the response contains the reason for the failure.
-       */
-      warning?: string
-    }
+  body: {
+    /**
+     * If the model is trained for named entity recognition (NER) tasks, the response contains the recognized entities.
+     */
+    entities?: TrainedModelEntities[]
+    /**
+     * Indicates whether the input text was truncated to meet the model's maximum sequence length limit. This property
+     * is present only when it is true.
+     */
+    is_truncated?: boolean
+    /**
+     * If the model is trained for a text classification or zero shot classification task, the response is the
+     * predicted class.
+     * For named entity recognition (NER) tasks, it contains the annotated text output.
+     * For fill mask tasks, it contains the top prediction for replacing the mask token.
+     * For text embedding tasks, it contains the raw numerical text embedding values.
+     */
+    predicted_value?: PredictedValue[]
+    /**
+     * For fill mask tasks, the response contains the input text sequence with the mask token replaced by the predicted
+     * value.
+     */
+    predicted_value_sequence?: string
+    /**
+     * Specifies a confidence score for the predicted value.
+     */
+    prediction_probability?: double
+    /**
+     * For fill mask, text classification, and zero shot classification tasks, the response contains a list of top
+     * class entries.
+     */
+    top_classes: TopClassEntry[]
+    /**
+     * If the request failed, the response contains the reason for the failure.
+     */
+    warning?: string
   }
 }

--- a/specification/ml/info/MlInfoResponse.ts
+++ b/specification/ml/info/MlInfoResponse.ts
@@ -20,12 +20,10 @@
 import { Defaults, Limits, NativeCode } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      defaults: Defaults
-      limits: Limits
-      upgrade_mode: boolean
-      native_code: NativeCode
-    }
+  body: {
+    defaults: Defaults
+    limits: Limits
+    upgrade_mode: boolean
+    native_code: NativeCode
   }
 }

--- a/specification/ml/open_job/MlOpenJobResponse.ts
+++ b/specification/ml/open_job/MlOpenJobResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { opened: boolean }
-  }
+  body: { opened: boolean }
 }

--- a/specification/ml/post_calendar_events/MlPostCalendarEventsResponse.ts
+++ b/specification/ml/post_calendar_events/MlPostCalendarEventsResponse.ts
@@ -20,7 +20,5 @@
 import { CalendarEvent } from '../_types/CalendarEvent'
 
 export class Response {
-  '200': {
-    body: { events: CalendarEvent[] }
-  }
+  body: { events: CalendarEvent[] }
 }

--- a/specification/ml/post_data/MlPostJobDataResponse.ts
+++ b/specification/ml/post_data/MlPostJobDataResponse.ts
@@ -21,23 +21,21 @@ import { Id } from '@_types/common'
 import { integer, long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      bucket_count: long
-      earliest_record_timestamp: long
-      empty_bucket_count: long
-      input_bytes: long
-      input_field_count: long
-      input_record_count: long
-      invalid_date_count: long
-      job_id: Id
-      last_data_time: integer
-      latest_record_timestamp: long
-      missing_field_count: long
-      out_of_order_timestamp_count: long
-      processed_field_count: long
-      processed_record_count: long
-      sparse_bucket_count: long
-    }
+  body: {
+    bucket_count: long
+    earliest_record_timestamp: long
+    empty_bucket_count: long
+    input_bytes: long
+    input_field_count: long
+    input_record_count: long
+    invalid_date_count: long
+    job_id: Id
+    last_data_time: integer
+    latest_record_timestamp: long
+    missing_field_count: long
+    out_of_order_timestamp_count: long
+    processed_field_count: long
+    processed_record_count: long
+    sparse_bucket_count: long
   }
 }

--- a/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsResponse.ts
+++ b/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsResponse.ts
@@ -21,10 +21,8 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Field } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      /** An array of objects that contain feature name and value pairs. The features have been processed and indicate what will be sent to the model for training. */
-      feature_values: Dictionary<Field, string>[]
-    }
+  body: {
+    /** An array of objects that contain feature name and value pairs. The features have been processed and indicate what will be sent to the model for training. */
+    feature_values: Dictionary<Field, string>[]
   }
 }

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedResponse.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedResponse.ts
@@ -18,9 +18,7 @@
  */
 
 export class Response<TDocument> {
-  '200': {
-    body: {
-      data: TDocument[]
-    }
+  body: {
+    data: TDocument[]
   }
 }

--- a/specification/ml/put_calendar/MlPutCalendarResponse.ts
+++ b/specification/ml/put_calendar/MlPutCalendarResponse.ts
@@ -20,14 +20,12 @@
 import { Id, Ids } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      /** A string that uniquely identifies a calendar. */
-      calendar_id: Id
-      /** A description of the calendar. */
-      description?: string
-      /** A list of anomaly detection job identifiers or group names. */
-      job_ids: Ids
-    }
+  body: {
+    /** A string that uniquely identifies a calendar. */
+    calendar_id: Id
+    /** A description of the calendar. */
+    description?: string
+    /** A list of anomaly detection job identifiers or group names. */
+    job_ids: Ids
   }
 }

--- a/specification/ml/put_calendar_job/MlPutCalendarJobResponse.ts
+++ b/specification/ml/put_calendar_job/MlPutCalendarJobResponse.ts
@@ -20,14 +20,12 @@
 import { Id, Ids } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      /** A string that uniquely identifies a calendar. */
-      calendar_id: Id
-      /** A description of the calendar. */
-      description?: string
-      /** A list of anomaly detection job identifiers or group names. */
-      job_ids: Ids
-    }
+  body: {
+    /** A string that uniquely identifies a calendar. */
+    calendar_id: Id
+    /** A description of the calendar. */
+    description?: string
+    /** A list of anomaly detection job identifiers or group names. */
+    job_ids: Ids
   }
 }

--- a/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsResponse.ts
+++ b/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsResponse.ts
@@ -27,19 +27,17 @@ import { Id, VersionString } from '@_types/common'
 import { integer, long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      id: Id
-      create_time: long
-      version: VersionString
-      source: DataframeAnalyticsSource
-      description?: string
-      dest: DataframeAnalyticsDestination
-      model_memory_limit: string
-      allow_lazy_start: boolean
-      max_num_threads: integer
-      analysis: DataframeAnalysisContainer
-      analyzed_fields?: DataframeAnalysisAnalyzedFields
-    }
+  body: {
+    id: Id
+    create_time: long
+    version: VersionString
+    source: DataframeAnalyticsSource
+    description?: string
+    dest: DataframeAnalyticsDestination
+    model_memory_limit: string
+    allow_lazy_start: boolean
+    max_num_threads: integer
+    analysis: DataframeAnalysisContainer
+    analyzed_fields?: DataframeAnalysisAnalyzedFields
   }
 }

--- a/specification/ml/put_datafeed/MlPutDatafeedResponse.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedResponse.ts
@@ -28,22 +28,20 @@ import { ScriptField } from '@_types/Scripting'
 import { Time } from '@_types/Time'
 
 export class Response {
-  '200': {
-    body: {
-      aggregations: Dictionary<string, AggregationContainer>
-      chunking_config: ChunkingConfig
-      delayed_data_check_config?: DelayedDataCheckConfig
-      datafeed_id: Id
-      frequency: Time
-      indices: string[]
-      job_id: Id
-      indices_options?: IndicesOptions
-      max_empty_searches: integer
-      query: QueryContainer
-      query_delay: Time
-      runtime_mappings?: RuntimeFields
-      script_fields?: Dictionary<string, ScriptField>
-      scroll_size: integer
-    }
+  body: {
+    aggregations: Dictionary<string, AggregationContainer>
+    chunking_config: ChunkingConfig
+    delayed_data_check_config?: DelayedDataCheckConfig
+    datafeed_id: Id
+    frequency: Time
+    indices: string[]
+    job_id: Id
+    indices_options?: IndicesOptions
+    max_empty_searches: integer
+    query: QueryContainer
+    query_delay: Time
+    runtime_mappings?: RuntimeFields
+    script_fields?: Dictionary<string, ScriptField>
+    scroll_size: integer
   }
 }

--- a/specification/ml/put_filter/MlPutFilterResponse.ts
+++ b/specification/ml/put_filter/MlPutFilterResponse.ts
@@ -20,11 +20,9 @@
 import { Id } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      description: string
-      filter_id: Id
-      items: string[]
-    }
+  body: {
+    description: string
+    filter_id: Id
+    items: string[]
   }
 }

--- a/specification/ml/put_job/MlPutJobResponse.ts
+++ b/specification/ml/put_job/MlPutJobResponse.ts
@@ -27,28 +27,26 @@ import { DateString, Time } from '@_types/Time'
 import { Datafeed } from '@ml/_types/Datafeed'
 
 export class Response {
-  '200': {
-    body: {
-      allow_lazy_open: boolean
-      analysis_config: AnalysisConfigRead
-      analysis_limits: AnalysisLimits
-      background_persist_interval?: Time
-      create_time: DateString
-      custom_settings?: CustomSettings
-      daily_model_snapshot_retention_after_days: long
-      data_description: DataDescription
-      datafeed_config?: Datafeed
-      description?: string
-      groups?: string[]
-      job_id: Id
-      job_type: string
-      job_version: string
-      model_plot_config?: ModelPlotConfig
-      model_snapshot_id?: Id
-      model_snapshot_retention_days: long
-      renormalization_window_days?: long
-      results_index_name: string
-      results_retention_days?: long
-    }
+  body: {
+    allow_lazy_open: boolean
+    analysis_config: AnalysisConfigRead
+    analysis_limits: AnalysisLimits
+    background_persist_interval?: Time
+    create_time: DateString
+    custom_settings?: CustomSettings
+    daily_model_snapshot_retention_after_days: long
+    data_description: DataDescription
+    datafeed_config?: Datafeed
+    description?: string
+    groups?: string[]
+    job_id: Id
+    job_type: string
+    job_version: string
+    model_plot_config?: ModelPlotConfig
+    model_snapshot_id?: Id
+    model_snapshot_retention_days: long
+    renormalization_window_days?: long
+    results_index_name: string
+    results_retention_days?: long
   }
 }

--- a/specification/ml/put_trained_model/MlPutTrainedModelResponse.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelResponse.ts
@@ -20,7 +20,5 @@
 import { TrainedModelConfig } from '@ml/_types/TrainedModel'
 
 export class Response {
-  '200': {
-    body: TrainedModelConfig
-  }
+  body: TrainedModelConfig
 }

--- a/specification/ml/put_trained_model_alias/MlPutTrainedModelAliasResponse.ts
+++ b/specification/ml/put_trained_model_alias/MlPutTrainedModelAliasResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartResponse.ts
+++ b/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyResponse.ts
+++ b/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/reset_job/MlResetJobResponse.ts
+++ b/specification/ml/reset_job/MlResetJobResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/revert_model_snapshot/MlRevertModelSnapshotResponse.ts
+++ b/specification/ml/revert_model_snapshot/MlRevertModelSnapshotResponse.ts
@@ -20,7 +20,5 @@
 import { ModelSnapshot } from '@ml/_types/Model'
 
 export class Response {
-  '200': {
-    body: { model: ModelSnapshot }
-  }
+  body: { model: ModelSnapshot }
 }

--- a/specification/ml/set_upgrade_mode/MlSetUpgradeModeResponse.ts
+++ b/specification/ml/set_upgrade_mode/MlSetUpgradeModeResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/start_data_frame_analytics/MlStartDataFrameAnalyticsResponse.ts
+++ b/specification/ml/start_data_frame_analytics/MlStartDataFrameAnalyticsResponse.ts
@@ -20,11 +20,9 @@
 import { NodeId } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      /** The ID of the node that the job was started on. If the job is allowed to open lazily and has not yet been assigned to a node, this value is an empty string. */
-      node: NodeId
-    }
+  body: {
+    acknowledged: boolean
+    /** The ID of the node that the job was started on. If the job is allowed to open lazily and has not yet been assigned to a node, this value is an empty string. */
+    node: NodeId
   }
 }

--- a/specification/ml/start_datafeed/MlStartDatafeedResponse.ts
+++ b/specification/ml/start_datafeed/MlStartDatafeedResponse.ts
@@ -20,17 +20,15 @@
 import { NodeIds } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      /**
-       * The ID of the node that the datafeed was started on. If the datafeed is allowed to open lazily and has not yet
-       * been assigned to a node, this value is an empty string.
-       */
-      node: NodeIds
-      /**
-       * For a successful response, this value is always `true`. On failure, an exception is returned instead.
-       */
-      started: boolean
-    }
+  body: {
+    /**
+     * The ID of the node that the datafeed was started on. If the datafeed is allowed to open lazily and has not yet
+     * been assigned to a node, this value is an empty string.
+     */
+    node: NodeIds
+    /**
+     * For a successful response, this value is always `true`. On failure, an exception is returned instead.
+     */
+    started: boolean
   }
 }

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentResponse.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentResponse.ts
@@ -20,9 +20,7 @@
 import { TrainedModelAllocation } from '../_types/TrainedModel'
 
 export class Response {
-  '200': {
-    body: {
-      allocation: TrainedModelAllocation
-    }
+  body: {
+    allocation: TrainedModelAllocation
   }
 }

--- a/specification/ml/stop_data_frame_analytics/MlStopDataFrameAnalyticsResponse.ts
+++ b/specification/ml/stop_data_frame_analytics/MlStopDataFrameAnalyticsResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { stopped: boolean }
-  }
+  body: { stopped: boolean }
 }

--- a/specification/ml/stop_datafeed/MlStopDatafeedResponse.ts
+++ b/specification/ml/stop_datafeed/MlStopDatafeedResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { stopped: boolean }
-  }
+  body: { stopped: boolean }
 }

--- a/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentResponse.ts
+++ b/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { stopped: boolean }
-  }
+  body: { stopped: boolean }
 }

--- a/specification/ml/update_data_frame_analytics/MlUpdateDataFrameAnalyticsResponse.ts
+++ b/specification/ml/update_data_frame_analytics/MlUpdateDataFrameAnalyticsResponse.ts
@@ -27,19 +27,17 @@ import { Id, VersionString } from '@_types/common'
 import { integer, long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      id: Id
-      create_time: long
-      version: VersionString
-      source: DataframeAnalyticsSource
-      description?: string
-      dest: DataframeAnalyticsDestination
-      model_memory_limit: string
-      allow_lazy_start: boolean
-      max_num_threads: integer
-      analysis: DataframeAnalysisContainer
-      analyzed_fields?: DataframeAnalysisAnalyzedFields
-    }
+  body: {
+    id: Id
+    create_time: long
+    version: VersionString
+    source: DataframeAnalyticsSource
+    description?: string
+    dest: DataframeAnalyticsDestination
+    model_memory_limit: string
+    allow_lazy_start: boolean
+    max_num_threads: integer
+    analysis: DataframeAnalysisContainer
+    analyzed_fields?: DataframeAnalysisAnalyzedFields
   }
 }

--- a/specification/ml/update_datafeed/MlUpdateDatafeedResponse.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedResponse.ts
@@ -28,22 +28,20 @@ import { ScriptField } from '@_types/Scripting'
 import { Time } from '@_types/Time'
 
 export class Response {
-  '200': {
-    body: {
-      aggregations: Dictionary<string, AggregationContainer>
-      chunking_config: ChunkingConfig
-      delayed_data_check_config?: DelayedDataCheckConfig
-      datafeed_id: Id
-      frequency: Time
-      indices: string[]
-      job_id: Id
-      indices_options?: IndicesOptions
-      max_empty_searches: integer
-      query: QueryContainer
-      query_delay: Time
-      runtime_mappings?: RuntimeFields
-      script_fields?: Dictionary<string, ScriptField>
-      scroll_size: integer
-    }
+  body: {
+    aggregations: Dictionary<string, AggregationContainer>
+    chunking_config: ChunkingConfig
+    delayed_data_check_config?: DelayedDataCheckConfig
+    datafeed_id: Id
+    frequency: Time
+    indices: string[]
+    job_id: Id
+    indices_options?: IndicesOptions
+    max_empty_searches: integer
+    query: QueryContainer
+    query_delay: Time
+    runtime_mappings?: RuntimeFields
+    script_fields?: Dictionary<string, ScriptField>
+    scroll_size: integer
   }
 }

--- a/specification/ml/update_filter/MlUpdateFilterResponse.ts
+++ b/specification/ml/update_filter/MlUpdateFilterResponse.ts
@@ -20,11 +20,9 @@
 import { Id } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      description: string
-      filter_id: Id
-      items: string[]
-    }
+  body: {
+    description: string
+    filter_id: Id
+    items: string[]
   }
 }

--- a/specification/ml/update_job/MlUpdateJobResponse.ts
+++ b/specification/ml/update_job/MlUpdateJobResponse.ts
@@ -27,29 +27,27 @@ import { long } from '@_types/Numeric'
 import { Time, EpochMillis } from '@_types/Time'
 
 export class Response {
-  '200': {
-    body: {
-      allow_lazy_open: boolean
-      analysis_config: AnalysisConfigRead
-      analysis_limits: AnalysisLimits
-      background_persist_interval?: Time
-      create_time: EpochMillis
-      finished_time?: EpochMillis
-      custom_settings?: Dictionary<string, string>
-      daily_model_snapshot_retention_after_days: long
-      data_description: DataDescription
-      datafeed_config?: Datafeed
-      description?: string
-      groups?: string[]
-      job_id: Id
-      job_type: string
-      job_version: VersionString
-      model_plot_config?: ModelPlotConfig
-      model_snapshot_id?: Id
-      model_snapshot_retention_days: long
-      renormalization_window_days?: long
-      results_index_name: IndexName
-      results_retention_days?: long
-    }
+  body: {
+    allow_lazy_open: boolean
+    analysis_config: AnalysisConfigRead
+    analysis_limits: AnalysisLimits
+    background_persist_interval?: Time
+    create_time: EpochMillis
+    finished_time?: EpochMillis
+    custom_settings?: Dictionary<string, string>
+    daily_model_snapshot_retention_after_days: long
+    data_description: DataDescription
+    datafeed_config?: Datafeed
+    description?: string
+    groups?: string[]
+    job_id: Id
+    job_type: string
+    job_version: VersionString
+    model_plot_config?: ModelPlotConfig
+    model_snapshot_id?: Id
+    model_snapshot_retention_days: long
+    renormalization_window_days?: long
+    results_index_name: IndexName
+    results_retention_days?: long
   }
 }

--- a/specification/ml/update_model_snapshot/MlUpdateModelSnapshotResponse.ts
+++ b/specification/ml/update_model_snapshot/MlUpdateModelSnapshotResponse.ts
@@ -20,10 +20,8 @@
 import { ModelSnapshot } from '@ml/_types/Model'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      model: ModelSnapshot
-    }
+  body: {
+    acknowledged: boolean
+    model: ModelSnapshot
   }
 }

--- a/specification/ml/upgrade_job_snapshot/MlUpgradeJobSnapshotResponse.ts
+++ b/specification/ml/upgrade_job_snapshot/MlUpgradeJobSnapshotResponse.ts
@@ -20,12 +20,10 @@
 import { NodeId } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      /** The ID of the assigned node for the upgrade task if it is still running. */
-      node: NodeId
-      /** When true, this means the task is complete. When false, it is still running. */
-      completed: boolean
-    }
+  body: {
+    /** The ID of the assigned node for the upgrade task if it is still running. */
+    node: NodeId
+    /** When true, this means the task is complete. When false, it is still running. */
+    completed: boolean
   }
 }

--- a/specification/ml/validate/MlValidateJobResponse.ts
+++ b/specification/ml/validate/MlValidateJobResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/ml/validate_detector/MlValidateDetectorResponse.ts
+++ b/specification/ml/validate_detector/MlValidateDetectorResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/monitoring/bulk/BulkMonitoringResponse.ts
+++ b/specification/monitoring/bulk/BulkMonitoringResponse.ts
@@ -21,14 +21,12 @@ import { long } from '@_types/Numeric'
 import { ErrorCause } from '@_types/Errors'
 
 export class Response {
-  '200': {
-    body: {
-      error?: ErrorCause
-      /** True if there is was an error */
-      errors: boolean
-      /** Was collection disabled? */
-      ignored: boolean
-      took: long
-    }
+  body: {
+    error?: ErrorCause
+    /** True if there is was an error */
+    errors: boolean
+    /** Was collection disabled? */
+    ignored: boolean
+    took: long
   }
 }

--- a/specification/nodes/clear_repositories_metering_archive/ClearRepositoriesMeteringArchiveResponse.ts
+++ b/specification/nodes/clear_repositories_metering_archive/ClearRepositoriesMeteringArchiveResponse.ts
@@ -34,7 +34,5 @@ export class ResponseBase extends NodesResponseBase {
 }
 
 export class Response {
-  '200': {
-    body: ResponseBase
-  }
+  body: ResponseBase
 }

--- a/specification/nodes/get_repositories_metering_info/GetRepositoriesMeteringInfoResponse.ts
+++ b/specification/nodes/get_repositories_metering_info/GetRepositoriesMeteringInfoResponse.ts
@@ -34,7 +34,5 @@ export class ResponseBase extends NodesResponseBase {
 }
 
 export class Response {
-  '200': {
-    body: ResponseBase
-  }
+  body: ResponseBase
 }

--- a/specification/nodes/hot_threads/NodesHotThreadsResponse.ts
+++ b/specification/nodes/hot_threads/NodesHotThreadsResponse.ts
@@ -20,7 +20,5 @@
 import { HotThread } from './types'
 
 export class Response {
-  '200': {
-    body: { hot_threads: HotThread[] }
-  }
+  body: { hot_threads: HotThread[] }
 }

--- a/specification/nodes/info/NodesInfoResponse.ts
+++ b/specification/nodes/info/NodesInfoResponse.ts
@@ -28,7 +28,5 @@ export class ResponseBase extends NodesResponseBase {
 }
 
 export class Response {
-  '200': {
-    body: ResponseBase
-  }
+  body: ResponseBase
 }

--- a/specification/nodes/reload_secure_settings/ReloadSecureSettingsResponse.ts
+++ b/specification/nodes/reload_secure_settings/ReloadSecureSettingsResponse.ts
@@ -28,7 +28,5 @@ export class ResponseBase extends NodesResponseBase {
 }
 
 export class Response {
-  '200': {
-    body: ResponseBase
-  }
+  body: ResponseBase
 }

--- a/specification/nodes/stats/NodesStatsResponse.ts
+++ b/specification/nodes/stats/NodesStatsResponse.ts
@@ -28,7 +28,5 @@ export class ResponseBase extends NodesResponseBase {
 }
 
 export class Response {
-  '200': {
-    body: ResponseBase
-  }
+  body: ResponseBase
 }

--- a/specification/nodes/usage/NodesUsageResponse.ts
+++ b/specification/nodes/usage/NodesUsageResponse.ts
@@ -28,7 +28,5 @@ export class ResponseBase extends NodesResponseBase {
 }
 
 export class Response {
-  '200': {
-    body: ResponseBase
-  }
+  body: ResponseBase
 }

--- a/specification/rollup/delete_job/DeleteRollupJobResponse.ts
+++ b/specification/rollup/delete_job/DeleteRollupJobResponse.ts
@@ -20,10 +20,8 @@
 import { TaskFailure } from '@_types/Errors'
 
 export class Response {
-  '200': {
-    body: {
-      acknowledged: boolean
-      task_failures?: TaskFailure[]
-    }
+  body: {
+    acknowledged: boolean
+    task_failures?: TaskFailure[]
   }
 }

--- a/specification/rollup/get_jobs/GetRollupJobResponse.ts
+++ b/specification/rollup/get_jobs/GetRollupJobResponse.ts
@@ -20,7 +20,5 @@
 import { RollupJob } from './types'
 
 export class Response {
-  '200': {
-    body: { jobs: RollupJob[] }
-  }
+  body: { jobs: RollupJob[] }
 }

--- a/specification/rollup/get_rollup_caps/GetRollupCapabilitiesResponse.ts
+++ b/specification/rollup/get_rollup_caps/GetRollupCapabilitiesResponse.ts
@@ -22,7 +22,5 @@ import { IndexName } from '@_types/common'
 import { RollupCapabilities } from './types'
 
 export class Response {
-  '200': {
-    body: Dictionary<IndexName, RollupCapabilities>
-  }
+  body: Dictionary<IndexName, RollupCapabilities>
 }

--- a/specification/rollup/get_rollup_index_caps/GetRollupIndexCapabilitiesResponse.ts
+++ b/specification/rollup/get_rollup_index_caps/GetRollupIndexCapabilitiesResponse.ts
@@ -22,7 +22,5 @@ import { IndexName } from '@_types/common'
 import { IndexCapabilities } from './types'
 
 export class Response {
-  '200': {
-    body: Dictionary<IndexName, IndexCapabilities>
-  }
+  body: Dictionary<IndexName, IndexCapabilities>
 }

--- a/specification/rollup/put_job/CreateRollupJobResponse.ts
+++ b/specification/rollup/put_job/CreateRollupJobResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/rollup/rollup/RollupResponse.ts
+++ b/specification/rollup/rollup/RollupResponse.ts
@@ -20,7 +20,5 @@
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
-  '200': {
-    body: UserDefinedValue // TODO: This API is experimental and no docs exist describing it. Requires reverse engineering if made stable
-  }
+  body: UserDefinedValue // TODO: This API is experimental and no docs exist describing it. Requires reverse engineering if made stable
 }

--- a/specification/rollup/rollup_search/RollupSearchResponse.ts
+++ b/specification/rollup/rollup_search/RollupSearchResponse.ts
@@ -25,14 +25,12 @@ import { long } from '@_types/Numeric'
 import { ShardStatistics } from '@_types/Stats'
 
 export class Response<TDocument> {
-  '200': {
-    body: {
-      took: long
-      timed_out: boolean
-      terminated_early?: boolean
-      _shards: ShardStatistics
-      hits: HitsMetadata<TDocument>
-      aggregations?: Dictionary<AggregateName, Aggregate>
-    }
+  body: {
+    took: long
+    timed_out: boolean
+    terminated_early?: boolean
+    _shards: ShardStatistics
+    hits: HitsMetadata<TDocument>
+    aggregations?: Dictionary<AggregateName, Aggregate>
   }
 }

--- a/specification/rollup/start_job/StartRollupJobResponse.ts
+++ b/specification/rollup/start_job/StartRollupJobResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { started: boolean }
-  }
+  body: { started: boolean }
 }

--- a/specification/rollup/stop_job/StopRollupJobResponse.ts
+++ b/specification/rollup/stop_job/StopRollupJobResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { stopped: boolean }
-  }
+  body: { stopped: boolean }
 }

--- a/specification/searchable_snapshots/cache_stats/Response.ts
+++ b/specification/searchable_snapshots/cache_stats/Response.ts
@@ -22,10 +22,8 @@ import { long, integer } from '@_types/Numeric'
 import { ByteSize } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      nodes: Dictionary<string, Node>
-    }
+  body: {
+    nodes: Dictionary<string, Node>
   }
 }
 

--- a/specification/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheResponse.ts
+++ b/specification/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheResponse.ts
@@ -20,7 +20,5 @@
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
-  '200': {
-    body: UserDefinedValue
-  }
+  body: UserDefinedValue
 }

--- a/specification/searchable_snapshots/mount/SearchableSnapshotsMountResponse.ts
+++ b/specification/searchable_snapshots/mount/SearchableSnapshotsMountResponse.ts
@@ -20,9 +20,7 @@
 import { MountedSnapshot } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      snapshot: MountedSnapshot
-    }
+  body: {
+    snapshot: MountedSnapshot
   }
 }

--- a/specification/searchable_snapshots/stats/SearchableSnapshotsStatsResponse.ts
+++ b/specification/searchable_snapshots/stats/SearchableSnapshotsStatsResponse.ts
@@ -20,10 +20,8 @@
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
-  '200': {
-    body: {
-      stats: UserDefinedValue // TODO: complete this definition
-      total: UserDefinedValue // TODO: complete this definition
-    }
+  body: {
+    stats: UserDefinedValue // TODO: complete this definition
+    total: UserDefinedValue // TODO: complete this definition
   }
 }

--- a/specification/security/authenticate/SecurityAuthenticateResponse.ts
+++ b/specification/security/authenticate/SecurityAuthenticateResponse.ts
@@ -23,20 +23,18 @@ import { Metadata, Name, Username } from '@_types/common'
 import { Token } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      api_key?: ApiKey
-      authentication_realm: RealmInfo
-      email?: string | null
-      full_name?: Name | null
-      lookup_realm: RealmInfo
-      metadata: Metadata
-      roles: string[]
-      username: Username
-      enabled: boolean
-      authentication_type: string
-      /** @since 7.14.0 */
-      token?: Token
-    }
+  body: {
+    api_key?: ApiKey
+    authentication_realm: RealmInfo
+    email?: string | null
+    full_name?: Name | null
+    lookup_realm: RealmInfo
+    metadata: Metadata
+    roles: string[]
+    username: Username
+    enabled: boolean
+    authentication_type: string
+    /** @since 7.14.0 */
+    token?: Token
   }
 }

--- a/specification/security/change_password/SecurityChangePasswordResponse.ts
+++ b/specification/security/change_password/SecurityChangePasswordResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: {}
-  }
+  body: {}
 }

--- a/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheResponse.ts
+++ b/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheResponse.ts
@@ -23,12 +23,10 @@ import { Name } from '@_types/common'
 import { NodeStatistics } from '@_types/Node'
 
 export class Response {
-  '200': {
-    body: {
-      /** @codegen_name node_stats */
-      _nodes: NodeStatistics
-      cluster_name: Name
-      nodes: Dictionary<string, ClusterNode>
-    }
+  body: {
+    /** @codegen_name node_stats */
+    _nodes: NodeStatistics
+    cluster_name: Name
+    nodes: Dictionary<string, ClusterNode>
   }
 }

--- a/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesResponse.ts
+++ b/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesResponse.ts
@@ -23,12 +23,10 @@ import { Name } from '@_types/common'
 import { NodeStatistics } from '@_types/Node'
 
 export class Response {
-  '200': {
-    body: {
-      /** @codegen_name node_stats */
-      _nodes: NodeStatistics
-      cluster_name: Name
-      nodes: Dictionary<string, ClusterNode>
-    }
+  body: {
+    /** @codegen_name node_stats */
+    _nodes: NodeStatistics
+    cluster_name: Name
+    nodes: Dictionary<string, ClusterNode>
   }
 }

--- a/specification/security/clear_cached_realms/SecurityClearCachedRealmsResponse.ts
+++ b/specification/security/clear_cached_realms/SecurityClearCachedRealmsResponse.ts
@@ -23,12 +23,10 @@ import { Name } from '@_types/common'
 import { NodeStatistics } from '@_types/Node'
 
 export class Response {
-  '200': {
-    body: {
-      /** @codegen_name node_stats */
-      _nodes: NodeStatistics
-      cluster_name: Name
-      nodes: Dictionary<string, ClusterNode>
-    }
+  body: {
+    /** @codegen_name node_stats */
+    _nodes: NodeStatistics
+    cluster_name: Name
+    nodes: Dictionary<string, ClusterNode>
   }
 }

--- a/specification/security/clear_cached_roles/ClearCachedRolesResponse.ts
+++ b/specification/security/clear_cached_roles/ClearCachedRolesResponse.ts
@@ -23,12 +23,10 @@ import { Name } from '@_types/common'
 import { NodeStatistics } from '@_types/Node'
 
 export class Response {
-  '200': {
-    body: {
-      /** @codegen_name node_stats */
-      _nodes: NodeStatistics
-      cluster_name: Name
-      nodes: Dictionary<string, ClusterNode>
-    }
+  body: {
+    /** @codegen_name node_stats */
+    _nodes: NodeStatistics
+    cluster_name: Name
+    nodes: Dictionary<string, ClusterNode>
   }
 }

--- a/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensResponse.ts
+++ b/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensResponse.ts
@@ -23,12 +23,10 @@ import { Name } from '@_types/common'
 import { NodeStatistics } from '@_types/Node'
 
 export class Response {
-  '200': {
-    body: {
-      /** @codegen_name node_stats */
-      _nodes: NodeStatistics
-      cluster_name: Name
-      nodes: Dictionary<string, ClusterNode>
-    }
+  body: {
+    /** @codegen_name node_stats */
+    _nodes: NodeStatistics
+    cluster_name: Name
+    nodes: Dictionary<string, ClusterNode>
   }
 }

--- a/specification/security/create_api_key/SecurityCreateApiKeyResponse.ts
+++ b/specification/security/create_api_key/SecurityCreateApiKeyResponse.ts
@@ -21,31 +21,29 @@ import { Id, Name } from '@_types/common'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      /**
-       * Generated API key.
-       */
-      api_key: string
-      /**
-       * Expiration in milliseconds for the API key.
-       */
-      expiration?: long
-      /**
-       * Unique ID for this API key.
-       */
-      id: Id
-      /**
-       * Specifies the name for this API key.
-       */
-      name: Name
-      /**
-       * API key credentials which is the base64-encoding of
-       * the UTF-8 representation of `id` and `api_key` joined
-       * by a colon (`:`).
-       * @since 7.16.0
-       */
-      encoded: string
-    }
+  body: {
+    /**
+     * Generated API key.
+     */
+    api_key: string
+    /**
+     * Expiration in milliseconds for the API key.
+     */
+    expiration?: long
+    /**
+     * Unique ID for this API key.
+     */
+    id: Id
+    /**
+     * Specifies the name for this API key.
+     */
+    name: Name
+    /**
+     * API key credentials which is the base64-encoding of
+     * the UTF-8 representation of `id` and `api_key` joined
+     * by a colon (`:`).
+     * @since 7.16.0
+     */
+    encoded: string
   }
 }

--- a/specification/security/create_service_token/CreateServiceTokenResponse.ts
+++ b/specification/security/create_service_token/CreateServiceTokenResponse.ts
@@ -20,10 +20,8 @@
 import { Token } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      created: boolean
-      token: Token
-    }
+  body: {
+    created: boolean
+    token: Token
   }
 }

--- a/specification/security/delete_privileges/SecurityDeletePrivilegesResponse.ts
+++ b/specification/security/delete_privileges/SecurityDeletePrivilegesResponse.ts
@@ -21,7 +21,5 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { FoundStatus } from './types'
 
 export class Response {
-  '200': {
-    body: Dictionary<string, Dictionary<string, FoundStatus>>
-  }
+  body: Dictionary<string, Dictionary<string, FoundStatus>>
 }

--- a/specification/security/delete_role/SecurityDeleteRoleResponse.ts
+++ b/specification/security/delete_role/SecurityDeleteRoleResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { found: boolean }
-  }
+  body: { found: boolean }
 }

--- a/specification/security/delete_role_mapping/SecurityDeleteRoleMappingResponse.ts
+++ b/specification/security/delete_role_mapping/SecurityDeleteRoleMappingResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { found: boolean }
-  }
+  body: { found: boolean }
 }

--- a/specification/security/delete_service_token/DeleteServiceTokenResponse.ts
+++ b/specification/security/delete_service_token/DeleteServiceTokenResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { found: boolean }
-  }
+  body: { found: boolean }
 }

--- a/specification/security/delete_user/SecurityDeleteUserResponse.ts
+++ b/specification/security/delete_user/SecurityDeleteUserResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { found: boolean }
-  }
+  body: { found: boolean }
 }

--- a/specification/security/disable_user/SecurityDisableUserResponse.ts
+++ b/specification/security/disable_user/SecurityDisableUserResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: {}
-  }
+  body: {}
 }

--- a/specification/security/enable_user/SecurityEnableUserResponse.ts
+++ b/specification/security/enable_user/SecurityEnableUserResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: {}
-  }
+  body: {}
 }

--- a/specification/security/enroll_kibana/Response.ts
+++ b/specification/security/enroll_kibana/Response.ts
@@ -18,11 +18,9 @@
  */
 
 export class Response {
-  '200': {
-    body: {
-      token: Token
-      http_ca: string
-    }
+  body: {
+    token: Token
+    http_ca: string
   }
 }
 

--- a/specification/security/enroll_node/Response.ts
+++ b/specification/security/enroll_node/Response.ts
@@ -18,14 +18,12 @@
  */
 
 export class Response {
-  '200': {
-    body: {
-      http_ca_key: string
-      http_ca_cert: string
-      transport_ca_cert: string
-      transport_key: string
-      transport_cert: string
-      nodes_addresses: string[]
-    }
+  body: {
+    http_ca_key: string
+    http_ca_cert: string
+    transport_ca_cert: string
+    transport_key: string
+    transport_cert: string
+    nodes_addresses: string[]
   }
 }

--- a/specification/security/get_api_key/SecurityGetApiKeyResponse.ts
+++ b/specification/security/get_api_key/SecurityGetApiKeyResponse.ts
@@ -20,7 +20,5 @@
 import { ApiKey } from '@security/_types/ApiKey'
 
 export class Response {
-  '200': {
-    body: { api_keys: ApiKey[] }
-  }
+  body: { api_keys: ApiKey[] }
 }

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
@@ -20,7 +20,5 @@
 import { Indices } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: { cluster: string[]; index: Indices }
-  }
+  body: { cluster: string[]; index: Indices }
 }

--- a/specification/security/get_privileges/SecurityGetPrivilegesResponse.ts
+++ b/specification/security/get_privileges/SecurityGetPrivilegesResponse.ts
@@ -21,7 +21,5 @@ import { Actions } from '@security/put_privileges/types'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  '200': {
-    body: Dictionary<string, Dictionary<string, Actions>>
-  }
+  body: Dictionary<string, Dictionary<string, Actions>>
 }

--- a/specification/security/get_role/SecurityGetRoleResponse.ts
+++ b/specification/security/get_role/SecurityGetRoleResponse.ts
@@ -21,7 +21,5 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Role } from './types'
 
 export class Response {
-  '200': {
-    body: Dictionary<string, Role>
-  }
+  body: Dictionary<string, Role>
 }

--- a/specification/security/get_role_mapping/SecurityGetRoleMappingResponse.ts
+++ b/specification/security/get_role_mapping/SecurityGetRoleMappingResponse.ts
@@ -21,7 +21,5 @@ import { RoleMapping } from '@security/_types/RoleMapping'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  '200': {
-    body: Dictionary<string, RoleMapping>
-  }
+  body: Dictionary<string, RoleMapping>
 }

--- a/specification/security/get_service_accounts/GetServiceAccountsResponse.ts
+++ b/specification/security/get_service_accounts/GetServiceAccountsResponse.ts
@@ -21,7 +21,5 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { RoleDescriptorWrapper } from './types'
 
 export class Response {
-  '200': {
-    body: Dictionary<string, RoleDescriptorWrapper>
-  }
+  body: Dictionary<string, RoleDescriptorWrapper>
 }

--- a/specification/security/get_service_credentials/GetServiceCredentialsResponse.ts
+++ b/specification/security/get_service_credentials/GetServiceCredentialsResponse.ts
@@ -23,13 +23,11 @@ import { integer } from '@_types/Numeric'
 import { NodesCredentials } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      service_account: string
-      count: integer
-      tokens: Dictionary<string, Metadata>
-      /** Contains service account credentials collected from all nodes of the cluster */
-      nodes_credentials: NodesCredentials
-    }
+  body: {
+    service_account: string
+    count: integer
+    tokens: Dictionary<string, Metadata>
+    /** Contains service account credentials collected from all nodes of the cluster */
+    nodes_credentials: NodesCredentials
   }
 }

--- a/specification/security/get_token/GetUserAccessTokenResponse.ts
+++ b/specification/security/get_token/GetUserAccessTokenResponse.ts
@@ -21,15 +21,13 @@ import { long } from '@_types/Numeric'
 import { AuthenticatedUser } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      access_token: string
-      expires_in: long
-      scope?: string
-      type: string
-      refresh_token: string
-      kerberos_authentication_response_token?: string
-      authentication: AuthenticatedUser
-    }
+  body: {
+    access_token: string
+    expires_in: long
+    scope?: string
+    type: string
+    refresh_token: string
+    kerberos_authentication_response_token?: string
+    authentication: AuthenticatedUser
   }
 }

--- a/specification/security/get_user/SecurityGetUserResponse.ts
+++ b/specification/security/get_user/SecurityGetUserResponse.ts
@@ -21,7 +21,5 @@ import { User } from '@security/_types/User'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  '200': {
-    body: Dictionary<string, User>
-  }
+  body: Dictionary<string, User>
 }

--- a/specification/security/get_user_privileges/SecurityGetUserPrivilegesResponse.ts
+++ b/specification/security/get_user_privileges/SecurityGetUserPrivilegesResponse.ts
@@ -24,13 +24,11 @@ import {
 } from '@security/_types/Privileges'
 
 export class Response {
-  '200': {
-    body: {
-      applications: ApplicationPrivileges[]
-      cluster: string[]
-      global: GlobalPrivilege[]
-      indices: IndicesPrivileges[]
-      run_as: string[]
-    }
+  body: {
+    applications: ApplicationPrivileges[]
+    cluster: string[]
+    global: GlobalPrivilege[]
+    indices: IndicesPrivileges[]
+    run_as: string[]
   }
 }

--- a/specification/security/grant_api_key/SecurityGrantApiKeyResponse.ts
+++ b/specification/security/grant_api_key/SecurityGrantApiKeyResponse.ts
@@ -21,7 +21,5 @@ import { Id, Name } from '@_types/common'
 import { EpochMillis } from '@_types/Time'
 
 export class Response {
-  '200': {
-    body: { api_key: string; id: Id; name: Name; expiration?: EpochMillis }
-  }
+  body: { api_key: string; id: Id; name: Name; expiration?: EpochMillis }
 }

--- a/specification/security/has_privileges/SecurityHasPrivilegesResponse.ts
+++ b/specification/security/has_privileges/SecurityHasPrivilegesResponse.ts
@@ -22,13 +22,11 @@ import { IndexName, Username } from '@_types/common'
 import { ApplicationsPrivileges, Privileges } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      application: ApplicationsPrivileges
-      cluster: Dictionary<string, boolean>
-      has_all_requested: boolean
-      index: Dictionary<IndexName, Privileges>
-      username: Username
-    }
+  body: {
+    application: ApplicationsPrivileges
+    cluster: Dictionary<string, boolean>
+    has_all_requested: boolean
+    index: Dictionary<IndexName, Privileges>
+    username: Username
   }
 }

--- a/specification/security/invalidate_api_key/SecurityInvalidateApiKeyResponse.ts
+++ b/specification/security/invalidate_api_key/SecurityInvalidateApiKeyResponse.ts
@@ -21,12 +21,10 @@ import { ErrorCause } from '@_types/Errors'
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      error_count: integer
-      error_details?: ErrorCause[]
-      invalidated_api_keys: string[]
-      previously_invalidated_api_keys: string[]
-    }
+  body: {
+    error_count: integer
+    error_details?: ErrorCause[]
+    invalidated_api_keys: string[]
+    previously_invalidated_api_keys: string[]
   }
 }

--- a/specification/security/invalidate_token/SecurityInvalidateTokenResponse.ts
+++ b/specification/security/invalidate_token/SecurityInvalidateTokenResponse.ts
@@ -21,12 +21,10 @@ import { ErrorCause } from '@_types/Errors'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      error_count: long
-      error_details?: ErrorCause[]
-      invalidated_tokens: long
-      previously_invalidated_tokens: long
-    }
+  body: {
+    error_count: long
+    error_details?: ErrorCause[]
+    invalidated_tokens: long
+    previously_invalidated_tokens: long
   }
 }

--- a/specification/security/put_privileges/SecurityPutPrivilegesResponse.ts
+++ b/specification/security/put_privileges/SecurityPutPrivilegesResponse.ts
@@ -21,7 +21,5 @@ import { CreatedStatus } from '@security/_types/CreatedStatus'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  '200': {
-    body: Dictionary<string, Dictionary<string, CreatedStatus>>
-  }
+  body: Dictionary<string, Dictionary<string, CreatedStatus>>
 }

--- a/specification/security/put_role/SecurityPutRoleResponse.ts
+++ b/specification/security/put_role/SecurityPutRoleResponse.ts
@@ -20,7 +20,5 @@
 import { CreatedStatus } from '@security/_types/CreatedStatus'
 
 export class Response {
-  '200': {
-    body: { role: CreatedStatus }
-  }
+  body: { role: CreatedStatus }
 }

--- a/specification/security/put_role_mapping/SecurityPutRoleMappingResponse.ts
+++ b/specification/security/put_role_mapping/SecurityPutRoleMappingResponse.ts
@@ -20,7 +20,5 @@
 import { CreatedStatus } from '@security/_types/CreatedStatus'
 
 export class Response {
-  '200': {
-    body: { created?: boolean; role_mapping: CreatedStatus }
-  }
+  body: { created?: boolean; role_mapping: CreatedStatus }
 }

--- a/specification/security/put_user/SecurityPutUserResponse.ts
+++ b/specification/security/put_user/SecurityPutUserResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { created: boolean }
-  }
+  body: { created: boolean }
 }

--- a/specification/security/query_api_keys/QueryApiKeysResponse.ts
+++ b/specification/security/query_api_keys/QueryApiKeysResponse.ts
@@ -21,11 +21,9 @@ import { ApiKey } from '@security/_types/ApiKey'
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      total: integer
-      count: integer
-      api_keys: ApiKey[]
-    }
+  body: {
+    total: integer
+    count: integer
+    api_keys: ApiKey[]
   }
 }

--- a/specification/security/saml_authenticate/Response.ts
+++ b/specification/security/saml_authenticate/Response.ts
@@ -20,13 +20,11 @@
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      access_token: string
-      username: string
-      expires_in: integer
-      refresh_token: string
-      realm: string
-    }
+  body: {
+    access_token: string
+    username: string
+    expires_in: integer
+    refresh_token: string
+    realm: string
   }
 }

--- a/specification/security/saml_complete_logout/Response.ts
+++ b/specification/security/saml_complete_logout/Response.ts
@@ -20,7 +20,5 @@
 import { Void } from '@spec_utils/VoidValue'
 
 export class Response {
-  '200': {
-    body: Void
-  }
+  body: Void
 }

--- a/specification/security/saml_invalidate/Response.ts
+++ b/specification/security/saml_invalidate/Response.ts
@@ -20,11 +20,9 @@
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      invalidated: integer
-      realm: string
-      redirect: string
-    }
+  body: {
+    invalidated: integer
+    realm: string
+    redirect: string
   }
 }

--- a/specification/security/saml_logout/Response.ts
+++ b/specification/security/saml_logout/Response.ts
@@ -18,9 +18,7 @@
  */
 
 export class Response {
-  '200': {
-    body: {
-      redirect: string
-    }
+  body: {
+    redirect: string
   }
 }

--- a/specification/security/saml_prepare_authentication/Response.ts
+++ b/specification/security/saml_prepare_authentication/Response.ts
@@ -20,11 +20,9 @@
 import { Id } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: {
-      id: Id
-      realm: string
-      redirect: string
-    }
+  body: {
+    id: Id
+    realm: string
+    redirect: string
   }
 }

--- a/specification/security/saml_service_provider_metadata/Response.ts
+++ b/specification/security/saml_service_provider_metadata/Response.ts
@@ -18,9 +18,7 @@
  */
 
 export class Response {
-  '200': {
-    body: {
-      metadata: string
-    }
+  body: {
+    metadata: string
   }
 }

--- a/specification/shutdown/delete_node/ShutdownDeleteNodeResponse.ts
+++ b/specification/shutdown/delete_node/ShutdownDeleteNodeResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/shutdown/get_node/ShutdownGetNodeResponse.ts
+++ b/specification/shutdown/get_node/ShutdownGetNodeResponse.ts
@@ -21,10 +21,8 @@ import { NodeId } from '@_types/common'
 import { EpochMillis, Timestamp } from '@_types/Time'
 
 export class Response {
-  '200': {
-    body: {
-      nodes: NodeShutdownStatus[]
-    }
+  body: {
+    nodes: NodeShutdownStatus[]
   }
 }
 

--- a/specification/shutdown/put_node/ShutdownPutNodeResponse.ts
+++ b/specification/shutdown/put_node/ShutdownPutNodeResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/slm/delete_lifecycle/DeleteSnapshotLifecycleResponse.ts
+++ b/specification/slm/delete_lifecycle/DeleteSnapshotLifecycleResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/slm/execute_lifecycle/ExecuteSnapshotLifecycleResponse.ts
+++ b/specification/slm/execute_lifecycle/ExecuteSnapshotLifecycleResponse.ts
@@ -20,7 +20,5 @@
 import { Name } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: { snapshot_name: Name }
-  }
+  body: { snapshot_name: Name }
 }

--- a/specification/slm/execute_retention/ExecuteRetentionResponse.ts
+++ b/specification/slm/execute_retention/ExecuteRetentionResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/slm/get_lifecycle/GetSnapshotLifecycleResponse.ts
+++ b/specification/slm/get_lifecycle/GetSnapshotLifecycleResponse.ts
@@ -22,7 +22,5 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Id } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: Dictionary<Id, SnapshotLifecycle>
-  }
+  body: Dictionary<Id, SnapshotLifecycle>
 }

--- a/specification/slm/get_stats/GetSnapshotLifecycleStatsResponse.ts
+++ b/specification/slm/get_stats/GetSnapshotLifecycleStatsResponse.ts
@@ -21,18 +21,16 @@ import { long } from '@_types/Numeric'
 import { EpochMillis } from '@_types/Time'
 
 export class Response {
-  '200': {
-    body: {
-      retention_deletion_time: string
-      retention_deletion_time_millis: EpochMillis
-      retention_failed: long
-      retention_runs: long
-      retention_timed_out: long
-      total_snapshots_deleted: long
-      total_snapshot_deletion_failures: long
-      total_snapshots_failed: long
-      total_snapshots_taken: long
-      policy_stats: string[]
-    }
+  body: {
+    retention_deletion_time: string
+    retention_deletion_time_millis: EpochMillis
+    retention_failed: long
+    retention_runs: long
+    retention_timed_out: long
+    total_snapshots_deleted: long
+    total_snapshot_deletion_failures: long
+    total_snapshots_failed: long
+    total_snapshots_taken: long
+    policy_stats: string[]
   }
 }

--- a/specification/slm/get_status/GetSnapshotLifecycleManagementStatusResponse.ts
+++ b/specification/slm/get_status/GetSnapshotLifecycleManagementStatusResponse.ts
@@ -20,7 +20,5 @@
 import { LifecycleOperationMode } from '@_types/Lifecycle'
 
 export class Response {
-  '200': {
-    body: { operation_mode: LifecycleOperationMode }
-  }
+  body: { operation_mode: LifecycleOperationMode }
 }

--- a/specification/slm/put_lifecycle/PutSnapshotLifecycleResponse.ts
+++ b/specification/slm/put_lifecycle/PutSnapshotLifecycleResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/slm/start/StartSnapshotLifecycleManagementResponse.ts
+++ b/specification/slm/start/StartSnapshotLifecycleManagementResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/slm/stop/StopSnapshotLifecycleManagementResponse.ts
+++ b/specification/slm/stop/StopSnapshotLifecycleManagementResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/snapshot/cleanup_repository/SnapshotCleanupRepositoryResponse.ts
+++ b/specification/snapshot/cleanup_repository/SnapshotCleanupRepositoryResponse.ts
@@ -20,11 +20,9 @@
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      /** Statistics for cleanup operations. */
-      results: CleanupRepositoryResults
-    }
+  body: {
+    /** Statistics for cleanup operations. */
+    results: CleanupRepositoryResults
   }
 }
 

--- a/specification/snapshot/clone/SnapshotCloneResponse.ts
+++ b/specification/snapshot/clone/SnapshotCloneResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/snapshot/create/SnapshotCreateResponse.ts
+++ b/specification/snapshot/create/SnapshotCreateResponse.ts
@@ -20,17 +20,15 @@
 import { SnapshotInfo } from '@snapshot/_types/SnapshotInfo'
 
 export class Response {
-  '200': {
-    body: {
-      /**
-       * Equals `true` if the snapshot was accepted. Present when the request had `wait_for_completion` set to `false`
-       * @since 7.15.0
-       */
-      accepted?: boolean
-      /**
-       * Snapshot information. Present when the request had `wait_for_completion` set to `true`
-       */
-      snapshot?: SnapshotInfo
-    }
+  body: {
+    /**
+     * Equals `true` if the snapshot was accepted. Present when the request had `wait_for_completion` set to `false`
+     * @since 7.15.0
+     */
+    accepted?: boolean
+    /**
+     * Snapshot information. Present when the request had `wait_for_completion` set to `true`
+     */
+    snapshot?: SnapshotInfo
   }
 }

--- a/specification/snapshot/create_repository/SnapshotCreateRepositoryResponse.ts
+++ b/specification/snapshot/create_repository/SnapshotCreateRepositoryResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/snapshot/delete/SnapshotDeleteResponse.ts
+++ b/specification/snapshot/delete/SnapshotDeleteResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/snapshot/delete_repository/SnapshotDeleteRepositoryResponse.ts
+++ b/specification/snapshot/delete_repository/SnapshotDeleteRepositoryResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/snapshot/get/SnapshotGetResponse.ts
+++ b/specification/snapshot/get/SnapshotGetResponse.ts
@@ -23,21 +23,19 @@ import { ErrorCause } from '@_types/Errors'
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      responses?: SnapshotResponseItem[]
-      snapshots?: SnapshotInfo[]
-      /**
-       * The total number of snapshots that match the request when ignoring size limit or after query parameter.
-       * @since 7.15.0
-       */
-      total: integer
-      /**
-       * The number of remaining snapshots that were not returned due to size limits and that can be fetched by additional requests using the next field value.
-       * @since 7.15.0
-       */
-      remaining: integer
-    }
+  body: {
+    responses?: SnapshotResponseItem[]
+    snapshots?: SnapshotInfo[]
+    /**
+     * The total number of snapshots that match the request when ignoring size limit or after query parameter.
+     * @since 7.15.0
+     */
+    total: integer
+    /**
+     * The number of remaining snapshots that were not returned due to size limits and that can be fetched by additional requests using the next field value.
+     * @since 7.15.0
+     */
+    remaining: integer
   }
 }
 

--- a/specification/snapshot/get_repository/SnapshotGetRepositoryResponse.ts
+++ b/specification/snapshot/get_repository/SnapshotGetRepositoryResponse.ts
@@ -21,7 +21,5 @@ import { Repository } from '@snapshot/_types/SnapshotRepository'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  '200': {
-    body: Dictionary<string, Repository>
-  }
+  body: Dictionary<string, Repository>
 }

--- a/specification/snapshot/restore/SnapshotRestoreResponse.ts
+++ b/specification/snapshot/restore/SnapshotRestoreResponse.ts
@@ -21,9 +21,7 @@ import { IndexName } from '@_types/common'
 import { ShardStatistics } from '@_types/Stats'
 
 export class Response {
-  '200': {
-    body: { snapshot: SnapshotRestore }
-  }
+  body: { snapshot: SnapshotRestore }
 }
 
 export class SnapshotRestore {

--- a/specification/snapshot/status/SnapshotStatusResponse.ts
+++ b/specification/snapshot/status/SnapshotStatusResponse.ts
@@ -20,7 +20,5 @@
 import { Status } from '@snapshot/_types/SnapshotStatus'
 
 export class Response {
-  '200': {
-    body: { snapshots: Status[] }
-  }
+  body: { snapshots: Status[] }
 }

--- a/specification/snapshot/verify_repository/SnapshotVerifyRepositoryResponse.ts
+++ b/specification/snapshot/verify_repository/SnapshotVerifyRepositoryResponse.ts
@@ -21,9 +21,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Name } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: { nodes: Dictionary<string, CompactNodeInfo> }
-  }
+  body: { nodes: Dictionary<string, CompactNodeInfo> }
 }
 
 export class CompactNodeInfo {

--- a/specification/sql/clear_cursor/ClearSqlCursorResponse.ts
+++ b/specification/sql/clear_cursor/ClearSqlCursorResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response {
-  '200': {
-    body: { succeeded: boolean }
-  }
+  body: { succeeded: boolean }
 }

--- a/specification/sql/delete_async/SqlDeleteAsyncResponse.ts
+++ b/specification/sql/delete_async/SqlDeleteAsyncResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/sql/get_async/SqlGetAsyncResponse.ts
+++ b/specification/sql/get_async/SqlGetAsyncResponse.ts
@@ -21,42 +21,40 @@ import { Id } from '@_types/common'
 import { Column, Row } from '../types'
 
 export class Response {
-  '200': {
-    body: {
-      /**
-       * Identifier for the search. This value is only returned for async and saved
-       * synchronous searches. For CSV, TSV, and TXT responses, this value is returned
-       * in the `Async-ID` HTTP header.
-       */
-      id: Id
-      /**
-       * If `true`, the search is still running. If false, the search has finished.
-       * This value is only returned for async and saved synchronous searches. For
-       * CSV, TSV, and TXT responses, this value is returned in the `Async-partial`
-       * HTTP header.
-       */
-      is_running: boolean
-      /**
-       * If `true`, the response does not contain complete search results. If `is_partial`
-       * is `true` and `is_running` is `true`, the search is still running. If `is_partial`
-       * is `true` but `is_running` is `false`, the results are partial due to a failure or
-       * timeout. This value is only returned for async and saved synchronous searches.
-       * For CSV, TSV, and TXT responses, this value is returned in the `Async-partial` HTTP header.
-       */
-      is_partial: boolean
-      /**
-       * Column headings for the search results. Each object is a column.
-       */
-      columns?: Column[]
-      /**
-       * Cursor for the next set of paginated results. For CSV, TSV, and
-       * TXT responses, this value is returned in the `Cursor` HTTP header.
-       */
-      cursor?: string
-      /**
-       * Values for the search results.
-       */
-      rows: Row[]
-    }
+  body: {
+    /**
+     * Identifier for the search. This value is only returned for async and saved
+     * synchronous searches. For CSV, TSV, and TXT responses, this value is returned
+     * in the `Async-ID` HTTP header.
+     */
+    id: Id
+    /**
+     * If `true`, the search is still running. If false, the search has finished.
+     * This value is only returned for async and saved synchronous searches. For
+     * CSV, TSV, and TXT responses, this value is returned in the `Async-partial`
+     * HTTP header.
+     */
+    is_running: boolean
+    /**
+     * If `true`, the response does not contain complete search results. If `is_partial`
+     * is `true` and `is_running` is `true`, the search is still running. If `is_partial`
+     * is `true` but `is_running` is `false`, the results are partial due to a failure or
+     * timeout. This value is only returned for async and saved synchronous searches.
+     * For CSV, TSV, and TXT responses, this value is returned in the `Async-partial` HTTP header.
+     */
+    is_partial: boolean
+    /**
+     * Column headings for the search results. Each object is a column.
+     */
+    columns?: Column[]
+    /**
+     * Cursor for the next set of paginated results. For CSV, TSV, and
+     * TXT responses, this value is returned in the `Cursor` HTTP header.
+     */
+    cursor?: string
+    /**
+     * Values for the search results.
+     */
+    rows: Row[]
   }
 }

--- a/specification/sql/get_async_status/SqlGetAsyncStatusResponse.ts
+++ b/specification/sql/get_async_status/SqlGetAsyncStatusResponse.ts
@@ -20,37 +20,35 @@
 import { uint, ulong } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      /**
-       * Identifier for the search.
-       */
-      id: string
-      /**
-       * If `true`, the search is still running. If `false`, the search has finished.
-       */
-      is_running: boolean
-      /**
-       * If `true`, the response does not contain complete search results. If `is_partial`
-       * is `true` and `is_running` is `true`, the search is still running. If `is_partial`
-       * is `true` but `is_running` is `false`, the results are partial due to a failure or
-       * timeout.
-       */
-      is_partial: boolean
-      /**
-       * Timestamp, in milliseconds since the Unix epoch, when the search started.
-       * The API only returns this property for running searches.
-       */
-      start_time_in_millis: ulong
-      /**
-       * Timestamp, in milliseconds since the Unix epoch, when Elasticsearch will delete
-       * the search and its results, even if the search is still running.
-       */
-      expiration_time_in_millis: ulong
-      /**
-       * HTTP status code for the search. The API only returns this property for completed searches.
-       */
-      completion_status?: uint
-    }
+  body: {
+    /**
+     * Identifier for the search.
+     */
+    id: string
+    /**
+     * If `true`, the search is still running. If `false`, the search has finished.
+     */
+    is_running: boolean
+    /**
+     * If `true`, the response does not contain complete search results. If `is_partial`
+     * is `true` and `is_running` is `true`, the search is still running. If `is_partial`
+     * is `true` but `is_running` is `false`, the results are partial due to a failure or
+     * timeout.
+     */
+    is_partial: boolean
+    /**
+     * Timestamp, in milliseconds since the Unix epoch, when the search started.
+     * The API only returns this property for running searches.
+     */
+    start_time_in_millis: ulong
+    /**
+     * Timestamp, in milliseconds since the Unix epoch, when Elasticsearch will delete
+     * the search and its results, even if the search is still running.
+     */
+    expiration_time_in_millis: ulong
+    /**
+     * HTTP status code for the search. The API only returns this property for completed searches.
+     */
+    completion_status?: uint
   }
 }

--- a/specification/sql/query/QuerySqlResponse.ts
+++ b/specification/sql/query/QuerySqlResponse.ts
@@ -21,42 +21,40 @@ import { Id } from '@_types/common'
 import { Column, Row } from '../types'
 
 export class Response {
-  '200': {
-    body: {
-      /**
-       * Identifier for the search. This value is only returned for async and saved
-       * synchronous searches. For CSV, TSV, and TXT responses, this value is returned
-       * in the `Async-ID` HTTP header.
-       */
-      id?: Id
-      /**
-       * If `true`, the search is still running. If false, the search has finished.
-       * This value is only returned for async and saved synchronous searches. For
-       * CSV, TSV, and TXT responses, this value is returned in the `Async-partial`
-       * HTTP header.
-       */
-      is_running?: boolean
-      /**
-       * If `true`, the response does not contain complete search results. If `is_partial`
-       * is `true` and `is_running` is `true`, the search is still running. If `is_partial`
-       * is `true` but `is_running` is `false`, the results are partial due to a failure or
-       * timeout. This value is only returned for async and saved synchronous searches.
-       * For CSV, TSV, and TXT responses, this value is returned in the `Async-partial` HTTP header.
-       */
-      is_partial?: boolean
-      /**
-       * Column headings for the search results. Each object is a column.
-       */
-      columns?: Column[]
-      /**
-       * Cursor for the next set of paginated results. For CSV, TSV, and
-       * TXT responses, this value is returned in the `Cursor` HTTP header.
-       */
-      cursor?: string
-      /**
-       * Values for the search results.
-       */
-      rows: Row[]
-    }
+  body: {
+    /**
+     * Identifier for the search. This value is only returned for async and saved
+     * synchronous searches. For CSV, TSV, and TXT responses, this value is returned
+     * in the `Async-ID` HTTP header.
+     */
+    id?: Id
+    /**
+     * If `true`, the search is still running. If false, the search has finished.
+     * This value is only returned for async and saved synchronous searches. For
+     * CSV, TSV, and TXT responses, this value is returned in the `Async-partial`
+     * HTTP header.
+     */
+    is_running?: boolean
+    /**
+     * If `true`, the response does not contain complete search results. If `is_partial`
+     * is `true` and `is_running` is `true`, the search is still running. If `is_partial`
+     * is `true` but `is_running` is `false`, the results are partial due to a failure or
+     * timeout. This value is only returned for async and saved synchronous searches.
+     * For CSV, TSV, and TXT responses, this value is returned in the `Async-partial` HTTP header.
+     */
+    is_partial?: boolean
+    /**
+     * Column headings for the search results. Each object is a column.
+     */
+    columns?: Column[]
+    /**
+     * Cursor for the next set of paginated results. For CSV, TSV, and
+     * TXT responses, this value is returned in the `Cursor` HTTP header.
+     */
+    cursor?: string
+    /**
+     * Values for the search results.
+     */
+    rows: Row[]
   }
 }

--- a/specification/sql/translate/TranslateSqlResponse.ts
+++ b/specification/sql/translate/TranslateSqlResponse.ts
@@ -24,12 +24,10 @@ import { Field, Fields } from '@_types/common'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      size: long
-      _source: SourceConfig
-      fields: Array<Dictionary<Field, string>>
-      sort: Sort
-    }
+  body: {
+    size: long
+    _source: SourceConfig
+    fields: Array<Dictionary<Field, string>>
+    sort: Sort
   }
 }

--- a/specification/ssl/certificates/GetCertificatesResponse.ts
+++ b/specification/ssl/certificates/GetCertificatesResponse.ts
@@ -20,7 +20,5 @@
 import { CertificateInformation } from './types'
 
 export class Response {
-  '200': {
-    body: Array<CertificateInformation>
-  }
+  body: Array<CertificateInformation>
 }

--- a/specification/tasks/cancel/CancelTasksResponse.ts
+++ b/specification/tasks/cancel/CancelTasksResponse.ts
@@ -20,7 +20,5 @@
 import { TaskListResponseBase } from '@tasks/_types/TaskListResponseBase'
 
 export class Response {
-  '200': {
-    body: TaskListResponseBase
-  }
+  body: TaskListResponseBase
 }

--- a/specification/tasks/get/GetTaskResponse.ts
+++ b/specification/tasks/get/GetTaskResponse.ts
@@ -22,12 +22,10 @@ import { ErrorCause } from '@_types/Errors'
 import { TaskInfo } from '../_types/TaskInfo'
 
 export class Response {
-  '200': {
-    body: {
-      completed: boolean
-      task: TaskInfo
-      response?: TaskStatus
-      error?: ErrorCause
-    }
+  body: {
+    completed: boolean
+    task: TaskInfo
+    response?: TaskStatus
+    error?: ErrorCause
   }
 }

--- a/specification/tasks/list/ListTasksResponse.ts
+++ b/specification/tasks/list/ListTasksResponse.ts
@@ -20,7 +20,5 @@
 import { TaskListResponseBase } from '@tasks/_types/TaskListResponseBase'
 
 export class Response {
-  '200': {
-    body: TaskListResponseBase
-  }
+  body: TaskListResponseBase
 }

--- a/specification/text_structure/find_structure/FindStructureResponse.ts
+++ b/specification/text_structure/find_structure/FindStructureResponse.ts
@@ -25,30 +25,28 @@ import { integer } from '@_types/Numeric'
 import { FieldStat } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      charset: string
-      has_header_row?: boolean
-      has_byte_order_marker: boolean
-      format: string
-      field_stats: Dictionary<Field, FieldStat>
-      sample_start: string
-      num_messages_analyzed: integer
-      mappings: TypeMapping
-      quote?: string
-      delimiter?: string
-      need_client_timezone: boolean
-      num_lines_analyzed: integer
-      column_names?: string[]
-      explanation?: string[]
-      grok_pattern?: string
-      multiline_start_pattern?: string
-      exclude_lines_pattern?: string
-      java_timestamp_formats?: string[]
-      joda_timestamp_formats?: string[]
-      timestamp_field?: Field
-      should_trim_fields?: boolean
-      ingest_pipeline: PipelineConfig
-    }
+  body: {
+    charset: string
+    has_header_row?: boolean
+    has_byte_order_marker: boolean
+    format: string
+    field_stats: Dictionary<Field, FieldStat>
+    sample_start: string
+    num_messages_analyzed: integer
+    mappings: TypeMapping
+    quote?: string
+    delimiter?: string
+    need_client_timezone: boolean
+    num_lines_analyzed: integer
+    column_names?: string[]
+    explanation?: string[]
+    grok_pattern?: string
+    multiline_start_pattern?: string
+    exclude_lines_pattern?: string
+    java_timestamp_formats?: string[]
+    joda_timestamp_formats?: string[]
+    timestamp_field?: Field
+    should_trim_fields?: boolean
+    ingest_pipeline: PipelineConfig
   }
 }

--- a/specification/transform/delete_transform/DeleteTransformResponse.ts
+++ b/specification/transform/delete_transform/DeleteTransformResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/transform/get_transform/GetTransformResponse.ts
+++ b/specification/transform/get_transform/GetTransformResponse.ts
@@ -21,7 +21,5 @@ import { long } from '@_types/Numeric'
 import { TransformSummary } from './types'
 
 export class Response {
-  '200': {
-    body: { count: long; transforms: TransformSummary[] }
-  }
+  body: { count: long; transforms: TransformSummary[] }
 }

--- a/specification/transform/get_transform_stats/GetTransformStatsResponse.ts
+++ b/specification/transform/get_transform_stats/GetTransformStatsResponse.ts
@@ -21,7 +21,5 @@ import { long } from '@_types/Numeric'
 import { TransformStats } from './types'
 
 export class Response {
-  '200': {
-    body: { count: long; transforms: TransformStats[] }
-  }
+  body: { count: long; transforms: TransformStats[] }
 }

--- a/specification/transform/preview_transform/PreviewTransformResponse.ts
+++ b/specification/transform/preview_transform/PreviewTransformResponse.ts
@@ -20,10 +20,8 @@
 import { IndexState } from '@indices/_types/IndexState'
 
 export class Response<TTransform> {
-  '200': {
-    body: {
-      generated_dest_index: IndexState
-      preview: TTransform[]
-    }
+  body: {
+    generated_dest_index: IndexState
+    preview: TTransform[]
   }
 }

--- a/specification/transform/put_transform/PutTransformResponse.ts
+++ b/specification/transform/put_transform/PutTransformResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/transform/reset_transform/ResetTransformResponse.ts
+++ b/specification/transform/reset_transform/ResetTransformResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/transform/start_transform/StartTransformResponse.ts
+++ b/specification/transform/start_transform/StartTransformResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/transform/stop_transform/StopTransformResponse.ts
+++ b/specification/transform/stop_transform/StopTransformResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/transform/update_transform/UpdateTransformResponse.ts
+++ b/specification/transform/update_transform/UpdateTransformResponse.ts
@@ -30,22 +30,20 @@ import { long } from '@_types/Numeric'
 import { Time } from '@_types/Time'
 
 export class Response {
-  '200': {
-    body: {
-      create_time: long
-      //  create_time_date_time?: DateString
-      description: string
-      dest: Destination
-      frequency?: Time
-      id: Id
-      latest?: Latest
-      pivot?: Pivot
-      retention_policy?: RetentionPolicyContainer
-      settings: Settings
-      source: Source
-      sync?: SyncContainer
-      version: VersionString
-      _meta?: Metadata
-    }
+  body: {
+    create_time: long
+    //  create_time_date_time?: DateString
+    description: string
+    dest: Destination
+    frequency?: Time
+    id: Id
+    latest?: Latest
+    pivot?: Pivot
+    retention_policy?: RetentionPolicyContainer
+    settings: Settings
+    source: Source
+    sync?: SyncContainer
+    version: VersionString
+    _meta?: Metadata
   }
 }

--- a/specification/transform/upgrade_transforms/UpgradeTransformsResponse.ts
+++ b/specification/transform/upgrade_transforms/UpgradeTransformsResponse.ts
@@ -23,14 +23,12 @@ import { long } from '@_types/Numeric'
 import { Transform } from '@_types/Transform'
 */
 export class Response {
-  '200': {
-    body: {
-      /** The number of transforms that need to be upgraded. */
-      needs_update: integer
-      /** The number of transforms that don’t require upgrading. */
-      no_action: integer
-      /** The number of transforms that have been upgraded. */
-      updated: integer
-    }
+  body: {
+    /** The number of transforms that need to be upgraded. */
+    needs_update: integer
+    /** The number of transforms that don’t require upgrading. */
+    no_action: integer
+    /** The number of transforms that have been upgraded. */
+    updated: integer
   }
 }

--- a/specification/watcher/ack_watch/WatcherAckWatchResponse.ts
+++ b/specification/watcher/ack_watch/WatcherAckWatchResponse.ts
@@ -20,7 +20,5 @@
 import { WatchStatus } from '@watcher/_types/Watch'
 
 export class Response {
-  '200': {
-    body: { status: WatchStatus }
-  }
+  body: { status: WatchStatus }
 }

--- a/specification/watcher/activate_watch/WatcherActivateWatchResponse.ts
+++ b/specification/watcher/activate_watch/WatcherActivateWatchResponse.ts
@@ -20,7 +20,5 @@
 import { ActivationStatus } from '@watcher/_types/Activation'
 
 export class Response {
-  '200': {
-    body: { status: ActivationStatus }
-  }
+  body: { status: ActivationStatus }
 }

--- a/specification/watcher/deactivate_watch/DeactivateWatchResponse.ts
+++ b/specification/watcher/deactivate_watch/DeactivateWatchResponse.ts
@@ -20,7 +20,5 @@
 import { ActivationStatus } from '@watcher/_types/Activation'
 
 export class Response {
-  '200': {
-    body: { status: ActivationStatus }
-  }
+  body: { status: ActivationStatus }
 }

--- a/specification/watcher/delete_watch/DeleteWatchResponse.ts
+++ b/specification/watcher/delete_watch/DeleteWatchResponse.ts
@@ -20,7 +20,5 @@
 import { Id, VersionNumber } from '@_types/common'
 
 export class Response {
-  '200': {
-    body: { found: boolean; _id: Id; _version: VersionNumber }
-  }
+  body: { found: boolean; _id: Id; _version: VersionNumber }
 }

--- a/specification/watcher/execute_watch/WatcherExecuteWatchResponse.ts
+++ b/specification/watcher/execute_watch/WatcherExecuteWatchResponse.ts
@@ -21,7 +21,5 @@ import { Id } from '@_types/common'
 import { WatchRecord } from './types'
 
 export class Response {
-  '200': {
-    body: { _id: Id; watch_record: WatchRecord }
-  }
+  body: { _id: Id; watch_record: WatchRecord }
 }

--- a/specification/watcher/get_watch/GetWatchResponse.ts
+++ b/specification/watcher/get_watch/GetWatchResponse.ts
@@ -22,15 +22,13 @@ import { Id, SequenceNumber, VersionNumber } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      found: boolean
-      _id: Id
-      status?: WatchStatus
-      watch?: Watch
-      _primary_term?: integer
-      _seq_no?: SequenceNumber
-      _version?: VersionNumber
-    }
+  body: {
+    found: boolean
+    _id: Id
+    status?: WatchStatus
+    watch?: Watch
+    _primary_term?: integer
+    _seq_no?: SequenceNumber
+    _version?: VersionNumber
   }
 }

--- a/specification/watcher/put_watch/WatcherPutWatchResponse.ts
+++ b/specification/watcher/put_watch/WatcherPutWatchResponse.ts
@@ -21,13 +21,11 @@ import { Id, SequenceNumber, VersionNumber } from '@_types/common'
 import { long } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      created: boolean
-      _id: Id
-      _primary_term: long
-      _seq_no: SequenceNumber
-      _version: VersionNumber
-    }
+  body: {
+    created: boolean
+    _id: Id
+    _primary_term: long
+    _seq_no: SequenceNumber
+    _version: VersionNumber
   }
 }

--- a/specification/watcher/query_watches/WatcherQueryWatchesResponse.ts
+++ b/specification/watcher/query_watches/WatcherQueryWatchesResponse.ts
@@ -21,10 +21,8 @@ import { QueryWatch } from '../_types/Watch'
 import { integer } from '@_types/Numeric'
 
 export class Response {
-  '200': {
-    body: {
-      count: integer
-      watches: QueryWatch[]
-    }
+  body: {
+    count: integer
+    watches: QueryWatch[]
   }
 }

--- a/specification/watcher/start/WatcherStartResponse.ts
+++ b/specification/watcher/start/WatcherStartResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/watcher/stats/WatcherStatsResponse.ts
+++ b/specification/watcher/stats/WatcherStatsResponse.ts
@@ -22,13 +22,11 @@ import { Name } from '@_types/common'
 import { WatcherNodeStats } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      /** @codegen_name node_stats */
-      _nodes: NodeStatistics
-      cluster_name: Name
-      manually_stopped: boolean
-      stats: WatcherNodeStats[]
-    }
+  body: {
+    /** @codegen_name node_stats */
+    _nodes: NodeStatistics
+    cluster_name: Name
+    manually_stopped: boolean
+    stats: WatcherNodeStats[]
   }
 }

--- a/specification/watcher/stop/WatcherStopResponse.ts
+++ b/specification/watcher/stop/WatcherStopResponse.ts
@@ -20,7 +20,5 @@
 import { AcknowledgedResponseBase } from '@_types/Base'
 
 export class Response {
-  '200': {
-    body: AcknowledgedResponseBase
-  }
+  body: AcknowledgedResponseBase
 }

--- a/specification/xpack/info/XPackInfoResponse.ts
+++ b/specification/xpack/info/XPackInfoResponse.ts
@@ -20,12 +20,10 @@
 import { BuildInformation, Features, MinimalLicenseInformation } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      build: BuildInformation
-      features: Features
-      license: MinimalLicenseInformation
-      tagline: string
-    }
+  body: {
+    build: BuildInformation
+    features: Features
+    license: MinimalLicenseInformation
+    tagline: string
   }
 }

--- a/specification/xpack/usage/XPackUsageResponse.ts
+++ b/specification/xpack/usage/XPackUsageResponse.ts
@@ -40,37 +40,35 @@ import {
 } from './types'
 
 export class Response {
-  '200': {
-    body: {
-      aggregate_metric: Base
-      analytics: Analytics
-      /** @since 8.2.0 */
-      archive: Archive
-      watcher: Watcher
-      ccr: Ccr
-      data_frame?: Base
-      data_science?: Base
-      data_streams?: DataStreams
-      data_tiers: DataTiers
-      enrich?: Base
-      eql: Eql
-      flattened?: Flattened
-      frozen_indices: FrozenIndices
-      graph: Base
-      ilm: Ilm
-      logstash: Base
-      ml: MachineLearning
-      monitoring: Monitoring
-      rollup: Base
-      runtime_fields?: RuntimeFieldTypes
-      spatial: Base
-      searchable_snapshots: SearchableSnapshots
-      security: Security
-      slm: Slm
-      sql: Sql
-      transform: Base
-      vectors?: Vector
-      voting_only: Base
-    }
+  body: {
+    aggregate_metric: Base
+    analytics: Analytics
+    /** @since 8.2.0 */
+    archive: Archive
+    watcher: Watcher
+    ccr: Ccr
+    data_frame?: Base
+    data_science?: Base
+    data_streams?: DataStreams
+    data_tiers: DataTiers
+    enrich?: Base
+    eql: Eql
+    flattened?: Flattened
+    frozen_indices: FrozenIndices
+    graph: Base
+    ilm: Ilm
+    logstash: Base
+    ml: MachineLearning
+    monitoring: Monitoring
+    rollup: Base
+    runtime_fields?: RuntimeFieldTypes
+    spatial: Base
+    searchable_snapshots: SearchableSnapshots
+    security: Security
+    slm: Slm
+    sql: Sql
+    transform: Base
+    vectors?: Vector
+    voting_only: Base
   }
 }


### PR DESCRIPTION
Hey folks! After a long and productive discussion during the ES spec sync we decided to roll partially back the change that introduced the status codes and move to the following format:

```ts
export class Response {
  body: SuccessResponseDefinition
  failures: [{
    statusCode: 404
    body: NonStandardFailure
  }]
}
```

This will make the life of code generators easier as well as the docs team, where users will have the successful case, the standard error, and one or more optional non-standard failures. Furthermore, this change won't introduce a breaking change in the specification schema, as it's an additive change.

This pr only partially everts the spec to the previous format, a subsequent pr will introduce the `failures` support. I said partially because it keeps the improvements done meanwhile, such as the removal of `DictionaryResponseBase`.

Related: #928
Supersedes: #1529