### PR TITLE
Add the 'geohex_tile' aggregation

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2581,6 +2581,7 @@ export interface AggregationsAggregationContainer {
   geohash_grid?: AggregationsGeoHashGridAggregation
   geo_line?: AggregationsGeoLineAggregation
   geotile_grid?: AggregationsGeoTileGridAggregation
+  geohex_grid?: AggregationsGeohexGridAggregation
   global?: AggregationsGlobalAggregation
   histogram?: AggregationsHistogramAggregation
   ip_range?: AggregationsIpRangeAggregation
@@ -3053,6 +3054,14 @@ export interface AggregationsGeoTileGridBucketKeys extends AggregationsMultiBuck
 }
 export type AggregationsGeoTileGridBucket = AggregationsGeoTileGridBucketKeys
   & { [property: string]: AggregationsAggregate | GeoTile | long }
+
+export interface AggregationsGeohexGridAggregation extends AggregationsBucketAggregationBase {
+  field: Field
+  precision?: integer
+  bounds?: GeoBounds
+  size?: integer
+  shard_size?: integer
+}
 
 export interface AggregationsGlobalAggregateKeys extends AggregationsSingleBucketAggregateBase {
 }

--- a/specification/_types/aggregations/AggregationContainer.ts
+++ b/specification/_types/aggregations/AggregationContainer.ts
@@ -35,6 +35,7 @@ import {
   GeoDistanceAggregation,
   GeoHashGridAggregation,
   GeoTileGridAggregation,
+  GeohexGridAggregation,
   GlobalAggregation,
   HistogramAggregation,
   IpRangeAggregation,
@@ -158,6 +159,7 @@ export class AggregationContainer {
   geohash_grid?: GeoHashGridAggregation
   geo_line?: GeoLineAggregation
   geotile_grid?: GeoTileGridAggregation
+  geohex_grid?: GeohexGridAggregation
   global?: GlobalAggregation
   histogram?: HistogramAggregation
   ip_range?: IpRangeAggregation

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -193,6 +193,34 @@ export class GeoTileGridAggregation extends BucketAggregationBase {
   bounds?: GeoBounds
 }
 
+export class GeohexGridAggregation extends BucketAggregationBase {
+  /**
+   * Field containing indexed geo-point values. Must be explicitly
+   * mapped as a `geo_point` field. If the field contains an array
+   * `geohex_grid` aggregates all array values.
+   */
+  field: Field
+  /**
+   * Integer zoom of the key used to defined cells or buckets
+   * in the results. Value should be between 0-15.
+   * @server_default 6
+   */
+  precision?: integer
+  /**
+   * Bounding box used to filter the geo-points in each bucket.
+   */
+  bounds?: GeoBounds
+  /**
+   * Maximum number of buckets to return.
+   * @server_default 10000
+   */
+  size?: integer
+  /**
+   * Number of buckets returned from each shard.
+   */
+  shard_size?: integer
+}
+
 export class GlobalAggregation extends BucketAggregationBase {}
 
 export class ExtendedBounds<T> {


### PR DESCRIPTION
Adds the `geohex_grid` aggregation which was added in 8.1.

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-geohexgrid-aggregation.html