### PR TITLE
Add 'jlh' property to SignificantTerms aggs

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3515,6 +3515,7 @@ export interface AggregationsSignificantTermsAggregation extends AggregationsBuc
   field?: Field
   gnd?: AggregationsGoogleNormalizedDistanceHeuristic
   include?: AggregationsTermsInclude
+  jlh?: EmptyObject
   min_doc_count?: long
   mutual_information?: AggregationsMutualInformationHeuristic
   percentage?: AggregationsPercentageScoreHeuristic
@@ -3538,6 +3539,7 @@ export interface AggregationsSignificantTextAggregation extends AggregationsBuck
   filter_duplicate_text?: boolean
   gnd?: AggregationsGoogleNormalizedDistanceHeuristic
   include?: string | string[]
+  jlh?: EmptyObject
   min_doc_count?: long
   mutual_information?: AggregationsMutualInformationHeuristic
   percentage?: AggregationsPercentageScoreHeuristic

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -20,6 +20,7 @@
 import { SortOrder } from '@_types/sort'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { EmptyObject } from '@_types/common'
 import { Field, RelationName, Fields } from '@_types/common'
 import {
   GeoDistanceType,
@@ -311,6 +312,7 @@ export class SignificantTermsAggregation extends BucketAggregationBase {
   field?: Field
   gnd?: GoogleNormalizedDistanceHeuristic
   include?: TermsInclude
+  jlh?: EmptyObject
   min_doc_count?: long
   mutual_information?: MutualInformationHeuristic
   percentage?: PercentageScoreHeuristic
@@ -329,6 +331,7 @@ export class SignificantTextAggregation extends BucketAggregationBase {
   filter_duplicate_text?: boolean
   gnd?: GoogleNormalizedDistanceHeuristic
   include?: string | string[]
+  jlh?: EmptyObject
   min_doc_count?: long
   mutual_information?: MutualInformationHeuristic
   percentage?: PercentageScoreHeuristic


### PR DESCRIPTION
`jlh` appears to be an empty object for both the `significant_terms` and `significant_text` aggs.