### PR TITLE
Allow quoted strings in comma-separated jstags

### DIFF
--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -607,7 +607,7 @@ export function hoistRequestAnnotations (
         'maintenance', 'manage', 'manage_follow_index', 'manage_ilm', 'manage_leader_index', 'monitor',
         'read', 'read_cross_cluster', 'view_index_metadata', 'write'
       ]
-      const values = value.split(',').map(v => v.trim())
+      const values = parseCommaSeparated(value)
       for (const v of values) {
         assert(jsDocs, privileges.includes(v), `The index privilege '${v}' does not exists.`)
       }
@@ -622,7 +622,7 @@ export function hoistRequestAnnotations (
         'manage_watcher', 'monitor', 'monitor_ml', 'monitor_rollup', 'monitor_snapshot', 'monitor_text_structure',
         'monitor_transform', 'monitor_watcher', 'read_ccr', 'read_ilm', 'read_pipeline', 'read_slm', 'transport_client'
       ]
-      const values = value.split(',').map(v => v.trim())
+      const values = parseCommaSeparated(value)
       for (const v of values) {
         assert(jsDocs, privileges.includes(v), `The cluster privilege '${v}' does not exists.`)
       }
@@ -675,7 +675,7 @@ export function hoistTypeAnnotations (type: model.TypeDefinition, jsDocs: JSDoc[
       assert(jsDocs, docUrl != null, `The @doc_id '${value.trim()}' is not present in _doc_ids/table.csv`)
       type.docUrl = docUrl[1]
     } else if (tag === 'codegen_names') {
-      type.codegenNames = value.split(',').map(v => v.trim())
+      type.codegenNames = parseCommaSeparated(value)
       assert(jsDocs,
         type.kind === 'type_alias' && type.type.kind === 'union_of' && type.type.items.length === type.codegenNames.length,
         '@codegen_names must have the number of items as the union definition'
@@ -711,7 +711,7 @@ function hoistPropertyAnnotations (property: model.Property, jsDocs: JSDoc[]): v
   setTags(jsDocs, property, tags, validTags, (tags, tag, value) => {
     if (tag.endsWith('_serializer')) {
     } else if (tag === 'aliases') {
-      property.aliases = value.split(',').map(v => v.trim())
+      property.aliases = parseCommaSeparated(value)
     } else if (tag === 'codegen_name') {
       property.codegenName = value
     } else if (tag === 'doc_url') {
@@ -808,7 +808,7 @@ function hoistEnumMemberAnnotations (member: model.EnumMember, jsDocs: JSDoc[]):
     if (tag === 'codegen_name') {
       member.codegenName = value
     } else if (tag === 'aliases') {
-      member.aliases = value.split(',').map(v => v.trim())
+      member.aliases = parseCommaSeparated(value)
     } else if (tag === 'since') {
       assert(jsDocs, semver.valid(value), `${member.name}'s @since is not valid semver: ${value}`)
       member.since = value
@@ -990,6 +990,14 @@ export function parseVariantNameTag (jsDoc: JSDoc[]): string | undefined {
   assert(jsDoc, typeof name === 'string', 'The @variant key should be "name"')
 
   return name.replace(/'/g, '')
+}
+
+/**
+ * Parses a list of comma-separated values as an array. Values can optionally be enclosed with single
+ * or double quotes.
+ */
+export function parseCommaSeparated(value: string): string[] {
+  return value.split(',').map(v => v.trim().replace(/["']/g, ''));
 }
 
 /**

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -996,8 +996,8 @@ export function parseVariantNameTag (jsDoc: JSDoc[]): string | undefined {
  * Parses a list of comma-separated values as an array. Values can optionally be enclosed with single
  * or double quotes.
  */
-export function parseCommaSeparated(value: string): string[] {
-  return value.split(',').map(v => v.trim().replace(/["']/g, ''));
+export function parseCommaSeparated (value: string): string[] {
+  return value.split(',').map(v => v.trim().replace(/["']/g, ''))
 }
 
 /**


### PR DESCRIPTION
Allows quoted strings in `@aliases` and other comma-separated jstags.

This is needed for `StorageType` where the empty string is an alias for the `fs` enum member (a follow-up PR will add it).

Asking for index defaults with `include_default=true` will return `""` for the storage type. When parsing this setting, Elasticsearch interprets the empty string as `fs`.