### PR TITLE
Add default value for internal tags

### DIFF
--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -183,7 +183,10 @@ export class ExternalTag {
 
 export class InternalTag {
   kind: 'internal_tag'
-  tag: string // Name of the property that holds the variant tag
+  /* Name of the property that holds the variant tag */
+  tag: string
+  /* Default value for the variant tag if it's missing */
+  defaultTag?: string
 }
 
 export class Container {

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -954,7 +954,7 @@ export function parseVariantsTag (jsDoc: JSDoc[]): model.Variants | undefined {
     return undefined
   }
 
-  const [type, value] = tags.variants.split(' ')
+  const [type, ...values] = tags.variants.split(' ')
   if (type === 'external') {
     return { kind: 'external_tag' }
   }
@@ -964,14 +964,14 @@ export function parseVariantsTag (jsDoc: JSDoc[]): model.Variants | undefined {
   }
 
   assert(jsDoc, type === 'internal', `Bad variant type: ${type}`)
-  assert(jsDoc, typeof value === 'string', 'Internal variant requires a tag definition')
-  const [tag, property] = value.split('=')
-  assert(jsDoc, tag === 'tag', 'The tag name should be "tag"')
-  assert(jsDoc, typeof property === 'string', 'The tag property is not defined')
+
+  const pairs = parseKeyValues(jsDoc, values, 'tag', 'default')
+  assert(jsDoc, typeof pairs.tag === 'string', 'Internal variant requires a tag definition')
 
   return {
     kind: 'internal_tag',
-    tag: property.replace(/'/g, '')
+    tag: pairs.tag,
+    defaultTag: pairs.default
   }
 }
 
@@ -998,6 +998,21 @@ export function parseVariantNameTag (jsDoc: JSDoc[]): string | undefined {
  */
 export function parseCommaSeparated (value: string): string[] {
   return value.split(',').map(v => v.trim().replace(/["']/g, ''))
+}
+
+/**
+ * Parses an array of "key=value" pairs and validate key names. Values can optionally be enclosed with single
+ * or double quotes.
+ */
+export function parseKeyValues (node: Node | Node[], pairs: string[], ...validKeys: string[]): Record<string, string> {
+  const result = {}
+  pairs.forEach(item => {
+    const kv = item.split('=')
+    assert(node, kv.length === 2, 'Malformed key/value list')
+    assert(node, validKeys.includes(kv[0]), `Unknown key '${kv[0]}'`)
+    result[kv[0]] = kv[1].replace(/["']/g, '')
+  })
+  return result
 }
 
 /**

--- a/specification/_types/analysis/analyzers.ts
+++ b/specification/_types/analysis/analyzers.ts
@@ -110,7 +110,7 @@ export class WhitespaceAnalyzer {
   version?: VersionString
 }
 
-/** @variants internal tag='type' */
+/** @variants internal tag='type' default='custom' */
 export type Analyzer =
   | CustomAnalyzer
   | FingerprintAnalyzer

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -50,7 +50,7 @@ export class PropertyBase {
   fields?: Dictionary<PropertyName, Property>
 }
 
-/** @variants internal tag='type' */
+/** @variants internal tag='type' default='object' */
 export type Property =
   | FlattenedProperty
   | JoinProperty


### PR DESCRIPTION
Adds an optional `default` configuration to internally tagged union definitions, e.g. `@variants internal tag='type' default='object'`

This is needed for:
* property mappings where `object` is the default (reported in [elasticsearch-java#45](https://github.com/elastic/elasticsearch-java/issues/45#issuecomment-978033425))
* analyzers where `custom` is the default (reported in [elasticsearch-java#216](https://github.com/elastic/elasticsearch-java/issues/216))