### PR TITLE
Add the 'classification' inference config for pipelines

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10948,10 +10948,20 @@ export interface IngestGsubProcessor extends IngestProcessorBase {
 
 export interface IngestInferenceConfig {
   regression?: IngestInferenceConfigRegression
+  classification?: IngestInferenceConfigClassification
+}
+
+export interface IngestInferenceConfigClassification {
+  num_top_classes?: integer
+  num_top_feature_importance_values?: integer
+  results_field?: Field
+  top_classes_results_field?: Field
+  prediction_field_type?: string
 }
 
 export interface IngestInferenceConfigRegression {
-  results_field: string
+  results_field?: Field
+  num_top_feature_importance_values?: integer
 }
 
 export interface IngestInferenceProcessor extends IngestProcessorBase {

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -240,12 +240,25 @@ export class InferenceProcessor extends ProcessorBase {
   inference_config?: InferenceConfig
 }
 
+/**
+ * @variants container
+ */
 export class InferenceConfig {
   regression?: InferenceConfigRegression
+  classification?: InferenceConfigClassification
 }
 
 export class InferenceConfigRegression {
-  results_field: string
+  results_field?: Field
+  num_top_feature_importance_values?: integer
+}
+
+export class InferenceConfigClassification {
+  num_top_classes?: integer
+  num_top_feature_importance_values?: integer
+  results_field?: Field
+  top_classes_results_field?: Field
+  prediction_field_type?: string
 }
 
 export class JoinProcessor extends ProcessorBase {


### PR DESCRIPTION
I don't think this is the complete set of options, however it's better than not being able to specify a `classification` inference config.