### PR TITLE
Remove generic property

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4554,7 +4554,7 @@ export interface MappingDenseVectorProperty extends MappingPropertyBase {
   index_options?: MappingDenseVectorIndexOptions
 }
 
-export type MappingDocValuesProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDateProperty | MappingDateNanosProperty | MappingKeywordProperty | MappingNumberProperty | MappingRangeProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingCompletionProperty | MappingGenericProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingShapeProperty | MappingTokenCountProperty | MappingVersionProperty | MappingWildcardProperty | MappingPointProperty
+export type MappingDocValuesProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDateProperty | MappingDateNanosProperty | MappingKeywordProperty | MappingNumberProperty | MappingRangeProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingCompletionProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingShapeProperty | MappingTokenCountProperty | MappingVersionProperty | MappingWildcardProperty | MappingPointProperty
 
 export interface MappingDocValuesPropertyBase extends MappingCorePropertyBase {
   doc_values?: boolean
@@ -4617,21 +4617,6 @@ export interface MappingFloatNumberProperty extends MappingStandardNumberPropert
 
 export interface MappingFloatRangeProperty extends MappingRangePropertyBase {
   type: 'float_range'
-}
-
-export interface MappingGenericProperty extends MappingDocValuesPropertyBase {
-  analyzer: string
-  boost: double
-  fielddata: IndicesStringFielddata
-  ignore_malformed: boolean
-  index: boolean
-  index_options: MappingIndexOptions
-  norms: boolean
-  null_value: string
-  position_increment_gap: integer
-  search_analyzer: string
-  term_vector: MappingTermVectorOption
-  type: string
 }
 
 export type MappingGeoOrientation = 'right' | 'RIGHT' | 'counterclockwise' | 'ccw' | 'left' | 'LEFT' | 'clockwise' | 'cw'
@@ -9573,12 +9558,6 @@ export interface IndicesStorage {
 }
 
 export type IndicesStorageType = 'fs' | 'niofs' | 'mmapfs' | 'hybridfs'
-
-export interface IndicesStringFielddata {
-  format: IndicesStringFielddataFormat
-}
-
-export type IndicesStringFielddataFormat = 'paged_bytes' | 'disabled'
 
 export interface IndicesTemplateMapping {
   aliases: Record<IndexName, IndicesAlias>

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -42,7 +42,6 @@ import { Property, PropertyBase } from './Property'
 import { RangeProperty } from './range'
 import {
   CompletionProperty,
-  GenericProperty,
   IpProperty,
   Murmur3HashProperty,
   TokenCountProperty
@@ -80,7 +79,6 @@ export type DocValuesProperty =
   | GeoPointProperty
   | GeoShapeProperty
   | CompletionProperty
-  | GenericProperty
   | IpProperty
   | Murmur3HashProperty
   | ShapeProperty

--- a/specification/_types/mapping/specialized.ts
+++ b/specification/_types/mapping/specialized.ts
@@ -17,13 +17,11 @@
  * under the License.
  */
 
-import { StringFielddata } from '@indices/_types/StringFielddata'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Field, Name } from '@_types/common'
 import { double, integer } from '@_types/Numeric'
 import { DocValuesPropertyBase, IndexOptions } from './core'
 import { PropertyBase } from './Property'
-import { TermVectorOption } from './TermVectorOption'
 
 export class CompletionProperty extends DocValuesPropertyBase {
   analyzer?: string
@@ -50,21 +48,6 @@ export class ConstantKeywordProperty extends PropertyBase {
 export class FieldAliasProperty extends PropertyBase {
   path?: Field
   type: 'alias'
-}
-
-export class GenericProperty extends DocValuesPropertyBase {
-  analyzer: string
-  boost: double
-  fielddata: StringFielddata
-  ignore_malformed: boolean
-  index: boolean
-  index_options: IndexOptions
-  norms: boolean
-  null_value: string
-  position_increment_gap: integer
-  search_analyzer: string
-  term_vector: TermVectorOption
-  type: string
 }
 
 export class HistogramProperty extends PropertyBase {


### PR DESCRIPTION
The `GenericProperty` is not a true property type in ES, and was ported from NEST in error originally. This PR removes it from the spec.