### PR TITLE
Remove 8.0 branch from update-rest-api-json GHA

### DIFF
--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        branch: ['main', '8.2', '8.1', '8.0', '7.17']
+        branch: ['main', '8.2', '8.1', '7.17']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Closes #1617 The 8.0 branch isn't available in the Elastic Artifacts API any more.