### PR TITLE
Rename media fields

### DIFF
--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -397,8 +397,8 @@ export class Endpoint {
   stability?: Stability
   visibility?: Visibility
   featureFlag?: string
-  accept?: string[]
-  contentType?: string[]
+  requestMediaType?: string[]
+  responseMediaType?: string[]
   privileges?: {
     index?: string[]
     cluster?: string[]

--- a/compiler/src/steps/add-content-type.ts
+++ b/compiler/src/steps/add-content-type.ts
@@ -22,8 +22,9 @@ import * as model from '../model/metamodel'
 import { JsonSpec } from '../model/json-spec'
 
 /**
- * Adds the `accept` and `contentType` fields to every endpoint
- * from the rest-api-spec if present.
+ * Adds the `responseMediaType` (accept in the rest-api-spec)
+ * and `responseMediaType` (content_type in the rest api spec)
+ * fields to every endpoint from the rest-api-spec if present.
  */
 export default async function addContentType (model: model.Model, jsonSpec: Map<string, JsonSpec>): Promise<model.Model> {
   for (const endpoint of model.endpoints) {
@@ -31,11 +32,11 @@ export default async function addContentType (model: model.Model, jsonSpec: Map<
     assert(spec, `Can't find the json spec for ${endpoint.name}`)
 
     if (Array.isArray(spec.headers.accept)) {
-      endpoint.accept = spec.headers.accept
+      endpoint.responseMediaType = spec.headers.accept
     }
 
     if (Array.isArray(spec.headers.content_type)) {
-      endpoint.contentType = spec.headers.content_type
+      endpoint.requestMediaType = spec.headers.content_type
     }
   }
 

--- a/typescript-generator/src/metamodel.ts
+++ b/typescript-generator/src/metamodel.ts
@@ -183,7 +183,10 @@ export class ExternalTag {
 
 export class InternalTag {
   kind: 'internal_tag'
-  tag: string // Name of the property that holds the variant tag
+  /* Name of the property that holds the variant tag */
+  tag: string
+  /* Default value for the variant tag if it's missing */
+  defaultTag?: string
 }
 
 export class Container {
@@ -393,8 +396,9 @@ export class Endpoint {
   since?: string
   stability?: Stability
   visibility?: Visibility
-  accept?: string[]
-  contentType?: string[]
+  featureFlag?: string
+  requestMediaType?: string[]
+  responseMediaType?: string[]
   privileges?: {
     index?: string[]
     cluster?: string[]


### PR DESCRIPTION
Renames `accept` to `responseMediaType` and `content_type` into `requestMediaType`.