### PR TITLE
Add support for non exhaustive variants

### DIFF
--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -183,7 +183,7 @@ export class VariantBase {
    * be extended with plugins. If true, target clients should allow for additional variants
    * with a variant tag outside the ones defined in the spec and arbitrary data as the value.
    */
-  isOpen?: boolean
+  nonExhaustive?: boolean
 }
 
 export class ExternalTag extends VariantBase {

--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -177,11 +177,20 @@ export abstract class BaseType {
 
 export type Variants = ExternalTag | InternalTag | Container
 
-export class ExternalTag {
+export class VariantBase {
+  /**
+   * Is this variant type open to extensions? Default to false. Used for variants that can
+   * be extended with plugins. If true, target clients should allow for additional variants
+   * with a variant tag outside the ones defined in the spec and arbitrary data as the value.
+   */
+  isOpen?: boolean
+}
+
+export class ExternalTag extends VariantBase {
   kind: 'external_tag'
 }
 
-export class InternalTag {
+export class InternalTag extends VariantBase {
   kind: 'internal_tag'
   /* Name of the property that holds the variant tag */
   tag: string
@@ -189,7 +198,7 @@ export class InternalTag {
   defaultTag?: string
 }
 
-export class Container {
+export class Container extends VariantBase {
   kind: 'container'
 }
 

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -954,22 +954,39 @@ export function parseVariantsTag (jsDoc: JSDoc[]): model.Variants | undefined {
     return undefined
   }
 
+  function parseOpen (open: string|undefined): boolean|undefined {
+    if (open != null) {
+      return open === 'true'
+    } else {
+      return undefined
+    }
+  }
+
   const [type, ...values] = tags.variants.split(' ')
   if (type === 'external') {
-    return { kind: 'external_tag' }
+    const pairs = parseKeyValues(jsDoc, values, 'open')
+    return {
+      kind: 'external_tag',
+      isOpen: parseOpen(pairs.open)
+    }
   }
 
   if (type === 'container') {
-    return { kind: 'container' }
+    const pairs = parseKeyValues(jsDoc, values, 'open')
+    return {
+      kind: 'container',
+      isOpen: parseOpen(pairs.open)
+    }
   }
 
   assert(jsDoc, type === 'internal', `Bad variant type: ${type}`)
 
-  const pairs = parseKeyValues(jsDoc, values, 'tag', 'default')
+  const pairs = parseKeyValues(jsDoc, values, 'tag', 'default', 'open')
   assert(jsDoc, typeof pairs.tag === 'string', 'Internal variant requires a tag definition')
 
   return {
     kind: 'internal_tag',
+    isOpen: parseOpen(pairs.open),
     tag: pairs.tag,
     defaultTag: pairs.default
   }

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -1019,13 +1019,16 @@ export function parseCommaSeparated (value: string): string[] {
 
 /**
  * Parses an array of "key=value" pairs and validate key names. Values can optionally be enclosed with single
- * or double quotes.
+ * or double quotes. If there is only a key with no value (no '=') the value is set to 'true'
  */
 export function parseKeyValues (node: Node | Node[], pairs: string[], ...validKeys: string[]): Record<string, string> {
   const result = {}
   pairs.forEach(item => {
     const kv = item.split('=')
-    assert(node, kv.length === 2, 'Malformed key/value list')
+    assert(node, kv.length <= 2, 'Malformed key/value list')
+    if (kv.length === 1) {
+      kv.push('true')
+    }
     assert(node, validKeys.includes(kv[0]), `Unknown key '${kv[0]}'`)
     result[kv[0]] = kv[1].replace(/["']/g, '')
   })

--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -98,11 +98,11 @@ enum Orientation {
 }
 ```
 
-Some enumerations can accept arbitrary values other than the one defined. The `@open_enum` jsdoc tac can be used to describe this behavior.
-By default, an enum is to be considered closed.
+Some enumerations can accept arbitrary values other than the ones defined. The `@non_exhaustive` jsdoc tag can be used to describe this behavior.
+By default, an enum is to be considered exhaustive.
 
 ```ts
-/** @open_enum */
+/** @non_exhaustive */
 export enum ScriptLanguage {
   painless,
   expression,
@@ -234,6 +234,11 @@ class Response {
 
 Variants is a special syntax that can be used by language generators to understand
 which type they will need to build based on the variant configuration.
+
+If the list of variants is not exhaustive (e.g. for types where new variants can be added by
+Elasticsearch plugins), you can add the `@non_exhaustive` js doc tag to indicate that additional
+variants can exist and should be accepted.
+
 There are three type of variants:
 
 #### Internal

--- a/specification/_global/search/_types/highlighting.ts
+++ b/specification/_global/search/_types/highlighting.ts
@@ -71,7 +71,7 @@ export enum HighlighterTagsSchema {
   styled = 0
 }
 
-/** @open_enum */
+/** @non_exhaustive */
 export enum HighlighterType {
   plain = 0,
   /** @codegen_name fast_vector */

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -99,7 +99,8 @@ export class Suggester implements AdditionalProperties<string, FieldSuggester> {
 }
 
 /**
- * @variants container open
+ * @variants container
+ * @non_exhaustive
  */
 export class FieldSuggester {
   completion?: CompletionSuggester

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -99,7 +99,7 @@ export class Suggester implements AdditionalProperties<string, FieldSuggester> {
 }
 
 /**
- * @variants container open=true
+ * @variants container open
  */
 export class FieldSuggester {
   completion?: CompletionSuggester

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -99,7 +99,7 @@ export class Suggester implements AdditionalProperties<string, FieldSuggester> {
 }
 
 /**
- * @variants container
+ * @variants container open=true
  */
 export class FieldSuggester {
   completion?: CompletionSuggester

--- a/specification/_types/Scripting.ts
+++ b/specification/_types/Scripting.ts
@@ -23,7 +23,7 @@ import { Id } from './common'
 
 /**
  * @doc_id modules-scripting
- * @open_enum
+ * @non_exhaustive
  */
 export enum ScriptLanguage {
   painless = 0,

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -28,7 +28,8 @@ import { DateMathTime, EpochMillis } from '@_types/Time'
 import { Void } from '@spec_utils/VoidValue'
 
 /**
- * @variants external open
+ * @variants external
+ * @non_exhaustive
  */
 export type Aggregate =
   | CardinalityAggregate

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -28,7 +28,7 @@ import { DateMathTime, EpochMillis } from '@_types/Time'
 import { Void } from '@spec_utils/VoidValue'
 
 /**
- * @variants external open=true
+ * @variants external open
  */
 export type Aggregate =
   | CardinalityAggregate

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -28,7 +28,7 @@ import { DateMathTime, EpochMillis } from '@_types/Time'
 import { Void } from '@spec_utils/VoidValue'
 
 /**
- * @variants external
+ * @variants external open=true
  */
 export type Aggregate =
   | CardinalityAggregate

--- a/specification/_types/aggregations/AggregationContainer.ts
+++ b/specification/_types/aggregations/AggregationContainer.ts
@@ -102,7 +102,8 @@ import {
 } from './pipeline'
 
 /**
- * @variants container open
+ * @variants container
+ * @non_exhaustive
  */
 export class AggregationContainer {
   /**

--- a/specification/_types/aggregations/AggregationContainer.ts
+++ b/specification/_types/aggregations/AggregationContainer.ts
@@ -102,7 +102,7 @@ import {
 } from './pipeline'
 
 /**
- * @variants container
+ * @variants container open=true
  */
 export class AggregationContainer {
   /**

--- a/specification/_types/aggregations/AggregationContainer.ts
+++ b/specification/_types/aggregations/AggregationContainer.ts
@@ -102,7 +102,7 @@ import {
 } from './pipeline'
 
 /**
- * @variants container open=true
+ * @variants container open
  */
 export class AggregationContainer {
   /**

--- a/specification/_types/analysis/analyzers.ts
+++ b/specification/_types/analysis/analyzers.ts
@@ -110,7 +110,7 @@ export class WhitespaceAnalyzer {
   version?: VersionString
 }
 
-/** @variants internal tag='type' default='custom' */
+/** @variants internal tag='type' default='custom' open=true */
 export type Analyzer =
   | CustomAnalyzer
   | FingerprintAnalyzer

--- a/specification/_types/analysis/analyzers.ts
+++ b/specification/_types/analysis/analyzers.ts
@@ -110,7 +110,10 @@ export class WhitespaceAnalyzer {
   version?: VersionString
 }
 
-/** @variants internal tag='type' default='custom' open */
+/**
+ * @variants internal tag='type' default='custom'
+ * @non_exhaustive
+ */
 export type Analyzer =
   | CustomAnalyzer
   | FingerprintAnalyzer

--- a/specification/_types/analysis/analyzers.ts
+++ b/specification/_types/analysis/analyzers.ts
@@ -110,7 +110,7 @@ export class WhitespaceAnalyzer {
   version?: VersionString
 }
 
-/** @variants internal tag='type' default='custom' open=true */
+/** @variants internal tag='type' default='custom' open */
 export type Analyzer =
   | CustomAnalyzer
   | FingerprintAnalyzer

--- a/specification/_types/analysis/char_filters.ts
+++ b/specification/_types/analysis/char_filters.ts
@@ -29,7 +29,10 @@ export class CharFilterBase {
 // ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
 export type CharFilter = string | CharFilterDefinition
 
-/** @variants internal tag='type' open */
+/**
+ * @variants internal tag='type'
+ * @non_exhaustive
+ */
 export type CharFilterDefinition =
   | HtmlStripCharFilter
   | MappingCharFilter

--- a/specification/_types/analysis/char_filters.ts
+++ b/specification/_types/analysis/char_filters.ts
@@ -29,7 +29,7 @@ export class CharFilterBase {
 // ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
 export type CharFilter = string | CharFilterDefinition
 
-/** @variants internal tag='type' */
+/** @variants internal tag='type' open=true */
 export type CharFilterDefinition =
   | HtmlStripCharFilter
   | MappingCharFilter

--- a/specification/_types/analysis/char_filters.ts
+++ b/specification/_types/analysis/char_filters.ts
@@ -29,7 +29,7 @@ export class CharFilterBase {
 // ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
 export type CharFilter = string | CharFilterDefinition
 
-/** @variants internal tag='type' open=true */
+/** @variants internal tag='type' open */
 export type CharFilterDefinition =
   | HtmlStripCharFilter
   | MappingCharFilter

--- a/specification/_types/analysis/token_filters.ts
+++ b/specification/_types/analysis/token_filters.ts
@@ -341,7 +341,7 @@ export class UppercaseTokenFilter extends TokenFilterBase {
 // ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
 export type TokenFilter = string | TokenFilterDefinition
 
-/** @variants internal tag='type' */
+/** @variants internal tag='type' open=true */
 export type TokenFilterDefinition =
   | AsciiFoldingTokenFilter
   | CommonGramsTokenFilter

--- a/specification/_types/analysis/token_filters.ts
+++ b/specification/_types/analysis/token_filters.ts
@@ -341,7 +341,7 @@ export class UppercaseTokenFilter extends TokenFilterBase {
 // ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
 export type TokenFilter = string | TokenFilterDefinition
 
-/** @variants internal tag='type' open=true */
+/** @variants internal tag='type' open */
 export type TokenFilterDefinition =
   | AsciiFoldingTokenFilter
   | CommonGramsTokenFilter

--- a/specification/_types/analysis/token_filters.ts
+++ b/specification/_types/analysis/token_filters.ts
@@ -341,7 +341,10 @@ export class UppercaseTokenFilter extends TokenFilterBase {
 // ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
 export type TokenFilter = string | TokenFilterDefinition
 
-/** @variants internal tag='type' open */
+/**
+ * @variants internal tag='type'
+ * @non_exhaustive
+ */
 export type TokenFilterDefinition =
   | AsciiFoldingTokenFilter
   | CommonGramsTokenFilter

--- a/specification/_types/analysis/tokenizers.ts
+++ b/specification/_types/analysis/tokenizers.ts
@@ -120,7 +120,7 @@ export class WhitespaceTokenizer extends TokenizerBase {
 // ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
 export type Tokenizer = string | TokenizerDefinition
 
-/** @variants internal tag='type' */
+/** @variants internal tag='type' open=true */
 export type TokenizerDefinition =
   | CharGroupTokenizer
   | EdgeNGramTokenizer

--- a/specification/_types/analysis/tokenizers.ts
+++ b/specification/_types/analysis/tokenizers.ts
@@ -120,7 +120,7 @@ export class WhitespaceTokenizer extends TokenizerBase {
 // ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
 export type Tokenizer = string | TokenizerDefinition
 
-/** @variants internal tag='type' open=true */
+/** @variants internal tag='type' open */
 export type TokenizerDefinition =
   | CharGroupTokenizer
   | EdgeNGramTokenizer

--- a/specification/_types/analysis/tokenizers.ts
+++ b/specification/_types/analysis/tokenizers.ts
@@ -120,7 +120,10 @@ export class WhitespaceTokenizer extends TokenizerBase {
 // ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
 export type Tokenizer = string | TokenizerDefinition
 
-/** @variants internal tag='type' open */
+/**
+ * @variants internal tag='type'
+ * @non_exhaustive
+ */
 export type TokenizerDefinition =
   | CharGroupTokenizer
   | EdgeNGramTokenizer

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -50,7 +50,10 @@ export class PropertyBase {
   fields?: Dictionary<PropertyName, Property>
 }
 
-/** @variants internal tag='type' default='object' open */
+/**
+ * @variants internal tag='type' default='object'
+ * @non_exhaustive
+ */
 export type Property =
   | FlattenedProperty
   | JoinProperty

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -50,7 +50,7 @@ export class PropertyBase {
   fields?: Dictionary<PropertyName, Property>
 }
 
-/** @variants internal tag='type' default='object' open=true */
+/** @variants internal tag='type' default='object' open */
 export type Property =
   | FlattenedProperty
   | JoinProperty

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -50,7 +50,7 @@ export class PropertyBase {
   fields?: Dictionary<PropertyName, Property>
 }
 
-/** @variants internal tag='type' default='object' */
+/** @variants internal tag='type' default='object' open=true */
 export type Property =
   | FlattenedProperty
   | JoinProperty

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -95,7 +95,7 @@ import {
 } from './term'
 
 /**
- * @variants container open=true
+ * @variants container open
  * @doc_id query-dsl
  */
 export class QueryContainer {

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -95,7 +95,7 @@ import {
 } from './term'
 
 /**
- * @variants container
+ * @variants container open=true
  * @doc_id query-dsl
  */
 export class QueryContainer {

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -95,7 +95,8 @@ import {
 } from './term'
 
 /**
- * @variants container open
+ * @variants container
+ * @non_exhaustive
  * @doc_id query-dsl
  */
 export class QueryContainer {

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -26,7 +26,7 @@ import { double, integer, long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 
 /**
- * @variants container open=true
+ * @variants container open
  */
 export class ProcessorContainer {
   attachment?: AttachmentProcessor

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -26,7 +26,7 @@ import { double, integer, long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 
 /**
- * @variants container
+ * @variants container open=true
  */
 export class ProcessorContainer {
   attachment?: AttachmentProcessor

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -26,7 +26,8 @@ import { double, integer, long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 
 /**
- * @variants container open
+ * @variants container
+ * @non_exhaustive
  */
 export class ProcessorContainer {
   attachment?: AttachmentProcessor


### PR DESCRIPTION
Elasticsearch plugins can add new implementations for a significant number of components, such as for example queries, aggregations and property types.

This PR adds an additional `@non_exhaustive` annotation (term borrowed from [Rust's equivalent feature](https://doc.rust-lang.org/reference/attributes/type_system.html)) that can be added to `@variants` types and enums (see below) to capture the fact that variants or enum members not present in the spec can exist, and clients should allow that.

This PR also adds the new `@non_exhaustive` annotation to the relevant types, found from the [plugin interface definitions](https://github.com/elastic/elasticsearch/blob/master/server/src/main/java/org/elasticsearch/plugins/) in the ES code base.

Example: 

```ts
/**
 * @variants container
 * @non_exhaustive
 */
export class QueryContainer {
  ...
}
```

The following pluggable components were left out from this PR as they require a bit more investigation in their specification: highlighters, score functions, significance heuristics.

**enums:** for consistency this PR also changes `@open_enum` for open enumerations to `@non_exhaustive`. The enum metamodel isn't changed, and this annotation still sets the `isOpen` property.

