### PR TITLE
Remove unnecessary ScoreFunctionBase

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4951,7 +4951,7 @@ export interface QueryDslConstantScoreQuery extends QueryDslQueryBase {
 export interface QueryDslDateDecayFunctionKeys extends QueryDslDecayFunctionBase {
 }
 export type QueryDslDateDecayFunction = QueryDslDateDecayFunctionKeys
-  & { [property: string]: QueryDslDecayPlacement<DateMath, Time> | QueryDslMultiValueMode | QueryDslQueryContainer | double }
+  & { [property: string]: QueryDslDecayPlacement<DateMath, Time> | QueryDslMultiValueMode }
 
 export interface QueryDslDateDistanceFeatureQuery extends QueryDslDistanceFeatureQueryBase<DateMath, Time> {
 }
@@ -4969,7 +4969,7 @@ export interface QueryDslDateRangeQuery extends QueryDslRangeQueryBase {
 
 export type QueryDslDecayFunction = QueryDslDateDecayFunction | QueryDslNumericDecayFunction | QueryDslGeoDecayFunction
 
-export interface QueryDslDecayFunctionBase extends QueryDslScoreFunctionBase {
+export interface QueryDslDecayFunctionBase {
   multi_value_mode?: QueryDslMultiValueMode
 }
 
@@ -5012,7 +5012,7 @@ export interface QueryDslFieldLookup {
 
 export type QueryDslFieldValueFactorModifier = 'none' | 'log' | 'log1p' | 'log2p' | 'ln' | 'ln1p' | 'ln2p' | 'square' | 'sqrt' | 'reciprocal'
 
-export interface QueryDslFieldValueFactorScoreFunction extends QueryDslScoreFunctionBase {
+export interface QueryDslFieldValueFactorScoreFunction {
   field: Field
   factor?: double
   missing?: double
@@ -5063,7 +5063,7 @@ export type QueryDslGeoBoundingBoxQuery = QueryDslGeoBoundingBoxQueryKeys
 export interface QueryDslGeoDecayFunctionKeys extends QueryDslDecayFunctionBase {
 }
 export type QueryDslGeoDecayFunction = QueryDslGeoDecayFunctionKeys
-  & { [property: string]: QueryDslDecayPlacement<GeoLocation, Distance> | QueryDslMultiValueMode | QueryDslQueryContainer | double }
+  & { [property: string]: QueryDslDecayPlacement<GeoLocation, Distance> | QueryDslMultiValueMode }
 
 export interface QueryDslGeoDistanceFeatureQuery extends QueryDslDistanceFeatureQueryBase<GeoLocation, Distance> {
 }
@@ -5329,7 +5329,7 @@ export interface QueryDslNumberRangeQuery extends QueryDslRangeQueryBase {
 export interface QueryDslNumericDecayFunctionKeys extends QueryDslDecayFunctionBase {
 }
 export type QueryDslNumericDecayFunction = QueryDslNumericDecayFunctionKeys
-  & { [property: string]: QueryDslDecayPlacement<double, double> | QueryDslMultiValueMode | QueryDslQueryContainer | double }
+  & { [property: string]: QueryDslDecayPlacement<double, double> | QueryDslMultiValueMode }
 
 export type QueryDslOperator = 'and' | 'AND' | 'or' | 'OR'
 
@@ -5459,7 +5459,7 @@ export interface QueryDslQueryStringQuery extends QueryDslQueryBase {
   type?: QueryDslTextQueryType
 }
 
-export interface QueryDslRandomScoreFunction extends QueryDslScoreFunctionBase {
+export interface QueryDslRandomScoreFunction {
   field?: Field
   seed?: long | string
 }
@@ -5509,16 +5509,11 @@ export interface QueryDslRegexpQuery extends QueryDslQueryBase {
   value: string
 }
 
-export interface QueryDslScoreFunctionBase {
-  filter?: QueryDslQueryContainer
-  weight?: double
-}
-
 export interface QueryDslScriptQuery extends QueryDslQueryBase {
   script: Script
 }
 
-export interface QueryDslScriptScoreFunction extends QueryDslScoreFunctionBase {
+export interface QueryDslScriptScoreFunction {
   script: Script
 }
 

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -58,23 +58,16 @@ export class FunctionScoreQuery extends QueryBase {
   score_mode?: FunctionScoreMode
 }
 
-export class ScoreFunctionBase {
-  filter?: QueryContainer
-  weight?: double
-}
-
-export class WeightScoreFunction extends ScoreFunctionBase {}
-
-export class ScriptScoreFunction extends ScoreFunctionBase {
+export class ScriptScoreFunction {
   script: Script
 }
 
-export class RandomScoreFunction extends ScoreFunctionBase {
+export class RandomScoreFunction {
   field?: Field
   seed?: long | string
 }
 
-export class FieldValueFactorScoreFunction extends ScoreFunctionBase {
+export class FieldValueFactorScoreFunction {
   field: Field
   factor?: double
   missing?: double
@@ -88,7 +81,7 @@ export class DecayPlacement<TOrigin, TScale> {
   origin?: TOrigin
 }
 
-export class DecayFunctionBase extends ScoreFunctionBase {
+export class DecayFunctionBase {
   multi_value_mode?: MultiValueMode
 }
 
@@ -113,7 +106,8 @@ export type DecayFunction =
 
 /** @variants container */
 // This container is valid without a variant. Also, despite being documented as a function, 'weight' is actually a
-// container property that can be combined with a function. From SearchModule#registerScoreFunctions in ES:
+// container property that can be combined with a function.
+// From SearchModule#registerScoreFunctions in ES:
 // Weight doesn't have its own parser, so every function supports it out of the box. Can be a single function too when
 // not associated to any other function, which is why it needs to be registered manually here.
 export class FunctionScoreContainer {


### PR DESCRIPTION
The `field` and `filter` parameters of function score queries are defined in the enclosing `FunctionScoreQuery` object, and not in the function definition itself. `ScoreFunctionQueryBase` is therefore unnecessary.

Also removes `WeightScoreFunction` that is still there but not referenced.

Verified in ES source code, `make validate api=search type=request` doesn't show new errors after this change.