### PR TITLE
Add range policy support to enrich

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ typescript-generator/lib
 report
 output/schema/import-*
 .github/**/package-lock.json
+
+# Editor lockfiles
+.*.swp

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8566,6 +8566,7 @@ export interface DanglingIndicesListDanglingIndicesResponse {
 export interface EnrichConfiguration {
   geo_match?: EnrichPolicy
   match: EnrichPolicy
+  range: EnrichPolicy
 }
 
 export interface EnrichPolicy {
@@ -8615,6 +8616,7 @@ export interface EnrichPutPolicyRequest extends RequestBase {
   body?: {
     geo_match?: EnrichPolicy
     match?: EnrichPolicy
+    range?: EnrichPolicy
   }
 }
 

--- a/specification/enrich/_types/Policy.ts
+++ b/specification/enrich/_types/Policy.ts
@@ -26,6 +26,7 @@ export class Summary {
 export class Configuration {
   geo_match?: Policy
   match: Policy
+  range: Policy
 }
 
 export class Policy {

--- a/specification/enrich/put_policy/PutEnrichPolicyRequest.ts
+++ b/specification/enrich/put_policy/PutEnrichPolicyRequest.ts
@@ -33,5 +33,6 @@ export interface Request extends RequestBase {
   body: {
     geo_match?: Policy
     match?: Policy
+    range?: Policy
   }
 }


### PR DESCRIPTION
This PR adds support for range policies, [as specified in the documentation](https://www.elastic.co/guide/en/elasticsearch/reference/8.1/put-enrich-policy-api.html).

It also adds `.*.swp`, nano lockfiles, to gitignore.