### PR TITLE
Add the "es_quirk" annotation to capture snowflakes in ES behavior

### DIFF
--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -139,6 +139,8 @@ export class Property {
   aliases?: string[]
   /** If the enclosing class is a variants container, is this a property of the container and not a variant? */
   containerProperty?: boolean
+  /** If this property has a quirk that needs special attention, give a short explanation about it */
+  esQuirk?: string
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -158,6 +160,8 @@ export abstract class BaseType {
   docUrl?: string
   docId?: string
   deprecation?: Deprecation
+  /** If this endpoint has a quirk that needs special attention, give a short explanation about it */
+  esQuirk?: string
   kind: string
   /** Variant name for externally tagged variants */
   variantName?: string

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -444,6 +444,10 @@ export function modelEnumDeclaration (declaration: EnumDeclaration): model.Enum 
     type.isOpen = true
   }
 
+  if (typeof tags.es_quirk === 'string') {
+    type.esQuirk = tags.es_quirk
+  }
+
   return type
 }
 
@@ -647,7 +651,8 @@ export function hoistTypeAnnotations (type: model.TypeDefinition, jsDocs: JSDoc[
   // We want to enforce a single jsDoc block.
   assert(jsDocs, jsDocs.length < 2, 'Use a single multiline jsDoc block instead of multiple single line blocks')
 
-  const validTags = ['class_serializer', 'doc_url', 'doc_id', 'behavior', 'variants', 'variant', 'shortcut_property', 'codegen_names', 'non_exhaustive']
+  const validTags = ['class_serializer', 'doc_url', 'doc_id', 'behavior', 'variants', 'variant', 'shortcut_property',
+    'codegen_names', 'non_exhaustive', 'es_quirk']
   const tags = parseJsDocTags(jsDocs)
   if (jsDocs.length === 1) {
     const description = jsDocs[0].getDescription()
@@ -682,6 +687,8 @@ export function hoistTypeAnnotations (type: model.TypeDefinition, jsDocs: JSDoc[
         type.kind === 'type_alias' && type.type.kind === 'union_of' && type.type.items.length === type.codegenNames.length,
         '@codegen_names must have the number of items as the union definition'
       )
+    } else if (tag === 'es_quirk') {
+      type.esQuirk = value
     } else {
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on type ${type.name.name}`)
     }
@@ -695,7 +702,8 @@ function hoistPropertyAnnotations (property: model.Property, jsDocs: JSDoc[]): v
   // We want to enforce a single jsDoc block.
   assert(jsDocs, jsDocs.length < 2, 'Use a single multiline jsDoc block instead of multiple single line blocks')
 
-  const validTags = ['stability', 'prop_serializer', 'doc_url', 'aliases', 'codegen_name', 'since', 'server_default', 'variant', 'doc_id']
+  const validTags = ['stability', 'prop_serializer', 'doc_url', 'aliases', 'codegen_name', 'since', 'server_default',
+    'variant', 'doc_id', 'es_quirk']
   const tags = parseJsDocTags(jsDocs)
   if (jsDocs.length === 1) {
     const description = jsDocs[0].getDescription()
@@ -787,6 +795,8 @@ function hoistPropertyAnnotations (property: model.Property, jsDocs: JSDoc[]): v
     } else if (tag === 'variant') {
       assert(jsDocs, value === 'container_property', `Unknown 'variant' value '${value}' on property ${property.name}`)
       property.containerProperty = true
+    } else if (tag === 'es_quirk') {
+      property.esQuirk = value
     } else {
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on property ${property.name}`)
     }

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -34,7 +34,7 @@ There is nothing that can be done here, it's a security limitation imposed by Gi
 
 #### Current solution
 
-Eitgher performa cherry-pick once merged or create a branch directly in this repository.
+Either perform a cherry-pick once merged or create a branch directly in this repository.
 Nit: if you do the latter, name the branch like this: `{username}/{feature_name}`
 
 ## Boolean in specific enum shouldn't be sent as string
@@ -45,4 +45,4 @@ Nit: if you do the latter, name the branch like this: `{username}/{feature_name}
 
 #### Current solution
 
-Handle the enum `true` and `false` to be serialized as booleans and not string. 
+Handle the enum `true` and `false` to be serialized as booleans and not string. These enums have an `es_quirk` annotation.

--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -399,6 +399,20 @@ export class TermQuery extends QueryBase {
 }
 ```
 
+### Tracking Elasticsearch quirks
+
+There are a few places where Elasticsearch has an uncommon behavior that does not deserve a specific feature in the API specification metamodel. These quirks still have to be captured so that code generators can act on them. The `eq_quirk` jsdoc tag is meant for that, and can be used on type definitions and properties.
+
+```ts
+/**
+ * @es_quirk This enum is a boolean that evolved into a tri-state enum. True and False have
+ *   to be (de)serialized as JSON booleans.
+ */
+enum Foo { true, false, bar }
+```
+
+Code generators should track the `es_quirk` they implement and fail if a new unhandled quirk is present on a type or a property. This behavior allows code generators to be updated whenever a new quirk is identified in the API specification.
+
 ### Additional information
 
 If needed, you can specify additional information on each type with the approariate JSDoc tag.

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9195,7 +9195,7 @@ export interface IndicesFielddataFrequencyFilter {
   min_segment_size: integer
 }
 
-export type IndicesIndexCheckOnStartup = boolean | 'false' | 'checksum' | 'true'
+export type IndicesIndexCheckOnStartup = boolean | 'true' | 'false' | 'checksum'
 
 export interface IndicesIndexRouting {
   allocation?: IndicesIndexRoutingAllocation

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -230,7 +230,9 @@ export enum OpType {
   create = 1
 }
 
-// Note: ES also accepts plain booleans for true and false. The TS generator implements this leniency rule.
+/**
+ * @es_quirk This is a boolean that evolved into an enum. ES also accepts plain booleans for true and false.
+ */
 export enum Refresh {
   true,
   false,

--- a/specification/_types/mapping/dynamic-template.ts
+++ b/specification/_types/mapping/dynamic-template.ts
@@ -34,6 +34,10 @@ export enum MatchType {
   regex = 1
 }
 
+/**
+ * @es_quirk This is a boolean that evolved into an enum. Boolean values should be accepted on reading, and
+ *   true and false must be serialized as JSON booleans, or it may break Kibana (see elasticsearch-java#139)
+ */
 export enum DynamicMapping {
   strict,
   runtime,

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -104,12 +104,14 @@ export type DecayFunction =
   | NumericDecayFunction
   | GeoDecayFunction
 
-/** @variants container */
-// This container is valid without a variant. Also, despite being documented as a function, 'weight' is actually a
-// container property that can be combined with a function.
-// From SearchModule#registerScoreFunctions in ES:
-// Weight doesn't have its own parser, so every function supports it out of the box. Can be a single function too when
-// not associated to any other function, which is why it needs to be registered manually here.
+/**
+ * @variants container
+ * @es_quirk this container is valid without a variant. Despite being documented as a function, 'weight'
+ *   is actually a container property that can be combined with a function. Comment in the ES code
+ *   (SearchModule#registerScoreFunctions) says: Weight doesn't have its own parser, so every function
+ *   supports it out of the box. Can be a single function too when not associated to any other function,
+ *   which is why it needs to be registered manually here.
+ */
 export class FunctionScoreContainer {
   exp?: DecayFunction
   gauss?: DecayFunction

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -245,10 +245,13 @@ export class IndexSettingBlocks {
   metadata?: boolean
 }
 
+/**
+ * @es_quirk This is a boolean that evolved into an enum. ES also accepts plain booleans for true and false.
+ */
 export enum IndexCheckOnStartup {
+  true,
   false,
-  checksum,
-  true
+  checksum
 }
 
 export class IndexVersioning {


### PR DESCRIPTION
Adds a new `@es_quirk` jsdoc tag to capture weird snowflakes in the specification. This tag's value is a description of the quirk.

It is exported in `schema.json` as an `esQuirk?: string` property on type definition and properties. This allows code generators to track the quirks they have effectively implemented and fail if a new quirk appears in the schema that needs to be handled in the code generator.