### PR TITLE
Add 'if_version' parameter to 'ingest.put_pipeline' API

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1264,9 +1264,7 @@
       "response": []
     },
     "ingest.put_pipeline": {
-      "request": [
-        "Request: missing json spec query parameter 'if_version'"
-      ],
+      "request": [],
       "response": [
         "response definition ingest.put_pipeline:Response / body / instance_of - Non-leaf type cannot be used here: '_types:AcknowledgedResponseBase'"
       ]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11166,6 +11166,7 @@ export interface IngestPutPipelineRequest extends RequestBase {
   id: Id
   master_timeout?: Time
   timeout?: Time
+  if_version?: VersionNumber
   body?: {
     _meta?: Metadata
     description?: string

--- a/specification/ingest/put_pipeline/PutPipelineRequest.ts
+++ b/specification/ingest/put_pipeline/PutPipelineRequest.ts
@@ -44,6 +44,10 @@ export interface Request extends RequestBase {
      * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s */
     timeout?: Time
+    /**
+     * Required version for optimistic concurrency control for pipeline updates
+     */
+    if_version?: VersionNumber
   }
   body: {
     /**


### PR DESCRIPTION
This parameter makes safe concurrent updates to ingest pipelines possible. Added in https://github.com/elastic/elasticsearch/pull/78551