### PR TITLE
[ML] Rename start deployment api threading params

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1577,9 +1577,9 @@
     },
     "ml.start_trained_model_deployment": {
       "request": [
-        "Request: query parameter 'inference_threads' does not exist in the json spec",
-        "Request: query parameter 'model_threads' does not exist in the json spec",
+        "Request: query parameter 'number_of_allocations' does not exist in the json spec",
         "Request: query parameter 'queue_capacity' does not exist in the json spec",
+        "Request: query parameter 'threads_per_allocation' does not exist in the json spec",
         "Request: should not have a body"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12443,14 +12443,14 @@ export interface MlTrainedModelDeploymentNodesStats {
   average_inference_time_ms: double
   error_count: integer
   inference_count: integer
-  inference_threads: integer
   last_access: long
-  model_threads: integer
   node: MlDiscoveryNode
+  number_of_allocations: integer
   number_of_pending_requests: integer
   rejection_execution_count: integer
   routing_state: MlTrainedModelAllocationRoutingTable
   start_time: long
+  threads_per_allocation: integer
   timeout_count: integer
 }
 
@@ -12458,15 +12458,15 @@ export interface MlTrainedModelDeploymentStats {
   allocation_status: MlTrainedModelDeploymentAllocationStatus
   error_count: integer
   inference_count: integer
-  inference_threads: integer
   model_id: Id
-  model_threads: integer
   nodes: MlTrainedModelDeploymentNodesStats
+  number_of_allocations: integer
   queue_capacity: integer
   rejected_execution_count: integer
   reason: string
   start_time: long
   state: MlDeploymentState
+  threads_per_allocation: integer
   timeout_count: integer
 }
 
@@ -13616,9 +13616,9 @@ export interface MlStartDatafeedResponse {
 
 export interface MlStartTrainedModelDeploymentRequest extends RequestBase {
   model_id: Id
-  inference_threads?: integer
-  model_threads?: integer
+  number_of_allocations?: integer
   queue_capacity?: integer
+  threads_per_allocation?: integer
   timeout?: Time
   wait_for?: MlDeploymentAllocationState
 }

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -60,14 +60,12 @@ export class TrainedModelDeploymentStats {
   error_count: integer
   /** The sum of `inference_count` for all nodes in the deployment. */
   inference_count: integer
-  /** The number of threads used by the inference process. */
-  inference_threads: integer
   /** The unique identifier for the trained model. */
   model_id: Id
-  /** The number of threads used when sending inference requests to the model. */
-  model_threads: integer
   /** The deployent stats for each node that currently has the model allocated. */
   nodes: TrainedModelDeploymentNodesStats
+  /** The number of allocations requested. */
+  number_of_allocations: integer
   /** The number of inference requests that can be queued before new requests are rejected. */
   queue_capacity: integer
   /**
@@ -85,6 +83,8 @@ export class TrainedModelDeploymentStats {
   start_time: long
   /** The overall state of the deployment. */
   state: DeploymentState
+  /** The number of threads used be each allocation during inference. */
+  threads_per_allocation: integer
   /** The sum of `timeout_count` for all nodes in the deployment. */
   timeout_count: integer
 }
@@ -125,23 +125,14 @@ export class TrainedModelDeploymentNodesStats {
   error_count: integer
   /** The total number of inference calls made against this node for this model. */
   inference_count: integer
-  /**
-   * The number of threads used by the inference process. This value is limited
-   * by the number of hardware threads on the node; it might therefore differ
-   * from the `inference_threads` value in the start trained model deployment API.
-   */
-  inference_threads: integer
   /** The epoch time stamp of the last inference call for the model on this node. */
   last_access: long
-  /**
-   * The number of threads used when sending inference requests to the model.
-   * This value is limited by the number of hardware threads on the node; it
-   * might therefore differ from the `model_threads` value in the start trained
-   * model deployment API.
-   */
-  model_threads: integer
   /** Information pertaining to the node. */
   node: DiscoveryNode
+  /**
+   * The number of allocations assigned to this node.
+   */
+  number_of_allocations: integer
   /** The number of inference requests queued to be processed. */
   number_of_pending_requests: integer
   /** The number of inference requests that were not processed because the queue was full. */
@@ -150,6 +141,8 @@ export class TrainedModelDeploymentNodesStats {
   routing_state: TrainedModelAllocationRoutingTable
   /** The epoch timestamp when the allocation started. */
   start_time: long
+  /** The number of threads used by each allocation during inference. */
+  threads_per_allocation: integer
   /** The number of inference requests that timed out before being processed. */
   timeout_count: integer
 }

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
@@ -39,24 +39,30 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
-     * Specifies the number of threads that are used by the inference process. If you increase this value, inference
-     * speed generally increases. However, the actual number of threads is limited by the number of available CPU
-     * cores.
+     * The number of model allocations on each node where the model is deployed.
+     * All allocations on a node share the same copy of the model in memory but use
+     * a separate set of threads to evaluate the model.
+     * Increasing this value generally increases the throughput.
+     * If this setting is greater than the number of hardware threads
+     * it will automatically be changed to a value less than the number of hardware threads.
      * @server_default 1
      */
-    inference_threads?: integer
-    /**
-     * Specifies the number of threads that are used when sending inference requests to the model. If you increase this value,
-     * throughput generally increases.
-     * @server_default 1
-     */
-    model_threads?: integer
+    number_of_allocations?: integer
     /**
      * Specifies the number of inference requests that are allowed in the queue. After the number of requests exceeds
      * this value, new requests are rejected with a 429 error.
      * @server_default 1024
      */
     queue_capacity?: integer
+    /**
+     * Sets the number of threads used by each model allocation during inference. This generally increases
+     * the inference speed. The inference process is a compute-bound process; any number
+     * greater than the number of available hardware threads on the machine does not increase the
+     * inference speed. If this setting is greater than the number of hardware threads
+     * it will automatically be changed to a value less than the number of hardware threads.
+     * @server_default 1
+     */
+    threads_per_allocation?: integer
     /**
      * Specifies the amount of time to wait for the model to deploy.
      * @server_default 20s


### PR DESCRIPTION
Renames start trained model deployment API parameters:

`model_threads` => `number_of_allocations`
`inference_threads` => `threads_per_allocation`