### PR TITLE
[Backport 7.17] Remove `Name` from `PropertyBase`

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4685,7 +4685,6 @@ export type MappingProperty = MappingFlattenedProperty | MappingJoinProperty | M
 export interface MappingPropertyBase {
   local_metadata?: Metadata
   meta?: Record<string, string>
-  name?: PropertyName
   properties?: Record<PropertyName, MappingProperty>
   ignore_above?: integer
   dynamic?: MappingDynamicMapping

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -42,7 +42,6 @@ import {
 export class PropertyBase {
   local_metadata?: Metadata
   meta?: Dictionary<string, string>
-  name?: PropertyName
   properties?: Dictionary<PropertyName, Property>
   ignore_above?: integer
   dynamic?: DynamicMapping

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -236,6 +236,12 @@ export class SearchAsYouTypeProperty extends CorePropertyBase {
   type: 'search_as_you_type'
 }
 
+// MatchOnlyTextProperty is an example of a property which does not derive from PropertyBase.
+// We have checked and this property does not support all properties of the base type.
+// In a future iteration we may remodel properties and identify truely common properties that should form
+// a base type that can be considered a common ancestor for all properties. Some clients will generate
+// a synthetic version of this today.
+
 /**
  * A variant of text that trades scoring and efficiency of positional queries for space efficiency. This field
  * effectively stores data the same way as a text field that only indexes documents (index_options: docs) and


### PR DESCRIPTION
Backport 80618757a29d8017316d4d40c21f77eee6c0d6e6 from #1710