### PR TITLE
Fix spec issues reported in the Java client

### DIFF
--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -301,6 +301,7 @@ export function modelType (node: Node): model.ValueOf {
           const generics = node.getTypeArguments().map(node => modelType(node))
           const identifier = node.getTypeName()
           assert(node, Node.isIdentifier(identifier), 'Not an identifier')
+          assert(node, identifier.getDefinitions().length > 0, 'Unknown definition (missing import?)')
 
           const declaration = identifier.getDefinitions()[0].getDeclarationNode()
           // We are looking at a generic parameter

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1620,7 +1620,8 @@
         "Request: query parameter 'allow_no_indices' does not exist in the json spec",
         "Request: query parameter 'expand_wildcards' does not exist in the json spec",
         "Request: query parameter 'ignore_throttled' does not exist in the json spec",
-        "Request: query parameter 'ignore_unavailable' does not exist in the json spec"
+        "Request: query parameter 'ignore_unavailable' does not exist in the json spec",
+        "Request: query parameter 'routing' does not exist in the json spec"
       ],
       "response": []
     },
@@ -1834,6 +1835,12 @@
       ],
       "response": []
     },
+    "security.create_api_key": {
+      "request": [
+        "interface definition security._types:RoleTemplateQueryContainer - Property template is a single-variant and must be required"
+      ],
+      "response": []
+    },
     "security.create_service_token": {
       "request": [
         "Request: missing json spec query parameter 'refresh'",
@@ -1933,9 +1940,7 @@
       "request": [
         "Request: should not have a body"
       ],
-      "response": [
-        "interface definition security._types:RoleTemplateQueryContainer - Property template is a single-variant and must be required"
-      ]
+      "response": []
     },
     "security.get_role_mapping": {
       "request": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -203,7 +203,7 @@ export interface DeleteByQueryRequest extends RequestBase {
   scroll_size?: long
   search_timeout?: Time
   search_type?: SearchType
-  slices?: long
+  slices?: Slices
   sort?: string[]
   stats?: string[]
   terminate_after?: long
@@ -562,20 +562,31 @@ export interface MsearchMultiSearchResult<TDocument = unknown> {
 export interface MsearchMultisearchBody {
   aggregations?: Record<string, AggregationsAggregationContainer>
   aggs?: Record<string, AggregationsAggregationContainer>
+  collapse?: SearchFieldCollapse
   query?: QueryDslQueryContainer
   explain?: boolean
   stored_fields?: Fields
   docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
   from?: integer
+  highlight?: SearchHighlight
+  indices_boost?: Record<IndexName, double>[]
+  min_score?: double
+  post_filter?: QueryDslQueryContainer
+  profile?: boolean
+  rescore?: SearchRescore | SearchRescore[]
+  script_fields?: Record<string, ScriptField>
+  search_after?: SortResults
   size?: integer
   sort?: Sort
   _source?: SearchSourceConfig
+  fields?: (QueryDslFieldAndFormat | Field)[]
   terminate_after?: long
   stats?: string[]
   timeout?: string
   track_scores?: boolean
   track_total_hits?: SearchTrackHits
   version?: boolean
+  runtime_mappings?: MappingRuntimeFields
   seq_no_primary_term?: boolean
   pit?: SearchPointInTimeReference
   suggest?: SearchSuggester
@@ -588,7 +599,7 @@ export interface MsearchMultisearchHeader {
   index?: Indices
   preference?: string
   request_cache?: boolean
-  routing?: string
+  routing?: Routing
   search_type?: SearchType
   ccs_minimize_roundtrips?: boolean
   allow_partial_search_results?: boolean
@@ -605,8 +616,9 @@ export interface MsearchRequest extends RequestBase {
   max_concurrent_searches?: long
   max_concurrent_shard_requests?: long
   pre_filter_shard_size?: long
-  search_type?: SearchType
   rest_total_hits_as_int?: boolean
+  routing?: Routing
+  search_type?: SearchType
   typed_keys?: boolean
   body?: MsearchRequestItem[]
 }
@@ -819,18 +831,19 @@ export interface ReindexDestination {
 }
 
 export interface ReindexRemoteSource {
-  connect_timeout: Time
+  connect_timeout?: Time
+  headers?: Record<string, string>
   host: Host
-  username: Username
-  password: Password
-  socket_timeout: Time
+  username?: Username
+  password?: Password
+  socket_timeout?: Time
 }
 
 export interface ReindexRequest extends RequestBase {
   refresh?: boolean
   requests_per_second?: long
   scroll?: Time
-  slices?: long
+  slices?: Slices
   timeout?: Time
   wait_for_active_shards?: WaitForActiveShards
   wait_for_completion?: boolean
@@ -1214,51 +1227,38 @@ export interface SearchFieldSuggester {
   text?: string
 }
 
-export interface SearchHighlight {
+export interface SearchHighlight extends SearchHighlightBase {
+  encoder?: SearchHighlighterEncoder
   fields: Record<Field, SearchHighlightField>
+}
+
+export interface SearchHighlightBase {
   type?: SearchHighlighterType
   boundary_chars?: string
   boundary_max_scan?: integer
   boundary_scanner?: SearchBoundaryScanner
   boundary_scanner_locale?: string
-  encoder?: SearchHighlighterEncoder
-  fragmenter?: SearchHighlighterFragmenter
-  fragment_offset?: integer
-  fragment_size?: integer
-  max_fragment_length?: integer
-  no_match_size?: integer
-  number_of_fragments?: integer
-  order?: SearchHighlighterOrder
-  post_tags?: string[]
-  pre_tags?: string[]
-  require_field_match?: boolean
-  tags_schema?: SearchHighlighterTagsSchema
-  highlight_query?: QueryDslQueryContainer
-  max_analyzed_offset?: string | integer
-}
-
-export interface SearchHighlightField {
-  boundary_chars?: string
-  boundary_max_scan?: integer
-  boundary_scanner?: SearchBoundaryScanner
-  boundary_scanner_locale?: string
-  field?: Field
   force_source?: boolean
   fragmenter?: SearchHighlighterFragmenter
-  fragment_offset?: integer
   fragment_size?: integer
+  highlight_filter?: boolean
   highlight_query?: QueryDslQueryContainer
-  matched_fields?: Fields
   max_fragment_length?: integer
+  max_analyzed_offset?: integer
   no_match_size?: integer
   number_of_fragments?: integer
+  options?: Record<string, any>
   order?: SearchHighlighterOrder
   phrase_limit?: integer
   post_tags?: string[]
   pre_tags?: string[]
   require_field_match?: boolean
   tags_schema?: SearchHighlighterTagsSchema
-  type?: SearchHighlighterType
+}
+
+export interface SearchHighlightField extends SearchHighlightBase {
+  fragment_offset?: integer
+  matched_fields?: Fields
 }
 
 export type SearchHighlighterEncoder = 'default' | 'html'
@@ -1477,11 +1477,11 @@ export interface SearchSuggestBase {
 }
 
 export interface SearchSuggestFuzziness {
-  fuzziness: Fuzziness
-  min_length: integer
-  prefix_length: integer
-  transpositions: boolean
-  unicode_aware: boolean
+  fuzziness?: Fuzziness
+  min_length?: integer
+  prefix_length?: integer
+  transpositions?: boolean
+  unicode_aware?: boolean
 }
 
 export type SearchSuggestSort = 'score' | 'frequency'
@@ -1697,7 +1697,7 @@ export interface TermvectorsTerm {
   doc_freq?: integer
   score?: double
   term_freq: integer
-  tokens: TermvectorsToken[]
+  tokens?: TermvectorsToken[]
   ttf?: integer
 }
 
@@ -1768,7 +1768,7 @@ export interface UpdateByQueryRequest extends RequestBase {
   scroll_size?: long
   search_timeout?: Time
   search_type?: SearchType
-  slices?: long
+  slices?: Slices
   sort?: string[]
   stats?: string[]
   terminate_after?: long
@@ -2393,6 +2393,10 @@ export interface SlicedScroll {
   id: integer
   max: integer
 }
+
+export type Slices = integer | SlicesEnum
+
+export type SlicesEnum = 'auto'
 
 export type Sort = SortCombinations | SortCombinations[]
 
@@ -4573,6 +4577,32 @@ export interface MappingDoubleRangeProperty extends MappingRangePropertyBase {
 
 export type MappingDynamicMapping = boolean | 'strict' | 'runtime' | 'true' | 'false'
 
+export interface MappingDynamicProperty extends MappingDocValuesPropertyBase {
+  type: '{dynamic_property}'
+  enabled?: boolean
+  null_value?: FieldValue
+  boost?: double
+  coerce?: boolean
+  script?: Script
+  on_script_error?: MappingOnScriptError
+  ignore_malformed?: boolean
+  time_series_metric?: MappingTimeSeriesMetricType
+  analyzer?: string
+  eager_global_ordinals?: boolean
+  index?: boolean
+  index_options?: MappingIndexOptions
+  index_phrases?: boolean
+  index_prefixes?: MappingTextIndexPrefixes
+  norms?: boolean
+  position_increment_gap?: integer
+  search_analyzer?: string
+  search_quote_analyzer?: string
+  term_vector?: MappingTermVectorOption
+  format?: string
+  precision_step?: integer
+  locale?: string
+}
+
 export interface MappingDynamicTemplate {
   mapping?: MappingProperty
   match?: string
@@ -4751,7 +4781,7 @@ export interface MappingPointProperty extends MappingDocValuesPropertyBase {
   type: 'point'
 }
 
-export type MappingProperty = MappingFlattenedProperty | MappingJoinProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingDenseVectorProperty | MappingAggregateMetricDoubleProperty | MappingCoreProperty
+export type MappingProperty = MappingFlattenedProperty | MappingJoinProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingDenseVectorProperty | MappingAggregateMetricDoubleProperty | MappingCoreProperty | MappingDynamicProperty
 
 export interface MappingPropertyBase {
   local_metadata?: Metadata
@@ -9012,7 +9042,7 @@ export interface IlmPhases {
 
 export interface IlmPolicy {
   phases: IlmPhases
-  name?: Name
+  _meta?: Metadata
 }
 
 export interface IlmShrinkConfiguration {
@@ -9643,7 +9673,7 @@ export interface IndicesAnalyzeCharFilterDetail {
   name: string
 }
 
-export interface IndicesAnalyzeExplainAnalyzeToken {
+export interface IndicesAnalyzeExplainAnalyzeTokenKeys {
   bytes: string
   end_offset: long
   keyword?: boolean
@@ -9654,6 +9684,8 @@ export interface IndicesAnalyzeExplainAnalyzeToken {
   token: string
   type: string
 }
+export type IndicesAnalyzeExplainAnalyzeToken = IndicesAnalyzeExplainAnalyzeTokenKeys
+  & { [property: string]: any }
 
 export interface IndicesAnalyzeRequest extends RequestBase {
   index?: IndexName
@@ -15259,11 +15291,6 @@ export interface SecurityClearCachedServiceTokensResponse {
   nodes: Record<string, SecurityClusterNode>
 }
 
-export interface SecurityCreateApiKeyIndexPrivileges {
-  names: Indices
-  privileges: SecurityIndexPrivilege[]
-}
-
 export interface SecurityCreateApiKeyRequest extends RequestBase {
   refresh?: Refresh
   body?: {
@@ -15284,8 +15311,13 @@ export interface SecurityCreateApiKeyResponse {
 
 export interface SecurityCreateApiKeyRoleDescriptor {
   cluster: string[]
-  index: SecurityCreateApiKeyIndexPrivileges[]
+  indices: SecurityIndicesPrivileges[]
+  index: SecurityIndicesPrivileges[]
+  global?: SecurityGlobalPrivilege[] | SecurityGlobalPrivilege
   applications?: SecurityApplicationPrivileges[]
+  metadata?: Metadata
+  run_as?: string[]
+  transient_metadata?: SecurityTransientMetadataConfig
 }
 
 export interface SecurityCreateServiceTokenRequest extends RequestBase {
@@ -15476,6 +15508,7 @@ export type SecurityGetServiceAccountsResponse = Record<string, SecurityGetServi
 export interface SecurityGetServiceAccountsRoleDescriptor {
   cluster: string[]
   indices: SecurityIndicesPrivileges[]
+  index: SecurityIndicesPrivileges[]
   global?: SecurityGlobalPrivilege[] | SecurityGlobalPrivilege
   applications?: SecurityApplicationPrivileges[]
   metadata?: Metadata

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -24,6 +24,7 @@ import {
   Indices,
   Routing,
   SearchType,
+  Slices,
   WaitForActiveShards
 } from '@_types/common'
 import { long } from '@_types/Numeric'
@@ -63,7 +64,7 @@ export interface Request extends RequestBase {
     scroll_size?: long
     search_timeout?: Time
     search_type?: SearchType
-    slices?: long
+    slices?: Slices
     sort?: string[]
     stats?: string[]
     terminate_after?: long

--- a/specification/_global/msearch/MultiSearchRequest.ts
+++ b/specification/_global/msearch/MultiSearchRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { ExpandWildcards, Indices, SearchType } from '@_types/common'
+import { ExpandWildcards, Indices, Routing, SearchType } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { RequestItem } from './types'
 
@@ -74,14 +74,18 @@ export interface Request extends RequestBase {
      */
     pre_filter_shard_size?: long
     /**
-     * Indicates whether global term and document frequencies should be used when scoring returned documents.
-     */
-    search_type?: SearchType
-    /**
      * If true, hits.total are returned as an integer in the response. Defaults to false, which returns an object.
      * @server_default false
      */
     rest_total_hits_as_int?: boolean
+    /**
+     * Custom routing value used to route search operations to a specific shard.
+     */
+    routing?: Routing
+    /**
+     * Indicates whether global term and document frequencies should be used when scoring returned documents.
+     */
+    search_type?: SearchType
     /**
      * Specifies whether aggregation and suggester names should be prefixed by their respective types in the response.
      */

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -26,6 +26,7 @@ import {
   Fields,
   IndexName,
   Indices,
+  Routing,
   SearchType
 } from '@_types/common'
 import { double, integer, long } from '@_types/Numeric'
@@ -57,16 +58,18 @@ export class MultisearchHeader {
   index?: Indices
   preference?: string
   request_cache?: boolean
-  routing?: string
+  routing?: Routing
   search_type?: SearchType
   ccs_minimize_roundtrips?: boolean
   allow_partial_search_results?: boolean
   ignore_throttled?: boolean
 }
+
 // We should keep this in sync with the normal search request body.
 export class MultisearchBody {
   /** @aliases aggs */ // ES uses "aggregations" in serialization
   aggregations?: Dictionary<string, AggregationContainer>
+  collapse?: FieldCollapse
   /**
    * Defines the search definition using the Query DSL.
    */
@@ -95,6 +98,24 @@ export class MultisearchBody {
    * @server_default 0
    */
   from?: integer
+  highlight?: Highlight
+  /**
+   * Boosts the _score of documents from specified indices.
+   */
+  indices_boost?: Array<Dictionary<IndexName, double>>
+  /**
+   * Minimum _score for matching documents. Documents with a lower _score are
+   * not included in the search results.
+   */
+  min_score?: double
+  post_filter?: QueryContainer
+  profile?: boolean
+  rescore?: Rescore | Rescore[]
+  /**
+   * Retrieve a script evaluation (based on different fields) for each hit.
+   */
+  script_fields?: Dictionary<string, ScriptField>
+  search_after?: SortResults
   /**
    * The number of hits to return. By default, you cannot page through more
    * than 10,000 hits using the from and size parameters. To page through more
@@ -109,6 +130,11 @@ export class MultisearchBody {
    * fields are returned in the hits._source property of the search response.
    */
   _source?: SourceConfig
+  /**
+   * Array of wildcard (*) patterns. The request returns values for field names
+   * matching these patterns in the hits.fields property of the response.
+   */
+  fields?: Array<FieldAndFormat>
   /**
    * Maximum number of documents to collect for each shard. If a query reaches this
    * limit, Elasticsearch terminates the query early. Elasticsearch collects documents
@@ -145,6 +171,11 @@ export class MultisearchBody {
    * @server_default false
    */
   version?: boolean
+  /**
+   * Defines one or more runtime fields in the search request. These fields take
+   * precedence over mapped fields with the same name.
+   */
+  runtime_mappings?: RuntimeFields
   /**
    * If true, returns sequence number and primary term of the last modification
    * of each hit. See Optimistic concurrency control.

--- a/specification/_global/reindex/ReindexRequest.ts
+++ b/specification/_global/reindex/ReindexRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Conflicts, WaitForActiveShards } from '@_types/common'
+import { Conflicts, Slices, WaitForActiveShards } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 import { Time } from '@_types/Time'
@@ -34,7 +34,7 @@ export interface Request extends RequestBase {
     refresh?: boolean
     requests_per_second?: long
     scroll?: Time
-    slices?: long
+    slices?: Slices
     timeout?: Time
     wait_for_active_shards?: WaitForActiveShards
     wait_for_completion?: boolean

--- a/specification/_global/reindex/types.ts
+++ b/specification/_global/reindex/types.ts
@@ -34,6 +34,7 @@ import { integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { Time } from '@_types/Time'
+import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Destination {
   index: IndexName
@@ -56,9 +57,10 @@ export class Source {
 }
 
 export class RemoteSource {
-  connect_timeout: Time
+  connect_timeout?: Time
+  headers?: Dictionary<string, string>
   host: Host
-  username: Username
-  password: Password
-  socket_timeout: Time
+  username?: Username
+  password?: Password
+  socket_timeout?: Time
 }

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -107,6 +107,7 @@ export interface Request extends RequestBase {
     from?: integer
     sort?: string | string[]
   }
+  // We should keep this in sync with the multi search request body.
   body: {
     /** @aliases aggs */ // ES uses "aggregations" in serialization
     aggregations?: Dictionary<string, AggregationContainer>

--- a/specification/_global/search/_types/highlighting.ts
+++ b/specification/_global/search/_types/highlighting.ts
@@ -21,6 +21,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Field, Fields } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export enum BoundaryScanner {
   chars = 0,
@@ -28,29 +29,33 @@ export enum BoundaryScanner {
   word = 2
 }
 
-export class Highlight {
-  fields: Dictionary<Field, HighlightField>
-
+export class HighlightBase {
   type?: HighlighterType
   boundary_chars?: string
   boundary_max_scan?: integer
   boundary_scanner?: BoundaryScanner
   boundary_scanner_locale?: string
-  encoder?: HighlighterEncoder
+  force_source?: boolean
   fragmenter?: HighlighterFragmenter
-  fragment_offset?: integer
   fragment_size?: integer
+  highlight_filter?: boolean
+  highlight_query?: QueryContainer
   max_fragment_length?: integer
+  max_analyzed_offset?: integer
   no_match_size?: integer
   number_of_fragments?: integer
+  options?: Dictionary<string, UserDefinedValue>
   order?: HighlighterOrder
+  phrase_limit?: integer
   post_tags?: string[]
   pre_tags?: string[]
   require_field_match?: boolean
   tags_schema?: HighlighterTagsSchema
-  highlight_query?: QueryContainer
-  // TODO this is too lenient! test reports "20" is accepted
-  max_analyzed_offset?: string | integer
+}
+
+export class Highlight extends HighlightBase {
+  encoder?: HighlighterEncoder
+  fields: Dictionary<Field, HighlightField>
 }
 
 export enum HighlighterEncoder {
@@ -79,27 +84,7 @@ export enum HighlighterType {
   unified = 2
 }
 
-export class HighlightField {
-  boundary_chars?: string
-  boundary_max_scan?: integer
-  boundary_scanner?: BoundaryScanner
-  boundary_scanner_locale?: string
-  //TODO I THINK this field does not exist
-  field?: Field
-  force_source?: boolean
-  fragmenter?: HighlighterFragmenter
+export class HighlightField extends HighlightBase {
   fragment_offset?: integer
-  fragment_size?: integer
-  highlight_query?: QueryContainer
   matched_fields?: Fields
-  max_fragment_length?: integer
-  no_match_size?: integer
-  number_of_fragments?: integer
-  order?: HighlighterOrder
-  phrase_limit?: integer
-  post_tags?: string[]
-  pre_tags?: string[]
-  require_field_match?: boolean
-  tags_schema?: HighlighterTagsSchema
-  type?: HighlighterType
 }

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -131,11 +131,11 @@ export class CompletionSuggester extends SuggesterBase {
 }
 
 export class SuggestFuzziness {
-  fuzziness: Fuzziness
-  min_length: integer
-  prefix_length: integer
-  transpositions: boolean
-  unicode_aware: boolean
+  fuzziness?: Fuzziness
+  min_length?: integer
+  prefix_length?: integer
+  transpositions?: boolean
+  unicode_aware?: boolean
 }
 
 // context suggester

--- a/specification/_global/termvectors/types.ts
+++ b/specification/_global/termvectors/types.ts
@@ -35,7 +35,7 @@ export class Term {
   doc_freq?: integer
   score?: double
   term_freq: integer
-  tokens: Token[]
+  tokens?: Token[]
   ttf?: integer
 }
 

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -24,6 +24,7 @@ import {
   Indices,
   Routing,
   SearchType,
+  Slices,
   WaitForActiveShards
 } from '@_types/common'
 import { long } from '@_types/Numeric'
@@ -64,7 +65,7 @@ export interface Request extends RequestBase {
     scroll_size?: long
     search_timeout?: Time
     search_type?: SearchType
-    slices?: long
+    slices?: Slices
     sort?: string[]
     stats?: string[]
     terminate_after?: long

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -315,3 +315,15 @@ export class IndicesOptions {
    */
   ignore_throttled?: boolean
 }
+
+/**
+ * Uses sliced scroll to parallelize process. Using `auto` chooses a reasonable number for most data streams
+ * and indices.
+ *
+ * @codegen_names value, auto
+ */
+export type Slices = integer | SlicesEnum
+
+export enum SlicesEnum {
+  auto
+}

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -27,6 +27,7 @@ import {
 } from './complex'
 import {
   CoreProperty,
+  DynamicProperty,
   JoinProperty,
   PercolatorProperty,
   RankFeatureProperty,
@@ -65,6 +66,7 @@ export type Property =
   | DenseVectorProperty
   | AggregateMetricDoubleProperty
   | CoreProperty
+  | DynamicProperty
 
 export enum FieldType {
   none,

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -20,7 +20,7 @@
 import { FielddataFrequencyFilter } from '@indices/_types/FielddataFrequencyFilter'
 import { NumericFielddata } from '@indices/_types/NumericFielddata'
 import { Dictionary } from '@spec_utils/Dictionary'
-import { Fields, PropertyName, RelationName } from '@_types/common'
+import { Fields, FieldValue, PropertyName, RelationName } from '@_types/common'
 import {
   byte,
   double,
@@ -311,4 +311,37 @@ export class WildcardProperty extends DocValuesPropertyBase {
   type: 'wildcard'
   /** @since 7.15.0  */
   null_value?: string
+}
+
+export class DynamicProperty extends DocValuesPropertyBase {
+  type: '{dynamic_property}'
+
+  enabled?: boolean
+  null_value?: FieldValue
+  boost?: double
+
+  // NumberPropertyBase & long, double
+  coerce?: boolean
+  script?: Script
+  on_script_error?: OnScriptError
+  ignore_malformed?: boolean
+  time_series_metric?: TimeSeriesMetricType
+
+  // string
+  analyzer?: string
+  eager_global_ordinals?: boolean
+  index?: boolean
+  index_options?: IndexOptions
+  index_phrases?: boolean
+  index_prefixes?: TextIndexPrefixes
+  norms?: boolean
+  position_increment_gap?: integer
+  search_analyzer?: string
+  search_quote_analyzer?: string
+  term_vector?: TermVectorOption
+
+  // date
+  format?: string
+  precision_step?: integer
+  locale?: string
 }

--- a/specification/ilm/_types/Policy.ts
+++ b/specification/ilm/_types/Policy.ts
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-import { Name } from '@_types/common'
+import { Metadata, Name } from '@_types/common'
 import { Phases } from './Phase'
 
 export class Policy {
   phases: Phases
-  name?: Name
+  _meta?: Metadata
 }

--- a/specification/indices/analyze/types.ts
+++ b/specification/indices/analyze/types.ts
@@ -18,6 +18,8 @@
  */
 
 import { long } from '@_types/Numeric'
+import { AdditionalProperties } from '@spec_utils/behaviors'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class AnalyzeDetail {
   analyzer?: AnalyzerDetail
@@ -46,7 +48,10 @@ export class CharFilterDetail {
   name: string
 }
 
-export class ExplainAnalyzeToken {
+// Additional properties are attributes that can be set by plugin-defined tokenizers
+export class ExplainAnalyzeToken
+  implements AdditionalProperties<string, UserDefinedValue>
+{
   bytes: string
   end_offset: long
   keyword?: boolean

--- a/specification/security/create_api_key/types.ts
+++ b/specification/security/create_api_key/types.ts
@@ -19,14 +19,23 @@
 
 import {
   IndexPrivilege,
-  ApplicationPrivileges
+  ApplicationPrivileges,
+  IndicesPrivileges,
+  GlobalPrivilege
 } from '@security/_types/Privileges'
-import { Indices } from '@_types/common'
+import { Indices, Metadata } from '@_types/common'
+import { TransientMetadataConfig } from '@security/_types/TransientMetadataConfig'
 
+// FIXME: should be merged with get_service_accounts/RoleDescriptor
 export class RoleDescriptor {
   cluster: string[]
-  index: IndexPrivileges[]
+  /** @aliases index */
+  indices: IndicesPrivileges[]
+  global?: GlobalPrivilege[] | GlobalPrivilege
   applications?: ApplicationPrivileges[]
+  metadata?: Metadata
+  run_as?: string[]
+  transient_metadata?: TransientMetadataConfig
 }
 
 export class IndexPrivileges {

--- a/specification/security/get_service_accounts/types.ts
+++ b/specification/security/get_service_accounts/types.ts
@@ -31,6 +31,7 @@ export class RoleDescriptorWrapper {
 
 export class RoleDescriptor {
   cluster: string[]
+  /** @aliases index */
   indices: IndicesPrivileges[]
   global?: GlobalPrivilege[] | GlobalPrivilege
   applications?: ApplicationPrivileges[]


### PR DESCRIPTION
This PR fixes a number of API spec issues that were reported in the Java client. We're experimenting a batch processing of these issue, as they are most of the time very tiny problems such as missing fields or required fields that should be optional.

This PR has 2 larger changes: the new `dynamic_property` property type, and a refactoring of `Higlight` and `HighlightField` with a common base class, as they have most attribute in common (same in the ES code base).

* ILM Policy has an invalid "name" field.  
  Found in https://github.com/elastic/elasticsearch-java/issues/160

* CreateApiKeyRequest.RoleDescriptor is missing some fields. Fixes #1555.  
  Found in https://github.com/elastic/elasticsearch-java/issues/106

* Missing support for {dynamic_type} property mapping. Fixes #1558.  
  Found in https://github.com/elastic/elasticsearch-java/issues/142

* Missing support for auto slicing.  
  Found in https://github.com/elastic/elasticsearch-java/issues/147

* RemoteSource username/password should be optional.  
  Found in https://github.com/elastic/elasticsearch-java/issues/152

* SuggestFuzziness requires optional attributes to be set.  
  Found in https://github.com/elastic/elasticsearch-java/issues/162

* Missing "attributes" in explain token with custom analyzer.  
  Found in https://github.com/elastic/elasticsearch-java/issues/154

* Missing fields in MultisearchBody  
  Found in https://github.com/elastic/elasticsearch-java/issues/161 and https://github.com/elastic/elasticsearch-java/issues/170

* TermVectors.terms.tokens should be optional  
  Found in https://github.com/elastic/elasticsearch-java/issues/184

* Missing fields in Highlight (also refactored Highlight & HighlightField with a common base class)  
  Found in https://github.com/elastic/elasticsearch-java/issues/185
