### PR TITLE
Wrap error message in quotes

### DIFF
--- a/.github/workflows/metamodel-sync.yml
+++ b/.github/workflows/metamodel-sync.yml
@@ -20,4 +20,4 @@ jobs:
 
     - name: Check file sync
       run: |
-        if [ -n "$(git status --porcelain)" ]; then echo Error: compiler's metamodel and ts generator metamodel are not in sync; git diff; git status; exit 1; fi
+        if [ -n "$(git status --porcelain)" ]; then echo "Error: compiler's metamodel and ts generator metamodel are not in sync"; git diff; git status; exit 1; fi


### PR DESCRIPTION
Message within `echo` should be wrapped in quotes, otherwise will never pass this step.

See: https://github.com/elastic/elasticsearch-specification/runs/6675231493?check_suite_focus=true

```
Run if [ -n "$(git status --porcelain)" ]; then echo Error: compiler's metamodel and ts generator metamodel are not in sync; git diff; git status; exit 1; fi
  if [ -n "$(git status --porcelain)" ]; then echo Error: compiler's metamodel and ts generator metamodel are not in sync; git diff; git status; exit 1; fi
  shell: /usr/bin/bash -e {0}
/home/runner/work/_temp/22d832cd-5cf4-4529-80be-b6de19ff6225.sh: line 1: unexpected EOF while looking for matching `''
Error: Process completed with exit code 2.
```