### PR TITLE
Fix property and field names for User Profile APIs

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15192,8 +15192,8 @@ export interface SecurityUser {
 export interface SecurityUserProfile {
   uid: string
   user: SecurityUserProfileUser
-  data?: Record<string, any>
-  labels?: Record<string, any>
+  data: Record<string, any>
+  labels: Record<string, any>
   enabled?: boolean
 }
 
@@ -15205,14 +15205,15 @@ export interface SecurityUserProfileHitMetadata {
 export interface SecurityUserProfileUser {
   email?: string | null
   full_name?: Name | null
-  metadata: Metadata
+  realm_name: Name
+  realm_domain?: Name
   roles: string[]
   username: Username
 }
 
 export interface SecurityUserProfileWithMetadata extends SecurityUserProfile {
   last_synchronized: long
-  _doc?: SecurityUserProfileHitMetadata
+  _doc: SecurityUserProfileHitMetadata
 }
 
 export interface SecurityActivateUserProfileRequest extends RequestBase {
@@ -15908,7 +15909,7 @@ export interface SecurityUpdateUserProfileDataRequest extends RequestBase {
   if_primary_term?: long
   refresh?: Refresh
   body?: {
-    access?: Record<string, any>
+    labels?: Record<string, any>
     data?: Record<string, any>
   }
 }

--- a/specification/security/_types/UserProfile.ts
+++ b/specification/security/_types/UserProfile.ts
@@ -32,7 +32,8 @@ export class UserProfileHitMetadata {
 export class UserProfileUser {
   email?: string | null
   full_name?: Name | null
-  metadata: Metadata
+  realm_name: Name
+  realm_domain?: Name
   roles: string[]
   username: Username
 }
@@ -40,12 +41,12 @@ export class UserProfileUser {
 export class UserProfile {
   uid: string
   user: UserProfileUser
-  data?: Dictionary<string, UserDefinedValue>
-  labels?: Dictionary<string, UserDefinedValue>
+  data: Dictionary<string, UserDefinedValue>
+  labels: Dictionary<string, UserDefinedValue>
   enabled?: boolean
 }
 
 export class UserProfileWithMetadata extends UserProfile {
   last_synchronized: long
-  _doc?: UserProfileHitMetadata
+  _doc: UserProfileHitMetadata
 }

--- a/specification/security/update_user_profile_data/Request.ts
+++ b/specification/security/update_user_profile_data/Request.ts
@@ -58,7 +58,7 @@ export interface Request extends RequestBase {
      * Searchable data that you want to associate with the user profile. This
      * field supports a nested data structure.
      */
-    access?: Dictionary<string, UserDefinedValue>
+    labels?: Dictionary<string, UserDefinedValue>
     /**
      * Non-searchable data that you want to associate with the user profile.
      * This field supports a nested data structure.


### PR DESCRIPTION
Now that we have test cases for UserProfile test cases we can fix these APIs. This model is defined [here](https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/Profile.java) in elastic/elasticsearch.

```
+ make validate api=security.activate_user_profile stack-version=8.4.0-SNAPSHOT
- Validating endpoints
✔ security.activate_user_profile request has been successfully validated!

✔ 4 out of 4 test request cases are passing.
✔ 4 out of 4 test response cases are passing.

+ make validate api=security.get_user_profile stack-version=8.4.0-SNAPSHOT
- Validating endpoints
✔ security.get_user_profile request has been successfully validated!

✔ 7 out of 7 test request cases are passing.
✔ 7 out of 7 test response cases are passing.

+ make validate api=security.enable_user_profile stack-version=8.4.0-SNAPSHOT
- Validating endpoints
✔ security.enable_user_profile request has been successfully validated!

✔ 1 out of 1 test request cases are passing.
✔ 1 out of 1 test response cases are passing.

+ make validate api=security.disable_user_profile stack-version=8.4.0-SNAPSHOT
- Validating endpoints
✔ security.disable_user_profile request has been successfully validated!

✔ 1 out of 1 test request cases are passing.
✔ 1 out of 1 test response cases are passing.

+ make validate api=security.suggest_user_profiles stack-version=8.4.0-SNAPSHOT
- Validating endpoints
✔ security.suggest_user_profiles request has been successfully validated!

✔ 1 out of 1 test request cases are passing.
✔ 1 out of 1 test response cases are passing.

+ make validate api=security.update_user_profile_data stack-version=8.4.0-SNAPSHOT
- Validating endpoints
✔ security.update_user_profile_data request has been successfully validated!

✔ 1 out of 1 test request cases are passing.
✔ 1 out of 1 test response cases are passing.
```