### PR TITLE
Update versions used for validate-pr workflow

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Download artifacts
         working-directory: ./clients-flight-recorder
         run: |
-          node scripts/upload-recording/download.js --branch master
-          node scripts/clone-elasticsearch/index.js --version 8.2.0-SNAPSHOT
+          node scripts/upload-recording/download.js --branch latest
+          node scripts/clone-elasticsearch/index.js --version 8.4-SNAPSHOT
         env:
           GCS_CREDENTIALS: ${{ secrets.GCS_CREDENTIALS }}
 
@@ -67,4 +67,4 @@ jobs:
 
       - name: Run validation
         working-directory: ./elasticsearch-specification
-        run: node .github/validate-pr --token ${{ secrets.GITHUB_TOKEN }} --version 8.2.0-SNAPSHOT
+        run: node .github/validate-pr --token ${{ secrets.GITHUB_TOKEN }} --version 8.4-SNAPSHOT


### PR DESCRIPTION
Noticed that the `validate-pr` workflow hasn't been working recently, wondering if it's related to a change in how we store recordings. If this fixes the issue then I'd like to introduce an automatic bump script so these values don't get out of date.