### PR TITLE
Fix snapshot repository definitions

### DIFF
--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -286,7 +286,8 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
           )
           assert(
             (bodyMember as PropertySignature).getJsDocs(),
-            !type.path.map(p => p.name).concat(type.query.map(p => p.name)).includes(tags.codegen_name),
+            !type.path.map(p => p.codegenName ?? p.name).concat(type.query.map(p => p.codegenName ?? p.name))
+              .includes(tags.codegen_name),
             `The codegen_name '${tags.codegen_name}' already exists as a property in the path or query.`
           )
           type.body = {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16380,22 +16380,23 @@ export interface SlmStopRequest extends RequestBase {
 
 export type SlmStopResponse = AcknowledgedResponseBase
 
-export interface SnapshotAzureRepository extends SnapshotBaseRepository<SnapshotAzureRepositorySettings> {
+export interface SnapshotAzureRepository extends SnapshotBaseRepository {
   type: 'azure'
+  settings: SnapshotAzureRepositorySettings
 }
 
-export type SnapshotAzureRepositoryLocation = 'primary_only' | 'secondary_only' | 'primary_then_secondary' | 'secondary_then_primary'
+export type SnapshotAzureRepositoryLocationMode = 'primary_only' | 'secondary_only' | 'primary_then_secondary' | 'secondary_then_primary'
 
 export interface SnapshotAzureRepositorySettings extends SnapshotBlobStoreSettings {
   client?: string
+  account?: string
   container?: string
-  location_mode: SnapshotAzureRepositoryLocation
+  location_mode: SnapshotAzureRepositoryLocationMode
   max_single_part_upload_size: ByteSize
 }
 
-export interface SnapshotBaseRepository<Settings = unknown> {
+export interface SnapshotBaseRepository {
   uuid?: Uuid
-  settings: Settings
 }
 
 export interface SnapshotBlobStoreSettings {
@@ -16415,25 +16416,29 @@ export interface SnapshotFileCountSnapshotStats {
   size_in_bytes: long
 }
 
-export interface SnapshotFsRepository extends SnapshotBaseRepository<SnapshotFsRepositorySettings> {
+export interface SnapshotFsRepository extends SnapshotBaseRepository {
   type: 'fs'
+  settings: SnapshotFsRepositorySettings
 }
 
 export interface SnapshotFsRepositorySettings extends SnapshotBlobStoreSettings {
   location?: string
 }
 
-export interface SnapshotGoogleCloudRepository extends SnapshotBaseRepository<SnapshotGoogleCloudRepositorySettings> {
+export interface SnapshotGoogleCloudRepository extends SnapshotBaseRepository {
   type: 'gcs'
+  settings: SnapshotGoogleCloudRepositorySettings
 }
 
 export interface SnapshotGoogleCloudRepositorySettings extends SnapshotBlobStoreSettings {
   bucket?: string
   base_path?: string
+  client?: string
 }
 
-export interface SnapshotHdfsRepository extends SnapshotBaseRepository<SnapshotHdfsRepositorySettings> {
+export interface SnapshotHdfsRepository extends SnapshotBaseRepository {
   type: 'hdfs'
+  settings: SnapshotHdfsRepositorySettings
 }
 
 export interface SnapshotHdfsRepositorySettings extends SnapshotBlobStoreSettings {
@@ -16456,11 +16461,12 @@ export interface SnapshotInfoFeatureState {
 
 export type SnapshotRepository = SnapshotS3Repository | SnapshotGoogleCloudRepository | SnapshotAzureRepository | SnapshotSourceRepository | SnapshotUrlRepository | SnapshotFsRepository | SnapshotHdfsRepository
 
-export interface SnapshotS3Repository extends SnapshotBaseRepository<SnapshotS3RepositorySettings> {
+export interface SnapshotS3Repository extends SnapshotBaseRepository {
   type: 's3'
+  settings: SnapshotS3RepositorySettings
 }
 
-export interface SnapshotS3RepositorySettings {
+export interface SnapshotS3RepositorySettings extends SnapshotBlobStoreSettings {
   base_path?: string
   bucket?: string
   buffer_size?: ByteSize
@@ -16547,8 +16553,9 @@ export interface SnapshotSnapshotStats {
   total: SnapshotFileCountSnapshotStats
 }
 
-export interface SnapshotSourceRepository extends SnapshotBaseRepository<SnapshotSourceRepositorySettings> {
+export interface SnapshotSourceRepository extends SnapshotBaseRepository {
   type: 'source'
+  settings: SnapshotSourceRepositorySettings
 }
 
 export interface SnapshotSourceRepositorySettingsKeys {
@@ -16568,14 +16575,20 @@ export interface SnapshotStatus {
   uuid: Uuid
 }
 
-export interface SnapshotUrlRepository extends SnapshotBaseRepository<SnapshotUrlRepositorySettings> {
+export interface SnapshotUrlRepository extends SnapshotBaseRepository {
   type: 'url'
+  settings: SnapshotUrlRepositorySettings
 }
 
 export interface SnapshotUrlRepositorySettings {
+  chunk_size: ByteSize
+  compress?: boolean
+  http_max_retries?: integer
+  http_socket_timeout?: Duration
+  max_number_of_snapshots?: integer
+  max_restore_bytes_per_sec: ByteSize
+  max_snapshot_bytes_per_sec: ByteSize
   url: string
-  supported_protocols?: string
-  allowed_urls?: string[]
 }
 
 export interface SnapshotCleanupRepositoryCleanupRepositoryResults {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16380,9 +16380,66 @@ export interface SlmStopRequest extends RequestBase {
 
 export type SlmStopResponse = AcknowledgedResponseBase
 
+export interface SnapshotAzureRepository extends SnapshotBaseRepository<SnapshotAzureRepositorySettings> {
+  type: 'azure'
+}
+
+export type SnapshotAzureRepositoryLocation = 'primary_only' | 'secondary_only' | 'primary_then_secondary' | 'secondary_then_primary'
+
+export interface SnapshotAzureRepositorySettings extends SnapshotBlobStoreSettings {
+  client?: string
+  container?: string
+  location_mode: SnapshotAzureRepositoryLocation
+  max_single_part_upload_size: ByteSize
+}
+
+export interface SnapshotBaseRepository<Settings = unknown> {
+  uuid?: Uuid
+  settings: Settings
+}
+
+export interface SnapshotBlobStoreSettings {
+  chunk_size?: ByteSize
+  concurrent_streams?: SpecUtilsStringified<integer>
+  compress?: SpecUtilsStringified<boolean>
+  max_number_of_snapshots?: integer
+  max_snapshot_bytes_per_sec?: ByteSize
+  max_restore_bytes_per_sec?: ByteSize
+  readonly?: SpecUtilsStringified<boolean>
+  read_only?: SpecUtilsStringified<boolean>
+  use_for_peer_recovery?: boolean
+}
+
 export interface SnapshotFileCountSnapshotStats {
   file_count: integer
   size_in_bytes: long
+}
+
+export interface SnapshotFsRepository extends SnapshotBaseRepository<SnapshotFsRepositorySettings> {
+  type: 'fs'
+}
+
+export interface SnapshotFsRepositorySettings extends SnapshotBlobStoreSettings {
+  location?: string
+}
+
+export interface SnapshotGoogleCloudRepository extends SnapshotBaseRepository<SnapshotGoogleCloudRepositorySettings> {
+  type: 'gcs'
+}
+
+export interface SnapshotGoogleCloudRepositorySettings extends SnapshotBlobStoreSettings {
+  bucket?: string
+  base_path?: string
+}
+
+export interface SnapshotHdfsRepository extends SnapshotBaseRepository<SnapshotHdfsRepositorySettings> {
+  type: 'hdfs'
+}
+
+export interface SnapshotHdfsRepositorySettings extends SnapshotBlobStoreSettings {
+  uri: string
+  path: string
+  'security.principal': string
 }
 
 export interface SnapshotIndexDetails {
@@ -16397,19 +16454,20 @@ export interface SnapshotInfoFeatureState {
   indices: Indices
 }
 
-export interface SnapshotRepository {
-  type: string
-  uuid?: Uuid
-  settings: SnapshotRepositorySettings
+export type SnapshotRepository = SnapshotS3Repository | SnapshotGoogleCloudRepository | SnapshotAzureRepository | SnapshotSourceRepository | SnapshotUrlRepository | SnapshotFsRepository | SnapshotHdfsRepository
+
+export interface SnapshotS3Repository extends SnapshotBaseRepository<SnapshotS3RepositorySettings> {
+  type: 's3'
 }
 
-export interface SnapshotRepositorySettings {
-  chunk_size?: string
-  compress?: string | boolean
-  concurrent_streams?: string | integer
+export interface SnapshotS3RepositorySettings {
+  base_path?: string
+  bucket?: string
+  buffer_size?: ByteSize
+  client?: string
   location: string
-  read_only?: string | boolean
-  readonly?: string | boolean
+  server_size_encryption?: boolean
+  storage_class?: string
 }
 
 export interface SnapshotShardsStats {
@@ -16489,6 +16547,16 @@ export interface SnapshotSnapshotStats {
   total: SnapshotFileCountSnapshotStats
 }
 
+export interface SnapshotSourceRepository extends SnapshotBaseRepository<SnapshotSourceRepositorySettings> {
+  type: 'source'
+}
+
+export interface SnapshotSourceRepositorySettingsKeys {
+  delegate_type: string
+}
+export type SnapshotSourceRepositorySettings = SnapshotSourceRepositorySettingsKeys
+  & { [property: string]: any }
+
 export interface SnapshotStatus {
   include_global_state: boolean
   indices: Record<string, SnapshotSnapshotIndexStats>
@@ -16498,6 +16566,16 @@ export interface SnapshotStatus {
   state: string
   stats: SnapshotSnapshotStats
   uuid: Uuid
+}
+
+export interface SnapshotUrlRepository extends SnapshotBaseRepository<SnapshotUrlRepositorySettings> {
+  type: 'url'
+}
+
+export interface SnapshotUrlRepositorySettings {
+  url: string
+  supported_protocols?: string
+  allowed_urls?: string[]
 }
 
 export interface SnapshotCleanupRepositoryCleanupRepositoryResults {
@@ -16553,11 +16631,7 @@ export interface SnapshotCreateRepositoryRequest extends RequestBase {
   master_timeout?: Duration
   timeout?: Duration
   verify?: boolean
-  body?: {
-    repository?: SnapshotRepository
-    type: string
-    settings: SnapshotRepositorySettings
-  }
+  body?: SnapshotRepository
 }
 
 export type SnapshotCreateRepositoryResponse = AcknowledgedResponseBase

--- a/specification/snapshot/_types/SnapshotRepository.ts
+++ b/specification/snapshot/_types/SnapshotRepository.ts
@@ -17,22 +17,119 @@
  * under the License.
  */
 
-import { Uuid } from '@_types/common'
+import { ByteSize, Uuid } from '@_types/common'
 import { integer } from '@_types/Numeric'
+import { Base } from '@xpack/usage/types'
+import { AdditionalProperties } from '@spec_utils/behaviors'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { Stringified } from '@spec_utils/Stringified'
 
-export class Repository {
-  type: string
+export class BaseRepository<Settings> {
   uuid?: Uuid
-  settings: RepositorySettings
+  settings: Settings
 }
 
-export class RepositorySettings {
-  chunk_size?: string
-  compress?: string | boolean
-  concurrent_streams?: string | integer
+/**
+ * @variants internal tag='type'
+ * @non_exhaustive
+ */
+export type Repository =
+  | S3Repository
+  | GoogleCloudRepository
+  | AzureRepository
+  | SourceRepository
+  | UrlRepository
+  | FsRepository
+  | HdfsRepository
+
+export class S3Repository extends BaseRepository<S3RepositorySettings> {
+  type: 's3'
+}
+
+class BlobStoreSettings {
+  chunk_size?: ByteSize
+  concurrent_streams?: Stringified<integer>
+  compress?: Stringified<boolean>
+  max_number_of_snapshots?: integer
+  max_snapshot_bytes_per_sec?: ByteSize
+  max_restore_bytes_per_sec?: ByteSize
+  /** @aliases read_only */
+  readonly?: Stringified<boolean>
+  use_for_peer_recovery?: boolean
+}
+
+export class S3RepositorySettings {
+  base_path?: string
+  bucket?: string
+  buffer_size?: ByteSize
+  client?: string
   location: string
-  /**
-   * @aliases readonly
-   */
-  read_only?: string | boolean
+  server_size_encryption?: boolean
+  storage_class?: string
+}
+
+export class AzureRepository extends BaseRepository<AzureRepositorySettings> {
+  type: 'azure'
+}
+
+export class AzureRepositorySettings extends BlobStoreSettings {
+  /** aliases account */
+  client?: string
+  container?: string
+  location_mode: AzureRepositoryLocation
+  max_single_part_upload_size: ByteSize
+}
+
+export enum AzureRepositoryLocation {
+  primary_only,
+  secondary_only,
+  primary_then_secondary,
+  secondary_then_primary
+}
+
+export class GoogleCloudRepository extends BaseRepository<GoogleCloudRepositorySettings> {
+  type: 'gcs'
+}
+
+export class GoogleCloudRepositorySettings extends BlobStoreSettings {
+  bucket?: string
+  base_path?: string
+}
+
+export class UrlRepository extends BaseRepository<UrlRepositorySettings> {
+  type: 'url'
+}
+
+export class UrlRepositorySettings {
+  url: string
+  supported_protocols?: string
+  allowed_urls?: string[]
+}
+
+export class SourceRepository extends BaseRepository<SourceRepositorySettings> {
+  type: 'source'
+}
+
+export class SourceRepositorySettings
+  implements AdditionalProperties<string, UserDefinedValue>
+{
+  delegate_type: string
+}
+
+export class FsRepository extends BaseRepository<FsRepositorySettings> {
+  type: 'fs'
+}
+
+export class FsRepositorySettings extends BlobStoreSettings {
+  location?: string
+}
+
+export class HdfsRepository extends BaseRepository<HdfsRepositorySettings> {
+  type: 'hdfs'
+}
+
+export class HdfsRepositorySettings extends BlobStoreSettings {
+  uri: string
+  path: string
+  'security.principal': string
 }

--- a/specification/snapshot/_types/SnapshotRepository.ts
+++ b/specification/snapshot/_types/SnapshotRepository.ts
@@ -23,10 +23,10 @@ import { Base } from '@xpack/usage/types'
 import { AdditionalProperties } from '@spec_utils/behaviors'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Stringified } from '@spec_utils/Stringified'
+import { Duration } from '@_types/Time'
 
-export class BaseRepository<Settings> {
+export class BaseRepository {
   uuid?: Uuid
-  settings: Settings
 }
 
 /**
@@ -42,8 +42,9 @@ export type Repository =
   | FsRepository
   | HdfsRepository
 
-export class S3Repository extends BaseRepository<S3RepositorySettings> {
+export class S3Repository extends BaseRepository {
   type: 's3'
+  settings: S3RepositorySettings
 }
 
 class BlobStoreSettings {
@@ -58,7 +59,7 @@ class BlobStoreSettings {
   use_for_peer_recovery?: boolean
 }
 
-export class S3RepositorySettings {
+export class S3RepositorySettings extends BlobStoreSettings {
   base_path?: string
   bucket?: string
   buffer_size?: ByteSize
@@ -68,46 +69,56 @@ export class S3RepositorySettings {
   storage_class?: string
 }
 
-export class AzureRepository extends BaseRepository<AzureRepositorySettings> {
+export class AzureRepository extends BaseRepository {
   type: 'azure'
+  settings: AzureRepositorySettings
 }
 
 export class AzureRepositorySettings extends BlobStoreSettings {
-  /** aliases account */
+  /** @aliases account */
   client?: string
   container?: string
-  location_mode: AzureRepositoryLocation
+  location_mode: AzureRepositoryLocationMode
   max_single_part_upload_size: ByteSize
 }
 
-export enum AzureRepositoryLocation {
+export enum AzureRepositoryLocationMode {
   primary_only,
   secondary_only,
   primary_then_secondary,
   secondary_then_primary
 }
 
-export class GoogleCloudRepository extends BaseRepository<GoogleCloudRepositorySettings> {
+export class GoogleCloudRepository extends BaseRepository {
   type: 'gcs'
+  settings: GoogleCloudRepositorySettings
 }
 
 export class GoogleCloudRepositorySettings extends BlobStoreSettings {
   bucket?: string
   base_path?: string
+  client?: string
 }
 
-export class UrlRepository extends BaseRepository<UrlRepositorySettings> {
+export class UrlRepository extends BaseRepository {
   type: 'url'
+  settings: UrlRepositorySettings
 }
 
 export class UrlRepositorySettings {
+  chunk_size: ByteSize
+  compress?: boolean
+  http_max_retries?: integer
+  http_socket_timeout?: Duration
+  max_number_of_snapshots?: integer
+  max_restore_bytes_per_sec: ByteSize
+  max_snapshot_bytes_per_sec: ByteSize
   url: string
-  supported_protocols?: string
-  allowed_urls?: string[]
 }
 
-export class SourceRepository extends BaseRepository<SourceRepositorySettings> {
+export class SourceRepository extends BaseRepository {
   type: 'source'
+  settings: SourceRepositorySettings
 }
 
 export class SourceRepositorySettings
@@ -116,16 +127,18 @@ export class SourceRepositorySettings
   delegate_type: string
 }
 
-export class FsRepository extends BaseRepository<FsRepositorySettings> {
+export class FsRepository extends BaseRepository {
   type: 'fs'
+  settings: FsRepositorySettings
 }
 
 export class FsRepositorySettings extends BlobStoreSettings {
   location?: string
 }
 
-export class HdfsRepository extends BaseRepository<HdfsRepositorySettings> {
+export class HdfsRepository extends BaseRepository {
   type: 'hdfs'
+  settings: HdfsRepositorySettings
 }
 
 export class HdfsRepositorySettings extends BlobStoreSettings {

--- a/specification/snapshot/create_repository/SnapshotCreateRepositoryRequest.ts
+++ b/specification/snapshot/create_repository/SnapshotCreateRepositoryRequest.ts
@@ -17,10 +17,7 @@
  * under the License.
  */
 
-import {
-  Repository,
-  RepositorySettings
-} from '@snapshot/_types/SnapshotRepository'
+import { Repository } from '@snapshot/_types/SnapshotRepository'
 import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 import { Duration } from '@_types/Time'
@@ -41,9 +38,6 @@ export interface Request extends RequestBase {
     timeout?: Duration
     verify?: boolean
   }
-  body: {
-    repository?: Repository
-    type: string
-    settings: RepositorySettings
-  }
+  /** @codegen_name repository */
+  body: Repository
 }


### PR DESCRIPTION
In the `snapshot` namespace we only have a (partial) definition of the S3 repository. This PR defines the settings for all repository implementations and groups them in a `@non_exhaustive` union (plugins can define new snapshot repositories).

Found in https://github.com/elastic/elasticsearch-java/issues/207