### PR TITLE
Misc java fixes 220617

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ typescript-generator/lib
 
 report
 output/schema/import-*
+output/schema/schema-no-generics.json
 .github/**/package-lock.json
 
 # Editor lockfiles

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10356,7 +10356,7 @@ export interface IndicesRecoveryShardRecovery {
   start_time?: DateTime
   start_time_in_millis: EpochTime<UnitMillis>
   stop_time?: DateTime
-  stop_time_in_millis: EpochTime<UnitMillis>
+  stop_time_in_millis?: EpochTime<UnitMillis>
   target: IndicesRecoveryRecoveryOrigin
   total_time?: Duration
   total_time_in_millis: DurationValue<UnitMillis>

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16559,10 +16559,12 @@ export interface SqlTranslateRequest extends RequestBase {
 }
 
 export interface SqlTranslateResponse {
-  size: long
-  _source: SearchSourceConfig
-  fields: Record<Field, string>[]
-  sort: Sort
+  aggregations?: Record<string, AggregationsAggregationContainer>
+  size?: long
+  _source?: SearchSourceConfig
+  fields?: (QueryDslFieldAndFormat | Field)[]
+  query?: QueryDslQueryContainer
+  sort?: Sort
 }
 
 export interface SslCertificatesCertificateInformation {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3859,7 +3859,7 @@ export type AnalysisAnalyzer = AnalysisCustomAnalyzer | AnalysisFingerprintAnaly
 
 export interface AnalysisAsciiFoldingTokenFilter extends AnalysisTokenFilterBase {
   type: 'asciifolding'
-  preserve_original: boolean
+  preserve_original?: boolean
 }
 
 export type AnalysisCharFilter = string | AnalysisCharFilterDefinition
@@ -3919,8 +3919,8 @@ export type AnalysisDelimitedPayloadEncoding = 'int' | 'float' | 'identity'
 
 export interface AnalysisDelimitedPayloadTokenFilter extends AnalysisTokenFilterBase {
   type: 'delimited_payload'
-  delimiter: string
-  encoding: AnalysisDelimitedPayloadEncoding
+  delimiter?: string
+  encoding?: AnalysisDelimitedPayloadEncoding
 }
 
 export interface AnalysisDictionaryDecompounderTokenFilter extends AnalysisCompoundWordTokenFilterBase {
@@ -3936,8 +3936,8 @@ export type AnalysisEdgeNGramSide = 'front' | 'back'
 
 export interface AnalysisEdgeNGramTokenFilter extends AnalysisTokenFilterBase {
   type: 'edge_ngram'
-  max_gram: integer
-  min_gram: integer
+  max_gram?: integer
+  min_gram?: integer
   side?: AnalysisEdgeNGramSide
   preserve_original?: boolean
 }
@@ -3952,8 +3952,9 @@ export interface AnalysisEdgeNGramTokenizer extends AnalysisTokenizerBase {
 
 export interface AnalysisElisionTokenFilter extends AnalysisTokenFilterBase {
   type: 'elision'
-  articles: string[]
-  articles_case: boolean
+  articles?: string[]
+  articles_path?: string
+  articles_case?: boolean
 }
 
 export interface AnalysisFingerprintAnalyzer {
@@ -3968,8 +3969,8 @@ export interface AnalysisFingerprintAnalyzer {
 
 export interface AnalysisFingerprintTokenFilter extends AnalysisTokenFilterBase {
   type: 'fingerprint'
-  max_output_size: integer
-  separator: string
+  max_output_size?: integer
+  separator?: string
 }
 
 export interface AnalysisHtmlStripCharFilter extends AnalysisCharFilterBase {
@@ -3978,10 +3979,12 @@ export interface AnalysisHtmlStripCharFilter extends AnalysisCharFilterBase {
 
 export interface AnalysisHunspellTokenFilter extends AnalysisTokenFilterBase {
   type: 'hunspell'
-  dedup: boolean
-  dictionary: string
+  dedup?: boolean
+  dictionary?: string
   locale: string
-  longest_only: boolean
+  lang: string
+  language: string
+  longest_only?: boolean
 }
 
 export interface AnalysisHyphenationDecompounderTokenFilter extends AnalysisCompoundWordTokenFilterBase {
@@ -4140,8 +4143,8 @@ export interface AnalysisLanguageAnalyzer {
 
 export interface AnalysisLengthTokenFilter extends AnalysisTokenFilterBase {
   type: 'length'
-  max: integer
-  min: integer
+  max?: integer
+  min?: integer
 }
 
 export interface AnalysisLetterTokenizer extends AnalysisTokenizerBase {
@@ -4150,8 +4153,8 @@ export interface AnalysisLetterTokenizer extends AnalysisTokenizerBase {
 
 export interface AnalysisLimitTokenCountTokenFilter extends AnalysisTokenFilterBase {
   type: 'limit'
-  consume_all_tokens: boolean
-  max_token_count: integer
+  consume_all_tokens?: boolean
+  max_token_count?: integer
 }
 
 export interface AnalysisLowercaseNormalizer {
@@ -4176,7 +4179,7 @@ export interface AnalysisMappingCharFilter extends AnalysisCharFilterBase {
 export interface AnalysisMultiplexerTokenFilter extends AnalysisTokenFilterBase {
   type: 'multiplexer'
   filters: string[]
-  preserve_original: boolean
+  preserve_original?: boolean
 }
 
 export interface AnalysisNGramTokenFilter extends AnalysisTokenFilterBase {
@@ -4206,7 +4209,7 @@ export type AnalysisNoriDecompoundMode = 'discard' | 'none' | 'mixed'
 
 export interface AnalysisNoriPartOfSpeechTokenFilter extends AnalysisTokenFilterBase {
   type: 'nori_part_of_speech'
-  stoptags: string[]
+  stoptags?: string[]
 }
 
 export interface AnalysisNoriTokenizer extends AnalysisTokenizerBase {
@@ -4240,7 +4243,7 @@ export interface AnalysisPatternAnalyzer {
 export interface AnalysisPatternCaptureTokenFilter extends AnalysisTokenFilterBase {
   type: 'pattern_capture'
   patterns: string[]
-  preserve_original: boolean
+  preserve_original?: boolean
 }
 
 export interface AnalysisPatternReplaceCharFilter extends AnalysisCharFilterBase {
@@ -4252,9 +4255,9 @@ export interface AnalysisPatternReplaceCharFilter extends AnalysisCharFilterBase
 
 export interface AnalysisPatternReplaceTokenFilter extends AnalysisTokenFilterBase {
   type: 'pattern_replace'
-  flags: string
+  all?: boolean
   pattern: string
-  replacement: string
+  replacement?: string
 }
 
 export interface AnalysisPatternTokenizer extends AnalysisTokenizerBase {
@@ -4361,7 +4364,7 @@ export interface AnalysisStopTokenFilter extends AnalysisTokenFilterBase {
   type: 'stop'
   ignore_case?: boolean
   remove_trailing?: boolean
-  stopwords: AnalysisStopWords
+  stopwords?: AnalysisStopWords
   stopwords_path?: string
 }
 
@@ -4415,7 +4418,7 @@ export interface AnalysisTrimTokenFilter extends AnalysisTokenFilterBase {
 
 export interface AnalysisTruncateTokenFilter extends AnalysisTokenFilterBase {
   type: 'truncate'
-  length: integer
+  length?: integer
 }
 
 export interface AnalysisUaxEmailUrlTokenizer extends AnalysisTokenizerBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2581,6 +2581,8 @@ export interface AggregationsAggregateBase {
   meta?: Metadata
 }
 
+export type AggregationsAggregateOrder = Partial<Record<Field, SortOrder>> | Partial<Record<Field, SortOrder>>[]
+
 export interface AggregationsAggregation {
   meta?: Metadata
   name?: string
@@ -2872,7 +2874,7 @@ export interface AggregationsDateHistogramAggregation extends AggregationsBucket
   min_doc_count?: integer
   missing?: DateTime
   offset?: Duration
-  order?: AggregationsHistogramOrder
+  order?: AggregationsAggregateOrder
   params?: Record<string, any>
   script?: Script
   time_zone?: TimeZone
@@ -3127,7 +3129,7 @@ export interface AggregationsHistogramAggregation extends AggregationsBucketAggr
   min_doc_count?: integer
   missing?: double
   offset?: double
-  order?: AggregationsHistogramOrder
+  order?: AggregationsAggregateOrder
   script?: Script
   format?: string
   keyed?: boolean
@@ -3139,11 +3141,6 @@ export interface AggregationsHistogramBucketKeys extends AggregationsMultiBucket
 }
 export type AggregationsHistogramBucket = AggregationsHistogramBucketKeys
   & { [property: string]: AggregationsAggregate | string | double | long }
-
-export interface AggregationsHistogramOrder {
-  _count?: SortOrder
-  _key?: SortOrder
-}
 
 export interface AggregationsHoltLinearModelSettings {
   alpha?: float
@@ -3363,6 +3360,13 @@ export interface AggregationsMultiTermsAggregate extends AggregationsTermsAggreg
 }
 
 export interface AggregationsMultiTermsAggregation extends AggregationsBucketAggregationBase {
+  collect_mode?: AggregationsTermsAggregationCollectMode
+  order?: AggregationsAggregateOrder
+  min_doc_count?: long
+  shard_min_doc_count?: long
+  shard_size?: integer
+  show_term_doc_count_error?: boolean
+  size?: integer
   terms: AggregationsMultiTermLookup[]
 }
 
@@ -3723,7 +3727,7 @@ export interface AggregationsTermsAggregation extends AggregationsBucketAggregat
   missing_order?: AggregationsMissingOrder
   missing_bucket?: boolean
   value_type?: string
-  order?: AggregationsTermsAggregationOrder
+  order?: AggregationsAggregateOrder
   script?: Script
   shard_size?: integer
   show_term_doc_count_error?: boolean
@@ -3734,8 +3738,6 @@ export interface AggregationsTermsAggregation extends AggregationsBucketAggregat
 export type AggregationsTermsAggregationCollectMode = 'depth_first' | 'breadth_first'
 
 export type AggregationsTermsAggregationExecutionHint = 'map' | 'global_ordinals' | 'global_ordinals_hash' | 'global_ordinals_low_cardinality'
-
-export type AggregationsTermsAggregationOrder = Record<Field, SortOrder> | Record<Field, SortOrder>[]
 
 export interface AggregationsTermsBucketBase extends AggregationsMultiBucketBase {
   doc_count_error?: long
@@ -10069,7 +10071,7 @@ export interface IndicesGetFieldMappingRequest extends RequestBase {
 export type IndicesGetFieldMappingResponse = Record<IndexName, IndicesGetFieldMappingTypeFieldMappings>
 
 export interface IndicesGetFieldMappingTypeFieldMappings {
-  mappings: Partial<Record<Field, MappingFieldMapping>>
+  mappings: Record<Field, MappingFieldMapping>
 }
 
 export interface IndicesGetIndexTemplateIndexTemplateItem {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3982,8 +3982,6 @@ export interface AnalysisHunspellTokenFilter extends AnalysisTokenFilterBase {
   dedup?: boolean
   dictionary?: string
   locale: string
-  lang: string
-  language: string
   longest_only?: boolean
 }
 
@@ -4256,6 +4254,7 @@ export interface AnalysisPatternReplaceCharFilter extends AnalysisCharFilterBase
 export interface AnalysisPatternReplaceTokenFilter extends AnalysisTokenFilterBase {
   type: 'pattern_replace'
   all?: boolean
+  flags?: string
   pattern: string
   replacement?: string
 }
@@ -9334,7 +9333,7 @@ export interface IndicesIndexSettingBlocks {
   metadata?: boolean
 }
 
-export interface IndicesIndexSettings {
+export interface IndicesIndexSettingsKeys {
   index?: IndicesIndexSettings
   mode?: string
   routing_path?: string | string[]
@@ -9388,11 +9387,13 @@ export interface IndicesIndexSettings {
   shards?: integer
   queries?: IndicesQueries
   similarity?: IndicesSettingsSimilarity
-  mappings?: IndicesMappingLimitSettings
+  mapping?: IndicesMappingLimitSettings
   'indexing.slowlog'?: IndicesSlowlogSettings
   indexing_pressure?: IndicesIndexingPressure
   store?: IndicesStorage
 }
+export type IndicesIndexSettings = IndicesIndexSettingsKeys
+  & { [property: string]: any }
 
 export interface IndicesIndexSettingsAnalysis {
   analyzer?: Record<string, AnalysisAnalyzer>

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -18,7 +18,7 @@
  */
 
 import { SortOrder } from '@_types/sort'
-import {Dictionary, SingleKeyDictionary} from '@spec_utils/Dictionary'
+import { Dictionary, SingleKeyDictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { EmptyObject } from '@_types/common'
 import { Field, RelationName, Fields } from '@_types/common'

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -18,7 +18,7 @@
  */
 
 import { SortOrder } from '@_types/sort'
-import { Dictionary } from '@spec_utils/Dictionary'
+import {Dictionary, SingleKeyDictionary} from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { EmptyObject } from '@_types/common'
 import { Field, RelationName, Fields } from '@_types/common'
@@ -99,7 +99,7 @@ export class DateHistogramAggregation extends BucketAggregationBase {
   min_doc_count?: integer
   missing?: DateTime
   offset?: Duration
-  order?: HistogramOrder
+  order?: AggregateOrder
   params?: Dictionary<string, UserDefinedValue>
   script?: Script
   time_zone?: TimeZone
@@ -237,15 +237,10 @@ export class HistogramAggregation extends BucketAggregationBase {
   min_doc_count?: integer
   missing?: double
   offset?: double
-  order?: HistogramOrder
+  order?: AggregateOrder
   script?: Script
   format?: string
   keyed?: boolean
-}
-
-export class HistogramOrder {
-  _count?: SortOrder
-  _key?: SortOrder
 }
 
 export class IpRangeAggregation extends BucketAggregationBase {
@@ -265,6 +260,13 @@ export class MissingAggregation extends BucketAggregationBase {
 }
 
 export class MultiTermsAggregation extends BucketAggregationBase {
+  collect_mode?: TermsAggregationCollectMode
+  order?: AggregateOrder
+  min_doc_count?: long
+  shard_min_doc_count?: long
+  shard_size?: integer
+  show_term_doc_count_error?: boolean
+  size?: integer
   terms: MultiTermLookup[]
 }
 
@@ -382,7 +384,7 @@ export class TermsAggregation extends BucketAggregationBase {
   missing_order?: MissingOrder
   missing_bucket?: boolean
   value_type?: string
-  order?: TermsAggregationOrder
+  order?: AggregateOrder
   script?: Script
   shard_size?: integer
   show_term_doc_count_error?: boolean
@@ -390,9 +392,9 @@ export class TermsAggregation extends BucketAggregationBase {
   format?: string
 }
 
-export type TermsAggregationOrder =
-  | Dictionary<Field, SortOrder>
-  | Dictionary<Field, SortOrder>[]
+export type AggregateOrder =
+  | SingleKeyDictionary<Field, SortOrder>
+  | SingleKeyDictionary<Field, SortOrder>[]
 
 export enum TermsAggregationCollectMode {
   depth_first = 0,

--- a/specification/_types/analysis/token_filters.ts
+++ b/specification/_types/analysis/token_filters.ts
@@ -66,8 +66,8 @@ export enum DelimitedPayloadEncoding {
 
 export class DelimitedPayloadTokenFilter extends TokenFilterBase {
   type: 'delimited_payload'
-  delimiter: string
-  encoding: DelimitedPayloadEncoding
+  delimiter?: string
+  encoding?: DelimitedPayloadEncoding
 }
 
 export enum EdgeNGramSide {
@@ -77,8 +77,8 @@ export enum EdgeNGramSide {
 
 export class EdgeNGramTokenFilter extends TokenFilterBase {
   type: 'edge_ngram'
-  max_gram: integer
-  min_gram: integer
+  max_gram?: integer
+  min_gram?: integer
   side?: EdgeNGramSide
   preserve_original?: boolean
 }
@@ -97,7 +97,7 @@ export class StopTokenFilter extends TokenFilterBase {
   type: 'stop'
   ignore_case?: boolean
   remove_trailing?: boolean
-  stopwords: StopWords
+  stopwords?: StopWords
   stopwords_path?: string
 }
 
@@ -166,7 +166,7 @@ export class WordDelimiterGraphTokenFilter extends TokenFilterBase {
 
 export class AsciiFoldingTokenFilter extends TokenFilterBase {
   type: 'asciifolding'
-  preserve_original: boolean
+  preserve_original?: boolean
 }
 
 export class CommonGramsTokenFilter extends TokenFilterBase {
@@ -185,27 +185,28 @@ export class ConditionTokenFilter extends TokenFilterBase {
 
 export class ElisionTokenFilter extends TokenFilterBase {
   type: 'elision'
-  articles: string[]
-  articles_case: boolean
+  articles?: string[]
+  articles_path?: string
+  articles_case?: boolean
 }
 
 export class FingerprintTokenFilter extends TokenFilterBase {
   type: 'fingerprint'
-  max_output_size: integer
-  separator: string
+  max_output_size?: integer
+  separator?: string
 }
 
 export class HunspellTokenFilter extends TokenFilterBase {
   type: 'hunspell'
-  dedup: boolean
-  dictionary: string
+  dedup?: boolean
+  dictionary?: string
   locale: string
-  longest_only: boolean
+  longest_only?: boolean
 }
 
 export class JaStopTokenFilter extends TokenFilterBase {
   type: 'ja_stop'
-  stopwords: StopWords
+  stopwords?: StopWords
 }
 
 export enum KeepTypesMode {
@@ -240,14 +241,14 @@ export class KStemTokenFilter extends TokenFilterBase {
 
 export class LengthTokenFilter extends TokenFilterBase {
   type: 'length'
-  max: integer
-  min: integer
+  max?: integer
+  min?: integer
 }
 
 export class LimitTokenCountTokenFilter extends TokenFilterBase {
   type: 'limit'
-  consume_all_tokens: boolean
-  max_token_count: integer
+  consume_all_tokens?: boolean
+  max_token_count?: integer
 }
 
 export class LowercaseTokenFilter extends TokenFilterBase {
@@ -258,7 +259,7 @@ export class LowercaseTokenFilter extends TokenFilterBase {
 export class MultiplexerTokenFilter extends TokenFilterBase {
   type: 'multiplexer'
   filters: string[]
-  preserve_original: boolean
+  preserve_original?: boolean
 }
 
 export class NGramTokenFilter extends TokenFilterBase {
@@ -270,20 +271,21 @@ export class NGramTokenFilter extends TokenFilterBase {
 
 export class NoriPartOfSpeechTokenFilter extends TokenFilterBase {
   type: 'nori_part_of_speech'
-  stoptags: string[]
+  stoptags?: string[]
 }
 
 export class PatternCaptureTokenFilter extends TokenFilterBase {
   type: 'pattern_capture'
   patterns: string[]
-  preserve_original: boolean
+  preserve_original?: boolean
 }
 
 export class PatternReplaceTokenFilter extends TokenFilterBase {
   type: 'pattern_replace'
-  flags: string
+  all?: boolean
+  flags?: string
   pattern: string
-  replacement: string
+  replacement?: string
 }
 
 export class PorterStemTokenFilter extends TokenFilterBase {
@@ -325,7 +327,7 @@ export class TrimTokenFilter extends TokenFilterBase {
 
 export class TruncateTokenFilter extends TokenFilterBase {
   type: 'truncate'
-  length: integer
+  length?: integer
 }
 
 export class UniqueTokenFilter extends TokenFilterBase {

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -44,6 +44,8 @@ import {
 } from '@_types/Similarity'
 import { Script } from '@_types/Scripting'
 import { Stringified } from '@spec_utils/Stringified'
+import { AdditionalProperties } from '@spec_utils/behaviors'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class SoftDeletes {
   /**
@@ -67,7 +69,9 @@ export class RetentionLease {
 /**
  * @doc_id index-modules-settings
  */
-export class IndexSettings {
+export class IndexSettings
+  implements AdditionalProperties<string, UserDefinedValue>
+{
   index?: IndexSettings
   mode?: string
   routing_path?: string | string[]
@@ -151,7 +155,7 @@ export class IndexSettings {
   /**
    * Enable or disable dynamic mapping for an index.
    */
-  mappings?: MappingLimitSettings
+  mapping?: MappingLimitSettings
   'indexing.slowlog'?: SlowlogSettings
   /**
    * Configure indexing back pressure limits.

--- a/specification/indices/get_field_mapping/types.ts
+++ b/specification/indices/get_field_mapping/types.ts
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-import { SingleKeyDictionary } from '@spec_utils/Dictionary'
+import { Dictionary } from '@spec_utils/Dictionary'
 import { Field } from '@_types/common'
 import { FieldMapping } from '@_types/mapping/meta-fields'
 
 export class TypeFieldMappings {
-  mappings: SingleKeyDictionary<Field, FieldMapping>
+  mappings: Dictionary<Field, FieldMapping>
 }

--- a/specification/indices/recovery/types.ts
+++ b/specification/indices/recovery/types.ts
@@ -125,7 +125,7 @@ export class ShardRecovery {
   start_time?: DateTime
   start_time_in_millis: EpochTime<UnitMillis>
   stop_time?: DateTime
-  stop_time_in_millis: EpochTime<UnitMillis>
+  stop_time_in_millis?: EpochTime<UnitMillis>
   target: RecoveryOrigin
   total_time?: Duration
   total_time_in_millis: DurationValue<UnitMillis>

--- a/specification/sql/translate/TranslateSqlResponse.ts
+++ b/specification/sql/translate/TranslateSqlResponse.ts
@@ -22,12 +22,17 @@ import { SourceConfig } from '@global/search/_types/SourceFilter'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { Field, Fields } from '@_types/common'
 import { long } from '@_types/Numeric'
+import { FieldAndFormat, QueryContainer } from '@_types/query_dsl/abstractions'
+import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 
 export class Response {
+  // This is a subset of SearchRequest's body (same data structure in the ES code)
   body: {
-    size: long
-    _source: SourceConfig
-    fields: Array<Dictionary<Field, string>>
-    sort: Sort
+    aggregations?: Dictionary<string, AggregationContainer>
+    size?: long
+    _source?: SourceConfig
+    fields?: Array<FieldAndFormat>
+    query?: QueryContainer
+    sort?: Sort
   }
 }


### PR DESCRIPTION
Fixes some spec issues found in the Java client:

* Missing fields in MultiTermsAggregation.  
  Found in https://github.com/elastic/elasticsearch-java/issues/319

* TypeFieldMappings is a multi-key dictionary.  
  Found in https://github.com/elastic/elasticsearch-java/issues/166

* Missing/wrong fields in ExplainSqlRequest.  
  Found in https://github.com/elastic/elasticsearch-java/issues/167

* Misc fixes on token filters.  
  Found in https://github.com/elastic/elasticsearch-java/issues/199

* Fix typo in IndexSettings.mapping and allow extended settings.  
  Found in https://github.com/elastic/elasticsearch-java/issues/295

* ShardRecovery.stop_time_in_millis is optional.  
  Found in https://github.com/elastic/elasticsearch-java/issues/202
