### PR TITLE
[7.17] Add note about AggregateOrder parsing lazyness (#1777)

### DIFF
--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -358,6 +358,10 @@ export class TermsAggregation extends BucketAggregationBase {
   size?: integer
 }
 
+// Note: ES is very lazy when parsing this data type: it accepts any number of properties in the objects below,
+// but will only keep the *last* property in JSON document order and ignore others.
+// This means that something like `"order": { "downloads": "desc", "_key": "asc" }` will actually be interpreted
+// as `"order": [ { "_key": "asc" } ]`
 export type AggregateOrder =
   | SingleKeyDictionary<Field, SortOrder>
   | SingleKeyDictionary<Field, SortOrder>[]


### PR DESCRIPTION
Backport #1777 to branch 7.17