### PR TITLE
Fix suggestion options and mapping char filter

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1152,7 +1152,7 @@ export interface SearchCompletionContext {
 }
 
 export interface SearchCompletionSuggest<TDocument = unknown> extends SearchSuggestBase {
-  options: SearchCompletionSuggestOption<TDocument>[]
+  options: SearchCompletionSuggestOption<TDocument> | SearchCompletionSuggestOption<TDocument>[]
 }
 
 export interface SearchCompletionSuggestOption<TDocument = unknown> {
@@ -1343,7 +1343,7 @@ export interface SearchNestedIdentity {
 }
 
 export interface SearchPhraseSuggest extends SearchSuggestBase {
-  options: SearchPhraseSuggestOption
+  options: SearchPhraseSuggestOption | SearchPhraseSuggestOption[]
 }
 
 export interface SearchPhraseSuggestCollate {
@@ -1503,7 +1503,7 @@ export interface SearchSuggesterBase {
 }
 
 export interface SearchTermSuggest extends SearchSuggestBase {
-  options: SearchTermSuggestOption
+  options: SearchTermSuggestOption | SearchTermSuggestOption[]
 }
 
 export interface SearchTermSuggestOption {
@@ -4170,7 +4170,7 @@ export interface AnalysisLowercaseTokenizer extends AnalysisTokenizerBase {
 
 export interface AnalysisMappingCharFilter extends AnalysisCharFilterBase {
   type: 'mapping'
-  mappings: string[]
+  mappings?: string[]
   mappings_path?: string
 }
 

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -49,21 +49,23 @@ export class SuggestBase {
  * @variant name=completion
  */
 export class CompletionSuggest<TDocument> extends SuggestBase {
-  options: CompletionSuggestOption<TDocument>[]
+  options:
+    | CompletionSuggestOption<TDocument>
+    | CompletionSuggestOption<TDocument>[]
 }
 
 /**
  * @variant name=phrase
  */
 export class PhraseSuggest extends SuggestBase {
-  options: PhraseSuggestOption
+  options: PhraseSuggestOption | PhraseSuggestOption[]
 }
 
 /**
  * @variant name=term
  */
 export class TermSuggest extends SuggestBase {
-  options: TermSuggestOption
+  options: TermSuggestOption | TermSuggestOption[]
 }
 
 // In the ES code a nested Hit object is expanded inline. Not all Hit fields have been

--- a/specification/_types/analysis/char_filters.ts
+++ b/specification/_types/analysis/char_filters.ts
@@ -46,7 +46,7 @@ export class HtmlStripCharFilter extends CharFilterBase {
 
 export class MappingCharFilter extends CharFilterBase {
   type: 'mapping'
-  mappings: string[]
+  mappings?: string[]
   mappings_path?: string
 }
 


### PR DESCRIPTION
Fixes issues found in the Java client:

* `MappingCharFilter.mapping` is optional. See https://github.com/elastic/elasticsearch-java/issues/318
* Suggester options are arrays (with their usual leniency rules). See https://github.com/elastic/elasticsearch-java/issues/214