### PR TITLE
Add model for _internal.health API

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -14,7 +14,7 @@
     },
     "_internal.health": {
       "request": [
-        "Missing request & response"
+        "Request: should not have a body"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1831,7 +1831,7 @@ export interface InternalHealthClusterCoordinationIndicators {
 }
 
 export interface InternalHealthClusterCoordinationMasterIsStableIndicator extends InternalHealthIndicator {
-  details: InternalHealthClusterCoordinationMasterIsStableIndicatorDetails
+  details?: InternalHealthClusterCoordinationMasterIsStableIndicatorDetails
 }
 
 export interface InternalHealthClusterCoordinationMasterIsStableIndicatorDetails {
@@ -1859,7 +1859,7 @@ export interface InternalHealthDataComponent extends InternalHealthComponent {
 }
 
 export interface InternalHealthDataIlmIndicator extends InternalHealthIndicator {
-  details: InternalHealthDataIlmIndicatorDetails
+  details?: InternalHealthDataIlmIndicatorDetails
 }
 
 export interface InternalHealthDataIlmIndicatorDetails {
@@ -1873,7 +1873,7 @@ export interface InternalHealthDataIndicators {
 }
 
 export interface InternalHealthDataShardsAvailabilityIndicator extends InternalHealthIndicator {
-  details: InternalHealthDataShardsAvailabilityIndicatorDetails
+  details?: InternalHealthDataShardsAvailabilityIndicatorDetails
 }
 
 export interface InternalHealthDataShardsAvailabilityIndicatorDetails {
@@ -1934,7 +1934,7 @@ export interface InternalHealthSnapshotRepositoryIntegrityIndiciator extends Int
 }
 
 export interface InternalHealthSnapshotSlmIndicator extends InternalHealthIndicator {
-  details: InternalHealthSnapshotSlmIndicatorDetails
+  details?: InternalHealthSnapshotSlmIndicatorDetails
 }
 
 export interface InternalHealthSnapshotSlmIndicatorDetails {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1822,6 +1822,126 @@ export interface UpdateByQueryRethrottleUpdateByQueryRethrottleNode extends Spec
   tasks: Record<TaskId, TasksTaskInfo>
 }
 
+export interface InternalHealthClusterCoordinationComponent extends InternalHealthComponent {
+  indicators: InternalHealthClusterCoordinationIndicators
+}
+
+export interface InternalHealthClusterCoordinationIndicators {
+  master_is_stable?: InternalHealthClusterCoordinationMasterIsStableIndicator
+}
+
+export interface InternalHealthClusterCoordinationMasterIsStableIndicator extends InternalHealthIndicator {
+  details: InternalHealthClusterCoordinationMasterIsStableIndicatorDetails
+}
+
+export interface InternalHealthClusterCoordinationMasterIsStableIndicatorDetails {
+  current_master: InternalHealthClusterCoordinationMasterIsStableIndicatorDetailsMaster
+  recent_masters?: InternalHealthClusterCoordinationMasterIsStableIndicatorDetailsMaster[]
+}
+
+export interface InternalHealthClusterCoordinationMasterIsStableIndicatorDetailsMaster {
+  name: NodeName
+  node_id: NodeId
+}
+
+export interface InternalHealthComponent {
+  status?: HealthStatus
+}
+
+export interface InternalHealthComponents {
+  cluster_coordination?: InternalHealthClusterCoordinationComponent
+  data?: InternalHealthDataComponent
+  snapshot?: InternalHealthSnapshotComponent
+}
+
+export interface InternalHealthDataComponent extends InternalHealthComponent {
+  indicators: InternalHealthDataIndicators
+}
+
+export interface InternalHealthDataIlmIndicator extends InternalHealthIndicator {
+  details: InternalHealthDataIlmIndicatorDetails
+}
+
+export interface InternalHealthDataIlmIndicatorDetails {
+  ilm_status: LifecycleOperationMode
+  policies: integer
+}
+
+export interface InternalHealthDataIndicators {
+  ilm?: InternalHealthDataIlmIndicator
+  shards_availability?: InternalHealthDataShardsAvailabilityIndicator
+}
+
+export interface InternalHealthDataShardsAvailabilityIndicator extends InternalHealthIndicator {
+  details: InternalHealthDataShardsAvailabilityIndicatorDetails
+}
+
+export interface InternalHealthDataShardsAvailabilityIndicatorDetails {
+  creating_primaries: long
+  initializing_primaries: long
+  initializing_replicas: long
+  restarting_primaries: long
+  restarting_replicas: long
+  started_primaries: long
+  started_replicas: long
+  unassigned_primaries: long
+  unassigned_replicas: long
+}
+
+export interface InternalHealthIndicator {
+  status: HealthStatus
+  summary: string
+  help_url?: string
+  impacts?: InternalHealthIndicatorImpact[]
+  user_actions?: InternalHealthIndicatorUserAction[]
+}
+
+export interface InternalHealthIndicatorImpact {
+  description: string
+  impact_areas: string[]
+  severity: integer
+}
+
+export interface InternalHealthIndicatorUserAction {
+  affected_resources: string[]
+  help_url: string
+  message: string
+}
+
+export interface InternalHealthRequest extends RequestBase {
+  component?: string
+  feature?: string
+  timeout?: Duration
+  explain?: boolean
+}
+
+export interface InternalHealthResponse {
+  cluster_name: string
+  status?: HealthStatus
+  components: InternalHealthComponents
+}
+
+export interface InternalHealthSnapshotComponent extends InternalHealthComponent {
+  indicators: InternalHealthSnapshotIndicators
+}
+
+export interface InternalHealthSnapshotIndicators {
+  repository_integrity?: InternalHealthSnapshotRepositoryIntegrityIndiciator
+  slm?: InternalHealthSnapshotSlmIndicator
+}
+
+export interface InternalHealthSnapshotRepositoryIntegrityIndiciator extends InternalHealthIndicator {
+}
+
+export interface InternalHealthSnapshotSlmIndicator extends InternalHealthIndicator {
+  details: InternalHealthSnapshotSlmIndicatorDetails
+}
+
+export interface InternalHealthSnapshotSlmIndicatorDetails {
+  policies: long
+  slm_status: LifecycleOperationMode
+}
+
 export interface SpecUtilsBaseNode {
   attributes: Record<string, string>
   host: Host

--- a/specification/_internal/health/Request.ts
+++ b/specification/_internal/health/Request.ts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Duration } from '@_types/Time'
+
+/**
+ * @rest_spec_name _internal.health
+ * @since 8.4.0
+ * @stability experimental
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    component?: string
+    feature?: string
+  }
+  query_parameters: {
+    timeout?: Duration
+    explain?: boolean
+  }
+}

--- a/specification/_internal/health/Response.ts
+++ b/specification/_internal/health/Response.ts
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { HealthStatus } from '@_types/common'
+import { Components } from './types'
+
+export class Response {
+  body: {
+    cluster_name: string
+    status?: HealthStatus
+    components: Components
+  }
+}

--- a/specification/_internal/health/types.ts
+++ b/specification/_internal/health/types.ts
@@ -1,0 +1,135 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { NodeId, NodeName } from '@_types/common'
+import { LifecycleOperationMode } from '@_types/Lifecycle'
+import { integer, long } from '@_types/Numeric'
+import { HealthStatus } from '@_types/common'
+
+export class Components {
+  cluster_coordination?: ClusterCoordinationComponent
+  data?: DataComponent
+  snapshot?: SnapshotComponent
+}
+
+export class Component {
+  status?: HealthStatus
+}
+
+export class Indicator {
+  status: HealthStatus
+  summary: string
+  help_url?: string
+  impacts?: IndicatorImpact[]
+  user_actions?: IndicatorUserAction[]
+}
+
+export class IndicatorImpact {
+  description: string
+  impact_areas: string[]
+  severity: integer
+}
+
+export class IndicatorUserAction {
+  affected_resources: string[]
+  help_url: string
+  message: string
+}
+
+/** CLUSTER COORDINATION */
+
+export class ClusterCoordinationComponent extends Component {
+  indicators: ClusterCoordinationIndicators
+}
+
+export class ClusterCoordinationIndicators {
+  master_is_stable?: ClusterCoordinationMasterIsStableIndicator
+}
+
+export class ClusterCoordinationMasterIsStableIndicator extends Indicator {
+  details: ClusterCoordinationMasterIsStableIndicatorDetails
+}
+
+export class ClusterCoordinationMasterIsStableIndicatorDetails {
+  current_master: ClusterCoordinationMasterIsStableIndicatorDetailsMaster
+  recent_masters?: ClusterCoordinationMasterIsStableIndicatorDetailsMaster[]
+}
+
+export class ClusterCoordinationMasterIsStableIndicatorDetailsMaster {
+  name: NodeName
+  node_id: NodeId
+}
+
+/** DATA */
+
+export class DataComponent extends Component {
+  indicators: DataIndicators
+}
+
+export class DataIndicators {
+  ilm?: DataIlmIndicator
+  shards_availability?: DataShardsAvailabilityIndicator
+}
+
+export class DataIlmIndicator extends Indicator {
+  details: DataIlmIndicatorDetails
+}
+
+export class DataIlmIndicatorDetails {
+  ilm_status: LifecycleOperationMode
+  policies: integer
+}
+
+export class DataShardsAvailabilityIndicator extends Indicator {
+  details: DataShardsAvailabilityIndicatorDetails
+}
+
+export class DataShardsAvailabilityIndicatorDetails {
+  creating_primaries: long
+  initializing_primaries: long
+  initializing_replicas: long
+  restarting_primaries: long
+  restarting_replicas: long
+  started_primaries: long
+  started_replicas: long
+  unassigned_primaries: long
+  unassigned_replicas: long
+}
+
+/** SNAPSHOT */
+
+export class SnapshotComponent extends Component {
+  indicators: SnapshotIndicators
+}
+
+export class SnapshotIndicators {
+  repository_integrity?: SnapshotRepositoryIntegrityIndiciator
+  slm?: SnapshotSlmIndicator
+}
+
+export class SnapshotRepositoryIntegrityIndiciator extends Indicator {}
+
+export class SnapshotSlmIndicator extends Indicator {
+  details: SnapshotSlmIndicatorDetails
+}
+
+export class SnapshotSlmIndicatorDetails {
+  policies: long
+  slm_status: LifecycleOperationMode
+}

--- a/specification/_internal/health/types.ts
+++ b/specification/_internal/health/types.ts
@@ -63,7 +63,7 @@ export class ClusterCoordinationIndicators {
 }
 
 export class ClusterCoordinationMasterIsStableIndicator extends Indicator {
-  details: ClusterCoordinationMasterIsStableIndicatorDetails
+  details?: ClusterCoordinationMasterIsStableIndicatorDetails
 }
 
 export class ClusterCoordinationMasterIsStableIndicatorDetails {
@@ -88,7 +88,7 @@ export class DataIndicators {
 }
 
 export class DataIlmIndicator extends Indicator {
-  details: DataIlmIndicatorDetails
+  details?: DataIlmIndicatorDetails
 }
 
 export class DataIlmIndicatorDetails {
@@ -97,7 +97,7 @@ export class DataIlmIndicatorDetails {
 }
 
 export class DataShardsAvailabilityIndicator extends Indicator {
-  details: DataShardsAvailabilityIndicatorDetails
+  details?: DataShardsAvailabilityIndicatorDetails
 }
 
 export class DataShardsAvailabilityIndicatorDetails {
@@ -126,7 +126,7 @@ export class SnapshotIndicators {
 export class SnapshotRepositoryIntegrityIndiciator extends Indicator {}
 
 export class SnapshotSlmIndicator extends Indicator {
-  details: SnapshotSlmIndicatorDetails
+  details?: SnapshotSlmIndicatorDetails
 }
 
 export class SnapshotSlmIndicatorDetails {


### PR DESCRIPTION
This API is an internal one so won't be generated by clients yet, however having a model for this API would be useful to teams building on the new Health API.