### PR TITLE
Fix snapshot.get validation errors

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -2166,10 +2166,7 @@
     },
     "snapshot.get": {
       "request": [
-        "Request: query parameter 'human' does not exist in the json spec",
-        "Request: missing json spec query parameter 'index_names'",
-        "Request: should not have a body",
-        "request definition snapshot.get:Request / query - Property 'human' is already defined in an ancestor class"
+        "Request: should not have a body"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16281,7 +16281,7 @@ export interface SnapshotSnapshotInfo {
   end_time_in_millis?: EpochTime<UnitMillis>
   failures?: SnapshotSnapshotShardFailure[]
   include_global_state?: boolean
-  indices: IndexName[]
+  indices?: IndexName[]
   index_details?: Record<IndexName, SnapshotIndexDetails>
   metadata?: Metadata
   reason?: string
@@ -16416,7 +16416,7 @@ export interface SnapshotGetRequest extends RequestBase {
   master_timeout?: Duration
   verbose?: boolean
   index_details?: boolean
-  human?: boolean
+  index_names?: boolean
   include_repository?: boolean
   sort?: SnapshotSnapshotSort
   size?: integer

--- a/specification/snapshot/_types/SnapshotInfo.ts
+++ b/specification/snapshot/_types/SnapshotInfo.ts
@@ -46,7 +46,7 @@ export class SnapshotInfo {
   end_time_in_millis?: EpochTime<UnitMillis>
   failures?: SnapshotShardFailure[]
   include_global_state?: boolean
-  indices: IndexName[]
+  indices?: IndexName[]
   /** @since 7.13.0 */
   index_details?: Dictionary<IndexName, IndexDetails>
   metadata?: Metadata

--- a/specification/snapshot/get/SnapshotGetRequest.ts
+++ b/specification/snapshot/get/SnapshotGetRequest.ts
@@ -64,7 +64,16 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     index_details?: boolean
-    human?: boolean
+    /**
+     * If true, returns the name of each index in each snapshot.
+     * @since 7.13.0
+     * @server_default true
+     */
+    index_names?: boolean
+    /**
+     * If true, returns the repository name in each snapshot.
+     * @server_default true
+     */
     include_repository?: boolean
     /**
      * Allows setting a sort order for the result. Defaults to start_time, i.e. sorting by snapshot start time stamp.

--- a/specification/snapshot/get/SnapshotGetRequest.ts
+++ b/specification/snapshot/get/SnapshotGetRequest.ts
@@ -66,7 +66,7 @@ export interface Request extends RequestBase {
     index_details?: boolean
     /**
      * If true, returns the name of each index in each snapshot.
-     * @since 7.13.0
+     * @since 8.3.0
      * @server_default true
      */
     index_names?: boolean


### PR DESCRIPTION
- Adds the missing `index_names` parameter which is a part of the JSON spec
- Only remaining validation errors will be fixed by https://github.com/elastic/elasticsearch/issues/88620