### PR TITLE
add new execution hint for cardinality

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2789,7 +2789,10 @@ export interface AggregationsCardinalityAggregate extends AggregationsAggregateB
 export interface AggregationsCardinalityAggregation extends AggregationsMetricAggregationBase {
   precision_threshold?: integer
   rehash?: boolean
+  execution_hint?: AggregationsCardinalityExecutionMode
 }
+
+export type AggregationsCardinalityExecutionMode = 'global_ordinals' | 'segment_ordinals' | 'direct' | 'save_memory_heuristic' | 'save_time_heuristic'
 
 export interface AggregationsCategorizeTextAggregation extends AggregationsAggregation {
   field: Field

--- a/specification/_types/aggregations/metric.ts
+++ b/specification/_types/aggregations/metric.ts
@@ -51,9 +51,18 @@ export class BoxplotAggregation extends MetricAggregationBase {
   compression?: double
 }
 
+export enum CardinalityExecutionMode {
+  global_ordinals,
+  segment_ordinals,
+  direct,
+  save_memory_heuristic,
+  save_time_heuristic
+}
+
 export class CardinalityAggregation extends MetricAggregationBase {
   precision_threshold?: integer
   rehash?: boolean
+  execution_hint?: CardinalityExecutionMode
 }
 
 export class ExtendedStatsAggregation extends FormatMetricAggregationBase {


### PR DESCRIPTION
This adds a specification for the new Cardinality aggregation execution hint parameter, which is optional and accepts an enum value from a list.  This parameter will be available from 8.4 forward.  Generally speaking, we do not expect users to set this value, but we are providing it as a option for tuning performance in extreme cases.  