### PR TITLE
Add 'knn' property to Search request body

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5842,6 +5842,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
     track_total_hits?: SearchTrackHits
     indices_boost?: Record<IndexName, double>[]
     docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
+    knn?: KnnQuery
     min_score?: double
     post_filter?: QueryDslQueryContainer
     profile?: boolean

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -569,6 +569,7 @@ export interface MsearchMultisearchBody {
   explain?: boolean
   stored_fields?: Fields
   docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
+  knn?: KnnQuery
   from?: integer
   highlight?: SearchHighlight
   indices_boost?: Record<IndexName, double>[]
@@ -2125,14 +2126,12 @@ export type Ip = string
 
 export interface KnnQuery {
   field: Field
-  query_vector: KnnQueryVector
+  query_vector: double[]
   k: long
   num_candidates: long
   boost?: float
   filter?: QueryDslQueryContainer | QueryDslQueryContainer[]
 }
-
-export type KnnQueryVector = double[]
 
 export interface LatLonGeoLocation {
   lat: double

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1030,6 +1030,7 @@ export interface SearchRequest extends RequestBase {
     track_total_hits?: SearchTrackHits
     indices_boost?: Record<IndexName, double>[]
     docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
+    knn?: KnnQuery
     min_score?: double
     post_filter?: QueryDslQueryContainer
     profile?: boolean
@@ -2121,6 +2122,17 @@ export interface InlineScript extends ScriptBase {
 }
 
 export type Ip = string
+
+export interface KnnQuery {
+  field: Field
+  query_vector: KnnQueryVector
+  k: long
+  num_candidates: long
+  boost?: float
+  filter?: QueryDslQueryContainer | QueryDslQueryContainer[]
+}
+
+export type KnnQueryVector = double[]
 
 export interface LatLonGeoLocation {
   lat: double
@@ -5259,12 +5271,6 @@ export interface QueryDslIntervalsWildcard {
   use_field?: Field
 }
 
-export interface QueryDslKnnQuery extends QueryDslQueryBase {
-  field: Field
-  num_candidates: integer
-  query_vector: double[]
-}
-
 export type QueryDslLike = string | QueryDslLikeDocument
 
 export interface QueryDslLikeDocument {
@@ -5454,7 +5460,6 @@ export interface QueryDslQueryContainer {
   has_parent?: QueryDslHasParentQuery
   ids?: QueryDslIdsQuery
   intervals?: Partial<Record<Field, QueryDslIntervalsQuery>>
-  knn?: QueryDslKnnQuery
   match?: Partial<Record<Field, QueryDslMatchQuery | string | float | boolean>>
   match_all?: QueryDslMatchAllQuery
   match_bool_prefix?: Partial<Record<Field, QueryDslMatchBoolPrefixQuery | string>>

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -42,6 +42,7 @@ import { SourceConfig } from '@global/search/_types/SourceFilter'
 import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { ScriptField } from '@_types/Scripting'
 import { SlicedScroll } from '@_types/SlicedScroll'
+import { KnnQuery } from '@_types/Knn'
 
 /**
  * @codegen_names header, body
@@ -91,6 +92,11 @@ export class MultisearchBody {
    * names matching these patterns in the hits.fields property of the response.
    */
   docvalue_fields?: FieldAndFormat[]
+  /**
+   * Defines the approximate kNN search to run.
+   * @since 8.4.0
+   */
+  knn?: KnnQuery
   /**
    * Starting document offset. By default, you cannot page through more than 10,000
    * hits using the from and size parameters. To page through more hits, use the

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -46,6 +46,7 @@ import { Suggester } from './_types/suggester'
 import { TrackHits } from '@global/search/_types/hits'
 import { Operator } from '@_types/query_dsl/Operator'
 import { Sort, SortResults } from '@_types/sort'
+import { KnnQuery } from '@_types/Knn'
 
 /**
  * @rest_spec_name search
@@ -141,6 +142,11 @@ export interface Request extends RequestBase {
      * names matching these patterns in the hits.fields property of the response.
      */
     docvalue_fields?: FieldAndFormat[]
+    /**
+     * Defines the approximate kNN search to run.
+     * @since 8.4.0
+     */
+    knn?: KnnQuery
     /**
      * Minimum _score for matching documents. Documents with a lower _score are
      * not included in the search results.

--- a/specification/_types/Knn.ts
+++ b/specification/_types/Knn.ts
@@ -21,13 +21,11 @@ import { Field } from '@_types/common'
 import { long, double, float } from '@_types/Numeric'
 import { QueryContainer } from './query_dsl/abstractions'
 
-export type KnnQueryVector = double[]
-
 export interface KnnQuery {
   /** The name of the vector field to search against */
   field: Field
   /** The query vector */
-  query_vector: KnnQueryVector
+  query_vector: double[]
   /** The final number of nearest neighbors to return as top hits */
   k: long
   /** The number of nearest neighbor candidates to consider per shard */

--- a/specification/_types/Knn.ts
+++ b/specification/_types/Knn.ts
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Field } from '@_types/common'
+import { long, double, float } from '@_types/Numeric'
+import { QueryContainer } from './query_dsl/abstractions'
+
+export type KnnQueryVector = double[]
+
+export interface KnnQuery {
+  /** The name of the vector field to search against */
+  field: Field
+  /** The query vector */
+  query_vector: KnnQueryVector
+  /** The final number of nearest neighbors to return as top hits */
+  k: long
+  /** The number of nearest neighbor candidates to consider per shard */
+  num_candidates: long
+  /** Boost value to apply to kNN scores */
+  boost?: float
+  /** Filters for the kNN search query */
+  filter?: QueryContainer | QueryContainer[]
+}

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -83,7 +83,6 @@ import {
   ExistsQuery,
   FuzzyQuery,
   IdsQuery,
-  KnnQuery,
   PrefixQuery,
   RangeQuery,
   RegexpQuery,
@@ -120,7 +119,6 @@ export class QueryContainer {
   has_parent?: HasParentQuery
   ids?: IdsQuery
   intervals?: SingleKeyDictionary<Field, IntervalsQuery>
-  knn?: KnnQuery
   match?: SingleKeyDictionary<Field, MatchQuery>
   match_all?: MatchAllQuery
   match_bool_prefix?: SingleKeyDictionary<Field, MatchBoolPrefixQuery>

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -37,15 +37,6 @@ export class ExistsQuery extends QueryBase {
   field: Field
 }
 
-/**
- * A k-nearest neighbor (kNN) search finds the k nearest vectors to a query vector, as measured by a similarity metric.
- */
-export class KnnQuery extends QueryBase {
-  field: Field
-  num_candidates: integer
-  query_vector: double[]
-}
-
 /** @shortcut_property value */
 export class FuzzyQuery extends QueryBase {
   max_expansions?: integer

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -49,6 +49,7 @@ import {
 import { Suggester } from '@global/search/_types/suggester'
 import { TrackHits } from '@global/search/_types/hits'
 import { Operator } from '@_types/query_dsl/Operator'
+import { KnnQuery } from '@_types/Knn'
 
 /**
  * @rest_spec_name async_search.submit
@@ -151,6 +152,11 @@ export interface Request extends RequestBase {
      * names matching these patterns in the hits.fields property of the response.
      */
     docvalue_fields?: FieldAndFormat[]
+    /**
+     * Defines the approximate kNN search to run.
+     * @since 8.4.0
+     */
+    knn?: KnnQuery
     /**
      * Minimum _score for matching documents. Documents with a lower _score are
      * not included in the search results.


### PR DESCRIPTION
Adds changes from these PRs:
- https://github.com/elastic/elasticsearch/pull/88002
- https://github.com/elastic/elasticsearch/pull/88217

Which add the `knn` property to the Search request body.

Questions for @jtibshirani:
- Is there a `knn` property for Async Search as well?
- Should we remove the `knn` query filter? I didn't see it documented on elastic.co and wasn't sure if it was supposed to be there.

Closes #1779 