### PR TITLE
Adds cache_size, fixes for TrainedModelDeployment models

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1596,7 +1596,6 @@
     },
     "ml.start_trained_model_deployment": {
       "request": [
-        "Request: missing json spec query parameter 'cache_size'",
         "Request: should not have a body"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12020,6 +12020,8 @@ export interface MlDelayedDataCheckConfig {
 
 export type MlDeploymentAllocationState = 'started' | 'starting' | 'fully_allocated'
 
+export type MlDeploymentAssignmentState = 'starting' | 'started' | 'stopping' | 'failed'
+
 export type MlDeploymentState = 'started' | 'starting' | 'stopping'
 
 export interface MlDetectionRule {
@@ -12496,21 +12498,27 @@ export interface MlTotalFeatureImportanceStatistics {
   min: integer
 }
 
-export interface MlTrainedModelAllocation {
-  allocation_state: MlDeploymentAllocationState
-  routing_table: Record<string, MlTrainedModelAllocationRoutingTable>
+export interface MlTrainedModelAssignment {
+  assignment_state: MlDeploymentAssignmentState
+  routing_table: Record<string, MlTrainedModelAssignmentRoutingTable>
   start_time: DateTime
-  task_parameters: MlTrainedModelAllocationTaskParameters
+  task_parameters: MlTrainedModelAssignmentTaskParameters
 }
 
-export interface MlTrainedModelAllocationRoutingTable {
+export interface MlTrainedModelAssignmentRoutingTable {
   reason: string
   routing_state: MlRoutingState
+  current_allocations: integer
+  target_allocations: integer
 }
 
-export interface MlTrainedModelAllocationTaskParameters {
+export interface MlTrainedModelAssignmentTaskParameters {
   model_bytes: integer
   model_id: Id
+  cache_size: ByteSize
+  number_of_allocations: integer
+  queue_capacity: integer
+  threads_per_allocation: integer
 }
 
 export interface MlTrainedModelConfig {
@@ -12559,7 +12567,7 @@ export interface MlTrainedModelDeploymentNodesStats {
   number_of_allocations: integer
   number_of_pending_requests: integer
   rejection_execution_count: integer
-  routing_state: MlTrainedModelAllocationRoutingTable
+  routing_state: MlTrainedModelAssignmentRoutingTable
   start_time: EpochTime<UnitMillis>
   threads_per_allocation: integer
   timeout_count: integer
@@ -13746,6 +13754,7 @@ export interface MlStartDatafeedResponse {
 
 export interface MlStartTrainedModelDeploymentRequest extends RequestBase {
   model_id: Id
+  cache_size?: ByteSize
   number_of_allocations?: integer
   queue_capacity?: integer
   threads_per_allocation?: integer
@@ -13754,7 +13763,7 @@ export interface MlStartTrainedModelDeploymentRequest extends RequestBase {
 }
 
 export interface MlStartTrainedModelDeploymentResponse {
-  allocation: MlTrainedModelAllocation
+  assignment: MlTrainedModelAssignment
 }
 
 export interface MlStopDataFrameAnalyticsRequest extends RequestBase {

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -144,7 +144,7 @@ export class TrainedModelDeploymentNodesStats {
   /** The number of inference requests that were not processed because the queue was full. */
   rejection_execution_count: integer
   /** The current routing state and reason for the current routing state for this allocation. */
-  routing_state: TrainedModelAllocationRoutingTable
+  routing_state: TrainedModelAssignmentRoutingTable
   /** The epoch timestamp when the allocation started. */
   start_time: EpochTime<UnitMillis>
   /** The number of threads used by each allocation during inference. */
@@ -289,7 +289,14 @@ export enum DeploymentAllocationState {
   fully_allocated = 3
 }
 
-export class TrainedModelAllocationTaskParameters {
+export enum DeploymentAssignmentState {
+  starting,
+  started,
+  stopping,
+  failed
+}
+
+export class TrainedModelAssignmentTaskParameters {
   /**
    * The size of the trained model in bytes.
    */
@@ -298,6 +305,23 @@ export class TrainedModelAllocationTaskParameters {
    * The unique identifier for the trained model.
    */
   model_id: Id
+  /**
+   * The size of the trained model cache.
+   * @since 8.4.0
+   */
+  cache_size: ByteSize
+  /**
+   * The total number of allocations this model is assigned across ML nodes.
+   */
+  number_of_allocations: integer
+  /**
+   * Number of inference requests are allowed in the queue at a time.
+   */
+  queue_capacity: integer
+  /**
+   * Number of threads per allocation.
+   */
+  threads_per_allocation: integer
 }
 
 export enum RoutingState {
@@ -323,7 +347,7 @@ export enum RoutingState {
   stopping = 4
 }
 
-export class TrainedModelAllocationRoutingTable {
+export class TrainedModelAssignmentRoutingTable {
   /**
    * The reason for the current state. It is usually populated only when the
    * `routing_state` is `failed`.
@@ -333,6 +357,14 @@ export class TrainedModelAllocationRoutingTable {
    * The current routing state.
    */
   routing_state: RoutingState
+  /**
+   * Current number of allocations.
+   */
+  current_allocations: integer
+  /**
+   * Target number of allocations.
+   */
+  target_allocations: integer
 }
 
 export class TrainedModelDeploymentAllocationStatus {
@@ -344,20 +376,20 @@ export class TrainedModelDeploymentAllocationStatus {
   target_allocation_count: integer
 }
 
-export class TrainedModelAllocation {
+export class TrainedModelAssignment {
   /**
-   * The overall allocation state.
+   * The overall assignment state.
    */
-  allocation_state: DeploymentAllocationState
+  assignment_state: DeploymentAssignmentState
   /**
    * The allocation state for each node.
    */
-  routing_table: Dictionary<string, TrainedModelAllocationRoutingTable>
+  routing_table: Dictionary<string, TrainedModelAssignmentRoutingTable>
   /**
    * The timestamp when the deployment started.
    */
   start_time: DateTime
-  task_parameters: TrainedModelAllocationTaskParameters
+  task_parameters: TrainedModelAssignmentTaskParameters
 }
 
 export class TrainedModelLocation {

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
+import { ByteSize, Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 import { DeploymentAllocationState } from '../_types/TrainedModel'
@@ -38,6 +38,12 @@ export interface Request extends RequestBase {
     model_id: Id
   }
   query_parameters: {
+    /**
+     * The inference cache size (in memory outside the JVM heap) per node for the model.
+     * The default value is the same size as the `model_size_bytes`. To disable the cache,
+     * `0b` can be provided.
+     */
+    cache_size?: ByteSize
     /**
      * The number of model allocations on each node where the model is deployed.
      * All allocations on a node share the same copy of the model in memory but use

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentResponse.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentResponse.ts
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-import { TrainedModelAllocation } from '../_types/TrainedModel'
+import { TrainedModelAssignment } from '../_types/TrainedModel'
 
 export class Response {
   body: {
-    allocation: TrainedModelAllocation
+    assignment: TrainedModelAssignment
   }
 }


### PR DESCRIPTION
While adding the `cache_size` parameter to `ml.start_trained_model_deployment` API for 8.4 I noticed a renaming of "allocation" to "assignment" had [happened during 8.3](https://github.com/elastic/elasticsearch/pull/85503) that we missed unfortunately. Made all the fixes for that renaming in this PR as well.