### PR TITLE
Fix snapshot_id to be required for ml.get_model_snapshot_upgrade_stats

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13175,7 +13175,7 @@ export interface MlGetMemoryStatsResponse {
 
 export interface MlGetModelSnapshotUpgradeStatsRequest extends RequestBase {
   job_id: Id
-  snapshot_id?: Id
+  snapshot_id: Id
   allow_no_match?: boolean
 }
 

--- a/specification/ml/get_model_snapshot_upgrade_stats/MlGetModelSnapshotUpgradeStatsRequest.ts
+++ b/specification/ml/get_model_snapshot_upgrade_stats/MlGetModelSnapshotUpgradeStatsRequest.ts
@@ -38,7 +38,7 @@ export interface Request extends RequestBase {
      * snapshots by using a comma-separated list or a wildcard expression. You can get all snapshots by using `_all`,
      * by specifying `*` as the snapshot ID, or by omitting the snapshot ID.
      */
-    snapshot_id?: Id
+    snapshot_id: Id
   }
   query_parameters: {
     /**


### PR DESCRIPTION
This API endpoint only has one path `/_ml/anomaly_detectors/{job_id}/model_snapshots/{snapshot_id}/_upgrade/_stats` Which means that the `snapshot_id` parameter should be required.