### PR TITLE
Fix optional/missing fields reported via Java client issues

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -567,6 +567,7 @@ export interface MsearchMultisearchBody {
   collapse?: SearchFieldCollapse
   query?: QueryDslQueryContainer
   explain?: boolean
+  ext?: Record<string, any>
   stored_fields?: Fields
   docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
   knn?: KnnQuery
@@ -1026,6 +1027,7 @@ export interface SearchRequest extends RequestBase {
     aggs?: Record<string, AggregationsAggregationContainer>
     collapse?: SearchFieldCollapse
     explain?: boolean
+    ext?: Record<string, any>
     from?: integer
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
@@ -1941,7 +1943,7 @@ export type EpochTime<Unit = unknown> = Unit
 
 export interface ErrorCauseKeys {
   type: string
-  reason: string
+  reason?: string
   stack_trace?: string
   caused_by?: ErrorCause
   root_cause?: ErrorCause[]
@@ -3019,7 +3021,7 @@ export interface AggregationsFormattableMetricAggregation extends AggregationsMe
 export type AggregationsGapPolicy = 'skip' | 'insert_zeros'
 
 export interface AggregationsGeoBoundsAggregate extends AggregationsAggregateBase {
-  bounds: GeoBounds
+  bounds?: GeoBounds
 }
 
 export interface AggregationsGeoBoundsAggregation extends AggregationsMetricAggregationBase {
@@ -4019,17 +4021,18 @@ export type AnalysisIcuCollationStrength = 'primary' | 'secondary' | 'tertiary' 
 
 export interface AnalysisIcuCollationTokenFilter extends AnalysisTokenFilterBase {
   type: 'icu_collation'
-  alternate: AnalysisIcuCollationAlternate
-  caseFirst: AnalysisIcuCollationCaseFirst
-  caseLevel: boolean
-  country: string
-  decomposition: AnalysisIcuCollationDecomposition
-  hiraganaQuaternaryMode: boolean
-  language: string
-  numeric: boolean
-  strength: AnalysisIcuCollationStrength
+  alternate?: AnalysisIcuCollationAlternate
+  caseFirst?: AnalysisIcuCollationCaseFirst
+  caseLevel?: boolean
+  country?: string
+  decomposition?: AnalysisIcuCollationDecomposition
+  hiraganaQuaternaryMode?: boolean
+  language?: string
+  numeric?: boolean
+  rules?: string
+  strength?: AnalysisIcuCollationStrength
   variableTop?: string
-  variant: string
+  variant?: string
 }
 
 export interface AnalysisIcuFoldingTokenFilter extends AnalysisTokenFilterBase {
@@ -4851,7 +4854,7 @@ export interface MappingRuntimeField {
 
 export type MappingRuntimeFieldType = 'boolean' | 'date' | 'double' | 'geo_point' | 'ip' | 'keyword' | 'long'
 
-export type MappingRuntimeFields = Record<Field, MappingRuntimeField | MappingRuntimeField[]>
+export type MappingRuntimeFields = Record<Field, MappingRuntimeField>
 
 export interface MappingScaledFloatNumberProperty extends MappingNumberPropertyBase {
   type: 'scaled_float'
@@ -5836,6 +5839,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
     aggs?: Record<string, AggregationsAggregationContainer>
     collapse?: SearchFieldCollapse
     explain?: boolean
+    ext?: Record<string, any>
     from?: integer
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
@@ -7971,7 +7975,7 @@ export interface ClusterComponentTemplateNode {
 export interface ClusterComponentTemplateSummary {
   _meta?: Metadata
   version?: VersionNumber
-  settings: Record<IndexName, IndicesIndexSettings>
+  settings?: Record<IndexName, IndicesIndexSettings>
   mappings?: MappingTypeMapping
   aliases?: Record<string, IndicesAliasDefinition>
 }
@@ -8934,6 +8938,7 @@ export interface FleetSearchRequest extends RequestBase {
     aggs?: Record<string, AggregationsAggregationContainer>
     collapse?: SearchFieldCollapse
     explain?: boolean
+    ext?: Record<string, any>
     from?: integer
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
@@ -9460,8 +9465,7 @@ export interface IndicesIndexTemplateSummary {
 }
 
 export interface IndicesIndexVersioning {
-  created: VersionString
-  created_string?: VersionString
+  created?: VersionString
 }
 
 export interface IndicesIndexingPressure {
@@ -15680,7 +15684,7 @@ export interface SecurityGetTokenResponse {
   expires_in: long
   scope?: string
   type: string
-  refresh_token: string
+  refresh_token?: string
   kerberos_authentication_response_token?: string
   authentication: SecurityGetTokenAuthenticatedUser
 }

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -43,6 +43,7 @@ import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { ScriptField } from '@_types/Scripting'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { KnnQuery } from '@_types/Knn'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * @codegen_names header, body
@@ -80,6 +81,10 @@ export class MultisearchBody {
    * @server_default false
    */
   explain?: boolean
+  /**
+   * Configuration of search extensions defined by Elasticsearch plugins.
+   */
+  ext?: Dictionary<string, UserDefinedValue>
   /**
    * List of stored fields to return as part of a hit. If no fields are specified,
    * no stored fields are included in the response. If this field is specified, the _source

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -47,6 +47,7 @@ import { TrackHits } from '@global/search/_types/hits'
 import { Operator } from '@_types/query_dsl/Operator'
 import { Sort, SortResults } from '@_types/sort'
 import { KnnQuery } from '@_types/Knn'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * @rest_spec_name search
@@ -118,6 +119,10 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     explain?: boolean
+    /**
+     * Configuration of search extensions defined by Elasticsearch plugins.
+     */
+    ext?: Dictionary<string, UserDefinedValue>
     /**
      * Starting document offset. By default, you cannot page through more than 10,000
      * hits using the from and size parameters. To page through more hits, use the

--- a/specification/_types/Errors.ts
+++ b/specification/_types/Errors.ts
@@ -36,7 +36,7 @@ export class ErrorCause
   /**
    * A human-readable explanation of the error, in english
    */
-  reason: string
+  reason?: string
   /**
    * The server stack trace. Present only if the `error_trace=true` parameter was sent with the request.
    */

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -289,7 +289,7 @@ export class ExtendedStatsBucketAggregate extends ExtendedStatsAggregate {}
 
 /** @variant name=geo_bounds */
 export class GeoBoundsAggregate extends AggregateBase {
-  bounds: GeoBounds
+  bounds?: GeoBounds
 }
 
 /** @variant name=geo_centroid */

--- a/specification/_types/analysis/icu-plugin.ts
+++ b/specification/_types/analysis/icu-plugin.ts
@@ -50,17 +50,18 @@ export class IcuFoldingTokenFilter extends TokenFilterBase {
 
 export class IcuCollationTokenFilter extends TokenFilterBase {
   type: 'icu_collation'
-  alternate: IcuCollationAlternate
-  caseFirst: IcuCollationCaseFirst
-  caseLevel: boolean
-  country: string
-  decomposition: IcuCollationDecomposition
-  hiraganaQuaternaryMode: boolean
-  language: string
-  numeric: boolean
-  strength: IcuCollationStrength
+  alternate?: IcuCollationAlternate
+  caseFirst?: IcuCollationCaseFirst
+  caseLevel?: boolean
+  country?: string
+  decomposition?: IcuCollationDecomposition
+  hiraganaQuaternaryMode?: boolean
+  language?: string
+  numeric?: boolean
+  rules?: string
+  strength?: IcuCollationStrength
   variableTop?: string
-  variant: string
+  variant?: string
 }
 
 export class IcuAnalyzer {

--- a/specification/_types/mapping/RuntimeFields.ts
+++ b/specification/_types/mapping/RuntimeFields.ts
@@ -21,7 +21,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Field } from '@_types/common'
 import { Script } from '@_types/Scripting'
 
-export type RuntimeFields = Dictionary<Field, RuntimeField | RuntimeField[]>
+export type RuntimeFields = Dictionary<Field, RuntimeField>
 
 export class RuntimeField {
   format?: string

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -50,6 +50,7 @@ import { Suggester } from '@global/search/_types/suggester'
 import { TrackHits } from '@global/search/_types/hits'
 import { Operator } from '@_types/query_dsl/Operator'
 import { KnnQuery } from '@_types/Knn'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * @rest_spec_name async_search.submit
@@ -128,6 +129,10 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     explain?: boolean
+    /**
+     * Configuration of search extensions defined by Elasticsearch plugins.
+     */
+    ext?: Dictionary<string, UserDefinedValue>
     /**
      * Starting document offset. By default, you cannot page through more than 10,000
      * hits using the from and size parameters. To page through more hits, use the

--- a/specification/cluster/_types/ComponentTemplate.ts
+++ b/specification/cluster/_types/ComponentTemplate.ts
@@ -39,7 +39,7 @@ export class ComponentTemplateSummary {
   /** @doc_id mapping-meta-field */
   _meta?: Metadata
   version?: VersionNumber
-  settings: Dictionary<IndexName, IndexSettings>
+  settings?: Dictionary<IndexName, IndexSettings>
   mappings?: TypeMapping
   aliases?: Dictionary<string, AliasDefinition>
 }

--- a/specification/fleet/search/SearchRequest.ts
+++ b/specification/fleet/search/SearchRequest.ts
@@ -50,6 +50,7 @@ import { SlicedScroll } from '@_types/SlicedScroll'
 import { Sort, SortResults } from '@_types/sort'
 import { Duration } from '@_types/Time'
 import { Checkpoint } from '../_types/Checkpoints'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * The purpose of the fleet search api is to provide a search api where the search will only be executed
@@ -138,6 +139,10 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     explain?: boolean
+    /**
+     * Configuration of search extensions defined by Elasticsearch plugins.
+     */
+    ext?: Dictionary<string, UserDefinedValue>
     /**
      * Starting document offset. By default, you cannot page through more than 10,000
      * hits using the from and size parameters. To page through more hits, use the

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -260,8 +260,7 @@ export enum IndexCheckOnStartup {
 }
 
 export class IndexVersioning {
-  created: VersionString
-  created_string?: VersionString
+  created?: VersionString
 }
 
 export class IndexSettingsLifecycle {

--- a/specification/security/get_token/GetUserAccessTokenResponse.ts
+++ b/specification/security/get_token/GetUserAccessTokenResponse.ts
@@ -26,7 +26,7 @@ export class Response {
     expires_in: long
     scope?: string
     type: string
-    refresh_token: string
+    refresh_token?: string
     kerberos_authentication_response_token?: string
     authentication: AuthenticatedUser
   }


### PR DESCRIPTION
This PR fixes a number of fields that should be optional and also adds `SearchRequest.ext` that is undocumented but is present in HLRC and used by some plugins to add new sections to search requests.

These are bug fixes that should be backported down to 7.17.

- `IndexVersioning.created` is optional (not present on default index settings)  
  Found in https://github.com/elastic/elasticsearch-java/issues/286

- `GeoBoundsAggregate.bounds` should be optional.  
  Found in https://github.com/elastic/elasticsearch-java/issues/383

- `RuntimeFields` is a dictionary of single values, not an array  
  Found in https://github.com/elastic/elasticsearch-java/issues/298

- Search requests have an `ext` field for plugin extensions  
  Found in https://github.com/elastic/elasticsearch-java/issues/264

- All fields in `IcuCollationTokenFilter` are optional  
  Found in https://github.com/elastic/elasticsearch-java/issues/353

- `ComponentTemplateSummary.settings` is optional  
  Found in https://github.com/elastic/elasticsearch-java/issues/282

- `GetUserAccessTokenResponse.refresh_token` is optional  
  Found in https://github.com/elastic/elasticsearch-java/issues/332

- `ErrorCause.reason` is optional  
  Found in https://github.com/elastic/elasticsearch-java/issues/339
