### PR TITLE
Add sortable option to filters agg

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3000,7 +3000,7 @@ export interface AggregationsFiltersAggregation extends AggregationsBucketAggreg
   filters?: AggregationsBuckets<QueryDslQueryContainer>
   other_bucket?: boolean
   other_bucket_key?: string
-  keyed?: boolean
+  sortable?: boolean
 }
 
 export interface AggregationsFiltersBucketKeys extends AggregationsMultiBucketBase {

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -167,7 +167,7 @@ export class FiltersAggregation extends BucketAggregationBase {
   filters?: Buckets<QueryContainer>
   other_bucket?: boolean
   other_bucket_key?: string
-  keyed?: boolean
+  sortable?: boolean
 }
 
 export class GeoDistanceAggregation extends BucketAggregationBase {


### PR DESCRIPTION
This adds the `sortable` option to the `filters` agg which modifies the
rendered json for named filters from
```
"buckets": {
  "filtera": {},
  "filterb": {},
  "filterc": {}
}
```

to:
```
"buckets": [
  { "filtera": {} },
  { "filterb": {} },
  { "filterc": {} }
]
```

That way when you sort the buckets, you can see the ordering. The json
parser won't throw it away.

Also drops the `keyed` parameter from the spec for `filters` - it
doesn't exist.

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
