### PR TITLE
Add missing superclass to get_source request

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -436,7 +436,7 @@ export interface GetScriptLanguagesResponse {
   types_allowed: string[]
 }
 
-export interface GetSourceRequest {
+export interface GetSourceRequest extends RequestBase {
   id: Id
   index: IndexName
   preference?: string

--- a/specification/_global/get_source/SourceRequest.ts
+++ b/specification/_global/get_source/SourceRequest.ts
@@ -33,7 +33,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
  * @since 0.0.0
  * @stability stable
  */
-export interface Request {
+export interface Request extends RequestBase {
   path_parts: {
     /** Unique identifier of the document. */
     id: Id


### PR DESCRIPTION
`get_source` request is missing the `RequestBase` superclass. It is needed as it accepts common requests parameters (and also IIRC all requests must inherit either `RequestBase` or `CatRequestBase`.