### PR TITLE
Rename position_length to positionLength

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9700,7 +9700,7 @@ export interface IndicesAnalyzeAnalyzeDetail {
 export interface IndicesAnalyzeAnalyzeToken {
   end_offset: long
   position: long
-  position_length?: long
+  positionLength?: long
   start_offset: long
   token: string
   type: string

--- a/specification/indices/analyze/types.ts
+++ b/specification/indices/analyze/types.ts
@@ -37,7 +37,7 @@ export class AnalyzerDetail {
 export class AnalyzeToken {
   end_offset: long
   position: long
-  position_length?: long
+  positionLength?: long
   start_offset: long
   token: string
   type: string


### PR DESCRIPTION
As reported in the Java Client repo, elastic/elasticsearch-java#391, `positionLength` is not being de-serialised by the Java API client, as the specification appears to mistakenly have `position_length` as the name of the property.

The change renames `position_length` to `positionLength` in the Specification, so the issue will be fixed in the Java API client when the client's entity classes are next generated.
