### PR TITLE
Fix IcuTransformTokenFilter definition

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4064,7 +4064,7 @@ export type AnalysisIcuTransformDirection = 'forward' | 'reverse'
 
 export interface AnalysisIcuTransformTokenFilter extends AnalysisTokenFilterBase {
   type: 'icu_transform'
-  dir: AnalysisIcuTransformDirection
+  dir?: AnalysisIcuTransformDirection
   id: string
 }
 

--- a/specification/_types/analysis/icu-plugin.ts
+++ b/specification/_types/analysis/icu-plugin.ts
@@ -23,7 +23,7 @@ import { TokenFilterBase } from './token_filters'
 
 export class IcuTransformTokenFilter extends TokenFilterBase {
   type: 'icu_transform'
-  dir: IcuTransformDirection
+  dir?: IcuTransformDirection
   id: string
 }
 


### PR DESCRIPTION
The documents describe that `icu_transform` token filter doesn't require `dir` option.

7.17 Document
https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/analysis-icu-transform.html
8.4 Document
https://www.elastic.co/guide/en/elasticsearch/plugins/8.4/analysis-icu-transform.html

Actually, Elasticsearch Server (7.17.x) accepts the following request successfully.

```
{"settings": {"index": {"analysis": {"filter": {"myLatinTransform": {"type": "icu_transform", "id": "Any-Latin; NFD; [:Nonspacing Mark:] Remove; NFC"}}}}}}
```

However, `elasticsearch-specification` defines the `dir` option is required.
Because of this, elasticsearch-java-client cannot send the request.

```
new co.elastic.clients.elasticsearch.indices.CreateIndexRequest.Builder().withJson(new java.io.StringReader("{\"settings\": {\"index\": {\"analysis\": {\"filter\": {\"myLatinTransform\": {\"type\": \"icu_transform\", \"id\": \"Any-
Latin; NFD; [:Nonspacing Mark:] Remove; NFC\"}}}}}}"))
```

```
co.elastic.clients.json.JsonpMappingException: Error deserializing co.elastic.clients.elasticsearch._types.analysis.TokenFilterDefinition: co.elastic.clients.util.MissingRequiredPropertyException: Missing required property 'IcuTransformTokenFilter.dir' (JSON path: settings.index.analysis.filter.myLatinTransform) (line no=1, column no=151, offset=150)
  at co.elastic.clients.json.JsonpMappingException.from0(JsonpMappingException.java:134)
  at co.elastic.clients.json.JsonpMappingException.from(JsonpMappingException.java:121)
  at co.elastic.clients.json.ObjectDeserializer.deserialize(ObjectDeserializer.java:206)
  at co.elastic.clients.json.ObjectDeserializer.deserialize(ObjectDeserializer.java:136)
  at co.elastic.clients.json.BuildFunctionDeserializer.deserialize(BuildFunctionDeserializer.java:53)
  at co.elastic.clients.json.DelegatingDeserializer$SameType.deserialize(DelegatingDeserializer.java:48)
  at co.elastic.clients.json.UnionDeserializer$SingleMemberHandler.deserialize(UnionDeserializer.java:74)
  at co.elastic.clients.json.UnionDeserializer.deserialize(UnionDeserializer.java:291)
  at co.elastic.clients.json.UnionDeserializer.deserialize(UnionDeserializer.java:258)
```

This PR fixes the wrong definition.

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
