### PR TITLE
Add IPProperty and missing properties in mappings

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -551,7 +551,11 @@
         "Request: query parameter 'flat_settings' does not exist in the json spec",
         "Request: should not have a body"
       ],
-      "response": []
+      "response": [
+        "interface definition _types.mapping:NumberPropertyBase - Property 'meta' is already defined in an ancestor class",
+        "interface definition _types.mapping:NumberPropertyBase - Property 'store' is already defined in an ancestor class",
+        "interface definition _types.mapping:ScaledFloatNumberProperty - Property 'coerce' is already defined in an ancestor class"
+      ]
     },
     "cluster.get_settings": {
       "request": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4719,16 +4719,6 @@ export interface MappingHistogramProperty extends MappingPropertyBase {
   type: 'histogram'
 }
 
-export interface MappingIPProperty extends MappingDocValuesPropertyBase {
-  index?: boolean
-  ignore_malformed?: boolean
-  null_value?: string
-  on_script_error?: MappingOnScriptError
-  script?: Script
-  time_series_dimension?: boolean
-  type: 'ip'
-}
-
 export interface MappingIndexField {
   enabled: boolean
 }
@@ -4747,8 +4737,11 @@ export interface MappingIntegerRangeProperty extends MappingRangePropertyBase {
 export interface MappingIpProperty extends MappingDocValuesPropertyBase {
   boost?: double
   index?: boolean
-  null_value?: string
   ignore_malformed?: boolean
+  null_value?: string
+  on_script_error?: MappingOnScriptError
+  script?: Script
+  time_series_dimension?: boolean
   type: 'ip'
 }
 
@@ -4834,7 +4827,7 @@ export interface MappingPointProperty extends MappingDocValuesPropertyBase {
   type: 'point'
 }
 
-export type MappingProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDynamicProperty | MappingJoinProperty | MappingKeywordProperty | MappingMatchOnlyTextProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingSearchAsYouTypeProperty | MappingTextProperty | MappingVersionProperty | MappingWildcardProperty | MappingIPProperty | MappingDateNanosProperty | MappingDateProperty | MappingAggregateMetricDoubleProperty | MappingDenseVectorProperty | MappingFlattenedProperty | MappingNestedProperty | MappingObjectProperty | MappingCompletionProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingTokenCountProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingPointProperty | MappingShapeProperty | MappingByteNumberProperty | MappingDoubleNumberProperty | MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingScaledFloatNumberProperty | MappingShortNumberProperty | MappingUnsignedLongNumberProperty | MappingDateRangeProperty | MappingDoubleRangeProperty | MappingFloatRangeProperty | MappingIntegerRangeProperty | MappingIpRangeProperty | MappingLongRangeProperty
+export type MappingProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDynamicProperty | MappingJoinProperty | MappingKeywordProperty | MappingMatchOnlyTextProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingSearchAsYouTypeProperty | MappingTextProperty | MappingVersionProperty | MappingWildcardProperty | MappingDateNanosProperty | MappingDateProperty | MappingAggregateMetricDoubleProperty | MappingDenseVectorProperty | MappingFlattenedProperty | MappingNestedProperty | MappingObjectProperty | MappingCompletionProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingTokenCountProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingPointProperty | MappingShapeProperty | MappingByteNumberProperty | MappingDoubleNumberProperty | MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingScaledFloatNumberProperty | MappingShortNumberProperty | MappingUnsignedLongNumberProperty | MappingDateRangeProperty | MappingDoubleRangeProperty | MappingFloatRangeProperty | MappingIntegerRangeProperty | MappingIpRangeProperty | MappingLongRangeProperty
 
 export interface MappingPropertyBase {
   local_metadata?: Metadata

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4501,6 +4501,7 @@ export interface MappingAggregateMetricDoubleProperty extends MappingPropertyBas
   type: 'aggregate_metric_double'
   default_metric: string
   metrics: string[]
+  time_series_metric?: MappingTimeSeriesMetricType
 }
 
 export interface MappingAllField {
@@ -4528,7 +4529,7 @@ export interface MappingBooleanProperty extends MappingDocValuesPropertyBase {
   type: 'boolean'
 }
 
-export interface MappingByteNumberProperty extends MappingStandardNumberProperty {
+export interface MappingByteNumberProperty extends MappingNumberPropertyBase {
   type: 'byte'
   null_value?: byte
 }
@@ -4603,7 +4604,7 @@ export interface MappingDocValuesPropertyBase extends MappingCorePropertyBase {
   doc_values?: boolean
 }
 
-export interface MappingDoubleNumberProperty extends MappingStandardNumberProperty {
+export interface MappingDoubleNumberProperty extends MappingNumberPropertyBase {
   type: 'double'
   null_value?: double
 }
@@ -4679,7 +4680,7 @@ export interface MappingFlattenedProperty extends MappingPropertyBase {
   type: 'flattened'
 }
 
-export interface MappingFloatNumberProperty extends MappingStandardNumberProperty {
+export interface MappingFloatNumberProperty extends MappingNumberPropertyBase {
   type: 'float'
   null_value?: float
 }
@@ -4708,7 +4709,7 @@ export interface MappingGeoShapeProperty extends MappingDocValuesPropertyBase {
 
 export type MappingGeoStrategy = 'recursive' | 'term'
 
-export interface MappingHalfFloatNumberProperty extends MappingStandardNumberProperty {
+export interface MappingHalfFloatNumberProperty extends MappingNumberPropertyBase {
   type: 'half_float'
   null_value?: float
 }
@@ -4718,13 +4719,23 @@ export interface MappingHistogramProperty extends MappingPropertyBase {
   type: 'histogram'
 }
 
+export interface MappingIPProperty extends MappingDocValuesPropertyBase {
+  index?: boolean
+  ignore_malformed?: boolean
+  null_value?: string
+  on_script_error?: MappingOnScriptError
+  script?: Script
+  time_series_dimension?: boolean
+  type: 'ip'
+}
+
 export interface MappingIndexField {
   enabled: boolean
 }
 
 export type MappingIndexOptions = 'docs' | 'freqs' | 'positions' | 'offsets'
 
-export interface MappingIntegerNumberProperty extends MappingStandardNumberProperty {
+export interface MappingIntegerNumberProperty extends MappingNumberPropertyBase {
   type: 'integer'
   null_value?: integer
 }
@@ -4763,7 +4774,7 @@ export interface MappingKeywordProperty extends MappingDocValuesPropertyBase {
   type: 'keyword'
 }
 
-export interface MappingLongNumberProperty extends MappingStandardNumberProperty {
+export interface MappingLongNumberProperty extends MappingNumberPropertyBase {
   type: 'long'
   null_value?: long
 }
@@ -4793,9 +4804,16 @@ export interface MappingNestedProperty extends MappingCorePropertyBase {
 }
 
 export interface MappingNumberPropertyBase extends MappingDocValuesPropertyBase {
-  index?: boolean
+  boost?: double
+  coerce?: boolean
   ignore_malformed?: boolean
+  index?: boolean
+  meta?: Record<string, string>
+  on_script_error?: MappingOnScriptError
+  script?: Script
+  store?: boolean
   time_series_metric?: MappingTimeSeriesMetricType
+  time_series_dimension?: boolean
 }
 
 export interface MappingObjectProperty extends MappingCorePropertyBase {
@@ -4816,7 +4834,7 @@ export interface MappingPointProperty extends MappingDocValuesPropertyBase {
   type: 'point'
 }
 
-export type MappingProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDynamicProperty | MappingJoinProperty | MappingKeywordProperty | MappingMatchOnlyTextProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingSearchAsYouTypeProperty | MappingTextProperty | MappingVersionProperty | MappingWildcardProperty | MappingDateNanosProperty | MappingDateProperty | MappingAggregateMetricDoubleProperty | MappingDenseVectorProperty | MappingFlattenedProperty | MappingNestedProperty | MappingObjectProperty | MappingCompletionProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingTokenCountProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingPointProperty | MappingShapeProperty | MappingByteNumberProperty | MappingDoubleNumberProperty | MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingScaledFloatNumberProperty | MappingShortNumberProperty | MappingUnsignedLongNumberProperty | MappingDateRangeProperty | MappingDoubleRangeProperty | MappingFloatRangeProperty | MappingIntegerRangeProperty | MappingIpRangeProperty | MappingLongRangeProperty
+export type MappingProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDynamicProperty | MappingJoinProperty | MappingKeywordProperty | MappingMatchOnlyTextProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingSearchAsYouTypeProperty | MappingTextProperty | MappingVersionProperty | MappingWildcardProperty | MappingIPProperty | MappingDateNanosProperty | MappingDateProperty | MappingAggregateMetricDoubleProperty | MappingDenseVectorProperty | MappingFlattenedProperty | MappingNestedProperty | MappingObjectProperty | MappingCompletionProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingTokenCountProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingPointProperty | MappingShapeProperty | MappingByteNumberProperty | MappingDoubleNumberProperty | MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingScaledFloatNumberProperty | MappingShortNumberProperty | MappingUnsignedLongNumberProperty | MappingDateRangeProperty | MappingDoubleRangeProperty | MappingFloatRangeProperty | MappingIntegerRangeProperty | MappingIpRangeProperty | MappingLongRangeProperty
 
 export interface MappingPropertyBase {
   local_metadata?: Metadata
@@ -4883,7 +4901,7 @@ export interface MappingShapeProperty extends MappingDocValuesPropertyBase {
   type: 'shape'
 }
 
-export interface MappingShortNumberProperty extends MappingStandardNumberProperty {
+export interface MappingShortNumberProperty extends MappingNumberPropertyBase {
   type: 'short'
   null_value?: short
 }
@@ -4898,12 +4916,6 @@ export interface MappingSourceField {
   enabled?: boolean
   excludes?: string[]
   includes?: string[]
-}
-
-export interface MappingStandardNumberProperty extends MappingNumberPropertyBase {
-  coerce?: boolean
-  script?: Script
-  on_script_error?: MappingOnScriptError
 }
 
 export interface MappingSuggestContext {

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -38,7 +38,6 @@ import {
   FloatNumberProperty,
   HalfFloatNumberProperty,
   IntegerNumberProperty,
-  IPProperty,
   JoinProperty,
   KeywordProperty,
   LongNumberProperty,
@@ -108,7 +107,6 @@ export type Property =
   | TextProperty
   | VersionProperty
   | WildcardProperty
-  | IPProperty
 
   // dates
   | DateNanosProperty

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -38,6 +38,7 @@ import {
   FloatNumberProperty,
   HalfFloatNumberProperty,
   IntegerNumberProperty,
+  IPProperty,
   JoinProperty,
   KeywordProperty,
   LongNumberProperty,
@@ -107,6 +108,7 @@ export type Property =
   | TextProperty
   | VersionProperty
   | WildcardProperty
+  | IPProperty
 
   // dates
   | DateNanosProperty

--- a/specification/_types/mapping/complex.ts
+++ b/specification/_types/mapping/complex.ts
@@ -21,6 +21,7 @@ import { double, integer } from '@_types/Numeric'
 import { CorePropertyBase, IndexOptions } from './core'
 import { DenseVectorIndexOptions } from './DenseVectorIndexOptions'
 import { PropertyBase } from './Property'
+import { TimeSeriesMetricType } from '@_types/mapping/TimeSeriesMetricType'
 
 export class FlattenedProperty extends PropertyBase {
   boost?: double
@@ -59,4 +60,5 @@ export class AggregateMetricDoubleProperty extends PropertyBase {
   type: 'aggregate_metric_double'
   default_metric: string
   metrics: string[]
+  time_series_metric?: TimeSeriesMetricType
 }

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -99,10 +99,34 @@ export class KeywordProperty extends DocValuesPropertyBase {
   type: 'keyword'
 }
 
-export class NumberPropertyBase extends DocValuesPropertyBase {
+export class IPProperty extends DocValuesPropertyBase {
   index?: boolean
   ignore_malformed?: boolean
+  null_value?: string
+  on_script_error?: OnScriptError
+  script?: Script
+  /** [experimental] For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false. */
+  time_series_dimension?: boolean
+  type: 'ip'
+}
+
+export class NumberPropertyBase extends DocValuesPropertyBase {
+  boost?: double
+  coerce?: boolean
+  ignore_malformed?: boolean
+  index?: boolean
+  /**
+   * Metadata about the field.
+   * @doc_id mapping-meta-field
+   */
+  meta?: Dictionary<string, string>
+  on_script_error?: OnScriptError
+  script?: Script
+  store?: boolean
+  /** [experimental] For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false. */
   time_series_metric?: TimeSeriesMetricType
+  /** [experimental] For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false. */
+  time_series_dimension?: boolean
 }
 
 export enum OnScriptError {
@@ -110,43 +134,37 @@ export enum OnScriptError {
   continue
 }
 
-export class StandardNumberProperty extends NumberPropertyBase {
-  coerce?: boolean
-  script?: Script
-  on_script_error?: OnScriptError
-}
-
-export class FloatNumberProperty extends StandardNumberProperty {
+export class FloatNumberProperty extends NumberPropertyBase {
   type: 'float'
   null_value?: float
 }
 
-export class HalfFloatNumberProperty extends StandardNumberProperty {
+export class HalfFloatNumberProperty extends NumberPropertyBase {
   type: 'half_float'
   null_value?: float
 }
 
-export class DoubleNumberProperty extends StandardNumberProperty {
+export class DoubleNumberProperty extends NumberPropertyBase {
   type: 'double'
   null_value?: double
 }
 
-export class IntegerNumberProperty extends StandardNumberProperty {
+export class IntegerNumberProperty extends NumberPropertyBase {
   type: 'integer'
   null_value?: integer
 }
 
-export class LongNumberProperty extends StandardNumberProperty {
+export class LongNumberProperty extends NumberPropertyBase {
   type: 'long'
   null_value?: long
 }
 
-export class ShortNumberProperty extends StandardNumberProperty {
+export class ShortNumberProperty extends NumberPropertyBase {
   type: 'short'
   null_value?: short
 }
 
-export class ByteNumberProperty extends StandardNumberProperty {
+export class ByteNumberProperty extends NumberPropertyBase {
   type: 'byte'
   null_value?: byte
 }

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -94,20 +94,12 @@ export class KeywordProperty extends DocValuesPropertyBase {
   norms?: boolean
   null_value?: string
   split_queries_on_whitespace?: boolean
-  /** [experimental] For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false. */
+  /**
+   * For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.
+   * @stability experimental
+   */
   time_series_dimension?: boolean
   type: 'keyword'
-}
-
-export class IPProperty extends DocValuesPropertyBase {
-  index?: boolean
-  ignore_malformed?: boolean
-  null_value?: string
-  on_script_error?: OnScriptError
-  script?: Script
-  /** [experimental] For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false. */
-  time_series_dimension?: boolean
-  type: 'ip'
 }
 
 export class NumberPropertyBase extends DocValuesPropertyBase {
@@ -123,9 +115,16 @@ export class NumberPropertyBase extends DocValuesPropertyBase {
   on_script_error?: OnScriptError
   script?: Script
   store?: boolean
-  /** [experimental] For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false. */
+  /**
+   * For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.
+   * @stability experimental
+   */
   time_series_metric?: TimeSeriesMetricType
-  /** [experimental] For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false. */
+  /**
+   * For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.
+   * @stability experimental
+   * @server_default false
+   */
   time_series_dimension?: boolean
 }
 

--- a/specification/_types/mapping/specialized.ts
+++ b/specification/_types/mapping/specialized.ts
@@ -20,8 +20,9 @@
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Field, Name } from '@_types/common'
 import { double, integer } from '@_types/Numeric'
-import { DocValuesPropertyBase, IndexOptions } from './core'
+import { DocValuesPropertyBase, IndexOptions, OnScriptError } from './core'
 import { PropertyBase } from './Property'
+import { Script } from '@_types/Scripting'
 
 export class CompletionProperty extends DocValuesPropertyBase {
   analyzer?: string
@@ -58,8 +59,15 @@ export class HistogramProperty extends PropertyBase {
 export class IpProperty extends DocValuesPropertyBase {
   boost?: double
   index?: boolean
-  null_value?: string
   ignore_malformed?: boolean
+  null_value?: string
+  on_script_error?: OnScriptError
+  script?: Script
+  /**
+   * For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.
+   * @stability experimental
+   */
+  time_series_dimension?: boolean
   type: 'ip'
 }
 


### PR DESCRIPTION
This PR adds the missing `IPProperty`, revamps the `NumberPropertyBase` to include missing possible properties and adds `time_series_metric` to `AggregateMetricDoubleProperty`.

Relates to #1881 