### PR TITLE
Add Mode to Mappings for _source

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4785,8 +4785,6 @@ export interface MappingMatchOnlyTextProperty {
 
 export type MappingMatchType = 'simple' | 'regex'
 
-export type MappingMode = 'disabled' | 'stored' | 'synthetic'
-
 export interface MappingMurmur3HashProperty extends MappingDocValuesPropertyBase {
   type: 'murmur3'
 }
@@ -4911,8 +4909,10 @@ export interface MappingSourceField {
   enabled?: boolean
   excludes?: string[]
   includes?: string[]
-  mode?: MappingMode
+  mode?: MappingSourceFieldMode
 }
+
+export type MappingSourceFieldMode = 'disabled' | 'stored' | 'synthetic'
 
 export interface MappingSuggestContext {
   name: Name

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4785,6 +4785,8 @@ export interface MappingMatchOnlyTextProperty {
 
 export type MappingMatchType = 'simple' | 'regex'
 
+export type MappingMode = 'disabled' | 'stored' | 'synthetic'
+
 export interface MappingMurmur3HashProperty extends MappingDocValuesPropertyBase {
   type: 'murmur3'
 }
@@ -4909,6 +4911,7 @@ export interface MappingSourceField {
   enabled?: boolean
   excludes?: string[]
   includes?: string[]
+  mode?: MappingMode
 }
 
 export interface MappingSuggestContext {

--- a/specification/_types/mapping/meta-fields.ts
+++ b/specification/_types/mapping/meta-fields.ts
@@ -61,4 +61,15 @@ export class SourceField {
   enabled?: boolean
   excludes?: string[]
   includes?: string[]
+  mode?: Mode
+}
+
+export enum Mode {
+  disabled = 0,
+  stored = 1,
+  /**
+   *  Instead of storing source documents on disk exactly as you send them,
+   *  Elasticsearch can reconstruct source content on the fly upon retrieval.
+   */
+  synthetic = 2
 }

--- a/specification/_types/mapping/meta-fields.ts
+++ b/specification/_types/mapping/meta-fields.ts
@@ -61,15 +61,15 @@ export class SourceField {
   enabled?: boolean
   excludes?: string[]
   includes?: string[]
-  mode?: Mode
+  mode?: SourceFieldMode
 }
 
-export enum Mode {
-  disabled = 0,
-  stored = 1,
+export enum SourceFieldMode {
+  disabled,
+  stored,
   /**
    *  Instead of storing source documents on disk exactly as you send them,
    *  Elasticsearch can reconstruct source content on the fly upon retrieval.
    */
-  synthetic = 2
+  synthetic
 }


### PR DESCRIPTION
This allows to set the `_source` storage to `synthetic`. ([doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html#synthetic-source))

Relates to https://github.com/elastic/elasticsearch-specification/issues/1881