### PR TITLE
Remove overriden properties

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -551,11 +551,7 @@
         "Request: query parameter 'flat_settings' does not exist in the json spec",
         "Request: should not have a body"
       ],
-      "response": [
-        "interface definition _types.mapping:NumberPropertyBase - Property 'meta' is already defined in an ancestor class",
-        "interface definition _types.mapping:NumberPropertyBase - Property 'store' is already defined in an ancestor class",
-        "interface definition _types.mapping:ScaledFloatNumberProperty - Property 'coerce' is already defined in an ancestor class"
-      ]
+      "response": []
     },
     "cluster.get_settings": {
       "request": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4825,10 +4825,8 @@ export interface MappingNumberPropertyBase extends MappingDocValuesPropertyBase 
   coerce?: boolean
   ignore_malformed?: boolean
   index?: boolean
-  meta?: Record<string, string>
   on_script_error?: MappingOnScriptError
   script?: Script
-  store?: boolean
   time_series_metric?: MappingTimeSeriesMetricType
   time_series_dimension?: boolean
 }
@@ -4893,7 +4891,6 @@ export type MappingRuntimeFields = Record<Field, MappingRuntimeField>
 
 export interface MappingScaledFloatNumberProperty extends MappingNumberPropertyBase {
   type: 'scaled_float'
-  coerce?: boolean
   null_value?: double
   scaling_factor?: double
 }

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -80,7 +80,10 @@ import {
 
 export class PropertyBase {
   local_metadata?: Metadata
-  /** @doc_id mapping-meta-field */
+  /**
+   * Metadata about the field.
+   * @doc_id mapping-meta-field
+   */
   meta?: Dictionary<string, string>
   properties?: Dictionary<PropertyName, Property>
   ignore_above?: integer

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -107,14 +107,8 @@ export class NumberPropertyBase extends DocValuesPropertyBase {
   coerce?: boolean
   ignore_malformed?: boolean
   index?: boolean
-  /**
-   * Metadata about the field.
-   * @doc_id mapping-meta-field
-   */
-  meta?: Dictionary<string, string>
   on_script_error?: OnScriptError
   script?: Script
-  store?: boolean
   /**
    * For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.
    * @stability experimental
@@ -175,7 +169,6 @@ export class UnsignedLongNumberProperty extends NumberPropertyBase {
 
 export class ScaledFloatNumberProperty extends NumberPropertyBase {
   type: 'scaled_float'
-  coerce?: boolean
   null_value?: double
   scaling_factor?: double
 }


### PR DESCRIPTION
This removes some property overrides that were introduced by the refactoring in #1920

Note to self: this should be caught by the model validation rules.