### PR TITLE
Use TaskId for DeleteByQueryRethrottleRequest path parameter

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -238,7 +238,7 @@ export interface DeleteByQueryResponse {
 }
 
 export interface DeleteByQueryRethrottleRequest extends RequestBase {
-  task_id: Id
+  task_id: TaskId
   requests_per_second?: float
 }
 

--- a/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
+++ b/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
+import { TaskId } from '@_types/common'
 import { float } from '@_types/Numeric'
 
 /**
@@ -28,7 +28,7 @@ import { float } from '@_types/Numeric'
  */
 export interface Request extends RequestBase {
   path_parts: {
-    task_id: Id
+    task_id: TaskId
   }
   query_parameters: {
     requests_per_second?: float


### PR DESCRIPTION
When using the delete by query API asynchronously, it returns a `TaskId` for the ongoing task. The DeleteByQueryRethrottleRequest accepts a `task_id` as a required path parameter, but it's currently typed as `Id`. For the .NET client, at least, it presents some usability hurdles as you can't just pass the value of the `Task` property from the `DeleteByQueryResponse` into subsequent API calls. Ideally, I believe we should align the typing here with the usage scenario.

My only concern is this being a breaking change for other clients that probably function today using the parameter typed as `Id`.