### PR TITLE
SLM config and retention are optional

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16183,7 +16183,7 @@ export type ShutdownPutNodeResponse = AcknowledgedResponseBase
 
 export interface SlmConfiguration {
   ignore_unavailable?: boolean
-  indices: Indices
+  indices?: Indices
   include_global_state?: boolean
   feature_states?: string[]
   metadata?: Metadata
@@ -16203,10 +16203,10 @@ export interface SlmInvocation {
 }
 
 export interface SlmPolicy {
-  config: SlmConfiguration
+  config?: SlmConfiguration
   name: Name
   repository: string
-  retention: SlmRetention
+  retention?: SlmRetention
   schedule: WatcherCronExpression
 }
 

--- a/specification/slm/_types/SnapshotLifecycle.ts
+++ b/specification/slm/_types/SnapshotLifecycle.ts
@@ -74,10 +74,10 @@ export class Statistics {
 }
 
 export class Policy {
-  config: Configuration
+  config?: Configuration
   name: Name
   repository: string
-  retention: Retention
+  retention?: Retention
   schedule: CronExpression
 }
 
@@ -106,7 +106,7 @@ export class Configuration {
    * A comma-separated list of data streams and indices to include in the snapshot. Multi-index syntax is supported.
    * By default, a snapshot includes all data streams and indices in the cluster. If this argument is provided, the snapshot only includes the specified data streams and clusters.
    */
-  indices: Indices
+  indices?: Indices
   /**
    * If true, the current global state is included in the snapshot.
    * @server_default true


### PR DESCRIPTION
Fixes #1917

The `config` and `retention` fields in the SLM policy are optional, and also `indices` in `config`.