### PR TITLE
Add ml.clear_trained_model_deployment_cache

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1367,7 +1367,7 @@
     },
     "ml.clear_trained_model_deployment_cache": {
       "request": [
-        "Missing request & response"
+        "Request: should not have a body"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12734,6 +12734,14 @@ export interface MlZeroShotClassificationInferenceUpdateOptions {
   labels: string[]
 }
 
+export interface MlClearTrainedModelDeploymentCacheRequest extends RequestBase {
+  model_id?: Id
+}
+
+export interface MlClearTrainedModelDeploymentCacheResponse {
+  cleared: boolean
+}
+
 export interface MlCloseJobRequest extends RequestBase {
   job_id: Id
   allow_no_match?: boolean

--- a/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheRequest.ts
+++ b/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheRequest.ts
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+import { integer } from '@_types/Numeric'
+import { Include } from '@ml/_types/Include'
+
+/**
+ * Clears a trained model deployment cache on all nodes where the trained model is assigned.
+ * A trained model deployment may have an inference cache enabled.
+ * As requests are handled by each allocated node, their responses may be cached on that individual node.
+ * Calling this API clears the caches without restarting the deployment.
+ * @rest_spec_name ml.clear_trained_model_deployment_cache
+ * @since 8.5.0
+ * @stability beta
+ * @cluster_privileges manage_ml
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the trained model.
+     */
+    model_id?: Id
+  }
+}

--- a/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheResponse.ts
+++ b/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class Response {
+  body: {
+    cleared: boolean
+  }
+}


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/89074

This PR adds definitions for https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-trained-model-deployment-cache.html (https://github.com/elastic/elasticsearch-specification/blob/main/specification/_json_spec/ml.clear_trained_model_deployment_cache.json)
