### PR TITLE
Fix user privileges

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15293,7 +15293,7 @@ export interface SecurityIndicesPrivileges {
   field_security?: SecurityFieldSecurity | SecurityFieldSecurity[]
   names: Indices
   privileges: SecurityIndexPrivilege[]
-  query?: SecurityIndicesPrivilegesQuery | SecurityIndicesPrivilegesQuery[]
+  query?: SecurityIndicesPrivilegesQuery
   allow_restricted_indices?: boolean
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15278,7 +15278,7 @@ export interface SecurityFieldRule {
 
 export interface SecurityFieldSecurity {
   except?: Fields
-  grant: Fields
+  grant?: Fields
 }
 
 export interface SecurityGlobalPrivilege {
@@ -15349,17 +15349,19 @@ export interface SecurityRoleMappingRule {
   except?: SecurityRoleMappingRule
 }
 
+export type SecurityRoleTemplateInlineQuery = string | QueryDslQueryContainer
+
 export interface SecurityRoleTemplateInlineScript extends ScriptBase {
   lang?: ScriptLanguage
   options?: Record<string, string>
-  source: string | QueryDslQueryContainer
+  source: SecurityRoleTemplateInlineQuery
 }
 
 export interface SecurityRoleTemplateQuery {
   template?: SecurityRoleTemplateScript
 }
 
-export type SecurityRoleTemplateScript = SecurityRoleTemplateInlineScript | string | QueryDslQueryContainer | StoredScriptId
+export type SecurityRoleTemplateScript = SecurityRoleTemplateInlineScript | SecurityRoleTemplateInlineQuery | StoredScriptId
 
 export interface SecurityTransientMetadataConfig {
   enabled: boolean
@@ -15373,6 +15375,14 @@ export interface SecurityUser {
   username: Username
   enabled: boolean
   profile_uid?: SecurityUserProfileId
+}
+
+export interface SecurityUserIndicesPrivileges {
+  field_security?: SecurityFieldSecurity[]
+  names: Indices
+  privileges: SecurityIndexPrivilege[]
+  query?: SecurityIndicesPrivilegesQuery[]
+  allow_restricted_indices: boolean
 }
 
 export interface SecurityUserProfile {
@@ -15789,7 +15799,7 @@ export interface SecurityGetUserPrivilegesResponse {
   applications: SecurityApplicationPrivileges[]
   cluster: string[]
   global: SecurityGlobalPrivilege[]
-  indices: SecurityIndicesPrivileges[]
+  indices: SecurityUserIndicesPrivileges[]
   run_as: string[]
 }
 

--- a/specification/security/_types/FieldSecurity.ts
+++ b/specification/security/_types/FieldSecurity.ts
@@ -21,5 +21,5 @@ import { Fields } from '@_types/common'
 
 export class FieldSecurity {
   except?: Fields
-  grant: Fields
+  grant?: Fields
 }

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -93,9 +93,9 @@ export class IndicesPrivileges {
    */
   privileges: IndexPrivilege[]
   /**
-   * Search queries that define the documents the owners of the role have read access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.
+   * A search query that defines the documents the owners of the role have read access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.
    */
-  query?: IndicesPrivilegesQuery | IndicesPrivilegesQuery[]
+  query?: IndicesPrivilegesQuery
   /**
    * Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.
    * @server_default false

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -93,7 +93,7 @@ export class IndicesPrivileges {
    */
   privileges: IndexPrivilege[]
   /**
-   * A search query that defines the documents the owners of the role have read access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.
+   * A search query that defines the documents the owners of the role have access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.
    */
   query?: IndicesPrivilegesQuery
   /**
@@ -101,6 +101,30 @@ export class IndicesPrivileges {
    * @server_default false
    */
   allow_restricted_indices?: boolean
+}
+
+export class UserIndicesPrivileges {
+  /**
+   * The document fields that the owners of the role have read access to.
+   * @doc_id field-and-document-access-control
+   */
+  field_security?: FieldSecurity[]
+  /**
+   * A list of indices (or index name patterns) to which the permissions in this entry apply.
+   */
+  names: Indices
+  /**
+   * The index level privileges that owners of the role have on the specified indices.
+   */
+  privileges: IndexPrivilege[]
+  /**
+   * Search queries that define the documents the user has access to. A document within the specified indices must match these queries for it to be accessible by the owners of the role.
+   */
+  query?: IndicesPrivilegesQuery[]
+  /**
+   * Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.
+   */
+  allow_restricted_indices: boolean
 }
 
 /**
@@ -129,8 +153,11 @@ export class RoleTemplateQuery {
 export class RoleTemplateInlineScript extends ScriptBase {
   lang?: ScriptLanguage
   options?: Dictionary<string, string>
-  source: string | QueryContainer
+  source: RoleTemplateInlineQuery
 }
+
+/** @codegen_names query_string, query_object */
+export type RoleTemplateInlineQuery = string | QueryContainer
 
 /** @codegen_names inline, stored */
 export type RoleTemplateScript = RoleTemplateInlineScript | StoredScriptId

--- a/specification/security/get_user_privileges/SecurityGetUserPrivilegesResponse.ts
+++ b/specification/security/get_user_privileges/SecurityGetUserPrivilegesResponse.ts
@@ -20,7 +20,8 @@
 import {
   IndicesPrivileges,
   GlobalPrivilege,
-  ApplicationPrivileges
+  ApplicationPrivileges,
+  UserIndicesPrivileges
 } from '@security/_types/Privileges'
 
 export class Response {
@@ -28,10 +29,7 @@ export class Response {
     applications: ApplicationPrivileges[]
     cluster: string[]
     global: GlobalPrivilege[]
-    /**
-     * In this context `IndicesPrivileges.query` property can only be a string, see `IndicesPrivileges` documentation for detail.
-     */
-    indices: IndicesPrivileges[]
+    indices: UserIndicesPrivileges[]
     run_as: string[]
   }
 }


### PR DESCRIPTION
Follow-up to PR #1963

`IndicesPrivileges` can contain multiple queries _only_ in the context of `GetUserPrivilegeResponses`, and not in the context of `RoleDescriptor`. We therefore have to introduce a new `UserIndicesPrivileges` type that has multiple queries.

Additionally, this PR adds missing  `@codegen_names` on `RoleTemplateInlineScript.source`, requiring to move it to a separate type to hold this annotation.

Finally, `FieldSecurity.grant` is actually optional.