### PR TITLE
Enforce path parameter required/optional with JSON specs

### DIFF
--- a/compiler/src/steps/validate-rest-spec.ts
+++ b/compiler/src/steps/validate-rest-spec.ts
@@ -69,7 +69,7 @@ export default async function validateRestSpec (model: model.Model, jsonSpec: Ma
       }
 
       // are all path parameters properly required or optional?
-      let urlPartsRequired = new Set(urlParts.slice())
+      let urlPartsRequired = new Set(urlParts)
       // A part is considered required if it is included in
       // every path for the API endpoint.
       for (const path of spec.url.paths) {

--- a/compiler/src/steps/validate-rest-spec.ts
+++ b/compiler/src/steps/validate-rest-spec.ts
@@ -68,6 +68,35 @@ export default async function validateRestSpec (model: model.Model, jsonSpec: Ma
         }
       }
 
+      // are all path parameters properly required or optional?
+      let urlPartsRequired = new Set(urlParts.slice())
+      // A part is considered required if it is included in
+      // every path for the API endpoint.
+      for (const path of spec.url.paths) {
+        if (path.parts == null) {
+          // No parts means that all path parameters are optional!
+          urlPartsRequired = new Set()
+          break
+        }
+        urlPartsRequired = new Set([...Object.keys(path.parts)].filter((x) => urlPartsRequired.has(x)))
+      }
+
+      // transform [{name: ..., required: ...}] -> {name: {required: ...}}
+      const pathPropertyMap: Record<string, model.Property> = requestProperties.path.reduce((prev, prop) => ({ ...prev, [prop.name]: prop }), {})
+      for (const name of pathProperties) {
+        // okay to skip if it's not included since this scenario
+        // is covered above with a different error.
+        if (!urlParts.includes(name)) {
+          continue
+        }
+        // Find the mismatches between the specs
+        if (urlPartsRequired.has(name) && !pathPropertyMap[name].required) {
+          errors.addEndpointError(endpoint.name, 'request', `${endpoint.request.name}: path parameter '${name}' is required in the json spec`)
+        } else if (!urlPartsRequired.has(name) && pathPropertyMap[name].required) {
+          errors.addEndpointError(endpoint.name, 'request', `${endpoint.request.name}: path parameter '${name}' is optional in the json spec`)
+        }
+      }
+
       if (spec.params != null) {
         const params = Object.keys(spec.params)
         const queryProperties = requestProperties.query.map(property => property.name)

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -754,7 +754,6 @@
     },
     "fleet.msearch": {
       "request": [
-        "Request: path parameter 'index' is optional in the json spec",
         "Request: query parameter 'allow_no_indices' does not exist in the json spec",
         "Request: query parameter 'ccs_minimize_roundtrips' does not exist in the json spec",
         "Request: query parameter 'expand_wildcards' does not exist in the json spec",
@@ -1368,7 +1367,6 @@
     },
     "ml.clear_trained_model_deployment_cache": {
       "request": [
-        "Request: path parameter 'model_id' is required in the json spec",
         "Request: should not have a body"
       ],
       "response": []
@@ -1722,12 +1720,6 @@
       "response": [
         "response definition _global.put_script:Response / body / instance_of - Non-leaf type cannot be used here: '_types:AcknowledgedResponseBase'"
       ]
-    },
-    "rank_eval": {
-      "request": [
-        "Request: path parameter 'index' is optional in the json spec"
-      ],
-      "response": []
     },
     "reindex": {
       "request": [

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -754,6 +754,7 @@
     },
     "fleet.msearch": {
       "request": [
+        "Request: path parameter 'index' is optional in the json spec",
         "Request: query parameter 'allow_no_indices' does not exist in the json spec",
         "Request: query parameter 'ccs_minimize_roundtrips' does not exist in the json spec",
         "Request: query parameter 'expand_wildcards' does not exist in the json spec",
@@ -1367,6 +1368,7 @@
     },
     "ml.clear_trained_model_deployment_cache": {
       "request": [
+        "Request: path parameter 'model_id' is required in the json spec",
         "Request: should not have a body"
       ],
       "response": []
@@ -1720,6 +1722,12 @@
       "response": [
         "response definition _global.put_script:Response / body / instance_of - Non-leaf type cannot be used here: '_types:AcknowledgedResponseBase'"
       ]
+    },
+    "rank_eval": {
+      "request": [
+        "Request: path parameter 'index' is optional in the json spec"
+      ],
+      "response": []
     },
     "reindex": {
       "request": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -805,7 +805,7 @@ export interface RankEvalRankEvalRequestItem {
 }
 
 export interface RankEvalRequest extends RequestBase {
-  index: Indices
+  index?: Indices
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
@@ -8924,7 +8924,7 @@ export interface FleetGlobalCheckpointsResponse {
 }
 
 export interface FleetMsearchRequest extends RequestBase {
-  index: IndexName | IndexAlias
+  index?: IndexName | IndexAlias
   allow_no_indices?: boolean
   ccs_minimize_roundtrips?: boolean
   expand_wildcards?: ExpandWildcards
@@ -12764,7 +12764,7 @@ export interface MlZeroShotClassificationInferenceUpdateOptions {
 }
 
 export interface MlClearTrainedModelDeploymentCacheRequest extends RequestBase {
-  model_id?: Id
+  model_id: Id
 }
 
 export interface MlClearTrainedModelDeploymentCacheResponse {

--- a/specification/_global/rank_eval/RankEvalRequest.ts
+++ b/specification/_global/rank_eval/RankEvalRequest.ts
@@ -34,7 +34,7 @@ export interface Request extends RequestBase {
      * Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (`*`) expressions are supported.
      * To target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.
      */
-    index: Indices
+    index?: Indices
   }
   query_parameters: {
     /**

--- a/specification/fleet/msearch/MultiSearchRequest.ts
+++ b/specification/fleet/msearch/MultiSearchRequest.ts
@@ -43,7 +43,7 @@ export interface Request extends RequestBase {
     /**
      * A single target to search. If the target is an index alias, it must resolve to a single index.
      */
-    index: IndexName | IndexAlias
+    index?: IndexName | IndexAlias
   }
   query_parameters: {
     /**

--- a/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheRequest.ts
+++ b/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheRequest.ts
@@ -37,6 +37,6 @@ export interface Request extends RequestBase {
     /**
      * The unique identifier of the trained model.
      */
-    model_id?: Id
+    model_id: Id
   }
 }


### PR DESCRIPTION
Path parameters aren't checked whether they're required or optional compared to the paths provided in the JSON specs. Found this through the newly added API `ml.clear_model_deployment_cache` which mistakenly was added with an optional path parameter `model_id` but the parameter should be marked as required in the spec.