### PR TITLE
[Backport 7.17] Remove local-metadata from PropertyBase

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4742,7 +4742,6 @@ export interface MappingPointProperty extends MappingDocValuesPropertyBase {
 export type MappingProperty = MappingFlattenedProperty | MappingJoinProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingDenseVectorProperty | MappingAggregateMetricDoubleProperty | MappingCoreProperty | MappingDynamicProperty
 
 export interface MappingPropertyBase {
-  local_metadata?: Metadata
   meta?: Record<string, string>
   properties?: Record<PropertyName, MappingProperty>
   ignore_above?: integer

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -41,7 +41,10 @@ import {
 } from './specialized'
 
 export class PropertyBase {
-  local_metadata?: Metadata
+  /**
+   * Metadata about the field.
+   * @doc_id mapping-meta-field
+   */
   meta?: Dictionary<string, string>
   properties?: Dictionary<PropertyName, Property>
   ignore_above?: integer


### PR DESCRIPTION
Backport 0f1a36891730a8a3c68bf88947d590107637fdd8 from #1979