### PR TITLE
Improve route serialization

### DIFF
--- a/compiler/src/dump/extract-routes.ts
+++ b/compiler/src/dump/extract-routes.ts
@@ -126,12 +126,12 @@ function serializeForest (forest: Forest): string {
 
       // Code generated from the elasticsearch-specification DO NOT EDIT.
       var routes = forest{
-        map[byte]trees{
+        map[string]trees{
           `
   output += begin
 
   for (const [version, tree] of forest.byVersion) {
-    output += `\n'${version}': { byMethod: map[string]node{`
+    output += `\n"${version}": { byMethod: map[string]node{`
     output += serializeTree(tree)
     output += '},'
   }

--- a/compiler/src/dump/extract-routes.ts
+++ b/compiler/src/dump/extract-routes.ts
@@ -79,18 +79,18 @@ export class Forest {
 function serializeNode (node: Node): string {
   let output: string = ''
   const template: string = `{
-    Name: "${node.name}",
-    Path: []byte("${node.path}"),
+    name: "${node.name}",
+    path: []byte("${node.path}"),
     `
 
   output += template
   if (node.children.length > 0) {
     for (const child of node.children) {
       if (child.isVariable) {
-        output += `Variable: &node${serializeNode(child)}`
+        output += `variable: &node${serializeNode(child)}`
       }
     }
-    output += `Children: []node{
+    output += `children: []node{
         `
     for (const child of node.children) {
       if (!child.isVariable) {
@@ -130,7 +130,7 @@ function serializeForest (forest: Forest): string {
   output += begin
 
   for (const [version, tree] of forest.byVersion) {
-    output += `\n'${version}': { ByMethod: map[string]node{`
+    output += `\n'${version}': { byMethod: map[string]node{`
     output += serializeTree(tree)
     output += '},'
   }

--- a/compiler/src/dump/extract-routes.ts
+++ b/compiler/src/dump/extract-routes.ts
@@ -124,6 +124,7 @@ function serializeForest (forest: Forest): string {
   let output: string = ''
   const begin: string = `package esroutes
 
+      // Code generated from the elasticsearch-specification DO NOT EDIT.
       var routes = forest{
         map[byte]trees{
           `


### PR DESCRIPTION
Follow up to https://github.com/elastic/elasticsearch-specification/pull/1992

This changes:
* Uses string for version in serialization.
* Unexports the field of the Go structures in serialization.
* Add the generated code disclaimer.
