### PR TITLE
Change StorageType to an open enumeration

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9705,7 +9705,7 @@ export interface IndicesStorage {
   allow_mmap?: boolean
 }
 
-export type IndicesStorageType = 'fs' | '' | 'niofs' | 'mmapfs' | 'hybridfs'
+export type IndicesStorageType = 'fs' | '' | 'niofs' | 'mmapfs' | 'hybridfs'| string
 
 export interface IndicesTemplateMapping {
   aliases: Record<IndexName, IndicesAlias>

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -505,6 +505,9 @@ export class Storage {
   allow_mmap?: boolean
 }
 
+/**
+ * @non_exhaustive
+ */
 export enum StorageType {
   /**
    * Default file system implementation. This will pick the best implementation depending on the operating environment, which


### PR DESCRIPTION
The `StorageType` enumeration is non exhaustive: some plugins may add additional storage types, and snapshot/frozen repositories, although they cannot be created directly, are identified with a storage type `snapshot`.

Reported in https://github.com/elastic/elasticsearch-java/issues/458