### PR TITLE
Add missing property for MultiTerms aggregation

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3420,6 +3420,7 @@ export interface AggregationsMultiBucketBase {
 
 export interface AggregationsMultiTermLookup {
   field: Field
+  missing?: AggregationsMissing
 }
 
 export interface AggregationsMultiTermsAggregate extends AggregationsTermsAggregateBase<AggregationsMultiTermsBucket> {

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -275,6 +275,7 @@ export class MultiTermsAggregation extends BucketAggregationBase {
 
 export class MultiTermLookup {
   field: Field
+  missing?: Missing
 }
 
 export class NestedAggregation extends BucketAggregationBase {


### PR DESCRIPTION
Adds a missing property for `MultiTermLookup` to support providing a missing value per [the documentation](https://www.elastic.co/guide/en/elasticsearch/reference/8.5/search-aggregations-bucket-multi-terms-aggregation.html#_missing_value_3).

Raised in https://github.com/elastic/elasticsearch-net/issues/7119