### PR TITLE
[Backport 7.17] Add missing property for MultiTerms aggregation

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3287,6 +3287,7 @@ export interface AggregationsMultiBucketBase {
 
 export interface AggregationsMultiTermLookup {
   field: Field
+  missing?: AggregationsMissing
 }
 
 export interface AggregationsMultiTermsAggregate extends AggregationsTermsAggregateBase<AggregationsMultiTermsBucket> {

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -246,6 +246,7 @@ export class MultiTermsAggregation extends BucketAggregationBase {
 
 export class MultiTermLookup {
   field: Field
+  missing?: Missing
 }
 
 export class NestedAggregation extends BucketAggregationBase {


### PR DESCRIPTION
Backport 9cc32aeefffbcf62c5d7b1e94110c759caac5bb8 from #2000
