### PR TITLE
Remove non-existent JSON specs when updating from artifacts API

### DIFF
--- a/.github/download-artifacts/index.js
+++ b/.github/download-artifacts/index.js
@@ -29,7 +29,7 @@ const rimraf = require('rimraf')
 const fetch = require('node-fetch')
 const crossZip = require('cross-zip')
 
-const { mkdir, rename, readdir } = promises
+const { mkdir, rename, readdir, unlink } = promises
 const pipeline = promisify(stream.pipeline)
 const unzip = promisify(crossZip.unzip)
 const rm = promisify(rimraf)
@@ -83,6 +83,14 @@ async function downloadArtifacts (opts) {
   for (const file of files) {
     if (file === '_common.json') continue
     await rename(join(downloadedSpec, file), join(specFolder, file))
+  }
+
+  /** Delete files that weren't in the zip file */
+  const specFiles = await readdir(specFolder)
+  for (const file of specFiles) {
+    if (!files.includes(file)) {
+      await unlink(join(specFolder, file))
+    }
   }
 
   core.info('Done')

--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        branch: ['main', '8.4', '8.5', '7.17']
+        branch: ['main', '8.6', '8.5', '7.17']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Currently if a JSON spec is deleted upstream (like was done to `semantic_search.json` for 8.6) then the `download-artifacts.js` script doesn't detect and delete the file. This amends that missing behavior.