### PR TITLE
Adding `job_type` as an argument to the `put_job` request specification

### DIFF
--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -86,6 +86,10 @@ export interface Request extends RequestBase {
      */
     groups?: string[]
     /**
+     * Type of job. Eg: anomaly_detector
+     */
+    job_type?: string
+    /**
      * This advanced configuration option stores model information along with the results. It provides a more detailed view into anomaly detection. If you enable model plot it can add considerable overhead to the performance of the system; it is not feasible for jobs with many entities. Model plot provides a simplified and indicative view of the model and its bounds. It does not display complex features such as multivariate correlations or multimodal data. As such, anomalies may occasionally be reported which cannot be seen in the model plot. Model plot config can be configured when the job is created or updated later. It must be disabled if performance issues are experienced.
      */
     model_plot_config?: ModelPlotConfig


### PR DESCRIPTION
## What this PR does
Adds `job_type` as an argument to the `put_job` request specification.

## Problem Description
I ran into the following error while trying to create [this](https://github.com/elastic/kibana/blob/main/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_rare_sudo_user.json) Anomaly Detection job in a cluster using the Python Elasticsearch client as follows:

```
es.ml.put_job(**job_body)
```
where `job_body` corresponds to the job configuration taken as is from the Kibana repo.

```
Traceback (most recent call last):
  File "/Users/apoorvajoshi/Documents/security-ml/projects/anomaly_data_generation/main.py", line 82, in <module>
    create_ad_artifacts(es, job_id, es_url, es_username, es_password)
  File "/Users/apoorvajoshi/Documents/security-ml/projects/anomaly_data_generation/utils/es_utils.py", line 142, in create_ad_artifacts
    create_job(es, job_id, df_id, job_body)
  File "/Users/apoorvajoshi/Documents/security-ml/projects/anomaly_data_generation/utils/es_utils.py", line 89, in create_job
    es.ml.put_job(**job_body)
  File "/Users/apoorvajoshi/.pyenv/versions/3.9.0/lib/python3.9/site-packages/elasticsearch/_sync/client/utils.py", line 414, in wrapped
    return api(*args, **kwargs)
TypeError: put_job() got an unexpected keyword argument 'job_type'
```