### PR TITLE
Update API spec from results of the Java flight records loader

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1438,7 +1438,6 @@
     },
     "ml.delete_job": {
       "request": [
-        "Request: missing json spec query parameter 'delete_user_annotations'",
         "Request: should not have a body"
       ],
       "response": [
@@ -1560,13 +1559,6 @@
       ],
       "response": []
     },
-    "ml.preview_datafeed": {
-      "request": [
-        "Request: missing json spec query parameter 'start'",
-        "Request: missing json spec query parameter 'end'"
-      ],
-      "response": []
-    },
     "ml.put_calendar_job": {
       "request": [
         "Request: should not have a body"
@@ -1604,7 +1596,6 @@
     },
     "ml.reset_job": {
       "request": [
-        "Request: missing json spec query parameter 'delete_user_annotations'",
         "Request: should not have a body"
       ],
       "response": [
@@ -1621,7 +1612,6 @@
     },
     "ml.start_trained_model_deployment": {
       "request": [
-        "Request: missing json spec query parameter 'priority'",
         "Request: should not have a body"
       ],
       "response": []
@@ -1803,8 +1793,8 @@
     },
     "search_mvt": {
       "request": [
-        "Request: missing json spec query parameter 'track_total_hits'",
-        "Request: missing json spec query parameter 'with_labels'"
+        "Request: query parameter 'grid_agg' does not exist in the json spec",
+        "Request: missing json spec query parameter 'track_total_hits'"
       ],
       "response": [
         "type_alias definition _types:MapboxVectorTiles / instance_of - No type definition for '_builtins:binary'"
@@ -2302,7 +2292,6 @@
     },
     "transform.get_transform_stats": {
       "request": [
-        "Request: missing json spec query parameter 'timeout'",
         "Request: should not have a body"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1082,8 +1082,23 @@ export interface SearchResponseBody<TDocument = unknown> {
   terminated_early?: boolean
 }
 
+export interface SearchAggregationBreakdown {
+  build_aggregation: long
+  build_aggregation_count: long
+  build_leaf_collector: long
+  build_leaf_collector_count: long
+  collect: long
+  collect_count: long
+  initialize: long
+  initialize_count: long
+  post_collection?: long
+  post_collection_count?: long
+  reduce: long
+  reduce_count: long
+}
+
 export interface SearchAggregationProfile {
-  breakdown: Record<string, long>
+  breakdown: SearchAggregationBreakdown
   description: string
   time_in_nanos: DurationValue<UnitNanos>
   type: string
@@ -1173,17 +1188,6 @@ export interface SearchCompletionSuggester extends SearchSuggesterBase {
 
 export type SearchContext = string | GeoLocation
 
-export interface SearchDfsProfile {
-  statistics: SearchDfsStatistics
-}
-
-export interface SearchDfsStatistics {
-  breakdown: Record<string, long>
-  description: string
-  time_in_nanos: DurationValue<UnitNanos>
-  type: string
-}
-
 export interface SearchDirectGenerator {
   field: Field
   max_edits?: integer
@@ -1202,9 +1206,20 @@ export interface SearchFetchProfile {
   type: string
   description: string
   time_in_nanos: DurationValue<UnitNanos>
-  breakdown: Record<string, long>
+  breakdown: SearchFetchProfileBreakdown
   debug?: SearchFetchProfileDebug
   children?: SearchFetchProfile[]
+}
+
+export interface SearchFetchProfileBreakdown {
+  load_source?: integer
+  load_source_count?: integer
+  load_stored_fields?: integer
+  load_stored_fields_count?: integer
+  next_reader?: integer
+  next_reader_count?: integer
+  process_count?: integer
+  process?: integer
 }
 
 export interface SearchFetchProfileDebug {
@@ -1392,8 +1407,29 @@ export interface SearchProfile {
   shards: SearchShardProfile[]
 }
 
+export interface SearchQueryBreakdown {
+  advance: long
+  advance_count: long
+  build_scorer: long
+  build_scorer_count: long
+  create_weight: long
+  create_weight_count: long
+  match: long
+  match_count: long
+  shallow_advance: long
+  shallow_advance_count: long
+  next_doc: long
+  next_doc_count: long
+  score: long
+  score_count: long
+  compute_max_score: long
+  compute_max_score_count: long
+  set_min_competitive_score: long
+  set_min_competitive_score_count: long
+}
+
 export interface SearchQueryProfile {
-  breakdown: Record<string, long>
+  breakdown: SearchQueryBreakdown
   description: string
   time_in_nanos: DurationValue<UnitNanos>
   type: string
@@ -1425,7 +1461,6 @@ export interface SearchShardProfile {
   id: string
   searches: SearchSearchProfile[]
   fetch?: SearchFetchProfile
-  dfs?: SearchDfsProfile
 }
 
 export interface SearchSmoothingModelContainer {

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -151,7 +151,7 @@ export interface Request extends RequestBase {
      * Defines the approximate kNN search to run.
      * @since 8.4.0
      */
-    knn?: KnnQuery
+    knn?: KnnQuery | KnnQuery[]
     /**
      * Minimum _score for matching documents. Documents with a lower _score are
      * not included in the search results.

--- a/specification/_global/search/_types/profile.ts
+++ b/specification/_global/search/_types/profile.ts
@@ -19,7 +19,21 @@
 
 import { integer, long } from '@_types/Numeric'
 import { DurationValue, UnitNanos } from '@_types/Time'
-import { Dictionary } from '@spec_utils/Dictionary'
+
+export class AggregationBreakdown {
+  build_aggregation: long
+  build_aggregation_count: long
+  build_leaf_collector: long
+  build_leaf_collector_count: long
+  collect: long
+  collect_count: long
+  initialize: long
+  initialize_count: long
+  post_collection?: long
+  post_collection_count?: long
+  reduce: long
+  reduce_count: long
+}
 
 // This is a Map<String, Object> in ES. Below are the known fields.
 export class AggregationProfileDebug {
@@ -61,7 +75,7 @@ export class AggregationProfileDelegateDebugFilter {
 }
 
 export class AggregationProfile {
-  breakdown: Dictionary<string, long>
+  breakdown: AggregationBreakdown
   description: string
   time_in_nanos: DurationValue<UnitNanos>
   type: string
@@ -80,8 +94,29 @@ export class Profile {
   shards: ShardProfile[]
 }
 
+export class QueryBreakdown {
+  advance: long
+  advance_count: long
+  build_scorer: long
+  build_scorer_count: long
+  create_weight: long
+  create_weight_count: long
+  match: long
+  match_count: long
+  shallow_advance: long
+  shallow_advance_count: long
+  next_doc: long
+  next_doc_count: long
+  score: long
+  score_count: long
+  compute_max_score: long
+  compute_max_score_count: long
+  set_min_competitive_score: long
+  set_min_competitive_score_count: long
+}
+
 export class QueryProfile {
-  breakdown: Dictionary<string, long>
+  breakdown: QueryBreakdown
   description: string
   time_in_nanos: DurationValue<UnitNanos>
   type: string
@@ -99,27 +134,26 @@ export class ShardProfile {
   id: string
   searches: SearchProfile[]
   fetch?: FetchProfile
-  dfs?: DfsProfile
-}
-
-export class DfsProfile {
-  statistics: DfsStatistics
-}
-
-export class DfsStatistics {
-  breakdown: Dictionary<string, long>
-  description: string
-  time_in_nanos: DurationValue<UnitNanos>
-  type: string
 }
 
 export class FetchProfile {
   type: string
   description: string
   time_in_nanos: DurationValue<UnitNanos>
-  breakdown: Dictionary<string, long>
+  breakdown: FetchProfileBreakdown
   debug?: FetchProfileDebug
   children?: FetchProfile[]
+}
+
+export class FetchProfileBreakdown {
+  load_source?: integer
+  load_source_count?: integer
+  load_stored_fields?: integer
+  load_stored_fields_count?: integer
+  next_reader?: integer
+  next_reader_count?: integer
+  process_count?: integer
+  process?: integer
 }
 
 export class FetchProfileDebug {

--- a/specification/_global/search/_types/profile.ts
+++ b/specification/_global/search/_types/profile.ts
@@ -19,21 +19,7 @@
 
 import { integer, long } from '@_types/Numeric'
 import { DurationValue, UnitNanos } from '@_types/Time'
-
-export class AggregationBreakdown {
-  build_aggregation: long
-  build_aggregation_count: long
-  build_leaf_collector: long
-  build_leaf_collector_count: long
-  collect: long
-  collect_count: long
-  initialize: long
-  initialize_count: long
-  post_collection?: long
-  post_collection_count?: long
-  reduce: long
-  reduce_count: long
-}
+import { Dictionary } from '@spec_utils/Dictionary'
 
 // This is a Map<String, Object> in ES. Below are the known fields.
 export class AggregationProfileDebug {
@@ -75,7 +61,7 @@ export class AggregationProfileDelegateDebugFilter {
 }
 
 export class AggregationProfile {
-  breakdown: AggregationBreakdown
+  breakdown: Dictionary<string, long>
   description: string
   time_in_nanos: DurationValue<UnitNanos>
   type: string
@@ -94,29 +80,8 @@ export class Profile {
   shards: ShardProfile[]
 }
 
-export class QueryBreakdown {
-  advance: long
-  advance_count: long
-  build_scorer: long
-  build_scorer_count: long
-  create_weight: long
-  create_weight_count: long
-  match: long
-  match_count: long
-  shallow_advance: long
-  shallow_advance_count: long
-  next_doc: long
-  next_doc_count: long
-  score: long
-  score_count: long
-  compute_max_score: long
-  compute_max_score_count: long
-  set_min_competitive_score: long
-  set_min_competitive_score_count: long
-}
-
 export class QueryProfile {
-  breakdown: QueryBreakdown
+  breakdown: Dictionary<string, long>
   description: string
   time_in_nanos: DurationValue<UnitNanos>
   type: string
@@ -134,26 +99,27 @@ export class ShardProfile {
   id: string
   searches: SearchProfile[]
   fetch?: FetchProfile
+  dfs?: DfsProfile
+}
+
+export class DfsProfile {
+  statistics: DfsStatistics
+}
+
+export class DfsStatistics {
+  breakdown: Dictionary<string, long>
+  description: string
+  time_in_nanos: DurationValue<UnitNanos>
+  type: string
 }
 
 export class FetchProfile {
   type: string
   description: string
   time_in_nanos: DurationValue<UnitNanos>
-  breakdown: FetchProfileBreakdown
+  breakdown: Dictionary<string, long>
   debug?: FetchProfileDebug
   children?: FetchProfile[]
-}
-
-export class FetchProfileBreakdown {
-  load_source?: integer
-  load_source_count?: integer
-  load_stored_fields?: integer
-  load_stored_fields_count?: integer
-  next_reader?: integer
-  next_reader_count?: integer
-  process_count?: integer
-  process?: integer
 }
 
 export class FetchProfileDebug {

--- a/specification/_global/search_mvt/SearchMvtRequest.ts
+++ b/specification/_global/search_mvt/SearchMvtRequest.ts
@@ -21,7 +21,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { RequestBase } from '@_types/Base'
 import { Field, Fields, Indices } from '@_types/common'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
-import { GridType } from './_types/GridType'
+import { GridAggregationType, GridType } from './_types/GridType'
 import { Coordinate } from './_types/Coordinate'
 import { Sort } from '@_types/sort'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
@@ -64,6 +64,10 @@ export interface Request extends RequestBase {
      */
     extent?: integer
     /**
+     * Aggregation used to create a grid for `field`.
+     */
+    grid_agg?: GridAggregationType
+    /**
      * Additional zoom levels available through the aggs layer. For example, if <zoom> is 7
      * and grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results
      * don’t include the aggs layer.
@@ -84,6 +88,11 @@ export interface Request extends RequestBase {
      * @server_default 10000
      */
     size?: integer
+    /**
+     * If `true`, the hits and aggs layers will contain additional point features representing
+     * suggested label positions for the original features.
+     */
+    with_labels?: boolean
   }
   body: {
     /**
@@ -97,6 +106,12 @@ export interface Request extends RequestBase {
      * - sum
      */
     aggs?: Dictionary<string, AggregationContainer>
+    /**
+     * Size, in pixels, of a clipping buffer outside the tile. This allows renderers
+     * to avoid outline artifacts from geometries that extend past the extent of the tile.
+     * @server_default 5
+     */
+    buffer?: integer
     /**
      * If false, the meta layer’s feature is the bounding box of the tile.
      * If true, the meta layer’s feature is a bounding box resulting from a
@@ -117,6 +132,10 @@ export interface Request extends RequestBase {
      * values may return inconsistent results.
      */
     fields?: Fields
+    /**
+     * Aggregation used to create a grid for the `field`.
+     */
+    grid_agg?: GridAggregationType
     /**
      * Additional zoom levels available through the aggs layer. For example, if <zoom> is 7
      * and grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results
@@ -160,5 +179,10 @@ export interface Request extends RequestBase {
      * @server_default 10000
      */
     track_total_hits?: TrackHits
+    /**
+     * If `true`, the hits and aggs layers will contain additional point features representing
+     * suggested label positions for the original features.
+     */
+    with_labels?: boolean
   }
 }

--- a/specification/_global/search_mvt/_types/GridType.ts
+++ b/specification/_global/search_mvt/_types/GridType.ts
@@ -23,3 +23,8 @@ export enum GridType {
   /** @since 7.16.0 */
   centroid
 }
+
+export enum GridAggregationType {
+  geotile,
+  geohex
+}

--- a/specification/_types/Node.ts
+++ b/specification/_types/Node.ts
@@ -53,7 +53,7 @@ export class NodeAttributes {
   /**
    * @since 8.3.0
    */
-  external_id: string
+  external_id?: string
 }
 
 export class NodeShard {
@@ -66,6 +66,11 @@ export class NodeShard {
   recovery_source?: Dictionary<string, Id>
   unassigned_info?: UnassignedInformation
   relocating_node?: NodeId | null
+  relocation_failure_info?: RelocationFailureInfo
+}
+
+export class RelocationFailureInfo {
+  failed_attempts: integer
 }
 
 /**

--- a/specification/_types/Stats.ts
+++ b/specification/_types/Stats.ts
@@ -21,7 +21,7 @@ import { ShardFileSizeInfo } from '@indices/stats/types'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { ByteSize, Field, Name, VersionString } from './common'
 import { ErrorCause, ShardFailure } from './Errors'
-import { integer, long, uint } from './Numeric'
+import { double, integer, long, uint } from './Numeric'
 import { Duration, DurationValue, UnitMillis } from '@_types/Time'
 
 export class ClusterStatistics {
@@ -113,6 +113,7 @@ export class IndexingStats {
   index_total: long
   index_failed: long
   types?: Dictionary<string, IndexingStats>
+  write_load?: double
 }
 
 export class MergesStats {
@@ -144,7 +145,6 @@ export class PluginStats {
   name: Name
   version: VersionString
   licensed: boolean
-  type: string
 }
 
 export class QueryCacheStats {

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -748,7 +748,7 @@ export class CumulativeCardinalityAggregate extends AggregateBase {
 /** @variant name=matrix_stats */
 export class MatrixStatsAggregate extends AggregateBase {
   doc_count: long
-  fields: MatrixStatsFields[]
+  fields?: MatrixStatsFields[]
 }
 
 export class MatrixStatsFields {

--- a/specification/_types/mapping/RuntimeFields.ts
+++ b/specification/_types/mapping/RuntimeFields.ts
@@ -18,15 +18,29 @@
  */
 
 import { Dictionary } from '@spec_utils/Dictionary'
-import { Field } from '@_types/common'
+import { Field, IndexName } from '@_types/common'
 import { Script } from '@_types/Scripting'
 
 export type RuntimeFields = Dictionary<Field, RuntimeField>
 
 export class RuntimeField {
+  /** For type `lookup` */
+  fetch_fields?: RuntimeFieldFetchFields[]
   format?: string
+  /** For type `lookup` */
+  input_field?: Field
+  /** For type `lookup` */
+  target_field?: Field
+  /** For type `lookup` */
+  target_index?: IndexName
   script?: Script
   type: RuntimeFieldType
+}
+
+/** @shortcut_property field */
+export class RuntimeFieldFetchFields {
+  field: Field
+  format?: string
 }
 
 export enum RuntimeFieldType {
@@ -36,5 +50,6 @@ export enum RuntimeFieldType {
   geo_point = 3,
   ip = 4,
   keyword = 5,
-  long = 6
+  long = 6,
+  lookup
 }

--- a/specification/cat/_types/CatBase.ts
+++ b/specification/cat/_types/CatBase.ts
@@ -572,7 +572,7 @@ export enum CatTrainedModelsColumn {
   /**
    * Identifier for the data frame analytics job that created the model. Only
    * displayed if it is still available.
-   * @aliases df, dataFrameAnalytics
+   * @aliases df, dataFrameAnalytics, dfid
    */
   data_frame_analytics_id,
   /**
@@ -586,7 +586,7 @@ export enum CatTrainedModelsColumn {
    */
   heap_size,
   /**
-   * Idetifier for the trained model.
+   * Identifier for the trained model.
    */
   id,
   /**

--- a/specification/cluster/reroute/ClusterRerouteResponse.ts
+++ b/specification/cluster/reroute/ClusterRerouteResponse.ts
@@ -29,6 +29,6 @@ export class Response {
      * Here you will find the internal representation of the cluster, which can
      * differ from the external representation.
      */
-    state: UserDefinedValue
+    state?: UserDefinedValue
   }
 }

--- a/specification/cluster/stats/types.ts
+++ b/specification/cluster/stats/types.ts
@@ -18,7 +18,7 @@
  */
 
 import { Dictionary } from '@spec_utils/Dictionary'
-import { Name, VersionString } from '@_types/common'
+import { ByteSize, Name, VersionString } from '@_types/common'
 import { double, integer, long } from '@_types/Numeric'
 import {
   CompletionStats,
@@ -96,12 +96,19 @@ export class ClusterIndices {
 export class FieldTypesMappings {
   field_types: FieldTypes[]
   runtime_field_types?: RuntimeFieldTypes[]
+  total_field_count?: integer
+  total_deduplicated_field_count?: integer
+  total_deduplicated_mapping_size?: ByteSize
+  total_deduplicated_mapping_size_in_bytes?: long
 }
 
 export class FieldTypes {
   name: Name
   count: integer
   index_count: integer
+  indexed_vector_count?: long
+  indexed_vector_dim_max?: long
+  indexed_vector_dim_min?: long
   /** @since 7.13.0 */
   script_count?: integer
 }

--- a/specification/indices/rollover/types.ts
+++ b/specification/indices/rollover/types.ts
@@ -28,10 +28,13 @@ export class RolloverConditions {
   min_docs?: long
   max_docs?: long
   max_size?: ByteSize
+  max_size_bytes?: long
   min_size?: ByteSize
-  max_size_bytes?: ByteSize
+  min_size_bytes?: long
   max_primary_shard_size?: ByteSize
+  max_primary_shard_size_bytes?: long
   min_primary_shard_size?: ByteSize
+  min_primary_shard_size_bytes?: long
   max_primary_shard_docs?: long
   min_primary_shard_docs?: long
 }

--- a/specification/indices/segments/types.ts
+++ b/specification/indices/segments/types.ts
@@ -31,7 +31,6 @@ export class Segment {
   compound: boolean
   deleted_docs: long
   generation: integer
-  memory_in_bytes: double
   search: boolean
   size_in_bytes: double
   num_docs: long

--- a/specification/indices/shard_stores/types.ts
+++ b/specification/indices/shard_stores/types.ts
@@ -19,21 +19,26 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { Id, VersionNumber, Name } from '@_types/common'
+import { Id, VersionNumber, Name, NodeId } from '@_types/common'
 import { TransportAddress } from '@_types/Networking'
+import { AdditionalProperty } from '@spec_utils/behaviors'
 
 export class IndicesShardStores {
   shards: Dictionary<string, ShardStoreWrapper>
 }
 
-export class ShardStore {
+export class ShardStore implements AdditionalProperty<NodeId, ShardStoreNode> {
   allocation: ShardStoreAllocation
-  allocation_id: Id
-  attributes: Dictionary<string, UserDefinedValue>
-  id: Id
-  legacy_version: VersionNumber
+  allocation_id?: Id
+  store_exception?: ShardStoreException
+}
+
+export class ShardStoreNode {
+  attributes: Dictionary<string, string>
+  ephemeral_id?: string
+  external_id?: string
   name: Name
-  store_exception: ShardStoreException
+  roles: string[]
   transport_address: TransportAddress
 }
 

--- a/specification/indices/stats/types.ts
+++ b/specification/indices/stats/types.ts
@@ -23,7 +23,9 @@ import {
   Id,
   SequenceNumber,
   VersionNumber,
-  HealthStatus
+  HealthStatus,
+  IndexName,
+  ByteSize
 } from '@_types/common'
 import { integer, long } from '@_types/Numeric'
 import {
@@ -45,6 +47,7 @@ import {
   TranslogStats,
   WarmerStats
 } from '@_types/Stats'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class IndexStats {
   /** Contains statistics about completions across all shards assigned to the node. */
@@ -171,6 +174,12 @@ export class ShardsTotalStats {
   total_count: long
 }
 
+export class MappingStats {
+  total_count: long
+  total_estimated_overhead?: ByteSize
+  total_estimated_overhead_in_bytes: long
+}
+
 export class ShardStats {
   commit?: ShardCommit
   completion?: CompletionStats
@@ -179,6 +188,7 @@ export class ShardStats {
   flush?: FlushStats
   get?: GetStats
   indexing?: IndexingStats
+  mappings?: MappingStats
   merges?: MergesStats
   shard_path?: ShardPath
   query_cache?: ShardQueryCache
@@ -195,7 +205,7 @@ export class ShardStats {
   warmer?: WarmerStats
   bulk?: BulkStats
   /** @since 7.15.0 */
-  shards?: ShardsTotalStats
+  shards?: Dictionary<IndexName, UserDefinedValue>
   shard_stats?: ShardsTotalStats
   indices?: IndicesStats
 }

--- a/specification/ml/_types/Analysis.ts
+++ b/specification/ml/_types/Analysis.ts
@@ -30,9 +30,9 @@ export class AnalysisConfig {
   /**
    *  The size of the interval that the analysis is aggregated into, typically between `5m` and `1h`. This value should be either a whole number of days or equate to a
 whole number of buckets in one day. If the anomaly detection job uses a datafeed with aggregations, this value must also be divisible by the interval of the date histogram aggregation.
-   * * @server_default 5m
+   * @server_default 5m
    */
-  bucket_span: Duration
+  bucket_span?: Duration
   /**
    * If `categorization_field_name` is specified, you can also define the analyzer that is used to interpret the categorization field. This property cannot be used at the same time as `categorization_filters`. The categorization analyzer specifies how the `categorization_field` is interpreted by the categorization process. The `categorization_analyzer` field can be specified either as a string or as an object. If it is a string, it must refer to a built-in analyzer or one added by another plugin.
    */

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -79,11 +79,11 @@ export class DatafeedConfig {
    * The interval at which scheduled queries are made while the datafeed runs in real time. The default value is either the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket span. For example: `150s`. When `frequency` is shorter than the bucket span, interim results for the last (partial) bucket are written then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value must be divisible by the interval of the date histogram aggregation.
    */
   frequency?: Duration
-  indexes?: string[]
   /**
    * An array of index names. Wildcards are supported. If any indices are in remote clusters, the machine learning nodes must have the `remote_cluster_client` role.
+   * @aliases indexes
    */
-  indices: string[]
+  indices?: string[]
   /**
    * Specifies index expansion options that are used during search.
    */
@@ -96,7 +96,7 @@ export class DatafeedConfig {
   /**
    * The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch.
    */
-  query: QueryContainer
+  query?: QueryContainer
   /**
    * The number of seconds behind real time that data is queried. For example, if data from 10:04 a.m. might not be searchable in Elasticsearch until 10:06 a.m., set this property to 120 seconds. The default value is randomly selected between `60s` and `120s`. This randomness improves the query performance when there are multiple jobs running on the same node.
    */

--- a/specification/ml/_types/Detector.ts
+++ b/specification/ml/_types/Detector.ts
@@ -50,7 +50,7 @@ export class Detector {
   /**
    * The analysis function that is used. For example, `count`, `rare`, `mean`, `min`, `max`, or `sum`.
    */
-  function: string
+  function?: string
   /**
    * The field used to split the data. In particular, this property is used for analyzing the splits with respect to the history of all splits. It is used for finding unusual values in the population of all splits.
    */

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -62,6 +62,7 @@ export class TrainedModelStats {
 export class TrainedModelDeploymentStats {
   /** The detailed allocation status for the deployment. */
   allocation_status: TrainedModelDeploymentAllocationStatus
+  cache_size?: ByteSize
   /** The sum of `error_count` for all nodes in the deployment. */
   error_count: integer
   /** The sum of `inference_count` for all nodes in the deployment. */
@@ -296,6 +297,11 @@ export enum DeploymentAssignmentState {
   failed
 }
 
+export enum TrainingPriority {
+  normal,
+  low
+}
+
 export class TrainedModelAssignmentTaskParameters {
   /**
    * The size of the trained model in bytes.
@@ -314,6 +320,8 @@ export class TrainedModelAssignmentTaskParameters {
    * The total number of allocations this model is assigned across ML nodes.
    */
   number_of_allocations: integer
+  priority: TrainingPriority
+
   /**
    * Number of inference requests are allowed in the queue at a time.
    */
@@ -381,6 +389,7 @@ export class TrainedModelAssignment {
    * The overall assignment state.
    */
   assignment_state: DeploymentAssignmentState
+  max_assigned_allocations?: integer
   /**
    * The allocation state for each node.
    */

--- a/specification/ml/_types/inference.ts
+++ b/specification/ml/_types/inference.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Field } from '@_types/common'
+import { Field, IndexName } from '@_types/common'
 import { double, integer } from '@_types/Numeric'
 
 /**
@@ -212,6 +212,11 @@ export class PassThroughInferenceOptions {
   tokenization?: TokenizationConfigContainer
   /** The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value. */
   results_field?: string
+  vocabulary?: Vocabulary
+}
+
+export class Vocabulary {
+  index: IndexName
 }
 
 /** Text embedding inference options */
@@ -230,6 +235,7 @@ export class NerInferenceOptions {
   results_field?: string
   /** The token classification labels. Must be IOB formatted tags */
   classification_labels?: string[]
+  vocabulary?: Vocabulary
 }
 
 /** Fill mask inference options */

--- a/specification/ml/delete_job/MlDeleteJobRequest.ts
+++ b/specification/ml/delete_job/MlDeleteJobRequest.ts
@@ -48,6 +48,13 @@ export interface Request extends RequestBase {
      */
     force?: boolean
     /**
+     * Specifies whether annotations that have been added by the
+     * user should be deleted along with any auto-generated annotations when the job is
+     * reset.
+     * @server_default false
+     */
+    delete_user_annotations?: boolean
+    /**
      * Specifies whether the request should return immediately or wait until the
      * job deletion completes.
      * @server_default true

--- a/specification/ml/open_job/MlOpenJobResponse.ts
+++ b/specification/ml/open_job/MlOpenJobResponse.ts
@@ -17,6 +17,11 @@
  * under the License.
  */
 
+import { NodeId } from '@_types/common'
+
 export class Response {
-  body: { opened: boolean }
+  body: {
+    opened: boolean
+    node: NodeId
+  }
 }

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 import { DatafeedConfig } from '@ml/_types/Datafeed'
 import { JobConfig } from '@ml/_types/Job'
+import { DateTime } from '@_types/Time'
 
 /**
  * Previews a datafeed.
@@ -47,6 +48,10 @@ export interface Request extends RequestBase {
      * configuration details in the request body.
      */
     datafeed_id?: Id
+  }
+  query_parameters: {
+    start?: DateTime
+    end?: DateTime
   }
   body: {
     /**

--- a/specification/ml/put_datafeed/MlPutDatafeedResponse.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedResponse.ts
@@ -30,16 +30,16 @@ import { Duration } from '@_types/Time'
 
 export class Response {
   body: {
-    aggregations: Dictionary<string, AggregationContainer>
+    aggregations?: Dictionary<string, AggregationContainer>
     authorization?: DatafeedAuthorization
     chunking_config: ChunkingConfig
     delayed_data_check_config?: DelayedDataCheckConfig
     datafeed_id: Id
-    frequency: Duration
+    frequency?: Duration
     indices: string[]
     job_id: Id
     indices_options?: IndicesOptions
-    max_empty_searches: integer
+    max_empty_searches?: integer
     query: QueryContainer
     query_delay: Duration
     runtime_mappings?: RuntimeFields

--- a/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
@@ -70,7 +70,7 @@ export interface Request extends RequestBase {
     /**
      * The input field names for the model definition.
      */
-    input: Input
+    input?: Input
     /**
      * An object map that contains metadata about the model.
      */

--- a/specification/ml/reset_job/MlResetJobRequest.ts
+++ b/specification/ml/reset_job/MlResetJobRequest.ts
@@ -45,5 +45,13 @@ export interface Request extends RequestBase {
      * @server_default true
      */
     wait_for_completion?: boolean
+
+    /**
+     * Specifies whether annotations that have been added by the
+     * user should be deleted along with any auto-generated annotations when the job is
+     * reset.
+     * @server_default false
+     */
+    delete_user_annotations?: boolean
   }
 }

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
@@ -21,7 +21,10 @@ import { RequestBase } from '@_types/Base'
 import { ByteSize, Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
-import { DeploymentAllocationState } from '../_types/TrainedModel'
+import {
+  DeploymentAllocationState,
+  TrainingPriority
+} from '../_types/TrainedModel'
 
 /**
  * Starts a trained model deployment, which allocates the model to every machine learning node.
@@ -54,6 +57,7 @@ export interface Request extends RequestBase {
      * @server_default 1
      */
     number_of_allocations?: integer
+    priority?: TrainingPriority
     /**
      * Specifies the number of inference requests that are allowed in the queue. After the number of requests exceeds
      * this value, new requests are rejected with a 429 error.

--- a/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
@@ -117,6 +117,7 @@ export interface Request extends RequestBase {
      * Specifies index expansion options that are used during search.
      */
     indices_options?: IndicesOptions
+    job_id?: Id
     /**
      * If a real-time datafeed has never seen any data (including during any initial training period), it automatically
      * stops and closes the associated job after this many real-time searches return no documents. In other words,

--- a/specification/ml/update_datafeed/MlUpdateDatafeedResponse.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedResponse.ts
@@ -31,15 +31,15 @@ import { Duration } from '@_types/Time'
 export class Response {
   body: {
     authorization?: DatafeedAuthorization
-    aggregations: Dictionary<string, AggregationContainer>
+    aggregations?: Dictionary<string, AggregationContainer>
     chunking_config: ChunkingConfig
     delayed_data_check_config?: DelayedDataCheckConfig
     datafeed_id: Id
-    frequency: Duration
+    frequency?: Duration
     indices: string[]
     indices_options?: IndicesOptions
     job_id: Id
-    max_empty_searches: integer
+    max_empty_searches?: integer
     query: QueryContainer
     query_delay: Duration
     runtime_mappings?: RuntimeFields

--- a/specification/ml/update_job/MlUpdateJobRequest.ts
+++ b/specification/ml/update_job/MlUpdateJobRequest.ts
@@ -86,6 +86,7 @@ export interface Request extends RequestBase {
      */
     description?: string
     model_plot_config?: ModelPlotConfig
+    model_prune_window?: Duration
     /**
      * Advanced configuration option, which affects the automatic removal of old
      * model snapshots for this job. It specifies a period of time (in days)

--- a/specification/nodes/_types/Stats.ts
+++ b/specification/nodes/_types/Stats.ts
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-import { IndexStats, IndicesStats, ShardStats } from '@indices/stats/types'
+import { ShardStats } from '@indices/stats/types'
 import { Dictionary } from '@spec_utils/Dictionary'
-import { Field, Name } from '@_types/common'
+import { ByteSize, Field, Name } from '@_types/common'
 import { Host, Ip, TransportAddress } from '@_types/Networking'
 import { NodeRoles } from '@_types/Node'
 import { double, float, integer, long } from '@_types/Numeric'
@@ -57,17 +57,23 @@ export class IndexingPressure {
 }
 
 export class IndexingPressureMemory {
+  limit?: ByteSize
   limit_in_bytes?: long
   current?: PressureMemory
   total?: PressureMemory
 }
 
 export interface PressureMemory {
-  combined_coordinating_and_primary_in_bytes?: long
-  coordinating_in_bytes?: long
-  primary_in_bytes?: long
-  replica_in_bytes?: long
+  all?: ByteSize
   all_in_bytes?: long
+  combined_coordinating_and_primary?: ByteSize
+  combined_coordinating_and_primary_in_bytes?: long
+  coordinating?: ByteSize
+  coordinating_in_bytes?: long
+  primary?: ByteSize
+  primary_in_bytes?: long
+  replica?: ByteSize
+  replica_in_bytes?: long
   coordinating_rejections?: long
   primary_rejections?: long
   replica_rejections?: long
@@ -162,9 +168,9 @@ export class Processor {
 
 export class AdaptiveSelection {
   avg_queue_size?: long
-  avg_response_time?: long
+  avg_response_time?: Duration
   avg_response_time_ns?: long
-  avg_service_time?: string
+  avg_service_time?: Duration
   avg_service_time_ns?: long
   outgoing_searches?: long
   rank?: string
@@ -383,6 +389,7 @@ export class Process {
 export class Scripting {
   cache_evictions?: long
   compilations?: long
+  compilations_history?: Dictionary<string, long>
   compilation_limit_triggered?: long
   contexts?: Context[]
 }

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -355,7 +355,7 @@ export class NodeJvmInfo {
   vm_name: Name
   vm_vendor: string
   vm_version: VersionString
-  bundled_jdk: boolean
+  /** @aliases bundled_jdk */
   using_bundled_jdk: boolean
   using_compressed_ordinary_object_pointers?: boolean | string
   input_arguments: string[]

--- a/specification/rollup/get_rollup_caps/types.ts
+++ b/specification/rollup/get_rollup_caps/types.ts
@@ -20,14 +20,21 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Field } from '@_types/common'
+import { Duration, TimeZone } from '@_types/Time'
 
 export class RollupCapabilities {
   rollup_jobs: RollupCapabilitySummary[]
 }
 
 export class RollupCapabilitySummary {
-  fields: Dictionary<Field, Dictionary<string, UserDefinedValue>>
+  fields: Dictionary<Field, RollupFieldSummary[]>
   index_pattern: string
   job_id: string
   rollup_index: string
+}
+
+export class RollupFieldSummary {
+  agg: string
+  calendar_interval?: Duration
+  time_zone?: TimeZone
 }

--- a/specification/transform/get_transform_stats/GetTransformStatsRequest.ts
+++ b/specification/transform/get_transform_stats/GetTransformStatsRequest.ts
@@ -20,6 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { Names } from '@_types/common'
 import { long } from '@_types/Numeric'
+import { Duration } from '@_types/Time'
 
 /**
  * Retrieves usage information for transforms.
@@ -62,5 +63,6 @@ export interface Request extends RequestBase {
      * @server_default 100
      */
     size?: long
+    timeout?: Duration
   }
 }

--- a/specification/transform/get_transform_stats/types.ts
+++ b/specification/transform/get_transform_stats/types.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Id } from '@_types/common'
+import { HealthStatus, Id } from '@_types/common'
 import { NodeAttributes } from '@_types/Node'
 import { double, long } from '@_types/Numeric'
 import {
@@ -30,11 +30,16 @@ import {
 
 export class TransformStats {
   checkpointing: Checkpointing
+  health?: TransformStatsHealth
   id: Id
   node?: NodeAttributes
   reason?: string
   state: string
   stats: TransformIndexerStats
+}
+
+export class TransformStatsHealth {
+  status: HealthStatus
 }
 
 export class TransformProgress {

--- a/specification/xpack/usage/XPackUsageResponse.ts
+++ b/specification/xpack/usage/XPackUsageResponse.ts
@@ -27,6 +27,7 @@ import {
   Eql,
   Flattened,
   FrozenIndices,
+  HealthStatistics,
   Ilm,
   MachineLearning,
   Monitoring,
@@ -56,6 +57,7 @@ export class Response {
     flattened?: Flattened
     frozen_indices: FrozenIndices
     graph: Base
+    health_api?: HealthStatistics
     ilm: Ilm
     logstash: Base
     ml: MachineLearning

--- a/specification/xpack/usage/types.ts
+++ b/specification/xpack/usage/types.ts
@@ -41,6 +41,10 @@ export class FeatureToggle {
   enabled: boolean
 }
 
+export class Invocations {
+  total: long
+}
+
 export class Archive extends Base {
   indices_count: long
 }
@@ -146,6 +150,10 @@ export class ForecastStatistics {
   total: long
 }
 
+export class HealthStatistics extends Base {
+  invocations: Invocations
+}
+
 export class IlmPolicyStatistics {
   indices_managed: integer
   phases: Phases
@@ -235,6 +243,7 @@ export class MlInferenceTrainedModelsCount {
   regression?: long
   classification?: long
   ner?: long
+  text_embedding?: long
 }
 
 export class MlCounter {


### PR DESCRIPTION
A collection or API spec fixes using flight-recorder recordings from a recent 8.7.0 snapshot and running them through the Java client's flight recordings validator. This validator is more strict than our JS/TS validator, and also reports unknown fields.

I've added the `backport 7.17` label, even if only a limited number of fixes actually apply to that branch. I'll cherry-pick those that are relevant.