### PR TITLE
[KNN] Add query vector builder

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -68,7 +68,8 @@
         "Request: query parameter 'min_compatible_shard_node' does not exist in the json spec",
         "Request: query parameter 'pre_filter_shard_size' does not exist in the json spec",
         "Request: query parameter 'scroll' does not exist in the json spec",
-        "Request: query parameter 'rest_total_hits_as_int' does not exist in the json spec"
+        "Request: query parameter 'rest_total_hits_as_int' does not exist in the json spec",
+        "interface definition _types:QueryVectorBuilder - Property text_embedding is a single-variant and must be required"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -508,12 +508,10 @@ export interface KnnSearchResponse<TDocument = unknown> {
 
 export interface KnnSearchQuery {
   field: Field
-  query_vector: KnnSearchQueryVector
+  query_vector: QueryVector
   k: long
   num_candidates: long
 }
-
-export type KnnSearchQueryVector = double[]
 
 export interface MgetMultiGetError {
   error: ErrorCause
@@ -2150,7 +2148,7 @@ export type Ip = string
 
 export interface KnnQuery {
   field: Field
-  query_vector?: double[]
+  query_vector?: QueryVector
   query_vector_builder?: QueryVectorBuilder
   k: long
   num_candidates: long
@@ -2284,8 +2282,10 @@ export interface QueryCacheStats {
   total_count: integer
 }
 
+export type QueryVector = float[]
+
 export interface QueryVectorBuilder {
-  text_embedding: TextEmbedding
+  text_embedding?: TextEmbedding
 }
 
 export interface RecoveryStats {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2150,7 +2150,8 @@ export type Ip = string
 
 export interface KnnQuery {
   field: Field
-  query_vector: double[]
+  query_vector?: double[]
+  query_vector_builder?: QueryVectorBuilder
   k: long
   num_candidates: long
   boost?: float
@@ -2281,6 +2282,10 @@ export interface QueryCacheStats {
   memory_size_in_bytes: integer
   miss_count: integer
   total_count: integer
+}
+
+export interface QueryVectorBuilder {
+  text_embedding: TextEmbedding
 }
 
 export interface RecoveryStats {
@@ -2504,6 +2509,11 @@ export interface TaskFailure {
 }
 
 export type TaskId = string | integer
+
+export interface TextEmbedding {
+  model_id: string
+  model_text: string
+}
 
 export type ThreadType = 'cpu' | 'wait' | 'block' | 'gpu' | 'mem'
 

--- a/specification/_global/knn_search/KnnSearchRequest.ts
+++ b/specification/_global/knn_search/KnnSearchRequest.ts
@@ -27,6 +27,7 @@ import { FieldAndFormat } from '@_types/query_dsl/abstractions'
 /**
  * @rest_spec_name knn_search
  * @since 8.0.0
+ * @deprecated 8.4.0
  * @stability experimental
  */
 export interface Request extends RequestBase {

--- a/specification/_global/knn_search/_types/Knn.ts
+++ b/specification/_global/knn_search/_types/Knn.ts
@@ -18,9 +18,8 @@
  */
 
 import { Field } from '@_types/common'
-import { long, double } from '@_types/Numeric'
-
-export type QueryVector = double[]
+import { long, float } from '@_types/Numeric'
+import { QueryVector } from '@_types/Knn'
 
 export interface Query {
   /** The name of the vector field to search against */

--- a/specification/_types/Knn.ts
+++ b/specification/_types/Knn.ts
@@ -21,11 +21,13 @@ import { Field } from '@_types/common'
 import { long, double, float } from '@_types/Numeric'
 import { QueryContainer } from './query_dsl/abstractions'
 
+export type QueryVector = float[]
+
 export interface KnnQuery {
   /** The name of the vector field to search against */
   field: Field
   /** The query vector */
-  query_vector?: double[]
+  query_vector?: QueryVector
   /** The query vector builder. You must provide a query_vector_builder or query_vector, but not both. */
   query_vector_builder?: QueryVectorBuilder
   /** The final number of nearest neighbors to return as top hits */

--- a/specification/_types/Knn.ts
+++ b/specification/_types/Knn.ts
@@ -25,7 +25,9 @@ export interface KnnQuery {
   /** The name of the vector field to search against */
   field: Field
   /** The query vector */
-  query_vector: double[]
+  query_vector?: double[]
+  /** The query vector builder. You must provide a query_vector_builder or query_vector, but not both. */
+  query_vector_builder?: QueryVectorBuilder
   /** The final number of nearest neighbors to return as top hits */
   k: long
   /** The number of nearest neighbor candidates to consider per shard */
@@ -34,4 +36,13 @@ export interface KnnQuery {
   boost?: float
   /** Filters for the kNN search query */
   filter?: QueryContainer | QueryContainer[]
+}
+
+export interface QueryVectorBuilder {
+  text_embedding: TextEmbedding
+}
+
+export interface TextEmbedding {
+  model_id: string
+  model_text: string
 }

--- a/specification/_types/Knn.ts
+++ b/specification/_types/Knn.ts
@@ -40,8 +40,9 @@ export interface KnnQuery {
   filter?: QueryContainer | QueryContainer[]
 }
 
+/** @variants container */
 export interface QueryVectorBuilder {
-  text_embedding: TextEmbedding
+  text_embedding?: TextEmbedding
 }
 
 export interface TextEmbedding {


### PR DESCRIPTION
This adds the `query_vector_builder` field to the KnnQuery for semantic search.
https://www.elastic.co/guide/en/elasticsearch/reference/master/knn-search.html#semantic-search
