### PR TITLE
Add parameters to compiler for specifying input and output

### DIFF
--- a/.github/workflows/gh-pages-report.yml
+++ b/.github/workflows/gh-pages-report.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Generate output
       run: |
-        npm run generate-schema --prefix compiler
+        make generate
 
     - name: Generate graph
       run: |

--- a/.github/workflows/output-check.yml
+++ b/.github/workflows/output-check.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Generate output
       run: |
-        npm run generate-schema --prefix compiler
+        make generate
         npm run start --prefix typescript-generator
 
     - name: Validate TS output

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ output/schema/routes.go
 
 # Editor lockfiles
 .*.swp
+
+# Test suite outputs
+compiler/test/**/output/

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ validate-no-cache: ## Validate a given endpoint request or response without loca
 
 generate:	  ## Generate the output spec
 	@echo ">> generating the spec .."
-	@npm run generate-schema --prefix compiler
+	@npm run generate-schema --prefix compiler -- --spec ../specification/ --output ../output/
 	@npm run start --prefix typescript-generator
 
 compile:	## Compile the specification

--- a/compiler/src/compiler.ts
+++ b/compiler/src/compiler.ts
@@ -66,7 +66,7 @@ export default class Compiler {
     await writeFile(
       join(this.outputFolder, 'schema', 'schema.json'),
       stringify(this.model, null, 2),
-      { encoding: 'utf8', flag: 'w' }
+      'utf8'
     )
 
     this.errors.log()
@@ -74,7 +74,7 @@ export default class Compiler {
     await writeFile(
       join(this.outputFolder, 'schema', 'validation-errors.json'),
       stringify(this.errors, null, 2),
-      { encoding: 'utf8', flag: 'w' }
+      'utf8'
     )
   }
 

--- a/compiler/src/index.ts
+++ b/compiler/src/index.ts
@@ -37,8 +37,8 @@ if (nodejsMajor !== nvmMajor) {
   process.exit(1)
 }
 
-let specsFolder: string = argv.spec
-if ((specsFolder ?? '') !== '') {
+let specsFolder: string|undefined = argv.spec
+if (specsFolder !== '' && specsFolder !== undefined) {
   // We were given a specification, let's make sure it's a directory.
   specsFolder = resolve(specsFolder)
 
@@ -56,8 +56,8 @@ if ((specsFolder ?? '') !== '') {
 }
 
 // It's okay if the output folder doesn't exist initially.
-const outputFolder: string = argv.output
-if ((outputFolder ?? '') === '') {
+const outputFolder: string|undefined = argv.output
+if (outputFolder === '' || outputFolder === undefined) {
   console.error('--output must be specified')
   process.exit(1)
 }

--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { writeFileSync } from 'fs'
+import { mkdirSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { STATUS_CODES } from 'http'
 import {
@@ -88,7 +88,7 @@ export function compileEndpoints (): Record<string, model.Endpoint> {
   return map
 }
 
-export function compileSpecification (endpointMappings: Record<string, model.Endpoint>, specsFolder: string): model.Model {
+export function compileSpecification (endpointMappings: Record<string, model.Endpoint>, specsFolder: string, outputFolder: string): model.Model {
   const tsConfigFilePath = join(specsFolder, 'tsconfig.json')
   const project = new Project({ tsConfigFilePath })
 
@@ -123,10 +123,11 @@ export function compileSpecification (endpointMappings: Record<string, model.End
     }
   }
 
+  mkdirSync(join(outputFolder, 'dangling-types'), { recursive: true })
   writeFileSync(
-    join(__dirname, '..', '..', '..', 'output', 'dangling-types', 'dangling.csv'),
+    join(outputFolder, 'dangling-types', 'dangling.csv'),
     definedButNeverUsed.join('\n'),
-    'utf8'
+    { encoding: 'utf8', flag: 'w' }
   )
   for (const api of jsonSpec.keys()) {
     model.endpoints.push(endpointMappings[api])

--- a/compiler/test/body-codegen-name/test.ts
+++ b/compiler/test/body-codegen-name/test.ts
@@ -23,9 +23,10 @@ import Compiler from '../../src/compiler'
 import * as Model from '../../src/model/metamodel'
 
 const specsFolder = join(__dirname, 'specification')
+const outputFolder = join(__dirname, 'output')
 
 test('type reference body must have a @codegen_name', t => {
-  const compiler = new Compiler(specsFolder)
+  const compiler = new Compiler(specsFolder, outputFolder)
   const error = t.throws(() => compiler.generateModel())
   t.is(error?.message, 'You should configure a body @codegen_name')
 })

--- a/compiler/test/duplicate-body-codegen-name/test.ts
+++ b/compiler/test/duplicate-body-codegen-name/test.ts
@@ -23,9 +23,10 @@ import Compiler from '../../src/compiler'
 import * as Model from '../../src/model/metamodel'
 
 const specsFolder = join(__dirname, 'specification')
+const outputFolder = join(__dirname, 'output')
 
 test('@codegen_name cannot already exist elsewhere', t => {
-  const compiler = new Compiler(specsFolder)
+  const compiler = new Compiler(specsFolder, outputFolder)
   const error = t.throws(() => compiler.generateModel())
   t.is(error?.message, "The codegen_name 'id' already exists as a property in the path or query.")
 })

--- a/compiler/test/no-body/test.ts
+++ b/compiler/test/no-body/test.ts
@@ -23,9 +23,10 @@ import Compiler from '../../src/compiler'
 import * as Model from '../../src/model/metamodel'
 
 const specsFolder = join(__dirname, 'specification')
+const outputFolder = join(__dirname, 'output')
 
 test("Body cannot be defined if the API methods don't allow it", t => {
-  const compiler = new Compiler(specsFolder)
+  const compiler = new Compiler(specsFolder, outputFolder)
   const error = t.throws(() => compiler.generateModel())
   t.is(error?.message, "_global.info.Request can't have a body, allowed methods: GET")
 })

--- a/compiler/test/request-fields/test.ts
+++ b/compiler/test/request-fields/test.ts
@@ -23,9 +23,10 @@ import Compiler from '../../src/compiler'
 import * as Model from '../../src/model/metamodel'
 
 const specsFolder = join(__dirname, 'specification')
+const outputFolder = join(__dirname, 'output')
 
 test('Request definition cannot have unknown properties', t => {
-  const compiler = new Compiler(specsFolder)
+  const compiler = new Compiler(specsFolder, outputFolder)
   const error = t.throws(() => compiler.generateModel())
   t.is(error?.message, 'Unknown request property: headers')
 })

--- a/compiler/test/response-exceptions-fields/test.ts
+++ b/compiler/test/response-exceptions-fields/test.ts
@@ -23,9 +23,10 @@ import Compiler from '../../src/compiler'
 import * as Model from '../../src/model/metamodel'
 
 const specsFolder = join(__dirname, 'specification')
+const outputFolder = join(__dirname, 'output')
 
 test('Response exceptions definition cannot have unknown properties', t => {
-  const compiler = new Compiler(specsFolder)
+  const compiler = new Compiler(specsFolder, outputFolder)
   const error = t.throws(() => compiler.generateModel())
   t.is(error?.message, 'Exception.body and Exception.statusCode are the only Exception properties supported')
 })

--- a/compiler/test/response-fields/test.ts
+++ b/compiler/test/response-fields/test.ts
@@ -23,9 +23,10 @@ import Compiler from '../../src/compiler'
 import * as Model from '../../src/model/metamodel'
 
 const specsFolder = join(__dirname, 'specification')
+const outputFolder = join(__dirname, 'output')
 
 test('Response definition cannot have unknown properties', t => {
-  const compiler = new Compiler(specsFolder)
+  const compiler = new Compiler(specsFolder, outputFolder)
   const error = t.throws(() => compiler.generateModel())
   t.is(error?.message, 'Response.body and Response.exceptions are the only Response properties supported')
 })

--- a/compiler/test/types/test.ts
+++ b/compiler/test/types/test.ts
@@ -23,7 +23,8 @@ import Compiler from '../../src/compiler'
 import * as Model from '../../src/model/metamodel'
 
 const specsFolder = join(__dirname, 'specification')
-const compiler = new Compiler(specsFolder)
+const outputFolder = join(__dirname, 'output')
+const compiler = new Compiler(specsFolder, outputFolder)
 const { model } = compiler.generateModel()
 
 test('interfaces', t => {

--- a/compiler/test/writes-to-output/specification/_global/index/request.ts
+++ b/compiler/test/writes-to-output/specification/_global/index/request.ts
@@ -17,16 +17,9 @@
  * under the License.
  */
 
-import { join } from 'path'
-import test from 'ava'
-import Compiler from '../../src/compiler'
-import * as Model from '../../src/model/metamodel'
-
-const specsFolder = join(__dirname, 'specification')
-const outputFolder = join(__dirname, 'output')
-
-test('Wrong rest_spec_name for request definition', t => {
-  const compiler = new Compiler(specsFolder, outputFolder)
-  const error = t.throws(() => compiler.generateModel())
-  t.true(error?.message.startsWith("The api 'foobar' does not exists, did you mean"))
-})
+/**
+ * @rest_spec_name index
+ * @since 0.0.0
+ * @stability stable
+ */
+export interface Request {}

--- a/compiler/test/writes-to-output/specification/tsconfig.json
+++ b/compiler/test/writes-to-output/specification/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../../specification/tsconfig.json",
+  "typeRoots": ["./**/*.ts"],
+  "include": ["./**/*.ts"]
+}

--- a/compiler/test/writes-to-output/test.ts
+++ b/compiler/test/writes-to-output/test.ts
@@ -18,6 +18,7 @@
  */
 
 import { join } from 'path'
+import { existsSync, lstatSync, rmSync } from 'fs'
 import test from 'ava'
 import Compiler from '../../src/compiler'
 import * as Model from '../../src/model/metamodel'
@@ -25,8 +26,12 @@ import * as Model from '../../src/model/metamodel'
 const specsFolder = join(__dirname, 'specification')
 const outputFolder = join(__dirname, 'output')
 
-test('Wrong rest_spec_name for request definition', t => {
+test('compiler creates schema directory at outputFolder', async t => {
+  rmSync(outputFolder, {recursive: true, force: true});
+
   const compiler = new Compiler(specsFolder, outputFolder)
-  const error = t.throws(() => compiler.generateModel())
-  t.true(error?.message.startsWith("The api 'foobar' does not exists, did you mean"))
+  await compiler.generateModel().write();
+
+  const schemaFolder = join(outputFolder, 'schema')
+  t.true(existsSync(schemaFolder) && lstatSync(schemaFolder).isDirectory());
 })

--- a/compiler/test/wrong-namespace/test.ts
+++ b/compiler/test/wrong-namespace/test.ts
@@ -23,9 +23,10 @@ import Compiler from '../../src/compiler'
 import * as Model from '../../src/model/metamodel'
 
 const specsFolder = join(__dirname, 'specification')
+const outputFolder = join(__dirname, 'output')
 
 test('Wrong namespace for request definition', t => {
-  const compiler = new Compiler(specsFolder)
+  const compiler = new Compiler(specsFolder, outputFolder)
   const error = t.throws(() => compiler.generateModel())
   t.is(error?.message, 'Cannot find url template for _global.foobar, very likely the specification folder does not follow the rest-api-spec')
 })


### PR DESCRIPTION
Currently the compiler is hardcoded for paths in this repository, we'd like to be able to compile specs that are elsewhere so I've added `--spec` and `--output` parameters to the compiler CLI.

Tested by running within a Dockerfile of the `compiler` directory. There are still some external dependencies like the rest-api-spec stubs, `nvmrc` file, and `tsconfig.json`.
