### PR TITLE
Remove union for dynamic_templates

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5049,7 +5049,7 @@ export interface MappingTypeMapping {
   date_detection?: boolean
   dynamic?: MappingDynamicMapping
   dynamic_date_formats?: string[]
-  dynamic_templates?: Record<string, MappingDynamicTemplate> | Record<string, MappingDynamicTemplate>[]
+  dynamic_templates?: Record<string, MappingDynamicTemplate>[]
   _field_names?: MappingFieldNamesField
   index_field?: MappingIndexField
   _meta?: Metadata

--- a/specification/_types/mapping/TypeMapping.ts
+++ b/specification/_types/mapping/TypeMapping.ts
@@ -36,9 +36,7 @@ export class TypeMapping {
   date_detection?: boolean
   dynamic?: DynamicMapping
   dynamic_date_formats?: string[]
-  dynamic_templates?:
-    | Dictionary<string, DynamicTemplate>
-    | Dictionary<string, DynamicTemplate>[]
+  dynamic_templates?: Dictionary<string, DynamicTemplate>[]
   _field_names?: FieldNamesField
   index_field?: IndexField
   /** @doc_id mapping-meta-field */


### PR DESCRIPTION
Creating an index with a mapping that includes `dynamic_templates` fails when sending the dictionary without wrapping it in an array: 

e.g.

```
PUT my-index
{
  "mappings": {
    "dynamic_templates": {
      "testTemplateName": {
        "mapping": {
          "type": "keyword"
        },
        "path_match": "testPathMatch"
      }
    }
  }
}
```

Error:

```
{
  "error": {
    "root_cause": [
      {
        "type": "mapper_parsing_exception",
        "reason": "Dynamic template syntax error. An array of named objects is expected."
      }
    ],
    "type": "mapper_parsing_exception",
    "reason": "Failed to parse mapping: Dynamic template syntax error. An array of named objects is expected.",
    "caused_by": {
      "type": "mapper_parsing_exception",
      "reason": "Dynamic template syntax error. An array of named objects is expected."
    }
  },
  "status": 400
}
```

I've made a check to the spec but can't validate locally, so pushing this WIP PR, for now, to see how the tests run in CI.