### PR TITLE
[Backport 7.17] Remove union for dynamic_templates

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4877,7 +4877,7 @@ export interface MappingTypeMapping {
   date_detection?: boolean
   dynamic?: MappingDynamicMapping
   dynamic_date_formats?: string[]
-  dynamic_templates?: Record<string, MappingDynamicTemplate> | Record<string, MappingDynamicTemplate>[]
+  dynamic_templates?: Record<string, MappingDynamicTemplate>[]
   _field_names?: MappingFieldNamesField
   index_field?: MappingIndexField
   _meta?: Metadata

--- a/specification/_types/mapping/TypeMapping.ts
+++ b/specification/_types/mapping/TypeMapping.ts
@@ -36,9 +36,7 @@ export class TypeMapping {
   date_detection?: boolean
   dynamic?: DynamicMapping
   dynamic_date_formats?: string[]
-  dynamic_templates?:
-    | Dictionary<string, DynamicTemplate>
-    | Dictionary<string, DynamicTemplate>[]
+  dynamic_templates?: Dictionary<string, DynamicTemplate>[]
   _field_names?: FieldNamesField
   index_field?: IndexField
   /** @doc_url https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-meta-field.html */


### PR DESCRIPTION
Backport d5e725afc0420d706e05319620a3e8b21e08cbbd from #2033