### PR TITLE
Fix completion suggester

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1179,8 +1179,7 @@ export interface SearchCompletionSuggestOption<TDocument = unknown> {
 export interface SearchCompletionSuggester extends SearchSuggesterBase {
   contexts?: Record<Field, SearchCompletionContext | SearchContext | (SearchCompletionContext | SearchContext)[]>
   fuzzy?: SearchSuggestFuzziness
-  prefix?: string
-  regex?: string
+  regex?: SearchRegexOptions
   skip_duplicates?: boolean
 }
 
@@ -1432,6 +1431,11 @@ export interface SearchQueryProfile {
   time_in_nanos: DurationValue<UnitNanos>
   type: string
   children?: SearchQueryProfile[]
+}
+
+export interface SearchRegexOptions {
+  flags?: string
+  max_determinized_states?: integer
 }
 
 export interface SearchRescore {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1434,7 +1434,7 @@ export interface SearchQueryProfile {
 }
 
 export interface SearchRegexOptions {
-  flags?: string
+  flags?: integer | string
   max_determinized_states?: integer
 }
 

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -135,7 +135,7 @@ export class CompletionSuggester extends SuggesterBase {
 }
 
 export class RegexOptions {
-  flags?: string
+  flags?: integer | string
   max_determinized_states?: integer
 }
 

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -27,7 +27,7 @@ import {
   Routing,
   SuggestMode
 } from '@_types/common'
-import { GeoHash, GeoHashPrecision, GeoLocation } from '@_types/Geo'
+import { GeoHashPrecision, GeoLocation } from '@_types/Geo'
 import { double, float, integer, long } from '@_types/Numeric'
 import { AdditionalProperties } from '@spec_utils/behaviors'
 
@@ -130,9 +130,13 @@ export class SuggesterBase {
 export class CompletionSuggester extends SuggesterBase {
   contexts?: Dictionary<Field, CompletionContext | CompletionContext[]>
   fuzzy?: SuggestFuzziness
-  prefix?: string
-  regex?: string
+  regex?: RegexOptions
   skip_duplicates?: boolean
+}
+
+export class RegexOptions {
+  flags?: string
+  max_determinized_states?: integer
 }
 
 export class SuggestFuzziness {


### PR DESCRIPTION
Fixes issues raised in https://github.com/elastic/elasticsearch-net/issues/7454.

The completion suggester doesn't support a field named "prefix" which is a FieldSuggester container property.

After reviewing the server code, I noticed that `regex` is not a string but an instance of `RegexOptions` used to control the regex provided via the container property.