### PR TITLE
Add from parameter for transform.start_transform

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1364,9 +1364,7 @@
       ]
     },
     "transform.start_transform": {
-      "request": [
-        "Request: missing json spec query parameter 'from'"
-      ],
+      "request": [],
       "response": [
         "response definition transform.start_transform:Response / body / instance_of - Non-leaf type cannot be used here: '_types:AcknowledgedResponseBase'"
       ]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17437,6 +17437,7 @@ export type TransformScheduleNowTransformResponse = AcknowledgedResponseBase
 export interface TransformStartTransformRequest extends RequestBase {
   transform_id: Id
   timeout?: Duration
+  from?: string
 }
 
 export type TransformStartTransformResponse = AcknowledgedResponseBase

--- a/specification/transform/start_transform/StartTransformRequest.ts
+++ b/specification/transform/start_transform/StartTransformRequest.ts
@@ -57,5 +57,9 @@ export interface Request extends RequestBase {
      * @server_default 30s
      */
     timeout?: Duration
+    /**
+     * Restricts the set of transformed entities to those changed after this time. Relative times like now-30d are supported. Only applicable for continuous transforms.
+     */
+    from?: string
   }
 }


### PR DESCRIPTION
This PR adds the `from` parameter for `transform.start_transform` API. Fixes #2064 
