### PR TITLE
Fix IndexPrivileges.field_security

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15590,7 +15590,7 @@ export type SecurityGrantType = 'password' | 'access_token'
 export type SecurityIndexPrivilege = 'none' | 'all' | 'auto_configure' | 'create' | 'create_doc' | 'create_index' | 'delete' | 'delete_index' | 'index' | 'maintenance' | 'manage' | 'manage_follow_index' | 'manage_ilm' | 'manage_leader_index' | 'monitor' | 'read' | 'read_cross_cluster' | 'view_index_metadata' | 'write'
 
 export interface SecurityIndicesPrivileges {
-  field_security?: SecurityFieldSecurity | SecurityFieldSecurity[]
+  field_security?: SecurityFieldSecurity
   names: Indices
   privileges: SecurityIndexPrivilege[]
   query?: SecurityIndicesPrivilegesQuery

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -83,7 +83,7 @@ export class IndicesPrivileges {
    * The document fields that the owners of the role have read access to.
    * @doc_id field-and-document-access-control
    */
-  field_security?: FieldSecurity | FieldSecurity[]
+  field_security?: FieldSecurity
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */


### PR DESCRIPTION
This field doesn't accept an array of `FieldSecurity` instances, only a single instance. This causes an issue in strongly-typed languages that collapse `X | X[]` type into `X[]` because users can't set a single object on a request.