### PR TITLE
Add support for multiple knn queries

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -713,7 +713,7 @@ export interface MsearchMultisearchBody {
   ext?: Record<string, any>
   stored_fields?: Fields
   docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
-  knn?: KnnQuery
+  knn?: KnnQuery | KnnQuery[]
   from?: integer
   highlight?: SearchHighlight
   indices_boost?: Record<IndexName, double>[]
@@ -6114,7 +6114,7 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
     track_total_hits?: SearchTrackHits
     indices_boost?: Record<IndexName, double>[]
     docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
-    knn?: KnnQuery
+    knn?: KnnQuery | KnnQuery[]
     min_score?: double
     post_filter?: QueryDslQueryContainer
     profile?: boolean

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -101,7 +101,7 @@ export class MultisearchBody {
    * Defines the approximate kNN search to run.
    * @since 8.4.0
    */
-  knn?: KnnQuery
+  knn?: KnnQuery | KnnQuery[]
   /**
    * Starting document offset. By default, you cannot page through more than 10,000
    * hits using the from and size parameters. To page through more hits, use the

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -161,7 +161,7 @@ export interface Request extends RequestBase {
      * Defines the approximate kNN search to run.
      * @since 8.4.0
      */
-    knn?: KnnQuery
+    knn?: KnnQuery | KnnQuery[]
     /**
      * Minimum _score for matching documents. Documents with a lower _score are
      * not included in the search results.


### PR DESCRIPTION
In 8.6 the `knn` search field only accepted a single value. In 8.7 it has been updated to allow a single value and an array of values.