### PR TITLE
Make node_id optional on SnapshotShardFailure

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16736,7 +16736,7 @@ export interface SnapshotSnapshotInfo {
 
 export interface SnapshotSnapshotShardFailure {
   index: IndexName
-  node_id: Id
+  node_id?: Id
   reason: string
   shard_id: Id
   status: string

--- a/specification/snapshot/_types/SnapshotShardFailure.ts
+++ b/specification/snapshot/_types/SnapshotShardFailure.ts
@@ -21,7 +21,7 @@ import { Id, IndexName } from '@_types/common'
 
 export class SnapshotShardFailure {
   index: IndexName
-  node_id: Id
+  node_id?: Id
   reason: string
   shard_id: Id
   status: string


### PR DESCRIPTION
If a shard isn't allocated, the `node_id` will be omitted in the shard failure object.