### PR TITLE
Changed Search Applications stability from beta to experimental

### DIFF
--- a/specification/_json_spec/search_application.delete.json
+++ b/specification/_json_spec/search_application.delete.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html",
       "description": "Deletes a search application."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/search_application.delete_behavioral_analytics.json
+++ b/specification/_json_spec/search_application.delete_behavioral_analytics.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html",
       "description": "Delete a behavioral analytics collection."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/search_application.get.json
+++ b/specification/_json_spec/search_application.get.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-search-application.html",
       "description": "Returns the details about a search application."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/search_application.get_behavioral_analytics.json
+++ b/specification/_json_spec/search_application.get_behavioral_analytics.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html",
       "description": "Returns the existing behavioral analytics collections."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/search_application.list.json
+++ b/specification/_json_spec/search_application.list.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-search-applications.html",
       "description": "Returns the existing search applications."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/search_application.put.json
+++ b/specification/_json_spec/search_application.put.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html",
       "description": "Creates or updates a search application."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"],

--- a/specification/_json_spec/search_application.put_behavioral_analytics.json
+++ b/specification/_json_spec/search_application.put_behavioral_analytics.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html",
       "description": "Creates a behavioral analytics collection."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/search_application.search.json
+++ b/specification/_json_spec/search_application.search.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-search.html",
       "description": "Perform a search against a search application"
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"],

--- a/specification/search_application/delete/SearchApplicationsDeleteRequest.ts
+++ b/specification/search_application/delete/SearchApplicationsDeleteRequest.ts
@@ -23,7 +23,7 @@ import { Name } from '@_types/common'
  * Deletes a search application.
  * @rest_spec_name search_application.delete
  * @since 8.8.0
- * @stability beta
+ * @stability experimental
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/get/SearchApplicationsGetRequest.ts
+++ b/specification/search_application/get/SearchApplicationsGetRequest.ts
@@ -23,7 +23,7 @@ import { Name } from '@_types/common'
  * Returns the details about a search application
  * @rest_spec_name search_application.get
  * @since 8.8.0
- * @stability beta
+ * @stability experimental
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/list/SearchApplicationsListRequest.ts
+++ b/specification/search_application/list/SearchApplicationsListRequest.ts
@@ -24,7 +24,7 @@ import { integer } from '@_types/Numeric'
  * Returns the existing search applications.
  * @rest_spec_name search_application.list
  * @since 8.8.0
- * @stability beta
+ * @stability experimental
  */
 interface Request extends RequestBase {
   query_parameters: {

--- a/specification/search_application/put/SearchApplicationsPutRequest.ts
+++ b/specification/search_application/put/SearchApplicationsPutRequest.ts
@@ -24,7 +24,7 @@ import { SearchApplication } from '../_types/SearchApplication'
  * Creates or updates a search application.
  * @rest_spec_name search_application.put
  * @since 8.8.0
- * @stability beta
+ * @stability experimental
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/search/SearchApplicationsSearchRequest.ts
+++ b/specification/search_application/search/SearchApplicationsSearchRequest.ts
@@ -25,7 +25,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * Perform a search against a search application
  * @rest_spec_name search_application.search
  * @since 8.8.0
- * @stability beta
+ * @stability experimental
  */
 interface Request extends RequestBase {
   path_parts: {


### PR DESCRIPTION
Follow up to https://github.com/elastic/elasticsearch-specification/pull/2082, merged the change in APIs stability done in Elasticsearch (https://github.com/elastic/elasticsearch/pull/95379) here and updated stability.