### PR TITLE
Move generic array to root of response body

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13781,9 +13781,7 @@ export interface MlPreviewDatafeedRequest extends RequestBase {
   }
 }
 
-export interface MlPreviewDatafeedResponse<TDocument = unknown> {
-  data: TDocument[]
-}
+export type MlPreviewDatafeedResponse<TDocument = unknown> = TDocument[]
 
 export interface MlPutCalendarRequest extends RequestBase {
   calendar_id: Id

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedResponse.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedResponse.ts
@@ -18,7 +18,5 @@
  */
 
 export class Response<TDocument> {
-  body: {
-    data: TDocument[]
-  }
+  body: Array<TDocument>
 }


### PR DESCRIPTION
Following tests and [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html), ml.preview_data_feed should have the array of generics at the root of its response.
