### PR TITLE
Add 408 as exception status code for normal behaviour on cluster_health

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8415,6 +8415,26 @@ export interface ClusterGetSettingsResponse {
   defaults?: Record<string, any>
 }
 
+export interface ClusterHealthHealthResponseBody {
+  active_primary_shards: integer
+  active_shards: integer
+  active_shards_percent_as_number: Percentage
+  cluster_name: Name
+  delayed_unassigned_shards: integer
+  indices?: Record<IndexName, ClusterHealthIndexHealthStats>
+  initializing_shards: integer
+  number_of_data_nodes: integer
+  number_of_in_flight_fetch: integer
+  number_of_nodes: integer
+  number_of_pending_tasks: integer
+  relocating_shards: integer
+  status: HealthStatus
+  task_max_waiting_in_queue?: Duration
+  task_max_waiting_in_queue_millis: DurationValue<UnitMillis>
+  timed_out: boolean
+  unassigned_shards: integer
+}
+
 export interface ClusterHealthIndexHealthStats {
   active_primary_shards: integer
   active_shards: integer
@@ -8442,27 +8462,7 @@ export interface ClusterHealthRequest extends RequestBase {
   wait_for_status?: HealthStatus
 }
 
-export type ClusterHealthResponse = ClusterHealthResponseBody
-
-export interface ClusterHealthResponseBody {
-  active_primary_shards: integer
-  active_shards: integer
-  active_shards_percent_as_number: Percentage
-  cluster_name: Name
-  delayed_unassigned_shards: integer
-  indices?: Record<IndexName, ClusterHealthIndexHealthStats>
-  initializing_shards: integer
-  number_of_data_nodes: integer
-  number_of_in_flight_fetch: integer
-  number_of_nodes: integer
-  number_of_pending_tasks: integer
-  relocating_shards: integer
-  status: HealthStatus
-  task_max_waiting_in_queue?: Duration
-  task_max_waiting_in_queue_millis: DurationValue<UnitMillis>
-  timed_out: boolean
-  unassigned_shards: integer
-}
+export type ClusterHealthResponse = ClusterHealthHealthResponseBody
 
 export interface ClusterHealthShardHealthStats {
   active_shards: integer

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8442,7 +8442,9 @@ export interface ClusterHealthRequest extends RequestBase {
   wait_for_status?: HealthStatus
 }
 
-export interface ClusterHealthResponse {
+export type ClusterHealthResponse = ClusterHealthResponseBody
+
+export interface ClusterHealthResponseBody {
   active_primary_shards: integer
   active_shards: integer
   active_shards_percent_as_number: Percentage

--- a/specification/cluster/health/ClusterHealthResponse.ts
+++ b/specification/cluster/health/ClusterHealthResponse.ts
@@ -27,16 +27,16 @@ import { IndexHealthStats } from './types'
  * @doc_id cluster-health
  */
 export class Response {
-  body: ResponseBody
+  body: HealthResponseBody
   exceptions: [
     {
       statusCodes: [408]
-      body: ResponseBody
+      body: HealthResponseBody
     }
   ]
 }
 
-export class ResponseBody {
+export class HealthResponseBody {
   /** The number of active primary shards. */
   active_primary_shards: integer
   /** The total number of active primary and replica shards. */

--- a/specification/cluster/health/ClusterHealthResponse.ts
+++ b/specification/cluster/health/ClusterHealthResponse.ts
@@ -27,38 +27,46 @@ import { IndexHealthStats } from './types'
  * @doc_id cluster-health
  */
 export class Response {
-  body: {
-    /** The number of active primary shards. */
-    active_primary_shards: integer
-    /** The total number of active primary and replica shards. */
-    active_shards: integer
-    /** The ratio of active shards in the cluster expressed as a percentage. */
-    active_shards_percent_as_number: Percentage
-    /** The name of the cluster. */
-    cluster_name: Name
-    /** The number of shards whose allocation has been delayed by the timeout settings. */
-    delayed_unassigned_shards: integer
-    indices?: Dictionary<IndexName, IndexHealthStats>
-    /** The number of shards that are under initialization. */
-    initializing_shards: integer
-    /** The number of nodes that are dedicated data nodes. */
-    number_of_data_nodes: integer
-    /** The number of unfinished fetches. */
-    number_of_in_flight_fetch: integer
-    /** The number of nodes within the cluster. */
-    number_of_nodes: integer
-    /** The number of cluster-level changes that have not yet been executed. */
-    number_of_pending_tasks: integer
-    /** The number of shards that are under relocation. */
-    relocating_shards: integer
-    status: HealthStatus
-    /** The time since the earliest initiated task is waiting for being performed. */
-    task_max_waiting_in_queue?: Duration
-    /** The time expressed in milliseconds since the earliest initiated task is waiting for being performed. */
-    task_max_waiting_in_queue_millis: DurationValue<UnitMillis>
-    /** If false the response returned within the period of time that is specified by the timeout parameter (30s by default) */
-    timed_out: boolean
-    /** The number of shards that are not allocated. */
-    unassigned_shards: integer
-  }
+  body: ResponseBody
+  exceptions: [
+    {
+      statusCodes: [408]
+      body: ResponseBody
+    }
+  ]
+}
+
+export class ResponseBody {
+  /** The number of active primary shards. */
+  active_primary_shards: integer
+  /** The total number of active primary and replica shards. */
+  active_shards: integer
+  /** The ratio of active shards in the cluster expressed as a percentage. */
+  active_shards_percent_as_number: Percentage
+  /** The name of the cluster. */
+  cluster_name: Name
+  /** The number of shards whose allocation has been delayed by the timeout settings. */
+  delayed_unassigned_shards: integer
+  indices?: Dictionary<IndexName, IndexHealthStats>
+  /** The number of shards that are under initialization. */
+  initializing_shards: integer
+  /** The number of nodes that are dedicated data nodes. */
+  number_of_data_nodes: integer
+  /** The number of unfinished fetches. */
+  number_of_in_flight_fetch: integer
+  /** The number of nodes within the cluster. */
+  number_of_nodes: integer
+  /** The number of cluster-level changes that have not yet been executed. */
+  number_of_pending_tasks: integer
+  /** The number of shards that are under relocation. */
+  relocating_shards: integer
+  status: HealthStatus
+  /** The time since the earliest initiated task is waiting for being performed. */
+  task_max_waiting_in_queue?: Duration
+  /** The time expressed in milliseconds since the earliest initiated task is waiting for being performed. */
+  task_max_waiting_in_queue_millis: DurationValue<UnitMillis>
+  /** If false the response returned within the period of time that is specified by the timeout parameter (30s by default) */
+  timed_out: boolean
+  /** The number of shards that are not allocated. */
+  unassigned_shards: integer
 }


### PR DESCRIPTION
`cluster_health` could return a valid payload with a `408` status code if one of the nodes from the cluster failed to respond before the timeout.
