### PR TITLE
ML Add trained model definition status to TrainedModelConfig

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12464,7 +12464,7 @@ export interface MlHyperparameters {
   soft_tree_depth_tolerance?: double
 }
 
-export type MlInclude = 'definition' | 'feature_importance_baseline' | 'hyperparameters' | 'total_feature_importance'
+export type MlInclude = 'definition' | 'feature_importance_baseline' | 'hyperparameters' | 'total_feature_importance' | 'definition_status'
 
 export interface MlInferenceConfigCreateContainer {
   regression?: MlRegressionInferenceOptions

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12866,6 +12866,7 @@ export interface MlTrainedModelAssignmentRoutingTable {
 export interface MlTrainedModelAssignmentTaskParameters {
   model_bytes: integer
   model_id: Id
+  deployment_id: Id
   cache_size: ByteSize
   number_of_allocations: integer
   priority: MlTrainingPriority
@@ -12885,6 +12886,7 @@ export interface MlTrainedModelConfig {
   description?: string
   estimated_heap_memory_usage_bytes?: integer
   estimated_operations?: integer
+  fully_defined?: boolean
   inference_config: MlInferenceConfigCreateContainer
   input: MlTrainedModelConfigInput
   license_level?: string

--- a/specification/ml/_types/Include.ts
+++ b/specification/ml/_types/Include.ts
@@ -38,5 +38,10 @@ export enum Include {
    * baseline and total feature importance values are returned in the metadata
    * field in the response body.
    */
-  total_feature_importance
+  total_feature_importance,
+
+  /**
+   * Includes the model definition status.
+   */
+  definition_status
 }

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -176,6 +176,8 @@ export class TrainedModelConfig {
   estimated_heap_memory_usage_bytes?: integer
   /** The estimated number of operations to use the trained model. */
   estimated_operations?: integer
+  /** True if the full model definition is present. */
+  fully_defined?: boolean
   /** The default configuration for inference. This can be either a regression, classification, or one of the many NLP focused configurations. It must match the underlying definition.trained_model's target_type. */
   inference_config: InferenceConfigCreateContainer
   /** The input field names for the model definition. */
@@ -311,6 +313,10 @@ export class TrainedModelAssignmentTaskParameters {
    * The unique identifier for the trained model.
    */
   model_id: Id
+    /**
+   * The unique identifier for the trained model deployment.
+   */
+  deployment_id: Id
   /**
    * The size of the trained model cache.
    * @since 8.4.0

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -313,7 +313,7 @@ export class TrainedModelAssignmentTaskParameters {
    * The unique identifier for the trained model.
    */
   model_id: Id
-    /**
+  /**
    * The unique identifier for the trained model deployment.
    */
   deployment_id: Id


### PR DESCRIPTION
Updates TrainedModelConfig for the new fully_defined field add in https://github.com/elastic/elasticsearch/pull/95271

Duplicate of #2081. Testing if opening against the repo instead of a fork fixes the CI failures