### PR TITLE
Add text expansion config for the NLP APIs

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12475,6 +12475,7 @@ export interface MlInferenceConfigCreateContainer {
   ner?: MlNerInferenceOptions
   pass_through?: MlPassThroughInferenceOptions
   text_embedding?: MlTextEmbeddingInferenceOptions
+  text_expansion?: MlTextExpansionInferenceOptions
   question_answering?: MlQuestionAnsweringInferenceOptions
 }
 
@@ -12487,6 +12488,7 @@ export interface MlInferenceConfigUpdateContainer {
   ner?: MlNerInferenceUpdateOptions
   pass_through?: MlPassThroughInferenceUpdateOptions
   text_embedding?: MlTextEmbeddingInferenceUpdateOptions
+  text_expansion?: MlTextExpansionInferenceUpdateOptions
   question_answering?: MlQuestionAnsweringInferenceUpdateOptions
 }
 
@@ -12803,11 +12805,22 @@ export interface MlTextClassificationInferenceUpdateOptions {
 }
 
 export interface MlTextEmbeddingInferenceOptions {
+  embedding_size?: integer
   tokenization?: MlTokenizationConfigContainer
   results_field?: string
 }
 
 export interface MlTextEmbeddingInferenceUpdateOptions {
+  tokenization?: MlNlpTokenizationUpdateOptions
+  results_field?: string
+}
+
+export interface MlTextExpansionInferenceOptions {
+  tokenization?: MlTokenizationConfigContainer
+  results_field?: string
+}
+
+export interface MlTextExpansionInferenceUpdateOptions {
   tokenization?: MlNlpTokenizationUpdateOptions
   results_field?: string
 }
@@ -12887,7 +12900,7 @@ export interface MlTrainedModelConfig {
   estimated_heap_memory_usage_bytes?: integer
   estimated_operations?: integer
   fully_defined?: boolean
-  inference_config: MlInferenceConfigCreateContainer
+  inference_config?: MlInferenceConfigCreateContainer
   input: MlTrainedModelConfigInput
   license_level?: string
   metadata?: MlTrainedModelConfigMetadata
@@ -12930,6 +12943,7 @@ export interface MlTrainedModelDeploymentNodesStats {
 export interface MlTrainedModelDeploymentStats {
   allocation_status: MlTrainedModelDeploymentAllocationStatus
   cache_size?: ByteSize
+  deployment_id: Id
   error_count: integer
   inference_count: integer
   model_id: Id

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -63,6 +63,8 @@ export class TrainedModelDeploymentStats {
   /** The detailed allocation status for the deployment. */
   allocation_status: TrainedModelDeploymentAllocationStatus
   cache_size?: ByteSize
+  /** The unique identifier for the trained model deployment. */
+  deployment_id: Id
   /** The sum of `error_count` for all nodes in the deployment. */
   error_count: integer
   /** The sum of `inference_count` for all nodes in the deployment. */
@@ -178,8 +180,8 @@ export class TrainedModelConfig {
   estimated_operations?: integer
   /** True if the full model definition is present. */
   fully_defined?: boolean
-  /** The default configuration for inference. This can be either a regression, classification, or one of the many NLP focused configurations. It must match the underlying definition.trained_model's target_type. */
-  inference_config: InferenceConfigCreateContainer
+  /** The default configuration for inference. This can be either a regression, classification, or one of the many NLP focused configurations. It must match the underlying definition.trained_model's target_type. For pre-packaged models such as ELSER the config is not required. */
+  inference_config?: InferenceConfigCreateContainer
   /** The input field names for the model definition. */
   input: TrainedModelConfigInput
   /** The license level of the trained model. */

--- a/specification/ml/_types/inference.ts
+++ b/specification/ml/_types/inference.ts
@@ -60,6 +60,11 @@ export class InferenceConfigCreateContainer {
    * */
   text_embedding?: TextEmbeddingInferenceOptions
   /**
+   * Text expansion configuration for inference.
+   * @since 8.8.0
+   * */
+  text_expansion?: TextExpansionInferenceOptions
+  /**
    * Question answering configuration for inference.
    * @since 8.3.0
    */
@@ -221,6 +226,16 @@ export class Vocabulary {
 
 /** Text embedding inference options */
 export class TextEmbeddingInferenceOptions {
+  /** The number of dimensions in the embedding output */
+  embedding_size?: integer
+  /** The tokenization options */
+  tokenization?: TokenizationConfigContainer
+  /** The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value. */
+  results_field?: string
+}
+
+/** Text expansion inference options */
+export class TextExpansionInferenceOptions {
   /** The tokenization options */
   tokenization?: TokenizationConfigContainer
   /** The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value. */
@@ -280,6 +295,8 @@ export class InferenceConfigUpdateContainer {
   pass_through?: PassThroughInferenceUpdateOptions
   /** Text embedding configuration for inference. */
   text_embedding?: TextEmbeddingInferenceUpdateOptions
+  /** Text expansion configuration for inference. */
+  text_expansion?: TextExpansionInferenceUpdateOptions
   /** Question answering configuration for inference */
   question_answering?: QuestionAnsweringInferenceUpdateOptions
 }
@@ -298,6 +315,8 @@ export class NlpInferenceConfigUpdateContainer {
   pass_through?: PassThroughInferenceUpdateOptions
   /** Text embedding configuration for inference. */
   text_embedding?: TextEmbeddingInferenceUpdateOptions
+  /** Text expansion configuration for inference. */
+  text_expansion?: TextExpansionInferenceUpdateOptions
   /** Question answering configuration for inference */
   question_answering?: QuestionAnsweringInferenceUpdateOptions
 }
@@ -355,6 +374,12 @@ export class PassThroughInferenceUpdateOptions {
 }
 
 export class TextEmbeddingInferenceUpdateOptions {
+  tokenization?: NlpTokenizationUpdateOptions
+  /** The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value. */
+  results_field?: string
+}
+
+export class TextExpansionInferenceUpdateOptions {
   tokenization?: NlpTokenizationUpdateOptions
   /** The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value. */
   results_field?: string


### PR DESCRIPTION
Updates the ML NLP APIs for new features added in 8.8. Namely the `text_expansion` config  and adding the new `deployment_id` field to stats results.

