### PR TITLE
Update rest endpoint specs to facilitate Data Lifecycle Management

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -467,8 +467,7 @@
     },
     "cluster.get_component_template": {
       "request": [
-        "Request: query parameter 'flat_settings' does not exist in the json spec",
-        "Request: missing json spec query parameter 'include_defaults'"
+        "Request: query parameter 'flat_settings' does not exist in the json spec"
       ],
       "response": []
     },
@@ -738,10 +737,10 @@
       ]
     },
     "indices.delete_data_lifecycle": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
+      "request": [],
+      "response": [
+        "response definition indices.delete_data_lifecycle:Response / body / instance_of - Non-leaf type cannot be used here: '_types:AcknowledgedResponseBase'"
+      ]
     },
     "indices.delete_data_stream": {
       "request": [],
@@ -768,12 +767,6 @@
       ],
       "response": []
     },
-    "indices.explain_data_lifecycle": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "indices.field_usage_stats": {
       "request": [
         "Request: query parameter 'master_timeout' does not exist in the json spec",
@@ -793,24 +786,6 @@
       "response": [
         "response definition indices.get:Response / body / dictionary_of / instance_of - Non-leaf type cannot be used here: 'indices._types:IndexState'"
       ]
-    },
-    "indices.get_data_lifecycle": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
-    "indices.get_data_stream": {
-      "request": [
-        "Request: missing json spec query parameter 'include_defaults'"
-      ],
-      "response": []
-    },
-    "indices.get_index_template": {
-      "request": [
-        "Request: missing json spec query parameter 'include_defaults'"
-      ],
-      "response": []
     },
     "indices.get_settings": {
       "request": [],
@@ -837,10 +812,10 @@
       ]
     },
     "indices.put_data_lifecycle": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
+      "request": [],
+      "response": [
+        "response definition indices.put_data_lifecycle:Response / body / instance_of - Non-leaf type cannot be used here: '_types:AcknowledgedResponseBase'"
+      ]
     },
     "indices.put_index_template": {
       "request": [
@@ -874,15 +849,13 @@
     },
     "indices.simulate_index_template": {
       "request": [
-        "Request: missing json spec query parameter 'cause'",
-        "Request: missing json spec query parameter 'include_defaults'"
+        "Request: missing json spec query parameter 'cause'"
       ],
       "response": []
     },
     "indices.simulate_template": {
       "request": [
-        "Request: missing json spec query parameter 'cause'",
-        "Request: missing json spec query parameter 'include_defaults'"
+        "Request: missing json spec query parameter 'cause'"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8248,6 +8248,7 @@ export interface ClusterComponentTemplateSummary {
   settings?: Record<IndexName, IndicesIndexSettings>
   mappings?: MappingTypeMapping
   aliases?: Record<string, IndicesAliasDefinition>
+  lifecycle?: IndicesDataLifecycleWithRollover
 }
 
 export interface ClusterAllocationExplainAllocationDecision {
@@ -8396,6 +8397,7 @@ export interface ClusterGetComponentTemplateRequest extends RequestBase {
   flat_settings?: boolean
   local?: boolean
   master_timeout?: Duration
+  include_defaults?: boolean
 }
 
 export interface ClusterGetComponentTemplateResponse {
@@ -9537,6 +9539,15 @@ export interface IndicesCacheQueries {
   enabled: boolean
 }
 
+export interface IndicesDataLifecycle {
+  data_retention?: Duration
+}
+
+export interface IndicesDataLifecycleWithRollover {
+  data_retention?: Duration
+  rollover?: IndicesDlmRolloverConditions
+}
+
 export interface IndicesDataStream {
   name: DataStreamName
   timestamp_field: IndicesDataStreamTimestampField
@@ -9550,6 +9561,7 @@ export interface IndicesDataStream {
   ilm_policy?: Name
   _meta?: Metadata
   allow_custom_routing?: boolean
+  lifecycle?: IndicesDataLifecycleWithRollover
 }
 
 export interface IndicesDataStreamIndex {
@@ -9563,6 +9575,19 @@ export interface IndicesDataStreamTimestampField {
 
 export interface IndicesDataStreamVisibility {
   hidden?: boolean
+}
+
+export interface IndicesDlmRolloverConditions {
+  min_age?: Duration
+  max_age?: string
+  min_docs?: long
+  max_docs?: long
+  min_size?: ByteSize
+  max_size?: ByteSize
+  min_primary_shard_size?: ByteSize
+  max_primary_shard_size?: ByteSize
+  min_primary_shard_docs?: long
+  max_primary_shard_docs?: long
 }
 
 export interface IndicesDownsampleConfig {
@@ -9719,6 +9744,7 @@ export interface IndicesIndexState {
   settings?: IndicesIndexSettings
   defaults?: IndicesIndexSettings
   data_stream?: DataStreamName
+  lifecycle?: IndicesDataLifecycle
 }
 
 export interface IndicesIndexTemplate {
@@ -9741,6 +9767,7 @@ export interface IndicesIndexTemplateSummary {
   aliases?: Record<IndexName, IndicesAlias>
   mappings?: MappingTypeMapping
   settings?: IndicesIndexSettings
+  lifecycle?: IndicesDataLifecycleWithRollover
 }
 
 export interface IndicesIndexVersioning {
@@ -10160,6 +10187,15 @@ export interface IndicesDeleteAliasRequest extends RequestBase {
 
 export type IndicesDeleteAliasResponse = AcknowledgedResponseBase
 
+export interface IndicesDeleteDataLifecycleRequest extends RequestBase {
+  name: DataStreamNames
+  expand_wildcards?: ExpandWildcards
+  master_timeout?: Duration
+  timeout?: Duration
+}
+
+export type IndicesDeleteDataLifecycleResponse = AcknowledgedResponseBase
+
 export interface IndicesDeleteDataStreamRequest extends RequestBase {
   name: DataStreamNames
   expand_wildcards?: ExpandWildcards
@@ -10240,6 +10276,29 @@ export interface IndicesExistsTemplateRequest extends RequestBase {
 }
 
 export type IndicesExistsTemplateResponse = boolean
+
+export interface IndicesExplainDataLifecycleDataLifecycleExplain {
+  index: IndexName
+  managed_by_dlm: boolean
+  index_creation_date_millis?: EpochTime<UnitMillis>
+  time_since_index_creation?: Duration
+  rollover_date_millis?: EpochTime<UnitMillis>
+  time_since_rollover?: Duration
+  lifecycle?: IndicesDataLifecycleWithRollover
+  generation_time?: Duration
+  error?: string
+}
+
+export interface IndicesExplainDataLifecycleRequest extends RequestBase {
+  index: IndexName
+  include_defaults?: boolean
+  master_timeout?: Duration
+  timeout?: Duration
+}
+
+export interface IndicesExplainDataLifecycleResponse {
+  indices: Record<IndexName, IndicesExplainDataLifecycleDataLifecycleExplain>
+}
 
 export interface IndicesFieldUsageStatsFieldSummary {
   any: uint
@@ -10358,9 +10417,25 @@ export interface IndicesGetAliasRequest extends RequestBase {
 
 export type IndicesGetAliasResponse = Record<IndexName, IndicesGetAliasIndexAliases>
 
+export interface IndicesGetDataLifecycleDataStreamLifecycle {
+  name: DataStreamName
+  lifecycle?: IndicesDataLifecycle
+}
+
+export interface IndicesGetDataLifecycleRequest extends RequestBase {
+  name: DataStreamNames
+  expand_wildcards?: ExpandWildcards
+  include_defaults?: boolean
+}
+
+export interface IndicesGetDataLifecycleResponse {
+  data_streams: IndicesGetDataLifecycleDataStreamLifecycle[]
+}
+
 export interface IndicesGetDataStreamRequest extends RequestBase {
   name?: DataStreamNames
   expand_wildcards?: ExpandWildcards
+  include_defaults?: boolean
 }
 
 export interface IndicesGetDataStreamResponse {
@@ -10393,6 +10468,7 @@ export interface IndicesGetIndexTemplateRequest extends RequestBase {
   local?: boolean
   flat_settings?: boolean
   master_timeout?: Duration
+  include_defaults?: boolean
 }
 
 export interface IndicesGetIndexTemplateResponse {
@@ -10499,10 +10575,23 @@ export interface IndicesPutAliasRequest extends RequestBase {
 
 export type IndicesPutAliasResponse = AcknowledgedResponseBase
 
+export interface IndicesPutDataLifecycleRequest extends RequestBase {
+  name: DataStreamNames
+  expand_wildcards?: ExpandWildcards
+  master_timeout?: Duration
+  timeout?: Duration
+  body?: {
+    data_retention?: Duration
+  }
+}
+
+export type IndicesPutDataLifecycleResponse = AcknowledgedResponseBase
+
 export interface IndicesPutIndexTemplateIndexTemplateMapping {
   aliases?: Record<IndexName, IndicesAlias>
   mappings?: MappingTypeMapping
   settings?: IndicesIndexSettings
+  lifecycle?: IndicesDataLifecycle
 }
 
 export interface IndicesPutIndexTemplateRequest extends RequestBase {
@@ -10895,6 +10984,7 @@ export interface IndicesSimulateIndexTemplateRequest extends RequestBase {
   name: Name
   create?: boolean
   master_timeout?: Duration
+  include_defaults?: boolean
   body?: {
     allow_auto_create?: boolean
     index_patterns?: Indices
@@ -10919,6 +11009,7 @@ export interface IndicesSimulateTemplateRequest extends RequestBase {
   name?: Name
   create?: boolean
   master_timeout?: Duration
+  include_defaults?: boolean
   body?: IndicesIndexTemplate
 }
 

--- a/specification/_json_spec/indices.explain_data_lifecycle.json
+++ b/specification/_json_spec/indices.explain_data_lifecycle.json
@@ -27,6 +27,14 @@
       "include_defaults": {
         "type": "boolean",
         "description": "indicates if the API should return the default values the system uses for the index's lifecycle"
+      },
+      "master_timeout": {
+        "type": "time",
+        "description": "Specify timeout for connection to master"
+      },
+      "timeout": {
+        "type": "time",
+        "description": "Explicit timestamp for the document"
       }
     }
   }

--- a/specification/cluster/_types/ComponentTemplate.ts
+++ b/specification/cluster/_types/ComponentTemplate.ts
@@ -22,7 +22,10 @@ import { IndexSettings } from '@indices/_types/IndexSettings'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { IndexName, Metadata, Name, VersionNumber } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
-import {DataLifecycle, DataLifecycleWithRollover} from "@indices/_types/DataLifecycle";
+import {
+  DataLifecycle,
+  DataLifecycleWithRollover
+} from '@indices/_types/DataLifecycle'
 
 export class ComponentTemplate {
   name: Name

--- a/specification/cluster/_types/ComponentTemplate.ts
+++ b/specification/cluster/_types/ComponentTemplate.ts
@@ -22,6 +22,7 @@ import { IndexSettings } from '@indices/_types/IndexSettings'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { IndexName, Metadata, Name, VersionNumber } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
+import {DataLifecycle, DataLifecycleWithRollover} from "@indices/_types/DataLifecycle";
 
 export class ComponentTemplate {
   name: Name
@@ -42,4 +43,9 @@ export class ComponentTemplateSummary {
   settings?: Dictionary<IndexName, IndexSettings>
   mappings?: TypeMapping
   aliases?: Dictionary<string, AliasDefinition>
+  /**
+   * @since 8.8.0
+   * @stability experimental
+   */
+  lifecycle?: DataLifecycleWithRollover
 }

--- a/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
+++ b/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
@@ -41,6 +41,7 @@ export interface Request extends RequestBase {
     /**
      * @since 8.8.0
      * @stability experimental
+     * @server_default false
      */
     include_defaults?: boolean
   }

--- a/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
+++ b/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
@@ -38,5 +38,10 @@ export interface Request extends RequestBase {
     local?: boolean
     /** @server_default 30s */
     master_timeout?: Duration
+    /**
+     * @since 8.8.0
+     * @stability experimental
+     */
+    include_defaults?: boolean
   }
 }

--- a/specification/indices/_types/DataLifecycle.ts
+++ b/specification/indices/_types/DataLifecycle.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Duration} from "@_types/Time";
+import {long} from "@_types/Numeric";
+import {ByteSize} from "@_types/common";
+
+export class DataLifecycle {
+    data_retention?: Duration
+}
+
+export class DataLifecycleWithRollover {
+    data_retention?: Duration
+    rollover?: DlmRolloverConditions
+}
+
+class DlmRolloverConditions {
+    min_age?: Duration
+    // max_age is a string because it can contain a label to signal that it's automatically calculated
+    max_age?: string
+    min_docs?: long
+    max_docs?: long
+    min_size?: ByteSize
+    max_size?: ByteSize
+    min_primary_shard_size?: ByteSize
+    max_primary_shard_size?: ByteSize
+    min_primary_shard_docs?: long
+    max_primary_shard_docs?: long
+}

--- a/specification/indices/_types/DataLifecycle.ts
+++ b/specification/indices/_types/DataLifecycle.ts
@@ -21,10 +21,17 @@ import { Duration } from '@_types/Time'
 import { long } from '@_types/Numeric'
 import { ByteSize } from '@_types/common'
 
+/**
+ * Data lifecycle denotes that a data stream is managed by DLM and contains the configuration.
+ */
 export class DataLifecycle {
   data_retention?: Duration
 }
 
+/**
+ * Data lifecycle with rollover can be used to display the configuration including the default rollover conditions,
+ * if asked.
+ */
 export class DataLifecycleWithRollover {
   data_retention?: Duration
   rollover?: DlmRolloverConditions

--- a/specification/indices/_types/DataLifecycle.ts
+++ b/specification/indices/_types/DataLifecycle.ts
@@ -17,29 +17,29 @@
  * under the License.
  */
 
-import {Duration} from "@_types/Time";
-import {long} from "@_types/Numeric";
-import {ByteSize} from "@_types/common";
+import { Duration } from '@_types/Time'
+import { long } from '@_types/Numeric'
+import { ByteSize } from '@_types/common'
 
 export class DataLifecycle {
-    data_retention?: Duration
+  data_retention?: Duration
 }
 
 export class DataLifecycleWithRollover {
-    data_retention?: Duration
-    rollover?: DlmRolloverConditions
+  data_retention?: Duration
+  rollover?: DlmRolloverConditions
 }
 
 class DlmRolloverConditions {
-    min_age?: Duration
-    // max_age is a string because it can contain a label to signal that it's automatically calculated
-    max_age?: string
-    min_docs?: long
-    max_docs?: long
-    min_size?: ByteSize
-    max_size?: ByteSize
-    min_primary_shard_size?: ByteSize
-    max_primary_shard_size?: ByteSize
-    min_primary_shard_docs?: long
-    max_primary_shard_docs?: long
+  min_age?: Duration
+  // max_age is a string because it can contain a label to signal that it's automatically calculated
+  max_age?: string
+  min_docs?: long
+  max_docs?: long
+  min_size?: ByteSize
+  max_size?: ByteSize
+  min_primary_shard_size?: ByteSize
+  max_primary_shard_size?: ByteSize
+  min_primary_shard_docs?: long
+  max_primary_shard_docs?: long
 }

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -27,6 +27,7 @@ import {
   Uuid
 } from '@_types/common'
 import { integer } from '@_types/Numeric'
+import {DataLifecycleWithRollover} from "@indices/_types/DataLifecycle";
 
 export class DataStream {
   name: DataStreamName
@@ -43,6 +44,11 @@ export class DataStream {
   /** @doc_id mapping-meta-field */
   _meta?: Metadata
   allow_custom_routing?: boolean
+  /**
+   * @since 8.8.0
+   * @stability experimental
+   */
+  lifecycle?: DataLifecycleWithRollover
 }
 
 export class DataStreamTimestampField {

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -27,7 +27,7 @@ import {
   Uuid
 } from '@_types/common'
 import { integer } from '@_types/Numeric'
-import {DataLifecycleWithRollover} from "@indices/_types/DataLifecycle";
+import { DataLifecycleWithRollover } from '@indices/_types/DataLifecycle'
 
 export class DataStream {
   name: DataStreamName

--- a/specification/indices/_types/IndexState.ts
+++ b/specification/indices/_types/IndexState.ts
@@ -22,6 +22,7 @@ import { DataStreamName, IndexName } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { Alias } from './Alias'
 import { IndexSettings } from './IndexSettings'
+import {DataLifecycle} from "@indices/_types/DataLifecycle";
 
 export class IndexState {
   aliases?: Dictionary<IndexName, Alias>
@@ -30,4 +31,10 @@ export class IndexState {
   /** Default settings, included when the request's `include_default` is `true`. */
   defaults?: IndexSettings
   data_stream?: DataStreamName
+  /**
+   * Data lifecycle applicable iff this is a data stream.
+   * @since 8.8.0
+   * @stability experimental
+   */
+  lifecycle?: DataLifecycle
 }

--- a/specification/indices/_types/IndexState.ts
+++ b/specification/indices/_types/IndexState.ts
@@ -22,7 +22,7 @@ import { DataStreamName, IndexName } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { Alias } from './Alias'
 import { IndexSettings } from './IndexSettings'
-import {DataLifecycle} from "@indices/_types/DataLifecycle";
+import { DataLifecycle } from '@indices/_types/DataLifecycle'
 
 export class IndexState {
   aliases?: Dictionary<IndexName, Alias>

--- a/specification/indices/_types/IndexTemplate.ts
+++ b/specification/indices/_types/IndexTemplate.ts
@@ -23,7 +23,10 @@ import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { long } from '@_types/Numeric'
 import { Alias } from './Alias'
 import { IndexSettings } from './IndexSettings'
-import {DataLifecycle, DataLifecycleWithRollover} from "@indices/_types/DataLifecycle";
+import {
+  DataLifecycle,
+  DataLifecycleWithRollover
+} from '@indices/_types/DataLifecycle'
 
 export class IndexTemplate {
   index_patterns: Names

--- a/specification/indices/_types/IndexTemplate.ts
+++ b/specification/indices/_types/IndexTemplate.ts
@@ -23,6 +23,7 @@ import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { long } from '@_types/Numeric'
 import { Alias } from './Alias'
 import { IndexSettings } from './IndexSettings'
+import {DataLifecycle, DataLifecycleWithRollover} from "@indices/_types/DataLifecycle";
 
 export class IndexTemplate {
   index_patterns: Names
@@ -53,4 +54,9 @@ export class IndexTemplateSummary {
   aliases?: Dictionary<IndexName, Alias>
   mappings?: TypeMapping
   settings?: IndexSettings
+  /**
+   * @since 8.8.0
+   * @stability experimental
+   */
+  lifecycle?: DataLifecycleWithRollover
 }

--- a/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
+++ b/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { ExpandWildcards, DataStreamNames } from '@_types/common'
+import {Duration} from "@_types/Time";
+
+/**
+ * @rest_spec_name indices.delete_data_lifecycle
+ * @since 8.8.0
+ * @stability experimental
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    name: DataStreamNames
+  }
+  query_parameters: {
+    expand_wildcards?: ExpandWildcards
+    master_timeout?: Duration
+    timeout?: Duration
+  }
+}

--- a/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
+++ b/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
@@ -19,7 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, DataStreamNames } from '@_types/common'
-import {Duration} from "@_types/Time";
+import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.delete_data_lifecycle

--- a/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
+++ b/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
@@ -22,6 +22,7 @@ import { ExpandWildcards, DataStreamNames } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Removes the data lifecycle from a data stream rendering it not managed by DLM
  * @rest_spec_name indices.delete_data_lifecycle
  * @since 8.8.0
  * @stability experimental

--- a/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleResponse.ts
+++ b/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  body: AcknowledgedResponseBase
+}

--- a/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts
+++ b/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { IndexName } from '@_types/common'
+import { Duration } from '@_types/Time'
+
+/**
+ * Retrieves information about the index's current DLM lifecycle, such as any potential encountered error, time since creation etc.
+ * @rest_spec_name indices.explain_data_lifecycle
+ * @since 8.8.0
+ * @stability experimental
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    index: IndexName
+  }
+  query_parameters: {
+    include_defaults?: boolean
+    master_timeout?: Duration
+    timeout?: Duration
+  }
+}

--- a/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleResponse.ts
+++ b/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleResponse.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Dictionary } from '@spec_utils/Dictionary'
+import { IndexName } from '@_types/common'
+import {Duration, EpochTime, UnitMillis} from "@_types/Time";
+import {DataLifecycleWithRollover} from "@indices/_types/DataLifecycle";
+
+export class Response {
+  body: {
+    indices: Dictionary<IndexName, DataLifecycleExplain>
+  }
+}
+
+class DataLifecycleExplain {
+  index: IndexName
+  managed_by_dlm: boolean
+  index_creation_date_millis?: EpochTime<UnitMillis>
+  time_since_index_creation?: Duration
+  rollover_date_millis?: EpochTime<UnitMillis>
+  time_since_rollover?: Duration
+  lifecycle?: DataLifecycleWithRollover
+  generation_time?: Duration
+  error?: string
+}

--- a/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleResponse.ts
+++ b/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleResponse.ts
@@ -19,8 +19,8 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { IndexName } from '@_types/common'
-import {Duration, EpochTime, UnitMillis} from "@_types/Time";
-import {DataLifecycleWithRollover} from "@indices/_types/DataLifecycle";
+import { Duration, EpochTime, UnitMillis } from '@_types/Time'
+import { DataLifecycleWithRollover } from '@indices/_types/DataLifecycle'
 
 export class Response {
   body: {

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, DataStreamNames } from '@_types/common'
 
 /**
+ * Retrieves the data lifecycle configuration of one or more data streams.
  * @rest_spec_name indices.get_data_lifecycle
  * @since 8.8.0
  * @stability experimental

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { ExpandWildcards, DataStreamNames } from '@_types/common'
+
+/**
+ * @rest_spec_name indices.get_data_lifecycle
+ * @since 8.8.0
+ * @stability experimental
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    name: DataStreamNames
+  }
+  query_parameters: {
+    expand_wildcards?: ExpandWildcards
+    include_defaults?: boolean
+  }
+}

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleResponse.ts
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleResponse.ts
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {DataStreamName} from "@_types/common";
+import {DataLifecycle} from "@indices/_types/DataLifecycle";
+
+export class Response {
+  body: { data_streams: DataStreamLifecycle[] }
+}
+
+class DataStreamLifecycle {
+  name: DataStreamName
+  lifecycle?: DataLifecycle
+}
+
+

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleResponse.ts
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import {DataStreamName} from "@_types/common";
-import {DataLifecycle} from "@indices/_types/DataLifecycle";
+import { DataStreamName } from '@_types/common'
+import { DataLifecycle } from '@indices/_types/DataLifecycle'
 
 export class Response {
   body: { data_streams: DataStreamLifecycle[] }
@@ -28,5 +28,3 @@ class DataStreamLifecycle {
   name: DataStreamName
   lifecycle?: DataLifecycle
 }
-
-

--- a/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
+++ b/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
@@ -31,5 +31,10 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     expand_wildcards?: ExpandWildcards
+    /**
+     * @since 8.8.0
+     * @stability experimental
+     */
+    include_defaults?: boolean
   }
 }

--- a/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
+++ b/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
@@ -32,6 +32,8 @@ export interface Request extends RequestBase {
   query_parameters: {
     expand_wildcards?: ExpandWildcards
     /**
+     * If true, returns all relevant default configurations for the index template.
+     * @server_default false
      * @since 8.8.0
      * @stability experimental
      */

--- a/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
+++ b/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
@@ -49,5 +49,12 @@ export interface Request extends RequestBase {
      * @server_default 30s
      */
     master_timeout?: Duration
+    /**
+     * If true, returns all relevant default configurations for the index template.
+     * @server_default false
+     * @since 8.8.0
+     * @stability experimental
+     */
+    include_defaults?: boolean
   }
 }

--- a/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
+++ b/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import {DataStreamNames, ExpandWildcards} from '@_types/common'
+import { Duration } from '@_types/Time'
+
+/**
+ * Update the data lifecycle of the specified data streams.
+ * @rest_spec_name indices.put_data_lifecycle
+ * @since 8.8.0
+ * @stability experimental
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    name: DataStreamNames
+  }
+  query_parameters: {
+    expand_wildcards?: ExpandWildcards
+    master_timeout?: Duration
+    timeout?: Duration
+  }
+  body: {
+    data_retention?: Duration
+  }
+}

--- a/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
+++ b/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import {DataStreamNames, ExpandWildcards} from '@_types/common'
+import { DataStreamNames, ExpandWildcards } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**

--- a/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleResponse.ts
+++ b/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  body: AcknowledgedResponseBase
+}

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
@@ -31,7 +31,7 @@ import {
 } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { integer } from '@_types/Numeric'
-import {DataLifecycle} from "@indices/_types/DataLifecycle";
+import { DataLifecycle } from '@indices/_types/DataLifecycle'
 
 /**
  * @rest_spec_name indices.put_index_template

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
@@ -31,6 +31,7 @@ import {
 } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { integer } from '@_types/Numeric'
+import {DataLifecycle} from "@indices/_types/DataLifecycle";
 
 /**
  * @rest_spec_name indices.put_index_template
@@ -61,4 +62,9 @@ export class IndexTemplateMapping {
   aliases?: Dictionary<IndexName, Alias>
   mappings?: TypeMapping
   settings?: IndexSettings
+  /**
+   * @since 8.8.0
+   * @stability experimental
+   */
+  lifecycle?: DataLifecycle
 }

--- a/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
+++ b/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
@@ -56,6 +56,13 @@ export interface Request extends RequestBase {
      * @server_default 30s
      */
     master_timeout?: Duration
+    /**
+     * If true, returns all relevant default configurations for the index template.
+     * @server_default false
+     * @since 8.8.0
+     * @stability experimental
+     */
+    include_defaults?: boolean
   }
   body: {
     allow_auto_create?: boolean

--- a/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
+++ b/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
@@ -48,6 +48,13 @@ export interface Request extends RequestBase {
      * @server_default 30s
      */
     master_timeout?: Duration
+    /**
+     * If true, returns all relevant default configurations for the index template.
+     * @server_default false
+     * @since 8.8.0
+     * @stability experimental
+     */
+    include_defaults?: boolean
   }
   /** @codegen_name template */
   body?: IndexTemplate


### PR DESCRIPTION
In this PR we update existing endpoints and we implement new ones to match the changes that the Data Lifecycle Management project is introducing (see https://github.com/elastic/elasticsearch/issues/93596).

We added the query param `include_defaults` where appropriate and introduced the `lifecycle` or `lifecycle` with rollover when necessary. This change affected the following:
- Data streams
- Component templates
- Index templates (composable)
- Template simulation

Furthermore, we implement the following endpoints:
- CRUD data lifecycle for a specific data stream
- Explain data lifecycle for a backing index of a data stream

I believe there are no backwards compatibility concerns because everything was added at the end. But please, correct me if I am wrong.