### PR TITLE
Added Behavioral Analytics APIs

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1186,24 +1186,12 @@
       ]
     },
     "search_application.delete_behavioral_analytics": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
-    "search_application.get_behavioral_analytics": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
+      "request": [],
+      "response": [
+        "response definition search_application.delete_behavioral_analytics:Response / body / instance_of - Non-leaf type cannot be used here: '_types:AcknowledgedResponseBase'"
+      ]
     },
     "search_application.post_behavioral_analytics_event": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
-    "search_application.put_behavioral_analytics": {
       "request": [
         "Missing request & response"
       ],

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15480,6 +15480,14 @@ export interface RollupStopJobResponse {
   stopped: boolean
 }
 
+export interface SearchApplicationAnalyticsCollection {
+  event_data_stream: SearchApplicationEventDataStream
+}
+
+export interface SearchApplicationEventDataStream {
+  name: IndexName
+}
+
 export interface SearchApplicationSearchApplication {
   name: Name
   indices: IndexName[]
@@ -15498,11 +15506,23 @@ export interface SearchApplicationDeleteRequest extends RequestBase {
 
 export type SearchApplicationDeleteResponse = AcknowledgedResponseBase
 
+export interface SearchApplicationDeleteBehavioralAnalyticsRequest extends RequestBase {
+  name: Name
+}
+
+export type SearchApplicationDeleteBehavioralAnalyticsResponse = AcknowledgedResponseBase
+
 export interface SearchApplicationGetRequest extends RequestBase {
   name: Name
 }
 
 export type SearchApplicationGetResponse = SearchApplicationSearchApplication
+
+export interface SearchApplicationGetBehavioralAnalyticsRequest extends RequestBase {
+  name?: Name[]
+}
+
+export type SearchApplicationGetBehavioralAnalyticsResponse = Record<Name, SearchApplicationAnalyticsCollection>
 
 export interface SearchApplicationListRequest extends RequestBase {
   q?: string
@@ -15531,6 +15551,16 @@ export interface SearchApplicationPutRequest extends RequestBase {
 export interface SearchApplicationPutResponse {
   result: Result
 }
+
+export interface SearchApplicationPutBehavioralAnalyticsAnalyticsAcknowledgeResponseBase extends AcknowledgedResponseBase {
+  name: Name
+}
+
+export interface SearchApplicationPutBehavioralAnalyticsRequest extends RequestBase {
+  name: Name
+}
+
+export type SearchApplicationPutBehavioralAnalyticsResponse = SearchApplicationPutBehavioralAnalyticsAnalyticsAcknowledgeResponseBase
 
 export interface SearchApplicationSearchRequest extends RequestBase {
   name: Name

--- a/specification/search_application/_types/AnalyticsEvent.ts
+++ b/specification/search_application/_types/AnalyticsEvent.ts
@@ -1,0 +1,28 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IndexName, Name } from '@_types/common'
+
+export class AnalyticsEvent {}
+
+export enum EventType {
+  PageView = 'page_view',
+  Search = 'search',
+  SearchClick = 'search_click'
+}

--- a/specification/search_application/_types/BehavioralAnalytics.ts
+++ b/specification/search_application/_types/BehavioralAnalytics.ts
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IndexName, Name } from '@_types/common'
+
+export class AnalyticsCollection {
+  /**
+   * Data stream for the collection
+   */
+  event_data_stream: EventDataStream
+}
+
+export class EventDataStream {
+  name: IndexName
+}

--- a/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteRequest.ts
+++ b/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteRequest.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { RequestBase } from '@_types/Base'
+import { Name } from '@_types/common'
+
+/**
+ * Delete a behavioral analytics collection.
+ * @rest_spec_name search_application.delete_behavioral_analytics
+ * @since 8.8.0
+ * @stability experimental
+ */
+interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The name of the analytics collection to be deleted
+     */
+    name: Name
+  }
+}

--- a/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteResponse.ts
+++ b/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  body: AcknowledgedResponseBase
+}

--- a/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
+++ b/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { RequestBase } from '@_types/Base'
+import { Name } from '@_types/common'
+
+/**
+ * Returns the existing behavioral analytics collections.
+ * @rest_spec_name search_application.get_behavioral_analytics
+ * @since 8.8.0
+ * @stability experimental
+ */
+interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * A list of analytics collections to limit the returned information
+     */
+    name?: Name[]
+  }
+}

--- a/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetResponse.ts
+++ b/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetResponse.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AnalyticsCollection } from '../_types/BehavioralAnalytics'
+import { Dictionary } from '@spec_utils/Dictionary'
+import { Name } from '@_types/common'
+
+export class Response {
+  body: Dictionary<Name, AnalyticsCollection>
+}

--- a/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutRequest.ts
+++ b/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutRequest.ts
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { RequestBase } from '@_types/Base'
+import { Name } from '@_types/common'
+import { SearchApplication } from '../_types/SearchApplication'
+
+/**
+ * Creates a behavioral analytics collection
+ * @rest_spec_name search_application.put_behavioral_analytics
+ * @since 8.8.0
+ * @stability experimental
+ */
+interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The name of the analytics collection to be created or updated
+     */
+    name: Name
+  }
+}

--- a/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutResponse.ts
+++ b/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutResponse.ts
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Result } from '@_types/Result'
+import { AcknowledgedResponseBase } from '@_types/Base'
+import { Name } from '@_types/common'
+
+export class Response {
+  body: AnalyticsAcknowledgeResponseBase
+}
+
+interface AnalyticsAcknowledgeResponseBase extends AcknowledgedResponseBase {
+  /**
+   * The name of the analytics collection created or updated
+   */
+  name: Name
+}


### PR DESCRIPTION
Add Behavioral Analytics APIs.

POST is missing - I understood from @afoucret and @joemcelroy that this API should not yet be available for clients. It can be contributed as a separate PR however.