### PR TITLE
Make index settings blocks stringified

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository_owner == 'elastic' # this action will fail if executed from a fork
     runs-on: ubuntu-latest
     env:
-      STACK_VERSION: 8.6-SNAPSHOT
+      STACK_VERSION: 8.9-SNAPSHOT
 
     steps:
       - uses: actions/checkout@v2

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9618,10 +9618,10 @@ export interface IndicesIndexSegmentSort {
 }
 
 export interface IndicesIndexSettingBlocks {
-  read_only?: boolean
-  read_only_allow_delete?: boolean
-  read?: boolean
-  write?: boolean | string
+  read_only?: SpecUtilsStringified<boolean>
+  read_only_allow_delete?: SpecUtilsStringified<boolean>
+  read?: SpecUtilsStringified<boolean>
+  write?: SpecUtilsStringified<boolean>
   metadata?: SpecUtilsStringified<boolean>
 }
 

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -243,10 +243,10 @@ export class SettingsQueryString {
 }
 
 export class IndexSettingBlocks {
-  read_only?: boolean
-  read_only_allow_delete?: boolean
-  read?: boolean
-  write?: boolean | string // TODO: should be bool only
+  read_only?: Stringified<boolean>
+  read_only_allow_delete?: Stringified<boolean>
+  read?: Stringified<boolean>
+  write?: Stringified<boolean>
   metadata?: Stringified<boolean>
 }
 


### PR DESCRIPTION
Raised in https://github.com/elastic/elasticsearch-net/issues/7714, it appears that the possible block values should all be stringified as they are each produced as an `APIBlock` ([see server code](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java#L264)).

This PR updates each possible block option to support the stringified value when getting index settings.