### PR TITLE
Add the text_expansion query

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5764,6 +5764,7 @@ export interface QueryDslQueryContainer {
   term?: Partial<Record<Field, QueryDslTermQuery | FieldValue>>
   terms?: QueryDslTermsQuery
   terms_set?: Partial<Record<Field, QueryDslTermsSetQuery>>
+  text_expansion?: QueryDslTextExpansionQuery | Field
   wildcard?: Partial<Record<Field, QueryDslWildcardQuery | string>>
   wrapper?: QueryDslWrapperQuery
   type?: QueryDslTypeQuery
@@ -5977,6 +5978,12 @@ export interface QueryDslTermsSetQuery extends QueryDslQueryBase {
   minimum_should_match_field?: Field
   minimum_should_match_script?: Script
   terms: string[]
+}
+
+export interface QueryDslTextExpansionQuery extends QueryDslQueryBase {
+  value: Field
+  model_id: string
+  model_text: string
 }
 
 export type QueryDslTextQueryType = 'best_fields' | 'most_fields' | 'cross_fields' | 'phrase' | 'phrase_prefix' | 'bool_prefix'

--- a/specification/_types/query_dsl/TextExpansionQuery.ts
+++ b/specification/_types/query_dsl/TextExpansionQuery.ts
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Field } from '@_types/common'
+import { QueryBase } from './abstractions'
+
+/** @shortcut_property value */
+export class TextExpansionQuery extends QueryBase {
+  /** The name of the rank features field to search against */
+  value: Field
+  /** The text expansion NLP model to use */
+  model_id: string
+  /** The query text */
+  model_text: string
+}

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -92,6 +92,7 @@ import {
   TypeQuery,
   WildcardQuery
 } from './term'
+import { TextExpansionQuery } from './TextExpansionQuery'
 
 /**
  * @variants container
@@ -152,6 +153,8 @@ export class QueryContainer {
   term?: SingleKeyDictionary<Field, TermQuery>
   terms?: TermsQuery
   terms_set?: SingleKeyDictionary<Field, TermsSetQuery>
+  /** @since 8.8.0 */
+  text_expansion?: TextExpansionQuery
   wildcard?: SingleKeyDictionary<Field, WildcardQuery>
   wrapper?: WrapperQuery
 


### PR DESCRIPTION
Documents the new `text_expansion` query created in https://github.com/elastic/elasticsearch/pull/93694
The query is first available in Elasticsearch version 8.8