### PR TITLE
Add support for the `@availability` annotations

### DIFF
--- a/.github/validate-pr/index.js
+++ b/.github/validate-pr/index.js
@@ -60,7 +60,7 @@ async function run () {
     }
   }
 
-  const specFiles = files.filter(file => file.includes('specification'))
+  const specFiles = files.filter(file => file.includes('specification') && !file.includes('compiler/test'))
   const table = []
 
   cd(tsValidationPath)

--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -68,6 +68,15 @@ export function compileEndpoints (): Record<string, model.Endpoint> {
       name: api,
       description: spec.documentation.description,
       docUrl: spec.documentation.url,
+      // Setting these values by default should be removed
+      // when we no longer use rest-api-spec stubs as the
+      // source of truth for stability/visibility.
+      availability: {
+        stack: {
+          stability: spec.stability,
+          visibility: spec.visibility
+        }
+      },
       stability: spec.stability,
       visibility: spec.visibility,
       request: null,

--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -369,7 +369,7 @@ export enum Stability {
 }
 export enum Visibility {
   public = 'public',
-  featureFlag = 'feature_flag',
+  feature_flag = 'feature_flag',
   private = 'private'
 }
 
@@ -378,12 +378,30 @@ export class Deprecation {
   description: string
 }
 
+export class Availability {
+  stack?: StackAvailability
+  serverless?: ServerlessAvailability
+}
+
+export class StackAvailability {
+  since?: string
+  featureFlag?: string
+  stability?: Stability
+  visibility?: Visibility
+}
+
+export class ServerlessAvailability {
+  stability?: Stability
+  visibility?: Visibility
+}
+
 export class Endpoint {
   name: string
   description: string
   docUrl: string
   docId?: string
   deprecation?: Deprecation
+  availability: Availability
 
   /**
    * If the request value is `null` it means that there is not yet a

--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -378,19 +378,14 @@ export class Deprecation {
   description: string
 }
 
-export class Availability {
-  stack?: StackAvailability
-  serverless?: ServerlessAvailability
+export class Availabilities {
+  stack?: Availability
+  serverless?: Availability
 }
 
-export class StackAvailability {
+export class Availability {
   since?: string
   featureFlag?: string
-  stability?: Stability
-  visibility?: Visibility
-}
-
-export class ServerlessAvailability {
   stability?: Stability
   visibility?: Visibility
 }
@@ -401,7 +396,7 @@ export class Endpoint {
   docUrl: string
   docId?: string
   deprecation?: Deprecation
-  availability: Availability
+  availability: Availabilities
 
   /**
    * If the request value is `null` it means that there is not yet a

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -1069,21 +1069,12 @@ export function parseAvailabilityTags (node: Node | Node[], values: string[]): m
     // Since we're using reduce() we need to check that there's no duplicates.
     assert(node, !(availabilityName in result), `Duplicate @availability tag: '${availabilityName}'`)
 
-    // Based on which availability definition we're parsing we have different valid tags.
-    let validKeys: string[] = []
-    switch (availabilityName) {
-      case 'stack':
-        validKeys = ['stability', 'visibility', 'since', 'feature_flag']
-        break
-      case 'serverless':
-        validKeys = ['stability', 'visibility']
-        break
-      default:
-        assert(node, false, 'The @availablility <name> value must either be stack or serverless')
-    }
+    // Enforce only known availability names.
+    assert(node, availabilityName === 'stack' || availabilityName === 'serverless', 'The @availablility <name> value must either be stack or serverless')
 
     // Now we can parse all the key-values and load them into variables
     // for easier access below.
+    const validKeys = ['stability', 'visibility', 'since', 'feature_flag']
     const parsedKeyValues = parseKeyValues(node, values, ...validKeys)
     const visibility = parsedKeyValues.visibility
     const stability = parsedKeyValues.stability
@@ -1108,11 +1099,9 @@ export function parseAvailabilityTags (node: Node | Node[], values: string[]): m
     }
     if (since !== undefined) {
       assert(node, semver.valid(since), `'since' is not valid semver: ${since}`)
-      assert(node, availabilityName === 'stack', `'since' is only valid on 'stack', not valid for '${availabilityName}'`)
     }
     if (featureFlag !== undefined) {
       assert(node, visibility === 'feature_flag', '\'visibility\' must be \'feature_flag\' if a feature flag is defined')
-      assert(node, availabilityName === 'stack', `'feature_flag' is only valid on 'stack', not valid for '${availabilityName}'`)
       parsedKeyValues.featureFlag = featureFlag
     }
 

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -648,10 +648,18 @@ export function hoistRequestAnnotations (
 
         // Backfilling deprecated fields on an endpoint.
         if (availabilityName === 'stack') {
-          endpoint.featureFlag = availabilityValue?.featureFlag
-          endpoint.since = availabilityValue?.since
-          endpoint.stability = availabilityValue?.stability
-          endpoint.visibility = availabilityValue?.visibility
+          if (availabilityValue.since !== undefined) {
+            endpoint.since = availabilityValue.since
+          }
+          if (availabilityValue.stability !== undefined) {
+            endpoint.stability = availabilityValue.stability
+          }
+          if (availabilityValue.visibility !== undefined) {
+            endpoint.visibility = availabilityValue.visibility
+          }
+          if (availabilityValue.featureFlag !== undefined) {
+            endpoint.featureFlag = availabilityValue.featureFlag
+          }
         }
       }
     } else {

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -643,24 +643,15 @@ export function hoistRequestAnnotations (
       const availabilities = parseAvailabilityTags(jsDocs, jsDocsMulti.availability)
 
       // Apply the availabilities to the Endpoint.
-      for (const availabilityName in availabilities) {
-        const availabilityValue = availabilities[availabilityName]
+      for (const [availabilityName, availabilityValue] of Object.entries(availabilities)) {
         endpoint.availability[availabilityName] = availabilityValue
 
         // Backfilling deprecated fields on an endpoint.
         if (availabilityName === 'stack') {
-          if (availabilityValue.since !== undefined) {
-            endpoint.since = availabilityValue.since
-          }
-          if (availabilityValue.stability !== undefined) {
-            endpoint.stability = availabilityValue.stability
-          }
-          if (availabilityValue.visibility !== undefined) {
-            endpoint.visibility = availabilityValue.visibility
-          }
-          if (availabilityValue.featureFlag !== undefined) {
-            endpoint.featureFlag = availabilityValue.featureFlag
-          }
+          endpoint.featureFlag = availabilityValue?.featureFlag
+          endpoint.since = availabilityValue?.since
+          endpoint.stability = availabilityValue?.stability
+          endpoint.visibility = availabilityValue?.visibility
         }
       }
     } else {

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -575,7 +575,7 @@ export function hoistRequestAnnotations (
   request: model.Request, jsDocs: JSDoc[], mappings: Record<string, model.Endpoint>, response: model.TypeName | null
 ): void {
   const knownRequestAnnotations = [
-    'since', 'rest_spec_name', 'stability', 'visibility', 'behavior', 'class_serializer', 'index_privileges', 'cluster_privileges', 'doc_id'
+    'rest_spec_name', 'behavior', 'class_serializer', 'index_privileges', 'cluster_privileges', 'doc_id', 'availability'
   ]
   // in most of the cases the jsDocs comes in a single block,
   // but it can happen that the user defines multiple single line jsDoc.
@@ -602,19 +602,6 @@ export function hoistRequestAnnotations (
   setTags(jsDocs, request, tags, knownRequestAnnotations, (tags, tag, value) => {
     if (tag.endsWith('_serializer')) {
     } else if (tag === 'rest_spec_name') {
-    } else if (tag === 'visibility') {
-      if (endpoint.visibility !== null && endpoint.visibility !== undefined) {
-        assert(jsDocs, endpoint.visibility === value,
-          `Request ${request.name.name} visibility on annotation ${value} does not match spec: ${endpoint.visibility ?? ''}`)
-      }
-      endpoint.visibility = model.Visibility[value]
-    } else if (tag === 'stability') {
-      assert(jsDocs, endpoint.stability === value,
-        `Request ${request.name.name} stability on annotation ${value} does not match spec: ${endpoint.stability ?? ''}`)
-      endpoint.stability = model.Stability[value]
-    } else if (tag === 'since') {
-      assert(jsDocs, semver.valid(value), `Request ${request.name.name}'s @since is not valid semver: ${value}`)
-      endpoint.since = value
     } else if (tag === 'index_privileges') {
       const privileges = [
         'all', 'auto_configure', 'create', 'create_doc', 'create_index', 'delete', 'delete_index', 'index',
@@ -648,6 +635,34 @@ export function hoistRequestAnnotations (
       const docUrl = docIds.find(entry => entry[0] === value.trim())
       assert(jsDocs, docUrl != null, `The @doc_id '${value.trim()}' is not present in _doc_ids/table.csv`)
       endpoint.docUrl = docUrl[1]
+    } else if (tag === 'availability') {
+      // The @availability jsTag is different than most because it allows
+      // multiple values within the same docstring, hence needing to parse
+      // the values again in order to preserve multiple values.
+      const jsDocsMulti = parseJsDocTagsAllowDuplicates(jsDocs)
+      const availabilities = parseAvailabilityTags(jsDocs, jsDocsMulti.availability)
+
+      // Apply the availabilities to the Endpoint.
+      for (const availabilityName in availabilities) {
+        const availabilityValue = availabilities[availabilityName]
+        endpoint.availability[availabilityName] = availabilityValue
+
+        // Backfilling deprecated fields on an endpoint.
+        if (availabilityName === 'stack') {
+          if (availabilityValue.since !== undefined) {
+            endpoint.since = availabilityValue.since
+          }
+          if (availabilityValue.stability !== undefined) {
+            endpoint.stability = availabilityValue.stability
+          }
+          if (availabilityValue.visibility !== undefined) {
+            endpoint.visibility = availabilityValue.visibility
+          }
+          if (availabilityValue.featureFlag !== undefined) {
+            endpoint.featureFlag = availabilityValue.featureFlag
+          }
+        }
+      }
     } else {
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on request ${request.name.name}`)
     }
@@ -899,7 +914,7 @@ export function getNameSpace (node: Node): string {
 
   function cleanPath (path: string): string {
     path = dirname(path)
-      .replace(/.*[/\\]specification[/\\]?/, '')
+      .replace(/.*[/\\]specification[^/\\]*[/\\]?/, '')
       .replace(/[/\\]/g, '.')
     if (path === '') path = '_builtins'
     return path
@@ -967,6 +982,25 @@ export function parseJsDocTags (jsDoc: JSDoc[]): Record<string, string> {
 }
 
 /**
+ * Given a JSDoc definition, return a mapping from a tag name to all its values.
+ * This function is similar to the above parseJsDocTags() function except
+ * it allows for multiple annotations with the same name.
+ */
+export function parseJsDocTagsAllowDuplicates (jsDoc: JSDoc[]): Record<string, string[]> {
+  const mapped = {}
+  jsDoc.forEach((elem: JSDoc) => {
+    elem.getTags().forEach((tag) => {
+      const tagName = tag.getTagName()
+      if (mapped[tagName] === undefined) {
+        mapped[tagName] = []
+      }
+      mapped[tagName].push(tag.getComment() ?? '')
+    })
+  })
+  return mapped
+}
+
+/**
  * Given a JSDoc definition, it returns the Variants is present.
  * It also validates the variants syntax.
  */
@@ -1021,6 +1055,71 @@ export function parseVariantNameTag (jsDoc: JSDoc[]): string | undefined {
   assert(jsDoc, typeof name === 'string', 'The @variant key should be "name"')
 
   return name.replace(/'/g, '')
+}
+
+/**
+ * Parses the '@availability' JS tags into known values.
+ */
+export function parseAvailabilityTags (node: Node | Node[], values: string[]): model.Availability {
+  return values.reduce((result, value, index, array) => {
+    // Ensure that there is actually a name for this availability definition.
+    assert(node, value.split(' ').length >= 1, 'The @availability tag must include a name (either stack or serverless)')
+    const [availabilityName, ...values] = value.split(' ')
+
+    // Since we're using reduce() we need to check that there's no duplicates.
+    assert(node, !(availabilityName in result), `Duplicate @availability tag: '${availabilityName}'`)
+
+    // Based on which availability definition we're parsing we have different valid tags.
+    let validKeys: string[] = []
+    switch (availabilityName) {
+      case 'stack':
+        validKeys = ['stability', 'visibility', 'since', 'feature_flag']
+        break
+      case 'serverless':
+        validKeys = ['stability', 'visibility']
+        break
+      default:
+        assert(node, false, 'The @availablility <name> value must either be stack or serverless')
+    }
+
+    // Now we can parse all the key-values and load them into variables
+    // for easier access below.
+    const parsedKeyValues = parseKeyValues(node, values, ...validKeys)
+    const visibility = parsedKeyValues.visibility
+    const stability = parsedKeyValues.stability
+    const since = parsedKeyValues.since
+    const featureFlag = parsedKeyValues.feature_flag
+
+    // Remove the 'feature_flag' name used in the annotations
+    // in favor of 'featureFlag' as used in the metamodel.
+    delete parsedKeyValues.feature_flag
+
+    // Lastly we go through all the fields and validate them.
+    if (visibility !== undefined) {
+      parsedKeyValues.visibility = model.Visibility[visibility]
+      assert(node, parsedKeyValues.visibility !== undefined, `visibility is not valid: ${visibility}`)
+      if (visibility === model.Visibility.feature_flag) {
+        assert(node, featureFlag !== undefined, '\'feature_flag\' must be defined if visibility is \'feature_flag\'')
+      }
+    }
+    if (stability !== undefined) {
+      parsedKeyValues.stability = model.Stability[stability]
+      assert(node, parsedKeyValues.stability !== undefined, `stability is not valid: ${stability}`)
+    }
+    if (since !== undefined) {
+      assert(node, semver.valid(since), `'since' is not valid semver: ${since}`)
+      assert(node, availabilityName === 'stack', `'since' is only valid on 'stack', not valid for '${availabilityName}'`)
+    }
+    if (featureFlag !== undefined) {
+      assert(node, visibility === 'feature_flag', '\'visibility\' must be \'feature_flag\' if a feature flag is defined')
+      assert(node, availabilityName === 'stack', `'feature_flag' is only valid on 'stack', not valid for '${availabilityName}'`)
+      parsedKeyValues.featureFlag = featureFlag
+    }
+
+    // Add the computed set of fields to the result.
+    result[availabilityName] = parsedKeyValues
+    return result
+  }, {})
 }
 
 /**

--- a/compiler/test/body-codegen-name/specification/_global/index/request.ts
+++ b/compiler/test/body-codegen-name/specification/_global/index/request.ts
@@ -19,8 +19,7 @@
 
 /**
  * @rest_spec_name index
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request {
   body: Foo

--- a/compiler/test/no-body/specification/_global/info/request.ts
+++ b/compiler/test/no-body/specification/_global/info/request.ts
@@ -19,8 +19,7 @@
 
 /**
  * @rest_spec_name info
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request {
   body: {

--- a/compiler/test/request-availability-failures/specification-duplicates/_global/index/request.ts
+++ b/compiler/test/request-availability-failures/specification-duplicates/_global/index/request.ts
@@ -19,16 +19,27 @@
 
 /**
  * @rest_spec_name index
- * @availability stack since=0.0.0 stability=stable
+ * @availability stack stability=stable
+ * @availability stack stability=stable
  */
-export interface Request {
+export interface Request<TDocument> {
   path_parts: {
-    id: string
+    id?: string
+    index: string
   }
-  /** @codegen_name id */
-  body: Foo
-}
-
-export class Foo {
-  bar: string
+  query_parameters: {
+    if_primary_term?: number
+    if_seq_no?: number
+    op_type?: string
+    pipeline?: string
+    refresh?: string
+    routing?: string
+    timeout?: string
+    version?: number
+    version_type?: string
+    wait_for_active_shards?: string
+    require_alias?: boolean
+  }
+  /** @codegen_name document */
+  body?: TDocument
 }

--- a/compiler/test/request-availability-failures/specification-duplicates/tsconfig.json
+++ b/compiler/test/request-availability-failures/specification-duplicates/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../../specification/tsconfig.json",
+  "typeRoots": ["./**/*.ts"],
+  "include": ["./**/*.ts"]
+}

--- a/compiler/test/request-availability-failures/specification-feature-flag/_global/index/request.ts
+++ b/compiler/test/request-availability-failures/specification-feature-flag/_global/index/request.ts
@@ -19,16 +19,26 @@
 
 /**
  * @rest_spec_name index
- * @availability stack since=0.0.0 stability=stable
+ * @availability stack stability=stable visibility=feature_flag
  */
-export interface Request {
+export interface Request<TDocument> {
   path_parts: {
-    id: string
+    id?: string
+    index: string
   }
-  /** @codegen_name id */
-  body: Foo
-}
-
-export class Foo {
-  bar: string
+  query_parameters: {
+    if_primary_term?: number
+    if_seq_no?: number
+    op_type?: string
+    pipeline?: string
+    refresh?: string
+    routing?: string
+    timeout?: string
+    version?: number
+    version_type?: string
+    wait_for_active_shards?: string
+    require_alias?: boolean
+  }
+  /** @codegen_name document */
+  body?: TDocument
 }

--- a/compiler/test/request-availability-failures/specification-feature-flag/tsconfig.json
+++ b/compiler/test/request-availability-failures/specification-feature-flag/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../../specification/tsconfig.json",
+  "typeRoots": ["./**/*.ts"],
+  "include": ["./**/*.ts"]
+}

--- a/compiler/test/request-availability-failures/specification-stability/_global/index/request.ts
+++ b/compiler/test/request-availability-failures/specification-stability/_global/index/request.ts
@@ -19,16 +19,26 @@
 
 /**
  * @rest_spec_name index
- * @availability stack since=0.0.0 stability=stable
+ * @availability stack stability=unknown
  */
-export interface Request {
+export interface Request<TDocument> {
   path_parts: {
-    id: string
+    id?: string
+    index: string
   }
-  /** @codegen_name id */
-  body: Foo
-}
-
-export class Foo {
-  bar: string
+  query_parameters: {
+    if_primary_term?: number
+    if_seq_no?: number
+    op_type?: string
+    pipeline?: string
+    refresh?: string
+    routing?: string
+    timeout?: string
+    version?: number
+    version_type?: string
+    wait_for_active_shards?: string
+    require_alias?: boolean
+  }
+  /** @codegen_name document */
+  body?: TDocument
 }

--- a/compiler/test/request-availability-failures/specification-stability/tsconfig.json
+++ b/compiler/test/request-availability-failures/specification-stability/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../../specification/tsconfig.json",
+  "typeRoots": ["./**/*.ts"],
+  "include": ["./**/*.ts"]
+}

--- a/compiler/test/request-availability-failures/specification-unknown/_global/index/request.ts
+++ b/compiler/test/request-availability-failures/specification-unknown/_global/index/request.ts
@@ -19,16 +19,26 @@
 
 /**
  * @rest_spec_name index
- * @availability stack since=0.0.0 stability=stable
+ * @availability internal
  */
-export interface Request {
+export interface Request<TDocument> {
   path_parts: {
-    id: string
+    id?: string
+    index: string
   }
-  /** @codegen_name id */
-  body: Foo
-}
-
-export class Foo {
-  bar: string
+  query_parameters: {
+    if_primary_term?: number
+    if_seq_no?: number
+    op_type?: string
+    pipeline?: string
+    refresh?: string
+    routing?: string
+    timeout?: string
+    version?: number
+    version_type?: string
+    wait_for_active_shards?: string
+    require_alias?: boolean
+  }
+  /** @codegen_name document */
+  body?: TDocument
 }

--- a/compiler/test/request-availability-failures/specification-unknown/tsconfig.json
+++ b/compiler/test/request-availability-failures/specification-unknown/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../../specification/tsconfig.json",
+  "typeRoots": ["./**/*.ts"],
+  "include": ["./**/*.ts"]
+}

--- a/compiler/test/request-availability-failures/specification-visibility/_global/index/request.ts
+++ b/compiler/test/request-availability-failures/specification-visibility/_global/index/request.ts
@@ -19,16 +19,26 @@
 
 /**
  * @rest_spec_name index
- * @availability stack since=0.0.0 stability=stable
+ * @availability serverless visibility=unknown
  */
-export interface Request {
+export interface Request<TDocument> {
   path_parts: {
-    id: string
+    id?: string
+    index: string
   }
-  /** @codegen_name id */
-  body: Foo
-}
-
-export class Foo {
-  bar: string
+  query_parameters: {
+    if_primary_term?: number
+    if_seq_no?: number
+    op_type?: string
+    pipeline?: string
+    refresh?: string
+    routing?: string
+    timeout?: string
+    version?: number
+    version_type?: string
+    wait_for_active_shards?: string
+    require_alias?: boolean
+  }
+  /** @codegen_name document */
+  body?: TDocument
 }

--- a/compiler/test/request-availability-failures/specification-visibility/tsconfig.json
+++ b/compiler/test/request-availability-failures/specification-visibility/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../../specification/tsconfig.json",
+  "typeRoots": ["./**/*.ts"],
+  "include": ["./**/*.ts"]
+}

--- a/compiler/test/request-availability-failures/test.ts
+++ b/compiler/test/request-availability-failures/test.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { join } from 'path'
+import test from 'ava'
+import Compiler from '../../src/compiler'
+import * as Model from '../../src/model/metamodel'
+
+const specsFolderFeatureFlag = join(__dirname, 'specification-feature-flag')
+const specsFolderStability = join(__dirname, 'specification-stability')
+const specsFolderUnknown = join(__dirname, 'specification-unknown')
+const specsFolderVisibility = join(__dirname, 'specification-visibility')
+const specsFolderDuplicate = join(__dirname, 'specification-duplicates')
+const outputFolder = join(__dirname, 'output')
+
+test('Request @availability fails when misconfigured', t => {
+  let compiler = new Compiler(specsFolderFeatureFlag, outputFolder)
+  let error = t.throws(() => compiler.generateModel())
+  console.log(error?.message);
+  t.true(error?.message === `'feature_flag' must be defined if visibility is 'feature_flag'`, error?.message)
+
+  compiler = new Compiler(specsFolderStability, outputFolder)
+  error = t.throws(() => compiler.generateModel())
+  t.true(error?.message === `stability is not valid: unknown`, error?.message)
+
+  compiler = new Compiler(specsFolderUnknown, outputFolder)
+  error = t.throws(() => compiler.generateModel())
+  t.true(error?.message.startsWith(`The @availablility <name> value must either be stack or serverless`), error?.message)
+
+  compiler = new Compiler(specsFolderVisibility, outputFolder)
+  error = t.throws(() => compiler.generateModel())
+  t.true(error?.message === `visibility is not valid: unknown`, error?.message)
+
+  compiler = new Compiler(specsFolderDuplicate, outputFolder)
+  error = t.throws(() => compiler.generateModel())
+  t.true(error?.message === `Duplicate @availability tag: 'stack'`, error?.message)
+})

--- a/compiler/test/request-availability/specification/_global/index/request.ts
+++ b/compiler/test/request-availability/specification/_global/index/request.ts
@@ -19,16 +19,27 @@
 
 /**
  * @rest_spec_name index
- * @availability stack since=0.0.0 stability=stable
+ * @availability serverless visibility=private stability=experimental
+ * @availability stack stability=beta since=1.2.3 visibility=feature_flag feature_flag=abc
  */
-export interface Request {
+export interface Request<TDocument> {
   path_parts: {
-    id: string
+    id?: string
+    index: string
   }
-  /** @codegen_name id */
-  body: Foo
-}
-
-export class Foo {
-  bar: string
+  query_parameters: {
+    if_primary_term?: number
+    if_seq_no?: number
+    op_type?: string
+    pipeline?: string
+    refresh?: string
+    routing?: string
+    timeout?: string
+    version?: number
+    version_type?: string
+    wait_for_active_shards?: string
+    require_alias?: boolean
+  }
+  /** @codegen_name document */
+  body?: TDocument
 }

--- a/compiler/test/request-availability/specification/tsconfig.json
+++ b/compiler/test/request-availability/specification/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../../specification/tsconfig.json",
+  "typeRoots": ["./**/*.ts"],
+  "include": ["./**/*.ts"]
+}

--- a/compiler/test/request-availability/test.ts
+++ b/compiler/test/request-availability/test.ts
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { join } from 'path'
+import test from 'ava'
+import Compiler from '../../src/compiler'
+import * as Model from '../../src/model/metamodel'
+
+const specsFolder = join(__dirname, 'specification')
+const outputFolder = join(__dirname, 'output')
+
+test('Request @availability can fulfill all the fields', t => {
+  const compiler = new Compiler(specsFolder, outputFolder)
+  const {model} = compiler.generateModel()
+  const endpoint = model.endpoints.find(endpoint => endpoint.name == 'index');
+  t.assert(endpoint);
+  // Assert the new 'availability' value is correct.
+  t.deepEqual(endpoint?.availability, {
+    stack: { stability: 'beta', visibility: 'feature_flag', featureFlag: 'abc', since: '1.2.3' },
+    serverless: { visibility: 'private', stability: 'experimental' }
+  });
+  // Assert backfilled values are correct
+  t.true(endpoint?.visibility === 'feature_flag');
+  t.true(endpoint?.stability === 'beta');
+  t.true(endpoint?.featureFlag === 'abc');
+  t.true(endpoint?.since === '1.2.3');
+})

--- a/compiler/test/request-fields/specification/_global/index/request.ts
+++ b/compiler/test/request-fields/specification/_global/index/request.ts
@@ -19,8 +19,7 @@
 
 /**
  * @rest_spec_name index
- * @since 0.0.0
- * @stability stable
+ * @availability stack stability=stable since=0.0.0
  */
 export interface Request<TDocument> {
   path_parts: {

--- a/compiler/test/types/specification/_global/info/request.ts
+++ b/compiler/test/types/specification/_global/info/request.ts
@@ -19,7 +19,6 @@
 
 /**
  * @rest_spec_name info
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request {}

--- a/compiler/test/types/test.ts
+++ b/compiler/test/types/test.ts
@@ -92,7 +92,7 @@ test('type_alias', t => {
 test('request', t => {
   const definition = model.types.find(t => t.kind === 'request') as Model.Request
   t.assert(definition)
-  t.true(definition?.specLocation.endsWith('test/types/specification/_global/info/request.ts#L20-L25'))
+  t.true(definition?.specLocation.endsWith('test/types/specification/_global/info/request.ts#L20-L24'))
   t.deepEqual(definition?.name, {
     name: 'Request',
     namespace: '_global.info'

--- a/compiler/test/writes-to-output/specification/_global/index/request.ts
+++ b/compiler/test/writes-to-output/specification/_global/index/request.ts
@@ -19,7 +19,6 @@
 
 /**
  * @rest_spec_name index
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request {}

--- a/compiler/test/wrong-api-name/specification/_global/info/request.ts
+++ b/compiler/test/wrong-api-name/specification/_global/info/request.ts
@@ -19,7 +19,6 @@
 
 /**
  * @rest_spec_name foobar
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request {}

--- a/compiler/test/wrong-namespace/specification/_global/foobar/request.ts
+++ b/compiler/test/wrong-namespace/specification/_global/foobar/request.ts
@@ -19,7 +19,6 @@
 
 /**
  * @rest_spec_name info
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request {}

--- a/docs/add-new-api.md
+++ b/docs/add-new-api.md
@@ -51,16 +51,20 @@ A request definition is an interface and should contains three top level keys:
 Furthermore, every request definition **must** contain three JS Doc tags:
 
 - `@rest_spec_name`: the API name (eg: `search`, `indices.create`...).
-- `@since`: the version of Elasticsearch when the API has been introduced (eg: `7.7.0`)
-- `@stability`: the API stability, one of `experimental`, `beta`, `stable`
+- `@availability` Which flavor of Elasticsearch is this API available for? (eg `stack` or `serverless`)
+  - `stability`: the API stability, one of `experimental`, `beta`, `stable`
+  - `visibility`: the API stability, one of `public` or `private`.
+  - `since`: the version of Elasticsearch when the API has been introduced (eg: `7.7.0`).
+    This field is only available for `stack`.
+  - `feature_flag`: the feature flag value, only valid if the `visibility` is set to `feature_flag`.
+    This field is only available for `stack`.
 
 Following you can find a template valid for any request definition.
 
 ```ts
  /*
  * @rest_spec_name endpoint.name
- * @since 1.2.3
- * @stability stable | beta | experimental
+ * @availability stack since=1.2.3 stability=stable|beta|experimental
  */
 interface Request extends RequestBase {
   path_parts: {
@@ -79,8 +83,7 @@ In some cases, the request could take one or more generics, in such case the def
 ```ts
  /*
  * @rest_spec_name endpoint.name
- * @since 1.2.3
- * @stability stable | beta | experimental
+ * @availability stack since=1.2.3 stability=stable|beta|experimental
  */
 interface Request<Generic> extends RequestBase {
   path_parts: {

--- a/docs/doc-comments-guide.md
+++ b/docs/doc-comments-guide.md
@@ -12,8 +12,7 @@ Additional lines start with a `*` followed by a space. Long lines are allowed bu
 /**
  * Enables you to evaluate the quality of ranked search results over a set of typical search queries.
  * @rest_spec_name rank_eval
- * @since 6.2.0
- * @stability stable
+ * @availability stack since=6.2.0 stability=stable
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -31,8 +31,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name bulk
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id docs-bulk
  *
  */

--- a/specification/_global/clear_scroll/ClearScrollRequest.ts
+++ b/specification/_global/clear_scroll/ClearScrollRequest.ts
@@ -22,8 +22,7 @@ import { Ids, ScrollIds } from '@_types/common'
 
 /**
  * @rest_spec_name clear_scroll
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id clear-scroll-api
  */
 export interface Request extends RequestBase {

--- a/specification/_global/close_point_in_time/ClosePointInTimeRequest.ts
+++ b/specification/_global/close_point_in_time/ClosePointInTimeRequest.ts
@@ -22,8 +22,7 @@ import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name close_point_in_time
- * @since 7.10.0
- * @stability stable
+ * @availability stack since=7.10.0 stability=stable
  * @doc_id point-in-time-api
  */
 export interface Request extends RequestBase {

--- a/specification/_global/count/CountRequest.ts
+++ b/specification/_global/count/CountRequest.ts
@@ -25,8 +25,7 @@ import { Operator } from '@_types/query_dsl/Operator'
 
 /**
  * @rest_spec_name count
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/create/CreateRequest.ts
+++ b/specification/_global/create/CreateRequest.ts
@@ -31,8 +31,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name create
- * @since 5.0.0
- * @stability stable
+ * @availability stack since=5.0.0 stability=stable
  *
  */
 export interface Request<TDocument> extends RequestBase {

--- a/specification/_global/delete/DeleteRequest.ts
+++ b/specification/_global/delete/DeleteRequest.ts
@@ -33,8 +33,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name delete
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -35,8 +35,7 @@ import { Operator } from '@_types/query_dsl/Operator'
 
 /**
  * @rest_spec_name delete_by_query
- * @since 5.0.0
- * @stability stable
+ * @availability stack since=5.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
+++ b/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
@@ -23,8 +23,7 @@ import { float } from '@_types/Numeric'
 
 /**
  * @rest_spec_name delete_by_query_rethrottle
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/delete_script/DeleteScriptRequest.ts
+++ b/specification/_global/delete_script/DeleteScriptRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name delete_script
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/exists/DocumentExistsRequest.ts
+++ b/specification/_global/exists/DocumentExistsRequest.ts
@@ -30,8 +30,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name exists
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/exists_source/SourceExistsRequest.ts
+++ b/specification/_global/exists_source/SourceExistsRequest.ts
@@ -30,8 +30,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name exists_source
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/explain/ExplainRequest.ts
+++ b/specification/_global/explain/ExplainRequest.ts
@@ -25,8 +25,7 @@ import { Operator } from '@_types/query_dsl/Operator'
 
 /**
  * @rest_spec_name explain
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/field_caps/FieldCapabilitiesRequest.ts
+++ b/specification/_global/field_caps/FieldCapabilitiesRequest.ts
@@ -27,8 +27,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
  * The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type
  * of keyword is returned as any other field that belongs to the `keyword` family.
  * @rest_spec_name field_caps
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @index_privileges view_index_metadata,read,manage
  */
 export interface Request extends RequestBase {

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -30,8 +30,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name get
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/get_script/GetScriptRequest.ts
+++ b/specification/_global/get_script/GetScriptRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name get_script
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/get_script_context/GetScriptContextRequest.ts
+++ b/specification/_global/get_script_context/GetScriptContextRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name get_script_context
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/_global/get_script_languages/GetScriptLanguagesRequest.ts
+++ b/specification/_global/get_script_languages/GetScriptLanguagesRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name get_script_languages
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/_global/get_source/SourceRequest.ts
+++ b/specification/_global/get_source/SourceRequest.ts
@@ -30,8 +30,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name get_source
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/health_report/Request.ts
+++ b/specification/_global/health_report/Request.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name health_report
- * @since 8.7.0
- * @stability stable
+ * @availability stack since=8.7.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/index/IndexRequest.ts
+++ b/specification/_global/index/IndexRequest.ts
@@ -34,8 +34,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name index
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request<TDocument> extends RequestBase {
   path_parts: {

--- a/specification/_global/info/RootNodeInfoRequest.ts
+++ b/specification/_global/info/RootNodeInfoRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name info
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/_global/knn_search/KnnSearchRequest.ts
+++ b/specification/_global/knn_search/KnnSearchRequest.ts
@@ -26,9 +26,8 @@ import { FieldAndFormat } from '@_types/query_dsl/abstractions'
 
 /**
  * @rest_spec_name knn_search
- * @since 8.0.0
+ * @availability stack since=8.0.0 stability=experimental
  * @deprecated 8.4.0
- * @stability experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -24,8 +24,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
  * @rest_spec_name mget
- * @since 1.3.0
- * @stability stable
+ * @availability stack since=1.3.0 stability=stable
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/_global/msearch/MultiSearchRequest.ts
+++ b/specification/_global/msearch/MultiSearchRequest.ts
@@ -24,8 +24,7 @@ import { RequestItem } from './types'
 
 /**
  * @rest_spec_name msearch
- * @since 1.3.0
- * @stability stable
+ * @availability stack since=1.3.0 stability=stable
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
@@ -25,8 +25,7 @@ import { RequestItem } from './types'
 /**
  * Runs multiple templated searches with a single request.
  * @rest_spec_name msearch_template
- * @since 5.0.0
- * @stability stable
+ * @availability stack since=5.0.0 stability=stable
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
+++ b/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
@@ -30,8 +30,7 @@ import { Operation } from './types'
 
 /**
  * @rest_spec_name mtermvectors
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
+++ b/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
@@ -29,8 +29,7 @@ import { Duration } from '@_types/Time'
  * `search_after` requests, then the results of those requests might not be consistent as changes happening
  * between searches are only visible to the more recent point in time.
  * @rest_spec_name open_point_in_time
- * @since 7.10.0
- * @stability stable
+ * @availability stack since=7.10.0 stability=stable
  * @doc_id point-in-time-api
  * @index_privileges read
  */

--- a/specification/_global/ping/PingRequest.ts
+++ b/specification/_global/ping/PingRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name ping
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/_global/put_script/PutScriptRequest.ts
+++ b/specification/_global/put_script/PutScriptRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name put_script
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/rank_eval/RankEvalRequest.ts
+++ b/specification/_global/rank_eval/RankEvalRequest.ts
@@ -24,8 +24,7 @@ import { RankEvalMetric, RankEvalRequestItem } from './types'
 /**
  * Enables you to evaluate the quality of ranked search results over a set of typical search queries.
  * @rest_spec_name rank_eval
- * @since 6.2.0
- * @stability stable
+ * @availability stack since=6.2.0 stability=stable
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/_global/reindex/ReindexRequest.ts
+++ b/specification/_global/reindex/ReindexRequest.ts
@@ -26,8 +26,7 @@ import { Destination, Source } from './types'
 
 /**
  * @rest_spec_name reindex
- * @since 2.3.0
- * @stability stable
+ * @availability stack since=2.3.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/_global/reindex_rethrottle/ReindexRethrottleRequest.ts
+++ b/specification/_global/reindex_rethrottle/ReindexRethrottleRequest.ts
@@ -23,8 +23,7 @@ import { float } from '@_types/Numeric'
 
 /**
  * @rest_spec_name reindex_rethrottle
- * @since 2.4.0
- * @stability stable
+ * @availability stack since=2.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
+++ b/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
@@ -24,8 +24,7 @@ import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name render_search_template
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/scripts_painless_execute/ExecutePainlessScriptRequest.ts
+++ b/specification/_global/scripts_painless_execute/ExecutePainlessScriptRequest.ts
@@ -23,8 +23,7 @@ import { PainlessContextSetup } from './types'
 
 /**
  * @rest_spec_name scripts_painless_execute
- * @since 6.3.0
- * @stability experimental
+ * @availability stack since=6.3.0 stability=experimental
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/_global/scroll/ScrollRequest.ts
+++ b/specification/_global/scroll/ScrollRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name scroll
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -51,8 +51,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * @rest_spec_name search
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/search_mvt/SearchMvtRequest.ts
+++ b/specification/_global/search_mvt/SearchMvtRequest.ts
@@ -32,8 +32,7 @@ import { TrackHits } from '@global/search/_types/hits'
 
 /**
  * @rest_spec_name search_mvt
- * @since 7.15.0
- * @stability experimental
+ * @availability stack since=7.15.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/search_shards/SearchShardsRequest.ts
+++ b/specification/_global/search_shards/SearchShardsRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Indices, Routing } from '@_types/common'
 
 /**
  * @rest_spec_name search_shards
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/search_template/SearchTemplateRequest.ts
+++ b/specification/_global/search_template/SearchTemplateRequest.ts
@@ -31,8 +31,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name search_template
- * @since 2.0.0
- * @stability stable
+ * @availability stack since=2.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/terms_enum/TermsEnumRequest.ts
+++ b/specification/_global/terms_enum/TermsEnumRequest.ts
@@ -25,8 +25,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name terms_enum
- * @since 7.14.0
- * @stability stable
+ * @availability stack since=7.14.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/termvectors/TermVectorsRequest.ts
+++ b/specification/_global/termvectors/TermVectorsRequest.ts
@@ -32,8 +32,7 @@ import { Filter } from './types'
 
 /**
  * @rest_spec_name termvectors
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request<TDocument> extends RequestBase {
   path_parts: {

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -37,8 +37,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name update
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request<TDocument, TPartialDocument> extends RequestBase {
   path_parts: {

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -36,8 +36,7 @@ import { Operator } from '@_types/query_dsl/Operator'
 
 /**
  * @rest_spec_name update_by_query
- * @since 2.4.0
- * @stability stable
+ * @availability stack since=2.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/update_by_query_rethrottle/UpdateByQueryRethrottleRequest.ts
+++ b/specification/_global/update_by_query_rethrottle/UpdateByQueryRethrottleRequest.ts
@@ -23,8 +23,7 @@ import { float, long } from '@_types/Numeric'
 
 /**
  * @rest_spec_name update_by_query_rethrottle
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/async_search/delete/AsyncSearchDeleteRequest.ts
+++ b/specification/async_search/delete/AsyncSearchDeleteRequest.ts
@@ -26,8 +26,7 @@ import { Id } from '@_types/common'
  * Otherwise, the saved search results are deleted.
  * If the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.
  * @rest_spec_name async_search.delete
- * @since 7.7.0
- * @stability stable
+ * @availability stack since=7.7.0 stability=stable
  * @doc_id async-search
  */
 export interface Request extends RequestBase {

--- a/specification/async_search/get/AsyncSearchGetRequest.ts
+++ b/specification/async_search/get/AsyncSearchGetRequest.ts
@@ -25,8 +25,7 @@ import { Duration } from '@_types/Time'
  * Retrieves the results of a previously submitted async search request given its identifier.
  * If the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.
  * @rest_spec_name async_search.get
- * @since 7.7.0
- * @stability stable
+ * @availability stack since=7.7.0 stability=stable
  * @doc_id async-search
  */
 export interface Request extends RequestBase {

--- a/specification/async_search/status/AsyncSearchStatusRequest.ts
+++ b/specification/async_search/status/AsyncSearchStatusRequest.ts
@@ -24,8 +24,7 @@ import { Id } from '@_types/common'
  * Retreives the status of a previously submitted async search request given its identifier, without retrieving search results.
  * If the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.
  * @rest_spec_name async_search.status
- * @since 7.11.0
- * @stability stable
+ * @availability stack since=7.11.0 stability=stable
  * @doc_id async-search
  */
 export interface Request extends RequestBase {

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -59,8 +59,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * By default, Elasticsearch doesn’t allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.
  * The maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.
  * @rest_spec_name async_search.submit
- * @since 7.7.0
- * @stability stable
+ * @availability stack since=7.7.0 stability=stable
  * @doc_id async-search
  */
 // NOTE: this is a SearchRequest with 3 added parameters: wait_for_completion_timeout, keep_on_completion and keep_alive

--- a/specification/autoscaling/delete_autoscaling_policy/DeleteAutoscalingPolicyRequest.ts
+++ b/specification/autoscaling/delete_autoscaling_policy/DeleteAutoscalingPolicyRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name autoscaling.delete_autoscaling_policy
- * @since 7.11.0
- * @stability stable
+ * @availability stack since=7.11.0 stability=stable
  * @doc_id autoscaling-delete-autoscaling-policy
  */
 export interface Request extends RequestBase {

--- a/specification/autoscaling/get_autoscaling_capacity/GetAutoscalingCapacityRequest.ts
+++ b/specification/autoscaling/get_autoscaling_capacity/GetAutoscalingCapacityRequest.ts
@@ -21,8 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name autoscaling.get_autoscaling_capacity
- * @since 7.11.0
- * @stability stable
+ * @availability stack since=7.11.0 stability=stable
  * @doc_id autoscaling-get-autoscaling-capacity
  */
 export interface Request extends RequestBase {}

--- a/specification/autoscaling/get_autoscaling_policy/GetAutoscalingPolicyRequest.ts
+++ b/specification/autoscaling/get_autoscaling_policy/GetAutoscalingPolicyRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name autoscaling.get_autoscaling_policy
- * @since 7.11.0
- * @stability stable
+ * @availability stack since=7.11.0 stability=stable
  * @doc_id autoscaling-get-autoscaling-capacity
  */
 export interface Request extends RequestBase {

--- a/specification/autoscaling/put_autoscaling_policy/PutAutoscalingPolicyRequest.ts
+++ b/specification/autoscaling/put_autoscaling_policy/PutAutoscalingPolicyRequest.ts
@@ -23,8 +23,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name autoscaling.put_autoscaling_policy
- * @since 7.11.0
- * @stability stable
+ * @availability stack since=7.11.0 stability=stable
  * @doc_id autoscaling-put-autoscaling-policy
  */
 export interface Request extends RequestBase {

--- a/specification/cat/aliases/CatAliasesRequest.ts
+++ b/specification/cat/aliases/CatAliasesRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Names } from '@_types/common'
 
 /**
  * @rest_spec_name cat.aliases
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-alias
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/allocation/CatAllocationRequest.ts
+++ b/specification/cat/allocation/CatAllocationRequest.ts
@@ -22,8 +22,7 @@ import { Bytes, NodeIds } from '@_types/common'
 
 /**
  * @rest_spec_name cat.allocation
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-allocation
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/component_templates/CatComponentTemplatesRequest.ts
+++ b/specification/cat/component_templates/CatComponentTemplatesRequest.ts
@@ -21,8 +21,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
  * @rest_spec_name cat.component_templates
- * @since 5.1.0
- * @stability stable
+ * @availability stack since=5.1.0 stability=stable
  */
 export interface Request extends CatRequestBase {
   path_parts: {

--- a/specification/cat/count/CatCountRequest.ts
+++ b/specification/cat/count/CatCountRequest.ts
@@ -22,8 +22,7 @@ import { Indices } from '@_types/common'
 
 /**
  * @rest_spec_name cat.count
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-count
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/fielddata/CatFielddataRequest.ts
+++ b/specification/cat/fielddata/CatFielddataRequest.ts
@@ -22,8 +22,7 @@ import { Bytes, Fields } from '@_types/common'
 
 /**
  * @rest_spec_name cat.fielddata
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-fielddata
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/health/CatHealthRequest.ts
+++ b/specification/cat/health/CatHealthRequest.ts
@@ -21,8 +21,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
  * @rest_spec_name cat.health
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-health
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/help/CatHelpRequest.ts
+++ b/specification/cat/help/CatHelpRequest.ts
@@ -21,8 +21,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
  * @rest_spec_name cat.help
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat
  */
 export interface Request extends CatRequestBase {}

--- a/specification/cat/indices/CatIndicesRequest.ts
+++ b/specification/cat/indices/CatIndicesRequest.ts
@@ -23,8 +23,7 @@ import { TimeUnit } from '@_types/Time'
 
 /**
  * @rest_spec_name cat.indices
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-indices
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/master/CatMasterRequest.ts
+++ b/specification/cat/master/CatMasterRequest.ts
@@ -21,8 +21,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
  * @rest_spec_name cat.master
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-master
  */
 export interface Request extends CatRequestBase {}

--- a/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
+++ b/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
@@ -29,8 +29,7 @@ import { Duration } from '@_types/Time'
  * application consumption, use the get data frame analytics jobs statistics API.
  *
  * @rest_spec_name cat.ml_data_frame_analytics
- * @since 7.7.0
- * @stability stable
+ * @availability stack since=7.7.0 stability=stable
  * @doc_id cat-dfanalytics
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -32,8 +32,7 @@ import { TimeUnit } from '@_types/Time'
  * application consumption, use the get datafeed statistics API.
  *
  * @rest_spec_name cat.ml_datafeeds
- * @since 7.7.0
- * @stability stable
+ * @availability stack since=7.7.0 stability=stable
  * @cluster_privileges monitor_ml
  * @doc_id cat-datafeeds
  */

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -32,8 +32,7 @@ import { TimeUnit } from '@_types/Time'
  * application consumption, use the get anomaly detection job statistics API.
  *
  * @rest_spec_name cat.ml_jobs
- * @since 7.7.0
- * @stability stable
+ * @availability stack since=7.7.0 stability=stable
  * @cluster_privileges monitor_ml
  * @doc_id cat-anomaly-detectors
  */

--- a/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
+++ b/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
@@ -29,8 +29,7 @@ import { integer } from '@_types/Numeric'
  * application consumption, use the get trained models statistics API.
  *
  * @rest_spec_name cat.ml_trained_models
- * @since 7.7.0
- * @stability stable
+ * @availability stack since=7.7.0 stability=stable
  * @doc_id cat-trained-model
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
+++ b/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
@@ -21,8 +21,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
  * @rest_spec_name cat.nodeattrs
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-nodeattrs
  */
 export interface Request extends CatRequestBase {}

--- a/specification/cat/nodes/CatNodesRequest.ts
+++ b/specification/cat/nodes/CatNodesRequest.ts
@@ -22,8 +22,7 @@ import { Bytes } from '@_types/common'
 
 /**
  * @rest_spec_name cat.nodes
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-nodes
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/pending_tasks/CatPendingTasksRequest.ts
+++ b/specification/cat/pending_tasks/CatPendingTasksRequest.ts
@@ -21,8 +21,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
  * @rest_spec_name cat.pending_tasks
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-pending-tasks
  */
 export interface Request extends CatRequestBase {}

--- a/specification/cat/plugins/CatPluginsRequest.ts
+++ b/specification/cat/plugins/CatPluginsRequest.ts
@@ -21,8 +21,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
  * @rest_spec_name cat.plugins
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-plugins
  */
 export interface Request extends CatRequestBase {}

--- a/specification/cat/recovery/CatRecoveryRequest.ts
+++ b/specification/cat/recovery/CatRecoveryRequest.ts
@@ -22,8 +22,7 @@ import { Bytes, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name cat.recovery
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-recovery
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/repositories/CatRepositoriesRequest.ts
+++ b/specification/cat/repositories/CatRepositoriesRequest.ts
@@ -21,8 +21,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
  * @rest_spec_name cat.repositories
- * @since 2.1.0
- * @stability stable
+ * @availability stack since=2.1.0 stability=stable
  * @doc_id cat-repositories
  */
 export interface Request extends CatRequestBase {}

--- a/specification/cat/segments/CatSegmentsRequest.ts
+++ b/specification/cat/segments/CatSegmentsRequest.ts
@@ -22,8 +22,7 @@ import { Bytes, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name cat.segments
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-segments
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/shards/CatShardsRequest.ts
+++ b/specification/cat/shards/CatShardsRequest.ts
@@ -22,8 +22,7 @@ import { Bytes, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name cat.shards
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-shards
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/snapshots/CatSnapshotsRequest.ts
+++ b/specification/cat/snapshots/CatSnapshotsRequest.ts
@@ -22,8 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * @rest_spec_name cat.snapshots
- * @since 2.1.0
- * @stability stable
+ * @availability stack since=2.1.0 stability=stable
  * @doc_id cat-snapshots
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/tasks/CatTasksRequest.ts
+++ b/specification/cat/tasks/CatTasksRequest.ts
@@ -22,8 +22,7 @@ import { long } from '@_types/Numeric'
 
 /**
  * @rest_spec_name cat.tasks
- * @since 5.0.0
- * @stability experimental
+ * @availability stack since=5.0.0 stability=experimental
  * @doc_id tasks
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/templates/CatTemplatesRequest.ts
+++ b/specification/cat/templates/CatTemplatesRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name cat.templates
- * @since 5.2.0
- * @stability stable
+ * @availability stack since=5.2.0 stability=stable
  * @doc_id cat-templates
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/thread_pool/CatThreadPoolRequest.ts
+++ b/specification/cat/thread_pool/CatThreadPoolRequest.ts
@@ -23,8 +23,7 @@ import { TimeUnit } from '@_types/Time'
 
 /**
  * @rest_spec_name cat.thread_pool
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cat-thread-pool
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/transforms/CatTransformsRequest.ts
+++ b/specification/cat/transforms/CatTransformsRequest.ts
@@ -30,8 +30,7 @@ import { Duration, TimeUnit } from '@_types/Time'
  * application consumption, use the get transform statistics API.
  *
  * @rest_spec_name cat.transforms
- * @since 7.7.0
- * @stability stable
+ * @availability stack since=7.7.0 stability=stable
  * @doc_id cat-transforms
  */
 export interface Request extends CatRequestBase {

--- a/specification/ccr/delete_auto_follow_pattern/DeleteAutoFollowPatternRequest.ts
+++ b/specification/ccr/delete_auto_follow_pattern/DeleteAutoFollowPatternRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name ccr.delete_auto_follow_pattern
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-delete-auto-follow-pattern
  */
 export interface Request extends RequestBase {

--- a/specification/ccr/follow/CreateFollowIndexRequest.ts
+++ b/specification/ccr/follow/CreateFollowIndexRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name ccr.follow
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-put-follow
  */
 export interface Request extends RequestBase {

--- a/specification/ccr/follow_info/FollowInfoRequest.ts
+++ b/specification/ccr/follow_info/FollowInfoRequest.ts
@@ -22,8 +22,7 @@ import { Indices } from '@_types/common'
 
 /**
  * @rest_spec_name ccr.follow_info
- * @since 6.7.0
- * @stability stable
+ * @availability stack since=6.7.0 stability=stable
  * @doc_id ccr-get-follow-info
  */
 export interface Request extends RequestBase {

--- a/specification/ccr/follow_stats/FollowIndexStatsRequest.ts
+++ b/specification/ccr/follow_stats/FollowIndexStatsRequest.ts
@@ -22,8 +22,7 @@ import { Indices } from '@_types/common'
 
 /**
  * @rest_spec_name ccr.follow_stats
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-get-follow-stats
  */
 export interface Request extends RequestBase {

--- a/specification/ccr/forget_follower/ForgetFollowerIndexRequest.ts
+++ b/specification/ccr/forget_follower/ForgetFollowerIndexRequest.ts
@@ -22,8 +22,7 @@ import { IndexName, Uuid } from '@_types/common'
 
 /**
  * @rest_spec_name ccr.forget_follower
- * @since 6.7.0
- * @stability stable
+ * @availability stack since=6.7.0 stability=stable
  * @doc_id ccr-post-forget-follower
  */
 export interface Request extends RequestBase {

--- a/specification/ccr/get_auto_follow_pattern/GetAutoFollowPatternRequest.ts
+++ b/specification/ccr/get_auto_follow_pattern/GetAutoFollowPatternRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name ccr.get_auto_follow_pattern
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-get-auto-follow-pattern
  */
 export interface Request extends RequestBase {

--- a/specification/ccr/pause_auto_follow_pattern/PauseAutoFollowPatternRequest.ts
+++ b/specification/ccr/pause_auto_follow_pattern/PauseAutoFollowPatternRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name ccr.pause_auto_follow_pattern
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  * @doc_id ccr-pause-auto-follow-pattern
  */
 export interface Request extends RequestBase {

--- a/specification/ccr/pause_follow/PauseFollowIndexRequest.ts
+++ b/specification/ccr/pause_follow/PauseFollowIndexRequest.ts
@@ -22,8 +22,7 @@ import { IndexName } from '@_types/common'
 
 /**
  * @rest_spec_name ccr.pause_follow
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-post-pause-follow
  */
 export interface Request extends RequestBase {

--- a/specification/ccr/put_auto_follow_pattern/PutAutoFollowPatternRequest.ts
+++ b/specification/ccr/put_auto_follow_pattern/PutAutoFollowPatternRequest.ts
@@ -26,8 +26,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name ccr.put_auto_follow_pattern
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-put-auto-follow-pattern
  */
 export interface Request extends RequestBase {

--- a/specification/ccr/resume_auto_follow_pattern/ResumeAutoFollowPatternRequest.ts
+++ b/specification/ccr/resume_auto_follow_pattern/ResumeAutoFollowPatternRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name ccr.resume_auto_follow_pattern
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  * @doc_id ccr-resume-auto-follow-pattern
  */
 export interface Request extends RequestBase {

--- a/specification/ccr/resume_follow/ResumeFollowIndexRequest.ts
+++ b/specification/ccr/resume_follow/ResumeFollowIndexRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name ccr.resume_follow
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-post-resume-follow
  */
 export interface Request extends RequestBase {

--- a/specification/ccr/stats/CcrStatsRequest.ts
+++ b/specification/ccr/stats/CcrStatsRequest.ts
@@ -21,8 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name ccr.stats
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-get-stats
  */
 export interface Request extends RequestBase {}

--- a/specification/ccr/unfollow/UnfollowIndexRequest.ts
+++ b/specification/ccr/unfollow/UnfollowIndexRequest.ts
@@ -22,8 +22,7 @@ import { IndexName } from '@_types/common'
 
 /**
  * @rest_spec_name ccr.unfollow
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-post-unfollow
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/allocation_explain/ClusterAllocationExplainRequest.ts
+++ b/specification/cluster/allocation_explain/ClusterAllocationExplainRequest.ts
@@ -23,8 +23,7 @@ import { integer } from '@_types/Numeric'
 
 /**
  * @rest_spec_name cluster.allocation_explain
- * @since 5.0.0
- * @stability stable
+ * @availability stack since=5.0.0 stability=stable
  * @doc_id cluster-allocation-explain
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/delete_component_template/ClusterDeleteComponentTemplateRequest.ts
+++ b/specification/cluster/delete_component_template/ClusterDeleteComponentTemplateRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name cluster.delete_component_template
- * @since 7.8.0
- * @stability stable
+ * @availability stack since=7.8.0 stability=stable
  * @doc_id indices-component-template
  * @cluster_privileges manage_index_templates,manage
  */

--- a/specification/cluster/delete_voting_config_exclusions/ClusterDeleteVotingConfigExclusionsRequest.ts
+++ b/specification/cluster/delete_voting_config_exclusions/ClusterDeleteVotingConfigExclusionsRequest.ts
@@ -21,8 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name cluster.delete_voting_config_exclusions
- * @since 7.0.0
- * @stability stable
+ * @availability stack since=7.0.0 stability=stable
  * @doc_id voting-config-exclusions
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/exists_component_template/ClusterComponentTemplateExistsRequest.ts
+++ b/specification/cluster/exists_component_template/ClusterComponentTemplateExistsRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name cluster.exists_component_template
- * @since 7.8.0
- * @stability stable
+ * @availability stack since=7.8.0 stability=stable
  * @doc_id indices-component-template
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
+++ b/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name cluster.get_component_template
- * @since 7.8.0
- * @stability stable
+ * @availability stack since=7.8.0 stability=stable
  * @doc_id indices-component-template
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
+++ b/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
@@ -22,8 +22,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name cluster.get_settings
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cluster-get-settings
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/health/ClusterHealthRequest.ts
+++ b/specification/cluster/health/ClusterHealthRequest.ts
@@ -33,8 +33,7 @@ import { Duration } from '@_types/Time'
  * The cluster health API returns a simple status on the health of the cluster. You can also use the API to get the health status of only specified data streams and indices. For data streams, the API retrieves the health status of the stream’s backing indices.
  * The cluster health status is: green, yellow or red. On the shard level, a red status indicates that the specific shard is not allocated in the cluster, yellow means that the primary shard is allocated but replicas are not, and green means that all shards are allocated. The index level status is controlled by the worst shard status. The cluster status is controlled by the worst index status.
  * @rest_spec_name cluster.health
- * @since 1.3.0
- * @stability stable
+ * @availability stack since=1.3.0 stability=stable
  * @cluster_privileges monitor, manage
  * @doc_id cluster-health
  */

--- a/specification/cluster/pending_tasks/ClusterPendingTasksRequest.ts
+++ b/specification/cluster/pending_tasks/ClusterPendingTasksRequest.ts
@@ -22,8 +22,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name cluster.pending_tasks
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cluster-pending
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/post_voting_config_exclusions/ClusterPostVotingConfigExclusionsRequest.ts
+++ b/specification/cluster/post_voting_config_exclusions/ClusterPostVotingConfigExclusionsRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name cluster.post_voting_config_exclusions
- * @since 7.0.0
- * @stability stable
+ * @availability stack since=7.0.0 stability=stable
  * @doc_id voting-config-exclusions
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/put_component_template/ClusterPutComponentTemplateRequest.ts
+++ b/specification/cluster/put_component_template/ClusterPutComponentTemplateRequest.ts
@@ -28,8 +28,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name cluster.put_component_template
- * @since 7.8.0
- * @stability stable
+ * @availability stack since=7.8.0 stability=stable
  * @doc_id indices-component-template
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/put_settings/ClusterPutSettingsRequest.ts
+++ b/specification/cluster/put_settings/ClusterPutSettingsRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name cluster.put_settings
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cluster-update-settings
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/remote_info/ClusterRemoteInfoRequest.ts
+++ b/specification/cluster/remote_info/ClusterRemoteInfoRequest.ts
@@ -25,8 +25,7 @@ import { Void } from '@spec_utils/VoidValue'
  * remote cluster information. It returns connection and endpoint information
  * keyed by the configured remote cluster alias.
  * @rest_spec_name cluster.remote_info
- * @since 6.1.0
- * @stability stable
+ * @availability stack since=6.1.0 stability=stable
  * @doc_id cluster-remote-info
  */
 export interface Request extends RequestBase {}

--- a/specification/cluster/reroute/ClusterRerouteRequest.ts
+++ b/specification/cluster/reroute/ClusterRerouteRequest.ts
@@ -24,8 +24,7 @@ import { Command } from './types'
 
 /**
  * @rest_spec_name cluster.reroute
- * @since 5.0.0
- * @stability stable
+ * @availability stack since=5.0.0 stability=stable
  * @doc_id cluster-reroute
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/state/ClusterStateRequest.ts
+++ b/specification/cluster/state/ClusterStateRequest.ts
@@ -28,8 +28,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name cluster.state
- * @since 1.3.0
- * @stability stable
+ * @availability stack since=1.3.0 stability=stable
  * @cluster_privileges monitor, manage
  * @doc_id cluster-state
  */

--- a/specification/cluster/stats/ClusterStatsRequest.ts
+++ b/specification/cluster/stats/ClusterStatsRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name cluster.stats
- * @since 1.3.0
- * @stability stable
+ * @availability stack since=1.3.0 stability=stable
  * @doc_id cluster-stats
  */
 export interface Request extends RequestBase {

--- a/specification/dangling_indices/delete_dangling_index/DeleteDanglingIndexRequest.ts
+++ b/specification/dangling_indices/delete_dangling_index/DeleteDanglingIndexRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name dangling_indices.delete_dangling_index
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/dangling_indices/import_dangling_index/ImportDanglingIndexRequest.ts
+++ b/specification/dangling_indices/import_dangling_index/ImportDanglingIndexRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name dangling_indices.import_dangling_index
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/dangling_indices/list_dangling_indices/ListDanglingIndicesRequest.ts
+++ b/specification/dangling_indices/list_dangling_indices/ListDanglingIndicesRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name dangling_indices.list_dangling_indices
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/enrich/delete_policy/DeleteEnrichPolicyRequest.ts
+++ b/specification/enrich/delete_policy/DeleteEnrichPolicyRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name enrich.delete_policy
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/enrich/execute_policy/ExecuteEnrichPolicyRequest.ts
+++ b/specification/enrich/execute_policy/ExecuteEnrichPolicyRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name enrich.execute_policy
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/enrich/get_policy/GetEnrichPolicyRequest.ts
+++ b/specification/enrich/get_policy/GetEnrichPolicyRequest.ts
@@ -22,8 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * @rest_spec_name enrich.get_policy
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/enrich/put_policy/PutEnrichPolicyRequest.ts
+++ b/specification/enrich/put_policy/PutEnrichPolicyRequest.ts
@@ -23,8 +23,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name enrich.put_policy
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/enrich/stats/EnrichStatsRequest.ts
+++ b/specification/enrich/stats/EnrichStatsRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name enrich.stats
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/eql/delete/EqlDeleteRequest.ts
+++ b/specification/eql/delete/EqlDeleteRequest.ts
@@ -22,8 +22,7 @@ import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name eql.delete
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/eql/get/EqlGetRequest.ts
+++ b/specification/eql/get/EqlGetRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name eql.get
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/eql/get_status/EqlGetStatusRequest.ts
+++ b/specification/eql/get_status/EqlGetStatusRequest.ts
@@ -22,8 +22,7 @@ import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name eql.get_status
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/eql/search/EqlSearchRequest.ts
+++ b/specification/eql/search/EqlSearchRequest.ts
@@ -27,8 +27,7 @@ import { ResultPosition } from './types'
 
 /**
  * @rest_spec_name eql.search
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/features/get_features/GetFeaturesRequest.ts
+++ b/specification/features/get_features/GetFeaturesRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name features.get_features
- * @since 7.12.0
- * @stability stable
+ * @availability stack since=7.12.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/features/reset_features/ResetFeaturesRequest.ts
+++ b/specification/features/reset_features/ResetFeaturesRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name features.reset_features
- * @since 7.12.0
- * @stability experimental
+ * @availability stack since=7.12.0 stability=experimental
  */
 export interface Request extends RequestBase {}

--- a/specification/fleet/global_checkpoints/GlobalCheckpointsRequest.ts
+++ b/specification/fleet/global_checkpoints/GlobalCheckpointsRequest.ts
@@ -24,8 +24,7 @@ import { Checkpoint } from '../_types/Checkpoints'
 
 /**
  * @rest_spec_name fleet.global_checkpoints
- * @since 7.13.0
- * @stability stable
+ * @availability stack since=7.13.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/fleet/msearch/MultiSearchRequest.ts
+++ b/specification/fleet/msearch/MultiSearchRequest.ts
@@ -34,8 +34,7 @@ import { Checkpoint } from '../_types/Checkpoints'
  * The API follows the same structure as the [multi search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html) API. However, similar to the fleet search API, it
  * supports the wait_for_checkpoints parameter.
  * @rest_spec_name fleet.msearch
- * @since 7.16.0
- * @stability experimental
+ * @availability stack since=7.16.0 stability=experimental
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/fleet/search/SearchRequest.ts
+++ b/specification/fleet/search/SearchRequest.ts
@@ -56,8 +56,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * The purpose of the fleet search api is to provide a search api where the search will only be executed
  * after provided checkpoint has been processed and is visible for searches inside of Elasticsearch.
  * @rest_spec_name fleet.search
- * @since 7.16.0
- * @stability experimental
+ * @availability stack since=7.16.0 stability=experimental
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/graph/explore/GraphExploreRequest.ts
+++ b/specification/graph/explore/GraphExploreRequest.ts
@@ -27,8 +27,7 @@ import { VertexDefinition } from '@graph/_types/Vertex'
 
 /**
  * @rest_spec_name graph.explore
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ilm/delete_lifecycle/DeleteLifecycleRequest.ts
+++ b/specification/ilm/delete_lifecycle/DeleteLifecycleRequest.ts
@@ -25,8 +25,7 @@ import { Duration } from '@_types/Time'
  * Deletes the specified lifecycle policy definition. You cannot delete policies that are currently in use. If the policy is being used to manage any indices, the request fails and returns an error.
  *
  * @rest_spec_name ilm.delete_lifecycle
- * @since 6.6.0
- * @stability stable
+ * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm
  */
 export interface Request extends RequestBase {

--- a/specification/ilm/explain_lifecycle/ExplainLifecycleRequest.ts
+++ b/specification/ilm/explain_lifecycle/ExplainLifecycleRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * Retrieves information about the index’s current lifecycle state, such as the currently executing phase, action, and step. Shows when the index entered each one, the definition of the running phase, and information about any failures.
  * @rest_spec_name ilm.explain_lifecycle
- * @since 6.6.0
- * @stability stable
+ * @availability stack since=6.6.0 stability=stable
  * @index_privileges view_index_metadata,manage_ilm
  */
 export interface Request extends RequestBase {

--- a/specification/ilm/get_lifecycle/GetLifecycleRequest.ts
+++ b/specification/ilm/get_lifecycle/GetLifecycleRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * Retrieves a lifecycle policy.
  * @rest_spec_name ilm.get_lifecycle
- * @since 6.6.0
- * @stability stable
+ * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm, read_ilm
  */
 export interface Request extends RequestBase {

--- a/specification/ilm/get_status/GetIlmStatusRequest.ts
+++ b/specification/ilm/get_status/GetIlmStatusRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name ilm.get_status
- * @since 6.6.0
- * @stability stable
+ * @availability stack since=6.6.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/ilm/migrate_to_data_tiers/Request.ts
+++ b/specification/ilm/migrate_to_data_tiers/Request.ts
@@ -25,8 +25,7 @@ import { RequestBase } from '@_types/Base'
  * Using node roles enables ILM to automatically move the indices between data tiers.
  *
  * @rest_spec_name ilm.migrate_to_data_tiers
- * @since 7.14.0
- * @stability stable
+ * @availability stack since=7.14.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/ilm/move_to_step/MoveToStepRequest.ts
+++ b/specification/ilm/move_to_step/MoveToStepRequest.ts
@@ -23,8 +23,7 @@ import { StepKey } from './types'
 
 /**
  * @rest_spec_name ilm.move_to_step
- * @since 6.6.0
- * @stability stable
+ * @availability stack since=6.6.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ilm/put_lifecycle/PutLifecycleRequest.ts
+++ b/specification/ilm/put_lifecycle/PutLifecycleRequest.ts
@@ -25,8 +25,7 @@ import { Duration } from '@_types/Time'
 /**
  * Creates a lifecycle policy. If the specified policy exists, the policy is replaced and the policy version is incremented.
  * @rest_spec_name ilm.put_lifecycle
- * @since 6.6.0
- * @stability stable
+ * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm
  * @index_privileges manage
  */

--- a/specification/ilm/remove_policy/RemovePolicyRequest.ts
+++ b/specification/ilm/remove_policy/RemovePolicyRequest.ts
@@ -22,8 +22,7 @@ import { IndexName } from '@_types/common'
 
 /**
  * @rest_spec_name ilm.remove_policy
- * @since 6.6.0
- * @stability stable
+ * @availability stack since=6.6.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ilm/retry/RetryIlmRequest.ts
+++ b/specification/ilm/retry/RetryIlmRequest.ts
@@ -22,8 +22,7 @@ import { IndexName } from '@_types/common'
 
 /**
  * @rest_spec_name ilm.retry
- * @since 6.6.0
- * @stability stable
+ * @availability stack since=6.6.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ilm/start/StartIlmRequest.ts
+++ b/specification/ilm/start/StartIlmRequest.ts
@@ -22,8 +22,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name ilm.start
- * @since 6.6.0
- * @stability stable
+ * @availability stack since=6.6.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/ilm/stop/StopIlmRequest.ts
+++ b/specification/ilm/stop/StopIlmRequest.ts
@@ -22,8 +22,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name ilm.stop
- * @since 6.6.0
- * @stability stable
+ * @availability stack since=6.6.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/indices/add_block/IndicesAddBlockRequest.ts
+++ b/specification/indices/add_block/IndicesAddBlockRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.add_block
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/analyze/IndicesAnalyzeRequest.ts
+++ b/specification/indices/analyze/IndicesAnalyzeRequest.ts
@@ -26,8 +26,7 @@ import { TextToAnalyze } from './types'
 
 /**
  * @rest_spec_name indices.analyze
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/clear_cache/IndicesIndicesClearCacheRequest.ts
+++ b/specification/indices/clear_cache/IndicesIndicesClearCacheRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Fields, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name indices.clear_cache
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/clone/IndicesCloneRequest.ts
+++ b/specification/indices/clone/IndicesCloneRequest.ts
@@ -26,8 +26,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.clone
- * @since 7.4.0
- * @stability stable
+ * @availability stack since=7.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/close/CloseIndexRequest.ts
+++ b/specification/indices/close/CloseIndexRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.close
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/create/IndicesCreateRequest.ts
+++ b/specification/indices/create/IndicesCreateRequest.ts
@@ -27,8 +27,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.create
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @index_privileges create_index, manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
+++ b/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
@@ -22,8 +22,7 @@ import { DataStreamName } from '@_types/common'
 
 /**
  * @rest_spec_name indices.create_data_stream
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, IndexName } from '@_types/common'
 
 /**
  * @rest_spec_name indices.data_streams_stats
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/delete/IndicesDeleteRequest.ts
+++ b/specification/indices/delete/IndicesDeleteRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.delete
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/delete_alias/IndicesDeleteAliasRequest.ts
+++ b/specification/indices/delete_alias/IndicesDeleteAliasRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.delete_alias
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
+++ b/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * Removes the data lifecycle from a data stream rendering it not managed by DLM
  * @rest_spec_name indices.delete_data_lifecycle
- * @since 8.8.0
- * @stability experimental
+ * @availability stack since=8.8.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
+++ b/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, DataStreamNames } from '@_types/common'
 
 /**
  * @rest_spec_name indices.delete_data_stream
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/delete_index_template/IndicesDeleteIndexTemplateRequest.ts
+++ b/specification/indices/delete_index_template/IndicesDeleteIndexTemplateRequest.ts
@@ -26,8 +26,7 @@ import { Duration } from '@_types/Time'
  * names are specified then there is no wildcard support and the provided names should match completely with
  * existing templates.
  * @rest_spec_name indices.delete_index_template
- * @since 7.8.0
- * @stability stable
+ * @availability stack since=7.8.0 stability=stable
  * @cluster_privileges manage_index_templates,manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/delete_template/IndicesDeleteTemplateRequest.ts
+++ b/specification/indices/delete_template/IndicesDeleteTemplateRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.delete_template
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/disk_usage/IndicesDiskUsageRequest.ts
+++ b/specification/indices/disk_usage/IndicesDiskUsageRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name indices.disk_usage
- * @since 7.15.0
- * @stability experimental
+ * @availability stack since=7.15.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/downsample/Request.ts
+++ b/specification/indices/downsample/Request.ts
@@ -23,8 +23,7 @@ import { IndexName } from '@_types/common'
 
 /**
  * @rest_spec_name indices.downsample
- * @since 8.5.0
- * @stability experimental
+ * @availability stack since=8.5.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/exists/IndicesExistsRequest.ts
+++ b/specification/indices/exists/IndicesExistsRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name indices.exists
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
+++ b/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Indices, Names } from '@_types/common'
 
 /**
  * @rest_spec_name indices.exists_alias
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/exists_index_template/IndicesExistsIndexTemplateRequest.ts
+++ b/specification/indices/exists_index_template/IndicesExistsIndexTemplateRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.exists_index_template
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/exists_template/IndicesExistsTemplateRequest.ts
+++ b/specification/indices/exists_template/IndicesExistsTemplateRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.exists_template
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts
+++ b/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * Retrieves information about the index's current DLM lifecycle, such as any potential encountered error, time since creation etc.
  * @rest_spec_name indices.explain_data_lifecycle
- * @since 8.8.0
- * @stability experimental
+ * @availability stack since=8.8.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/field_usage_stats/IndicesFieldUsageStatsRequest.ts
+++ b/specification/indices/field_usage_stats/IndicesFieldUsageStatsRequest.ts
@@ -28,8 +28,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.field_usage_stats
- * @since 7.15.0
- * @stability experimental
+ * @availability stack since=7.15.0 stability=experimental
  * @index_privileges manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/flush/IndicesFlushRequest.ts
+++ b/specification/indices/flush/IndicesFlushRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name indices.flush
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/forcemerge/IndicesForceMergeRequest.ts
+++ b/specification/indices/forcemerge/IndicesForceMergeRequest.ts
@@ -23,8 +23,7 @@ import { long } from '@_types/Numeric'
 
 /**
  * @rest_spec_name indices.forcemerge
- * @since 2.1.0
- * @stability stable
+ * @availability stack since=2.1.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get/IndicesGetRequest.ts
+++ b/specification/indices/get/IndicesGetRequest.ts
@@ -25,8 +25,7 @@ import { Duration } from '@_types/Time'
  * Returns information about one or more indices. For data streams, the API returns information about the
  * stream’s backing indices.
  * @rest_spec_name indices.get
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @index_privileges view_index_metadata, manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/get_alias/IndicesGetAliasRequest.ts
+++ b/specification/indices/get_alias/IndicesGetAliasRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Indices, Names } from '@_types/common'
 
 /**
  * @rest_spec_name indices.get_alias
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
@@ -23,8 +23,7 @@ import { ExpandWildcards, DataStreamNames } from '@_types/common'
 /**
  * Retrieves the data lifecycle configuration of one or more data streams.
  * @rest_spec_name indices.get_data_lifecycle
- * @since 8.8.0
- * @stability experimental
+ * @availability stack since=8.8.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
+++ b/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, DataStreamNames } from '@_types/common'
 
 /**
  * @rest_spec_name indices.get_data_stream
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_field_mapping/IndicesGetFieldMappingRequest.ts
+++ b/specification/indices/get_field_mapping/IndicesGetFieldMappingRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Fields, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name indices.get_field_mapping
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
+++ b/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * Returns information about one or more index templates.
  * @rest_spec_name indices.get_index_template
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  * @cluster_privileges manage_index_templates,manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/get_mapping/IndicesGetMappingRequest.ts
+++ b/specification/indices/get_mapping/IndicesGetMappingRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.get_mapping
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_settings/IndicesGetSettingsRequest.ts
+++ b/specification/indices/get_settings/IndicesGetSettingsRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.get_settings
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_template/IndicesGetTemplateRequest.ts
+++ b/specification/indices/get_template/IndicesGetTemplateRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.get_template
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
+++ b/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
@@ -22,8 +22,7 @@ import { IndexName } from '@_types/common'
 
 /**
  * @rest_spec_name indices.migrate_to_data_stream
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/modify_data_stream/IndicesModifyDataStreamRequest.ts
+++ b/specification/indices/modify_data_stream/IndicesModifyDataStreamRequest.ts
@@ -22,8 +22,7 @@ import { Action } from './types'
 
 /**
  * @rest_spec_name indices.modify_data_stream
- * @since 7.16.0
- * @stability stable
+ * @availability stack since=7.16.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/indices/open/IndicesOpenRequest.ts
+++ b/specification/indices/open/IndicesOpenRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.open
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/promote_data_stream/IndicesPromoteDataStreamRequest.ts
+++ b/specification/indices/promote_data_stream/IndicesPromoteDataStreamRequest.ts
@@ -22,8 +22,7 @@ import { IndexName } from '@_types/common'
 
 /**
  * @rest_spec_name indices.promote_data_stream
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_alias/IndicesPutAliasRequest.ts
+++ b/specification/indices/put_alias/IndicesPutAliasRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.put_alias
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
+++ b/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * Update the data lifecycle of the specified data streams.
  * @rest_spec_name indices.put_data_lifecycle
- * @since 8.8.0
- * @stability experimental
+ * @availability stack since=8.8.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
@@ -35,8 +35,7 @@ import { DataLifecycle } from '@indices/_types/DataLifecycle'
 
 /**
  * @rest_spec_name indices.put_index_template
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_mapping/IndicesPutMappingRequest.ts
+++ b/specification/indices/put_mapping/IndicesPutMappingRequest.ts
@@ -41,8 +41,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.put_mapping
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_settings/IndicesPutSettingsRequest.ts
+++ b/specification/indices/put_settings/IndicesPutSettingsRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.put_settings
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_template/IndicesPutTemplateRequest.ts
+++ b/specification/indices/put_template/IndicesPutTemplateRequest.ts
@@ -28,8 +28,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.put_template
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/recovery/IndicesRecoveryRequest.ts
+++ b/specification/indices/recovery/IndicesRecoveryRequest.ts
@@ -22,8 +22,7 @@ import { Indices } from '@_types/common'
 
 /**
  * @rest_spec_name indices.recovery
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/refresh/IndicesRefreshRequest.ts
+++ b/specification/indices/refresh/IndicesRefreshRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name indices.refresh
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/reload_search_analyzers/ReloadSearchAnalyzersRequest.ts
+++ b/specification/indices/reload_search_analyzers/ReloadSearchAnalyzersRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name indices.reload_search_analyzers
- * @since 7.3.0
- * @stability stable
+ * @availability stack since=7.3.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/resolve_index/ResolveIndexRequest.ts
+++ b/specification/indices/resolve_index/ResolveIndexRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Names } from '@_types/common'
 
 /**
  * @rest_spec_name indices.resolve_index
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/rollover/IndicesRolloverRequest.ts
+++ b/specification/indices/rollover/IndicesRolloverRequest.ts
@@ -28,8 +28,7 @@ import { RolloverConditions } from './types'
 
 /**
  * @rest_spec_name indices.rollover
- * @since 5.0.0
- * @stability stable
+ * @availability stack since=5.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/segments/IndicesSegmentsRequest.ts
+++ b/specification/indices/segments/IndicesSegmentsRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name indices.segments
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/shard_stores/IndicesShardStoresRequest.ts
+++ b/specification/indices/shard_stores/IndicesShardStoresRequest.ts
@@ -23,8 +23,7 @@ import { ShardStoreStatus } from './types'
 
 /**
  * @rest_spec_name indices.shard_stores
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/shrink/IndicesShrinkRequest.ts
+++ b/specification/indices/shrink/IndicesShrinkRequest.ts
@@ -26,8 +26,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.shrink
- * @since 5.0.0
- * @stability stable
+ * @availability stack since=5.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
+++ b/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
@@ -32,8 +32,7 @@ import { IndexTemplateMapping } from '../put_index_template/IndicesPutIndexTempl
 
 /**
  * @rest_spec_name indices.simulate_index_template
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
+++ b/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
@@ -25,8 +25,7 @@ import { Duration } from '@_types/Time'
 /**
  * Returns the index configuration that would be applied by a particular index template.
  * @rest_spec_name indices.simulate_template
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @cluster_privileges manage_index_templates,manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/split/IndicesSplitRequest.ts
+++ b/specification/indices/split/IndicesSplitRequest.ts
@@ -26,8 +26,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.split
- * @since 6.1.0
- * @stability stable
+ * @availability stack since=6.1.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/stats/IndicesStatsRequest.ts
+++ b/specification/indices/stats/IndicesStatsRequest.ts
@@ -28,8 +28,7 @@ import {
 
 /**
  * @rest_spec_name indices.stats
- * @since 1.3.0
- * @stability stable
+ * @availability stack since=1.3.0 stability=stable
  * @index_privileges manage, monitor
  */
 export interface Request extends RequestBase {

--- a/specification/indices/unfreeze/IndicesUnfreezeRequest.ts
+++ b/specification/indices/unfreeze/IndicesUnfreezeRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name indices.unfreeze
- * @since 6.6.0
- * @stability stable
+ * @availability stack since=6.6.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/update_aliases/IndicesUpdateAliasesRequest.ts
+++ b/specification/indices/update_aliases/IndicesUpdateAliasesRequest.ts
@@ -23,8 +23,7 @@ import { Action } from './types'
 
 /**
  * @rest_spec_name indices.update_aliases
- * @since 1.3.0
- * @stability stable
+ * @availability stack since=1.3.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/indices/validate_query/IndicesValidateQueryRequest.ts
+++ b/specification/indices/validate_query/IndicesValidateQueryRequest.ts
@@ -24,8 +24,7 @@ import { Operator } from '@_types/query_dsl/Operator'
 
 /**
  * @rest_spec_name indices.validate_query
- * @since 1.3.0
- * @stability stable
+ * @availability stack since=1.3.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ingest/delete_pipeline/DeletePipelineRequest.ts
+++ b/specification/ingest/delete_pipeline/DeletePipelineRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name ingest.delete_pipeline
- * @since 5.0.0
- * @stability stable
+ * @availability stack since=5.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ingest/geo_ip_stats/IngestGeoIpStatsRequest.ts
+++ b/specification/ingest/geo_ip_stats/IngestGeoIpStatsRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name ingest.geo_ip_stats
- * @since 7.13.0
- * @stability stable
+ * @availability stack since=7.13.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/ingest/get_pipeline/GetPipelineRequest.ts
+++ b/specification/ingest/get_pipeline/GetPipelineRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name ingest.get_pipeline
- * @since 5.0.0
- * @stability stable
+ * @availability stack since=5.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ingest/processor_grok/GrokProcessorPatternsRequest.ts
+++ b/specification/ingest/processor_grok/GrokProcessorPatternsRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name ingest.processor_grok
- * @since 6.1.0
- * @stability stable
+ * @availability stack since=6.1.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/ingest/put_pipeline/PutPipelineRequest.ts
+++ b/specification/ingest/put_pipeline/PutPipelineRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name ingest.put_pipeline
- * @since 5.0.0
- * @stability stable
+ * @availability stack since=5.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ingest/simulate/SimulatePipelineRequest.ts
+++ b/specification/ingest/simulate/SimulatePipelineRequest.ts
@@ -24,8 +24,7 @@ import { Document } from './types'
 
 /**
  * @rest_spec_name ingest.simulate
- * @since 5.0.0
- * @stability stable
+ * @availability stack since=5.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/license/delete/DeleteLicenseRequest.ts
+++ b/specification/license/delete/DeleteLicenseRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name license.delete
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/license/get/GetLicenseRequest.ts
+++ b/specification/license/get/GetLicenseRequest.ts
@@ -23,8 +23,7 @@ import { RequestBase } from '@_types/Base'
  * This API returns information about the type of license, when it was issued, and when it expires, for example.
  * For more information about the different types of licenses, see https://www.elastic.co/subscriptions.
  * @rest_spec_name license.get
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/license/get_basic_status/GetBasicLicenseStatusRequest.ts
+++ b/specification/license/get_basic_status/GetBasicLicenseStatusRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name license.get_basic_status
- * @since 6.3.0
- * @stability stable
+ * @availability stack since=6.3.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/license/get_trial_status/GetTrialLicenseStatusRequest.ts
+++ b/specification/license/get_trial_status/GetTrialLicenseStatusRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name license.get_trial_status
- * @since 6.1.0
- * @stability stable
+ * @availability stack since=6.1.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/license/post/PostLicenseRequest.ts
+++ b/specification/license/post/PostLicenseRequest.ts
@@ -22,8 +22,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name license.post
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @cluster_privileges manage
  */
 export interface Request extends RequestBase {

--- a/specification/license/post_start_basic/StartBasicLicenseRequest.ts
+++ b/specification/license/post_start_basic/StartBasicLicenseRequest.ts
@@ -23,8 +23,7 @@ import { RequestBase } from '@_types/Base'
  * The start basic API enables you to initiate an indefinite basic license, which gives access to all the basic features. If the basic license does not support all of the features that are available with your current license, however, you are notified in the response. You must then re-submit the API request with the acknowledge parameter set to true.
  * To check the status of your basic license, use the following API: [Get basic status](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-basic-status.html).
  * @rest_spec_name license.post_start_basic
- * @since 6.3.0
- * @stability stable
+ * @availability stack since=6.3.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/license/post_start_trial/StartTrialLicenseRequest.ts
+++ b/specification/license/post_start_trial/StartTrialLicenseRequest.ts
@@ -22,8 +22,7 @@ import { RequestBase } from '@_types/Base'
 /**
  * The start trial API enables you to start a 30-day trial, which gives access to all subscription features.
  * @rest_spec_name license.post_start_trial
- * @since 6.1.0
- * @stability stable
+ * @availability stack since=6.1.0 stability=stable
  * @cluster_privileges manage
  */
 export interface Request extends RequestBase {

--- a/specification/logstash/delete_pipeline/LogstashDeletePipelineRequest.ts
+++ b/specification/logstash/delete_pipeline/LogstashDeletePipelineRequest.ts
@@ -22,8 +22,7 @@ import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name logstash.delete_pipeline
- * @since 7.12.0
- * @stability stable
+ * @availability stack since=7.12.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/logstash/get_pipeline/LogstashGetPipelineRequest.ts
+++ b/specification/logstash/get_pipeline/LogstashGetPipelineRequest.ts
@@ -22,8 +22,7 @@ import { Ids } from '@_types/common'
 
 /**
  * @rest_spec_name logstash.get_pipeline
- * @since 7.12.0
- * @stability stable
+ * @availability stack since=7.12.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/logstash/put_pipeline/LogstashPutPipelineRequest.ts
+++ b/specification/logstash/put_pipeline/LogstashPutPipelineRequest.ts
@@ -23,8 +23,7 @@ import { Pipeline } from '@logstash/_types/Pipeline'
 
 /**
  * @rest_spec_name logstash.put_pipeline
- * @since 7.12.0
- * @stability stable
+ * @availability stack since=7.12.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/migration/deprecations/DeprecationInfoRequest.ts
+++ b/specification/migration/deprecations/DeprecationInfoRequest.ts
@@ -22,8 +22,7 @@ import { IndexName } from '@_types/common'
 
 /**
  * @rest_spec_name migration.deprecations
- * @since 6.1.0
- * @stability stable
+ * @availability stack since=6.1.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/migration/get_feature_upgrade_status/GetFeatureUpgradeStatusRequest.ts
+++ b/specification/migration/get_feature_upgrade_status/GetFeatureUpgradeStatusRequest.ts
@@ -21,8 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name migration.get_feature_upgrade_status
- * @since 7.16.0
- * @stability stable
+ * @availability stack since=7.16.0 stability=stable
  * @index_privileges manage
  */
 export interface Request extends RequestBase {}

--- a/specification/migration/post_feature_upgrade/PostFeatureUpgradeRequest.ts
+++ b/specification/migration/post_feature_upgrade/PostFeatureUpgradeRequest.ts
@@ -21,8 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name migration.post_feature_upgrade
- * @since 7.16.0
- * @stability stable
+ * @availability stack since=7.16.0 stability=stable
  * @index_privileges manage
  */
 export interface Request extends RequestBase {}

--- a/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheRequest.ts
+++ b/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheRequest.ts
@@ -28,8 +28,7 @@ import { Include } from '@ml/_types/Include'
  * As requests are handled by each allocated node, their responses may be cached on that individual node.
  * Calling this API clears the caches without restarting the deployment.
  * @rest_spec_name ml.clear_trained_model_deployment_cache
- * @since 8.5.0
- * @stability stable
+ * @availability stack since=8.5.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/close_job/MlCloseJobRequest.ts
+++ b/specification/ml/close_job/MlCloseJobRequest.ts
@@ -28,8 +28,7 @@ import { Duration } from '@_types/Time'
  * If you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request.
  * When a datafeed that has a specified end date stops, it automatically closes its associated job.
  * @rest_spec_name ml.close_job
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  * @doc_id ml-close-job
  */

--- a/specification/ml/delete_calendar/MlDeleteCalendarRequest.ts
+++ b/specification/ml/delete_calendar/MlDeleteCalendarRequest.ts
@@ -23,8 +23,7 @@ import { Id } from '@_types/common'
 /**
  * Removes all scheduled events from a calendar, then deletes it.
  * @rest_spec_name ml.delete_calendar
- * @since 6.2.0
- * @stability stable
+ * @availability stack since=6.2.0 stability=stable
  * @cluster_privileges manage_ml
  * @doc_id ml-delete-calendar
  */

--- a/specification/ml/delete_calendar_event/MlDeleteCalendarEventRequest.ts
+++ b/specification/ml/delete_calendar_event/MlDeleteCalendarEventRequest.ts
@@ -23,8 +23,7 @@ import { Id } from '@_types/common'
 /**
  * Deletes scheduled events from a calendar.
  * @rest_spec_name ml.delete_calendar_event
- * @since 6.2.0
- * @stability stable
+ * @availability stack since=6.2.0 stability=stable
  * @doc_id ml-delete-calendar-event
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_calendar_job/MlDeleteCalendarJobRequest.ts
+++ b/specification/ml/delete_calendar_job/MlDeleteCalendarJobRequest.ts
@@ -23,8 +23,7 @@ import { Id, Ids } from '@_types/common'
 /**
  * Deletes anomaly detection jobs from a calendar.
  * @rest_spec_name ml.delete_calendar_job
- * @since 6.2.0
- * @stability stable
+ * @availability stack since=6.2.0 stability=stable
  * @cluster_privileges manage_ml
  * @doc_id ml-delete-calendar-job
  */

--- a/specification/ml/delete_data_frame_analytics/MlDeleteDataFrameAnalyticsRequest.ts
+++ b/specification/ml/delete_data_frame_analytics/MlDeleteDataFrameAnalyticsRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * Deletes a data frame analytics job.
  * @rest_spec_name ml.delete_data_frame_analytics
- * @since 7.3.0
- * @stability stable
+ * @availability stack since=7.3.0 stability=stable
  * @cluster_privileges manage_ml
  * @doc_id ml-delete-dfanalytics
  */

--- a/specification/ml/delete_datafeed/MlDeleteDatafeedRequest.ts
+++ b/specification/ml/delete_datafeed/MlDeleteDatafeedRequest.ts
@@ -23,8 +23,7 @@ import { Id } from '@_types/common'
 /**
  * Deletes an existing datafeed.
  * @rest_spec_name ml.delete_datafeed
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  * @doc_id ml-delete-datafeed
  */

--- a/specification/ml/delete_expired_data/MlDeleteExpiredDataRequest.ts
+++ b/specification/ml/delete_expired_data/MlDeleteExpiredDataRequest.ts
@@ -33,8 +33,7 @@ import { Duration } from '@_types/Time'
  * jobs by using _all, by specifying * as the <job_id>, or by omitting the
  * <job_id>.
  * @rest_spec_name ml.delete_expired_data
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_filter/MlDeleteFilterRequest.ts
+++ b/specification/ml/delete_filter/MlDeleteFilterRequest.ts
@@ -25,8 +25,7 @@ import { Id } from '@_types/common'
  * If an anomaly detection job references the filter, you cannot delete the
  * filter. You must update or delete the job before you can delete the filter.
  * @rest_spec_name ml.delete_filter
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_forecast/MlDeleteForecastRequest.ts
+++ b/specification/ml/delete_forecast/MlDeleteForecastRequest.ts
@@ -28,8 +28,7 @@ import { Duration } from '@_types/Time'
  * jobs API. The delete forecast API enables you to delete one or more
  * forecasts before they expire.
  * @rest_spec_name ml.delete_forecast
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_job/MlDeleteJobRequest.ts
+++ b/specification/ml/delete_job/MlDeleteJobRequest.ts
@@ -30,8 +30,7 @@ import { Id } from '@_types/common'
  * the delete datafeed API with the same timeout and force parameters as the
  * delete job request.
  * @rest_spec_name ml.delete_job
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_model_snapshot/MlDeleteModelSnapshotRequest.ts
+++ b/specification/ml/delete_model_snapshot/MlDeleteModelSnapshotRequest.ts
@@ -26,8 +26,7 @@ import { Id } from '@_types/common'
  * revert to a different one. To identify the active model snapshot, refer to
  * the `model_snapshot_id` in the results from the get jobs API.
  * @rest_spec_name ml.delete_model_snapshot
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_trained_model/MlDeleteTrainedModelRequest.ts
+++ b/specification/ml/delete_trained_model/MlDeleteTrainedModelRequest.ts
@@ -24,8 +24,7 @@ import { Id } from '@_types/common'
  * Deletes an existing trained inference model that is currently not referenced
  * by an ingest pipeline.
  * @rest_spec_name ml.delete_trained_model
- * @since 7.10.0
- * @stability stable
+ * @availability stack since=7.10.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_trained_model_alias/MlDeleteTrainedModelAliasRequest.ts
+++ b/specification/ml/delete_trained_model_alias/MlDeleteTrainedModelAliasRequest.ts
@@ -26,8 +26,7 @@ import { Id, Name } from '@_types/common'
  * the model alias is missing or refers to a model other than the one identified
  * by the `model_id`, this API returns an error.
  * @rest_spec_name ml.delete_trained_model_alias
- * @since 7.13.0
- * @stability stable
+ * @availability stack since=7.13.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/estimate_model_memory/MlEstimateModelMemoryRequest.ts
+++ b/specification/ml/estimate_model_memory/MlEstimateModelMemoryRequest.ts
@@ -28,8 +28,7 @@ import { long } from '@_types/Numeric'
  * It is based on analysis configuration details for the job and cardinality
  * estimates for the fields it references.
  * @rest_spec_name ml.estimate_model_memory
- * @since 7.7.0
- * @stability stable
+ * @availability stack since=7.7.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/evaluate_data_frame/MlEvaluateDataFrameRequest.ts
+++ b/specification/ml/evaluate_data_frame/MlEvaluateDataFrameRequest.ts
@@ -29,8 +29,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
  * created by data frame analytics. Evaluation requires both a ground truth
  * field and an analytics result field to be present.
  * @rest_spec_name ml.evaluate_data_frame
- * @since 7.3.0
- * @stability stable
+ * @availability stack since=7.3.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/explain_data_frame_analytics/MlExplainDataFrameAnalyticsRequest.ts
+++ b/specification/ml/explain_data_frame_analytics/MlExplainDataFrameAnalyticsRequest.ts
@@ -36,8 +36,7 @@ import { integer } from '@_types/Numeric'
  * * how much memory is estimated to be required. The estimate can be used when deciding the appropriate value for model_memory_limit setting later on.
  * If you have object fields or fields that are excluded via source filtering, they are not included in the explanation.
  * @rest_spec_name ml.explain_data_frame_analytics
- * @since 7.3.0
- * @stability stable
+ * @availability stack since=7.3.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/flush_job/MlFlushJobRequest.ts
+++ b/specification/ml/flush_job/MlFlushJobRequest.ts
@@ -32,8 +32,7 @@ import { DateTime } from '@_types/Time'
  * persists the model state to disk and the job must be opened again before
  * analyzing further data.
  * @rest_spec_name ml.flush_job
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/forecast/MlForecastJobRequest.ts
+++ b/specification/ml/forecast/MlForecastJobRequest.ts
@@ -30,8 +30,7 @@ import { Duration } from '@_types/Time'
  * `over_field_name` in its configuration.
  *
  * @rest_spec_name ml.forecast
- * @since 6.1.0
- * @stability stable
+ * @availability stack since=6.1.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_buckets/MlGetBucketsRequest.ts
+++ b/specification/ml/get_buckets/MlGetBucketsRequest.ts
@@ -27,8 +27,7 @@ import { DateTime } from '@_types/Time'
  * Retrieves anomaly detection job results for one or more buckets.
  * The API presents a chronological view of the records, grouped by bucket.
  * @rest_spec_name ml.get_buckets
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
+++ b/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
@@ -25,8 +25,7 @@ import { DateTime } from '@_types/Time'
 /**
  * Retrieves information about the scheduled events in calendars.
  * @rest_spec_name ml.get_calendar_events
- * @since 6.2.0
- * @stability stable
+ * @availability stack since=6.2.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_calendars/MlGetCalendarsRequest.ts
+++ b/specification/ml/get_calendars/MlGetCalendarsRequest.ts
@@ -25,8 +25,7 @@ import { integer } from '@_types/Numeric'
 /**
  * Retrieves configuration information for calendars.
  * @rest_spec_name ml.get_calendars
- * @since 6.2.0
- * @stability stable
+ * @availability stack since=6.2.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_categories/MlGetCategoriesRequest.ts
+++ b/specification/ml/get_categories/MlGetCategoriesRequest.ts
@@ -25,8 +25,7 @@ import { integer } from '@_types/Numeric'
 /**
  * Retrieves anomaly detection job results for one or more categories.
  * @rest_spec_name ml.get_categories
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_data_frame_analytics/MlGetDataFrameAnalyticsRequest.ts
+++ b/specification/ml/get_data_frame_analytics/MlGetDataFrameAnalyticsRequest.ts
@@ -27,8 +27,7 @@ import { integer } from '@_types/Numeric'
  * API request by using a comma-separated list of data frame analytics jobs or a
  * wildcard expression.
  * @rest_spec_name ml.get_data_frame_analytics
- * @since 7.3.0
- * @stability stable
+ * @availability stack since=7.3.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_data_frame_analytics_stats/MlGetDataFrameAnalyticsStatsRequest.ts
+++ b/specification/ml/get_data_frame_analytics_stats/MlGetDataFrameAnalyticsStatsRequest.ts
@@ -24,8 +24,7 @@ import { integer } from '@_types/Numeric'
 /**
  * Retrieves usage information for data frame analytics jobs.
  * @rest_spec_name ml.get_data_frame_analytics_stats
- * @since 7.3.0
- * @stability stable
+ * @availability stack since=7.3.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_datafeed_stats/MlGetDatafeedStatsRequest.ts
+++ b/specification/ml/get_datafeed_stats/MlGetDatafeedStatsRequest.ts
@@ -29,8 +29,7 @@ import { Ids } from '@_types/common'
  * only information you receive is the `datafeed_id` and the `state`.
  * This API returns a maximum of 10,000 datafeeds.
  * @rest_spec_name ml.get_datafeed_stats
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_datafeeds/MlGetDatafeedsRequest.ts
+++ b/specification/ml/get_datafeeds/MlGetDatafeedsRequest.ts
@@ -28,8 +28,7 @@ import { Ids } from '@_types/common'
  * `<feed_id>`, or by omitting the `<feed_id>`.
  * This API returns a maximum of 10,000 datafeeds.
  * @rest_spec_name ml.get_datafeeds
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_filters/MlGetFiltersRequest.ts
+++ b/specification/ml/get_filters/MlGetFiltersRequest.ts
@@ -25,8 +25,7 @@ import { integer } from '@_types/Numeric'
  * Retrieves filters.
  * You can get a single filter or all filters.
  * @rest_spec_name ml.get_filters
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_influencers/MlGetInfluencersRequest.ts
+++ b/specification/ml/get_influencers/MlGetInfluencersRequest.ts
@@ -29,8 +29,7 @@ import { DateTime } from '@_types/Time'
  * the anomalies. Influencer results are available only if an
  * `influencer_field_name` is specified in the job configuration.
  * @rest_spec_name ml.get_influencers
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
+++ b/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
@@ -23,8 +23,7 @@ import { Id } from '@_types/common'
 /**
  * Retrieves usage information for anomaly detection jobs.
  * @rest_spec_name ml.get_job_stats
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_jobs/MlGetJobsRequest.ts
+++ b/specification/ml/get_jobs/MlGetJobsRequest.ts
@@ -27,8 +27,7 @@ import { Ids } from '@_types/common'
  * expression. You can get information for all anomaly detection jobs by using
  * `_all`, by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.
  * @rest_spec_name ml.get_jobs
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_memory_stats/MlGetMemoryStatsRequest.ts
+++ b/specification/ml/get_memory_stats/MlGetMemoryStatsRequest.ts
@@ -25,8 +25,7 @@ import { Duration } from '@_types/Time'
  * Get information about how machine learning jobs and trained models are using memory,
  * on each node, both within the JVM heap, and natively, outside of the JVM.
  * @rest_spec_name ml.get_memory_stats
- * @since 8.2.0
- * @stability stable
+ * @availability stack since=8.2.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_model_snapshot_upgrade_stats/MlGetModelSnapshotUpgradeStatsRequest.ts
+++ b/specification/ml/get_model_snapshot_upgrade_stats/MlGetModelSnapshotUpgradeStatsRequest.ts
@@ -23,8 +23,7 @@ import { Id } from '@_types/common'
 /**
  * Retrieves usage information for anomaly detection job model snapshot upgrades.
  * @rest_spec_name ml.get_model_snapshot_upgrade_stats
- * @since 7.16.0
- * @stability stable
+ * @availability stack since=7.16.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_model_snapshots/MlGetModelSnapshotsRequest.ts
+++ b/specification/ml/get_model_snapshots/MlGetModelSnapshotsRequest.ts
@@ -26,8 +26,7 @@ import { Duration, DateTime } from '@_types/Time'
 /**
  * Retrieves information about model snapshots.
  * @rest_spec_name ml.get_model_snapshots
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
+++ b/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
@@ -41,8 +41,7 @@ import { Duration, DateTime } from '@_types/Time'
  * `overall_score` of the overall buckets that have a span equal to the
  * jobs' largest bucket span.
  * @rest_spec_name ml.get_overall_buckets
- * @since 6.1.0
- * @stability stable
+ * @availability stack since=6.1.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_records/MlGetAnomalyRecordsRequest.ts
+++ b/specification/ml/get_records/MlGetAnomalyRecordsRequest.ts
@@ -36,8 +36,7 @@ import { DateTime } from '@_types/Time'
  * bucket, which relates to the number of time series being modeled and the
  * number of detectors.
  * @rest_spec_name ml.get_records
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
+++ b/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
@@ -25,8 +25,7 @@ import { Include } from '@ml/_types/Include'
 /**
  * Retrieves configuration information for a trained model.
  * @rest_spec_name ml.get_trained_models
- * @since 7.10.0
- * @stability stable
+ * @availability stack since=7.10.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsRequest.ts
+++ b/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsRequest.ts
@@ -25,8 +25,7 @@ import { integer } from '@_types/Numeric'
  * Retrieves usage information for trained models. You can get usage information for multiple trained
  * models in a single API request by using a comma-separated list of model IDs or a wildcard expression.
  * @rest_spec_name ml.get_trained_models_stats
- * @since 7.10.0
- * @stability stable
+ * @availability stack since=7.10.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/infer_trained_model/MlInferTrainedModelRequest.ts
+++ b/specification/ml/infer_trained_model/MlInferTrainedModelRequest.ts
@@ -27,8 +27,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 /**
  * Evaluates a trained model.
  * @rest_spec_name ml.infer_trained_model
- * @since 8.3.0
- * @stability stable
+ * @availability stack since=8.3.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ml/info/MlInfoRequest.ts
+++ b/specification/ml/info/MlInfoRequest.ts
@@ -28,8 +28,7 @@ import { RequestBase } from '@_types/Base'
  * the maximum size of machine learning jobs that could run in the current
  * cluster configuration.
  * @rest_spec_name ml.info
- * @since 6.3.0
- * @stability stable
+ * @availability stack since=6.3.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {}

--- a/specification/ml/open_job/MlOpenJobRequest.ts
+++ b/specification/ml/open_job/MlOpenJobRequest.ts
@@ -31,8 +31,7 @@ import { Duration } from '@_types/Time'
  * loaded. The job is ready to resume its analysis from where it left off, once
  * new data is received.
  * @rest_spec_name ml.open_job
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
+++ b/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
@@ -24,8 +24,7 @@ import { CalendarEvent } from '../_types/CalendarEvent'
 /**
  * Adds scheduled events to a calendar.
  * @rest_spec_name ml.post_calendar_events
- * @since 6.2.0
- * @stability stable
+ * @availability stack since=6.2.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/post_data/MlPostJobDataRequest.ts
+++ b/specification/ml/post_data/MlPostJobDataRequest.ts
@@ -27,8 +27,7 @@ import { DateTime } from '@_types/Time'
  * IMPORTANT: For each job, data can be accepted from only a single connection at a time.
  * It is not currently possible to post data to multiple jobs using wildcards or a comma-separated list.
  * @rest_spec_name ml.post_data
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @deprecated 7.11.0 Posting data directly to anomaly detection jobs is deprecated, in a future major version a datafeed will be required.
  * @cluster_privileges manage_ml
  */

--- a/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsRequest.ts
+++ b/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsRequest.ts
@@ -24,8 +24,7 @@ import { DataframePreviewConfig } from './types'
 /**
  * Previews the extracted features used by a data frame analytics config.
  * @rest_spec_name ml.preview_data_frame_analytics
- * @since 7.13.0
- * @stability stable
+ * @availability stack since=7.13.0 stability=stable
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
@@ -34,8 +34,7 @@ import { DateTime } from '@_types/Time'
  * datafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials.
  * You can also use secondary authorization headers to supply the credentials.
  * @rest_spec_name ml.preview_datafeed
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @index_privileges read
  * @cluster_privileges manage_ml
  */

--- a/specification/ml/put_calendar/MlPutCalendarRequest.ts
+++ b/specification/ml/put_calendar/MlPutCalendarRequest.ts
@@ -23,8 +23,7 @@ import { Id } from '@_types/common'
 /**
  * Creates a calendar.
  * @rest_spec_name ml.put_calendar
- * @since 6.2.0
- * @stability stable
+ * @availability stack since=6.2.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/put_calendar_job/MlPutCalendarJobRequest.ts
+++ b/specification/ml/put_calendar_job/MlPutCalendarJobRequest.ts
@@ -23,8 +23,7 @@ import { Id } from '@_types/common'
 /**
  * Adds an anomaly detection job to a calendar.
  * @rest_spec_name ml.put_calendar_job
- * @since 6.2.0
- * @stability stable
+ * @availability stack since=6.2.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
+++ b/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
@@ -32,8 +32,7 @@ import { integer } from '@_types/Numeric'
  * This API creates a data frame analytics job that performs an analysis on the
  * source indices and stores the outcome in a destination index.
  * @rest_spec_name ml.put_data_frame_analytics
- * @since 7.3.0
- * @stability stable
+ * @availability stack since=7.3.0 stability=stable
  * @cluster_privileges manage_ml
  * @index_privileges create_index, index, manage, read, view_index_metadata
  * @doc_id put-dfanalytics

--- a/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
@@ -46,8 +46,7 @@ import { Duration } from '@_types/Time'
  * You must use Kibana, this API, or the create anomaly detection jobs API to create a datafeed. Do not add a datafeed
  * directly to the `.ml-config` index. Do not give users `write` privileges on the `.ml-config` index.
  * @rest_spec_name ml.put_datafeed
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @index_privileges read
  * @cluster_privileges manage_ml
  */

--- a/specification/ml/put_filter/MlPutFilterRequest.ts
+++ b/specification/ml/put_filter/MlPutFilterRequest.ts
@@ -25,8 +25,7 @@ import { Id } from '@_types/common'
  * A filter contains a list of strings. It can be used by one or more anomaly detection jobs.
  * Specifically, filters are referenced in the `custom_rules` property of detector configuration objects.
  * @rest_spec_name ml.put_filter
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -30,8 +30,7 @@ import { DatafeedConfig } from '@ml/_types/Datafeed'
 /**
  * Instantiates an anomaly detection job. If you include a `datafeed_config`, you must have read index privileges on the source index.
  * @rest_spec_name ml.put_job
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @index_privileges read
  * @cluster_privileges manage_ml
  */

--- a/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
@@ -28,8 +28,7 @@ import { InferenceConfigCreateContainer } from '@ml/_types/inference'
 /**
  * Enables you to supply a trained model that is not created by data frame analytics.
  * @rest_spec_name ml.put_trained_model
- * @since 7.10.0
- * @stability stable
+ * @availability stack since=7.10.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/put_trained_model_alias/MlPutTrainedModelAliasRequest.ts
+++ b/specification/ml/put_trained_model_alias/MlPutTrainedModelAliasRequest.ts
@@ -38,8 +38,7 @@ import { Id, Name } from '@_types/common'
  * common between the old and new trained models for the model alias, the API
  * returns a warning.
  * @rest_spec_name ml.put_trained_model_alias
- * @since 7.13.0
- * @stability stable
+ * @availability stack since=7.13.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartRequest.ts
+++ b/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartRequest.ts
@@ -24,8 +24,7 @@ import { Id } from '@_types/common'
 /**
  * Creates part of a trained model definition.
  * @rest_spec_name ml.put_trained_model_definition_part
- * @since 8.0.0
- * @stability stable
+ * @availability stack since=8.0.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
+++ b/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
@@ -25,8 +25,7 @@ import { Id } from '@_types/common'
  * This API is supported only for natural language processing (NLP) models.
  * The vocabulary is stored in the index as described in `inference_config.*.vocabulary` of the trained model definition.
  * @rest_spec_name ml.put_trained_model_vocabulary
- * @since 8.0.0
- * @stability stable
+ * @availability stack since=8.0.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/reset_job/MlResetJobRequest.ts
+++ b/specification/ml/reset_job/MlResetJobRequest.ts
@@ -27,8 +27,7 @@ import { Id } from '@_types/common'
  * It is not currently possible to reset multiple jobs using wildcards or a
  * comma separated list.
  * @rest_spec_name ml.reset_job
- * @since 7.14.0
- * @stability stable
+ * @availability stack since=7.14.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/revert_model_snapshot/MlRevertModelSnapshotRequest.ts
+++ b/specification/ml/revert_model_snapshot/MlRevertModelSnapshotRequest.ts
@@ -30,8 +30,7 @@ import { Id } from '@_types/common'
  * before this event. For example, you might consider reverting to a saved
  * snapshot after Black Friday or a critical system failure.
  * @rest_spec_name ml.revert_model_snapshot
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/set_upgrade_mode/MlSetUpgradeModeRequest.ts
+++ b/specification/ml/set_upgrade_mode/MlSetUpgradeModeRequest.ts
@@ -34,8 +34,7 @@ import { Duration } from '@_types/Time'
  * You can see the current value for the upgrade_mode setting by using the get
  * machine learning info API.
  * @rest_spec_name ml.set_upgrade_mode
- * @since 6.7.0
- * @stability stable
+ * @availability stack since=6.7.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/start_data_frame_analytics/MlStartDataFrameAnalyticsRequest.ts
+++ b/specification/ml/start_data_frame_analytics/MlStartDataFrameAnalyticsRequest.ts
@@ -35,8 +35,7 @@ import { Duration } from '@_types/Time'
  * If the destination index exists, it is used as is. You can therefore set up
  * the destination index in advance with custom settings and mappings.
  * @rest_spec_name ml.start_data_frame_analytics
- * @since 7.3.0
- * @stability stable
+ * @availability stack since=7.3.0 stability=stable
  * @cluster_privileges manage_ml
  * @index_privileges create_index, index, manage, read, view_index_metadata
  */

--- a/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
+++ b/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
@@ -36,8 +36,7 @@ import { Duration, DateTime } from '@_types/Time'
  * update it had at the time of creation or update and runs the query using those same roles. If you provided secondary
  * authorization headers when you created or updated the datafeed, those credentials are used instead.
  * @rest_spec_name ml.start_datafeed
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
@@ -29,8 +29,7 @@ import {
 /**
  * Starts a trained model deployment, which allocates the model to every machine learning node.
  * @rest_spec_name ml.start_trained_model_deployment
- * @since 8.0.0
- * @stability stable
+ * @availability stack since=8.0.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/stop_data_frame_analytics/MlStopDataFrameAnalyticsRequest.ts
+++ b/specification/ml/stop_data_frame_analytics/MlStopDataFrameAnalyticsRequest.ts
@@ -26,8 +26,7 @@ import { Duration } from '@_types/Time'
  * A data frame analytics job can be started and stopped multiple times
  * throughout its lifecycle.
  * @rest_spec_name ml.stop_data_frame_analytics
- * @since 7.3.0
- * @stability stable
+ * @availability stack since=7.3.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
+++ b/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
@@ -26,8 +26,7 @@ import { Duration } from '@_types/Time'
  * A datafeed that is stopped ceases to retrieve data from Elasticsearch. A datafeed can be started and stopped
  * multiple times throughout its lifecycle.
  * @rest_spec_name ml.stop_datafeed
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentRequest.ts
+++ b/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentRequest.ts
@@ -23,8 +23,7 @@ import { Id } from '@_types/common'
 /**
  * Stops a trained model deployment.
  * @rest_spec_name ml.stop_trained_model_deployment
- * @since 8.0.0
- * @stability stable
+ * @availability stack since=8.0.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/update_data_frame_analytics/MlUpdateDataFrameAnalyticsRequest.ts
+++ b/specification/ml/update_data_frame_analytics/MlUpdateDataFrameAnalyticsRequest.ts
@@ -24,8 +24,7 @@ import { integer } from '@_types/Numeric'
 /**
  * Updates an existing data frame analytics job.
  * @rest_spec_name ml.update_data_frame_analytics
- * @since 7.3.0
- * @stability stable
+ * @availability stack since=7.3.0 stability=stable
  * @cluster_privileges manage_ml
  * @index_privileges read, create_index, manage, index, view_index_metadata
  */

--- a/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
@@ -35,8 +35,7 @@ import { ScriptField } from '@_types/Scripting'
  * the time of the update and runs the query using those same roles. If you provide secondary authorization headers,
  * those credentials are used instead.
  * @rest_spec_name ml.update_datafeed
- * @since 6.4.0
- * @stability stable
+ * @availability stack since=6.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/update_filter/MlUpdateFilterRequest.ts
+++ b/specification/ml/update_filter/MlUpdateFilterRequest.ts
@@ -23,8 +23,7 @@ import { Id } from '@_types/common'
 /**
  * Updates the description of a filter, adds items, or removes items from the list.
  * @rest_spec_name ml.update_filter
- * @since 6.4.0
- * @stability stable
+ * @availability stack since=6.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/update_job/MlUpdateJobRequest.ts
+++ b/specification/ml/update_job/MlUpdateJobRequest.ts
@@ -33,8 +33,7 @@ import { Duration } from '@_types/Time'
 /**
  * Updates certain properties of an anomaly detection job.
  * @rest_spec_name ml.update_job
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/update_model_snapshot/MlUpdateModelSnapshotRequest.ts
+++ b/specification/ml/update_model_snapshot/MlUpdateModelSnapshotRequest.ts
@@ -23,8 +23,7 @@ import { Id } from '@_types/common'
 /**
  * Updates certain properties of a snapshot.
  * @rest_spec_name ml.update_model_snapshot
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/upgrade_job_snapshot/MlUpgradeJobSnapshotRequest.ts
+++ b/specification/ml/upgrade_job_snapshot/MlUpgradeJobSnapshotRequest.ts
@@ -32,8 +32,7 @@ import { Duration } from '@_types/Time'
  * upgraded snapshot cannot be the current snapshot of the anomaly detection
  * job.
  * @rest_spec_name ml.upgrade_job_snapshot
- * @since 5.4.0
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/validate/MlValidateJobRequest.ts
+++ b/specification/ml/validate/MlValidateJobRequest.ts
@@ -26,9 +26,7 @@ import { long } from '@_types/Numeric'
 
 /**
  * @rest_spec_name ml.validate
- * @since 6.3.0
- * @stability stable
- * @visibility private
+ * @availability stack since=6.3.0 stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/ml/validate_detector/MlValidateDetectorRequest.ts
+++ b/specification/ml/validate_detector/MlValidateDetectorRequest.ts
@@ -22,9 +22,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name ml.validate_detector
- * @since 5.4.0
- * @visibility private
- * @stability stable
+ * @availability stack since=5.4.0 stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   /** @codegen_name detector */

--- a/specification/monitoring/bulk/BulkMonitoringRequest.ts
+++ b/specification/monitoring/bulk/BulkMonitoringRequest.ts
@@ -23,8 +23,7 @@ import { OperationContainer, UpdateAction } from '@global/bulk/types'
 
 /**
  * @rest_spec_name monitoring.bulk
- * @since 6.3.0
- * @stability stable
+ * @availability stack since=6.3.0 stability=stable
  */
 export interface Request<TDocument, TPartialDocument> extends RequestBase {
   path_parts: {

--- a/specification/nodes/clear_repositories_metering_archive/ClearRepositoriesMeteringArchiveRequest.ts
+++ b/specification/nodes/clear_repositories_metering_archive/ClearRepositoriesMeteringArchiveRequest.ts
@@ -24,8 +24,7 @@ import { long } from '@_types/Numeric'
 /**
  * You can use this API to clear the archived repositories metering information in the cluster.
  * @rest_spec_name nodes.clear_repositories_metering_archive
- * @since 7.16.0
- * @stability experimental
+ * @availability stack since=7.16.0 stability=experimental
  * @cluster_privileges monitor, manage
  */
 export interface Request extends RequestBase {

--- a/specification/nodes/get_repositories_metering_info/GetRepositoriesMeteringInfoRequest.ts
+++ b/specification/nodes/get_repositories_metering_info/GetRepositoriesMeteringInfoRequest.ts
@@ -26,8 +26,7 @@ import { NodeIds } from '@_types/common'
  * information needed to compute aggregations over a period of time. Additionally, the information exposed by this
  * API is volatile, meaning that it won’t be present after node restarts.
  * @rest_spec_name nodes.get_repositories_metering_info
- * @since 7.16.0
- * @stability experimental
+ * @availability stack since=7.16.0 stability=experimental
  * @cluster_privileges monitor, manage
  */
 export interface Request extends RequestBase {

--- a/specification/nodes/hot_threads/NodesHotThreadsRequest.ts
+++ b/specification/nodes/hot_threads/NodesHotThreadsRequest.ts
@@ -26,8 +26,7 @@ import { Duration } from '@_types/Time'
  * This API yields a breakdown of the hot threads on each selected node in the cluster.
  * The output is plain text with a breakdown of each node’s top hot threads.
  * @rest_spec_name nodes.hot_threads
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @cluster_privileges monitor,manage
  * @doc_id cluster-nodes-hot-threads
  */

--- a/specification/nodes/info/NodesInfoRequest.ts
+++ b/specification/nodes/info/NodesInfoRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name nodes.info
- * @since 1.3.0
- * @stability stable
+ * @availability stack since=1.3.0 stability=stable
  * @doc_id cluster-nodes-info
  */
 export interface Request extends RequestBase {

--- a/specification/nodes/reload_secure_settings/ReloadSecureSettingsRequest.ts
+++ b/specification/nodes/reload_secure_settings/ReloadSecureSettingsRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name nodes.reload_secure_settings
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/nodes/stats/NodesStatsRequest.ts
+++ b/specification/nodes/stats/NodesStatsRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name nodes.stats
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @doc_id cluster-nodes-stats
  */
 export interface Request extends RequestBase {

--- a/specification/nodes/usage/NodesUsageRequest.ts
+++ b/specification/nodes/usage/NodesUsageRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name nodes.usage
- * @since 6.0.0
- * @stability stable
+ * @availability stack since=6.0.0 stability=stable
  * @doc_id cluster-nodes-usage
  */
 export interface Request extends RequestBase {

--- a/specification/rollup/delete_job/DeleteRollupJobRequest.ts
+++ b/specification/rollup/delete_job/DeleteRollupJobRequest.ts
@@ -22,8 +22,7 @@ import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name rollup.delete_job
- * @since 6.3.0
- * @stability experimental
+ * @availability stack since=6.3.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/rollup/get_jobs/GetRollupJobRequest.ts
+++ b/specification/rollup/get_jobs/GetRollupJobRequest.ts
@@ -22,8 +22,7 @@ import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name rollup.get_jobs
- * @since 6.3.0
- * @stability experimental
+ * @availability stack since=6.3.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/rollup/get_rollup_caps/GetRollupCapabilitiesRequest.ts
+++ b/specification/rollup/get_rollup_caps/GetRollupCapabilitiesRequest.ts
@@ -22,8 +22,7 @@ import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name rollup.get_rollup_caps
- * @since 6.3.0
- * @stability experimental
+ * @availability stack since=6.3.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/rollup/get_rollup_index_caps/GetRollupIndexCapabilitiesRequest.ts
+++ b/specification/rollup/get_rollup_index_caps/GetRollupIndexCapabilitiesRequest.ts
@@ -22,8 +22,7 @@ import { Ids } from '@_types/common'
 
 /**
  * @rest_spec_name rollup.get_rollup_index_caps
- * @since 6.4.0
- * @stability experimental
+ * @availability stack since=6.4.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/rollup/put_job/CreateRollupJobRequest.ts
+++ b/specification/rollup/put_job/CreateRollupJobRequest.ts
@@ -26,8 +26,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name rollup.put_job
- * @since 6.3.0
- * @stability experimental
+ * @availability stack since=6.3.0 stability=experimental
  * @cluster_privileges manage, manage_rollup
  */
 export interface Request extends RequestBase {

--- a/specification/rollup/rollup_search/RollupSearchRequest.ts
+++ b/specification/rollup/rollup_search/RollupSearchRequest.ts
@@ -26,8 +26,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 
 /**
  * @rest_spec_name rollup.rollup_search
- * @since 6.3.0
- * @stability experimental
+ * @availability stack since=6.3.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/rollup/start_job/StartRollupJobRequest.ts
+++ b/specification/rollup/start_job/StartRollupJobRequest.ts
@@ -22,8 +22,7 @@ import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name rollup.start_job
- * @since 6.3.0
- * @stability experimental
+ * @availability stack since=6.3.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/rollup/stop_job/StopRollupJobRequest.ts
+++ b/specification/rollup/stop_job/StopRollupJobRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name rollup.stop_job
- * @since 6.3.0
- * @stability experimental
+ * @availability stack since=6.3.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/delete/SearchApplicationsDeleteRequest.ts
+++ b/specification/search_application/delete/SearchApplicationsDeleteRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 /**
  * Deletes a search application.
  * @rest_spec_name search_application.delete
- * @since 8.8.0
- * @stability experimental
+ * @availability stack since=8.8.0 stability=experimental
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteRequest.ts
+++ b/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 /**
  * Delete a behavioral analytics collection.
  * @rest_spec_name search_application.delete_behavioral_analytics
- * @since 8.8.0
- * @stability experimental
+ * @availability stack since=8.8.0 stability=experimental
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/get/SearchApplicationsGetRequest.ts
+++ b/specification/search_application/get/SearchApplicationsGetRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 /**
  * Returns the details about a search application
  * @rest_spec_name search_application.get
- * @since 8.8.0
- * @stability experimental
+ * @availability stack since=8.8.0 stability=experimental
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
+++ b/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 /**
  * Returns the existing behavioral analytics collections.
  * @rest_spec_name search_application.get_behavioral_analytics
- * @since 8.8.0
- * @stability experimental
+ * @availability stack since=8.8.0 stability=experimental
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/list/SearchApplicationsListRequest.ts
+++ b/specification/search_application/list/SearchApplicationsListRequest.ts
@@ -23,8 +23,7 @@ import { integer } from '@_types/Numeric'
 /**
  * Returns the existing search applications.
  * @rest_spec_name search_application.list
- * @since 8.8.0
- * @stability experimental
+ * @availability stack since=8.8.0 stability=experimental
  */
 interface Request extends RequestBase {
   query_parameters: {

--- a/specification/search_application/put/SearchApplicationsPutRequest.ts
+++ b/specification/search_application/put/SearchApplicationsPutRequest.ts
@@ -23,8 +23,7 @@ import { SearchApplication } from '../_types/SearchApplication'
 /**
  * Creates or updates a search application.
  * @rest_spec_name search_application.put
- * @since 8.8.0
- * @stability experimental
+ * @availability stack since=8.8.0 stability=experimental
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutRequest.ts
+++ b/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutRequest.ts
@@ -23,8 +23,7 @@ import { SearchApplication } from '../_types/SearchApplication'
 /**
  * Creates a behavioral analytics collection
  * @rest_spec_name search_application.put_behavioral_analytics
- * @since 8.8.0
- * @stability experimental
+ * @availability stack since=8.8.0 stability=experimental
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/search/SearchApplicationsSearchRequest.ts
+++ b/specification/search_application/search/SearchApplicationsSearchRequest.ts
@@ -24,8 +24,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 /**
  * Perform a search against a search application
  * @rest_spec_name search_application.search
- * @since 8.8.0
- * @stability experimental
+ * @availability stack since=8.8.0 stability=experimental
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/searchable_snapshots/cache_stats/Request.ts
+++ b/specification/searchable_snapshots/cache_stats/Request.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name searchable_snapshots.cache_stats
- * @since 7.13.0
- * @stability experimental
+ * @availability stack since=7.13.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheRequest.ts
+++ b/specification/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheRequest.ts
@@ -22,8 +22,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
 
 /**
  * @rest_spec_name searchable_snapshots.clear_cache
- * @since 7.10.0
- * @stability experimental
+ * @availability stack since=7.10.0 stability=experimental
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/searchable_snapshots/mount/SearchableSnapshotsMountRequest.ts
+++ b/specification/searchable_snapshots/mount/SearchableSnapshotsMountRequest.ts
@@ -25,8 +25,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name searchable_snapshots.mount
- * @since 7.10.0
- * @stability stable
+ * @availability stack since=7.10.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/searchable_snapshots/stats/SearchableSnapshotsStatsRequest.ts
+++ b/specification/searchable_snapshots/stats/SearchableSnapshotsStatsRequest.ts
@@ -23,8 +23,7 @@ import { Indices } from '@_types/common'
 
 /**
  * @rest_spec_name searchable_snapshots.stats
- * @since 7.10.0
- * @stability stable
+ * @availability stack since=7.10.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/activate_user_profile/Request.ts
+++ b/specification/security/activate_user_profile/Request.ts
@@ -23,8 +23,7 @@ import { GrantType } from '@security/_types/GrantType'
 /**
  * Creates or updates a user profile on behalf of another user.
  * @rest_spec_name security.activate_user_profile
- * @since 8.2.0
- * @stability stable
+ * @availability stack since=8.2.0 stability=stable
  * @cluster_privileges manage_user_profile
  */
 export interface Request extends RequestBase {

--- a/specification/security/authenticate/SecurityAuthenticateRequest.ts
+++ b/specification/security/authenticate/SecurityAuthenticateRequest.ts
@@ -22,7 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * Enables you to submit a request with a basic auth header to authenticate a user and retrieve information about the authenticated user.
  * @rest_spec_name security.authenticate
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/security/change_password/SecurityChangePasswordRequest.ts
+++ b/specification/security/change_password/SecurityChangePasswordRequest.ts
@@ -22,8 +22,7 @@ import { Password, Refresh, Username } from '@_types/common'
 
 /**
  * @rest_spec_name security.change_password
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
+++ b/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
@@ -22,8 +22,7 @@ import { Ids } from '@_types/common'
 
 /**
  * @rest_spec_name security.clear_api_key_cache
- * @since 7.10.0
- * @stability stable
+ * @availability stack since=7.10.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesRequest.ts
+++ b/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name security.clear_cached_privileges
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/clear_cached_realms/SecurityClearCachedRealmsRequest.ts
+++ b/specification/security/clear_cached_realms/SecurityClearCachedRealmsRequest.ts
@@ -22,8 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * @rest_spec_name security.clear_cached_realms
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/clear_cached_roles/ClearCachedRolesRequest.ts
+++ b/specification/security/clear_cached_roles/ClearCachedRolesRequest.ts
@@ -22,8 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * @rest_spec_name security.clear_cached_roles
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensRequest.ts
+++ b/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensRequest.ts
@@ -22,8 +22,7 @@ import { Names, Namespace, Service } from '@_types/common'
 
 /**
  * @rest_spec_name security.clear_cached_service_tokens
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
+++ b/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
@@ -25,8 +25,7 @@ import { RoleDescriptor } from '@security/_types/RoleDescriptor'
 
 /**
  * @rest_spec_name security.create_api_key
- * @since 6.7.0
- * @stability stable
+ * @availability stack since=6.7.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/security/create_service_token/CreateServiceTokenRequest.ts
+++ b/specification/security/create_service_token/CreateServiceTokenRequest.ts
@@ -24,8 +24,7 @@ import { Refresh } from '@_types/common'
 /**
  * Creates a service accounts token for access without requiring basic authentication.
  * @rest_spec_name security.create_service_token
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/delete_privileges/SecurityDeletePrivilegesRequest.ts
+++ b/specification/security/delete_privileges/SecurityDeletePrivilegesRequest.ts
@@ -22,8 +22,7 @@ import { Name, Names, Refresh } from '@_types/common'
 
 /**
  * @rest_spec_name security.delete_privileges
- * @since 6.4.0
- * @stability stable
+ * @availability stack since=6.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/delete_role/SecurityDeleteRoleRequest.ts
+++ b/specification/security/delete_role/SecurityDeleteRoleRequest.ts
@@ -22,8 +22,7 @@ import { Name, Refresh } from '@_types/common'
 
 /**
  * @rest_spec_name security.delete_role
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/delete_role_mapping/SecurityDeleteRoleMappingRequest.ts
+++ b/specification/security/delete_role_mapping/SecurityDeleteRoleMappingRequest.ts
@@ -22,8 +22,7 @@ import { Name, Refresh } from '@_types/common'
 
 /**
  * @rest_spec_name security.delete_role_mapping
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/delete_service_token/DeleteServiceTokenRequest.ts
+++ b/specification/security/delete_service_token/DeleteServiceTokenRequest.ts
@@ -22,8 +22,7 @@ import { Name, Namespace, Refresh, Service } from '@_types/common'
 
 /**
  * @rest_spec_name security.delete_service_token
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/delete_user/SecurityDeleteUserRequest.ts
+++ b/specification/security/delete_user/SecurityDeleteUserRequest.ts
@@ -22,8 +22,7 @@ import { Refresh, Username } from '@_types/common'
 
 /**
  * @rest_spec_name security.delete_user
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/disable_user/SecurityDisableUserRequest.ts
+++ b/specification/security/disable_user/SecurityDisableUserRequest.ts
@@ -22,8 +22,7 @@ import { Refresh, Username } from '@_types/common'
 
 /**
  * @rest_spec_name security.disable_user
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/disable_user_profile/Request.ts
+++ b/specification/security/disable_user_profile/Request.ts
@@ -24,8 +24,7 @@ import { UserProfileId } from '@security/_types/UserProfile'
 /**
  * Disables a user profile so it's not visible in user profile searches.
  * @rest_spec_name security.disable_user_profile
- * @since 8.2.0
- * @stability stable
+ * @availability stack since=8.2.0 stability=stable
  * @cluster_privileges manage_user_profile
  */
 export interface Request extends RequestBase {

--- a/specification/security/enable_user/SecurityEnableUserRequest.ts
+++ b/specification/security/enable_user/SecurityEnableUserRequest.ts
@@ -22,8 +22,7 @@ import { Refresh, Username } from '@_types/common'
 
 /**
  * @rest_spec_name security.enable_user
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/enable_user_profile/Request.ts
+++ b/specification/security/enable_user_profile/Request.ts
@@ -24,8 +24,7 @@ import { UserProfileId } from '@security/_types/UserProfile'
 /**
  * Enables a user profile so it's visible in user profile searches.
  * @rest_spec_name security.enable_user_profile
- * @since 8.2.0
- * @stability stable
+ * @availability stack since=8.2.0 stability=stable
  * @cluster_privileges manage_user_profile
  */
 export interface Request extends RequestBase {

--- a/specification/security/enroll_kibana/Request.ts
+++ b/specification/security/enroll_kibana/Request.ts
@@ -22,7 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * Enables a Kibana instance to configure itself for communication with a secured Elasticsearch cluster.
  * @rest_spec_name security.enroll_kibana
- * @since 8.0.0
- * @stability stable
+ * @availability stack since=8.0.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/security/enroll_node/Request.ts
+++ b/specification/security/enroll_node/Request.ts
@@ -22,7 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * Allows a new node to join an existing cluster with security features enabled.
  * @rest_spec_name security.enroll_node
- * @since 8.0.0
- * @stability stable
+ * @availability stack since=8.0.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
+++ b/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
@@ -22,8 +22,7 @@ import { Id, Name, Username } from '@_types/common'
 
 /**
  * @rest_spec_name security.get_api_key
- * @since 6.7.0
- * @stability stable
+ * @availability stack since=6.7.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
@@ -21,8 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name security.get_builtin_privileges
- * @since 7.3.0
- * @stability stable
+ * @availability stack since=7.3.0 stability=stable
  * @cluster_privileges manage_security
  */
 export interface Request extends RequestBase {}

--- a/specification/security/get_privileges/SecurityGetPrivilegesRequest.ts
+++ b/specification/security/get_privileges/SecurityGetPrivilegesRequest.ts
@@ -22,8 +22,7 @@ import { Name, Names } from '@_types/common'
 
 /**
  * @rest_spec_name security.get_privileges
- * @since 6.4.0
- * @stability stable
+ * @availability stack since=6.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/get_role/SecurityGetRoleRequest.ts
+++ b/specification/security/get_role/SecurityGetRoleRequest.ts
@@ -24,8 +24,7 @@ import { Names } from '@_types/common'
  * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
  * The get roles API cannot retrieve roles that are defined in roles files.
  * @rest_spec_name security.get_role
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @cluster_privileges manage_security
  */
 export interface Request extends RequestBase {

--- a/specification/security/get_role_mapping/SecurityGetRoleMappingRequest.ts
+++ b/specification/security/get_role_mapping/SecurityGetRoleMappingRequest.ts
@@ -22,8 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * @rest_spec_name security.get_role_mapping
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  * @cluster_privileges manage_security
  */
 export interface Request extends RequestBase {

--- a/specification/security/get_service_accounts/GetServiceAccountsRequest.ts
+++ b/specification/security/get_service_accounts/GetServiceAccountsRequest.ts
@@ -23,8 +23,7 @@ import { Namespace, Service } from '@_types/common'
 /**
  * This API returns a list of service accounts that match the provided path parameter(s).
  * @rest_spec_name security.get_service_accounts
- * @since 7.13.0
- * @stability stable
+ * @availability stack since=7.13.0 stability=stable
  * @cluster_privileges manage_service_account
  */
 export interface Request extends RequestBase {

--- a/specification/security/get_service_credentials/GetServiceCredentialsRequest.ts
+++ b/specification/security/get_service_credentials/GetServiceCredentialsRequest.ts
@@ -22,8 +22,7 @@ import { Name, Namespace } from '@_types/common'
 
 /**
  * @rest_spec_name security.get_service_credentials
- * @since 7.13.0
- * @stability stable
+ * @availability stack since=7.13.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/get_token/GetUserAccessTokenRequest.ts
+++ b/specification/security/get_token/GetUserAccessTokenRequest.ts
@@ -24,8 +24,7 @@ import { AccessTokenGrantType } from './types'
 
 /**
  * @rest_spec_name security.get_token
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/get_user/SecurityGetUserRequest.ts
+++ b/specification/security/get_user/SecurityGetUserRequest.ts
@@ -22,8 +22,7 @@ import { Username } from '@_types/common'
 
 /**
  * @rest_spec_name security.get_user
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/get_user_privileges/SecurityGetUserPrivilegesRequest.ts
+++ b/specification/security/get_user_privileges/SecurityGetUserPrivilegesRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name security.get_user_privileges
- * @since 6.5.0
- * @stability stable
+ * @availability stack since=6.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/security/get_user_profile/Request.ts
+++ b/specification/security/get_user_profile/Request.ts
@@ -23,8 +23,7 @@ import { UserProfileId } from '@security/_types/UserProfile'
 /**
  * Retrieves a user's profile using the unique profile ID.
  * @rest_spec_name security.get_user_profile
- * @since 8.2.0
- * @stability stable
+ * @availability stack since=8.2.0 stability=stable
  * @cluster_privileges manage_user_profile
  */
 export interface Request extends RequestBase {

--- a/specification/security/grant_api_key/SecurityGrantApiKeyRequest.ts
+++ b/specification/security/grant_api_key/SecurityGrantApiKeyRequest.ts
@@ -23,8 +23,7 @@ import { GrantApiKey, ApiKeyGrantType } from './types'
 
 /**
  * @rest_spec_name security.grant_api_key
- * @since 7.9.0
- * @stability stable
+ * @availability stack since=7.9.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/has_privileges/SecurityHasPrivilegesRequest.ts
+++ b/specification/security/has_privileges/SecurityHasPrivilegesRequest.ts
@@ -24,8 +24,7 @@ import { ApplicationPrivilegesCheck, IndexPrivilegesCheck } from './types'
 
 /**
  * @rest_spec_name security.has_privileges
- * @since 6.4.0
- * @stability stable
+ * @availability stack since=6.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/has_privileges_user_profile/Request.ts
+++ b/specification/security/has_privileges_user_profile/Request.ts
@@ -23,8 +23,7 @@ import { PrivilegesCheck } from './types'
 
 /**
  * @rest_spec_name security.has_privileges_user_profile
- * @since 8.3.0
- * @stability stable
+ * @availability stack since=8.3.0 stability=stable
  * @cluster_privileges manage_user_profile
  */
 export interface Request extends RequestBase {

--- a/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
+++ b/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
@@ -22,8 +22,7 @@ import { Id, Name, Username } from '@_types/common'
 
 /**
  * @rest_spec_name security.invalidate_api_key
- * @since 6.7.0
- * @stability stable
+ * @availability stack since=6.7.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/invalidate_token/SecurityInvalidateTokenRequest.ts
+++ b/specification/security/invalidate_token/SecurityInvalidateTokenRequest.ts
@@ -22,8 +22,7 @@ import { Name, Username } from '@_types/common'
 
 /**
  * @rest_spec_name security.invalidate_token
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/put_privileges/SecurityPutPrivilegesRequest.ts
+++ b/specification/security/put_privileges/SecurityPutPrivilegesRequest.ts
@@ -24,9 +24,8 @@ import { Actions } from './types'
 
 /**
  * @rest_spec_name security.put_privileges
- * @since 6.4.0
+ * @availability stack since=6.4.0 stability=stable
  *
- * @stability stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -32,8 +32,7 @@ import { Metadata, Name, Refresh } from '@_types/common'
  * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
  * The create or update roles API cannot update roles that are defined in roles files.
  * @rest_spec_name security.put_role
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @cluster_privileges manage_security
  */
 export interface Request extends RequestBase {

--- a/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
+++ b/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
@@ -23,8 +23,7 @@ import { Metadata, Name, Refresh } from '@_types/common'
 
 /**
  * @rest_spec_name security.put_role_mapping
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/put_user/SecurityPutUserRequest.ts
+++ b/specification/security/put_user/SecurityPutUserRequest.ts
@@ -22,8 +22,7 @@ import { Metadata, Password, Refresh, Username } from '@_types/common'
 
 /**
  * @rest_spec_name security.put_user
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -24,8 +24,7 @@ import { Sort, SortResults } from '@_types/sort'
 
 /**
  * @rest_spec_name security.query_api_keys
- * @since 7.15.0
- * @stability stable
+ * @availability stack since=7.15.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/security/saml_authenticate/Request.ts
+++ b/specification/security/saml_authenticate/Request.ts
@@ -23,8 +23,7 @@ import { Ids } from '@_types/common'
 /**
  * Submits a SAML Response message to Elasticsearch for consumption.
  * @rest_spec_name security.saml_authenticate
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/saml_complete_logout/Request.ts
+++ b/specification/security/saml_complete_logout/Request.ts
@@ -23,8 +23,7 @@ import { Ids } from '@_types/common'
 /**
  * Verifies the logout response sent from the SAML IdP.
  * @rest_spec_name security.saml_complete_logout
- * @since 7.14.0
- * @stability stable
+ * @availability stack since=7.14.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/saml_invalidate/Request.ts
+++ b/specification/security/saml_invalidate/Request.ts
@@ -22,8 +22,7 @@ import { RequestBase } from '@_types/Base'
 /**
  * Submits a SAML LogoutRequest message to Elasticsearch for consumption.
  * @rest_spec_name security.saml_invalidate
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/saml_logout/Request.ts
+++ b/specification/security/saml_logout/Request.ts
@@ -22,8 +22,7 @@ import { RequestBase } from '@_types/Base'
 /**
  * Submits a request to invalidate an access token and refresh token.
  * @rest_spec_name security.saml_logout
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/saml_prepare_authentication/Request.ts
+++ b/specification/security/saml_prepare_authentication/Request.ts
@@ -22,8 +22,7 @@ import { RequestBase } from '@_types/Base'
 /**
  * Creates a SAML authentication request (<AuthnRequest>) as a URL string, based on the configuration of the respective SAML realm in Elasticsearch.
  * @rest_spec_name security.saml_prepare_authentication
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/saml_service_provider_metadata/Request.ts
+++ b/specification/security/saml_service_provider_metadata/Request.ts
@@ -23,8 +23,7 @@ import { Name } from '@_types/common'
 /**
  * Generate SAML metadata for a SAML 2.0 Service Provider.
  * @rest_spec_name security.saml_service_provider_metadata
- * @since 7.11.0
- * @stability stable
+ * @availability stack since=7.11.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/suggest_user_profiles/Request.ts
+++ b/specification/security/suggest_user_profiles/Request.ts
@@ -24,8 +24,7 @@ import { Hint } from './types'
 /**
  * Get suggestions for user profiles that match specified search criteria.
  * @rest_spec_name security.suggest_user_profiles
- * @since 8.2.0
- * @stability stable
+ * @availability stack since=8.2.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/security/update_api_key/Request.ts
+++ b/specification/security/update_api_key/Request.ts
@@ -25,8 +25,7 @@ import { RoleDescriptor } from '@security/_types/RoleDescriptor'
 /**
  * Updates attributes of an existing API key.
  * @rest_spec_name security.update_api_key
- * @since 8.4.0
- * @stability stable
+ * @availability stack since=8.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/update_user_profile_data/Request.ts
+++ b/specification/security/update_user_profile_data/Request.ts
@@ -27,8 +27,7 @@ import { UserProfileId } from '@security/_types/UserProfile'
 /**
  * Updates specific data for the user profile that's associated with the specified unique ID.
  * @rest_spec_name security.update_user_profile_data
- * @since 8.2.0
- * @stability stable
+ * @availability stack since=8.2.0 stability=stable
  * @cluster_privileges manage_user_profile
  */
 export interface Request extends RequestBase {

--- a/specification/shutdown/delete_node/ShutdownDeleteNodeRequest.ts
+++ b/specification/shutdown/delete_node/ShutdownDeleteNodeRequest.ts
@@ -23,8 +23,7 @@ import { TimeUnit } from '@_types/Time'
 
 /**
  * @rest_spec_name shutdown.delete_node
- * @since 7.13.0
- * @stability stable
+ * @availability stack since=7.13.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/shutdown/get_node/ShutdownGetNodeRequest.ts
+++ b/specification/shutdown/get_node/ShutdownGetNodeRequest.ts
@@ -23,8 +23,7 @@ import { TimeUnit } from '@_types/Time'
 
 /**
  * @rest_spec_name shutdown.get_node
- * @since 7.13.0
- * @stability stable
+ * @availability stack since=7.13.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/shutdown/put_node/ShutdownPutNodeRequest.ts
+++ b/specification/shutdown/put_node/ShutdownPutNodeRequest.ts
@@ -24,8 +24,7 @@ import { Type } from '../_types/types'
 
 /**
  * @rest_spec_name shutdown.put_node
- * @since 7.13.0
- * @stability stable
+ * @availability stack since=7.13.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/slm/delete_lifecycle/DeleteSnapshotLifecycleRequest.ts
+++ b/specification/slm/delete_lifecycle/DeleteSnapshotLifecycleRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name slm.delete_lifecycle
- * @since 7.4.0
- * @stability stable
+ * @availability stack since=7.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/slm/execute_lifecycle/ExecuteSnapshotLifecycleRequest.ts
+++ b/specification/slm/execute_lifecycle/ExecuteSnapshotLifecycleRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name slm.execute_lifecycle
- * @since 7.4.0
- * @stability stable
+ * @availability stack since=7.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/slm/execute_retention/ExecuteRetentionRequest.ts
+++ b/specification/slm/execute_retention/ExecuteRetentionRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name slm.execute_retention
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/slm/get_lifecycle/GetSnapshotLifecycleRequest.ts
+++ b/specification/slm/get_lifecycle/GetSnapshotLifecycleRequest.ts
@@ -22,8 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * @rest_spec_name slm.get_lifecycle
- * @since 7.4.0
- * @stability stable
+ * @availability stack since=7.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/slm/get_stats/GetSnapshotLifecycleStatsRequest.ts
+++ b/specification/slm/get_stats/GetSnapshotLifecycleStatsRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name slm.get_stats
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/slm/get_status/GetSnapshotLifecycleManagementStatusRequest.ts
+++ b/specification/slm/get_status/GetSnapshotLifecycleManagementStatusRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name slm.get_status
- * @since 7.6.0
- * @stability stable
+ * @availability stack since=7.6.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/slm/put_lifecycle/PutSnapshotLifecycleRequest.ts
+++ b/specification/slm/put_lifecycle/PutSnapshotLifecycleRequest.ts
@@ -25,8 +25,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name slm.put_lifecycle
- * @since 7.4.0
- * @stability stable
+ * @availability stack since=7.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/slm/start/StartSnapshotLifecycleManagementRequest.ts
+++ b/specification/slm/start/StartSnapshotLifecycleManagementRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name slm.start
- * @since 7.6.0
- * @stability stable
+ * @availability stack since=7.6.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/slm/stop/StopSnapshotLifecycleManagementRequest.ts
+++ b/specification/slm/stop/StopSnapshotLifecycleManagementRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name slm.stop
- * @since 7.6.0
- * @stability stable
+ * @availability stack since=7.6.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/snapshot/cleanup_repository/SnapshotCleanupRepositoryRequest.ts
+++ b/specification/snapshot/cleanup_repository/SnapshotCleanupRepositoryRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * Triggers the review of a snapshot repository’s contents and deletes any stale data not referenced by existing snapshots.
  * @rest_spec_name snapshot.cleanup_repository
- * @since 7.4.0
- * @stability stable
+ * @availability stack since=7.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/clone/SnapshotCloneRequest.ts
+++ b/specification/snapshot/clone/SnapshotCloneRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name snapshot.clone
- * @since 7.10.0
- * @stability stable
+ * @availability stack since=7.10.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/create/SnapshotCreateRequest.ts
+++ b/specification/snapshot/create/SnapshotCreateRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name snapshot.create
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/create_repository/SnapshotCreateRepositoryRequest.ts
+++ b/specification/snapshot/create_repository/SnapshotCreateRepositoryRequest.ts
@@ -27,9 +27,8 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name snapshot.create_repository
- * @since 0.0.0
+ * @availability stack since=0.0.0 stability=stable
  *
- * @stability stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/delete/SnapshotDeleteRequest.ts
+++ b/specification/snapshot/delete/SnapshotDeleteRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name snapshot.delete
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/delete_repository/SnapshotDeleteRepositoryRequest.ts
+++ b/specification/snapshot/delete_repository/SnapshotDeleteRepositoryRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name snapshot.delete_repository
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/get/SnapshotGetRequest.ts
+++ b/specification/snapshot/get/SnapshotGetRequest.ts
@@ -26,8 +26,7 @@ import { SortOrder } from '@_types/sort'
 
 /**
  * @rest_spec_name snapshot.get
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/get_repository/SnapshotGetRepositoryRequest.ts
+++ b/specification/snapshot/get_repository/SnapshotGetRepositoryRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name snapshot.get_repository
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/restore/SnapshotRestoreRequest.ts
+++ b/specification/snapshot/restore/SnapshotRestoreRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name snapshot.restore
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/status/SnapshotStatusRequest.ts
+++ b/specification/snapshot/status/SnapshotStatusRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name snapshot.status
- * @since 7.8.0
- * @stability stable
+ * @availability stack since=7.8.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/verify_repository/SnapshotVerifyRepositoryRequest.ts
+++ b/specification/snapshot/verify_repository/SnapshotVerifyRepositoryRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name snapshot.verify_repository
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/sql/clear_cursor/ClearSqlCursorRequest.ts
+++ b/specification/sql/clear_cursor/ClearSqlCursorRequest.ts
@@ -21,8 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name sql.clear_cursor
- * @since 6.3.0
- * @stability stable
+ * @availability stack since=6.3.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/sql/delete_async/SqlDeleteAsyncRequest.ts
+++ b/specification/sql/delete_async/SqlDeleteAsyncRequest.ts
@@ -22,8 +22,7 @@ import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name sql.delete_async
- * @since 7.15.0
- * @stability stable
+ * @availability stack since=7.15.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/sql/get_async/SqlGetAsyncRequest.ts
+++ b/specification/sql/get_async/SqlGetAsyncRequest.ts
@@ -23,8 +23,7 @@ import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name sql.get_async
- * @since 7.15.0
- * @stability stable
+ * @availability stack since=7.15.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/sql/get_async_status/SqlGetAsyncStatusRequest.ts
+++ b/specification/sql/get_async_status/SqlGetAsyncStatusRequest.ts
@@ -23,8 +23,7 @@ import { Id } from '@_types/common'
 
 /**
  * @rest_spec_name sql.get_async_status
- * @since 7.15.0
- * @stability stable
+ * @availability stack since=7.15.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/sql/query/QuerySqlRequest.ts
+++ b/specification/sql/query/QuerySqlRequest.ts
@@ -27,8 +27,7 @@ import { Duration, TimeZone } from '@_types/Time'
 
 /**
  * @rest_spec_name sql.query
- * @since 6.3.0
- * @stability stable
+ * @availability stack since=6.3.0 stability=stable
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/sql/translate/TranslateSqlRequest.ts
+++ b/specification/sql/translate/TranslateSqlRequest.ts
@@ -24,8 +24,7 @@ import { TimeZone } from '@_types/Time'
 
 /**
  * @rest_spec_name sql.translate
- * @since 6.3.0
- * @stability stable
+ * @availability stack since=6.3.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/ssl/certificates/GetCertificatesRequest.ts
+++ b/specification/ssl/certificates/GetCertificatesRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name ssl.certificates
- * @since 6.2.0
- * @stability stable
+ * @availability stack since=6.2.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/tasks/cancel/CancelTasksRequest.ts
+++ b/specification/tasks/cancel/CancelTasksRequest.ts
@@ -22,8 +22,7 @@ import { TaskId } from '@_types/common'
 
 /**
  * @rest_spec_name tasks.cancel
- * @since 2.3.0
- * @stability experimental
+ * @availability stack since=2.3.0 stability=experimental
  * @doc_id tasks
  */
 export interface Request extends RequestBase {

--- a/specification/tasks/get/GetTaskRequest.ts
+++ b/specification/tasks/get/GetTaskRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name tasks.get
- * @since 5.0.0
- * @stability experimental
+ * @availability stack since=5.0.0 stability=experimental
  * @doc_id tasks
  */
 export interface Request extends RequestBase {

--- a/specification/tasks/list/ListTasksRequest.ts
+++ b/specification/tasks/list/ListTasksRequest.ts
@@ -25,8 +25,7 @@ import { GroupBy } from '@tasks/_types/GroupBy'
 /**
  * The task management API returns information about tasks currently executing on one or more nodes in the cluster.
  * @rest_spec_name tasks.list
- * @since 2.3.0
- * @stability experimental
+ * @availability stack since=2.3.0 stability=experimental
  * @cluster_privileges monitor, manage
  * @doc_id tasks
  */

--- a/specification/text_structure/find_structure/FindStructureRequest.ts
+++ b/specification/text_structure/find_structure/FindStructureRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * @rest_spec_name text_structure.find_structure
- * @since 7.13.0
- * @stability stable
+ * @availability stack since=7.13.0 stability=stable
  */
 export interface Request<TJsonDocument> {
   query_parameters: {

--- a/specification/transform/delete_transform/DeleteTransformRequest.ts
+++ b/specification/transform/delete_transform/DeleteTransformRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * Deletes a transform.
  * @rest_spec_name transform.delete_transform
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  * @cluster_privileges manage_transform
  */
 export interface Request extends RequestBase {

--- a/specification/transform/get_transform/GetTransformRequest.ts
+++ b/specification/transform/get_transform/GetTransformRequest.ts
@@ -24,8 +24,7 @@ import { integer } from '@_types/Numeric'
 /**
  * Retrieves configuration information for transforms.
  * @rest_spec_name transform.get_transform
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  * @cluster_privileges monitor_transform
  */
 export interface Request extends RequestBase {

--- a/specification/transform/get_transform_stats/GetTransformStatsRequest.ts
+++ b/specification/transform/get_transform_stats/GetTransformStatsRequest.ts
@@ -25,8 +25,7 @@ import { Duration } from '@_types/Time'
 /**
  * Retrieves usage information for transforms.
  * @rest_spec_name transform.get_transform_stats
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  * @cluster_privileges monitor_transform
  * @index_privileges read, view_index_metadata
  */

--- a/specification/transform/preview_transform/PreviewTransformRequest.ts
+++ b/specification/transform/preview_transform/PreviewTransformRequest.ts
@@ -37,8 +37,7 @@ import { Duration } from '@_types/Time'
  * generates a list of mappings and settings for the destination index. These values are determined based on the field
  * types of the source index and the transform aggregations.
  * @rest_spec_name transform.preview_transform
- * @since 7.2.0
- * @stability stable
+ * @availability stack since=7.2.0 stability=stable
  * @cluster_privileges manage_transform
  * @index_privileges read, view_index_metadata
  */

--- a/specification/transform/put_transform/PutTransformRequest.ts
+++ b/specification/transform/put_transform/PutTransformRequest.ts
@@ -54,8 +54,7 @@ import { Duration } from '@_types/Time'
  * give users any privileges on `.data-frame-internal*` indices.
  *
  * @rest_spec_name transform.put_transform
- * @since 7.2.0
- * @stability stable
+ * @availability stack since=7.2.0 stability=stable
  * @cluster_privileges manage_transform
  * @index_privileges create_index, read, index, view_index_metadata
  */

--- a/specification/transform/reset_transform/ResetTransformRequest.ts
+++ b/specification/transform/reset_transform/ResetTransformRequest.ts
@@ -25,8 +25,7 @@ import { Id } from '@_types/common'
  * Before you can reset it, you must stop it; alternatively, use the `force` query parameter.
  * If the destination index was created by the transform, it is deleted.
  * @rest_spec_name transform.reset_transform
- * @since 8.1.0
- * @stability stable
+ * @availability stack since=8.1.0 stability=stable
  * @cluster_privileges manage_transform
  */
 export interface Request extends RequestBase {

--- a/specification/transform/schedule_now_transform/ScheduleNowTransformRequest.ts
+++ b/specification/transform/schedule_now_transform/ScheduleNowTransformRequest.ts
@@ -28,8 +28,7 @@ import { Duration } from '@_types/Time'
  * the transform will be processed again at now + frequency unless _schedule_now API
  * is called again in the meantime.
  * @rest_spec_name transform.schedule_now_transform
- * @since 8.7.0
- * @stability stable
+ * @availability stack since=8.7.0 stability=stable
  * @cluster_privileges manage_transform
  */
 export interface Request extends RequestBase {

--- a/specification/transform/start_transform/StartTransformRequest.ts
+++ b/specification/transform/start_transform/StartTransformRequest.ts
@@ -39,8 +39,7 @@ import { Duration } from '@_types/Time'
  * time of creation and uses those same roles. If those roles do not have the required privileges on the source and
  * destination indices, the transform fails when it attempts unauthorized operations.
  * @rest_spec_name transform.start_transform
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  * @cluster_privileges manage_transform
  * @index_privileges read, view_index_metadata
  */

--- a/specification/transform/stop_transform/StopTransformRequest.ts
+++ b/specification/transform/stop_transform/StopTransformRequest.ts
@@ -24,8 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * Stops one or more transforms.
  * @rest_spec_name transform.stop_transform
- * @since 7.5.0
- * @stability stable
+ * @availability stack since=7.5.0 stability=stable
  * @cluster_privileges manage_transform
  */
 export interface Request extends RequestBase {

--- a/specification/transform/update_transform/UpdateTransformRequest.ts
+++ b/specification/transform/update_transform/UpdateTransformRequest.ts
@@ -37,8 +37,7 @@ import { Duration } from '@_types/Time'
  * Elasticsearch security features are enabled, the transform remembers which roles the user who updated it had at the
  * time of update and runs with those privileges.
  * @rest_spec_name transform.update_transform
- * @since 7.2.0
- * @stability stable
+ * @availability stack since=7.2.0 stability=stable
  * @cluster_privileges manage_transform
  * @index_privileges read, index, view_index_metadata
  */

--- a/specification/transform/upgrade_transforms/UpgradeTransformsRequest.ts
+++ b/specification/transform/upgrade_transforms/UpgradeTransformsRequest.ts
@@ -28,8 +28,7 @@ import { Duration } from '@_types/Time'
  * Elasticsearch security features are enabled; the role used to read source data and write to the destination index
  * remains unchanged.
  * @rest_spec_name transform.upgrade_transforms
- * @since 7.16.0
- * @stability stable
+ * @availability stack since=7.16.0 stability=stable
  * @cluster_privileges manage_transform
  */
 export interface Request extends RequestBase {

--- a/specification/watcher/ack_watch/WatcherAckWatchRequest.ts
+++ b/specification/watcher/ack_watch/WatcherAckWatchRequest.ts
@@ -22,8 +22,7 @@ import { Name, Names } from '@_types/common'
 
 /**
  * @rest_spec_name watcher.ack_watch
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/watcher/activate_watch/WatcherActivateWatchRequest.ts
+++ b/specification/watcher/activate_watch/WatcherActivateWatchRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name watcher.activate_watch
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/watcher/deactivate_watch/DeactivateWatchRequest.ts
+++ b/specification/watcher/deactivate_watch/DeactivateWatchRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name watcher.deactivate_watch
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/watcher/delete_watch/DeleteWatchRequest.ts
+++ b/specification/watcher/delete_watch/DeleteWatchRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name watcher.delete_watch
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/watcher/execute_watch/WatcherExecuteWatchRequest.ts
+++ b/specification/watcher/execute_watch/WatcherExecuteWatchRequest.ts
@@ -29,8 +29,7 @@ import { Id } from '@_types/common'
  * This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes.
  * For testing and debugging purposes, you also have fine-grained control on how the watch runs. You can execute the watch without executing all of its actions or alternatively by simulating them. You can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after execution.
  * @rest_spec_name watcher.execute_watch
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @cluster_privileges manage_watcher
  */
 export interface Request extends RequestBase {

--- a/specification/watcher/get_watch/GetWatchRequest.ts
+++ b/specification/watcher/get_watch/GetWatchRequest.ts
@@ -22,8 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * @rest_spec_name watcher.get_watch
- * @since 5.6.0
- * @stability stable
+ * @availability stack since=5.6.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/watcher/put_watch/WatcherPutWatchRequest.ts
+++ b/specification/watcher/put_watch/WatcherPutWatchRequest.ts
@@ -29,8 +29,7 @@ import { TransformContainer } from '@_types/Transform'
 
 /**
  * @rest_spec_name watcher.put_watch
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/watcher/query_watches/WatcherQueryWatchesRequest.ts
+++ b/specification/watcher/query_watches/WatcherQueryWatchesRequest.ts
@@ -24,8 +24,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 
 /**
  * @rest_spec_name watcher.query_watches
- * @since 7.11.0
- * @stability stable
+ * @availability stack since=7.11.0 stability=stable
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/watcher/start/WatcherStartRequest.ts
+++ b/specification/watcher/start/WatcherStartRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name watcher.start
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/watcher/stats/WatcherStatsRequest.ts
+++ b/specification/watcher/stats/WatcherStatsRequest.ts
@@ -22,8 +22,7 @@ import { WatcherMetric } from './types'
 
 /**
  * @rest_spec_name watcher.stats
- * @since 5.5.0
- * @stability stable
+ * @availability stack since=5.5.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/watcher/stop/WatcherStopRequest.ts
+++ b/specification/watcher/stop/WatcherStopRequest.ts
@@ -21,7 +21,6 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * @rest_spec_name watcher.stop
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {}

--- a/specification/xpack/info/XPackInfoRequest.ts
+++ b/specification/xpack/info/XPackInfoRequest.ts
@@ -22,8 +22,7 @@ import { RequestBase } from '@_types/Base'
 /**
  * Provides general information about the installed X-Pack features.
  * @rest_spec_name xpack.info
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @cluster_privileges monitor,manage
  */
 export interface Request extends RequestBase {

--- a/specification/xpack/usage/XPackUsageRequest.ts
+++ b/specification/xpack/usage/XPackUsageRequest.ts
@@ -23,8 +23,7 @@ import { Duration } from '@_types/Time'
 /**
  * This API provides information about which features are currently enabled and available under the current license and some usage statistics.
  * @rest_spec_name xpack.usage
- * @since 0.0.0
- * @stability stable
+ * @availability stack since=0.0.0 stability=stable
  * @cluster_privileges monitor,manage
  */
 export interface Request extends RequestBase {

--- a/typescript-generator/src/metamodel.ts
+++ b/typescript-generator/src/metamodel.ts
@@ -369,7 +369,7 @@ export enum Stability {
 }
 export enum Visibility {
   public = 'public',
-  featureFlag = 'feature_flag',
+  feature_flag = 'feature_flag',
   private = 'private'
 }
 
@@ -378,12 +378,30 @@ export class Deprecation {
   description: string
 }
 
+export class Availability {
+  stack?: StackAvailability
+  serverless?: ServerlessAvailability
+}
+
+export class StackAvailability {
+  since?: string
+  featureFlag?: string
+  stability?: Stability
+  visibility?: Visibility
+}
+
+export class ServerlessAvailability {
+  stability?: Stability
+  visibility?: Visibility
+}
+
 export class Endpoint {
   name: string
   description: string
   docUrl: string
   docId?: string
   deprecation?: Deprecation
+  availability: Availability
 
   /**
    * If the request value is `null` it means that there is not yet a

--- a/typescript-generator/src/metamodel.ts
+++ b/typescript-generator/src/metamodel.ts
@@ -378,19 +378,14 @@ export class Deprecation {
   description: string
 }
 
-export class Availability {
-  stack?: StackAvailability
-  serverless?: ServerlessAvailability
+export class Availabilities {
+  stack?: Availability
+  serverless?: Availability
 }
 
-export class StackAvailability {
+export class Availability {
   since?: string
   featureFlag?: string
-  stability?: Stability
-  visibility?: Visibility
-}
-
-export class ServerlessAvailability {
   stability?: Stability
   visibility?: Visibility
 }
@@ -401,7 +396,7 @@ export class Endpoint {
   docUrl: string
   docId?: string
   deprecation?: Deprecation
-  availability: Availability
+  availability: Availabilities
 
   /**
    * If the request value is `null` it means that there is not yet a


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-specification/issues/2107

- Removed the individual `@since`, `@stability`, and `@visibility` annotations in favor of `@availability` with those annotations now being set via key-value pairs.
- Always set `availability.stack.*` to the values from the rest-api-spec stubs for now, in the future once the Elasticsearch specification becomes the source of truth we can remove this.
- Updates all existing request definitions to use the new annotation.