### PR TITLE
Ability to remove ingest pipeline

### DIFF
--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -127,7 +127,7 @@ export class IndexSettings
   /** @server_default 60s */
   gc_deletes?: Duration
   /** @server_default _none */
-  default_pipeline?: PipelineName
+  default_pipeline?: PipelineName | null
   /** @server_default _none */
   final_pipeline?: PipelineName
   lifecycle?: IndexSettingsLifecycle


### PR DESCRIPTION
I'm trying to remove an ingest pipeline from an index using the javascript elasticsearch client:

```ts
await client.indices.putSettings({
  index: 'foo',
  body: { index: { default_pipeline: null } },
});
```

However, this gives the error:
```
Type 'null' is not assignable to type 'string | undefined'.
```

By allowing `null` values it will be possible to remove ingest pipelines.