### PR TITLE
Add `@availability` annotations for Serverless

### DIFF
--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -32,6 +32,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 /**
  * @rest_spec_name bulk
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id docs-bulk
  *
  */

--- a/specification/_global/clear_scroll/ClearScrollRequest.ts
+++ b/specification/_global/clear_scroll/ClearScrollRequest.ts
@@ -23,6 +23,7 @@ import { Ids, ScrollIds } from '@_types/common'
 /**
  * @rest_spec_name clear_scroll
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id clear-scroll-api
  */
 export interface Request extends RequestBase {

--- a/specification/_global/close_point_in_time/ClosePointInTimeRequest.ts
+++ b/specification/_global/close_point_in_time/ClosePointInTimeRequest.ts
@@ -23,6 +23,7 @@ import { Id } from '@_types/common'
 /**
  * @rest_spec_name close_point_in_time
  * @availability stack since=7.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id point-in-time-api
  */
 export interface Request extends RequestBase {

--- a/specification/_global/count/CountRequest.ts
+++ b/specification/_global/count/CountRequest.ts
@@ -26,6 +26,7 @@ import { Operator } from '@_types/query_dsl/Operator'
 /**
  * @rest_spec_name count
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/create/CreateRequest.ts
+++ b/specification/_global/create/CreateRequest.ts
@@ -32,6 +32,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name create
  * @availability stack since=5.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  *
  */
 export interface Request<TDocument> extends RequestBase {

--- a/specification/_global/delete/DeleteRequest.ts
+++ b/specification/_global/delete/DeleteRequest.ts
@@ -34,6 +34,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name delete
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -36,6 +36,7 @@ import { Operator } from '@_types/query_dsl/Operator'
 /**
  * @rest_spec_name delete_by_query
  * @availability stack since=5.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/delete_script/DeleteScriptRequest.ts
+++ b/specification/_global/delete_script/DeleteScriptRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name delete_script
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/exists/DocumentExistsRequest.ts
+++ b/specification/_global/exists/DocumentExistsRequest.ts
@@ -31,6 +31,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 /**
  * @rest_spec_name exists
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/exists_source/SourceExistsRequest.ts
+++ b/specification/_global/exists_source/SourceExistsRequest.ts
@@ -31,6 +31,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 /**
  * @rest_spec_name exists_source
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/field_caps/FieldCapabilitiesRequest.ts
+++ b/specification/_global/field_caps/FieldCapabilitiesRequest.ts
@@ -28,6 +28,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
  * of keyword is returned as any other field that belongs to the `keyword` family.
  * @rest_spec_name field_caps
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @index_privileges view_index_metadata,read,manage
  */
 export interface Request extends RequestBase {

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -31,6 +31,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 /**
  * @rest_spec_name get
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/get_script/GetScriptRequest.ts
+++ b/specification/_global/get_script/GetScriptRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name get_script
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/get_source/SourceRequest.ts
+++ b/specification/_global/get_source/SourceRequest.ts
@@ -31,6 +31,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 /**
  * @rest_spec_name get_source
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/index/IndexRequest.ts
+++ b/specification/_global/index/IndexRequest.ts
@@ -35,6 +35,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name index
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request<TDocument> extends RequestBase {
   path_parts: {

--- a/specification/_global/info/RootNodeInfoRequest.ts
+++ b/specification/_global/info/RootNodeInfoRequest.ts
@@ -22,5 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name info
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {}

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -25,6 +25,7 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 /**
  * @rest_spec_name mget
  * @availability stack since=1.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/_global/msearch/MultiSearchRequest.ts
+++ b/specification/_global/msearch/MultiSearchRequest.ts
@@ -25,6 +25,7 @@ import { RequestItem } from './types'
 /**
  * @rest_spec_name msearch
  * @availability stack since=1.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
@@ -26,6 +26,7 @@ import { RequestItem } from './types'
  * Runs multiple templated searches with a single request.
  * @rest_spec_name msearch_template
  * @availability stack since=5.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
+++ b/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
@@ -31,6 +31,7 @@ import { Operation } from './types'
 /**
  * @rest_spec_name mtermvectors
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
+++ b/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
@@ -30,6 +30,7 @@ import { Duration } from '@_types/Time'
  * between searches are only visible to the more recent point in time.
  * @rest_spec_name open_point_in_time
  * @availability stack since=7.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id point-in-time-api
  * @index_privileges read
  */

--- a/specification/_global/ping/PingRequest.ts
+++ b/specification/_global/ping/PingRequest.ts
@@ -22,5 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name ping
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {}

--- a/specification/_global/put_script/PutScriptRequest.ts
+++ b/specification/_global/put_script/PutScriptRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name put_script
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/rank_eval/RankEvalRequest.ts
+++ b/specification/_global/rank_eval/RankEvalRequest.ts
@@ -25,6 +25,7 @@ import { RankEvalMetric, RankEvalRequestItem } from './types'
  * Enables you to evaluate the quality of ranked search results over a set of typical search queries.
  * @rest_spec_name rank_eval
  * @availability stack since=6.2.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
+++ b/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
@@ -25,6 +25,7 @@ import { Id } from '@_types/common'
 /**
  * @rest_spec_name render_search_template
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/scripts_painless_execute/ExecutePainlessScriptRequest.ts
+++ b/specification/_global/scripts_painless_execute/ExecutePainlessScriptRequest.ts
@@ -24,6 +24,7 @@ import { PainlessContextSetup } from './types'
 /**
  * @rest_spec_name scripts_painless_execute
  * @availability stack since=6.3.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/_global/scroll/ScrollRequest.ts
+++ b/specification/_global/scroll/ScrollRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name scroll
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -52,6 +52,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 /**
  * @rest_spec_name search
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/search_template/SearchTemplateRequest.ts
+++ b/specification/_global/search_template/SearchTemplateRequest.ts
@@ -32,6 +32,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name search_template
  * @availability stack since=2.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/terms_enum/TermsEnumRequest.ts
+++ b/specification/_global/terms_enum/TermsEnumRequest.ts
@@ -26,6 +26,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name terms_enum
  * @availability stack since=7.14.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/termvectors/TermVectorsRequest.ts
+++ b/specification/_global/termvectors/TermVectorsRequest.ts
@@ -33,6 +33,7 @@ import { Filter } from './types'
 /**
  * @rest_spec_name termvectors
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request<TDocument> extends RequestBase {
   path_parts: {

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -38,6 +38,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name update
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request<TDocument, TPartialDocument> extends RequestBase {
   path_parts: {

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -37,6 +37,7 @@ import { Operator } from '@_types/query_dsl/Operator'
 /**
  * @rest_spec_name update_by_query
  * @availability stack since=2.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/async_search/delete/AsyncSearchDeleteRequest.ts
+++ b/specification/async_search/delete/AsyncSearchDeleteRequest.ts
@@ -27,6 +27,7 @@ import { Id } from '@_types/common'
  * If the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.
  * @rest_spec_name async_search.delete
  * @availability stack since=7.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id async-search
  */
 export interface Request extends RequestBase {

--- a/specification/async_search/get/AsyncSearchGetRequest.ts
+++ b/specification/async_search/get/AsyncSearchGetRequest.ts
@@ -26,6 +26,7 @@ import { Duration } from '@_types/Time'
  * If the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.
  * @rest_spec_name async_search.get
  * @availability stack since=7.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id async-search
  */
 export interface Request extends RequestBase {

--- a/specification/async_search/status/AsyncSearchStatusRequest.ts
+++ b/specification/async_search/status/AsyncSearchStatusRequest.ts
@@ -25,6 +25,7 @@ import { Id } from '@_types/common'
  * If the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.
  * @rest_spec_name async_search.status
  * @availability stack since=7.11.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id async-search
  */
 export interface Request extends RequestBase {

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -60,6 +60,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * The maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.
  * @rest_spec_name async_search.submit
  * @availability stack since=7.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id async-search
  */
 // NOTE: this is a SearchRequest with 3 added parameters: wait_for_completion_timeout, keep_on_completion and keep_alive

--- a/specification/cat/aliases/CatAliasesRequest.ts
+++ b/specification/cat/aliases/CatAliasesRequest.ts
@@ -23,6 +23,7 @@ import { ExpandWildcards, Names } from '@_types/common'
 /**
  * @rest_spec_name cat.aliases
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id cat-alias
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/allocation/CatAllocationRequest.ts
+++ b/specification/cat/allocation/CatAllocationRequest.ts
@@ -23,6 +23,7 @@ import { Bytes, NodeIds } from '@_types/common'
 /**
  * @rest_spec_name cat.allocation
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-allocation
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/component_templates/CatComponentTemplatesRequest.ts
+++ b/specification/cat/component_templates/CatComponentTemplatesRequest.ts
@@ -22,6 +22,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 /**
  * @rest_spec_name cat.component_templates
  * @availability stack since=5.1.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends CatRequestBase {
   path_parts: {

--- a/specification/cat/count/CatCountRequest.ts
+++ b/specification/cat/count/CatCountRequest.ts
@@ -23,6 +23,7 @@ import { Indices } from '@_types/common'
 /**
  * @rest_spec_name cat.count
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id cat-count
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/fielddata/CatFielddataRequest.ts
+++ b/specification/cat/fielddata/CatFielddataRequest.ts
@@ -23,6 +23,7 @@ import { Bytes, Fields } from '@_types/common'
 /**
  * @rest_spec_name cat.fielddata
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-fielddata
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/help/CatHelpRequest.ts
+++ b/specification/cat/help/CatHelpRequest.ts
@@ -22,6 +22,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 /**
  * @rest_spec_name cat.help
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id cat
  */
 export interface Request extends CatRequestBase {}

--- a/specification/cat/indices/CatIndicesRequest.ts
+++ b/specification/cat/indices/CatIndicesRequest.ts
@@ -24,6 +24,7 @@ import { TimeUnit } from '@_types/Time'
 /**
  * @rest_spec_name cat.indices
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id cat-indices
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/master/CatMasterRequest.ts
+++ b/specification/cat/master/CatMasterRequest.ts
@@ -22,6 +22,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 /**
  * @rest_spec_name cat.master
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-master
  */
 export interface Request extends CatRequestBase {}

--- a/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
+++ b/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
@@ -30,6 +30,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name cat.ml_data_frame_analytics
  * @availability stack since=7.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id cat-dfanalytics
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -33,6 +33,7 @@ import { TimeUnit } from '@_types/Time'
  *
  * @rest_spec_name cat.ml_datafeeds
  * @availability stack since=7.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_id cat-datafeeds
  */

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -33,6 +33,7 @@ import { TimeUnit } from '@_types/Time'
  *
  * @rest_spec_name cat.ml_jobs
  * @availability stack since=7.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_id cat-anomaly-detectors
  */

--- a/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
+++ b/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
@@ -30,6 +30,7 @@ import { integer } from '@_types/Numeric'
  *
  * @rest_spec_name cat.ml_trained_models
  * @availability stack since=7.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id cat-trained-model
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
+++ b/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
@@ -22,6 +22,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 /**
  * @rest_spec_name cat.nodeattrs
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-nodeattrs
  */
 export interface Request extends CatRequestBase {}

--- a/specification/cat/nodes/CatNodesRequest.ts
+++ b/specification/cat/nodes/CatNodesRequest.ts
@@ -23,6 +23,7 @@ import { Bytes } from '@_types/common'
 /**
  * @rest_spec_name cat.nodes
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-nodes
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/pending_tasks/CatPendingTasksRequest.ts
+++ b/specification/cat/pending_tasks/CatPendingTasksRequest.ts
@@ -22,6 +22,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 /**
  * @rest_spec_name cat.pending_tasks
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-pending-tasks
  */
 export interface Request extends CatRequestBase {}

--- a/specification/cat/plugins/CatPluginsRequest.ts
+++ b/specification/cat/plugins/CatPluginsRequest.ts
@@ -22,6 +22,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 /**
  * @rest_spec_name cat.plugins
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-plugins
  */
 export interface Request extends CatRequestBase {}

--- a/specification/cat/segments/CatSegmentsRequest.ts
+++ b/specification/cat/segments/CatSegmentsRequest.ts
@@ -23,6 +23,7 @@ import { Bytes, Indices } from '@_types/common'
 /**
  * @rest_spec_name cat.segments
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-segments
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/shards/CatShardsRequest.ts
+++ b/specification/cat/shards/CatShardsRequest.ts
@@ -23,6 +23,7 @@ import { Bytes, Indices } from '@_types/common'
 /**
  * @rest_spec_name cat.shards
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-shards
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/snapshots/CatSnapshotsRequest.ts
+++ b/specification/cat/snapshots/CatSnapshotsRequest.ts
@@ -23,6 +23,7 @@ import { Names } from '@_types/common'
 /**
  * @rest_spec_name cat.snapshots
  * @availability stack since=2.1.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-snapshots
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/tasks/CatTasksRequest.ts
+++ b/specification/cat/tasks/CatTasksRequest.ts
@@ -23,6 +23,7 @@ import { long } from '@_types/Numeric'
 /**
  * @rest_spec_name cat.tasks
  * @availability stack since=5.0.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
  * @doc_id tasks
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/templates/CatTemplatesRequest.ts
+++ b/specification/cat/templates/CatTemplatesRequest.ts
@@ -23,6 +23,7 @@ import { Name } from '@_types/common'
 /**
  * @rest_spec_name cat.templates
  * @availability stack since=5.2.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-templates
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/thread_pool/CatThreadPoolRequest.ts
+++ b/specification/cat/thread_pool/CatThreadPoolRequest.ts
@@ -24,6 +24,7 @@ import { TimeUnit } from '@_types/Time'
 /**
  * @rest_spec_name cat.thread_pool
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-thread-pool
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/transforms/CatTransformsRequest.ts
+++ b/specification/cat/transforms/CatTransformsRequest.ts
@@ -31,6 +31,7 @@ import { Duration, TimeUnit } from '@_types/Time'
  *
  * @rest_spec_name cat.transforms
  * @availability stack since=7.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id cat-transforms
  */
 export interface Request extends CatRequestBase {

--- a/specification/cluster/allocation_explain/ClusterAllocationExplainRequest.ts
+++ b/specification/cluster/allocation_explain/ClusterAllocationExplainRequest.ts
@@ -24,6 +24,7 @@ import { integer } from '@_types/Numeric'
 /**
  * @rest_spec_name cluster.allocation_explain
  * @availability stack since=5.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cluster-allocation-explain
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/delete_component_template/ClusterDeleteComponentTemplateRequest.ts
+++ b/specification/cluster/delete_component_template/ClusterDeleteComponentTemplateRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name cluster.delete_component_template
  * @availability stack since=7.8.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id indices-component-template
  * @cluster_privileges manage_index_templates,manage
  */

--- a/specification/cluster/exists_component_template/ClusterComponentTemplateExistsRequest.ts
+++ b/specification/cluster/exists_component_template/ClusterComponentTemplateExistsRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name cluster.exists_component_template
  * @availability stack since=7.8.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id indices-component-template
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
+++ b/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name cluster.get_component_template
  * @availability stack since=7.8.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id indices-component-template
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
+++ b/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
@@ -23,6 +23,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name cluster.get_settings
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id cluster-get-settings
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/health/ClusterHealthRequest.ts
+++ b/specification/cluster/health/ClusterHealthRequest.ts
@@ -34,6 +34,7 @@ import { Duration } from '@_types/Time'
  * The cluster health status is: green, yellow or red. On the shard level, a red status indicates that the specific shard is not allocated in the cluster, yellow means that the primary shard is allocated but replicas are not, and green means that all shards are allocated. The index level status is controlled by the worst shard status. The cluster status is controlled by the worst index status.
  * @rest_spec_name cluster.health
  * @availability stack since=1.3.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor, manage
  * @doc_id cluster-health
  */

--- a/specification/cluster/pending_tasks/ClusterPendingTasksRequest.ts
+++ b/specification/cluster/pending_tasks/ClusterPendingTasksRequest.ts
@@ -23,6 +23,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name cluster.pending_tasks
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id cluster-pending
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/put_component_template/ClusterPutComponentTemplateRequest.ts
+++ b/specification/cluster/put_component_template/ClusterPutComponentTemplateRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name cluster.put_component_template
  * @availability stack since=7.8.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id indices-component-template
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/put_settings/ClusterPutSettingsRequest.ts
+++ b/specification/cluster/put_settings/ClusterPutSettingsRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name cluster.put_settings
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id cluster-update-settings
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/reroute/ClusterRerouteRequest.ts
+++ b/specification/cluster/reroute/ClusterRerouteRequest.ts
@@ -25,6 +25,7 @@ import { Command } from './types'
 /**
  * @rest_spec_name cluster.reroute
  * @availability stack since=5.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cluster-reroute
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/state/ClusterStateRequest.ts
+++ b/specification/cluster/state/ClusterStateRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name cluster.state
  * @availability stack since=1.3.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor, manage
  * @doc_id cluster-state
  */

--- a/specification/cluster/stats/ClusterStatsRequest.ts
+++ b/specification/cluster/stats/ClusterStatsRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name cluster.stats
  * @availability stack since=1.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id cluster-stats
  */
 export interface Request extends RequestBase {

--- a/specification/enrich/delete_policy/DeleteEnrichPolicyRequest.ts
+++ b/specification/enrich/delete_policy/DeleteEnrichPolicyRequest.ts
@@ -23,6 +23,7 @@ import { Name } from '@_types/common'
 /**
  * @rest_spec_name enrich.delete_policy
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/enrich/execute_policy/ExecuteEnrichPolicyRequest.ts
+++ b/specification/enrich/execute_policy/ExecuteEnrichPolicyRequest.ts
@@ -23,6 +23,7 @@ import { Name } from '@_types/common'
 /**
  * @rest_spec_name enrich.execute_policy
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/enrich/get_policy/GetEnrichPolicyRequest.ts
+++ b/specification/enrich/get_policy/GetEnrichPolicyRequest.ts
@@ -23,6 +23,7 @@ import { Names } from '@_types/common'
 /**
  * @rest_spec_name enrich.get_policy
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/enrich/put_policy/PutEnrichPolicyRequest.ts
+++ b/specification/enrich/put_policy/PutEnrichPolicyRequest.ts
@@ -24,6 +24,7 @@ import { Name } from '@_types/common'
 /**
  * @rest_spec_name enrich.put_policy
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/enrich/stats/EnrichStatsRequest.ts
+++ b/specification/enrich/stats/EnrichStatsRequest.ts
@@ -22,5 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name enrich.stats
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {}

--- a/specification/fleet/global_checkpoints/GlobalCheckpointsRequest.ts
+++ b/specification/fleet/global_checkpoints/GlobalCheckpointsRequest.ts
@@ -25,6 +25,7 @@ import { Checkpoint } from '../_types/Checkpoints'
 /**
  * @rest_spec_name fleet.global_checkpoints
  * @availability stack since=7.13.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/fleet/msearch/MultiSearchRequest.ts
+++ b/specification/fleet/msearch/MultiSearchRequest.ts
@@ -35,6 +35,7 @@ import { Checkpoint } from '../_types/Checkpoints'
  * supports the wait_for_checkpoints parameter.
  * @rest_spec_name fleet.msearch
  * @availability stack since=7.16.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/fleet/search/SearchRequest.ts
+++ b/specification/fleet/search/SearchRequest.ts
@@ -57,6 +57,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * after provided checkpoint has been processed and is visible for searches inside of Elasticsearch.
  * @rest_spec_name fleet.search
  * @availability stack since=7.16.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
  * @index_privileges read
  */
 export interface Request extends RequestBase {

--- a/specification/graph/explore/GraphExploreRequest.ts
+++ b/specification/graph/explore/GraphExploreRequest.ts
@@ -28,6 +28,7 @@ import { VertexDefinition } from '@graph/_types/Vertex'
 /**
  * @rest_spec_name graph.explore
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/analyze/IndicesAnalyzeRequest.ts
+++ b/specification/indices/analyze/IndicesAnalyzeRequest.ts
@@ -27,6 +27,7 @@ import { TextToAnalyze } from './types'
 /**
  * @rest_spec_name indices.analyze
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/close/CloseIndexRequest.ts
+++ b/specification/indices/close/CloseIndexRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.close
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/create/IndicesCreateRequest.ts
+++ b/specification/indices/create/IndicesCreateRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.create
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @index_privileges create_index, manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
+++ b/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
@@ -23,6 +23,7 @@ import { DataStreamName } from '@_types/common'
 /**
  * @rest_spec_name indices.create_data_stream
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -23,6 +23,7 @@ import { ExpandWildcards, IndexName } from '@_types/common'
 /**
  * @rest_spec_name indices.data_streams_stats
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/delete/IndicesDeleteRequest.ts
+++ b/specification/indices/delete/IndicesDeleteRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.delete
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/delete_alias/IndicesDeleteAliasRequest.ts
+++ b/specification/indices/delete_alias/IndicesDeleteAliasRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.delete_alias
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
+++ b/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
  * Removes the data lifecycle from a data stream rendering it not managed by DLM
  * @rest_spec_name indices.delete_data_lifecycle
  * @availability stack since=8.8.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
+++ b/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
@@ -23,6 +23,7 @@ import { ExpandWildcards, DataStreamNames } from '@_types/common'
 /**
  * @rest_spec_name indices.delete_data_stream
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/delete_index_template/IndicesDeleteIndexTemplateRequest.ts
+++ b/specification/indices/delete_index_template/IndicesDeleteIndexTemplateRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * existing templates.
  * @rest_spec_name indices.delete_index_template
  * @availability stack since=7.8.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_index_templates,manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/delete_template/IndicesDeleteTemplateRequest.ts
+++ b/specification/indices/delete_template/IndicesDeleteTemplateRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.delete_template
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/disk_usage/IndicesDiskUsageRequest.ts
+++ b/specification/indices/disk_usage/IndicesDiskUsageRequest.ts
@@ -23,6 +23,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
 /**
  * @rest_spec_name indices.disk_usage
  * @availability stack since=7.15.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/downsample/Request.ts
+++ b/specification/indices/downsample/Request.ts
@@ -24,6 +24,7 @@ import { IndexName } from '@_types/common'
 /**
  * @rest_spec_name indices.downsample
  * @availability stack since=8.5.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/exists/IndicesExistsRequest.ts
+++ b/specification/indices/exists/IndicesExistsRequest.ts
@@ -23,6 +23,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
 /**
  * @rest_spec_name indices.exists
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
+++ b/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
@@ -23,6 +23,7 @@ import { ExpandWildcards, Indices, Names } from '@_types/common'
 /**
  * @rest_spec_name indices.exists_alias
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/exists_index_template/IndicesExistsIndexTemplateRequest.ts
+++ b/specification/indices/exists_index_template/IndicesExistsIndexTemplateRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.exists_index_template
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/exists_template/IndicesExistsTemplateRequest.ts
+++ b/specification/indices/exists_template/IndicesExistsTemplateRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.exists_template
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts
+++ b/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
  * Retrieves information about the index's current DLM lifecycle, such as any potential encountered error, time since creation etc.
  * @rest_spec_name indices.explain_data_lifecycle
  * @availability stack since=8.8.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get/IndicesGetRequest.ts
+++ b/specification/indices/get/IndicesGetRequest.ts
@@ -26,6 +26,7 @@ import { Duration } from '@_types/Time'
  * stream’s backing indices.
  * @rest_spec_name indices.get
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @index_privileges view_index_metadata, manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/get_alias/IndicesGetAliasRequest.ts
+++ b/specification/indices/get_alias/IndicesGetAliasRequest.ts
@@ -23,6 +23,7 @@ import { ExpandWildcards, Indices, Names } from '@_types/common'
 /**
  * @rest_spec_name indices.get_alias
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
@@ -24,6 +24,7 @@ import { ExpandWildcards, DataStreamNames } from '@_types/common'
  * Retrieves the data lifecycle configuration of one or more data streams.
  * @rest_spec_name indices.get_data_lifecycle
  * @availability stack since=8.8.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
+++ b/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
@@ -23,6 +23,7 @@ import { ExpandWildcards, DataStreamNames } from '@_types/common'
 /**
  * @rest_spec_name indices.get_data_stream
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
+++ b/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
  * Returns information about one or more index templates.
  * @rest_spec_name indices.get_index_template
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_index_templates,manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/get_mapping/IndicesGetMappingRequest.ts
+++ b/specification/indices/get_mapping/IndicesGetMappingRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.get_mapping
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_settings/IndicesGetSettingsRequest.ts
+++ b/specification/indices/get_settings/IndicesGetSettingsRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.get_settings
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_template/IndicesGetTemplateRequest.ts
+++ b/specification/indices/get_template/IndicesGetTemplateRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.get_template
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
+++ b/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
@@ -23,6 +23,7 @@ import { IndexName } from '@_types/common'
 /**
  * @rest_spec_name indices.migrate_to_data_stream
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/modify_data_stream/IndicesModifyDataStreamRequest.ts
+++ b/specification/indices/modify_data_stream/IndicesModifyDataStreamRequest.ts
@@ -23,6 +23,7 @@ import { Action } from './types'
 /**
  * @rest_spec_name indices.modify_data_stream
  * @availability stack since=7.16.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/indices/open/IndicesOpenRequest.ts
+++ b/specification/indices/open/IndicesOpenRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.open
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_alias/IndicesPutAliasRequest.ts
+++ b/specification/indices/put_alias/IndicesPutAliasRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.put_alias
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
+++ b/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
  * Update the data lifecycle of the specified data streams.
  * @rest_spec_name indices.put_data_lifecycle
  * @availability stack since=8.8.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
@@ -36,6 +36,7 @@ import { DataLifecycle } from '@indices/_types/DataLifecycle'
 /**
  * @rest_spec_name indices.put_index_template
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_mapping/IndicesPutMappingRequest.ts
+++ b/specification/indices/put_mapping/IndicesPutMappingRequest.ts
@@ -42,6 +42,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.put_mapping
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_settings/IndicesPutSettingsRequest.ts
+++ b/specification/indices/put_settings/IndicesPutSettingsRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.put_settings
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_template/IndicesPutTemplateRequest.ts
+++ b/specification/indices/put_template/IndicesPutTemplateRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.put_template
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/recovery/IndicesRecoveryRequest.ts
+++ b/specification/indices/recovery/IndicesRecoveryRequest.ts
@@ -23,6 +23,7 @@ import { Indices } from '@_types/common'
 /**
  * @rest_spec_name indices.recovery
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/resolve_index/ResolveIndexRequest.ts
+++ b/specification/indices/resolve_index/ResolveIndexRequest.ts
@@ -23,6 +23,7 @@ import { ExpandWildcards, Names } from '@_types/common'
 /**
  * @rest_spec_name indices.resolve_index
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/rollover/IndicesRolloverRequest.ts
+++ b/specification/indices/rollover/IndicesRolloverRequest.ts
@@ -29,6 +29,7 @@ import { RolloverConditions } from './types'
 /**
  * @rest_spec_name indices.rollover
  * @availability stack since=5.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
+++ b/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
@@ -33,6 +33,7 @@ import { IndexTemplateMapping } from '../put_index_template/IndicesPutIndexTempl
 /**
  * @rest_spec_name indices.simulate_index_template
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
+++ b/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
@@ -26,6 +26,7 @@ import { Duration } from '@_types/Time'
  * Returns the index configuration that would be applied by a particular index template.
  * @rest_spec_name indices.simulate_template
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_index_templates,manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/stats/IndicesStatsRequest.ts
+++ b/specification/indices/stats/IndicesStatsRequest.ts
@@ -29,6 +29,7 @@ import {
 /**
  * @rest_spec_name indices.stats
  * @availability stack since=1.3.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @index_privileges manage, monitor
  */
 export interface Request extends RequestBase {

--- a/specification/indices/update_aliases/IndicesUpdateAliasesRequest.ts
+++ b/specification/indices/update_aliases/IndicesUpdateAliasesRequest.ts
@@ -24,6 +24,7 @@ import { Action } from './types'
 /**
  * @rest_spec_name indices.update_aliases
  * @availability stack since=1.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/indices/validate_query/IndicesValidateQueryRequest.ts
+++ b/specification/indices/validate_query/IndicesValidateQueryRequest.ts
@@ -25,6 +25,7 @@ import { Operator } from '@_types/query_dsl/Operator'
 /**
  * @rest_spec_name indices.validate_query
  * @availability stack since=1.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ingest/delete_pipeline/DeletePipelineRequest.ts
+++ b/specification/ingest/delete_pipeline/DeletePipelineRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name ingest.delete_pipeline
  * @availability stack since=5.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ingest/geo_ip_stats/IngestGeoIpStatsRequest.ts
+++ b/specification/ingest/geo_ip_stats/IngestGeoIpStatsRequest.ts
@@ -22,5 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name ingest.geo_ip_stats
  * @availability stack since=7.13.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {}

--- a/specification/ingest/get_pipeline/GetPipelineRequest.ts
+++ b/specification/ingest/get_pipeline/GetPipelineRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name ingest.get_pipeline
  * @availability stack since=5.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ingest/processor_grok/GrokProcessorPatternsRequest.ts
+++ b/specification/ingest/processor_grok/GrokProcessorPatternsRequest.ts
@@ -22,5 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name ingest.processor_grok
  * @availability stack since=6.1.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {}

--- a/specification/ingest/put_pipeline/PutPipelineRequest.ts
+++ b/specification/ingest/put_pipeline/PutPipelineRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name ingest.put_pipeline
  * @availability stack since=5.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ingest/simulate/SimulatePipelineRequest.ts
+++ b/specification/ingest/simulate/SimulatePipelineRequest.ts
@@ -25,6 +25,7 @@ import { Document } from './types'
 /**
  * @rest_spec_name ingest.simulate
  * @availability stack since=5.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/logstash/delete_pipeline/LogstashDeletePipelineRequest.ts
+++ b/specification/logstash/delete_pipeline/LogstashDeletePipelineRequest.ts
@@ -23,6 +23,7 @@ import { Id } from '@_types/common'
 /**
  * @rest_spec_name logstash.delete_pipeline
  * @availability stack since=7.12.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/logstash/get_pipeline/LogstashGetPipelineRequest.ts
+++ b/specification/logstash/get_pipeline/LogstashGetPipelineRequest.ts
@@ -23,6 +23,7 @@ import { Ids } from '@_types/common'
 /**
  * @rest_spec_name logstash.get_pipeline
  * @availability stack since=7.12.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/logstash/put_pipeline/LogstashPutPipelineRequest.ts
+++ b/specification/logstash/put_pipeline/LogstashPutPipelineRequest.ts
@@ -24,6 +24,7 @@ import { Pipeline } from '@logstash/_types/Pipeline'
 /**
  * @rest_spec_name logstash.put_pipeline
  * @availability stack since=7.12.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheRequest.ts
+++ b/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheRequest.ts
@@ -29,6 +29,7 @@ import { Include } from '@ml/_types/Include'
  * Calling this API clears the caches without restarting the deployment.
  * @rest_spec_name ml.clear_trained_model_deployment_cache
  * @availability stack since=8.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/close_job/MlCloseJobRequest.ts
+++ b/specification/ml/close_job/MlCloseJobRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
  * When a datafeed that has a specified end date stops, it automatically closes its associated job.
  * @rest_spec_name ml.close_job
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_id ml-close-job
  */

--- a/specification/ml/delete_calendar/MlDeleteCalendarRequest.ts
+++ b/specification/ml/delete_calendar/MlDeleteCalendarRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
  * Removes all scheduled events from a calendar, then deletes it.
  * @rest_spec_name ml.delete_calendar
  * @availability stack since=6.2.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_id ml-delete-calendar
  */

--- a/specification/ml/delete_calendar_event/MlDeleteCalendarEventRequest.ts
+++ b/specification/ml/delete_calendar_event/MlDeleteCalendarEventRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
  * Deletes scheduled events from a calendar.
  * @rest_spec_name ml.delete_calendar_event
  * @availability stack since=6.2.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @doc_id ml-delete-calendar-event
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_calendar_job/MlDeleteCalendarJobRequest.ts
+++ b/specification/ml/delete_calendar_job/MlDeleteCalendarJobRequest.ts
@@ -24,6 +24,7 @@ import { Id, Ids } from '@_types/common'
  * Deletes anomaly detection jobs from a calendar.
  * @rest_spec_name ml.delete_calendar_job
  * @availability stack since=6.2.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_id ml-delete-calendar-job
  */

--- a/specification/ml/delete_data_frame_analytics/MlDeleteDataFrameAnalyticsRequest.ts
+++ b/specification/ml/delete_data_frame_analytics/MlDeleteDataFrameAnalyticsRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
  * Deletes a data frame analytics job.
  * @rest_spec_name ml.delete_data_frame_analytics
  * @availability stack since=7.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_id ml-delete-dfanalytics
  */

--- a/specification/ml/delete_datafeed/MlDeleteDatafeedRequest.ts
+++ b/specification/ml/delete_datafeed/MlDeleteDatafeedRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
  * Deletes an existing datafeed.
  * @rest_spec_name ml.delete_datafeed
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_id ml-delete-datafeed
  */

--- a/specification/ml/delete_expired_data/MlDeleteExpiredDataRequest.ts
+++ b/specification/ml/delete_expired_data/MlDeleteExpiredDataRequest.ts
@@ -34,6 +34,7 @@ import { Duration } from '@_types/Time'
  * <job_id>.
  * @rest_spec_name ml.delete_expired_data
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_filter/MlDeleteFilterRequest.ts
+++ b/specification/ml/delete_filter/MlDeleteFilterRequest.ts
@@ -26,6 +26,7 @@ import { Id } from '@_types/common'
  * filter. You must update or delete the job before you can delete the filter.
  * @rest_spec_name ml.delete_filter
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_forecast/MlDeleteForecastRequest.ts
+++ b/specification/ml/delete_forecast/MlDeleteForecastRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
  * forecasts before they expire.
  * @rest_spec_name ml.delete_forecast
  * @availability stack since=6.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_job/MlDeleteJobRequest.ts
+++ b/specification/ml/delete_job/MlDeleteJobRequest.ts
@@ -31,6 +31,7 @@ import { Id } from '@_types/common'
  * delete job request.
  * @rest_spec_name ml.delete_job
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_model_snapshot/MlDeleteModelSnapshotRequest.ts
+++ b/specification/ml/delete_model_snapshot/MlDeleteModelSnapshotRequest.ts
@@ -27,6 +27,7 @@ import { Id } from '@_types/common'
  * the `model_snapshot_id` in the results from the get jobs API.
  * @rest_spec_name ml.delete_model_snapshot
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_trained_model/MlDeleteTrainedModelRequest.ts
+++ b/specification/ml/delete_trained_model/MlDeleteTrainedModelRequest.ts
@@ -25,6 +25,7 @@ import { Id } from '@_types/common'
  * by an ingest pipeline.
  * @rest_spec_name ml.delete_trained_model
  * @availability stack since=7.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_trained_model_alias/MlDeleteTrainedModelAliasRequest.ts
+++ b/specification/ml/delete_trained_model_alias/MlDeleteTrainedModelAliasRequest.ts
@@ -27,6 +27,7 @@ import { Id, Name } from '@_types/common'
  * by the `model_id`, this API returns an error.
  * @rest_spec_name ml.delete_trained_model_alias
  * @availability stack since=7.13.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/estimate_model_memory/MlEstimateModelMemoryRequest.ts
+++ b/specification/ml/estimate_model_memory/MlEstimateModelMemoryRequest.ts
@@ -29,6 +29,7 @@ import { long } from '@_types/Numeric'
  * estimates for the fields it references.
  * @rest_spec_name ml.estimate_model_memory
  * @availability stack since=7.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/evaluate_data_frame/MlEvaluateDataFrameRequest.ts
+++ b/specification/ml/evaluate_data_frame/MlEvaluateDataFrameRequest.ts
@@ -30,6 +30,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
  * field and an analytics result field to be present.
  * @rest_spec_name ml.evaluate_data_frame
  * @availability stack since=7.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/explain_data_frame_analytics/MlExplainDataFrameAnalyticsRequest.ts
+++ b/specification/ml/explain_data_frame_analytics/MlExplainDataFrameAnalyticsRequest.ts
@@ -37,6 +37,7 @@ import { integer } from '@_types/Numeric'
  * If you have object fields or fields that are excluded via source filtering, they are not included in the explanation.
  * @rest_spec_name ml.explain_data_frame_analytics
  * @availability stack since=7.3.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/flush_job/MlFlushJobRequest.ts
+++ b/specification/ml/flush_job/MlFlushJobRequest.ts
@@ -33,6 +33,7 @@ import { DateTime } from '@_types/Time'
  * analyzing further data.
  * @rest_spec_name ml.flush_job
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/forecast/MlForecastJobRequest.ts
+++ b/specification/ml/forecast/MlForecastJobRequest.ts
@@ -31,6 +31,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name ml.forecast
  * @availability stack since=6.1.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_buckets/MlGetBucketsRequest.ts
+++ b/specification/ml/get_buckets/MlGetBucketsRequest.ts
@@ -28,6 +28,7 @@ import { DateTime } from '@_types/Time'
  * The API presents a chronological view of the records, grouped by bucket.
  * @rest_spec_name ml.get_buckets
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
+++ b/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
@@ -26,6 +26,7 @@ import { DateTime } from '@_types/Time'
  * Retrieves information about the scheduled events in calendars.
  * @rest_spec_name ml.get_calendar_events
  * @availability stack since=6.2.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_calendars/MlGetCalendarsRequest.ts
+++ b/specification/ml/get_calendars/MlGetCalendarsRequest.ts
@@ -26,6 +26,7 @@ import { integer } from '@_types/Numeric'
  * Retrieves configuration information for calendars.
  * @rest_spec_name ml.get_calendars
  * @availability stack since=6.2.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_categories/MlGetCategoriesRequest.ts
+++ b/specification/ml/get_categories/MlGetCategoriesRequest.ts
@@ -26,6 +26,7 @@ import { integer } from '@_types/Numeric'
  * Retrieves anomaly detection job results for one or more categories.
  * @rest_spec_name ml.get_categories
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_data_frame_analytics/MlGetDataFrameAnalyticsRequest.ts
+++ b/specification/ml/get_data_frame_analytics/MlGetDataFrameAnalyticsRequest.ts
@@ -28,6 +28,7 @@ import { integer } from '@_types/Numeric'
  * wildcard expression.
  * @rest_spec_name ml.get_data_frame_analytics
  * @availability stack since=7.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_data_frame_analytics_stats/MlGetDataFrameAnalyticsStatsRequest.ts
+++ b/specification/ml/get_data_frame_analytics_stats/MlGetDataFrameAnalyticsStatsRequest.ts
@@ -25,6 +25,7 @@ import { integer } from '@_types/Numeric'
  * Retrieves usage information for data frame analytics jobs.
  * @rest_spec_name ml.get_data_frame_analytics_stats
  * @availability stack since=7.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_datafeed_stats/MlGetDatafeedStatsRequest.ts
+++ b/specification/ml/get_datafeed_stats/MlGetDatafeedStatsRequest.ts
@@ -30,6 +30,7 @@ import { Ids } from '@_types/common'
  * This API returns a maximum of 10,000 datafeeds.
  * @rest_spec_name ml.get_datafeed_stats
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_datafeeds/MlGetDatafeedsRequest.ts
+++ b/specification/ml/get_datafeeds/MlGetDatafeedsRequest.ts
@@ -29,6 +29,7 @@ import { Ids } from '@_types/common'
  * This API returns a maximum of 10,000 datafeeds.
  * @rest_spec_name ml.get_datafeeds
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_filters/MlGetFiltersRequest.ts
+++ b/specification/ml/get_filters/MlGetFiltersRequest.ts
@@ -26,6 +26,7 @@ import { integer } from '@_types/Numeric'
  * You can get a single filter or all filters.
  * @rest_spec_name ml.get_filters
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_influencers/MlGetInfluencersRequest.ts
+++ b/specification/ml/get_influencers/MlGetInfluencersRequest.ts
@@ -30,6 +30,7 @@ import { DateTime } from '@_types/Time'
  * `influencer_field_name` is specified in the job configuration.
  * @rest_spec_name ml.get_influencers
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
+++ b/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
  * Retrieves usage information for anomaly detection jobs.
  * @rest_spec_name ml.get_job_stats
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_jobs/MlGetJobsRequest.ts
+++ b/specification/ml/get_jobs/MlGetJobsRequest.ts
@@ -28,6 +28,7 @@ import { Ids } from '@_types/common'
  * `_all`, by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.
  * @rest_spec_name ml.get_jobs
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_memory_stats/MlGetMemoryStatsRequest.ts
+++ b/specification/ml/get_memory_stats/MlGetMemoryStatsRequest.ts
@@ -26,6 +26,7 @@ import { Duration } from '@_types/Time'
  * on each node, both within the JVM heap, and natively, outside of the JVM.
  * @rest_spec_name ml.get_memory_stats
  * @availability stack since=8.2.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_model_snapshot_upgrade_stats/MlGetModelSnapshotUpgradeStatsRequest.ts
+++ b/specification/ml/get_model_snapshot_upgrade_stats/MlGetModelSnapshotUpgradeStatsRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
  * Retrieves usage information for anomaly detection job model snapshot upgrades.
  * @rest_spec_name ml.get_model_snapshot_upgrade_stats
  * @availability stack since=7.16.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_model_snapshots/MlGetModelSnapshotsRequest.ts
+++ b/specification/ml/get_model_snapshots/MlGetModelSnapshotsRequest.ts
@@ -27,6 +27,7 @@ import { Duration, DateTime } from '@_types/Time'
  * Retrieves information about model snapshots.
  * @rest_spec_name ml.get_model_snapshots
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
+++ b/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
@@ -42,6 +42,7 @@ import { Duration, DateTime } from '@_types/Time'
  * jobs' largest bucket span.
  * @rest_spec_name ml.get_overall_buckets
  * @availability stack since=6.1.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_records/MlGetAnomalyRecordsRequest.ts
+++ b/specification/ml/get_records/MlGetAnomalyRecordsRequest.ts
@@ -37,6 +37,7 @@ import { DateTime } from '@_types/Time'
  * number of detectors.
  * @rest_spec_name ml.get_records
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
+++ b/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
@@ -26,6 +26,7 @@ import { Include } from '@ml/_types/Include'
  * Retrieves configuration information for a trained model.
  * @rest_spec_name ml.get_trained_models
  * @availability stack since=7.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsRequest.ts
+++ b/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsRequest.ts
@@ -26,6 +26,7 @@ import { integer } from '@_types/Numeric'
  * models in a single API request by using a comma-separated list of model IDs or a wildcard expression.
  * @rest_spec_name ml.get_trained_models_stats
  * @availability stack since=7.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/infer_trained_model/MlInferTrainedModelRequest.ts
+++ b/specification/ml/infer_trained_model/MlInferTrainedModelRequest.ts
@@ -28,6 +28,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * Evaluates a trained model.
  * @rest_spec_name ml.infer_trained_model
  * @availability stack since=8.3.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ml/info/MlInfoRequest.ts
+++ b/specification/ml/info/MlInfoRequest.ts
@@ -29,6 +29,7 @@ import { RequestBase } from '@_types/Base'
  * cluster configuration.
  * @rest_spec_name ml.info
  * @availability stack since=6.3.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {}

--- a/specification/ml/open_job/MlOpenJobRequest.ts
+++ b/specification/ml/open_job/MlOpenJobRequest.ts
@@ -32,6 +32,7 @@ import { Duration } from '@_types/Time'
  * new data is received.
  * @rest_spec_name ml.open_job
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
+++ b/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
@@ -25,6 +25,7 @@ import { CalendarEvent } from '../_types/CalendarEvent'
  * Adds scheduled events to a calendar.
  * @rest_spec_name ml.post_calendar_events
  * @availability stack since=6.2.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/post_data/MlPostJobDataRequest.ts
+++ b/specification/ml/post_data/MlPostJobDataRequest.ts
@@ -28,6 +28,7 @@ import { DateTime } from '@_types/Time'
  * It is not currently possible to post data to multiple jobs using wildcards or a comma-separated list.
  * @rest_spec_name ml.post_data
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @deprecated 7.11.0 Posting data directly to anomaly detection jobs is deprecated, in a future major version a datafeed will be required.
  * @cluster_privileges manage_ml
  */

--- a/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsRequest.ts
+++ b/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsRequest.ts
@@ -25,6 +25,7 @@ import { DataframePreviewConfig } from './types'
  * Previews the extracted features used by a data frame analytics config.
  * @rest_spec_name ml.preview_data_frame_analytics
  * @availability stack since=7.13.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
@@ -35,6 +35,7 @@ import { DateTime } from '@_types/Time'
  * You can also use secondary authorization headers to supply the credentials.
  * @rest_spec_name ml.preview_datafeed
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @index_privileges read
  * @cluster_privileges manage_ml
  */

--- a/specification/ml/put_calendar/MlPutCalendarRequest.ts
+++ b/specification/ml/put_calendar/MlPutCalendarRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
  * Creates a calendar.
  * @rest_spec_name ml.put_calendar
  * @availability stack since=6.2.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/put_calendar_job/MlPutCalendarJobRequest.ts
+++ b/specification/ml/put_calendar_job/MlPutCalendarJobRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
  * Adds an anomaly detection job to a calendar.
  * @rest_spec_name ml.put_calendar_job
  * @availability stack since=6.2.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
+++ b/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
@@ -33,6 +33,7 @@ import { integer } from '@_types/Numeric'
  * source indices and stores the outcome in a destination index.
  * @rest_spec_name ml.put_data_frame_analytics
  * @availability stack since=7.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @index_privileges create_index, index, manage, read, view_index_metadata
  * @doc_id put-dfanalytics

--- a/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
@@ -47,6 +47,7 @@ import { Duration } from '@_types/Time'
  * directly to the `.ml-config` index. Do not give users `write` privileges on the `.ml-config` index.
  * @rest_spec_name ml.put_datafeed
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @index_privileges read
  * @cluster_privileges manage_ml
  */

--- a/specification/ml/put_filter/MlPutFilterRequest.ts
+++ b/specification/ml/put_filter/MlPutFilterRequest.ts
@@ -26,6 +26,7 @@ import { Id } from '@_types/common'
  * Specifically, filters are referenced in the `custom_rules` property of detector configuration objects.
  * @rest_spec_name ml.put_filter
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -31,6 +31,7 @@ import { DatafeedConfig } from '@ml/_types/Datafeed'
  * Instantiates an anomaly detection job. If you include a `datafeed_config`, you must have read index privileges on the source index.
  * @rest_spec_name ml.put_job
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @index_privileges read
  * @cluster_privileges manage_ml
  */

--- a/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
@@ -29,6 +29,7 @@ import { InferenceConfigCreateContainer } from '@ml/_types/inference'
  * Enables you to supply a trained model that is not created by data frame analytics.
  * @rest_spec_name ml.put_trained_model
  * @availability stack since=7.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/put_trained_model_alias/MlPutTrainedModelAliasRequest.ts
+++ b/specification/ml/put_trained_model_alias/MlPutTrainedModelAliasRequest.ts
@@ -39,6 +39,7 @@ import { Id, Name } from '@_types/common'
  * returns a warning.
  * @rest_spec_name ml.put_trained_model_alias
  * @availability stack since=7.13.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartRequest.ts
+++ b/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartRequest.ts
@@ -25,6 +25,7 @@ import { Id } from '@_types/common'
  * Creates part of a trained model definition.
  * @rest_spec_name ml.put_trained_model_definition_part
  * @availability stack since=8.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
+++ b/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
@@ -26,6 +26,7 @@ import { Id } from '@_types/common'
  * The vocabulary is stored in the index as described in `inference_config.*.vocabulary` of the trained model definition.
  * @rest_spec_name ml.put_trained_model_vocabulary
  * @availability stack since=8.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/reset_job/MlResetJobRequest.ts
+++ b/specification/ml/reset_job/MlResetJobRequest.ts
@@ -28,6 +28,7 @@ import { Id } from '@_types/common'
  * comma separated list.
  * @rest_spec_name ml.reset_job
  * @availability stack since=7.14.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/revert_model_snapshot/MlRevertModelSnapshotRequest.ts
+++ b/specification/ml/revert_model_snapshot/MlRevertModelSnapshotRequest.ts
@@ -31,6 +31,7 @@ import { Id } from '@_types/common'
  * snapshot after Black Friday or a critical system failure.
  * @rest_spec_name ml.revert_model_snapshot
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/set_upgrade_mode/MlSetUpgradeModeRequest.ts
+++ b/specification/ml/set_upgrade_mode/MlSetUpgradeModeRequest.ts
@@ -35,6 +35,7 @@ import { Duration } from '@_types/Time'
  * machine learning info API.
  * @rest_spec_name ml.set_upgrade_mode
  * @availability stack since=6.7.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/start_data_frame_analytics/MlStartDataFrameAnalyticsRequest.ts
+++ b/specification/ml/start_data_frame_analytics/MlStartDataFrameAnalyticsRequest.ts
@@ -36,6 +36,7 @@ import { Duration } from '@_types/Time'
  * the destination index in advance with custom settings and mappings.
  * @rest_spec_name ml.start_data_frame_analytics
  * @availability stack since=7.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @index_privileges create_index, index, manage, read, view_index_metadata
  */

--- a/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
+++ b/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
@@ -37,6 +37,7 @@ import { Duration, DateTime } from '@_types/Time'
  * authorization headers when you created or updated the datafeed, those credentials are used instead.
  * @rest_spec_name ml.start_datafeed
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
@@ -30,6 +30,7 @@ import {
  * Starts a trained model deployment, which allocates the model to every machine learning node.
  * @rest_spec_name ml.start_trained_model_deployment
  * @availability stack since=8.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/stop_data_frame_analytics/MlStopDataFrameAnalyticsRequest.ts
+++ b/specification/ml/stop_data_frame_analytics/MlStopDataFrameAnalyticsRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * throughout its lifecycle.
  * @rest_spec_name ml.stop_data_frame_analytics
  * @availability stack since=7.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
+++ b/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * multiple times throughout its lifecycle.
  * @rest_spec_name ml.stop_datafeed
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentRequest.ts
+++ b/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
  * Stops a trained model deployment.
  * @rest_spec_name ml.stop_trained_model_deployment
  * @availability stack since=8.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/update_data_frame_analytics/MlUpdateDataFrameAnalyticsRequest.ts
+++ b/specification/ml/update_data_frame_analytics/MlUpdateDataFrameAnalyticsRequest.ts
@@ -25,6 +25,7 @@ import { integer } from '@_types/Numeric'
  * Updates an existing data frame analytics job.
  * @rest_spec_name ml.update_data_frame_analytics
  * @availability stack since=7.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @index_privileges read, create_index, manage, index, view_index_metadata
  */

--- a/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
@@ -36,6 +36,7 @@ import { ScriptField } from '@_types/Scripting'
  * those credentials are used instead.
  * @rest_spec_name ml.update_datafeed
  * @availability stack since=6.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/update_filter/MlUpdateFilterRequest.ts
+++ b/specification/ml/update_filter/MlUpdateFilterRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
  * Updates the description of a filter, adds items, or removes items from the list.
  * @rest_spec_name ml.update_filter
  * @availability stack since=6.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/update_job/MlUpdateJobRequest.ts
+++ b/specification/ml/update_job/MlUpdateJobRequest.ts
@@ -34,6 +34,7 @@ import { Duration } from '@_types/Time'
  * Updates certain properties of an anomaly detection job.
  * @rest_spec_name ml.update_job
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/update_model_snapshot/MlUpdateModelSnapshotRequest.ts
+++ b/specification/ml/update_model_snapshot/MlUpdateModelSnapshotRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
  * Updates certain properties of a snapshot.
  * @rest_spec_name ml.update_model_snapshot
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/upgrade_job_snapshot/MlUpgradeJobSnapshotRequest.ts
+++ b/specification/ml/upgrade_job_snapshot/MlUpgradeJobSnapshotRequest.ts
@@ -33,6 +33,7 @@ import { Duration } from '@_types/Time'
  * job.
  * @rest_spec_name ml.upgrade_job_snapshot
  * @availability stack since=5.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  */
 export interface Request extends RequestBase {

--- a/specification/ml/validate/MlValidateJobRequest.ts
+++ b/specification/ml/validate/MlValidateJobRequest.ts
@@ -27,6 +27,7 @@ import { long } from '@_types/Numeric'
 /**
  * @rest_spec_name ml.validate
  * @availability stack since=6.3.0 stability=stable visibility=private
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/ml/validate_detector/MlValidateDetectorRequest.ts
+++ b/specification/ml/validate_detector/MlValidateDetectorRequest.ts
@@ -23,6 +23,7 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name ml.validate_detector
  * @availability stack since=5.4.0 stability=stable visibility=private
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   /** @codegen_name detector */

--- a/specification/nodes/hot_threads/NodesHotThreadsRequest.ts
+++ b/specification/nodes/hot_threads/NodesHotThreadsRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * The output is plain text with a breakdown of each node’s top hot threads.
  * @rest_spec_name nodes.hot_threads
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor,manage
  * @doc_id cluster-nodes-hot-threads
  */

--- a/specification/nodes/info/NodesInfoRequest.ts
+++ b/specification/nodes/info/NodesInfoRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name nodes.info
  * @availability stack since=1.3.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cluster-nodes-info
  */
 export interface Request extends RequestBase {

--- a/specification/nodes/stats/NodesStatsRequest.ts
+++ b/specification/nodes/stats/NodesStatsRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name nodes.stats
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cluster-nodes-stats
  */
 export interface Request extends RequestBase {

--- a/specification/nodes/usage/NodesUsageRequest.ts
+++ b/specification/nodes/usage/NodesUsageRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name nodes.usage
  * @availability stack since=6.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cluster-nodes-usage
  */
 export interface Request extends RequestBase {

--- a/specification/search_application/delete/SearchApplicationsDeleteRequest.ts
+++ b/specification/search_application/delete/SearchApplicationsDeleteRequest.ts
@@ -23,6 +23,7 @@ import { Name } from '@_types/common'
  * Deletes a search application.
  * @rest_spec_name search_application.delete
  * @availability stack since=8.8.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteRequest.ts
+++ b/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteRequest.ts
@@ -23,6 +23,7 @@ import { Name } from '@_types/common'
  * Delete a behavioral analytics collection.
  * @rest_spec_name search_application.delete_behavioral_analytics
  * @availability stack since=8.8.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/get/SearchApplicationsGetRequest.ts
+++ b/specification/search_application/get/SearchApplicationsGetRequest.ts
@@ -23,6 +23,7 @@ import { Name } from '@_types/common'
  * Returns the details about a search application
  * @rest_spec_name search_application.get
  * @availability stack since=8.8.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
+++ b/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
@@ -23,6 +23,7 @@ import { Name } from '@_types/common'
  * Returns the existing behavioral analytics collections.
  * @rest_spec_name search_application.get_behavioral_analytics
  * @availability stack since=8.8.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/list/SearchApplicationsListRequest.ts
+++ b/specification/search_application/list/SearchApplicationsListRequest.ts
@@ -24,6 +24,7 @@ import { integer } from '@_types/Numeric'
  * Returns the existing search applications.
  * @rest_spec_name search_application.list
  * @availability stack since=8.8.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 interface Request extends RequestBase {
   query_parameters: {

--- a/specification/search_application/put/SearchApplicationsPutRequest.ts
+++ b/specification/search_application/put/SearchApplicationsPutRequest.ts
@@ -24,6 +24,7 @@ import { SearchApplication } from '../_types/SearchApplication'
  * Creates or updates a search application.
  * @rest_spec_name search_application.put
  * @availability stack since=8.8.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutRequest.ts
+++ b/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutRequest.ts
@@ -24,6 +24,7 @@ import { SearchApplication } from '../_types/SearchApplication'
  * Creates a behavioral analytics collection
  * @rest_spec_name search_application.put_behavioral_analytics
  * @availability stack since=8.8.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/search_application/search/SearchApplicationsSearchRequest.ts
+++ b/specification/search_application/search/SearchApplicationsSearchRequest.ts
@@ -25,6 +25,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * Perform a search against a search application
  * @rest_spec_name search_application.search
  * @availability stack since=8.8.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/activate_user_profile/Request.ts
+++ b/specification/security/activate_user_profile/Request.ts
@@ -24,6 +24,7 @@ import { GrantType } from '@security/_types/GrantType'
  * Creates or updates a user profile on behalf of another user.
  * @rest_spec_name security.activate_user_profile
  * @availability stack since=8.2.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_user_profile
  */
 export interface Request extends RequestBase {

--- a/specification/security/authenticate/SecurityAuthenticateRequest.ts
+++ b/specification/security/authenticate/SecurityAuthenticateRequest.ts
@@ -23,5 +23,6 @@ import { RequestBase } from '@_types/Base'
  * Enables you to submit a request with a basic auth header to authenticate a user and retrieve information about the authenticated user.
  * @rest_spec_name security.authenticate
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {}

--- a/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
+++ b/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
@@ -23,6 +23,7 @@ import { Ids } from '@_types/common'
 /**
  * @rest_spec_name security.clear_api_key_cache
  * @availability stack since=7.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesRequest.ts
+++ b/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesRequest.ts
@@ -23,6 +23,7 @@ import { Name } from '@_types/common'
 /**
  * @rest_spec_name security.clear_cached_privileges
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/clear_cached_realms/SecurityClearCachedRealmsRequest.ts
+++ b/specification/security/clear_cached_realms/SecurityClearCachedRealmsRequest.ts
@@ -23,6 +23,7 @@ import { Names } from '@_types/common'
 /**
  * @rest_spec_name security.clear_cached_realms
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/clear_cached_roles/ClearCachedRolesRequest.ts
+++ b/specification/security/clear_cached_roles/ClearCachedRolesRequest.ts
@@ -23,6 +23,7 @@ import { Names } from '@_types/common'
 /**
  * @rest_spec_name security.clear_cached_roles
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensRequest.ts
+++ b/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensRequest.ts
@@ -23,6 +23,7 @@ import { Names, Namespace, Service } from '@_types/common'
 /**
  * @rest_spec_name security.clear_cached_service_tokens
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
+++ b/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
@@ -26,6 +26,7 @@ import { RoleDescriptor } from '@security/_types/RoleDescriptor'
 /**
  * @rest_spec_name security.create_api_key
  * @availability stack since=6.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/security/create_service_token/CreateServiceTokenRequest.ts
+++ b/specification/security/create_service_token/CreateServiceTokenRequest.ts
@@ -25,6 +25,7 @@ import { Refresh } from '@_types/common'
  * Creates a service accounts token for access without requiring basic authentication.
  * @rest_spec_name security.create_service_token
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/delete_privileges/SecurityDeletePrivilegesRequest.ts
+++ b/specification/security/delete_privileges/SecurityDeletePrivilegesRequest.ts
@@ -23,6 +23,7 @@ import { Name, Names, Refresh } from '@_types/common'
 /**
  * @rest_spec_name security.delete_privileges
  * @availability stack since=6.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/delete_role/SecurityDeleteRoleRequest.ts
+++ b/specification/security/delete_role/SecurityDeleteRoleRequest.ts
@@ -23,6 +23,7 @@ import { Name, Refresh } from '@_types/common'
 /**
  * @rest_spec_name security.delete_role
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/delete_role_mapping/SecurityDeleteRoleMappingRequest.ts
+++ b/specification/security/delete_role_mapping/SecurityDeleteRoleMappingRequest.ts
@@ -23,6 +23,7 @@ import { Name, Refresh } from '@_types/common'
 /**
  * @rest_spec_name security.delete_role_mapping
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/delete_service_token/DeleteServiceTokenRequest.ts
+++ b/specification/security/delete_service_token/DeleteServiceTokenRequest.ts
@@ -23,6 +23,7 @@ import { Name, Namespace, Refresh, Service } from '@_types/common'
 /**
  * @rest_spec_name security.delete_service_token
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/disable_user_profile/Request.ts
+++ b/specification/security/disable_user_profile/Request.ts
@@ -25,6 +25,7 @@ import { UserProfileId } from '@security/_types/UserProfile'
  * Disables a user profile so it's not visible in user profile searches.
  * @rest_spec_name security.disable_user_profile
  * @availability stack since=8.2.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_user_profile
  */
 export interface Request extends RequestBase {

--- a/specification/security/enable_user_profile/Request.ts
+++ b/specification/security/enable_user_profile/Request.ts
@@ -25,6 +25,7 @@ import { UserProfileId } from '@security/_types/UserProfile'
  * Enables a user profile so it's visible in user profile searches.
  * @rest_spec_name security.enable_user_profile
  * @availability stack since=8.2.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_user_profile
  */
 export interface Request extends RequestBase {

--- a/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
+++ b/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
@@ -23,6 +23,7 @@ import { Id, Name, Username } from '@_types/common'
 /**
  * @rest_spec_name security.get_api_key
  * @availability stack since=6.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
@@ -22,6 +22,7 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name security.get_builtin_privileges
  * @availability stack since=7.3.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_security
  */
 export interface Request extends RequestBase {}

--- a/specification/security/get_privileges/SecurityGetPrivilegesRequest.ts
+++ b/specification/security/get_privileges/SecurityGetPrivilegesRequest.ts
@@ -23,6 +23,7 @@ import { Name, Names } from '@_types/common'
 /**
  * @rest_spec_name security.get_privileges
  * @availability stack since=6.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/get_role/SecurityGetRoleRequest.ts
+++ b/specification/security/get_role/SecurityGetRoleRequest.ts
@@ -25,6 +25,7 @@ import { Names } from '@_types/common'
  * The get roles API cannot retrieve roles that are defined in roles files.
  * @rest_spec_name security.get_role
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_security
  */
 export interface Request extends RequestBase {

--- a/specification/security/get_role_mapping/SecurityGetRoleMappingRequest.ts
+++ b/specification/security/get_role_mapping/SecurityGetRoleMappingRequest.ts
@@ -23,6 +23,7 @@ import { Names } from '@_types/common'
 /**
  * @rest_spec_name security.get_role_mapping
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_security
  */
 export interface Request extends RequestBase {

--- a/specification/security/get_service_accounts/GetServiceAccountsRequest.ts
+++ b/specification/security/get_service_accounts/GetServiceAccountsRequest.ts
@@ -24,6 +24,7 @@ import { Namespace, Service } from '@_types/common'
  * This API returns a list of service accounts that match the provided path parameter(s).
  * @rest_spec_name security.get_service_accounts
  * @availability stack since=7.13.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_service_account
  */
 export interface Request extends RequestBase {

--- a/specification/security/get_service_credentials/GetServiceCredentialsRequest.ts
+++ b/specification/security/get_service_credentials/GetServiceCredentialsRequest.ts
@@ -23,6 +23,7 @@ import { Name, Namespace } from '@_types/common'
 /**
  * @rest_spec_name security.get_service_credentials
  * @availability stack since=7.13.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/get_token/GetUserAccessTokenRequest.ts
+++ b/specification/security/get_token/GetUserAccessTokenRequest.ts
@@ -25,6 +25,7 @@ import { AccessTokenGrantType } from './types'
 /**
  * @rest_spec_name security.get_token
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/get_user_privileges/SecurityGetUserPrivilegesRequest.ts
+++ b/specification/security/get_user_privileges/SecurityGetUserPrivilegesRequest.ts
@@ -23,6 +23,7 @@ import { Name } from '@_types/common'
 /**
  * @rest_spec_name security.get_user_privileges
  * @availability stack since=6.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/security/get_user_profile/Request.ts
+++ b/specification/security/get_user_profile/Request.ts
@@ -24,6 +24,7 @@ import { UserProfileId } from '@security/_types/UserProfile'
  * Retrieves a user's profile using the unique profile ID.
  * @rest_spec_name security.get_user_profile
  * @availability stack since=8.2.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_user_profile
  */
 export interface Request extends RequestBase {

--- a/specification/security/grant_api_key/SecurityGrantApiKeyRequest.ts
+++ b/specification/security/grant_api_key/SecurityGrantApiKeyRequest.ts
@@ -24,6 +24,7 @@ import { GrantApiKey, ApiKeyGrantType } from './types'
 /**
  * @rest_spec_name security.grant_api_key
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/has_privileges/SecurityHasPrivilegesRequest.ts
+++ b/specification/security/has_privileges/SecurityHasPrivilegesRequest.ts
@@ -25,6 +25,7 @@ import { ApplicationPrivilegesCheck, IndexPrivilegesCheck } from './types'
 /**
  * @rest_spec_name security.has_privileges
  * @availability stack since=6.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/has_privileges_user_profile/Request.ts
+++ b/specification/security/has_privileges_user_profile/Request.ts
@@ -24,6 +24,7 @@ import { PrivilegesCheck } from './types'
 /**
  * @rest_spec_name security.has_privileges_user_profile
  * @availability stack since=8.3.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_user_profile
  */
 export interface Request extends RequestBase {

--- a/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
+++ b/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
@@ -23,6 +23,7 @@ import { Id, Name, Username } from '@_types/common'
 /**
  * @rest_spec_name security.invalidate_api_key
  * @availability stack since=6.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/invalidate_token/SecurityInvalidateTokenRequest.ts
+++ b/specification/security/invalidate_token/SecurityInvalidateTokenRequest.ts
@@ -23,6 +23,7 @@ import { Name, Username } from '@_types/common'
 /**
  * @rest_spec_name security.invalidate_token
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/put_privileges/SecurityPutPrivilegesRequest.ts
+++ b/specification/security/put_privileges/SecurityPutPrivilegesRequest.ts
@@ -25,6 +25,7 @@ import { Actions } from './types'
 /**
  * @rest_spec_name security.put_privileges
  * @availability stack since=6.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  *
  */
 export interface Request extends RequestBase {

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -33,6 +33,7 @@ import { Metadata, Name, Refresh } from '@_types/common'
  * The create or update roles API cannot update roles that are defined in roles files.
  * @rest_spec_name security.put_role
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_security
  */
 export interface Request extends RequestBase {

--- a/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
+++ b/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
@@ -24,6 +24,7 @@ import { Metadata, Name, Refresh } from '@_types/common'
 /**
  * @rest_spec_name security.put_role_mapping
  * @availability stack since=5.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -25,6 +25,7 @@ import { Sort, SortResults } from '@_types/sort'
 /**
  * @rest_spec_name security.query_api_keys
  * @availability stack since=7.15.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/security/saml_authenticate/Request.ts
+++ b/specification/security/saml_authenticate/Request.ts
@@ -24,6 +24,7 @@ import { Ids } from '@_types/common'
  * Submits a SAML Response message to Elasticsearch for consumption.
  * @rest_spec_name security.saml_authenticate
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/saml_complete_logout/Request.ts
+++ b/specification/security/saml_complete_logout/Request.ts
@@ -24,6 +24,7 @@ import { Ids } from '@_types/common'
  * Verifies the logout response sent from the SAML IdP.
  * @rest_spec_name security.saml_complete_logout
  * @availability stack since=7.14.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/saml_invalidate/Request.ts
+++ b/specification/security/saml_invalidate/Request.ts
@@ -23,6 +23,7 @@ import { RequestBase } from '@_types/Base'
  * Submits a SAML LogoutRequest message to Elasticsearch for consumption.
  * @rest_spec_name security.saml_invalidate
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/saml_logout/Request.ts
+++ b/specification/security/saml_logout/Request.ts
@@ -23,6 +23,7 @@ import { RequestBase } from '@_types/Base'
  * Submits a request to invalidate an access token and refresh token.
  * @rest_spec_name security.saml_logout
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/saml_prepare_authentication/Request.ts
+++ b/specification/security/saml_prepare_authentication/Request.ts
@@ -23,6 +23,7 @@ import { RequestBase } from '@_types/Base'
  * Creates a SAML authentication request (<AuthnRequest>) as a URL string, based on the configuration of the respective SAML realm in Elasticsearch.
  * @rest_spec_name security.saml_prepare_authentication
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/saml_service_provider_metadata/Request.ts
+++ b/specification/security/saml_service_provider_metadata/Request.ts
@@ -24,6 +24,7 @@ import { Name } from '@_types/common'
  * Generate SAML metadata for a SAML 2.0 Service Provider.
  * @rest_spec_name security.saml_service_provider_metadata
  * @availability stack since=7.11.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/suggest_user_profiles/Request.ts
+++ b/specification/security/suggest_user_profiles/Request.ts
@@ -25,6 +25,7 @@ import { Hint } from './types'
  * Get suggestions for user profiles that match specified search criteria.
  * @rest_spec_name security.suggest_user_profiles
  * @availability stack since=8.2.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/security/update_api_key/Request.ts
+++ b/specification/security/update_api_key/Request.ts
@@ -26,6 +26,7 @@ import { RoleDescriptor } from '@security/_types/RoleDescriptor'
  * Updates attributes of an existing API key.
  * @rest_spec_name security.update_api_key
  * @availability stack since=8.4.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/update_user_profile_data/Request.ts
+++ b/specification/security/update_user_profile_data/Request.ts
@@ -28,6 +28,7 @@ import { UserProfileId } from '@security/_types/UserProfile'
  * Updates specific data for the user profile that's associated with the specified unique ID.
  * @rest_spec_name security.update_user_profile_data
  * @availability stack since=8.2.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_user_profile
  */
 export interface Request extends RequestBase {

--- a/specification/ssl/certificates/GetCertificatesRequest.ts
+++ b/specification/ssl/certificates/GetCertificatesRequest.ts
@@ -22,5 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name ssl.certificates
  * @availability stack since=6.2.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {}

--- a/specification/text_structure/find_structure/FindStructureRequest.ts
+++ b/specification/text_structure/find_structure/FindStructureRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name text_structure.find_structure
  * @availability stack since=7.13.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request<TJsonDocument> {
   query_parameters: {

--- a/specification/transform/delete_transform/DeleteTransformRequest.ts
+++ b/specification/transform/delete_transform/DeleteTransformRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
  * Deletes a transform.
  * @rest_spec_name transform.delete_transform
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
  */
 export interface Request extends RequestBase {

--- a/specification/transform/get_transform/GetTransformRequest.ts
+++ b/specification/transform/get_transform/GetTransformRequest.ts
@@ -25,6 +25,7 @@ import { integer } from '@_types/Numeric'
  * Retrieves configuration information for transforms.
  * @rest_spec_name transform.get_transform
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_transform
  */
 export interface Request extends RequestBase {

--- a/specification/transform/get_transform_stats/GetTransformStatsRequest.ts
+++ b/specification/transform/get_transform_stats/GetTransformStatsRequest.ts
@@ -26,6 +26,7 @@ import { Duration } from '@_types/Time'
  * Retrieves usage information for transforms.
  * @rest_spec_name transform.get_transform_stats
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_transform
  * @index_privileges read, view_index_metadata
  */

--- a/specification/transform/preview_transform/PreviewTransformRequest.ts
+++ b/specification/transform/preview_transform/PreviewTransformRequest.ts
@@ -38,6 +38,7 @@ import { Duration } from '@_types/Time'
  * types of the source index and the transform aggregations.
  * @rest_spec_name transform.preview_transform
  * @availability stack since=7.2.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
  * @index_privileges read, view_index_metadata
  */

--- a/specification/transform/put_transform/PutTransformRequest.ts
+++ b/specification/transform/put_transform/PutTransformRequest.ts
@@ -55,6 +55,7 @@ import { Duration } from '@_types/Time'
  *
  * @rest_spec_name transform.put_transform
  * @availability stack since=7.2.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
  * @index_privileges create_index, read, index, view_index_metadata
  */

--- a/specification/transform/reset_transform/ResetTransformRequest.ts
+++ b/specification/transform/reset_transform/ResetTransformRequest.ts
@@ -26,6 +26,7 @@ import { Id } from '@_types/common'
  * If the destination index was created by the transform, it is deleted.
  * @rest_spec_name transform.reset_transform
  * @availability stack since=8.1.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
  */
 export interface Request extends RequestBase {

--- a/specification/transform/schedule_now_transform/ScheduleNowTransformRequest.ts
+++ b/specification/transform/schedule_now_transform/ScheduleNowTransformRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
  * is called again in the meantime.
  * @rest_spec_name transform.schedule_now_transform
  * @availability stack since=8.7.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
  */
 export interface Request extends RequestBase {

--- a/specification/transform/start_transform/StartTransformRequest.ts
+++ b/specification/transform/start_transform/StartTransformRequest.ts
@@ -40,6 +40,7 @@ import { Duration } from '@_types/Time'
  * destination indices, the transform fails when it attempts unauthorized operations.
  * @rest_spec_name transform.start_transform
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
  * @index_privileges read, view_index_metadata
  */

--- a/specification/transform/stop_transform/StopTransformRequest.ts
+++ b/specification/transform/stop_transform/StopTransformRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
  * Stops one or more transforms.
  * @rest_spec_name transform.stop_transform
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
  */
 export interface Request extends RequestBase {

--- a/specification/transform/update_transform/UpdateTransformRequest.ts
+++ b/specification/transform/update_transform/UpdateTransformRequest.ts
@@ -38,6 +38,7 @@ import { Duration } from '@_types/Time'
  * time of update and runs with those privileges.
  * @rest_spec_name transform.update_transform
  * @availability stack since=7.2.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
  * @index_privileges read, index, view_index_metadata
  */

--- a/specification/transform/upgrade_transforms/UpgradeTransformsRequest.ts
+++ b/specification/transform/upgrade_transforms/UpgradeTransformsRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
  * remains unchanged.
  * @rest_spec_name transform.upgrade_transforms
  * @availability stack since=7.16.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_transform
  */
 export interface Request extends RequestBase {

--- a/specification/xpack/info/XPackInfoRequest.ts
+++ b/specification/xpack/info/XPackInfoRequest.ts
@@ -23,6 +23,7 @@ import { RequestBase } from '@_types/Base'
  * Provides general information about the installed X-Pack features.
  * @rest_spec_name xpack.info
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor,manage
  */
 export interface Request extends RequestBase {


### PR DESCRIPTION
Follow-up from https://github.com/elastic/elasticsearch-specification/pull/2122 using data from the `elastic/elasticsearch` project's current state of annotations on APIs.