### PR TITLE
Added RRF rank parameter to search

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1152,7 +1152,8 @@
     "search": {
       "request": [
         "Request: missing json spec query parameter 'force_synthetic_source'",
-        "Request: missing json spec query parameter 'include_named_queries_score'"
+        "Request: missing json spec query parameter 'include_named_queries_score'",
+        "interface definition _types:RankContainer - Property rrf is a single-variant and must be required"
       ],
       "response": [
         "response definition _global.search:Response / body / instance_of - Non-leaf type cannot be used here: '_global.search:ResponseBody'"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1180,7 +1180,7 @@ export interface SearchRequest extends RequestBase {
     indices_boost?: Record<IndexName, double>[]
     docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
     knn?: KnnQuery | KnnQuery[]
-    rank?: RankQuery
+    rank?: RankContainer
     min_score?: double
     post_filter?: QueryDslQueryContainer
     profile?: boolean
@@ -2437,8 +2437,12 @@ export interface QueryVectorBuilder {
   text_embedding?: TextEmbedding
 }
 
-export interface RankQuery {
-  rrf: RrfType
+export interface RankBase {
+  [key: string]: never
+}
+
+export interface RankContainer {
+  rrf?: RrfRank
 }
 
 export interface RecoveryStats {
@@ -2485,7 +2489,7 @@ export interface Retries {
 
 export type Routing = string
 
-export interface RrfType {
+export interface RrfRank {
   rank_constant?: long
   window_size?: long
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1180,6 +1180,7 @@ export interface SearchRequest extends RequestBase {
     indices_boost?: Record<IndexName, double>[]
     docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
     knn?: KnnQuery | KnnQuery[]
+    rank?: RankQuery
     min_score?: double
     post_filter?: QueryDslQueryContainer
     profile?: boolean
@@ -2436,6 +2437,10 @@ export interface QueryVectorBuilder {
   text_embedding?: TextEmbedding
 }
 
+export interface RankQuery {
+  rrf: RrfType
+}
+
 export interface RecoveryStats {
   current_as_source: long
   current_as_target: long
@@ -2479,6 +2484,11 @@ export interface Retries {
 }
 
 export type Routing = string
+
+export interface RrfType {
+  rank_constant?: long
+  window_size?: long
+}
 
 export interface ScoreSort {
   order?: SortOrder

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -47,6 +47,7 @@ import { TrackHits } from '@global/search/_types/hits'
 import { Operator } from '@_types/query_dsl/Operator'
 import { Sort, SortResults } from '@_types/sort'
 import { KnnQuery } from '@_types/Knn'
+import { RankQuery } from '@_types/Rank'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
@@ -152,6 +153,11 @@ export interface Request extends RequestBase {
      * @since 8.4.0
      */
     knn?: KnnQuery | KnnQuery[]
+    /**
+     * Defines the Reciprocal Rank Fusion (RRF) to use
+     * @since 8.8.0
+     */
+    rank?: RankQuery
     /**
      * Minimum _score for matching documents. Documents with a lower _score are
      * not included in the search results.

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -47,7 +47,7 @@ import { TrackHits } from '@global/search/_types/hits'
 import { Operator } from '@_types/query_dsl/Operator'
 import { Sort, SortResults } from '@_types/sort'
 import { KnnQuery } from '@_types/Knn'
-import { RankQuery } from '@_types/Rank'
+import { RankContainer } from '@_types/Rank'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
@@ -157,7 +157,7 @@ export interface Request extends RequestBase {
      * Defines the Reciprocal Rank Fusion (RRF) to use
      * @since 8.8.0
      */
-    rank?: RankQuery
+    rank?: RankContainer
     /**
      * Minimum _score for matching documents. Documents with a lower _score are
      * not included in the search results.

--- a/specification/_types/Rank.ts
+++ b/specification/_types/Rank.ts
@@ -19,12 +19,17 @@
 
 import { long } from '@_types/Numeric'
 
-export interface RankQuery {
+/**
+ * @variants container
+ */
+export class RankContainer {
   /** The reciprocal rank fusion parameters */
-  rrf: RrfType
+  rrf?: RrfRank
 }
 
-export interface RrfType {
+export class RankBase {}
+
+export class RrfRank extends RankBase {
   /** How much influence documents in individual result sets per query have over the final ranked result set  */
   rank_constant?: long
   /** Size of the individual result sets per query */

--- a/specification/_types/Rank.ts
+++ b/specification/_types/Rank.ts
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { long } from '@_types/Numeric'
+
+export interface RankQuery {
+  /** The reciprocal rank fusion parameters */
+  rrf: RrfType
+}
+
+export interface RrfType {
+  /** How much influence documents in individual result sets per query have over the final ranked result set  */
+  rank_constant?: long
+  /** Size of the individual result sets per query */
+  window_size?: long
+}


### PR DESCRIPTION
This PR adds the `rank` parameter for [Reciprocal Rank Fusion](https://www.elastic.co/guide/en/elasticsearch/reference/8.8/rrf.html) (RRF) to the search API. This parameter has been introduced in 8.8.0.
