### PR TITLE
Add descriptions for final cat APIs

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -358,10 +358,8 @@
     "cat.tasks": {
       "request": [
         "Request: query parameter 'node_id' does not exist in the json spec",
-        "Request: query parameter 'parent_task' does not exist in the json spec",
         "Request: missing json spec query parameter 'format'",
         "Request: missing json spec query parameter 'nodes'",
-        "Request: missing json spec query parameter 'parent_task_id'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",
         "Request: missing json spec query parameter 's'",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -7813,7 +7813,7 @@ export interface CatTasksRequest extends CatCatRequestBase {
   actions?: string[]
   detailed?: boolean
   node_id?: string[]
-  parent_task?: long
+  parent_task_id?: string
 }
 
 export type CatTasksResponse = CatTasksTasksRecord[]

--- a/specification/cat/ml_data_frame_analytics/types.ts
+++ b/specification/cat/ml_data_frame_analytics/types.ts
@@ -21,81 +21,81 @@ import { Id, IndexName, Name, VersionString } from '@_types/common'
 
 export class DataFrameAnalyticsRecord {
   /**
-   * the id
+   * The identifier for the job.
    */
   'id'?: Id
   /**
-   * analysis type
+   * The type of analysis that the job performs.
    * @aliases t
    */
   'type'?: string
   /**
-   * job creation time
+   * The time when the job was created.
    * @aliases ct, createTime
    */
   'create_time'?: string
   /**
-   * the version of Elasticsearch when the analytics was created
+   * The version of Elasticsearch when the job was created.
    * @aliases v
    */
   'version'?: VersionString
   /**
-   * source index
+   * The name of the source index.
    * @aliases si, sourceIndex
    */
   'source_index'?: IndexName
   /**
-   * destination index
+   * The name of the destination index.
    * @aliases di, destIndex
    */
   'dest_index'?: IndexName
   /**
-   * description
+   * A description of the job.
    * @aliases d
    */
   'description'?: string
   /**
-   * model memory limit
+   * The approximate maximum amount of memory resources that are permitted for the job.
    * @aliases mml, modelMemoryLimit
    */
   'model_memory_limit'?: string
   /**
-   * job state
+   * The current status of the job.
    * @aliases s
    */
   'state'?: string
   /**
-   * failure reason
+   * Messages about the reason why the job failed.
    * @aliases fr, failureReason
    */
   'failure_reason'?: string
   /**
-   * progress
+   * The progress report for the job by phase.
    * @aliases p
    */
   'progress'?: string
   /**
-   * why the job is or is not assigned to a node
+   * Messages related to the selection of a node.
    * @aliases ae, assignmentExplanation
    */
   'assignment_explanation'?: string
   /**
-   * id of the assigned node
+   * The unique identifier of the assigned node.
    * @aliases ni, nodeId
    */
   'node.id'?: Id
   /**
-   * name of the assigned node
+   * The name of the assigned node.
    * @aliases nn, nodeName
    */
   'node.name'?: Name
   /**
-   * ephemeral id of the assigned node
+   * The ephemeral identifier of the assigned node.
    * @aliases ne, nodeEphemeralId
    */
   'node.ephemeral_id'?: Id
   /**
-   * network address of the assigned node
+   * The network address of the assigned node.
    * @aliases na, nodeAddress
    */
   'node.address'?: string

--- a/specification/cat/ml_datafeeds/types.ts
+++ b/specification/cat/ml_datafeeds/types.ts
@@ -21,62 +21,66 @@ import { DatafeedState } from '@ml/_types/Datafeed'
 
 export class DatafeedsRecord {
   /**
-   * the datafeed_id
+   * The datafeed identifier.
    */
   'id'?: string
   /**
-   * the datafeed state
+   * The status of the datafeed.
    * @aliases s
    */
   'state'?: DatafeedState
   /**
-   * why the datafeed is or is not assigned to a node
+   * For started datafeeds only, contains messages relating to the selection of a node.
    * @aliases ae
    */
   'assignment_explanation'?: string
   /**
-   * bucket count
+   * The number of buckets processed.
    * @aliases bc, bucketsCount
    */
   'buckets.count'?: string
   /**
-   * number of searches ran by the datafeed
+   * The number of searches run by the datafeed.
    * @aliases sc, searchCount
    */
   'search.count'?: string
   /**
-   * the total search time
+   * The total time the datafeed spent searching, in milliseconds.
    * @aliases st, searchTime
    */
   'search.time'?: string
   /**
-   * the average search time per bucket (millisecond)
+   * The average search time per bucket, in milliseconds.
    * @aliases sba, searchBucketAvg
    */
   'search.bucket_avg'?: string
   /**
-   * the exponential average search time per hour (millisecond)
+   * The exponential average search time per hour, in milliseconds.
    * @aliases seah, searchExpAvgHour
    */
   //Node info
   'search.exp_avg_hour'?: string
   /**
-   * id of the assigned node
+   * The unique identifier of the assigned node.
+   * For started datafeeds only, this information pertains to the node upon which the datafeed is started.
    * @aliases ni, nodeId
    */
   'node.id'?: string
   /**
-   * name of the assigned node
+   * The name of the assigned node.
+   * For started datafeeds only, this information pertains to the node upon which the datafeed is started.
    * @aliases nn, nodeName
    */
   'node.name'?: string
   /**
-   * ephemeral id of the assigned node
+   * The ephemeral identifier of the assigned node.
+   * For started datafeeds only, this information pertains to the node upon which the datafeed is started.
    * @aliases ne, nodeEphemeralId
    */
   'node.ephemeral_id'?: string
   /**
-   * network address of the assigned node
+   * The network address of the assigned node.
+   * For started datafeeds only, this information pertains to the node upon which the datafeed is started.
    * @aliases na, nodeAddress
    */
   'node.address'?: string

--- a/specification/cat/ml_jobs/types.ts
+++ b/specification/cat/ml_jobs/types.ts
@@ -23,302 +23,324 @@ import { ByteSize, Id, NodeId } from '@_types/common'
 
 export class JobsRecord {
   /**
-   * the job_id
+   * The anomaly detection job identifier.
    */
   id?: Id
-
   /**
-   * the job state
+   * The status of the anomaly detection job.
    * @aliases s
    */
   'state'?: JobState
   /**
-   * the amount of time the job has been opened
+   * For open jobs only, the amount of time the job has been opened.
    * @aliases ot
    */
   'opened_time'?: string
   /**
-   * why the job is or is not assigned to a node
+   * For open anomaly detection jobs only, contains messages relating to the selection of a node to run the job.
    * @aliases ae
    */
   'assignment_explanation'?: string
   /**
-   * number of processed records
+   * The number of input documents that have been processed by the anomaly detection job.
+   * This value includes documents with missing fields, since they are nonetheless analyzed.
+   * If you use datafeeds and have aggregations in your search query, the `processed_record_count` is the number of aggregation results processed, not the number of Elasticsearch documents.
    * @aliases dpr, dataProcessedRecords
    */
   'data.processed_records'?: string
   /**
-   * number of processed fields
+   * The total number of fields in all the documents that have been processed by the anomaly detection job.
+   * Only fields that are specified in the detector configuration object contribute to this count.
+   * The timestamp is not included in this count.
    * @aliases dpf, dataProcessedFields
    */
   'data.processed_fields'?: string
   /**
-   * total input bytes
+   * The number of bytes of input data posted to the anomaly detection job.
    * @aliases dib, dataInputBytes
    */
   'data.input_bytes'?: ByteSize
   /**
-   * total record count
+   * The number of input documents posted to the anomaly detection job.
    * @aliases dir, dataInputRecords
    */
   'data.input_records'?: string
   /**
-   * total field count
+   * The total number of fields in input documents posted to the anomaly detection job.
+   * This count includes fields that are not used in the analysis.
+   * However, be aware that if you are using a datafeed, it extracts only the required fields from the documents it retrieves before posting them to the job.
    * @aliases dif, dataInputFields
    */
   'data.input_fields'?: string
   /**
-   * number of records with invalid dates
+   * The number of input documents with either a missing date field or a date that could not be parsed.
    * @aliases did, dataInvalidDates
    */
   'data.invalid_dates'?: string
   /**
-   * number of records with missing fields
+   * The number of input documents that are missing a field that the anomaly detection job is configured to analyze.
+   * Input documents with missing fields are still processed because it is possible that not all fields are missing.
+   * If you are using datafeeds or posting data to the job in JSON format, a high `missing_field_count` is often not an indication of data issues.
+   * It is not necessarily a cause for concern.
    * @aliases dmf, dataMissingFields
    */
   'data.missing_fields'?: string
   /**
-   * number of records handled out of order
+   * The number of input documents that have a timestamp chronologically preceding the start of the current anomaly detection bucket offset by the latency window.
+   * This information is applicable only when you provide data to the anomaly detection job by using the post data API.
+   * These out of order documents are discarded, since jobs require time series data to be in ascending chronological order.
    * @aliases doot, dataOutOfOrderTimestamps
    */
   'data.out_of_order_timestamps'?: string
   /**
-   * number of empty buckets
+   * The number of buckets which did not contain any data.
+   * If your data contains many empty buckets, consider increasing your `bucket_span` or using functions that are tolerant to gaps in data such as mean, `non_null_sum` or `non_zero_count`.
    * @aliases deb, dataEmptyBuckets
    */
   'data.empty_buckets'?: string
   /**
-   * number of sparse buckets
+   * The number of buckets that contained few data points compared to the expected number of data points.
+   * If your data contains many sparse buckets, consider using a longer `bucket_span`.
    * @aliases dsb, dataSparseBuckets
    */
   'data.sparse_buckets'?: string
   /**
-   * total bucket count
+   * The total number of buckets processed.
    * @aliases db, dataBuckets
    */
   'data.buckets'?: string
   /**
-   * earliest record time
+   * The timestamp of the earliest chronologically input document.
    * @aliases der, dataEarliestRecord
    */
   'data.earliest_record'?: string
   /**
-   * latest record time
+   * The timestamp of the latest chronologically input document.
    * @aliases dlr, dataLatestRecord
    */
   'data.latest_record'?: string
   /**
-   * last time data was seen
+   * The timestamp at which data was last analyzed, according to server time.
    * @aliases dl, dataLast
    */
   'data.last'?: string
   /**
-   * last time an empty bucket occurred
+   * The timestamp of the last bucket that did not contain any data.
    * @aliases dleb, dataLastEmptyBucket
    */
   'data.last_empty_bucket'?: string
   /**
-   * last time a sparse bucket occurred
+   * The timestamp of the last bucket that was considered sparse.
    * @aliases dlsb, dataLastSparseBucket
    */
   'data.last_sparse_bucket'?: string
   /**
-   * model size
+   * The number of bytes of memory used by the models.
+   * This is the maximum value since the last time the model was persisted.
+   * If the job is closed, this value indicates the latest size.
    * @aliases mb, modelBytes
    */
   'model.bytes'?: ByteSize
   /**
-   * current memory status
+   * The status of the mathematical models.
    * @aliases mms, modelMemoryStatus
    */
   'model.memory_status'?: MemoryStatus
   /**
-   * how much the model has exceeded the limit
+   * The number of bytes over the high limit for memory usage at the last allocation failure.
    * @aliases mbe, modelBytesExceeded
    */
   'model.bytes_exceeded'?: ByteSize
   /**
-   * model memory limit
+   * The upper limit for model memory usage, checked on increasing values.
    * @aliases mml, modelMemoryLimit
    */
   'model.memory_limit'?: string
   /**
-   * count of 'by' fields
+   * The number of `by` field values that were analyzed by the models.
+   * This value is cumulative for all detectors in the job.
    * @aliases mbf, modelByFields
    */
   'model.by_fields'?: string
   /**
-   * count of 'over' fields
+   * The number of `over` field values that were analyzed by the models.
+   * This value is cumulative for all detectors in the job.
    * @aliases mof, modelOverFields
    */
   'model.over_fields'?: string
   /**
-   * count of 'partition' fields
+   * The number of `partition` field values that were analyzed by the models.
+   * This value is cumulative for all detectors in the job.
    * @aliases mpf, modelPartitionFields
    */
   'model.partition_fields'?: string
   /**
-   * number of bucket allocation failures
+   * The number of buckets for which new entities in incoming data were not processed due to insufficient model memory.
+   * This situation is also signified by a `hard_limit: memory_status` property value.
    * @aliases mbaf, modelBucketAllocationFailures
    */
   'model.bucket_allocation_failures'?: string
   /**
-   * current categorization status
+   * The status of categorization for the job.
    * @aliases mcs, modelCategorizationStatus
    */
   'model.categorization_status'?: CategorizationStatus
   /**
-   * count of categorized documents
+   * The number of documents that have had a field categorized.
    * @aliases mcdc, modelCategorizedDocCount
    */
   'model.categorized_doc_count'?: string
   /**
-   * count of categories
+   * The number of categories created by categorization.
    * @aliases mtcc, modelTotalCategoryCount
    */
   'model.total_category_count'?: string
   /**
-   * count of frequent categories
+   * The number of categories that match more than 1% of categorized documents.
    * @aliases modelFrequentCategoryCount
    */
   'model.frequent_category_count'?: string
   /**
-   * count of rare categories
+   * The number of categories that match just one categorized document.
    * @aliases mrcc, modelRareCategoryCount
    */
   'model.rare_category_count'?: string
   /**
-   * count of dead categories
+   * The number of categories created by categorization that will never be assigned again because another category’s definition makes it a superset of the dead category.
+   * Dead categories are a side effect of the way categorization has no prior training.
    * @aliases mdcc, modelDeadCategoryCount
    */
   'model.dead_category_count'?: string
   /**
-   * count of failed categories
+   * The number of times that categorization wanted to create a new category but couldn’t because the job had hit its `model_memory_limit`.
+   * This count does not track which specific categories failed to be created.
+   * Therefore you cannot use this value to determine the number of unique categories that were missed.
    * @aliases mfcc, modelFailedCategoryCount
    */
   'model.failed_category_count'?: string
   /**
-   * when the model stats were gathered
+   * The timestamp when the model stats were gathered, according to server time.
    * @aliases mlt, modelLogTime
    */
   'model.log_time'?: string
   /**
-   * the time of the last record when the model stats were gathered
+   * The timestamp of the last record when the model stats were gathered.
    * @aliases mt, modelTimestamp
    */
   'model.timestamp'?: string
   /**
-   * total number of forecasts
+   * The number of individual forecasts currently available for the job.
+   * A value of one or more indicates that forecasts exist.
    * @aliases ft, forecastsTotal
    */
   'forecasts.total'?: string
   /**
-   * minimum memory used by forecasts
+   * The minimum memory usage in bytes for forecasts related to the anomaly detection job.
    * @aliases fmmin, forecastsMemoryMin
    */
   'forecasts.memory.min'?: string
   /**
-   * maximum memory used by forecasts
+   * The maximum memory usage in bytes for forecasts related to the anomaly detection job.
    * @aliases fmmax, forecastsMemoryMax
    */
   'forecasts.memory.max'?: string
   /**
-   * average memory used by forecasts
+   * The average memory usage in bytes for forecasts related to the anomaly detection job.
    * @aliases fmavg, forecastsMemoryAvg
    */
   'forecasts.memory.avg'?: string
   /**
-   * total memory used by all forecasts
+   * The total memory usage in bytes for forecasts related to the anomaly detection job.
    * @aliases fmt, forecastsMemoryTotal
    */
   'forecasts.memory.total'?: string
   /**
-   * minimum record count for forecasts
+   * The minimum number of `model_forecast` documents written for forecasts related to the anomaly detection job.
    * @aliases frmin, forecastsRecordsMin
    */
   'forecasts.records.min'?: string
   /**
-   * maximum record count for forecasts
+   * The maximum number of `model_forecast` documents written for forecasts related to the anomaly detection job.
    * @aliases frmax, forecastsRecordsMax
    */
   'forecasts.records.max'?: string
   /**
-   * average record count for forecasts
+   * The average number of `model_forecast` documents written for forecasts related to the anomaly detection job.
    * @aliases fravg, forecastsRecordsAvg
    */
   'forecasts.records.avg'?: string
   /**
-   * total record count for all forecasts
+   * The total number of `model_forecast` documents written for forecasts related to the anomaly detection job.
    * @aliases frt, forecastsRecordsTotal
    */
   'forecasts.records.total'?: string
   /**
-   * minimum runtime for forecasts
+   * The minimum runtime in milliseconds for forecasts related to the anomaly detection job.
    * @aliases ftmin, forecastsTimeMin
    */
   'forecasts.time.min'?: string
   /**
-   * maximum run time for forecasts
+   * The maximum runtime in milliseconds for forecasts related to the anomaly detection job.
    * @aliases ftmax, forecastsTimeMax
    */
   'forecasts.time.max'?: string
   /**
-   * average runtime for all forecasts (milliseconds)
+   * The average runtime in milliseconds for forecasts related to the anomaly detection job.
    * @aliases ftavg, forecastsTimeAvg
    */
   'forecasts.time.avg'?: string
   /**
-   * total runtime for all forecasts
+   * The total runtime in milliseconds for forecasts related to the anomaly detection job.
    * @aliases ftt, forecastsTimeTotal
    */
   'forecasts.time.total'?: string
   /**
-   * id of the assigned node
+   * The uniqe identifier of the assigned node.
    * @aliases ni, nodeId
    */
   'node.id'?: NodeId
   /**
-   * name of the assigned node
+   * The name of the assigned node.
    * @aliases nn, nodeName
    */
   'node.name'?: string
   /**
-   * ephemeral id of the assigned node
+   * The ephemeral identifier of the assigned node.
    * @aliases ne, nodeEphemeralId
    */
   'node.ephemeral_id'?: NodeId
   /**
-   * network address of the assigned node
+   * The network address of the assigned node.
    * @aliases na, nodeAddress
    */
   'node.address'?: string
   /**
-   * bucket count
+   * The number of bucket results produced by the job.
    * @aliases bc, bucketsCount
    */
   'buckets.count'?: string
   /**
-   * total bucket processing time
+   * The sum of all bucket processing times, in milliseconds.
    * @aliases btt, bucketsTimeTotal
    */
   'buckets.time.total'?: string
   /**
-   * minimum bucket processing time
+   * The minimum of all bucket processing times, in milliseconds.
    * @aliases btmin, bucketsTimeMin
    */
   'buckets.time.min'?: string
   /**
-   * maximum bucket processing time
+   * The maximum of all bucket processing times, in milliseconds.
    * @aliases btmax, bucketsTimeMax
    */
   'buckets.time.max'?: string
   /**
-   * exponential average bucket processing time (milliseconds)
+   * The exponential moving average of all bucket processing times, in milliseconds.
    * @aliases btea, bucketsTimeExpAvg
    */
   'buckets.time.exp_avg'?: string
   /**
-   * exponential average bucket processing time by hour (milliseconds)
+   * The exponential moving average of bucket processing times calculated in a one hour time window, in milliseconds.
    * @aliases bteah, bucketsTimeExpAvgHour
    */
   'buckets.time.exp_avg_hour'?: string

--- a/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
+++ b/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
@@ -32,17 +32,32 @@ import { integer } from '@_types/Numeric'
  * @availability stack since=7.7.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_id cat-trained-model
+ * @cluster_privileges monitor_ml
  */
 export interface Request extends CatRequestBase {
   path_parts: {
+    /**
+     * A unique identifier for the trained model.
+     */
     model_id?: Id
   }
   query_parameters: {
+    /**
+     * Specifies what to do when the request: contains wildcard expressions and there are no models that match; contains the `_all` string or no identifiers and there are no matches; contains wildcard expressions and there are only partial matches.
+     * If `true`, the API returns an empty array when there are no matches and the subset of results when there are partial matches.
+     * If `false`, the API returns a 404 status code when there are no matches or only partial matches.
+     * @server_default true
+     */
     allow_no_match?: boolean
+    /** The unit used to display byte values. */
     bytes?: Bytes
+    /** A comma-separated list of column names to display. */
     h?: CatTrainedModelsColumns
+    /** A comma-separated list of column names or aliases used to sort the response. */
     s?: CatTrainedModelsColumns
+    /** Skips the specified number of transforms. */
     from?: integer
+    /** The maximum number of transforms to display. */
     size?: integer
   }
 }

--- a/specification/cat/ml_trained_models/types.ts
+++ b/specification/cat/ml_trained_models/types.ts
@@ -22,87 +22,88 @@ import { DateTime } from '@_types/Time'
 
 export class TrainedModelsRecord {
   /**
-   * the trained model id
+   * The model identifier.
    */
   'id'?: Id
   /**
-   * who created the model
+   * Information about the creator of the model.
    * @aliases c, createdBy
    */
   'created_by'?: string
   /**
-   * the estimated heap size to keep the model in memory
+   * The estimated heap size to keep the model in memory.
    * @aliases hs,modelHeapSize
    */
   'heap_size'?: ByteSize
   /**
-   * the estimated number of operations to use the model
+   * The estimated number of operations to use the model.
+   * This number helps to measure the computational complexity of the model.
    * @aliases o, modelOperations
    */
   'operations'?: string
   /**
-   * The license level of the model
+   * The license level of the model.
    * @aliases l
    */
   'license'?: string
   /**
-   * The time the model was created
+   * The time the model was created.
    * @aliases ct
    */
   'create_time'?: DateTime
   /**
-   * The version of Elasticsearch when the model was created
+   * The version of Elasticsearch when the model was created.
    * @aliases v
    */
   'version'?: VersionString
   /**
-   * The model description
+   * A description of the model.
    * @aliases d
    */
   'description'?: string
   /**
-   * The number of pipelines referencing the model
+   * The number of pipelines that are referencing the model.
    * @aliases ip, ingestPipelines
    */
   'ingest.pipelines'?: string
   /**
-   * The total number of docs processed by the model
+   * The total number of documents that are processed by the model.
    * @aliases ic, ingestCount
    */
   'ingest.count'?: string
   /**
-   * The total time spent processing docs with this model
+   * The total time spent processing documents with thie model.
    * @aliases it, ingestTime
    */
   'ingest.time'?: string
   /**
-   * The total documents currently being handled by the model
+   * The total number of documents that are currently being handled by the model.
    * @aliases icurr, ingestCurrent
    */
   'ingest.current'?: string
   /**
-   * The total count of failed ingest attempts with this model
+   * The total number of failed ingest attempts with the model.
    * @aliases if, ingestFailed
    */
   'ingest.failed'?: string
-
   /**
-   * The data frame analytics config id that created the model (if still available)
+   * The identifier for the data frame analytics job that created the model.
+   * Only displayed if the job is still available.
    * @aliases dfid, dataFrameAnalytics
    */
   'data_frame.id'?: string
   /**
-   * The time the data frame analytics config was created
+   * The time the data frame analytics job was created.
    * @aliases dft, dataFrameAnalyticsTime
    */
   'data_frame.create_time'?: string
   /**
-   * The source index used to train in the data frame analysis
+   * The source index used to train in the data frame analysis.
    * @aliases dfsi, dataFrameAnalyticsSrcIndex
    */
   'data_frame.source_index'?: string
   /**
-   * The analysis used by the data frame to build the model
+   * The analysis used by the data frame to build the model.
    * @aliases dfa, dataFrameAnalyticsAnalysis
    */
   'data_frame.analysis'?: string

--- a/specification/cat/nodes/types.ts
+++ b/specification/cat/nodes/types.ts
@@ -498,7 +498,6 @@ export class NodesRecord {
    * @aliases sfbm,fixedBitsetMemory
    */
   'segments.fixed_bitset_memory'?: string
-
   /**
    * The number of current suggest operations.
    * @aliases suc,suggestCurrent

--- a/specification/cat/segments/CatSegmentsRequest.ts
+++ b/specification/cat/segments/CatSegmentsRequest.ts
@@ -21,16 +21,29 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { Bytes, Indices } from '@_types/common'
 
 /**
+ * Returns low-level information about the Lucene segments in index shards.
+ * For data streams, the API returns information about the backing indices.
+ * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index segments API.
  * @rest_spec_name cat.segments
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @doc_id cat-segments
+ * @cluster_privileges monitor
+ * @index_privileges monitor
  */
 export interface Request extends CatRequestBase {
   path_parts: {
+    /**
+     * A comma-separated list of data streams, indices, and aliases used to limit the request.
+     * Supports wildcards (`*`).
+     * To target all data streams and indices, omit this parameter or use `*` or `_all`.
+     */
     index?: Indices
   }
   query_parameters: {
+    /**
+     * The unit used to display byte values.
+     */
     bytes?: Bytes
   }
 }

--- a/specification/cat/segments/types.ts
+++ b/specification/cat/segments/types.ts
@@ -21,75 +21,86 @@ import { ByteSize, IndexName, NodeId, VersionString } from '@_types/common'
 
 export class SegmentsRecord {
   /**
-   * index name
+   * The index name.
    * @aliases i, idx
    */
   'index'?: IndexName
   /**
-   * shard name
+   * The shard name.
    * @aliases s, sh
    */
   'shard'?: string
   /**
-   * primary or replica
+   * The shard type. Returned values are `primary` or `replica`.
    * @aliases p,pr,primaryOrReplica
    */
   'prirep'?: string
   /**
-   * ip of node where it lives
+   * The IP address of the node where it lives.
    */
   'ip'?: string
   /**
-   * unique id of node where it lives
+   * The unique identifier of the node where it lives.
    */
   'id'?: NodeId
   /**
-   * segment name
+   * The segment name, which is derived from the segment generation and used internally to create file names in the directory of the shard.
    * @aliases seg
    */
   'segment'?: string
   /**
-   * segment generation
+   * The segment generation number.
+   * Elasticsearch increments this generation number for each segment written then uses this number to derive the segment name.
    * @aliases g,gen
    */
   'generation'?: string
   /**
-   * number of docs in segment
+   * The number of documents in the segment.
+   * This excludes deleted documents and counts any nested documents separately from their parents.
+   * It also excludes documents which were indexed recently and do not yet belong to a segment.
    * @aliases dc,docsCount
    */
   'docs.count'?: string
   /**
-   * number of deleted docs in segment
+   * The number of deleted documents in the segment, which might be higher or lower than the number of delete operations you have performed.
+   * This number excludes deletes that were performed recently and do not yet belong to a segment.
+   * Deleted documents are cleaned up by the automatic merge process if it makes sense to do so.
+   * Also, Elasticsearch creates extra deleted documents to internally track the recent history of operations on a shard.
    * @aliases dd,docsDeleted
    */
   'docs.deleted'?: string
   /**
-   * segment size in bytes
+   * The segment size in bytes.
    * @aliases si
    */
   'size'?: ByteSize
   /**
-   * segment memory in bytes
+   * The segment memory in bytes.
+   * A value of `-1` indicates Elasticsearch was unable to compute this number.
    * @aliases sm,sizeMemory
    */
   'size.memory'?: ByteSize
   /**
-   * is segment committed
+   * If `true`, the segment is synced to disk.
+   * Segments that are synced can survive a hard reboot.
+   * If `false`, the data from uncommitted segments is also stored in the transaction log so that Elasticsearch is able to replay changes on the next start.
    * @aliases ic,isCommitted
    */
   'committed'?: string
   /**
-   * is segment searched
+   * If `true`, the segment is searchable.
+   * If `false`, the segment has most likely been written to disk but needs a refresh to be searchable.
    * @aliases is,isSearchable
    */
   'searchable'?: string
   /**
-   * version
+   * The version of Lucene used to write the segment.
    * @aliases v
    */
   'version'?: VersionString
   /**
-   * is segment compound
+   * If `true`, the segment is stored in a compound file.
+   * This means Lucene merged all files from the segment in a single file to save file descriptors.
    * @aliases ico,isCompound
    */
   'compound'?: string

--- a/specification/cat/segments/types.ts
+++ b/specification/cat/segments/types.ts
@@ -31,7 +31,7 @@ export class SegmentsRecord {
    */
   'shard'?: string
   /**
-   * The shard type. Returned values are `primary` or `replica`.
+   * The shard type: `primary` or `replica`.
    * @aliases p,pr,primaryOrReplica
    */
   'prirep'?: string

--- a/specification/cat/shards/CatShardsRequest.ts
+++ b/specification/cat/shards/CatShardsRequest.ts
@@ -21,16 +21,29 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { Bytes, Indices } from '@_types/common'
 
 /**
+ * Returns information about the shards in a cluster.
+ * For data streams, the API returns information about the backing indices.
+ * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.
  * @rest_spec_name cat.shards
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @doc_id cat-shards
+ * @cluster_privileges monitor
+ * @index_privileges monitor
  */
 export interface Request extends CatRequestBase {
   path_parts: {
+    /**
+     * A comma-separated list of data streams, indices, and aliases used to limit the request.
+     * Supports wildcards (`*`).
+     * To target all data streams and indices, omit this parameter or use `*` or `_all`.
+     */
     index?: Indices
   }
   query_parameters: {
+    /**
+     * The unit used to display byte values.
+     */
     bytes?: Bytes
   }
 }

--- a/specification/cat/shards/types.ts
+++ b/specification/cat/shards/types.ts
@@ -19,377 +19,402 @@
 
 export class ShardsRecord {
   /**
-   * index name
+   * The index name.
    * @aliases i,idx
    */
   'index'?: string
   /**
-   * shard name
+   * The shard name.
    * @aliases s,sh
    */
   'shard'?: string
   /**
-   * primary or replica
+   * The shard type: `primary` or `replica`.
    * @aliases p,pr,primaryOrReplica
    */
   'prirep'?: string
   /**
-   * shard state
+   * The shard state.
+   * Returned values include:
+   * `INITIALIZING`: The shard is recovering from a peer shard or gateway.
+   * `RELOCATING`: The shard is relocating.
+   * `STARTED`: The shard has started.
+   * `UNASSIGNED`: The shard is not assigned to any node.
    * @aliases st
    */
   'state'?: string
   /**
-   * number of docs in shard
+   * The number of documents in the shard.
    * @aliases d,dc
    */
   'docs'?: string | null
   /**
-   * store size of shard (how much disk it uses)
+   * The disk space used by the shard.
    * @aliases sto
    */
   'store'?: string | null
   /**
-   * ip of node where it lives
+   * The IP address of the node.
    */
   'ip'?: string | null
   /**
-   * unique id of node where it lives
+   * The unique identifier for the node.
    */
   'id'?: string
   /**
-   * name of node where it lives
+   * The name of node.
    * @aliases n
    */
   'node'?: string | null
   /**
-   * sync id
+   * The sync identifier.
    */
   'sync_id'?: string
   /**
-   * reason shard is unassigned
+   * The reason for the last change to the state of an unassigned shard.
+   * It does not explain why the shard is currently unassigned; use the cluster allocation explain API for that information.
+   * Returned values include:
+   * `ALLOCATION_FAILED`: Unassigned as a result of a failed allocation of the shard.
+   * `CLUSTER_RECOVERED`: Unassigned as a result of a full cluster recovery.
+   * `DANGLING_INDEX_IMPORTED`: Unassigned as a result of importing a dangling index.
+   * `EXISTING_INDEX_RESTORED`: Unassigned as a result of restoring into a closed index.
+   * `FORCED_EMPTY_PRIMARY`: The shard’s allocation was last modified by forcing an empty primary using the cluster reroute API.
+   * `INDEX_CLOSED`: Unassigned because the index was closed.
+   * `INDEX_CREATED`: Unassigned as a result of an API creation of an index.
+   * `INDEX_REOPENED`: Unassigned as a result of opening a closed index.
+   * `MANUAL_ALLOCATION`: The shard’s allocation was last modified by the cluster reroute API.
+   * `NEW_INDEX_RESTORED`: Unassigned as a result of restoring into a new index.
+   * `NODE_LEFT`: Unassigned as a result of the node hosting it leaving the cluster.
+   * `NODE_RESTARTING`: Similar to `NODE_LEFT`, except that the node was registered as restarting using the node shutdown API.
+   * `PRIMARY_FAILED`: The shard was initializing as a replica, but the primary shard failed before the initialization completed.
+   * `REALLOCATED_REPLICA`: A better replica location is identified and causes the existing replica allocation to be cancelled.
+   * `REINITIALIZED`: When a shard moves from started back to initializing.
+   * `REPLICA_ADDED`: Unassigned as a result of explicit addition of a replica.
+   * `REROUTE_CANCELLED`: Unassigned as a result of explicit cancel reroute command.
    * @aliases ur
    */
   'unassigned.reason'?: string
   /**
-   * time shard became unassigned (UTC)
+   * The time at which the shard became unassigned in Coordinated Universal Time (UTC).
    * @aliases ua
    */
   'unassigned.at'?: string
   /**
-   * time has been unassigned
+   * The time at which the shard was requested to be unassigned in Coordinated Universal Time (UTC).
    * @aliases uf
    */
   'unassigned.for'?: string
   /**
-   * additional details as to why the shard became unassigned
+   * Additional details as to why the shard became unassigned.
+   * It does not explain why the shard is not assigned; use the cluster allocation explain API for that information.
    * @aliases ud
    */
   'unassigned.details'?: string
   /**
-   * recovery source type
+   * The type of recovery source.
    * @aliases rs
    */
   'recoverysource.type'?: string
   /**
-   * size of completion
+   * The size of completion.
    * @aliases cs,completionSize
    */
   'completion.size'?: string
   /**
-   * used fielddata cache
+   * The used fielddata cache memory.
    * @aliases fm,fielddataMemory
    */
   'fielddata.memory_size'?: string
   /**
-   * fielddata evictions
+   * The fielddata cache evictions.
    * @aliases fe,fielddataEvictions
    */
   'fielddata.evictions'?: string
   /**
-   * used query cache
+   * The used query cache memory.
    * @aliases qcm,queryCacheMemory
    */
   'query_cache.memory_size'?: string
   /**
-   * query cache evictions
+   * The query cache evictions.
    * @aliases qce,queryCacheEvictions
    */
   'query_cache.evictions'?: string
   /**
-   * number of flushes
+   * The number of flushes.
    * @aliases ft,flushTotal
    */
   'flush.total'?: string
   /**
-   * time spent in flush
+   * The time spent in flush.
    * @aliases ftt,flushTotalTime
    */
   'flush.total_time'?: string
   /**
-   * number of current get ops
+   * The number of current get operations.
    * @aliases gc,getCurrent
    */
   'get.current'?: string
   /**
-   * time spent in get
+   * The time spent in get operations.
    * @aliases gti,getTime
    */
   'get.time'?: string
   /**
-   * number of get ops
+   * The number of get operations.
    * @aliases gto,getTotal
    */
   'get.total'?: string
   /**
-   * time spent in successful gets
+   * The time spent in successful get operations.
    * @aliases geti,getExistsTime
    */
   'get.exists_time'?: string
   /**
-   * number of successful gets
+   * The number of successful get operations.
    * @aliases geto,getExistsTotal
    */
   'get.exists_total'?: string
   /**
-   * time spent in failed gets
+   * The time spent in failed get operations.
    * @aliases gmti,getMissingTime
    */
   'get.missing_time'?: string
   /**
-   * number of failed gets
+   * The number of failed get operations.
    * @aliases gmto,getMissingTotal
    */
   'get.missing_total'?: string
   /**
-   * number of current deletions
+   * The number of current deletion operations.
    * @aliases idc,indexingDeleteCurrent
    */
   'indexing.delete_current'?: string
   /**
-   * time spent in deletions
+   * The time spent in deletion operations.
    * @aliases idti,indexingDeleteTime
    */
   'indexing.delete_time'?: string
   /**
-   * number of delete ops
+   * The number of delete operations.
    * @aliases idto,indexingDeleteTotal
    */
   'indexing.delete_total'?: string
   /**
-   * number of current indexing ops
+   * The number of current indexing operations.
    * @aliases iic,indexingIndexCurrent
    */
   'indexing.index_current'?: string
   /**
-   * time spent in indexing
+   * The time spent in indexing operations.
    * @aliases iiti,indexingIndexTime
    */
   'indexing.index_time'?: string
   /**
-   * number of indexing ops
+   * The number of indexing operations.
    * @aliases iito,indexingIndexTotal
    */
   'indexing.index_total'?: string
   /**
-   * number of failed indexing ops
+   * The number of failed indexing operations.
    * @aliases iif,indexingIndexFailed
    */
   'indexing.index_failed'?: string
   /**
-   * number of current merges
+   * The number of current merge operations.
    * @aliases mc,mergesCurrent
    */
   'merges.current'?: string
   /**
-   * number of current merging docs
+   * The number of current merging documents.
    * @aliases mcd,mergesCurrentDocs
    */
   'merges.current_docs'?: string
   /**
-   * size of current merges
+   * The size of current merge operations.
    * @aliases mcs,mergesCurrentSize
    */
   'merges.current_size'?: string
   /**
-   * number of completed merge ops
+   * The number of completed merge operations.
    * @aliases mt,mergesTotal
    */
   'merges.total'?: string
   /**
-   * docs merged
+   * The nuber of merged documents.
    * @aliases mtd,mergesTotalDocs
    */
   'merges.total_docs'?: string
   /**
-   * size merged
+   * The size of current merges.
    * @aliases mts,mergesTotalSize
    */
   'merges.total_size'?: string
   /**
-   * time spent in merges
+   * The time spent merging documents.
    * @aliases mtt,mergesTotalTime
    */
   'merges.total_time'?: string
   /**
-   * total refreshes
+   * The total number of refreshes.
    */
   'refresh.total'?: string
   /**
-   * time spent in refreshes
+   * The time spent in refreshes.
    */
   'refresh.time'?: string
   /**
-   * total external refreshes
+   * The total nunber of external refreshes.
    * @aliases rto,refreshTotal
    */
   'refresh.external_total'?: string
   /**
-   * time spent in external refreshes
+   * The time spent in external refreshes.
    * @aliases rti,refreshTime
    */
   'refresh.external_time'?: string
   /**
-   * number of pending refresh listeners
+   * The number of pending refresh listeners.
    * @aliases rli,refreshListeners
    */
   'refresh.listeners'?: string
   /**
-   * current fetch phase ops
+   * The current fetch phase operations.
    * @aliases sfc,searchFetchCurrent
    */
   'search.fetch_current'?: string
   /**
-   * time spent in fetch phase
+   * The time spent in fetch phase.
    * @aliases sfti,searchFetchTime
    */
   'search.fetch_time'?: string
   /**
-   * total fetch ops
+   * The total number of fetch operations.
    * @aliases sfto,searchFetchTotal
    */
   'search.fetch_total'?: string
   /**
-   * open search contexts
+   * The number of open search contexts.
    * @aliases so,searchOpenContexts
    */
   'search.open_contexts'?: string
   /**
-   * current query phase ops
+   * The current query phase operations.
    * @aliases sqc,searchQueryCurrent
    */
   'search.query_current'?: string
   /**
-   * time spent in query phase
+   * The time spent in query phase.
    * @aliases sqti,searchQueryTime
    */
   'search.query_time'?: string
   /**
-   * total query phase ops
+   * The total number of query phase operations.
    * @aliases sqto,searchQueryTotal
    */
   'search.query_total'?: string
   /**
-   * open scroll contexts
+   * The open scroll contexts.
    * @aliases scc,searchScrollCurrent
    */
   'search.scroll_current'?: string
   /**
-   * time scroll contexts held open
+   * The time scroll contexts were held open.
    * @aliases scti,searchScrollTime
    */
   'search.scroll_time'?: string
   /**
-   * completed scroll contexts
+   * The number of completed scroll contexts.
    * @aliases scto,searchScrollTotal
    */
   'search.scroll_total'?: string
   /**
-   * number of segments
+   * The number of segments.
    * @aliases sc,segmentsCount
    */
   'segments.count'?: string
   /**
-   * memory used by segments
+   * The memory used by segments.
    * @aliases sm,segmentsMemory
    */
   'segments.memory'?: string
   /**
-   * memory used by index writer
+   * The memory used by the index writer.
    * @aliases siwm,segmentsIndexWriterMemory
    */
   'segments.index_writer_memory'?: string
   /**
-   * memory used by version map
+   * The memory used by the version map.
    * @aliases svmm,segmentsVersionMapMemory
    */
   'segments.version_map_memory'?: string
   /**
-   * memory used by fixed bit sets for nested object field types and export type filters for types referred in _parent fields
+   * The memory used by fixed bit sets for nested object field types and export type filters for types referred in `_parent` fields.
    * @aliases sfbm,fixedBitsetMemory
    */
   'segments.fixed_bitset_memory'?: string
   /**
-   * max sequence number
+   * The maximum sequence number.
    * @aliases sqm,maxSeqNo
    */
   'seq_no.max'?: string
   /**
-   * local checkpoint
+   * The local checkpoint.
    * @aliases sql,localCheckpoint
    */
   'seq_no.local_checkpoint'?: string
   /**
-   * global checkpoint
+   * The global checkpoint.
    * @aliases sqg,globalCheckpoint
    */
   'seq_no.global_checkpoint'?: string
   /**
-   * current warmer ops
+   * The number of current warmer operations.
    * @aliases wc,warmerCurrent
    */
   'warmer.current'?: string
   /**
-   * total warmer ops
+   * The total number of warmer operations.
    * @aliases wto,warmerTotal
    */
   'warmer.total'?: string
   /**
-   * time spent in warmers
+   * The time spent in warmer operations.
    * @aliases wtt,warmerTotalTime
    */
   'warmer.total_time'?: string
   /**
-   * shard data path
+   * The shard data path.
    * @aliases pd,dataPath
    */
   'path.data'?: string
   /**
-   * shard state path
+   * The shard state path.
    * @aliases ps,statsPath
    */
   'path.state'?: string
   /**
-   * number of bulk shard ops
+   * The number of bulk shard operations.
    * @aliases bto,bulkTotalOperations
    */
   'bulk.total_operations'?: string
   /**
-   * time spend in shard bulk
+   * The time spent in shard bulk operations.
    * @aliases btti,bulkTotalTime
    */
   'bulk.total_time'?: string
   /**
-   * total size in bytes of shard bulk
+   * The total size in bytes of shard bulk operations.
    * @aliases btsi,bulkTotalSizeInBytes
    */
   'bulk.total_size_in_bytes'?: string
   /**
-   * average time spend in shard bulk
+   * The average time spent in shard bulk operations.
    * @aliases bati,bulkAvgTime
    */
   'bulk.avg_time'?: string
   /**
-   * avg size in bytes of shard bulk
+   * The average size in bytes of shard bulk operations.
    * @aliases basi,bulkAvgSizeInBytes
    */
   'bulk.avg_size_in_bytes'?: string

--- a/specification/cat/snapshots/CatSnapshotsRequest.ts
+++ b/specification/cat/snapshots/CatSnapshotsRequest.ts
@@ -21,16 +21,30 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { Names } from '@_types/common'
 
 /**
+ * Returns information about the snapshots stored in one or more repositories.
+ * A snapshot is a backup of an index or running Elasticsearch cluster.
+ * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot API.
  * @rest_spec_name cat.snapshots
  * @availability stack since=2.1.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @doc_id cat-snapshots
+ * @cluster_privileges monitor_snapshot
  */
 export interface Request extends CatRequestBase {
   path_parts: {
+    /**
+     * A comma-separated list of snapshot repositories used to limit the request.
+     * Accepts wildcard expressions.
+     * `_all` returns all repositories.
+     * If any repository fails during the request, Elasticsearch returns an error.
+     */
     repository?: Names
   }
   query_parameters: {
+    /**
+     * If `true`, the response does not include information from unavailable snapshots.
+     * @server_default false
+     */
     ignore_unavailable?: boolean
   }
 }

--- a/specification/cat/snapshots/types.ts
+++ b/specification/cat/snapshots/types.ts
@@ -23,67 +23,73 @@ import { Stringified } from '@spec_utils/Stringified'
 
 export class SnapshotsRecord {
   /**
-   * unique snapshot
+   * The unique identifier for the snapshot.
    * @aliases snapshot
    */
   'id'?: string
   /**
-   * repository name
+   * The repository name.
    * @aliases re,repo
    */
   'repository'?: string
   /**
-   * snapshot name
+   * The state of the snapshot process.
+   * Returned values include:
+   * `FAILED`: The snapshot process failed.
+   * `INCOMPATIBLE`: The snapshot process is incompatible with the current cluster version.
+   * `IN_PROGRESS`: The snapshot process started but has not completed.
+   * `PARTIAL`: The snapshot process completed with a partial success.
+   * `SUCCESS`: The snapshot process completed with a full success.
    * @aliases s
    */
   'status'?: string
   /**
-   * start time in seconds since 1970-01-01 00:00:00
+   * The Unix epoch time (seconds since 1970-01-01 00:00:00) at which the snapshot process started.
    * @aliases ste,startEpoch
    */
   'start_epoch'?: Stringified<EpochTime<UnitSeconds>>
   /**
-   * start time in HH:MM:SS
+   * The time (HH:MM:SS) at which the snapshot process started.
    * @aliases sti,startTime
    */
   'start_time'?: ScheduleTimeOfDay
   /**
-   * end time in seconds since 1970-01-01 00:00:00
+   * The Unix epoch time (seconds since 1970-01-01 00:00:00) at which the snapshot process ended.
    * @aliases ete,endEpoch
    */
   'end_epoch'?: Stringified<EpochTime<UnitSeconds>>
   /**
-   * end time in HH:MM:SS
+   * The time (HH:MM:SS) at which the snapshot process ended.
    * @aliases eti,endTime
    */
   'end_time'?: TimeOfDay
   /**
-   * duration
+   * The time it took the snapshot process to complete, in time units.
    * @aliases dur
    */
   'duration'?: Duration
   /**
-   * number of indices
+   * The number of indices in the snapshot.
    * @aliases i
    */
   'indices'?: string
   /**
-   * number of successful shards
+   * The number of successful shards in the snapshot.
    * @aliases ss
    */
   'successful_shards'?: string
   /**
-   * number of failed shards
+   * The number of failed shards in the snapshot.
    * @aliases fs
    */
   'failed_shards'?: string
   /**
-   * number of total shards
+   * The total number of shards in the snapshot.
    * @aliases ts
    */
   'total_shards'?: string
   /**
-   * reason for failures
+   * The reason for any snapshot failures.
    * @aliases r
    */
   'reason'?: string

--- a/specification/cat/tasks/CatTasksRequest.ts
+++ b/specification/cat/tasks/CatTasksRequest.ts
@@ -27,7 +27,6 @@ import { long } from '@_types/Numeric'
  * @availability stack since=5.0.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
  * @doc_id tasks
- * @stability beta
  * @cluster_privileges monitor
  */
 export interface Request extends CatRequestBase {

--- a/specification/cat/tasks/CatTasksRequest.ts
+++ b/specification/cat/tasks/CatTasksRequest.ts
@@ -21,16 +21,29 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { long } from '@_types/Numeric'
 
 /**
+ * Returns information about tasks currently executing in the cluster.
+ * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the task management API.
  * @rest_spec_name cat.tasks
  * @availability stack since=5.0.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
  * @doc_id tasks
+ * @stability beta
+ * @cluster_privileges monitor
  */
 export interface Request extends CatRequestBase {
   query_parameters: {
+    /**
+     * The task action names, which are used to limit the response.
+     */
     actions?: string[]
+    /**
+     * If `true`, the response includes detailed information about shard recoveries.
+     * @server_default false
+     */
     detailed?: boolean
+    /** Unique node identifiers, which are used to limit the response. */
     node_id?: string[]
-    parent_task?: long
+    /** The parent task identifier, which is used to limit the response. */
+    parent_task_id?: string
   }
 }

--- a/specification/cat/tasks/types.ts
+++ b/specification/cat/tasks/types.ts
@@ -21,80 +21,80 @@ import { Id, NodeId, VersionString } from '@_types/common'
 
 export class TasksRecord {
   /**
-   * id of the task with the node
+   * The identifier of the task with the node.
    */
   'id'?: Id
   /**
-   * task action
+   * The task action.
    * @aliases ac
    */
   'action'?: string
   /**
-   * unique task id
+   * The unique task identifier.
    * @aliases ti
    */
   'task_id'?: Id
   /**
-   * parent task id
+   * The parent task identifier.
    * @aliases pti
    */
   'parent_task_id'?: string
   /**
-   * task type
+   * The task type.
    * @aliases ty
    */
   'type'?: string
   /**
-   * start time in ms
+   * The start time in milliseconds.
    * @aliases start
    */
   'start_time'?: string
   /**
-   * start time in HH:MM:SS
+   * The start time in `HH:MM:SS` format.
    * @aliases ts,hms,hhmmss
    */
   'timestamp'?: string
   /**
-   * running time ns
+   * The running time in nanoseconds.
    */
   'running_time_ns'?: string
   /**
-   * running time
+   * The running time.
    * @aliases time
    */
   'running_time'?: string
   /**
-   * unique node id
+   * The unique node identifier.
    * @aliases ni
    */
   'node_id'?: NodeId
   /**
-   * ip address
+   * The IP address for the node.
    * @aliases i
    */
   'ip'?: string
   /**
-   * bound transport port
+   * The bound transport port for the node.
    * @aliases po
    */
   'port'?: string
   /**
-   * node name
+   * The node name.
    * @aliases n
    */
   'node'?: string
   /**
-   * es version
+   * The Elasticsearch version.
    * @aliases v
    */
   'version'?: VersionString
   /**
-   * X-Opaque-ID header
+   * The X-Opaque-ID header.
    * @aliases x
    */
   'x_opaque_id'?: string
   /**
-   * task action
+   * The task action description.
    * @aliases desc
    */
   'description'?: string

--- a/specification/cat/templates/CatTemplatesRequest.ts
+++ b/specification/cat/templates/CatTemplatesRequest.ts
@@ -21,13 +21,21 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { Name } from '@_types/common'
 
 /**
+ * Returns information about index templates in a cluster.
+ * You can use index templates to apply index settings and field mappings to new indices at creation.
+ * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index template API.
  * @rest_spec_name cat.templates
  * @availability stack since=5.2.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @doc_id cat-templates
+ * @cluster_privileges monitor
  */
 export interface Request extends CatRequestBase {
   path_parts: {
+    /**
+     * The name of the template to return.
+     * Accepts wildcard expressions. If omitted, all templates are returned.
+     */
     name?: Name
   }
 }

--- a/specification/cat/templates/types.ts
+++ b/specification/cat/templates/types.ts
@@ -21,27 +21,27 @@ import { Name, VersionString } from '@_types/common'
 
 export class TemplatesRecord {
   /**
-   * template name
+   * The template name.
    * @aliases n
    */
   'name'?: Name
   /**
-   * template index patterns
+   * The template index patterns.
    * @aliases t
    */
   'index_patterns'?: string
   /**
-   * template application order/priority number
+   * The template application order or priority number.
    * @aliases o,p
    */
   'order'?: string
   /**
-   * version
+   * The template version.
    * @aliases v
    */
   'version'?: VersionString | null
   /**
-   * component templates comprising index template
+   * The component templates that comprise the index template.
    * @aliases c
    */
   'composed_of'?: string

--- a/specification/cat/thread_pool/CatThreadPoolRequest.ts
+++ b/specification/cat/thread_pool/CatThreadPoolRequest.ts
@@ -22,21 +22,26 @@ import { Names } from '@_types/common'
 import { TimeUnit } from '@_types/Time'
 
 /**
+ * Returns thread pool statistics for each node in a cluster.
+ * Returned information includes all built-in thread pools and custom thread pools.
+ * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.
  * @rest_spec_name cat.thread_pool
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @doc_id cat-thread-pool
+ * @cluster_privileges monitor
  */
 export interface Request extends CatRequestBase {
   path_parts: {
     /**
-     * List of thread pool names used to limit the request. Accepts wildcard expressions.
+     * A comma-separated list of thread pool names used to limit the request.
+     * Accepts wildcard expressions.
      */
     thread_pool_patterns?: Names
   }
   query_parameters: {
     /**
-     * Unit used to display time values.
+     * The unit used to display time values.
      */
     time?: TimeUnit
   }

--- a/specification/cat/thread_pool/types.ts
+++ b/specification/cat/thread_pool/types.ts
@@ -21,102 +21,103 @@ import { NodeId } from '@_types/common'
 
 export class ThreadPoolRecord {
   /**
-   * node name
+   * The node name.
    * @aliases nn
    */
   'node_name'?: string
   /**
-   * persistent node id
+   * The persistent node identifier.
    * @aliases id
    */
   'node_id'?: NodeId
   /**
-   * ephemeral node id
+   * The ephemeral node identifier.
    * @aliases eid
    */
   'ephemeral_node_id'?: string
   /**
-   * process id
+   * The process identifier.
    * @aliases p
    */
   'pid'?: string
   /**
-   * host name
+   * The host name for the current node.
    * @aliases h
    */
   'host'?: string
   /**
-   * ip address
+   * The IP address for the current node.
    * @aliases i
    */
   'ip'?: string
   /**
-   * bound transport port
+   * The bound transport port for the current node.
    * @aliases po
    */
   'port'?: string
   /**
-   * thread pool name
+   * The thread pool name.
    * @aliases n
    */
   'name'?: string
   /**
-   * thread pool type
+   * The thread pool type.
+   * Returned values include `fixed`, `fixed_auto_queue_size`, `direct`, and `scaling`.
    * @aliases t
    */
   'type'?: string
   /**
-   * number of active threads
+   * The number of active threads in the current thread pool.
    * @aliases a
    */
   'active'?: string
   /**
-   * number of threads
+   * The number of threads in the current thread pool.
    * @aliases psz
    */
   'pool_size'?: string
   /**
-   * number of tasks currently in queue
+   * The number of tasks currently in queue.
    * @aliases q
    */
   'queue'?: string
   /**
-   * maximum number of tasks permitted in queue
+   * The maximum number of tasks permitted in the queue.
    * @aliases qs
    */
   'queue_size'?: string
   /**
-   * number of rejected tasks
+   * The number of rejected tasks.
    * @aliases r
    */
   'rejected'?: string
   /**
-   * highest number of seen active threads
+   * The highest number of active threads in the current thread pool.
    * @aliases l
    */
   'largest'?: string
   /**
-   * number of completed tasks
+   * The number of completed tasks.
    * @aliases c
    */
   'completed'?: string
   /**
-   * core number of threads in a scaling thread pool
+   * The core number of active threads allowed in a scaling thread pool.
    * @aliases cr
    */
   'core'?: string | null
   /**
-   * maximum number of threads in a scaling thread pool
+   * The maximum number of active threads allowed in a scaling thread pool.
    * @aliases mx
    */
   'max'?: string | null
   /**
-   * number of threads in a fixed thread pool
+   * The number of active threads allowed in a fixed thread pool.
    * @aliases sz
    */
   'size'?: string | null
   /**
-   * thread keep alive time
+   * The thread keep alive time.
    * @aliases ka
    */
   'keep_alive'?: string | null

--- a/specification/cat/transforms/CatTransformsRequest.ts
+++ b/specification/cat/transforms/CatTransformsRequest.ts
@@ -33,27 +33,45 @@ import { Duration, TimeUnit } from '@_types/Time'
  * @availability stack since=7.7.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_id cat-transforms
+ * @cluster_privileges monitor_transform
  */
 export interface Request extends CatRequestBase {
   path_parts: {
+    /**
+     * A transform identifier or a wildcard expression.
+     * If you do not specify one of these options, the API returns information for all transforms.
+     */
     transform_id?: Id
   }
   query_parameters: {
+    /**
+     * Specifies what to do when the request: contains wildcard expressions and there are no transforms that match; contains the `_all` string or no identifiers and there are no matches; contains wildcard expressions and there are only partial matches.
+     * If `true`, it returns an empty transforms array when there are no matches and the subset of results when there are partial matches.
+     * If `false`, the request returns a 404 status code when there are no matches or only partial matches.
+     * @server_default true
+     */
     allow_no_match?: boolean
+    /**
+     * Skips the specified number of transforms.
+     * @server_default 0
+     */
     from?: integer
     /**
      * Comma-separated list of column names to display.
-     * @server_default create_time,id,state,type
+     * @server_default changes_last_detection_time,checkpoint,checkpoint_progress,documents_processed,id,last_search_time,state
      */
     h?: CatTransformColumns
-    /** Comma-separated list of column names or column aliases used to sort the
-     * response.
+    /** Comma-separated list of column names or column aliases used to sort the response.
      */
     s?: CatTransformColumns
     /**
-     * Unit used to display time values.
+     * The unit used to display time values.
      */
     time?: TimeUnit
+    /**
+     * The maximum number of transforms to obtain.
+     * @server_default 100
+     */
     size?: integer
   }
 }

--- a/specification/cat/transforms/types.ts
+++ b/specification/cat/transforms/types.ts
@@ -21,166 +21,176 @@ import { Id, VersionString } from '@_types/common'
 
 export class TransformsRecord {
   /**
-   * the id
+   * The transform identifier.
    */
   'id'?: Id
   /**
-   * transform state
+   * The status of the transform.
+   * Returned values include:
+   * `aborting`: The transform is aborting.
+   * `failed: The transform failed. For more information about the failure, check the `reason` field.
+   * `indexing`: The transform is actively processing data and creating new documents.
+   * `started`: The transform is running but not actively indexing data.
+   * `stopped`: The transform is stopped.
+   * `stopping`: The transform is stopping.
    * @aliases s
    */
   'state'?: string
   /**
-   * checkpoint
+   * The sequence number for the checkpoint.
    * @aliases c
    */
   'checkpoint'?: string
   /**
-   * the number of documents read from source indices and processed
+   * The number of documents that have been processed from the source index of the transform.
    * @aliases docp, documentsProcessed
    */
   'documents_processed'?: string
   /**
-   * progress of the checkpoint
+   * The progress of the next checkpoint that is currently in progress.
    * @aliases cp, checkpointProgress
    */
   'checkpoint_progress'?: string | null
   /**
-   * last time transform searched for updates
+   * The timestamp of the last search in the source indices.
+   * This field is shown only if the transform is running.
    * @aliases lst, lastSearchTime
    */
   'last_search_time'?: string | null
   /**
-   * changes last detected time
+   * The timestamp when changes were last detected in the source indices.
    * @aliases cldt
    */
   'changes_last_detection_time'?: string | null
   /**
-   * transform creation time
+   * The time the transform was created.
    * @aliases ct, createTime
    */
   'create_time'?: string
   /**
-   * the version of Elasticsearch when the transform was created
+   * The version of Elasticsearch that existed on the node when the transform was created.
    * @aliases v
    */
   'version'?: VersionString
   /**
-   * source index
+   * The source indices for the transform.
    * @aliases si, sourceIndex
    */
   'source_index'?: string
   /**
-   * destination index
+   * The destination index for the transform.
    * @aliases di, destIndex
    */
   'dest_index'?: string
   /**
-   * transform pipeline
+   * The unique identifier for the ingest pipeline.
    * @aliases p
    */
   'pipeline'?: string
   /**
-   * description
+   * The description of the transform.
    * @aliases d
    */
   'description'?: string
   /**
-   * batch or continuous transform
+   * The type of transform: `batch` or `continuous`.
    * @aliases tt
    */
   'transform_type'?: string
   /**
-   * frequency of transform
+   * The interval between checks for changes in the source indices when the transform is running continuously.
    * @aliases f
    */
   'frequency'?: string
   /**
-   * max page search size
+   * The initial page size that is used for the composite aggregation for each checkpoint.
    * @aliases mpsz
    */
   'max_page_search_size'?: string
   /**
-   * docs per second
+   * The number of input documents per second.
    * @aliases dps
    */
   'docs_per_second'?: string
   /**
-   * reason for the current state
+   * If a transform has a `failed` state, these details describe the reason for failure.
    * @aliases r
    */
   'reason'?: string
   /**
-   * total number of search phases
+   * The total number of search operations on the source index for the transform.
    * @aliases st
    */
   'search_total'?: string
   /**
-   * total number of search failures
+   * The total number of search failures.
    * @aliases sf
    */
   'search_failure'?: string
   /**
-   * total search time
+   * The total amount of search time, in milliseconds.
    * @aliases stime
    */
   'search_time'?: string
   /**
-   * total number of index phases done by the transform
+   * The total number of index operations done by the transform.
    * @aliases it
    */
   'index_total'?: string
   /**
-   * total number of index failures
+   * The total number of indexing failures.
    * @aliases if
    */
   'index_failure'?: string
   /**
-   * total time spent indexing documents
+   * The total time spent indexing documents, in milliseconds.
    * @aliases itime
    */
   'index_time'?: string
   /**
-   * the number of documents written to the destination index
+   * The number of documents that have been indexed into the destination index for the transform.
    * @aliases doci
    */
   'documents_indexed'?: string
   /**
-   * total time spent deleting documents
+   * The total time spent deleting documents, in milliseconds.
    * @aliases dtime
    */
   'delete_time'?: string
   /**
-   * the number of documents deleted from the destination index
+   * The number of documents deleted from the destination index due to the retention policy for the transform.
    * @aliases docd
    */
   'documents_deleted'?: string
   /**
-   * the number of times the transform has been triggered
+   * The number of times the transform has been triggered by the scheduler.
+   * For example, the scheduler triggers the transform indexer to check for updates or ingest new data at an interval specified in the `frequency` property.
    * @aliases tc
    */
   'trigger_count'?: string
   /**
-   * the number of pages processed
+   * The number of search or bulk index operations processed.
+   * Documents are processed in batches instead of individually.
    * @aliases pp
    */
   'pages_processed'?: string
   /**
-   * the total time spent processing documents
+   * The total time spent processing results, in milliseconds.
    * @aliases pt
    */
   'processing_time'?: string
   /**
-   * exponential average checkpoint processing time (milliseconds)
+   * The exponential moving average of the duration of the checkpoint, in milliseconds.
    * @aliases cdtea, checkpointTimeExpAvg
    */
   'checkpoint_duration_time_exp_avg'?: string
   /**
-   * exponential average number of documents indexed
+   * The exponential moving average of the number of new documents that have been indexed.
    * @aliases idea
    */
   'indexed_documents_exp_avg'?: string
   /**
-   * exponential average number of documents processed
+   * The exponential moving average of the number of documents that have been processed.
    * @aliases pdea
    */
   'processed_documents_exp_avg'?: string

--- a/specification/ml/_types/Job.ts
+++ b/specification/ml/_types/Job.ts
@@ -34,10 +34,20 @@ import { ModelSizeStats } from './Model'
 import { Datafeed, DatafeedConfig } from '@ml/_types/Datafeed'
 
 export enum JobState {
+  /** The job close action is in progress and has not yet completed. A closing job cannot accept further data. */
   closing = 0,
+  /** The job finished successfully with its model state persisted. The job must be opened before it can accept further data. */
   closed = 1,
+  /** The job is available to receive and process data. */
   opened = 2,
+  /**
+   * The job did not finish successfully due to an error.
+   * This situation can occur due to invalid input data, a fatal error occurring during the analysis, or an external interaction such as the process being killed by the Linux out of memory (OOM) killer.
+   * If the job had irrevocably failed, it must be force closed and then deleted.
+   * If the datafeed can be corrected, the job can be closed and then re-opened.
+   */
   failed = 3,
+  /** The job open action is in progress and has not yet completed. */
   opening = 4
 }
 


### PR DESCRIPTION
This PR pulls descriptions from these docs:

- https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-segments.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-shards.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-snapshots.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-tasks.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-templates.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-thread-pool.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-trained-model.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-transforms.html

NOTE: I changed `parent_task?: long` to `parent_task_id?: string` in cat tasks due to local tests.