### PR TITLE
Add types for new cluster info api (`_info/<target>`)

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -468,12 +468,6 @@
       ],
       "response": []
     },
-    "cluster.info": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "cluster.post_voting_config_exclusions": {
       "request": [
         "Request: missing json spec query parameter 'master_timeout'"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2037,9 +2037,9 @@ export type Bytes = 'b' | 'kb' | 'mb' | 'gb' | 'tb' | 'pb'
 
 export type CategoryId = string
 
-export type ClusterInfoTarget = 'http' | 'ingest' | 'thread_pool' | 'script'
+export type ClusterInfoTarget = '_all' | 'http' | 'ingest' | 'thread_pool' | 'script'
 
-export type ClusterInfoTargets = '_all' | ClusterInfoTarget | ClusterInfoTarget[]
+export type ClusterInfoTargets = ClusterInfoTarget | ClusterInfoTarget[]
 
 export interface ClusterStatistics {
   skipped: integer

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2039,7 +2039,7 @@ export type CategoryId = string
 
 export type ClusterInfoTarget = 'http' | 'ingest' | 'thread_pool' | 'script'
 
-export type ClusterInfoTargets = '"_all"' | ClusterInfoTarget | ClusterInfoTarget[]
+export type ClusterInfoTargets = '_all' | ClusterInfoTarget | ClusterInfoTarget[]
 
 export interface ClusterStatistics {
   skipped: integer

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2037,6 +2037,10 @@ export type Bytes = 'b' | 'kb' | 'mb' | 'gb' | 'tb' | 'pb'
 
 export type CategoryId = string
 
+export type ClusterInfoTarget = 'http' | 'ingest' | 'thread_pool' | 'script'
+
+export type ClusterInfoTargets = '"_all"' | ClusterInfoTarget | ClusterInfoTarget[]
+
 export interface ClusterStatistics {
   skipped: integer
   successful: integer
@@ -8496,6 +8500,18 @@ export interface ClusterHealthShardHealthStats {
   relocating_shards: integer
   status: HealthStatus
   unassigned_shards: integer
+}
+
+export interface ClusterInfoRequest extends RequestBase {
+  target: ClusterInfoTargets
+}
+
+export interface ClusterInfoResponse {
+  cluster_name: Name
+  http?: NodesHttp
+  ingest?: NodesIngest
+  thread_pool?: Record<string, NodesThreadCount>
+  script?: NodesScripting
 }
 
 export interface ClusterPendingTasksPendingTask {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -49,6 +49,7 @@ indices-component-template,https://www.elastic.co/guide/en/elasticsearch/referen
 voting-config-exclusions,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/voting-config-exclusions.html
 cluster-get-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-get-settings.html
 cluster-health,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-health.html
+cluster-info,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-info.html
 cluster-pending,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-pending.html
 cluster-update-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-update-settings.html
 cluster-remote-info,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-remote-info.html

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -339,3 +339,13 @@ export enum SlicesCalculation {
    */
   auto
 }
+
+
+export enum ClusterInfoTarget {
+  http,
+  ingest,
+  thread_pool,
+  script
+}
+
+export type ClusterInfoTargets = "_all" | ClusterInfoTarget | ClusterInfoTarget[]

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -340,13 +340,7 @@ export enum SlicesCalculation {
   auto
 }
 
-export enum ClusterInfoTarget {
-  http,
-  ingest,
-  thread_pool,
-  script
-}
-
+export type ClusterInfoTarget = 'http' | 'ingest' | 'thread_pool' | 'script'
 export type ClusterInfoTargets =
   | '_all'
   | ClusterInfoTarget

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -341,13 +341,11 @@ export enum SlicesCalculation {
 }
 
 export enum ClusterInfoTarget {
-  http = 'http',
-  ingest = 'ingest',
-  thread_pool = 'thread_pool',
-  script = 'script'
+  _all,
+  http,
+  ingest,
+  thread_pool,
+  script
 }
 
-export type ClusterInfoTargets =
-  | '_all'
-  | ClusterInfoTarget
-  | ClusterInfoTarget[]
+export type ClusterInfoTargets = ClusterInfoTarget | ClusterInfoTarget[]

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -340,7 +340,6 @@ export enum SlicesCalculation {
   auto
 }
 
-
 export enum ClusterInfoTarget {
   http,
   ingest,
@@ -348,4 +347,7 @@ export enum ClusterInfoTarget {
   script
 }
 
-export type ClusterInfoTargets = "_all" | ClusterInfoTarget | ClusterInfoTarget[]
+export type ClusterInfoTargets =
+  | '_all'
+  | ClusterInfoTarget
+  | ClusterInfoTarget[]

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -340,7 +340,13 @@ export enum SlicesCalculation {
   auto
 }
 
-export type ClusterInfoTarget = 'http' | 'ingest' | 'thread_pool' | 'script'
+export enum ClusterInfoTarget {
+  http = 'http',
+  ingest = 'ingest',
+  thread_pool = 'thread_pool',
+  script = 'script'
+}
+
 export type ClusterInfoTargets =
   | '_all'
   | ClusterInfoTarget

--- a/specification/cluster/info/ClusterInfoRequest.ts
+++ b/specification/cluster/info/ClusterInfoRequest.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { ClusterInfoTargets } from '@_types/common'
+
+/**
+ * @rest_spec_name cluster.info
+ * @availability stack since=8.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
+ * @doc_id cluster-info
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /** Limits the information returned to the specific target. Supports a comma-separated list, such as http,ingest. */
+    target: ClusterInfoTargets
+  }
+}

--- a/specification/cluster/info/ClusterInfoResponse.ts
+++ b/specification/cluster/info/ClusterInfoResponse.ts
@@ -18,10 +18,10 @@
  */
 
 import { Name } from '@_types/common'
-import { Http, Ingest, Scripting, ThreadCount,  } from '@nodes/_types/Stats'
+import { Http, Ingest, Scripting, ThreadCount } from '@nodes/_types/Stats'
 import { Dictionary } from '@spec_utils/Dictionary'
 
-// The cluster info response can be filtered by target. Every property needs to 
+// The cluster info response can be filtered by target. Every property needs to
 // be optional to be compliant with the API behaviour
 export class Response {
   body: {

--- a/specification/cluster/info/ClusterInfoResponse.ts
+++ b/specification/cluster/info/ClusterInfoResponse.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Name } from '@_types/common'
+import { Http, Ingest, Scripting, ThreadCount,  } from '@nodes/_types/Stats'
+import { Dictionary } from '@spec_utils/Dictionary'
+
+// The cluster info response can be filtered by target. Every property needs to 
+// be optional to be compliant with the API behaviour
+export class Response {
+  body: {
+    cluster_name: Name
+    http?: Http
+    ingest?: Ingest
+    thread_pool?: Dictionary<string, ThreadCount>
+    script?: Scripting
+  }
+}


### PR DESCRIPTION
<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->

Closes elastic/elasticsearch#96477