### PR TITLE
[DOCS] Update modeling-guide.md

### DIFF
--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -662,21 +662,6 @@ class Foo {
 }
 ```
 
-#### `@stability`
+#### `@stability` and `@visibility`
 
-Use `@availability` instead.
-
-#### `@visibility`
-
-You can mark a request as `public`/`feature_flag`/`private` with this tag (the default is `public`).
-
-```ts
-/**
- * @rest_spec_name namespace.api
- * @availability stack since=7.5.0
- * @visibility private
- */
-export interface Request extends RequestBase {
- ...
-}
-```
+These annotations have been removed, use `@availability` instead.

--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -664,16 +664,7 @@ class Foo {
 
 #### `@stability`
 
-You can mark a class or property of a type as stable/beta/experimental with this tag (the default is stable).
-
-```ts
-class Foo {
-  bar: string
-  /** @stability experimental */
-  baz?: string
-  faz: string
-}
-```
+Use `@availability` instead.
 
 #### `@visibility`
 


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2107

I received an error in https://github.com/elastic/elasticsearch-specification/pull/2139 until I realized that `@stability` is now a property of `@availability`, so I've updated the readme.