### PR TITLE
add posotion to TimeSeriesMetricType

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5221,7 +5221,7 @@ export interface MappingTextProperty extends MappingCorePropertyBase {
   type: 'text'
 }
 
-export type MappingTimeSeriesMetricType = 'gauge' | 'counter' | 'summary' | 'histogram'
+export type MappingTimeSeriesMetricType = 'gauge' | 'counter' | 'summary' | 'histogram' | 'position'
 
 export interface MappingTokenCountProperty extends MappingDocValuesPropertyBase {
   analyzer?: string

--- a/specification/_types/mapping/TimeSeriesMetricType.ts
+++ b/specification/_types/mapping/TimeSeriesMetricType.ts
@@ -21,5 +21,6 @@ export enum TimeSeriesMetricType {
   gauge,
   counter,
   summary,
-  histogram
+  histogram,
+  position
 }


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/93946 added `position` time series metric. This PR updates `TimeSeriesMetricType` to include `position`.