### PR TITLE
Add shards_capacity to health_report

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -521,6 +521,7 @@ export interface HealthReportIndicators {
   repository_integrity?: HealthReportRepositoryIntegrityIndicator
   ilm?: HealthReportIlmIndicator
   slm?: HealthReportSlmIndicator
+  shards_capacity?: HealthReportShardsCapacityIndicator
 }
 
 export interface HealthReportMasterIsStableIndicator extends HealthReportBaseIndicator {
@@ -581,6 +582,20 @@ export interface HealthReportShardsAvailabilityIndicatorDetails {
   started_replicas: long
   unassigned_primaries: long
   unassigned_replicas: long
+}
+
+export interface HealthReportShardsCapacityIndicator extends HealthReportBaseIndicator {
+  details?: HealthReportShardsCapacityIndicatorDetails
+}
+
+export interface HealthReportShardsCapacityIndicatorDetails {
+  data: HealthReportShardsCapacityIndicatorTierDetail
+  frozen: HealthReportShardsCapacityIndicatorTierDetail
+}
+
+export interface HealthReportShardsCapacityIndicatorTierDetail {
+  max_shards_in_cluster: integer
+  current_used_shards?: integer
 }
 
 export interface HealthReportSlmIndicator extends HealthReportBaseIndicator {

--- a/specification/_global/health_report/types.ts
+++ b/specification/_global/health_report/types.ts
@@ -36,6 +36,7 @@ export class Indicators {
   repository_integrity?: RepositoryIntegrityIndicator
   ilm?: IlmIndicator
   slm?: SlmIndicator
+  shards_capacity?: ShardsCapacityIndicator
 }
 
 export class BaseIndicator {
@@ -165,4 +166,20 @@ export class SlmIndicatorDetails {
 export class SlmIndicatorUnhealthyPolicies {
   count: long
   invocations_since_last_success?: Dictionary<string, long>
+}
+
+/** SHARDS_CAPACITY */
+
+export class ShardsCapacityIndicator extends BaseIndicator {
+  details?: ShardsCapacityIndicatorDetails
+}
+
+export class ShardsCapacityIndicatorDetails {
+  data: ShardsCapacityIndicatorTierDetail
+  frozen: ShardsCapacityIndicatorTierDetail
+}
+
+export class ShardsCapacityIndicatorTierDetail {
+  max_shards_in_cluster: integer
+  current_used_shards?: integer
 }


### PR DESCRIPTION
Adds new [`shards_capacity`](https://www.elastic.co/guide/en/elasticsearch/reference/8.8/health-api.html#health-api-response-details-shards-capacity) to the health API.

My first time making a spec change so let me know if I missed anything important here. :pray:

Done per @rudolf's needs mentioned in https://github.com/elastic/kibana/pull/159587#discussion_r1230997505.
