### PR TITLE
Throttling info in DeleteByQueryResponse is optional

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -228,9 +228,9 @@ export interface DeleteByQueryResponse {
   slice_id?: integer
   task?: TaskId
   throttled?: Duration
-  throttled_millis: DurationValue<UnitMillis>
+  throttled_millis?: DurationValue<UnitMillis>
   throttled_until?: Duration
-  throttled_until_millis: DurationValue<UnitMillis>
+  throttled_until_millis?: DurationValue<UnitMillis>
   timed_out?: boolean
   took?: DurationValue<UnitMillis>
   total?: long

--- a/specification/_global/delete_by_query/DeleteByQueryResponse.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryResponse.ts
@@ -34,9 +34,9 @@ export class Response {
     slice_id?: integer
     task?: TaskId
     throttled?: Duration
-    throttled_millis: DurationValue<UnitMillis>
+    throttled_millis?: DurationValue<UnitMillis>
     throttled_until?: Duration
-    throttled_until_millis: DurationValue<UnitMillis>
+    throttled_until_millis?: DurationValue<UnitMillis>
     timed_out?: boolean
     took?: DurationValue<UnitMillis>
     total?: long


### PR DESCRIPTION
As titled. Reported in https://github.com/elastic/elasticsearch-java/issues/413