### PR TITLE
Add descriptions to pending cluster tasks API

### DIFF
--- a/specification/cluster/pending_tasks/ClusterPendingTasksRequest.ts
+++ b/specification/cluster/pending_tasks/ClusterPendingTasksRequest.ts
@@ -21,15 +21,28 @@ import { RequestBase } from '@_types/Base'
 import { Duration } from '@_types/Time'
 
 /**
+ * Returns cluster-level changes (such as create index, update mapping, allocate or fail shard) that have not yet been executed.
+ * NOTE: This API returns a list of any pending updates to the cluster state.
+ * These are distinct from the tasks reported by the Task Management API which include periodic tasks and tasks initiated by the user, such as node stats, search queries, or create index requests.
+ * However, if a user-initiated task such as a create index command causes a cluster state update, the activity of this task might be reported by both task api and pending cluster tasks API.
  * @rest_spec_name cluster.pending_tasks
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges monitor
  * @doc_id cluster-pending
  */
 export interface Request extends RequestBase {
   query_parameters: {
+    /**
+     * If `true`, the request retrieves information from the local node only.
+     * If `false`, information is retrieved from the master node.
+     * @server_default false
+     */
     local?: boolean
-    /** @server_default 30s */
+    /**
+     * Period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s */
     master_timeout?: Duration
   }
 }

--- a/specification/cluster/pending_tasks/types.ts
+++ b/specification/cluster/pending_tasks/types.ts
@@ -21,10 +21,27 @@ import { integer, long } from '@_types/Numeric'
 import { DateTime, Duration, DurationValue, UnitMillis } from '@_types/Time'
 
 export class PendingTask {
+  /** Indicates whether the pending tasks are currently executing or not. */
   executing: boolean
+  /**
+   * The number that represents when the task has been inserted into the task queue.
+   */
   insert_order: integer
+  /**
+   * The priority of the pending task.
+   * The valid priorities in descending priority order are: `IMMEDIATE` > `URGENT` > `HIGH` > `NORMAL` > `LOW` > `LANGUID`.
+   */
   priority: string
+  /**
+   * A general description of the cluster task that may include a reason and origin.
+   */
   source: string
+  /**
+   * The time since the task is waiting for being performed.
+   */
   time_in_queue?: Duration
+  /** 
+   * The time expressed in milliseconds since the task is waiting for being performed.
+   */
   time_in_queue_millis: DurationValue<UnitMillis>
 }

--- a/specification/cluster/pending_tasks/types.ts
+++ b/specification/cluster/pending_tasks/types.ts
@@ -40,7 +40,7 @@ export class PendingTask {
    * The time since the task is waiting for being performed.
    */
   time_in_queue?: Duration
-  /** 
+  /**
    * The time expressed in milliseconds since the task is waiting for being performed.
    */
   time_in_queue_millis: DurationValue<UnitMillis>


### PR DESCRIPTION
Adds descriptions derived from https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-pending.html