### PR TITLE
fix composite aggregation, terms, histogram, date_histogram and geoti…

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3071,12 +3071,11 @@ export interface AggregationsCompositeAggregation extends AggregationsBucketAggr
 
 export interface AggregationsCompositeAggregationBase {
   field?: Field
-  missing?: AggregationsMissing
-  missing_order?: AggregationsMissingOrder
   missing_bucket?: boolean
+  missing_order?: AggregationsMissingOrder
   script?: Script
-  value_type?: string
-  order: SortOrder
+  value_type?: AggregationsValueType
+  order?: SortOrder
 }
 
 export interface AggregationsCompositeAggregationSource {
@@ -3093,14 +3092,15 @@ export type AggregationsCompositeBucket = AggregationsCompositeBucketKeys
   & { [property: string]: AggregationsAggregate | AggregationsCompositeAggregateKey | long }
 
 export interface AggregationsCompositeDateHistogramAggregation extends AggregationsCompositeAggregationBase {
-  format: string
-  calendar_interval: DurationLarge
+  format?: string
+  calendar_interval?: DurationLarge
+  fixed_interval?: DurationLarge
   offset?: Duration
   time_zone?: TimeZone
 }
 
 export interface AggregationsCompositeGeoTileGridAggregation extends AggregationsCompositeAggregationBase {
-  precision: integer
+  precision?: integer
   bounds?: GeoBounds
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3069,11 +3069,21 @@ export interface AggregationsCompositeAggregation extends AggregationsBucketAggr
   sources?: Record<string, AggregationsCompositeAggregationSource>[]
 }
 
+export interface AggregationsCompositeAggregationBase {
+  field?: Field
+  missing?: AggregationsMissing
+  missing_order?: AggregationsMissingOrder
+  missing_bucket?: boolean
+  script?: Script
+  value_type?: string
+  order: SortOrder
+}
+
 export interface AggregationsCompositeAggregationSource {
-  terms?: AggregationsTermsAggregation
-  histogram?: AggregationsHistogramAggregation
-  date_histogram?: AggregationsDateHistogramAggregation
-  geotile_grid?: AggregationsGeoTileGridAggregation
+  terms?: AggregationsCompositeTermsAggregation
+  histogram?: AggregationsCompositeHistogramAggregation
+  date_histogram?: AggregationsCompositeDateHistogramAggregation
+  geotile_grid?: AggregationsCompositeGeoTileGridAggregation
 }
 
 export interface AggregationsCompositeBucketKeys extends AggregationsMultiBucketBase {
@@ -3081,6 +3091,25 @@ export interface AggregationsCompositeBucketKeys extends AggregationsMultiBucket
 }
 export type AggregationsCompositeBucket = AggregationsCompositeBucketKeys
   & { [property: string]: AggregationsAggregate | AggregationsCompositeAggregateKey | long }
+
+export interface AggregationsCompositeDateHistogramAggregation extends AggregationsCompositeAggregationBase {
+  format: string
+  calendar_interval: DurationLarge
+  offset?: Duration
+  time_zone?: TimeZone
+}
+
+export interface AggregationsCompositeGeoTileGridAggregation extends AggregationsCompositeAggregationBase {
+  precision: integer
+  bounds?: GeoBounds
+}
+
+export interface AggregationsCompositeHistogramAggregation extends AggregationsCompositeAggregationBase {
+  interval: double
+}
+
+export interface AggregationsCompositeTermsAggregation extends AggregationsCompositeAggregationBase {
+}
 
 export interface AggregationsCumulativeCardinalityAggregate extends AggregationsAggregateBase {
   value: long

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -33,10 +33,18 @@ import {
 import { integer, float, long, double } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Script } from '@_types/Scripting'
-import { DateTime, Duration, DateMath, TimeZone } from '@_types/Time'
-import { Buckets } from './Aggregate'
+import {
+  DateTime,
+  Duration,
+  DateMath,
+  TimeZone,
+  DurationLarge
+} from '@_types/Time'
+import { Buckets, TermsAggregateBase } from './Aggregate'
 import { Aggregation } from './Aggregation'
 import { Missing, MissingOrder } from './AggregationContainer'
+import { OverloadOf } from '@spec_utils/behaviors'
+import { Term } from '@global/termvectors/types'
 
 /**
  * Base type for bucket aggregations. These aggregations also accept sub-aggregations.
@@ -130,19 +138,47 @@ export class CompositeAggregationSource {
   /**
    * A terms aggregation.
    */
-  terms?: TermsAggregation
+  terms?: CompositeTermsAggregation
   /**
    * A histogram aggregation.
    */
-  histogram?: HistogramAggregation
+  histogram?: CompositeHistogramAggregation
   /**
    * A date histogram aggregation.
    */
-  date_histogram?: DateHistogramAggregation
+  date_histogram?: CompositeDateHistogramAggregation
   /**
    * A geotile grid aggregation.
    */
-  geotile_grid?: GeoTileGridAggregation
+  geotile_grid?: CompositeGeoTileGridAggregation
+}
+
+export class CompositeAggregationBase {
+  field?: Field
+  missing?: Missing
+  missing_order?: MissingOrder
+  missing_bucket?: boolean
+  script?: Script
+  value_type?: string
+  order: SortOrder
+}
+
+export class CompositeTermsAggregation extends CompositeAggregationBase {}
+
+export class CompositeHistogramAggregation extends CompositeAggregationBase {
+  interval: double
+}
+
+export class CompositeDateHistogramAggregation extends CompositeAggregationBase {
+  format: string
+  calendar_interval: DurationLarge
+  offset?: Duration
+  time_zone?: TimeZone
+}
+
+export class CompositeGeoTileGridAggregation extends CompositeAggregationBase {
+  precision: integer
+  bounds?: GeoBounds
 }
 
 export class DateHistogramAggregation extends BucketAggregationBase {

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -45,6 +45,7 @@ import { Aggregation } from './Aggregation'
 import { Missing, MissingOrder } from './AggregationContainer'
 import { OverloadOf } from '@spec_utils/behaviors'
 import { Term } from '@global/termvectors/types'
+import { ValueType } from '@_types/aggregations/metric'
 
 /**
  * Base type for bucket aggregations. These aggregations also accept sub-aggregations.
@@ -154,13 +155,14 @@ export class CompositeAggregationSource {
 }
 
 export class CompositeAggregationBase {
+  /** Either `field` or `script` must be present */
   field?: Field
-  missing?: Missing
-  missing_order?: MissingOrder
   missing_bucket?: boolean
+  missing_order?: MissingOrder
+  /** Either `field` or `script` must be present */
   script?: Script
-  value_type?: string
-  order: SortOrder
+  value_type?: ValueType
+  order?: SortOrder
 }
 
 export class CompositeTermsAggregation extends CompositeAggregationBase {}
@@ -170,14 +172,17 @@ export class CompositeHistogramAggregation extends CompositeAggregationBase {
 }
 
 export class CompositeDateHistogramAggregation extends CompositeAggregationBase {
-  format: string
-  calendar_interval: DurationLarge
+  format?: string
+  /** Either `calendar_interval` or `fixed_interval` must be present */
+  calendar_interval?: DurationLarge
+  /** Either `calendar_interval` or `fixed_interval` must be present */
+  fixed_interval?: DurationLarge
   offset?: Duration
   time_zone?: TimeZone
 }
 
 export class CompositeGeoTileGridAggregation extends CompositeAggregationBase {
-  precision: integer
+  precision?: integer
   bounds?: GeoBounds
 }
 


### PR DESCRIPTION
This fixes composite aggregation which members are not standard aggregations.

Documentation:
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html#search-aggregations-bucket-composite-aggregation

Source for ref:
https://github.com/elastic/elasticsearch/tree/main/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite

Found in https://github.com/elastic/elasticsearch-java/issues/534