### PR TITLE
Add descriptions for cluster settings and cluster stats

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2173,8 +2173,17 @@ export type FieldSortNumericType = 'long' | 'double' | 'date' | 'date_nanos'
 export type FieldValue = long | double | string | boolean | null | any
 
 export interface FielddataStats {
+  /**
+   * Total number of evictions from the field data cache across all shards assigned to selected nodes.
+   */
   evictions?: long
+  /**
+   * Total amount of memory used for the field data cache across all shards assigned to selected nodes.
+   */
   memory_size?: ByteSize
+  /**
+   * Total amount, in bytes, of memory used for the field data cache across all shards assigned to selected nodes.
+   */
   memory_size_in_bytes: long
   fields?: Record<Field, FieldMemoryUsage>
 }
@@ -2409,10 +2418,22 @@ export interface NodeShard {
 }
 
 export interface NodeStatistics {
-  failures?: ErrorCause[]
-  total: integer
-  successful: integer
+  /**
+   * Number of nodes that rejected the request or failed to respond.
+   */
   failed: integer
+  /**
+   * If the `failed` value is not 0, the reason for the rejection or failure is returned.
+   */
+  failures?: ErrorCause[]
+  /**
+   * Number of nodes that responded successfully to the request.
+   */
+  successful: integer
+  /**
+   * Total number of nodes selected by the request.
+   */
+  total: integer
 }
 
 export type Normalization = 'no' | 'h1' | 'h2' | 'h3' | 'z'
@@ -2426,15 +2447,37 @@ export type Percentage = string | float
 export type PipelineName = string
 
 export interface PluginStats {
+  /**
+   * The class name used as the plugin entry point.
+   */
   classname: string
+  /**
+   * A short description of the plugin.
+   */
   description: string
+  /**
+   * Elasticsearch version for which the plugin was built.
+   */
   elasticsearch_version: VersionString
+  /**
+   * An array of other plugins extended by this plugin through the Java Service Provider Interface (SPI).
+   * If this plugin extends no other plugins, this array is empty.
+   */
   extended_plugins: string[]
+  /**
+   * If `true`, the plugin has a native controller process.
+   */
   has_native_controller: boolean
+  /**
+   * Java version for which the plugin was built.
+   */
   java_version: VersionString
+  licensed: boolean
+  /**
+   * Name of the Elasticsearch plugin.
+   */
   name: Name
   version: VersionString
-  licensed: boolean
 }
 
 export type PropertyName = string

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2173,17 +2173,8 @@ export type FieldSortNumericType = 'long' | 'double' | 'date' | 'date_nanos'
 export type FieldValue = long | double | string | boolean | null | any
 
 export interface FielddataStats {
-  /**
-   * Total number of evictions from the field data cache across all shards assigned to selected nodes.
-   */
   evictions?: long
-  /**
-   * Total amount of memory used for the field data cache across all shards assigned to selected nodes.
-   */
   memory_size?: ByteSize
-  /**
-   * Total amount, in bytes, of memory used for the field data cache across all shards assigned to selected nodes.
-   */
   memory_size_in_bytes: long
   fields?: Record<Field, FieldMemoryUsage>
 }
@@ -2418,22 +2409,10 @@ export interface NodeShard {
 }
 
 export interface NodeStatistics {
-  /**
-   * Number of nodes that rejected the request or failed to respond.
-   */
-  failed: integer
-  /**
-   * If the `failed` value is not 0, the reason for the rejection or failure is returned.
-   */
   failures?: ErrorCause[]
-  /**
-   * Number of nodes that responded successfully to the request.
-   */
-  successful: integer
-  /**
-   * Total number of nodes selected by the request.
-   */
   total: integer
+  successful: integer
+  failed: integer
 }
 
 export type Normalization = 'no' | 'h1' | 'h2' | 'h3' | 'z'
@@ -2447,37 +2426,15 @@ export type Percentage = string | float
 export type PipelineName = string
 
 export interface PluginStats {
-  /**
-   * The class name used as the plugin entry point.
-   */
   classname: string
-  /**
-   * A short description of the plugin.
-   */
   description: string
-  /**
-   * Elasticsearch version for which the plugin was built.
-   */
   elasticsearch_version: VersionString
-  /**
-   * An array of other plugins extended by this plugin through the Java Service Provider Interface (SPI).
-   * If this plugin extends no other plugins, this array is empty.
-   */
   extended_plugins: string[]
-  /**
-   * If `true`, the plugin has a native controller process.
-   */
   has_native_controller: boolean
-  /**
-   * Java version for which the plugin was built.
-   */
   java_version: VersionString
-  licensed: boolean
-  /**
-   * Name of the Elasticsearch plugin.
-   */
   name: Name
   version: VersionString
+  licensed: boolean
 }
 
 export type PropertyName = string
@@ -8746,14 +8703,14 @@ export interface ClusterStateRequest extends RequestBase {
 export type ClusterStateResponse = any
 
 export interface ClusterStatsCharFilterTypes {
-  char_filter_types: ClusterStatsFieldTypes[]
-  tokenizer_types: ClusterStatsFieldTypes[]
-  filter_types: ClusterStatsFieldTypes[]
   analyzer_types: ClusterStatsFieldTypes[]
-  built_in_char_filters: ClusterStatsFieldTypes[]
-  built_in_tokenizers: ClusterStatsFieldTypes[]
-  built_in_filters: ClusterStatsFieldTypes[]
   built_in_analyzers: ClusterStatsFieldTypes[]
+  built_in_char_filters: ClusterStatsFieldTypes[]
+  built_in_filters: ClusterStatsFieldTypes[]
+  built_in_tokenizers: ClusterStatsFieldTypes[]
+  char_filter_types: ClusterStatsFieldTypes[]
+  filter_types: ClusterStatsFieldTypes[]
+  tokenizer_types: ClusterStatsFieldTypes[]
 }
 
 export interface ClusterStatsClusterFileSystem {
@@ -8763,6 +8720,7 @@ export interface ClusterStatsClusterFileSystem {
 }
 
 export interface ClusterStatsClusterIndices {
+  analysis: ClusterStatsCharFilterTypes
   completion: CompletionStats
   count: long
   docs: DocStats
@@ -8772,7 +8730,6 @@ export interface ClusterStatsClusterIndices {
   shards: ClusterStatsClusterIndicesShards
   store: StoreStats
   mappings: ClusterStatsFieldTypesMappings
-  analysis: ClusterStatsCharFilterTypes
   versions?: ClusterStatsIndicesVersions[]
 }
 
@@ -8824,24 +8781,25 @@ export interface ClusterStatsClusterNetworkTypes {
 export interface ClusterStatsClusterNodeCount {
   coordinating_only: integer
   data: integer
+  data_cold: integer
+  data_content: integer
+  data_frozen?: integer
+  data_hot: integer
+  data_warm: integer
   ingest: integer
   master: integer
-  total: integer
-  voting_only: integer
-  data_cold: integer
-  data_frozen?: integer
-  data_content: integer
-  data_warm: integer
-  data_hot: integer
   ml: integer
   remote_cluster_client: integer
+  total: integer
   transform: integer
+  voting_only: integer
 }
 
 export interface ClusterStatsClusterNodes {
   count: ClusterStatsClusterNodeCount
   discovery_types: Record<string, integer>
   fs: ClusterStatsClusterFileSystem
+  indexing_pressure: ClusterStatsIndexingPressure
   ingest: ClusterStatsClusterIngest
   jvm: ClusterStatsClusterJvm
   network_types: ClusterStatsClusterNetworkTypes
@@ -8850,21 +8808,20 @@ export interface ClusterStatsClusterNodes {
   plugins: PluginStats[]
   process: ClusterStatsClusterProcess
   versions: VersionString[]
-  indexing_pressure: ClusterStatsIndexingPressure
 }
 
 export interface ClusterStatsClusterOperatingSystem {
   allocated_processors: integer
+  architectures?: ClusterStatsClusterOperatingSystemArchitecture[]
   available_processors: integer
   mem: ClusterStatsOperatingSystemMemoryInfo
   names: ClusterStatsClusterOperatingSystemName[]
   pretty_names: ClusterStatsClusterOperatingSystemPrettyName[]
-  architectures?: ClusterStatsClusterOperatingSystemArchitecture[]
 }
 
 export interface ClusterStatsClusterOperatingSystemArchitecture {
-  count: integer
   arch: string
+  count: integer
 }
 
 export interface ClusterStatsClusterOperatingSystemName {
@@ -8930,8 +8887,8 @@ export interface ClusterStatsIndexingPressure {
 }
 
 export interface ClusterStatsIndexingPressureMemory {
-  limit_in_bytes: long
   current: ClusterStatsIndexingPressureMemorySummary
+  limit_in_bytes: long
   total: ClusterStatsIndexingPressureMemorySummary
 }
 
@@ -8960,12 +8917,12 @@ export interface ClusterStatsNodePackagingType {
 }
 
 export interface ClusterStatsOperatingSystemMemoryInfo {
+  adjusted_total_in_bytes?: long
   free_in_bytes: long
   free_percent: integer
   total_in_bytes: long
   used_in_bytes: long
   used_percent: integer
-  adjusted_total_in_bytes?: long
 }
 
 export interface ClusterStatsRequest extends RequestBase {
@@ -8977,20 +8934,20 @@ export interface ClusterStatsRequest extends RequestBase {
 export type ClusterStatsResponse = ClusterStatsStatsResponseBase
 
 export interface ClusterStatsRuntimeFieldTypes {
-  name: Name
+  chars_max: integer
+  chars_total: integer
   count: integer
+  doc_max: integer
+  doc_total: integer
   index_count: integer
-  scriptless_count: integer
-  shadowed_count: integer
   lang: string[]
   lines_max: integer
   lines_total: integer
-  chars_max: integer
-  chars_total: integer
+  name: Name
+  scriptless_count: integer
+  shadowed_count: integer
   source_max: integer
   source_total: integer
-  doc_max: integer
-  doc_total: integer
 }
 
 export interface ClusterStatsStatsResponseBase extends NodesNodesResponseBase {

--- a/specification/_types/Stats.ts
+++ b/specification/_types/Stats.ts
@@ -57,7 +57,13 @@ export class BulkStats {
 }
 
 export class CompletionStats {
+  /**
+   * Total amount, in bytes, of memory used for completion across all shards assigned to selected nodes.
+   */
   size_in_bytes: long
+  /**
+   * Total amount of memory used for completion across all shards assigned to selected nodes.
+   */
   size?: ByteSize
   fields?: Dictionary<Field, FieldSizeUsage>
 }
@@ -68,7 +74,16 @@ export class FieldSizeUsage {
 }
 
 export class DocStats {
+  /**
+   * Total number of non-deleted documents across all primary shards assigned to selected nodes.
+   * This number is based on documents in Lucene segments and may include documents from nested fields.
+   */
   count: long
+  /**
+   * Total number of deleted documents across all primary shards assigned to selected nodes.
+   * This number is based on documents in Lucene segments.
+   * Elasticsearch reclaims the disk space of deleted Lucene documents when a segment is merged.
+   */
   deleted?: long
 }
 
@@ -154,13 +169,38 @@ export class PluginStats {
 }
 
 export class QueryCacheStats {
+  /**
+   * Total number of entries added to the query cache across all shards assigned to selected nodes.
+   * This number includes current and evicted entries.
+   */
   cache_count: integer
+  /**
+   * Total number of entries currently in the query cache across all shards assigned to selected nodes.
+   */
   cache_size: integer
+  /**
+   * Total number of query cache evictions across all shards assigned to selected nodes.
+   */
   evictions: integer
+  /**
+   * Total count of query cache hits across all shards assigned to selected nodes.
+   */
   hit_count: integer
+  /**
+   * Total amount of memory used for the query cache across all shards assigned to selected nodes.
+   */
   memory_size?: ByteSize
+  /**
+   * Total amount, in bytes, of memory used for the query cache across all shards assigned to selected nodes.
+   */
   memory_size_in_bytes: long
+  /**
+   * Total count of query cache misses across all shards assigned to selected nodes.
+   */
   miss_count: integer
+  /**
+   * Total count of hits and misses in the query cache across all shards assigned to selected nodes.
+   */
   total_count: integer
 }
 
@@ -210,38 +250,126 @@ export class SearchStats {
 }
 
 export class SegmentsStats {
+  /**
+   * Total number of segments across all shards assigned to selected nodes.
+   */
   count: integer
+  /**
+   * Total amount of memory used for doc values across all shards assigned to selected nodes.
+   */
   doc_values_memory?: ByteSize
+  /**
+   * Total amount, in bytes, of memory used for doc values across all shards assigned to selected nodes.
+   */
   doc_values_memory_in_bytes: long
+  /**
+   * This object is not populated by the cluster stats API.
+   * To get information on segment files, use the node stats API.
+   */
   file_sizes: Dictionary<string, ShardFileSizeInfo>
+  /**
+   * Total amount of memory used by fixed bit sets across all shards assigned to selected nodes.
+   * Fixed bit sets are used for nested object field types and type filters for join fields.
+   */
   fixed_bit_set?: ByteSize
+  /**
+   * Total amount of memory, in bytes, used by fixed bit sets across all shards assigned to selected nodes.
+   */
   fixed_bit_set_memory_in_bytes: long
+  /**
+   * Total amount of memory used by all index writers across all shards assigned to selected nodes.
+   */
   index_writer_memory?: ByteSize
   index_writer_max_memory_in_bytes?: long
+  /**
+   * Total amount, in bytes, of memory used by all index writers across all shards assigned to selected nodes.
+   */
   index_writer_memory_in_bytes: long
+  /**
+   * Unix timestamp, in milliseconds, of the most recently retried indexing request.
+   */
   max_unsafe_auto_id_timestamp: long
+  /**
+   * Total amount of memory used for segments across all shards assigned to selected nodes.
+   */
   memory?: ByteSize
+  /**
+   * Total amount, in bytes, of memory used for segments across all shards assigned to selected nodes.
+   */
   memory_in_bytes: long
+  /**
+   * Total amount of memory used for normalization factors across all shards assigned to selected nodes.
+   */
   norms_memory?: ByteSize
+  /**
+   * Total amount, in bytes, of memory used for normalization factors across all shards assigned to selected nodes.
+   */
   norms_memory_in_bytes: long
+  /**
+   * Total amount of memory used for points across all shards assigned to selected nodes.
+   */
   points_memory?: ByteSize
+  /**
+   * Total amount, in bytes, of memory used for points across all shards assigned to selected nodes.
+   */
   points_memory_in_bytes: long
   stored_memory?: ByteSize
+  /**
+   * Total amount, in bytes, of memory used for stored fields across all shards assigned to selected nodes.
+   */
   stored_fields_memory_in_bytes: long
+  /**
+   * Total amount, in bytes, of memory used for terms across all shards assigned to selected nodes.
+   */
   terms_memory_in_bytes: long
+  /**
+   * Total amount of memory used for terms across all shards assigned to selected nodes.
+   */
   terms_memory?: ByteSize
+  /**
+   * Total amount of memory used for term vectors across all shards assigned to selected nodes.
+   */
   term_vectory_memory?: ByteSize
+  /**
+   * Total amount, in bytes, of memory used for term vectors across all shards assigned to selected nodes.
+   */
   term_vectors_memory_in_bytes: long
+  /**
+   * Total amount of memory used by all version maps across all shards assigned to selected nodes.
+   */
   version_map_memory?: ByteSize
+  /**
+   * Total amount, in bytes, of memory used by all version maps across all shards assigned to selected nodes.
+   */
   version_map_memory_in_bytes: long
 }
 
 export class StoreStats {
+  /**
+   * Total size of all shards assigned to selected nodes.
+   */
   size?: ByteSize
+  /**
+   * Total size, in bytes, of all shards assigned to selected nodes.
+   */
   size_in_bytes: long
+  /**
+   * A prediction of how much larger the shard stores will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities.
+   */
   reserved?: ByteSize
+  /**
+   * A prediction, in bytes, of how much larger the shard stores will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities.
+   */
   reserved_in_bytes: long
+  /**
+   * Total data set size of all shards assigned to selected nodes.
+   * This includes the size of shards not stored fully on the nodes, such as the cache for partially mounted indices.
+   */
   total_data_set_size?: ByteSize
+  /**
+   * Total data set size, in bytes, of all shards assigned to selected nodes.
+   * This includes the size of shards not stored fully on the nodes, such as the cache for partially mounted indices.
+   */
   total_data_set_size_in_bytes?: long
 }
 

--- a/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
+++ b/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
@@ -37,7 +37,7 @@ export interface Request extends RequestBase {
      */
     flat_settings?: boolean
     /**
-     * If `true`, returns default cluster settings from the local node. 
+     * If `true`, returns default cluster settings from the local node.
      * @server_default false
      */
     include_defaults?: boolean

--- a/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
+++ b/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
@@ -21,16 +21,37 @@ import { RequestBase } from '@_types/Base'
 import { Duration } from '@_types/Time'
 
 /**
+ * Returns cluster-wide settings.
+ * By default, it returns only settings that have been explicitly defined.
  * @rest_spec_name cluster.get_settings
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges monitor
  * @doc_id cluster-get-settings
  */
 export interface Request extends RequestBase {
   query_parameters: {
+    /**
+     * If `true`, returns settings in flat format.
+     * @server_default false
+     */
     flat_settings?: boolean
+    /**
+     * If `true`, returns default cluster settings from the local node. 
+     * @server_default false
+     */
     include_defaults?: boolean
+    /**
+     * Period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
     master_timeout?: Duration
+    /**
+     * Period to wait for a response.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
     timeout?: Duration
   }
 }

--- a/specification/cluster/stats/ClusterStatsRequest.ts
+++ b/specification/cluster/stats/ClusterStatsRequest.ts
@@ -22,9 +22,12 @@ import { NodeIds } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Returns cluster statistics.
+ * It returns basic index metrics (shard numbers, store size, memory usage) and information about the current nodes that form the cluster (number, roles, os, jvm versions, memory usage, cpu and installed plugins).
  * @rest_spec_name cluster.stats
  * @availability stack since=1.3.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges monitor
  * @doc_id cluster-stats
  */
 export interface Request extends RequestBase {
@@ -33,8 +36,15 @@ export interface Request extends RequestBase {
     node_id?: NodeIds
   }
   query_parameters: {
+    /**
+     * If `true`, returns settings in flat format.
+     * @server_default false
+     */
     flat_settings?: boolean
-    /** Period to wait for each node to respond. If a node does not respond before its timeout expires, the response does not include its stats. However, timed out nodes are included in the response’s _nodes.failed property. Defaults to no timeout. */
+    /**
+     * Period to wait for each node to respond.
+     * If a node does not respond before its timeout expires, the response does not include its stats.
+     * However, timed out nodes are included in the response’s `_nodes.failed` property. Defaults to no timeout. */
     timeout?: Duration
   }
 }

--- a/specification/cluster/stats/ClusterStatsResponse.ts
+++ b/specification/cluster/stats/ClusterStatsResponse.ts
@@ -24,8 +24,7 @@ import { ClusterIndices, ClusterNodes } from './types'
 
 export class StatsResponseBase extends NodesResponseBase {
   /**
-   * Name of the cluster, based on the Cluster name setting setting.
-   * @doc_id cluster-name
+   * Name of the cluster, based on the cluster name setting.
    */
   cluster_name: Name
   /**
@@ -46,8 +45,7 @@ export class StatsResponseBase extends NodesResponseBase {
    */
   status: HealthStatus
   /**
-   * Unix timestamp, in milliseconds, of the last time the cluster statistics were refreshed.
-   * @doc_url https://en.wikipedia.org/wiki/Unix_time
+   * Unix timestamp, in milliseconds, for the last time the cluster statistics were refreshed.
    */
   timestamp: long
 }

--- a/specification/cluster/stats/types.ts
+++ b/specification/cluster/stats/types.ts
@@ -245,7 +245,7 @@ export class CharFilterTypes {
   /**
    * Contains statistics about built-in tokenizers used in selected nodes.
    */
-  built_in_tokenizers: FieldTypes[]  
+  built_in_tokenizers: FieldTypes[]
   /**
    * Contains statistics about character filter types used in selected nodes.
    */
@@ -417,7 +417,7 @@ export class ClusterOperatingSystem {
    * Number of processors used to calculate thread pool size across all selected nodes.
    * This number can be set with the processors setting of a node and defaults to the number of processors reported by the operating system.
    * In both cases, this number will never be larger than 32.
-   */ 
+   */
   allocated_processors: integer
   /**
    * Contains statistics about processor architectures (for example, x86_64 or aarch64) used by selected nodes.

--- a/specification/cluster/stats/types.ts
+++ b/specification/cluster/stats/types.ts
@@ -32,8 +32,19 @@ import {
 import { Duration, DurationValue, UnitMillis } from '@_types/Time'
 
 export class ClusterFileSystem {
+  /**
+   * Total number of bytes available to JVM in file stores across all selected nodes.
+   * Depending on operating system or process-level restrictions, this number may be less than `nodes.fs.free_in_byes`.
+   * This is the actual amount of free disk space the selected Elasticsearch nodes can use.
+   */
   available_in_bytes: long
+  /**
+   * Total number of unallocated bytes in file stores across all selected nodes.
+   */
   free_in_bytes: long
+  /**
+   * Total size, in bytes, of all file stores across all selected nodes.
+   */
   total_in_bytes: long
 }
 
@@ -61,6 +72,10 @@ export class ClusterIndicesShards {
 }
 
 export class ClusterIndices {
+  /**
+   * Contains statistics about analyzers and analyzer components used in selected nodes.
+   */
+  analysis: CharFilterTypes
   /** Contains statistics about memory used for completion in selected nodes. */
   completion: CompletionStats
   /** Total number of indices with shards assigned to selected nodes. */
@@ -82,34 +97,69 @@ export class ClusterIndices {
   store: StoreStats
   /**
    * Contains statistics about field mappings in selected nodes.
-   * @doc_id mapping
    */
   mappings: FieldTypesMappings
   /**
    * Contains statistics about analyzers and analyzer components used in selected nodes.
    * @doc_id analyzer-anatomy
    */
-  analysis: CharFilterTypes
   versions?: IndicesVersions[]
 }
 
 export class FieldTypesMappings {
+  /**
+   * Contains statistics about field data types used in selected nodes.
+   */
   field_types: FieldTypes[]
+  /**
+   * Contains statistics about runtime field data types used in selected nodes.
+   */
   runtime_field_types?: RuntimeFieldTypes[]
+  /**
+   * Total number of fields in all non-system indices.
+   */
   total_field_count?: integer
+  /**
+   * Total number of fields in all non-system indices, accounting for mapping deduplication.
+   */
   total_deduplicated_field_count?: integer
+  /**
+   * Total size of all mappings after deduplication and compression.
+   */
   total_deduplicated_mapping_size?: ByteSize
+  /**
+   * Total size of all mappings, in bytes, after deduplication and compression.
+   */
   total_deduplicated_mapping_size_in_bytes?: long
 }
 
 export class FieldTypes {
+  /**
+   * The name for the field type in selected nodes.
+   */
   name: Name
+  /**
+   * The number of occurrences of the field type in selected nodes.
+   */
   count: integer
+  /**
+   * The number of indices containing the field type in selected nodes.
+   */
   index_count: integer
+  /**
+   * For dense_vector field types, number of indexed vector types in selected nodes.
+   */
   indexed_vector_count?: long
+  /**
+   * For dense_vector field types, the maximum dimension of all indexed vector types in selected nodes.
+   */
   indexed_vector_dim_max?: long
+  /**
+   * For dense_vector field types, the minimum dimension of all indexed vector types in selected nodes.
+   */
   indexed_vector_dim_min?: long
   /**
+   * The number of fields that declare a script.
    * @availability stack since=7.13.0
    * @availability serverless
    */
@@ -117,31 +167,97 @@ export class FieldTypes {
 }
 
 export class RuntimeFieldTypes {
-  name: Name
-  count: integer
-  index_count: integer
-  scriptless_count: integer
-  shadowed_count: integer
-  lang: string[]
-  lines_max: integer
-  lines_total: integer
+  /**
+   * Maximum number of characters for a single runtime field script.
+   */
   chars_max: integer
+  /**
+   * Total number of characters for the scripts that define the current runtime field data type.
+   */
   chars_total: integer
-  source_max: integer
-  source_total: integer
+  /**
+   * Number of runtime fields mapped to the field data type in selected nodes.
+   */
+  count: integer
+  /**
+   * Maximum number of accesses to doc_values for a single runtime field script
+   */
   doc_max: integer
+  /**
+   * Total number of accesses to doc_values for the scripts that define the current runtime field data type.
+   */
   doc_total: integer
+  /**
+   * Number of indices containing a mapping of the runtime field data type in selected nodes.
+   */
+  index_count: integer
+  /**
+   * Script languages used for the runtime fields scripts.
+   */
+  lang: string[]
+  /**
+   * Maximum number of lines for a single runtime field script.
+   */
+  lines_max: integer
+  /**
+   * Total number of lines for the scripts that define the current runtime field data type.
+   */
+  lines_total: integer
+  /**
+   * Field data type used in selected nodes.
+   */
+  name: Name
+  /**
+   * Number of runtime fields that don’t declare a script.
+   */
+  scriptless_count: integer
+  /**
+   * Number of runtime fields that shadow an indexed field.
+   */
+  shadowed_count: integer
+  /**
+   * Maximum number of accesses to _source for a single runtime field script.
+   */
+  source_max: integer
+  /**
+   * Total number of accesses to _source for the scripts that define the current runtime field data type.
+   */
+  source_total: integer
 }
 
 export class CharFilterTypes {
-  char_filter_types: FieldTypes[]
-  tokenizer_types: FieldTypes[]
-  filter_types: FieldTypes[]
+  /**
+   * Contains statistics about analyzer types used in selected nodes.
+   */
   analyzer_types: FieldTypes[]
-  built_in_char_filters: FieldTypes[]
-  built_in_tokenizers: FieldTypes[]
-  built_in_filters: FieldTypes[]
+  /**
+   * Contains statistics about built-in analyzers used in selected nodes.
+   */
   built_in_analyzers: FieldTypes[]
+  /**
+   * Contains statistics about built-in character filters used in selected nodes.
+   */
+  built_in_char_filters: FieldTypes[]
+  /**
+   * Contains statistics about built-in token filters used in selected nodes.
+   */
+  built_in_filters: FieldTypes[]
+  /**
+   * Contains statistics about built-in tokenizers used in selected nodes.
+   */
+  built_in_tokenizers: FieldTypes[]  
+  /**
+   * Contains statistics about character filter types used in selected nodes.
+   */
+  char_filter_types: FieldTypes[]
+  /**
+   * Contains statistics about token filter types used in selected nodes.
+   */
+  filter_types: FieldTypes[]
+  /**
+   * Contains statistics about tokenizer types used in selected nodes.
+   */
+  tokenizer_types: FieldTypes[]
 }
 
 export class IndicesVersions {
@@ -157,51 +273,97 @@ export class ClusterIngest {
 }
 
 export class ClusterJvm {
+  /**
+   * Uptime duration, in milliseconds, since JVM last started.
+   */
   max_uptime_in_millis: DurationValue<UnitMillis>
+  /**
+   * Contains statistics about memory used by selected nodes.
+   */
   mem: ClusterJvmMemory
+  /**
+   * Number of active threads in use by JVM across all selected nodes.
+   */
   threads: long
+  /**
+   * Contains statistics about the JVM versions used by selected nodes.
+   */
   versions: ClusterJvmVersion[]
 }
 
 export class ClusterJvmMemory {
+  /**
+   * Maximum amount of memory, in bytes, available for use by the heap across all selected nodes.
+   */
   heap_max_in_bytes: long
+  /**
+   * Memory, in bytes, currently in use by the heap across all selected nodes.
+   */
   heap_used_in_bytes: long
 }
 
 export class ClusterJvmVersion {
+  /**
+   * Always `true`. All distributions come with a bundled Java Development Kit (JDK).
+   */
   bundled_jdk: boolean
+  /**
+   * Total number of selected nodes using JVM.
+   */
   count: integer
+  /**
+   * If `true`, a bundled JDK is in use by JVM.
+   */
   using_bundled_jdk: boolean
+  /**
+   * Version of JVM used by one or more selected nodes.
+   */
   version: VersionString
+  /**
+   * Name of the JVM.
+   */
   vm_name: string
+  /**
+   * Vendor of the JVM.
+   */
   vm_vendor: string
+  /**
+   * Full version number of JVM.
+   * The full version number includes a plus sign (+) followed by the build number.
+   */
   vm_version: VersionString
 }
 
 export class ClusterNetworkTypes {
+  /**
+   * Contains statistics about the HTTP network types used by selected nodes.
+   */
   http_types: Dictionary<string, integer>
+  /**
+   * Contains statistics about the transport network types used by selected nodes.
+   */
   transport_types: Dictionary<string, integer>
 }
 
 export class ClusterNodeCount {
   coordinating_only: integer
   data: integer
-  ingest: integer
-  master: integer
-  total: integer
-  voting_only: integer
   data_cold: integer
+  data_content: integer
   /**
    * @availability stack since=7.13.0
    * @availability serverless
    */
   data_frozen?: integer
-  data_content: integer
-  data_warm: integer
   data_hot: integer
+  data_warm: integer
+  ingest: integer
+  master: integer
   ml: integer
   remote_cluster_client: integer
+  total: integer
   transform: integer
+  voting_only: integer
 }
 
 export class ClusterNodes {
@@ -214,6 +376,11 @@ export class ClusterNodes {
   discovery_types: Dictionary<string, integer>
   /** Contains statistics about file stores by selected nodes. */
   fs: ClusterFileSystem
+  /**
+   * @availability stack since=7.16.0
+   * @availability serverless
+   */
+  indexing_pressure: IndexingPressure
   ingest: ClusterIngest
   /** Contains statistics about the Java Virtual Machines (JVMs) used by selected nodes. */
   jvm: ClusterJvm
@@ -223,55 +390,113 @@ export class ClusterNodes {
   os: ClusterOperatingSystem
   /** Contains statistics about Elasticsearch distributions installed on selected nodes. */
   packaging_types: NodePackagingType[]
-  /** Contains statistics about installed plugins and modules by selected nodes. */
+  /**
+   * Contains statistics about installed plugins and modules by selected nodes.
+   * If no plugins or modules are installed, this array is empty.
+   */
   plugins: PluginStats[]
   /** Contains statistics about processes used by selected nodes. */
   process: ClusterProcess
   /** Array of Elasticsearch versions used on selected nodes. */
   versions: VersionString[]
-  /**
-   * @availability stack since=7.16.0
-   * @availability serverless
-   */
-  indexing_pressure: IndexingPressure
 }
 
 export class ClusterOperatingSystemArchitecture {
-  count: integer
+  /**
+   * Name of an architecture used by one or more selected nodes.
+   */
   arch: string
+  /**
+   * Number of selected nodes using the architecture.
+   */
+  count: integer
 }
 
 export class ClusterOperatingSystem {
+  /**
+   * Number of processors used to calculate thread pool size across all selected nodes.
+   * This number can be set with the processors setting of a node and defaults to the number of processors reported by the operating system.
+   * In both cases, this number will never be larger than 32.
+   */ 
   allocated_processors: integer
-  available_processors: integer
-  mem: OperatingSystemMemoryInfo
-  names: ClusterOperatingSystemName[]
-  pretty_names: ClusterOperatingSystemPrettyName[]
+  /**
+   * Contains statistics about processor architectures (for example, x86_64 or aarch64) used by selected nodes.
+   */
   architectures?: ClusterOperatingSystemArchitecture[]
+  /**
+   * Number of processors available to JVM across all selected nodes.
+   */
+  available_processors: integer
+  /**
+   * Contains statistics about memory used by selected nodes.
+   */
+  mem: OperatingSystemMemoryInfo
+  /**
+   * Contains statistics about operating systems used by selected nodes.
+   */
+  names: ClusterOperatingSystemName[]
+  /**
+   * Contains statistics about operating systems used by selected nodes.
+   */
+  pretty_names: ClusterOperatingSystemPrettyName[]
 }
 
 export class ClusterOperatingSystemName {
+  /**
+   * Number of selected nodes using the operating system.
+   */
   count: integer
+  /**
+   * Name of an operating system used by one or more selected nodes.
+   */
   name: Name
 }
 
 export class ClusterOperatingSystemPrettyName {
+  /**
+   * Number of selected nodes using the operating system.
+   */
   count: integer
+  /**
+   * Human-readable name of an operating system used by one or more selected nodes.
+   */
   pretty_name: Name
 }
 
 export class ClusterProcess {
+  /**
+   * Contains statistics about CPU used by selected nodes.
+   */
   cpu: ClusterProcessCpu
+  /**
+   * Contains statistics about open file descriptors in selected nodes.
+   */
   open_file_descriptors: ClusterProcessOpenFileDescriptors
 }
 
 export class ClusterProcessCpu {
+  /**
+   * Percentage of CPU used across all selected nodes.
+   * Returns `-1` if not supported.
+   */
   percent: integer
 }
 
 export class ClusterProcessOpenFileDescriptors {
+  /**
+   * Average number of concurrently open file descriptors.
+   * Returns `-1` if not supported.
+   */
   avg: long
+  /**
+   * Maximum number of concurrently open file descriptors allowed across all selected nodes.
+   * Returns `-1` if not supported.
+   */
   max: long
+  /**
+   * Minimum number of concurrently open file descriptors across all selected nodes.
+   * Returns -1 if not supported.
+   */
   min: long
 }
 
@@ -284,28 +509,62 @@ export class ClusterProcessor {
 }
 
 export class ClusterShardMetrics {
+  /**
+   * Mean number of shards in an index, counting only shards assigned to selected nodes.
+   */
   avg: double
+  /**
+   * Maximum number of shards in an index, counting only shards assigned to selected nodes.
+   */
   max: double
+  /**
+   * Minimum number of shards in an index, counting only shards assigned to selected nodes.
+   */
   min: double
 }
 
 export class NodePackagingType {
+  /**
+   * Number of selected nodes using the distribution flavor and file type.
+   */
   count: integer
+  /**
+   * Type of Elasticsearch distribution. This is always `default`.
+   */
   flavor: string
+  /**
+   * File type (such as `tar` or `zip`) used for the distribution package.
+   */
   type: string
 }
 
 export class OperatingSystemMemoryInfo {
-  free_in_bytes: long
-  free_percent: integer
-  total_in_bytes: long
-  used_in_bytes: long
-  used_percent: integer
   /**
+   * Total amount, in bytes, of memory across all selected nodes, but using the value specified using the `es.total_memory_bytes` system property instead of measured total memory for those nodes where that system property was set.
    * @availability stack since=7.16.0
    * @availability serverless
    */
   adjusted_total_in_bytes?: long
+  /**
+   * Amount, in bytes, of free physical memory across all selected nodes.
+   */
+  free_in_bytes: long
+  /**
+   * Percentage of free physical memory across all selected nodes.
+   */
+  free_percent: integer
+  /**
+   * Total amount, in bytes, of physical memory across all selected nodes.
+   */
+  total_in_bytes: long
+  /**
+   * Amount, in bytes, of physical memory in use across all selected nodes.
+   */
+  used_in_bytes: long
+  /**
+   * Percentage of physical memory in use across all selected nodes.
+   */
+  used_percent: integer
 }
 
 export class IndexingPressure {
@@ -313,8 +572,8 @@ export class IndexingPressure {
 }
 
 export class IndexingPressureMemory {
-  limit_in_bytes: long
   current: IndexingPressureMemorySummary
+  limit_in_bytes: long
   total: IndexingPressureMemorySummary
 }
 


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/964

This PR adds descriptions for the [cluster settings](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-get-settings.html) and [cluster stats](https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-stats.html) endpoints. It also sorts the properties into alphabetic order since that seems to currently affect how they're sorted in the OAS.