### PR TITLE
Add exception to core.get to handle index_not_found & document not found

### DIFF
--- a/specification/_global/get/GetResponse.ts
+++ b/specification/_global/get/GetResponse.ts
@@ -18,7 +18,14 @@
  */
 
 import { GetResult } from '@global/get/types'
+import { ErrorResponseBase } from '@_types/Base'
 
 export class Response<TDocument> {
   body: GetResult<TDocument>
+  exceptions: [
+    {
+      statusCodes: [404]
+      body: GetResult<TDocument> | ErrorResponseBase
+    }
+  ]
 }

--- a/specification/_global/get/GetResponse.ts
+++ b/specification/_global/get/GetResponse.ts
@@ -24,6 +24,9 @@ export class Response<TDocument> {
   body: GetResult<TDocument>
   exceptions: [
     {
+      // Special case exception for 404 status code, Elasticsearch will return either:
+      //  * index_not_found_exception as an error if the index doesn't exist
+      //  * GetResult with only the requested _id, _index properties and found as a false boolean
       statusCodes: [404]
       body: GetResult<TDocument> | ErrorResponseBase
     }


### PR DESCRIPTION
This adds an exception to the `core.get` response to handle `index_not_found_exception` and document not found.