### PR TITLE
Fix incorrect "fork check" condition in `validate_pr` workflow

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   validate-pr:
     name: build
-    if: github.repository_owner == 'elastic' # this action will fail if executed from a fork
+    if: github.event.pull_request.head.repo.owner.login == 'elastic' # this action will fail if executed from a fork
     runs-on: ubuntu-latest
     env:
       STACK_VERSION: 8.9-SNAPSHOT


### PR DESCRIPTION
This expression:

https://github.com/elastic/elasticsearch-specification/blob/9eff69a2a7b3f764a1e39ac50418ca184a68612f/.github/workflows/validate-pr.yml#L18

always evaluates to `true` as `github.repository_owner` refers to the "target" repository for `pull_request` triggers.

It should instead check `github.event.pull_request.head.repo.owner.login`.

Related: https://github.com/elastic/elasticsearch-specification/pull/2160