### PR TITLE
Add data stream descriptions

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9603,19 +9603,19 @@ export interface IndicesDataLifecycleWithRollover {
 }
 
 export interface IndicesDataStream {
-  name: DataStreamName
-  timestamp_field: IndicesDataStreamTimestampField
-  indices: IndicesDataStreamIndex[]
-  generation: integer
-  template: Name
-  hidden: boolean
-  replicated?: boolean
-  system?: boolean
-  status: HealthStatus
-  ilm_policy?: Name
   _meta?: Metadata
   allow_custom_routing?: boolean
+  generation: integer
+  hidden: boolean
+  ilm_policy?: Name
+  indices: IndicesDataStreamIndex[]
   lifecycle?: IndicesDataLifecycleWithRollover
+  name: DataStreamName
+  replicated?: boolean
+  status: HealthStatus
+  system?: boolean
+  template: Name
+  timestamp_field: IndicesDataStreamTimestampField
 }
 
 export interface IndicesDataStreamIndex {

--- a/specification/indices/_types/DataLifecycle.ts
+++ b/specification/indices/_types/DataLifecycle.ts
@@ -33,7 +33,17 @@ export class DataLifecycle {
  * if asked.
  */
 export class DataLifecycleWithRollover {
+  /**
+   * If defined, every document added to this data stream will be stored at least for this time frame.
+   * Any time after this duration the document could be deleted.
+   * When empty, every document in this data stream will be stored indefinitely.
+   */
   data_retention?: Duration
+  /**
+   * The conditions which will trigger the rollover of a backing index as configured by the cluster setting `cluster.lifecycle.default.rollover`.
+   * This property is an implementation detail and it will only be retrieved when the query param `include_defaults` is set to true.
+   * The contents of this field are subject to change.
+   */
   rollover?: DlmRolloverConditions
 }
 

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -60,9 +60,9 @@ export class DataStream {
    */
   indices: DataStreamIndex[]
   /**
+   * Contains the configuration for the data lifecycle management of this data stream.
    * @availability stack since=8.8.0 stability=experimental
    * @availability serverless stability=experimental
-   * Contains the configuration for the data lifecycle management of this data stream.
    */
   lifecycle?: DataLifecycleWithRollover
   /**
@@ -74,14 +74,14 @@ export class DataStream {
    */
   replicated?: boolean
   /**
-   *  Health status of the data stream.
+   * Health status of the data stream.
    * This health status is based on the state of the primary and replica shards of the stream’s backing indices.
    */
   status: HealthStatus
   /**
+   * If `true`, the data stream is created and managed by an Elastic stack component and cannot be modified through normal user interaction.
    * @availability stack since=7.10.0
    * @availability serverless
-   * If `true`, the data stream is created and managed by an Elastic stack component and cannot be modified through normal user interaction.
    */
   system?: boolean
   /**
@@ -97,7 +97,7 @@ export class DataStream {
 
 export class DataStreamTimestampField {
   /**
-   * Name of the timestamp field for the data stream, which must be `@timestamp`. The @timestamp field must be included in every document indexed to the data stream.
+   * Name of the timestamp field for the data stream, which must be `@timestamp`. The `@timestamp` field must be included in every document indexed to the data stream.
    */
   name: Field
 }

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -30,36 +30,86 @@ import { integer } from '@_types/Numeric'
 import { DataLifecycleWithRollover } from '@indices/_types/DataLifecycle'
 
 export class DataStream {
-  name: DataStreamName
-  timestamp_field: DataStreamTimestampField
-  indices: DataStreamIndex[]
-  generation: integer
-  template: Name
-  hidden: boolean
-  replicated?: boolean
   /**
-   * @availability stack since=7.10.0
-   * @availability serverless
-   */
-  system?: boolean
-  status: HealthStatus
-  ilm_policy?: Name
-  /** @doc_id mapping-meta-field */
+   * Custom metadata for the stream, copied from the `_meta` object of the stream’s matching index template.
+   * If empty, the response omits this property.
+   * @doc_id mapping-meta-field */
   _meta?: Metadata
+  /**
+   *  If `true`, the data stream allows custom routing on write request.
+   */
   allow_custom_routing?: boolean
+  /**
+   * Current generation for the data stream. This number acts as a cumulative count of the stream’s rollovers, starting at 1.
+   */
+  generation: integer
+  /**
+   *  If `true`, the data stream is hidden.
+   */
+  hidden: boolean
+  /**
+   * Name of the current ILM lifecycle policy in the stream’s matching index template.
+   * This lifecycle policy is set in the `index.lifecycle.name` setting.
+   * If the template does not include a lifecycle policy, this property is not included in the response.
+   * NOTE: A data stream’s backing indices may be assigned different lifecycle policies. To retrieve the lifecycle policy for individual backing indices, use the get index settings API.
+   */
+  ilm_policy?: Name
+  /**
+   * Array of objects containing information about the data stream’s backing indices.
+   * The last item in this array contains information about the stream’s current write index.
+   */
+  indices: DataStreamIndex[]
   /**
    * @availability stack since=8.8.0 stability=experimental
    * @availability serverless stability=experimental
+   * Contains the configuration for the data lifecycle management of this data stream.
    */
   lifecycle?: DataLifecycleWithRollover
+  /**
+   * Name of the data stream.
+   */
+  name: DataStreamName
+  /**
+   *  If `true`, the data stream is created and managed by cross-cluster replication and the local cluster can not write into this data stream or change its mappings.
+   */
+  replicated?: boolean
+  /**
+   *  Health status of the data stream.
+   * This health status is based on the state of the primary and replica shards of the stream’s backing indices.
+   */
+  status: HealthStatus
+  /**
+   * @availability stack since=7.10.0
+   * @availability serverless
+   * If `true`, the data stream is created and managed by an Elastic stack component and cannot be modified through normal user interaction.
+   */
+  system?: boolean
+  /**
+   * Name of the index template used to create the data stream’s backing indices.
+   * The template’s index pattern must match the name of this data stream.
+   */
+  template: Name
+  /**
+   * Information about the `@timestamp` field in the data stream.
+   */
+  timestamp_field: DataStreamTimestampField
 }
 
 export class DataStreamTimestampField {
+  /**
+   * Name of the timestamp field for the data stream, which must be `@timestamp`. The @timestamp field must be included in every document indexed to the data stream.
+   */
   name: Field
 }
 
 export class DataStreamIndex {
+  /**
+   * Name of the backing index.
+   */
   index_name: IndexName
+  /**
+   * Universally unique identifier (UUID) for the index.
+   */
   index_uuid: Uuid
 }
 

--- a/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
+++ b/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
@@ -21,12 +21,23 @@ import { RequestBase } from '@_types/Base'
 import { DataStreamName } from '@_types/common'
 
 /**
+ * Creates a data stream.
+ * You must have a matching index template with data stream enabled.
  * @rest_spec_name indices.create_data_stream
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges create_index
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Name of the data stream, which must meet the following criteria:
+     * Lowercase only
+     * Cannot include `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`, `#`, `:`, or a space character
+     * Cannot start with `-`, `_`, `+`, or `.ds-`
+     * Cannot be `.` or `..`
+     * Cannot be longer than 255 bytes. Multi-byte characters count towards this limit faster.
+     */
     name: DataStreamName
   }
 }

--- a/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
+++ b/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
@@ -32,10 +32,10 @@ export interface Request extends RequestBase {
   path_parts: {
     /**
      * Name of the data stream, which must meet the following criteria:
-     * Lowercase only
-     * Cannot include `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`, `#`, `:`, or a space character
-     * Cannot start with `-`, `_`, `+`, or `.ds-`
-     * Cannot be `.` or `..`
+     * Lowercase only;
+     * Cannot include `\`, `/`, `*`, `?`, `"`, `<`, `>`, `|`, `,`, `#`, `:`, or a space character;
+     * Cannot start with `-`, `_`, `+`, or `.ds-`;
+     * Cannot be `.` or `..`;
      * Cannot be longer than 255 bytes. Multi-byte characters count towards this limit faster.
      */
     name: DataStreamName

--- a/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
+++ b/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
@@ -21,15 +21,24 @@ import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, DataStreamNames } from '@_types/common'
 
 /**
+ * Deletes one or more data streams and their backing indices.
  * @rest_spec_name indices.delete_data_stream
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges delete_index
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Comma-separated list of data streams to delete. Wildcard (`*`) expressions are supported.
+     */
     name: DataStreamNames
   }
   query_parameters: {
+    /**
+     * Type of data stream that wildcard patterns can match. Supports comma-separated values,such as `open,hidden`.
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards
   }
 }

--- a/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
+++ b/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
@@ -21,15 +21,26 @@ import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, DataStreamNames } from '@_types/common'
 
 /**
+ * Retrieves information about one or more data streams.
  * @rest_spec_name indices.get_data_stream
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges view_index_metadata
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Comma-separated list of data stream names used to limit the request.
+     * Wildcard (`*`) expressions are supported. If omitted, all data streams are returned.
+     */
     name?: DataStreamNames
   }
   query_parameters: {
+    /**
+     * Type of data stream that wildcard patterns can match.
+     * Supports comma-separated values, such as `open,hidden`.
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards
     /**
      * If true, returns all relevant default configurations for the index template.


### PR DESCRIPTION
This PR adds descriptions from:

- https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-data-stream.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-data-stream.html
- https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-data-stream.html

NOTE: In addition to adding descriptions in `specification/indices/_types/DataStream.ts`, I've sorted the properties alphabetically so they show up nicely in our output.