### PR TITLE
mark GeoDistanceQuery distance property as required

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5447,7 +5447,7 @@ export interface QueryDslGeoDistanceFeatureQuery extends QueryDslDistanceFeature
 }
 
 export interface QueryDslGeoDistanceQueryKeys extends QueryDslQueryBase {
-  distance?: Distance
+  distance: Distance
   distance_type?: GeoDistanceType
   validation_method?: QueryDslGeoValidationMethod
 }

--- a/specification/_types/query_dsl/geo.ts
+++ b/specification/_types/query_dsl/geo.ts
@@ -49,7 +49,7 @@ export class GeoDistanceQuery
   extends QueryBase
   implements AdditionalProperty<Field, GeoLocation>
 {
-  distance?: Distance
+  distance: Distance
   /** @server_default 'arc' */
   distance_type?: GeoDistanceType
   /** @server_default 'strict' */


### PR DESCRIPTION
geo_distance.distance parameter is required. If not provided, elasticsearch _search API returns a 400

Example of working query
```
GET kibana_sample_data_logs/_search
{
  "size": 10,
  "query": {
    "bool": {
      "must": [],
      "filter": [
        {
          "bool": {
            "must": [
              {
                "exists": {
                  "field": "geo.coordinates"
                }
              },
              {
                "geo_distance": {
                  "distance": "100km",
                  "geo.coordinates": [
                    -107.31,
                    40.66
                  ]
                }
              }
            ]
          }
        }
      ],
      "should": [],
      "must_not": []
    }
  }
}
```

Example of 400 query with `distance` not provided
```
GET kibana_sample_data_logs/_search
{
  "size": 10,
  "query": {
    "bool": {
      "must": [],
      "filter": [
        {
          "bool": {
            "must": [
              {
                "exists": {
                  "field": "geo.coordinates"
                }
              },
              {
                "geo_distance": {
                  "geo.coordinates": [
                    -107.31,
                    40.66
                  ]
                }
              }
            ]
          }
        }
      ],
      "should": [],
      "must_not": []
    }
  }
}
```

Error response
```
{
  "error": {
    "root_cause": [
      {
        "type": "parsing_exception",
        "reason": "geo_distance requires 'distance' to be specified",
        "line": 21,
        "col": 17
      }
    ],
    "type": "x_content_parse_exception",
    "reason": "[21:17] [bool] failed to parse field [filter]",
    "caused_by": {
      "type": "x_content_parse_exception",
      "reason": "[21:17] [bool] failed to parse field [must]",
      "caused_by": {
        "type": "parsing_exception",
        "reason": "geo_distance requires 'distance' to be specified",
        "line": 21,
        "col": 17
      }
    }
  },
  "status": 400
}
```