### PR TITLE
Add descriptions for API key API

### DIFF
--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -621,7 +621,7 @@ export function hoistRequestAnnotations (
         'manage_ml', 'manage_oidc', 'manage_own_api_key', 'manage_pipeline', 'manage_rollup', 'manage_saml',
         'manage_security', 'manage_service_account', 'manage_slm', 'manage_token', 'manage_transform', 'manage_user_profile',
         'manage_watcher', 'monitor', 'monitor_ml', 'monitor_rollup', 'monitor_snapshot', 'monitor_text_structure',
-        'monitor_transform', 'monitor_watcher', 'read_ccr', 'read_ilm', 'read_pipeline', 'read_slm', 'transport_client'
+        'monitor_transform', 'monitor_watcher', 'read_ccr', 'read_ilm', 'read_pipeline', 'read_security', 'read_slm', 'transport_client'
       ]
       const values = parseCommaSeparated(value)
       for (const v of values) {

--- a/specification/security/_types/ApiKey.ts
+++ b/specification/security/_types/ApiKey.ts
@@ -37,8 +37,8 @@ export class ApiKey {
    * Id for the API key
    */
   id: Id
-  /** 
-   * Invalidation status for the API key. 
+  /**
+   * Invalidation status for the API key.
    * If the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.
    */
   invalidated?: boolean

--- a/specification/security/_types/ApiKey.ts
+++ b/specification/security/_types/ApiKey.ts
@@ -25,20 +25,50 @@ import { SortResults } from '@_types/sort'
 import { RoleDescriptor } from './RoleDescriptor'
 
 export class ApiKey {
+  /**
+   * Creation time for the API key in milliseconds.
+   */
   creation?: long
+  /**
+   * Expiration time for the API key in milliseconds.
+   */
   expiration?: long
+  /**
+   * Id for the API key
+   */
   id: Id
+  /** 
+   * Invalidation status for the API key. 
+   * If the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.
+   */
   invalidated?: boolean
+  /**
+   * Name of the API key.
+   */
   name: Name
+  /**
+   * Realm name of the principal for which this API key was created.
+   */
   realm?: string
+  /**
+   * Principal for which this API key was created
+   */
   username?: Username
   /**
+   * Metadata of the API key
    * @availability stack since=7.13.0
    * @availability serverless
    */
   metadata?: Metadata
+  /**
+   * The role descriptors assigned to this API key when it was created or last updated.
+   * An empty role descriptor means the API key inherits the owner user’s permissions.
+   */
   role_descriptors?: Dictionary<string, RoleDescriptor>
   /**
+   * The owner user’s permissions associated with the API key.
+   * It is a point-in-time snapshot captured at creation and subsequent updates.
+   * An API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.
    * @availability stack since=8.5.0
    * @availability serverless
    */

--- a/specification/security/_types/GrantType.ts
+++ b/specification/security/_types/GrantType.ts
@@ -18,6 +18,13 @@
  */
 
 export enum GrantType {
+  /**
+   * In this type of grant, you must supply the user ID and password for which you want to create the API key.
+   */
   password,
+  /**
+   * In this type of grant, you must supply an access token that was created by the Elasticsearch token service. 
+   * @doc_id security-api-get-token
+   */
   access_token
 }

--- a/specification/security/_types/GrantType.ts
+++ b/specification/security/_types/GrantType.ts
@@ -23,8 +23,7 @@ export enum GrantType {
    */
   password,
   /**
-   * In this type of grant, you must supply an access token that was created by the Elasticsearch token service. 
-   * @doc_id security-api-get-token
+   * In this type of grant, you must supply an access token that was created by the Elasticsearch token service.
    */
   access_token
 }

--- a/specification/security/_types/RoleDescriptor.ts
+++ b/specification/security/_types/RoleDescriptor.ts
@@ -25,23 +25,61 @@ import { Metadata } from '@_types/common'
 import { OverloadOf } from '@spec_utils/behaviors'
 
 export class RoleDescriptor {
+  /**  
+   * A list of cluster privileges. These privileges define the cluster level actions that API keys are able to execute. 
+   */
   cluster?: string[]
-  /** @aliases index */
+  /** 
+   * A list of indices permissions entries.
+   * @aliases index 
+   */
   indices?: IndicesPrivileges[]
+  /**
+   * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges. This field is optional.
+   */
   global?: GlobalPrivilege[] | GlobalPrivilege
+  /** 
+   * A list of application privilege entries 
+   */
   applications?: ApplicationPrivileges[]
+  /** 
+   * Optional meta-data. Within the metadata object, keys that begin with `_` are reserved for system usage. 
+   */
   metadata?: Metadata
+  /** 
+   * A list of users that the API keys can impersonate. 
+   * @doc_id run-as-privilege
+   */
   run_as?: string[]
   transient_metadata?: TransientMetadataConfig
 }
 
 export class RoleDescriptorRead implements OverloadOf<RoleDescriptor> {
+  /**  
+   * A list of cluster privileges. These privileges define the cluster level actions that API keys are able to execute. 
+   */
   cluster: string[]
-  /** @aliases index */
+  /** 
+   * A list of indices permissions entries.
+   * @aliases index 
+   */
   indices: IndicesPrivileges[]
+  /**
+   * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges. This field is optional.
+   */
   global?: GlobalPrivilege[] | GlobalPrivilege
+  /**
+   * A list of application privilege entries 
+   */
   applications?: ApplicationPrivileges[]
+  /**
+   * Optional meta-data. Within the metadata object, keys that begin with `_` are reserved for system usage. 
+   */
   metadata?: Metadata
+  /** 
+   * A list of users that the API keys can impersonate. 
+   * @doc_id run-as-privilege
+   */
   run_as?: string[]
   transient_metadata?: TransientMetadataConfig
 }

--- a/specification/security/_types/RoleDescriptor.ts
+++ b/specification/security/_types/RoleDescriptor.ts
@@ -25,29 +25,29 @@ import { Metadata } from '@_types/common'
 import { OverloadOf } from '@spec_utils/behaviors'
 
 export class RoleDescriptor {
-  /**  
-   * A list of cluster privileges. These privileges define the cluster level actions that API keys are able to execute. 
+  /**
+   * A list of cluster privileges. These privileges define the cluster level actions that API keys are able to execute.
    */
   cluster?: string[]
-  /** 
+  /**
    * A list of indices permissions entries.
-   * @aliases index 
+   * @aliases index
    */
   indices?: IndicesPrivileges[]
   /**
    * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges. This field is optional.
    */
   global?: GlobalPrivilege[] | GlobalPrivilege
-  /** 
-   * A list of application privilege entries 
+  /**
+   * A list of application privilege entries
    */
   applications?: ApplicationPrivileges[]
-  /** 
-   * Optional meta-data. Within the metadata object, keys that begin with `_` are reserved for system usage. 
+  /**
+   * Optional meta-data. Within the metadata object, keys that begin with `_` are reserved for system usage.
    */
   metadata?: Metadata
-  /** 
-   * A list of users that the API keys can impersonate. 
+  /**
+   * A list of users that the API keys can impersonate.
    * @doc_id run-as-privilege
    */
   run_as?: string[]
@@ -55,13 +55,13 @@ export class RoleDescriptor {
 }
 
 export class RoleDescriptorRead implements OverloadOf<RoleDescriptor> {
-  /**  
-   * A list of cluster privileges. These privileges define the cluster level actions that API keys are able to execute. 
+  /**
+   * A list of cluster privileges. These privileges define the cluster level actions that API keys are able to execute.
    */
   cluster: string[]
-  /** 
+  /**
    * A list of indices permissions entries.
-   * @aliases index 
+   * @aliases index
    */
   indices: IndicesPrivileges[]
   /**
@@ -69,15 +69,15 @@ export class RoleDescriptorRead implements OverloadOf<RoleDescriptor> {
    */
   global?: GlobalPrivilege[] | GlobalPrivilege
   /**
-   * A list of application privilege entries 
+   * A list of application privilege entries
    */
   applications?: ApplicationPrivileges[]
   /**
-   * Optional meta-data. Within the metadata object, keys that begin with `_` are reserved for system usage. 
+   * Optional meta-data. Within the metadata object, keys that begin with `_` are reserved for system usage.
    */
   metadata?: Metadata
-  /** 
-   * A list of users that the API keys can impersonate. 
+  /**
+   * A list of users that the API keys can impersonate.
    * @doc_id run-as-privilege
    */
   run_as?: string[]

--- a/specification/security/_types/RoleDescriptor.ts
+++ b/specification/security/_types/RoleDescriptor.ts
@@ -35,7 +35,7 @@ export class RoleDescriptor {
    */
   indices?: IndicesPrivileges[]
   /**
-   * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges. This field is optional.
+   * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges.
    */
   global?: GlobalPrivilege[] | GlobalPrivilege
   /**
@@ -65,7 +65,7 @@ export class RoleDescriptorRead implements OverloadOf<RoleDescriptor> {
    */
   indices: IndicesPrivileges[]
   /**
-   * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges. This field is optional.
+   * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges.
    */
   global?: GlobalPrivilege[] | GlobalPrivilege
   /**

--- a/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
+++ b/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
@@ -21,12 +21,20 @@ import { RequestBase } from '@_types/Base'
 import { Ids } from '@_types/common'
 
 /**
+ * Evicts a subset of all entries from the API key cache.
+ * The cache is also automatically cleared on state changes of the security index.
  * @rest_spec_name security.clear_api_key_cache
  * @availability stack since=7.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_security
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Comma-separated list of API key IDs to evict from the API key cache.
+     * To evict all API keys, use `*`.
+     * Does not support other wildcard patterns.
+     */
     ids: Ids
   }
 }

--- a/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
+++ b/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
@@ -25,10 +25,10 @@ import { RoleDescriptor } from '@security/_types/RoleDescriptor'
 
 /**
  * Creates an API key for access without requiring basic authentication.
- * A successful request returns a JSON structure that contains the API key, its unique id, and its name. 
+ * A successful request returns a JSON structure that contains the API key, its unique id, and its name.
  * If applicable, it also returns expiration information for the API key in milliseconds.
  * NOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.
- * 
+ *
  * @rest_spec_name security.create_api_key
  * @availability stack since=6.7.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
+++ b/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
@@ -24,9 +24,15 @@ import { Duration } from '@_types/Time'
 import { RoleDescriptor } from '@security/_types/RoleDescriptor'
 
 /**
+ * Creates an API key for access without requiring basic authentication.
+ * A successful request returns a JSON structure that contains the API key, its unique id, and its name. 
+ * If applicable, it also returns expiration information for the API key in milliseconds.
+ * NOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.
+ * 
  * @rest_spec_name security.create_api_key
  * @availability stack since=6.7.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_own_api_key
  */
 export interface Request extends RequestBase {
   query_parameters: {
@@ -43,7 +49,7 @@ export interface Request extends RequestBase {
      */
     role_descriptors?: Dictionary<string, RoleDescriptor>
     /**
-     * Arbitrary metadata that you want to associate with the API key. It supports nested data structure. Within the metadata object, keys beginning with _ are reserved for system usage.
+     * Arbitrary metadata that you want to associate with the API key. It supports nested data structure. Within the metadata object, keys beginning with `_` are reserved for system usage.
      * @availability stack since=7.13.0
      * @availability serverless
      */

--- a/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
+++ b/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
@@ -21,16 +21,42 @@ import { RequestBase } from '@_types/Base'
 import { Id, Name, Username } from '@_types/common'
 
 /**
+ * Retrieves information for one or more API keys.
+ * NOTE: If you have only the `manage_own_api_key` privilege, this API returns only the API keys that you own. 
+ * If you have `read_security`, `manage_api_key` or greater privileges (including `manage_security`), this API returns all API keys regardless of ownership.
  * @rest_spec_name security.get_api_key
  * @availability stack since=6.7.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_own_api_key, read_security
  */
 export interface Request extends RequestBase {
   query_parameters: {
+    /**
+     * An API key id. 
+     * This parameter cannot be used with any of `name`, `realm_name` or `username`.
+     */
     id?: Id
+    /**
+     * An API key name. 
+     * This parameter cannot be used with any of `id`, `realm_name` or `username`.
+     * It supports prefix search with wildcard.
+     */
     name?: Name
+    /**
+     * A boolean flag that can be used to query API keys owned by the currently authenticated user. 
+     * The `realm_name` or `username` parameters cannot be specified when this parameter is set to `true` as they are assumed to be the currently authenticated ones.
+     * @server_default false
+     */
     owner?: boolean
+    /**
+     * The name of an authentication realm. 
+     * This parameter cannot be used with either `id` or `name` or when `owner` flag is set to `true`.
+     */
     realm_name?: Name
+    /**
+     * The username of a user. 
+     * This parameter cannot be used with either `id` or `name` or when `owner` flag is set to `true`.
+     */
     username?: Username
     /**
      * Return the snapshot of the owner user's role descriptors

--- a/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
+++ b/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
@@ -22,7 +22,7 @@ import { Id, Name, Username } from '@_types/common'
 
 /**
  * Retrieves information for one or more API keys.
- * NOTE: If you have only the `manage_own_api_key` privilege, this API returns only the API keys that you own. 
+ * NOTE: If you have only the `manage_own_api_key` privilege, this API returns only the API keys that you own.
  * If you have `read_security`, `manage_api_key` or greater privileges (including `manage_security`), this API returns all API keys regardless of ownership.
  * @rest_spec_name security.get_api_key
  * @availability stack since=6.7.0 stability=stable
@@ -32,29 +32,29 @@ import { Id, Name, Username } from '@_types/common'
 export interface Request extends RequestBase {
   query_parameters: {
     /**
-     * An API key id. 
+     * An API key id.
      * This parameter cannot be used with any of `name`, `realm_name` or `username`.
      */
     id?: Id
     /**
-     * An API key name. 
+     * An API key name.
      * This parameter cannot be used with any of `id`, `realm_name` or `username`.
      * It supports prefix search with wildcard.
      */
     name?: Name
     /**
-     * A boolean flag that can be used to query API keys owned by the currently authenticated user. 
+     * A boolean flag that can be used to query API keys owned by the currently authenticated user.
      * The `realm_name` or `username` parameters cannot be specified when this parameter is set to `true` as they are assumed to be the currently authenticated ones.
      * @server_default false
      */
     owner?: boolean
     /**
-     * The name of an authentication realm. 
+     * The name of an authentication realm.
      * This parameter cannot be used with either `id` or `name` or when `owner` flag is set to `true`.
      */
     realm_name?: Name
     /**
-     * The username of a user. 
+     * The username of a user.
      * This parameter cannot be used with either `id` or `name` or when `owner` flag is set to `true`.
      */
     username?: Username

--- a/specification/security/grant_api_key/SecurityGrantApiKeyRequest.ts
+++ b/specification/security/grant_api_key/SecurityGrantApiKeyRequest.ts
@@ -22,17 +22,54 @@ import { Password, Username } from '@_types/common'
 import { GrantApiKey, ApiKeyGrantType } from './types'
 
 /**
+ * Creates an API key on behalf of another user.
+ * This API is similar to Create API keys, however it creates the API key for a user that is different than the user that runs the API.
+ * The caller must have authentication credentials (either an access token, or a username and password) for the user on whose behalf the API key will be created.
+ * It is not possible to use this API to create an API key without that user’s credentials.
+ * The user, for whom the authentication credentials is provided, can optionally "run as" (impersonate) another user.
+ * In this case, the API key will be created on behalf of the impersonated user.
+ * 
+ * This API is intended be used by applications that need to create and manage API keys for end users, but cannot guarantee that those users have permission to create API keys on their own behalf.
+ * 
+ * A successful grant API key API call returns a JSON structure that contains the API key, its unique id, and its name.
+ * If applicable, it also returns expiration information for the API key in milliseconds.
+ * 
+ * By default, API keys never expire. You can specify expiration information when you create the API keys.
  * @rest_spec_name security.grant_api_key
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @cluster_privileges grant_api_key
  */
 export interface Request extends RequestBase {
   body: {
+    /**
+     * Defines the API key.
+     */
     api_key: GrantApiKey
+    /**
+     * The type of grant. Supported grant types are: `access_token`, `password`.
+     */
     grant_type: ApiKeyGrantType
+    /**
+     * The user’s access token. 
+     * If you specify the `access_token` grant type, this parameter is required. 
+     * It is not valid with other grant types.
+     */
     access_token?: string
+    /** 
+     * The user name that identifies the user. 
+     * If you specify the `password` grant type, this parameter is required. 
+     * It is not valid with other grant types.
+     */
     username?: Username
+    /**
+     * The user’s password. If you specify the `password` grant type, this parameter is required. 
+     * It is not valid with other grant types.
+     */
     password?: Password
+    /**
+     * The name of the user to be impersonated.
+     */
     run_as?: Username
   }
 }

--- a/specification/security/grant_api_key/SecurityGrantApiKeyRequest.ts
+++ b/specification/security/grant_api_key/SecurityGrantApiKeyRequest.ts
@@ -28,12 +28,12 @@ import { GrantApiKey, ApiKeyGrantType } from './types'
  * It is not possible to use this API to create an API key without that user’s credentials.
  * The user, for whom the authentication credentials is provided, can optionally "run as" (impersonate) another user.
  * In this case, the API key will be created on behalf of the impersonated user.
- * 
+ *
  * This API is intended be used by applications that need to create and manage API keys for end users, but cannot guarantee that those users have permission to create API keys on their own behalf.
- * 
+ *
  * A successful grant API key API call returns a JSON structure that contains the API key, its unique id, and its name.
  * If applicable, it also returns expiration information for the API key in milliseconds.
- * 
+ *
  * By default, API keys never expire. You can specify expiration information when you create the API keys.
  * @rest_spec_name security.grant_api_key
  * @availability stack since=7.9.0 stability=stable
@@ -51,19 +51,19 @@ export interface Request extends RequestBase {
      */
     grant_type: ApiKeyGrantType
     /**
-     * The user’s access token. 
-     * If you specify the `access_token` grant type, this parameter is required. 
+     * The user’s access token.
+     * If you specify the `access_token` grant type, this parameter is required.
      * It is not valid with other grant types.
      */
     access_token?: string
-    /** 
-     * The user name that identifies the user. 
-     * If you specify the `password` grant type, this parameter is required. 
+    /**
+     * The user name that identifies the user.
+     * If you specify the `password` grant type, this parameter is required.
      * It is not valid with other grant types.
      */
     username?: Username
     /**
-     * The user’s password. If you specify the `password` grant type, this parameter is required. 
+     * The user’s password. If you specify the `password` grant type, this parameter is required.
      * It is not valid with other grant types.
      */
     password?: Password

--- a/specification/security/grant_api_key/types.ts
+++ b/specification/security/grant_api_key/types.ts
@@ -29,17 +29,17 @@ export class GrantApiKey {
    */
   expiration?: DurationLarge
   /**
-   * The role descriptors for this API key. 
-   * This parameter is optional. 
-   * When it is not specified or is an empty array, the API key has a point in time snapshot of permissions of the specified user or access token. 
+   * The role descriptors for this API key.
+   * This parameter is optional.
+   * When it is not specified or is an empty array, the API key has a point in time snapshot of permissions of the specified user or access token.
    * If you supply role descriptors, the resultant permissions are an intersection of API keys permissions and the permissions of the user or access token.
    */
   role_descriptors?:
     | Dictionary<string, RoleDescriptor>
     | Dictionary<string, RoleDescriptor>[]
-  /** 
-   * Arbitrary metadata that you want to associate with the API key. 
-   * It supports nested data structure. 
+  /**
+   * Arbitrary metadata that you want to associate with the API key.
+   * It supports nested data structure.
    * Within the `metadata` object, keys beginning with `_` are reserved for system usage.
    */
   metadata?: Metadata

--- a/specification/security/grant_api_key/types.ts
+++ b/specification/security/grant_api_key/types.ts
@@ -24,10 +24,24 @@ import { DurationLarge } from '@_types/Time'
 
 export class GrantApiKey {
   name: Name
+  /**
+   * Expiration time for the API key. By default, API keys never expire.
+   */
   expiration?: DurationLarge
+  /**
+   * The role descriptors for this API key. 
+   * This parameter is optional. 
+   * When it is not specified or is an empty array, the API key has a point in time snapshot of permissions of the specified user or access token. 
+   * If you supply role descriptors, the resultant permissions are an intersection of API keys permissions and the permissions of the user or access token.
+   */
   role_descriptors?:
     | Dictionary<string, RoleDescriptor>
     | Dictionary<string, RoleDescriptor>[]
+  /** 
+   * Arbitrary metadata that you want to associate with the API key. 
+   * It supports nested data structure. 
+   * Within the `metadata` object, keys beginning with `_` are reserved for system usage.
+   */
   metadata?: Metadata
 }
 

--- a/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
+++ b/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
@@ -21,17 +21,46 @@ import { RequestBase } from '@_types/Base'
 import { Id, Name, Username } from '@_types/common'
 
 /**
+ * Invalidates one or more API keys.
+ * The `manage_api_key` privilege allows deleting any API keys. 
+ * The `manage_own_api_key` only allows deleting API keys that are owned by the user.
+ * In addition, with the `manage_own_api_key` privilege, an invalidation request must be issued in one of the three formats:
+ * - Set the parameter `owner=true`.
+ * - Or, set both `username` and `realm_name` to match the user’s identity.
+ * - Or, if the request is issued by an API key, i.e. an API key invalidates itself, specify its ID in the `ids` field.
  * @rest_spec_name security.invalidate_api_key
  * @availability stack since=6.7.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_api_key, manage_own_api_key
  */
 export interface Request extends RequestBase {
   body: {
     id?: Id
+    /**
+     * A list of API key ids. 
+     * This parameter cannot be used with any of `name`, `realm_name`, or `username`.
+     */
     ids?: Id[]
+    /**
+     * An API key name. 
+     * This parameter cannot be used with any of `ids`, `realm_name` or `username`.
+     */
     name?: Name
+    /**
+     * Can be used to query API keys owned by the currently authenticated user.
+     * The `realm_name` or `username` parameters cannot be specified when this parameter is set to `true` as they are assumed to be the currently authenticated ones.
+     * @server_default false
+     */
     owner?: boolean
+    /**
+     * The name of an authentication realm.
+     * This parameter cannot be used with either `ids` or `name`, or when `owner` flag is set to `true`.
+     */
     realm_name?: string
+    /**
+     * The username of a user. 
+     * This parameter cannot be used with either `ids` or `name`, or when `owner` flag is set to `true`.
+     */
     username?: Username
   }
 }

--- a/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
+++ b/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
@@ -22,7 +22,7 @@ import { Id, Name, Username } from '@_types/common'
 
 /**
  * Invalidates one or more API keys.
- * The `manage_api_key` privilege allows deleting any API keys. 
+ * The `manage_api_key` privilege allows deleting any API keys.
  * The `manage_own_api_key` only allows deleting API keys that are owned by the user.
  * In addition, with the `manage_own_api_key` privilege, an invalidation request must be issued in one of the three formats:
  * - Set the parameter `owner=true`.
@@ -37,12 +37,12 @@ export interface Request extends RequestBase {
   body: {
     id?: Id
     /**
-     * A list of API key ids. 
+     * A list of API key ids.
      * This parameter cannot be used with any of `name`, `realm_name`, or `username`.
      */
     ids?: Id[]
     /**
-     * An API key name. 
+     * An API key name.
      * This parameter cannot be used with any of `ids`, `realm_name` or `username`.
      */
     name?: Name
@@ -58,7 +58,7 @@ export interface Request extends RequestBase {
      */
     realm_name?: string
     /**
-     * The username of a user. 
+     * The username of a user.
      * This parameter cannot be used with either `ids` or `name`, or when `owner` flag is set to `true`.
      */
     username?: Username

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -48,19 +48,19 @@ export interface Request extends RequestBase {
      */
     query?: QueryContainer
     /**
-     * Starting document offset. 
-     * By default, you cannot page through more than 10,000 hits using the from and size parameters. 
+     * Starting document offset.
+     * By default, you cannot page through more than 10,000 hits using the from and size parameters.
      * To page through more hits, use the `search_after` parameter.
      * @server_default 0
      */
     from?: integer
-    /** 
+    /**
      * Other than `id`, all public fields of an API key are eligible for sorting.
-     * In addition, sort can also be applied to the `_doc` field to sort by index order. 
+     * In addition, sort can also be applied to the `_doc` field to sort by index order.
      * @doc_id sort-search-results */
     sort?: Sort
     /**
-     * The number of hits to return. 
+     * The number of hits to return.
      * By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.
      * To page through more hits, use the `search_after` parameter.
      * @server_default 10

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -23,46 +23,52 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Sort, SortResults } from '@_types/sort'
 
 /**
+ * Retrieves information for API keys in a paginated manner. You can optionally filter the results with a query.
  * @rest_spec_name security.query_api_keys
  * @availability stack since=7.15.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_own_api_key, read_security
  */
 export interface Request extends RequestBase {
   query_parameters: {
     /**
-     * Return the snapshot of the owner user's role descriptors
-     * associated with the API key. An API key's actual
-     * permission is the intersection of its assigned role
-     * descriptors and the owner user's role descriptors.
+     * Return the snapshot of the owner user's role descriptors associated with the API key. 
+     * An API key's actual permission is the intersection of its assigned role descriptors and the owner user's role descriptors.
      * @availability stack since=8.5.0
      * @availability serverless
+
      */
     with_limited_by?: boolean
   }
   body: {
     /**
      * A query to filter which API keys to return.
-     * The query supports a subset of query types, including match_all, bool, term, terms, ids, prefix, wildcard, and range.
-     * You can query all public information associated with an API key
+     * The query supports a subset of query types, including `match_all`, `bool`, `term`, `terms`, `ids`, `prefix`, `wildcard`, and `range`.
+     * You can query all public information associated with an API key.
      */
     query?: QueryContainer
     /**
-     * Starting document offset. By default, you cannot page through more than 10,000
-     * hits using the from and size parameters. To page through more hits, use the
-     * search_after parameter.
+     * Starting document offset. 
+     * By default, you cannot page through more than 10,000 hits using the from and size parameters. 
+     * To page through more hits, use the `search_after` parameter.
      * @server_default 0
      */
     from?: integer
-    /** @doc_id sort-search-results */
+    /** 
+     * Other than `id`, all public fields of an API key are eligible for sorting.
+     * In addition, sort can also be applied to the `_doc` field to sort by index order. 
+     * @doc_id sort-search-results */
     sort?: Sort
     /**
-     * The number of hits to return. By default, you cannot page through more
-     * than 10,000 hits using the from and size parameters. To page through more
-     * hits, use the search_after parameter.
-     * @server_default false
+     * The number of hits to return. 
+     * By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.
+     * To page through more hits, use the `search_after` parameter.
      * @server_default 10
      */
     size?: integer
+    /**
+     * Search after definition
+     */
     search_after?: SortResults
   }
 }

--- a/specification/security/query_api_keys/QueryApiKeysResponse.ts
+++ b/specification/security/query_api_keys/QueryApiKeysResponse.ts
@@ -22,8 +22,17 @@ import { integer } from '@_types/Numeric'
 
 export class Response {
   body: {
+    /**
+     * The total number of API keys found.
+     */
     total: integer
+    /**
+     * The number of API keys returned in the response.
+     */
     count: integer
+    /**
+     * A list of API key information.
+     */
     api_keys: ApiKey[]
   }
 }

--- a/specification/security/update_api_key/Request.ts
+++ b/specification/security/update_api_key/Request.ts
@@ -25,16 +25,16 @@ import { RoleDescriptor } from '@security/_types/RoleDescriptor'
 /**
  * Updates attributes of an existing API key.
  * Users can only update API keys that they created or that were granted to them.
- * Use this API to update API keys created by the create API Key or grant API Key APIs. 
+ * Use this API to update API keys created by the create API Key or grant API Key APIs.
  * If you need to apply the same update to many API keys, you can use bulk update API Keys to reduce overhead.
  * It’s not possible to update expired API keys, or API keys that have been invalidated by invalidate API Key.
  * This API supports updates to an API key’s access scope and metadata.
  * The access scope of an API key is derived from the `role_descriptors` you specify in the request, and a snapshot of the owner user’s permissions at the time of the request.
  * The snapshot of the owner’s permissions is updated automatically on every call.
- * If you don’t specify `role_descriptors` in the request, a call to this API might still change the API key’s access scope. 
+ * If you don’t specify `role_descriptors` in the request, a call to this API might still change the API key’s access scope.
  * This change can occur if the owner user’s permissions have changed since the API key was created or last modified.
  * To update another user’s API key, use the `run_as` feature to submit a request on behalf of another user.
- * IMPORTANT: It’s not possible to use an API key as the authentication credential for this API. 
+ * IMPORTANT: It’s not possible to use an API key as the authentication credential for this API.
  * To update an API key, the owner user’s credentials are required.
  * @rest_spec_name security.update_api_key
  * @availability stack since=8.4.0 stability=stable

--- a/specification/security/update_api_key/Request.ts
+++ b/specification/security/update_api_key/Request.ts
@@ -24,9 +24,22 @@ import { RoleDescriptor } from '@security/_types/RoleDescriptor'
 
 /**
  * Updates attributes of an existing API key.
+ * Users can only update API keys that they created or that were granted to them.
+ * Use this API to update API keys created by the create API Key or grant API Key APIs. 
+ * If you need to apply the same update to many API keys, you can use bulk update API Keys to reduce overhead.
+ * It’s not possible to update expired API keys, or API keys that have been invalidated by invalidate API Key.
+ * This API supports updates to an API key’s access scope and metadata.
+ * The access scope of an API key is derived from the `role_descriptors` you specify in the request, and a snapshot of the owner user’s permissions at the time of the request.
+ * The snapshot of the owner’s permissions is updated automatically on every call.
+ * If you don’t specify `role_descriptors` in the request, a call to this API might still change the API key’s access scope. 
+ * This change can occur if the owner user’s permissions have changed since the API key was created or last modified.
+ * To update another user’s API key, use the `run_as` feature to submit a request on behalf of another user.
+ * IMPORTANT: It’s not possible to use an API key as the authentication credential for this API. 
+ * To update an API key, the owner user’s credentials are required.
  * @rest_spec_name security.update_api_key
  * @availability stack since=8.4.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_own_api_key
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/update_api_key/Response.ts
+++ b/specification/security/update_api_key/Response.ts
@@ -20,7 +20,7 @@
 export class Response {
   body: {
     /**
-     * If `true`, the API key was updated. 
+     * If `true`, the API key was updated.
      * If `false`, the API key didn’t change because no change was detected.
      */
     updated: boolean

--- a/specification/security/update_api_key/Response.ts
+++ b/specification/security/update_api_key/Response.ts
@@ -19,6 +19,10 @@
 
 export class Response {
   body: {
+    /**
+     * If `true`, the API key was updated. 
+     * If `false`, the API key didn’t change because no change was detected.
+     */
     updated: boolean
   }
 }


### PR DESCRIPTION
Adds descriptions for these API key APIs:

- Create API key
- Grant API key
- Update API key
- Get API key information
- Invalidate API key
- Query API key information
- Clear API key cache

Source for the descriptions: https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api.html#security-api-keys

I also had to add the `read_security` cluster privilege. It was missing from `utils.ts`, but it is mentioned in several docs. I don't know if that was the right thing to do?