### PR TITLE
Fix put trained model spec

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14150,7 +14150,7 @@ export interface MlPutTrainedModelRequest extends RequestBase {
     compressed_definition?: string
     definition?: MlPutTrainedModelDefinition
     description?: string
-    inference_config: MlInferenceConfigCreateContainer
+    inference_config?: MlInferenceConfigCreateContainer
     input?: MlPutTrainedModelInput
     metadata?: any
     model_type?: MlTrainedModelType

--- a/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
@@ -65,9 +65,10 @@ export interface Request extends RequestBase {
     /**
      * The default configuration for inference. This can be either a regression
      * or classification configuration. It must match the underlying
-     * definition.trained_model's target_type.
+     * definition.trained_model's target_type. For pre-packaged models such as
+     * ELSER the config is not required.
      */
-    inference_config: InferenceConfigCreateContainer
+    inference_config?: InferenceConfigCreateContainer
     /**
      * The input field names for the model definition.
      */


### PR DESCRIPTION
Built in models like ELSER do not require an inference_config be
specified. #2098 adjusted the spec to reflect this in one place,
but not in the put trained model API spec. This PR completes the
change.