### PR TITLE
Add descriptions for index settings APIs

### DIFF
--- a/specification/indices/get_settings/IndicesGetSettingsRequest.ts
+++ b/specification/indices/get_settings/IndicesGetSettingsRequest.ts
@@ -22,22 +22,70 @@ import { ExpandWildcards, Indices, Names } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Returns setting information for one or more indices. For data streams,
+ * returns setting information for the stream’s backing indices.
  * @rest_spec_name indices.get_settings
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges view_index_metadata, monitor, manage
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Comma-separated list of data streams, indices, and aliases used to limit
+     * the request. Supports wildcards (`*`). To target all data streams and
+     * indices, omit this parameter or use `*` or `_all`.
+     */
     index?: Indices
+    /**
+     * Comma-separated list or wildcard expression of settings to retrieve.
+     */
     name?: Names
   }
   query_parameters: {
+    /**
+     * If `false`, the request returns an error if any wildcard expression, index
+     * alias, or `_all` value targets only missing or closed indices. This
+     * behavior applies even if the request targets other open indices. For
+     * example, a request targeting `foo*,bar*` returns an error if an index
+     * starts with foo but no index starts with `bar`.
+     * @server_default true
+     */
     allow_no_indices?: boolean
+    /**
+     * Type of index that wildcard patterns can match.
+     * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
+     * Supports comma-separated values, such as `open,hidden`.
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards
+    /**
+     * If `true`, returns settings in flat format.
+     * @server_default false
+     */
     flat_settings?: boolean
+    /**
+     * If `false`, the request returns an error if it targets a missing or closed index.
+     * @server_default false
+     */
     ignore_unavailable?: boolean
+    /**
+     * If `true`, return all default settings in the response.
+     * @server_default false
+     */
     include_defaults?: boolean
+    /**
+     * If `true`, the request retrieves information from the local node only. If
+     * `false`, information is retrieved from the master node.
+     * @server_default false
+     */
     local?: boolean
+    /**
+     * Period to wait for a connection to the master node. If no response is
+     * received before the timeout expires, the request fails and returns an
+     * error.
+     * @server_default 30s
+     */
     master_timeout?: Duration
   }
 }

--- a/specification/indices/put_settings/IndicesPutSettingsRequest.ts
+++ b/specification/indices/put_settings/IndicesPutSettingsRequest.ts
@@ -23,23 +23,70 @@ import { ExpandWildcards, Indices } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Changes a dynamic index setting in real time. For data streams, index setting
+ * changes are applied to all backing indices by default.
  * @rest_spec_name indices.put_settings
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges manage
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Comma-separated list of data streams, indices, and aliases used to limit
+     * the request. Supports wildcards (`*`). To target all data streams and
+     * indices, omit this parameter or use `*` or `_all`.
+     */
     index?: Indices
   }
   query_parameters: {
+    /**
+     * If `false`, the request returns an error if any wildcard expression, index
+     * alias, or `_all` value targets only missing or closed indices. This
+     * behavior applies even if the request targets other open indices. For
+     * example, a request targeting `foo*,bar*` returns an error if an index
+     * starts with `foo` but no index starts with `bar`.
+     * @server_default false
+     */
     allow_no_indices?: boolean
+    /**
+     * Type of index that wildcard patterns can match. If the request can target
+     * data streams, this argument determines whether wildcard expressions match
+     * hidden data streams. Supports comma-separated values, such as
+     * `open,hidden`.
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards
+    /**
+     * If `true`, returns settings in flat format.
+     * @server_default false
+     */
     flat_settings?: boolean
+    /**
+     * If `true`, returns settings in flat format.
+     * @server_default false
+     */
     ignore_unavailable?: boolean
+    /**
+     * Period to wait for a connection to the master node. If no response is
+     * received before the timeout expires, the request fails and returns an
+     * error.
+     * @server_default 30s
+     */
     master_timeout?: Duration
+    /**
+     *  If `true`, existing index settings remain unchanged.
+     * @server_default false
+     */
     preserve_existing?: boolean
+    /**
+     *  Period to wait for a response. If no response is received before the
+     *  timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
     timeout?: Duration
   }
-  /** @codegen_name settings */
+  /** Configuration options for the index.
+   * @codegen_name settings */
   body: IndexSettings
 }


### PR DESCRIPTION
Adds descriptions for the following APIs:
- Get index settings API
- Put index settings API

This PR **doesn't** update index setting descriptions. I have an [open request regarding setting type annotations](https://github.com/elastic/elasticsearch-specification/issues/2172) I'd like to resolve first.


## Source for descriptions
Source for the descriptions:
- https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-settings.html
- https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html