### PR TITLE
[DOCS] Add descriptions for data stream stats

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10202,9 +10202,9 @@ export type IndicesCreateDataStreamResponse = AcknowledgedResponseBase
 export interface IndicesDataStreamsStatsDataStreamsStatsItem {
   backing_indices: integer
   data_stream: Name
+  maximum_timestamp: EpochTime<UnitMillis>
   store_size?: ByteSize
   store_size_bytes: integer
-  maximum_timestamp: EpochTime<UnitMillis>
 }
 
 export interface IndicesDataStreamsStatsRequest extends RequestBase {
@@ -10216,9 +10216,9 @@ export interface IndicesDataStreamsStatsResponse {
   _shards: ShardStatistics
   backing_indices: integer
   data_stream_count: integer
+  data_streams: IndicesDataStreamsStatsDataStreamsStatsItem[]
   total_store_sizes?: ByteSize
   total_store_size_bytes: integer
-  data_streams: IndicesDataStreamsStatsDataStreamsStatsItem[]
 }
 
 export interface IndicesDeleteRequest extends RequestBase {

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -21,15 +21,27 @@ import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, IndexName } from '@_types/common'
 
 /**
+ * Retrieves statistics for one or more data streams.
  * @rest_spec_name indices.data_streams_stats
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges monitor
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Comma-separated list of data streams used to limit the request.
+     * Wildcard expressions (`*`) are supported.
+     * To target all data streams in a cluster, omit this parameter or use `*`.
+     */
     name?: IndexName
   }
   query_parameters: {
-    expand_wildcards?: ExpandWildcards // default: open
+    /**
+     * Type of data stream that wildcard patterns can match.
+     * Supports comma-separated values, such as `open,hidden`.
+     * @server_default open 
+     */
+    expand_wildcards?: ExpandWildcards
   }
 }

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -40,7 +40,7 @@ export interface Request extends RequestBase {
     /**
      * Type of data stream that wildcard patterns can match.
      * Supports comma-separated values, such as `open,hidden`.
-     * @server_default open 
+     * @server_default open
      */
     expand_wildcards?: ExpandWildcards
   }

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsResponse.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsResponse.ts
@@ -24,19 +24,42 @@ import { EpochTime, UnitMillis } from '@_types/Time'
 
 export class Response {
   body: {
+    /** Contains information about shards that attempted to execute the request. */
     _shards: ShardStatistics
+    /** Total number of backing indices for the selected data streams. */
     backing_indices: integer
+    /** Total number of selected data streams. */
     data_stream_count: integer
-    total_store_sizes?: ByteSize
-    total_store_size_bytes: integer
+    /** Contains statistics for the selected data streams. */
     data_streams: DataStreamsStatsItem[]
+    /**
+     * Total size of all shards for the selected data streams.
+     * This property is included only if the `human` query parameter is `true`
+     */
+    total_store_sizes?: ByteSize
+    /** Total size, in bytes, of all shards for the selected data streams. */
+    total_store_size_bytes: integer
   }
 }
 
 export class DataStreamsStatsItem {
+  /** Current number of backing indices for the data stream. */
   backing_indices: integer
+  /** Name of the data stream. */
   data_stream: Name
-  store_size?: ByteSize
-  store_size_bytes: integer
+  /**
+   * The data stream’s highest `@timestamp` value, converted to milliseconds since the Unix epoch.
+   * NOTE: This timestamp is provided as a best effort.
+   * The data stream may contain `@timestamp` values higher than this if one or more of the following conditions are met:
+   * The stream contains closed backing indices;
+   * Backing indices with a lower generation contain higher `@timestamp` values.
+   */
   maximum_timestamp: EpochTime<UnitMillis>
+  /**
+   * Total size of all shards for the data stream’s backing indices.
+   * This parameter is only returned if the `human` query parameter is `true`.
+   */
+  store_size?: ByteSize
+  /** Total size, in bytes, of all shards for the data stream’s backing indices. */
+  store_size_bytes: integer
 }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/964

This PR adds descriptions from https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-stats-api.html