### PR TITLE
[Transform] Filter availability

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -10,6 +10,7 @@
     "format:fix": "prettier --config .prettierrc.json --write ../specification/",
     "generate-schema": "ts-node src/index.ts",
     "transform-expand-generics": "ts-node src/transform/expand-generics.ts",
+    "filter-by-availability": "ts-node src/transform/filter-by-availability.ts",
     "dump-routes": "ts-node src/dump/extract-routes.ts",
     "compile:specification": "tsc --project ../specification/tsconfig.json --noEmit",
     "build": "rm -rf lib && tsc",

--- a/compiler/src/transform/filter-by-availability.ts
+++ b/compiler/src/transform/filter-by-availability.ts
@@ -236,6 +236,10 @@ function filterEndpoints(inputModel: Model, stack, serverless: boolean): Model {
 }
 
 async function filterSchema(inPath: string, outPath: string, stack: boolean, serverless: boolean): Promise<void> {
+  if (!stack && !serverless) {
+    throw new Error("Expected one of --stack or --serverless to be specified.");
+  }
+
   const inputText = await readFile(
     inPath,
     {encoding: 'utf8'}
@@ -243,9 +247,6 @@ async function filterSchema(inPath: string, outPath: string, stack: boolean, ser
 
   const inputModel = JSON.parse(inputText)
   const outputModel = filterEndpoints(inputModel, stack, serverless)
-
-  console.log("Endpoints: " + outputModel.endpoints.length)
-  console.log("Types: " + outputModel.types.length)
 
   await writeFile(
     outPath,
@@ -265,5 +266,7 @@ const serverless = !!argv.serverless
 // input, if not provided default to versioned schema.json
 // output, if not provided default to schema-filtered.json
 filterSchema(inputPath, outputPath, stack, serverless)
-  .catch(reason => console.error(reason))
+  .catch(reason => {
+    console.error(reason.message? reason.message:reason)
+  })
   .finally(() => console.log('Done, filtered schema is at', outputPath))

--- a/compiler/src/transform/filter-by-availability.ts
+++ b/compiler/src/transform/filter-by-availability.ts
@@ -189,11 +189,11 @@ function filterModel (inputModel: Model, stack, serverless: boolean): Model {
     }
   })
 
-  // from what was gathered we filter out anything that doesn't match the requested tags
+  // filter type items (properties / enum members)
   inputModel.types.forEach((typeDef) => {
     switch (typeDef.kind) {
       case 'interface':
-        typeDef.properties.filter(filterItem())
+        typeDef.properties = typeDef.properties.filter(filterItem())
         break
       case 'enum':
         typeDef.members = typeDef.members.filter(filterItem())
@@ -207,7 +207,7 @@ function filterModel (inputModel: Model, stack, serverless: boolean): Model {
             // filter out body properties
             switch (typeDef.body.kind) {
               case 'properties':
-                typeDef.body.properties.filter(filterItem())
+                typeDef.body.properties = typeDef.body.properties.filter(filterItem())
                 break
             }
           }
@@ -219,7 +219,7 @@ function filterModel (inputModel: Model, stack, serverless: boolean): Model {
             // filter out body properties
             switch (typeDef.body.kind) {
               case 'properties':
-                typeDef.body.properties.filter(filterItem())
+                typeDef.body.properties = typeDef.body.properties.filter(filterItem())
                 break
             }
           }
@@ -250,6 +250,9 @@ async function filterSchema (inPath: string, outPath: string, stack: boolean, se
 
   const inputModel = JSON.parse(inputText)
   const outputModel = filterModel(inputModel, stack, serverless)
+
+  console.log(outputModel.endpoints.length)
+  console.log(outputModel.types.length)
 
   await writeFile(
     outPath,

--- a/compiler/src/transform/filter-by-availability.ts
+++ b/compiler/src/transform/filter-by-availability.ts
@@ -66,9 +66,11 @@ function filterModel (inputModel: Model, stack, serverless: boolean): Model {
         output.types.push(typeDef)
 
         // store the type infos to prevent doubles & recursive calls
-        ;(seen.get(typeName.namespace) != null)
-          ? seen.get(typeName.namespace)?.push(typeName.name)
-          : seen.set(typeName.namespace, [typeName.name])
+        if (seen.get(typeName.namespace) !== undefined) {
+          seen.get(typeName.namespace)?.push(typeName.name)
+        } else {
+          seen.set(typeName.namespace, [typeName.name])
+        }
 
         // first time seeing this type so we explore the type
         exploreTypedef(typeDef)

--- a/compiler/src/transform/filter-by-availability.ts
+++ b/compiler/src/transform/filter-by-availability.ts
@@ -1,0 +1,264 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {Availabilities, Endpoint, Model, TypeDefinition, TypeName, ValueOf} from '../model/metamodel'
+import {readFile, writeFile} from 'fs/promises'
+import stringify from 'safe-stable-stringify'
+import {argv} from 'zx'
+import {join} from 'path'
+
+function filterEndpoints(inputModel: Model, stack, serverless: boolean): Model {
+  // filter used against the provided availability
+  // used to filter out endpoints and as a filter for items with availability (Enum & Property).
+  function include(availabilities: Availabilities, stack: boolean, serverless: boolean): boolean {
+    if (availabilities.stack && stack && !serverless) {
+      return true
+    }
+    if (availabilities.serverless && serverless && !stack) {
+      return true
+    }
+    if ((availabilities.serverless || availabilities.stack) && serverless && stack) {
+      return true
+    }
+    return false
+  }
+
+  // used to filter out individual items within types.
+  function filterItem() {
+    return (item) => {
+      return item.availability ? include(item.availability, stack, serverless) : true
+    };
+  }
+
+  // short comparison for two TypeNames
+  function cmpTypeNames(t1, t2: TypeName): boolean {
+    return t1.name === t2.name && t1.namespace == t2.namespace
+  }
+
+  // return early if the type already has been added
+  // fetches the original type from the input model
+  // save its presence to prevent recursion and doubles
+  // continues down the type tree for any new types
+  function addTypeToOutput(typeName: TypeName) {
+    if (seen.get(typeName.namespace)?.includes(typeName.name)) {
+      return
+    }
+
+    inputModel.types.forEach((typeDef) => {
+      if (cmpTypeNames(typeName, typeDef.name)) {
+        // add the TypeDefinition to the output
+        output.types.push(typeDef)
+
+        // store the type infos to prevent doubles & recursive calls
+        seen.get(typeName.namespace) ?
+          seen.get(typeName.namespace)?.push(typeName.name) :
+          seen.set(typeName.namespace, [typeName.name])
+
+        // first time seeing this type so we explore the type
+        exploreTypedef(typeDef)
+      }
+    })
+  }
+
+  // handles the basic type field we can find
+  // user_defined_value and literal_value are omitted.
+  function addValueOf(item: ValueOf) {
+    switch (item.kind) {
+      case "instance_of":
+        addTypeToOutput(item.type)
+        break;
+      case "array_of":
+        addValueOf(item.value)
+        break;
+      case "union_of":
+        item.items.forEach((member) => {
+          addValueOf(member)
+        })
+        break;
+      case "dictionary_of":
+        addValueOf(item.key)
+        addValueOf(item.value)
+        break;
+    }
+  }
+
+  function exploreTypedef(typeDef: TypeDefinition) {
+    // handle generics
+    // not really useful for everyone, still useful for type_alias
+    if (typeDef.kind === "interface" || typeDef.kind === "request" || typeDef.kind === "response" || typeDef.kind === "type_alias") {
+      typeDef.generics?.forEach((generic) => {
+        addTypeToOutput(generic)
+      })
+    }
+
+    // handle behaviors
+    if (typeDef.kind === "interface" || typeDef.kind === "request" || typeDef.kind === "response") {
+      typeDef.behaviors?.forEach((behavior) => {
+        addTypeToOutput(behavior.type)
+        behavior.generics?.forEach((generic) => {
+          addValueOf(generic)
+        })
+      })
+    }
+
+    // handle inherits & implements
+    if (typeDef.kind === "interface" || typeDef.kind === "request") {
+      typeDef.inherits ? addTypeToOutput(typeDef.inherits.type) : void 0
+      typeDef.implements?.forEach((implemented) => {
+        addTypeToOutput(implemented.type)
+      })
+    }
+
+    // handle body value and body properties for request and response
+    if (typeDef.kind === "request" || typeDef.kind === "response") {
+      switch (typeDef.body.kind) {
+        case "value":
+          addValueOf(typeDef.body.value)
+          break;
+        case "properties":
+          typeDef.body.properties.forEach((property) => {
+            addValueOf(property.type);
+          })
+          break;
+      }
+    }
+
+    // left over specific cases
+    switch (typeDef.kind) {
+      case "interface":
+        typeDef.properties.forEach((property) => {
+          addValueOf(property.type);
+        })
+        break;
+
+      case "request":
+        typeDef.path.forEach((path) => {
+          addValueOf(path.type)
+        })
+        typeDef.query.forEach((query) => {
+          addValueOf(query.type)
+        })
+        break;
+
+      case "type_alias":
+        addValueOf(typeDef.type)
+        break;
+
+    }
+  }
+
+  let seen = new Map<string, string[]>();
+
+  let output: Model = {
+    _info: inputModel._info,
+    types: new Array<TypeDefinition>(),
+    endpoints: new Array<Endpoint>()
+  };
+
+  // we filter to include only the matching endpoints
+  inputModel.endpoints.forEach((endpoint) => {
+    if (include(endpoint.availability, stack, serverless)) {
+      // add the current endpoint
+      output.endpoints.push(endpoint);
+
+      // add the request and response type for current endpoint
+      inputModel.types.forEach((typeDef) => {
+        if ((endpoint.request && cmpTypeNames(endpoint.request, typeDef.name)) || (endpoint.response && cmpTypeNames(endpoint.response, typeDef.name))) {
+          output.types.push(typeDef)
+        }
+      })
+    }
+  })
+
+  // from what was gathered we filter out anything that doesn't match the requested tags
+  inputModel.types.forEach((typeDef) => {
+    switch (typeDef.kind) {
+      case "interface":
+        typeDef.properties.filter(filterItem())
+        break;
+      case "enum":
+        typeDef.members = typeDef.members.filter(filterItem())
+        addTypeToOutput(typeDef.name)
+        break;
+      case "request":
+        output.endpoints.forEach((endpoint) => {
+          if (endpoint.request?.name == typeDef.name.name && endpoint.request.namespace == typeDef.name.namespace) {
+            typeDef.path = typeDef.path.filter(filterItem())
+            typeDef.query = typeDef.query.filter(filterItem())
+            //filter out body properties
+            switch (typeDef.body.kind) {
+              case "properties":
+                typeDef.body.properties.filter(filterItem())
+                break;
+            }
+          }
+        })
+        break;
+      case "response":
+        output.endpoints.forEach((endpoint) => {
+          if (endpoint.response?.name == typeDef.name.name && endpoint.response.namespace == typeDef.name.namespace) {
+            //filter out body properties
+            switch (typeDef.body.kind) {
+              case "properties":
+                typeDef.body.properties.filter(filterItem())
+                break;
+            }
+          }
+        })
+        break;
+      case "type_alias":
+        addTypeToOutput(typeDef.name)
+    }
+  })
+
+  // we complete the spec with the missing types for the tree until exhaustion
+  output.types.forEach((typeDef) => {
+    exploreTypedef(typeDef);
+  })
+
+  return output;
+}
+
+async function filterSchema(inPath: string, outPath: string, stack: boolean, serverless: boolean): Promise<void> {
+  const inputText = await readFile(
+    inPath,
+    {encoding: 'utf8'}
+  )
+
+  const inputModel = JSON.parse(inputText)
+  const outputModel = filterEndpoints(inputModel, stack, serverless)
+
+  console.log("Endpoints: " + outputModel.endpoints.length)
+  console.log("Types: " + outputModel.types.length)
+
+  await writeFile(
+    outPath,
+    stringify(outputModel, null, 2),
+    'utf8'
+  )
+}
+
+const inputPath = argv.input ?? join(__dirname, '..', '..', '..', 'output', 'schema', 'schema-no-generics.json')
+const outputPath = argv.output ?? join(__dirname, '..', '..', '..', 'output', 'schema', 'schema-filtered.json')
+const stack = !!argv.stack
+const serverless = !!argv.serverless
+
+filterSchema(inputPath, outputPath, stack, serverless)
+  .catch(reason => console.error(reason))
+  .finally(() => console.log('Done, filtered schema is at', outputPath))

--- a/compiler/src/transform/filter-by-availability.ts
+++ b/compiler/src/transform/filter-by-availability.ts
@@ -254,11 +254,16 @@ async function filterSchema(inPath: string, outPath: string, stack: boolean, ser
   )
 }
 
-const inputPath = argv.input ?? join(__dirname, '..', '..', '..', 'output', 'schema', 'schema-no-generics.json')
+const inputPath: string = argv.input ?? join(__dirname, '..', '..', '..', 'output', 'schema', 'schema.json')
 const outputPath = argv.output ?? join(__dirname, '..', '..', '..', 'output', 'schema', 'schema-filtered.json')
 const stack = !!argv.stack
 const serverless = !!argv.serverless
 
+// Usage:
+// npm run filter-by-availability -- [--serverless|--stack]
+// Optional args:
+// input, if not provided default to versioned schema.json
+// output, if not provided default to schema-filtered.json
 filterSchema(inputPath, outputPath, stack, serverless)
   .catch(reason => console.error(reason))
   .finally(() => console.log('Done, filtered schema is at', outputPath))

--- a/compiler/src/transform/filter-by-availability.ts
+++ b/compiler/src/transform/filter-by-availability.ts
@@ -57,12 +57,17 @@ function filterModel (inputModel: Model, stack: boolean, serverless: boolean, vi
     return t1.name === t2.name && t1.namespace === t2.namespace
   }
 
+  // Returns the fully-qualified name of a type name
+  function fqn (name: TypeName): string {
+    return `${name.namespace}:${name.name}`
+  }
+
   // return early if the type already has been added
   // fetches the original type from the input model
   // save its presence to prevent recursion and doubles
   // continues down the type tree for any new types
   function addTypeToOutput (typeName: TypeName): void {
-    if (seen.get(typeName.namespace)?.includes(typeName.name) === true) {
+    if (seen.has(fqn(typeName))) {
       return
     }
 
@@ -72,11 +77,7 @@ function filterModel (inputModel: Model, stack: boolean, serverless: boolean, vi
         output.types.push(typeDef)
 
         // store the type infos to prevent doubles & recursive calls
-        if (seen.get(typeName.namespace) !== undefined) {
-          seen.get(typeName.namespace)?.push(typeName.name)
-        } else {
-          seen.set(typeName.namespace, [typeName.name])
-        }
+        seen.add(fqn(typeName))
 
         // first time seeing this type so we explore the type
         exploreTypedef(typeDef)
@@ -172,12 +173,7 @@ function filterModel (inputModel: Model, stack: boolean, serverless: boolean, vi
     }
   }
 
-  // Returns the fully-qualified name of a type name
-  function fqn (name: TypeName): string {
-    return `${name.namespace}:${name.name}`
-  }
-
-  const seen = new Map<string, string[]>()
+  const seen = new Set<string>()
 
   const output: Model = {
     _info: inputModel._info,

--- a/compiler/src/transform/filter-by-availability.ts
+++ b/compiler/src/transform/filter-by-availability.ts
@@ -265,20 +265,26 @@ async function filterSchema (inPath: string, outPath: string, stack: boolean, se
   const inputModel = JSON.parse(inputText)
   const outputModel = filterModel(inputModel, stack, serverless)
 
-  console.log(outputModel.endpoints.length)
-  console.log(outputModel.types.length)
-
   await writeFile(
     outPath,
     stringify(outputModel, null, 2),
     'utf8'
   )
 }
-
-const inputPath: string = argv.input ?? join(__dirname, '..', '..', '..', 'output', 'schema', 'schema.json')
-const outputPath = argv.output ?? join(__dirname, '..', '..', '..', 'output', 'schema', 'schema-filtered.json')
 const stack: boolean = (argv.stack !== undefined)
 const serverless: boolean = (argv.serverless !== undefined)
+let target: string = ''
+
+if (stack && serverless) {
+  target = 'stack-serverless'
+} else if (serverless) {
+  target = 'serverless'
+} else if (stack) {
+  target = 'stack'
+}
+
+const inputPath: string = argv.input ?? join(__dirname, '..', '..', '..', 'output', 'schema', 'schema.json')
+const outputPath = argv.output ?? join(__dirname, '..', '..', '..', 'output', 'schema', `schema-filtered-${target}.json`)
 
 // Usage:
 // npm run filter-by-availability -- [--serverless|--stack]

--- a/compiler/src/transform/filter-by-availability.ts
+++ b/compiler/src/transform/filter-by-availability.ts
@@ -180,7 +180,7 @@ function filterModel (inputModel: Model, stack, serverless: boolean): Model {
 
       // add the request and response type for current endpoint
       inputModel.types.forEach((typeDef) => {
-        if (((endpoint.request != null) && cmpTypeNames(endpoint.request, typeDef.name)) || ((endpoint.response != null) && cmpTypeNames(endpoint.response, typeDef.name))) {
+        if (((endpoint.request !== null) && cmpTypeNames(endpoint.request, typeDef.name)) || ((endpoint.response !== null) && cmpTypeNames(endpoint.response, typeDef.name))) {
           output.types.push(typeDef)
         }
       })

--- a/compiler/src/transform/filter-by-availability.ts
+++ b/compiler/src/transform/filter-by-availability.ts
@@ -197,12 +197,12 @@ function filterModel (inputModel: Model, stack: boolean, serverless: boolean, vi
       // add the current endpoint
       output.endpoints.push(endpoint)
 
-      if (endpoint.request != null) {
+      if (endpoint.request !== null) {
         const requestType = typeDefByName.get(fqn(endpoint.request))
         if (requestType !== undefined) output.types.push(requestType)
       }
 
-      if (endpoint.response != null) {
+      if (endpoint.response !== null) {
         const responseType = typeDefByName.get(fqn(endpoint.response))
         if (responseType !== undefined) output.types.push(responseType)
       }

--- a/compiler/src/transform/filter-by-availability.ts
+++ b/compiler/src/transform/filter-by-availability.ts
@@ -23,7 +23,7 @@ import stringify from 'safe-stable-stringify'
 import {argv} from 'zx'
 import {join} from 'path'
 
-function filterEndpoints(inputModel: Model, stack, serverless: boolean): Model {
+function filterModel(inputModel: Model, stack, serverless: boolean): Model {
   // filter used against the provided availability
   // used to filter out endpoints and as a filter for items with availability (Enum & Property).
   function include(availabilities: Availabilities, stack: boolean, serverless: boolean): boolean {
@@ -246,7 +246,7 @@ async function filterSchema(inPath: string, outPath: string, stack: boolean, ser
   )
 
   const inputModel = JSON.parse(inputText)
-  const outputModel = filterEndpoints(inputModel, stack, serverless)
+  const outputModel = filterModel(inputModel, stack, serverless)
 
   await writeFile(
     outPath,


### PR DESCRIPTION
This PR adds a subscript to the transform list to filter the specification and types based on the `@availability` tags.

The script defaults to the standard `schema.json` and output a `schema-filtered.json` in the same directory based on the provided flags. (e.g. `--stack` or `--serverless`)
Input and output path the different source and target can be provided.