### PR TITLE
[NLP] Support the different mask tokens used by NLP models for Fill Mask

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12554,6 +12554,7 @@ export interface MlDiscoveryNode {
 export type MlExcludeFrequent = 'all' | 'none' | 'by' | 'over'
 
 export interface MlFillMaskInferenceOptions {
+  mask_token?: string
   num_top_classes?: integer
   tokenization?: MlTokenizationConfigContainer
   results_field?: string

--- a/specification/ml/_types/inference.ts
+++ b/specification/ml/_types/inference.ts
@@ -265,6 +265,12 @@ export class NerInferenceOptions {
 
 /** Fill mask inference options */
 export class FillMaskInferenceOptions {
+  /** The string/token which will be removed from incoming documents and replaced with the inference prediction(s).
+   * In a response, this field contains the mask token for the specified model/tokenizer. Each model and tokenizer
+   * has a predefined mask token which cannot be changed. Thus, it is recommended not to set this value in requests.
+   * However, if this field is present in a request, its value must match the predefined value for that model/tokenizer,
+   * otherwise the request will fail. */
+  mask_token?: string
   /** Specifies the number of top class predictions to return. Defaults to 0. */
   num_top_classes?: integer
   /** The tokenization options to update when inferring */


### PR DESCRIPTION
Adds the specification for the new mask token field added in https://github.com/elastic/elasticsearch/pull/97453.


