### PR TITLE
Add serverless annotation to search mvt

### DIFF
--- a/specification/_global/search_mvt/SearchMvtRequest.ts
+++ b/specification/_global/search_mvt/SearchMvtRequest.ts
@@ -32,7 +32,8 @@ import { TrackHits } from '@global/search/_types/hits'
 
 /**
  * @rest_spec_name search_mvt
- * @availability stack since=7.15.0 stability=experimental
+ * @availability stack since=7.15.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {


### PR DESCRIPTION
The search mvt API is a public API in serverless, therefore adding corresponding annotation.