### PR TITLE
Minor generation workflow bugfix

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -24,6 +24,8 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # The actor check currently does not work. The `secrets.PAT` belongs to `delvedor` and not
+    # `elasticmachine`. We should make sure to change this in the future.
     if: github.repository_owner == 'elastic' && github.actor != 'elasticmachine'
     steps:
     - name: Checkout
@@ -64,13 +66,8 @@ jobs:
     - name: Push Output
       if: steps.changes.outputs.has-changes == '1'
       run: |
-        cd ./output
-
-        git add -A
+        git add -A ./output
         git commit -m "Update specification output"
-
-        git status
-
         git push
 
     # For debugging purposes:
@@ -79,14 +76,9 @@ jobs:
     #   env:
     #     BRANCH_NAME: output_${{ github.run_id }}_${{ github.run_attempt }}
     #   run: |
-    #     cd ./output
-
     #     git fetch
     #     git switch main
 
-    #     git add -A
+    #     git add -A ./output
     #     git commit -m "Update specification output"
-
-    #     git status
-
     #     git push origin HEAD:refs/heads/${{ env.BRANCH_NAME }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Check for Changed Files
       id: changes
       run: |
-        if [ -n "$(git status --porcelain)" ]; then
+        if [ -n "$(git status --porcelain ./output)" ]; then
           echo "has-changes=1" >> $GITHUB_OUTPUT
         fi
 


### PR DESCRIPTION
Makes sure to only commit files in the `./output` directory.