### PR TITLE
[DOCS] Add descriptions for queries A-G

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -403,3 +403,17 @@ templating-role-query,https://www.elastic.co/guide/en/elasticsearch/reference/{b
 mapping-settings-limit,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-settings-limit.html
 index-modules-slowlog-slowlog,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-modules-slowlog.html#index-slow-log
 multi-fields,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/multi-fields.html
+query-dsl-bool-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-bool-query.html
+query-dsl-boosting-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-boosting-query.html
+query-dsl-combined-fields-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-combined-fields-query.html
+query-dsl-constant-score-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-constant-score-query.html
+query-dsl-dis-max-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-dis-max-query.html
+query-dsl-distance-feature-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-distance-feature-query.html
+query-dsl-exists-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-exists-query.html
+query-dsl-function-score-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-function-score-query.html
+fuzziness,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/common-options.html#fuzziness
+query-dsl-fuzzy-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-fuzzy-query.html
+query-dsl-geo-bounding-box-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-geo-bounding-box-query.html
+query-dsl-geo-distance-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-geo-distance-query.html
+distance-units,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/api-conventions.html#distance-units
+query-dsl-geo-shape-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-geo-shape-query.html

--- a/specification/_types/Geo.ts
+++ b/specification/_types/Geo.ts
@@ -65,9 +65,22 @@ export class GeoLine {
 }
 
 export enum GeoShapeRelation {
+  /**
+   * Return all documents whose `geo_shape` or `geo_point` field intersects the query geometry.
+   */
   intersects = 0,
+  /**
+   * Return all documents whose `geo_shape` or `geo_point` field has nothing in common with the query geometry.
+   */
   disjoint = 1,
+  /**
+   * Return all documents whose `geo_shape` or `geo_point` field is within the query geometry.
+   * Line geometries are not supported.
+   */
   within = 2,
+  /**
+   * Return all documents whose `geo_shape` or `geo_point` field contains the query geometry.
+   */
   contains = 3
 }
 

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -111,6 +111,7 @@ export type SequenceNumber = long
 export type PropertyName = string
 export type RelationName = string
 export type TaskId = string | integer
+/** @doc_id fuzziness */
 export type Fuzziness = string | integer
 /** @doc_id query-dsl-multi-term-rewrite */
 export type MultiTermQueryRewrite = string

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -100,24 +100,72 @@ import { TextExpansionQuery } from './TextExpansionQuery'
  * @doc_id query-dsl
  */
 export class QueryContainer {
+  /**
+   * matches documents matching boolean combinations of other queries.
+   * @doc_id query-dsl-bool-query
+   */
   bool?: BoolQuery
+  /**
+   * Returns documents matching a `positive` query while reducing the relevance score of documents that also match a `negative` query.
+   * @doc_id query-dsl-boosting-query
+   */
   boosting?: BoostingQuery
   /** @deprecated 7.3.0 */
   common?: SingleKeyDictionary<Field, CommonTermsQuery>
   /**
+   * The `combined_fields` query supports searching multiple text fields as if their contents had been indexed into one combined field.
+   * @doc_id query-dsl-combined-fields-query
    * @availability stack since=7.13.0
    * @availability serverless
    */
   combined_fields?: CombinedFieldsQuery
+  /**
+   * Wraps a filter query and returns every matching document with a relevance score equal to the `boost` parameter value.
+   * @doc_id query-dsl-constant-score-query
+   */
   constant_score?: ConstantScoreQuery
+  /**
+   * Returns documents matching one or more wrapped queries, called query clauses or clauses.
+   * If a returned document matches multiple query clauses, the `dis_max` query assigns the document the highest relevance score from any matching clause, plus a tie breaking increment for any additional matching subqueries.
+   * @doc_id query-dsl-dis-max-query
+   */
   dis_max?: DisMaxQuery
+  /**
+   * Boosts the relevance score of documents closer to a provided origin date or point.
+   * For example, you can use this query to give more weight to documents closer to a certain date or location.
+   * @doc_id query-dsl-distance-feature-query
+   */
   distance_feature?: DistanceFeatureQuery
+  /**
+   * Returns documents that contain an indexed value for a field.
+   * @doc_id query-dsl-exists-query
+   */
   exists?: ExistsQuery
+  /**
+   * The `function_score` enables you to modify the score of documents that are retrieved by a query.
+   * @doc_id query-dsl-function-score-query
+   */
   function_score?: FunctionScoreQuery
+  /**
+   * Returns documents that contain terms similar to the search term, as measured by a Levenshtein edit distance.
+   * @doc_id query-dsl-fuzzy-query
+   */
   fuzzy?: SingleKeyDictionary<Field, FuzzyQuery>
+  /**
+   * Matches geo_point and geo_shape values that intersect a bounding box.
+   * @doc_id query-dsl-geo-bounding-box-query
+   */
   geo_bounding_box?: GeoBoundingBoxQuery
+  /**
+   * Matches `geo_point` and `geo_shape` values within a given distance of a geopoint.
+   * @doc_id query-dsl-geo-distance-query
+   */
   geo_distance?: GeoDistanceQuery
   geo_polygon?: GeoPolygonQuery
+  /**
+   * Filter documents indexed using either the `geo_shape` or the `geo_point` type.
+   * @doc_id query-dsl-geo-shape-query
+   */
   geo_shape?: GeoShapeQuery
   has_child?: HasChildQuery
   has_parent?: HasParentQuery
@@ -171,9 +219,21 @@ export class QueryContainer {
 }
 
 export class FieldLookup {
+  /**
+   * `id` of the document.
+   */
   id: Id
+  /**
+   * Index from which to retrieve the document.
+   */
   index?: IndexName
+  /**
+   * Name of the field.
+   */
   path?: Field
+  /**
+   * Custom routing value.
+   */
   routing?: Routing
 }
 
@@ -182,24 +242,51 @@ export class FieldNameQuery {
 }
 
 export class QueryBase {
+  /**
+   * Floating point number used to decrease or increase the relevance scores of the query.
+   * Boost values are relative to the default value of 1.0.
+   * A boost value between 0 and 1.0 decreases the relevance score.
+   * A value greater than 1.0 increases the relevance score.
+   * @server_default 1.0
+   */
   boost?: float
   /** @codegen_name query_name */
   _name?: string
 }
 
 export class CombinedFieldsQuery extends QueryBase {
+  /**
+   * List of fields to search. Field wildcard patterns are allowed. Only `text` fields are supported, and they must all have the same search `analyzer`.
+   */
   fields: Field[]
+  /**
+   * Text to search for in the provided `fields`.
+   * The `combined_fields` query analyzes the provided text before performing a search.
+   */
   query: string
 
-  /** @server_default true */
+  /**
+   * If true, match phrase queries are automatically created for multi-term synonyms.
+   * @server_default true
+   */
   auto_generate_synonyms_phrase_query?: boolean
 
-  /** @server_default or */
+  /**
+   * Boolean logic used to interpret text in the query value.
+   * @server_default or
+   */
   operator?: CombinedFieldsOperator
 
+  /**
+   * Minimum number of clauses that must match for a document to be returned.
+   * @doc_id query-dsl-minimum-should-match
+   */
   minimum_should_match?: MinimumShouldMatch
 
-  /** @server_default none */
+  /**
+   * Indicates whether no documents are returned if the analyzer removes all tokens, such as when using a `stop` filter.
+   * @server_default none
+   */
   zero_terms_query?: CombinedFieldsZeroTerms
 }
 
@@ -214,7 +301,13 @@ export enum CombinedFieldsOperator {
 }
 
 export enum CombinedFieldsZeroTerms {
+  /**
+   * No documents are returned if the analyzer removes all tokens.
+   */
   none,
+  /**
+   * Returns all documents, similar to a `match_all` query.
+   */
   all
 }
 

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -26,39 +26,101 @@ import { DateMath, Duration } from '@_types/Time'
 import { QueryBase, QueryContainer } from './abstractions'
 
 export class BoolQuery extends QueryBase {
+  /**
+   * The clause (query) must appear in matching documents.
+   * However, unlike `must`, the score of the query will be ignored.
+   */
   filter?: QueryContainer | QueryContainer[]
+  /**
+   * Specifies the number or percentage of `should` clauses returned documents must match.
+   * @doc_id query-dsl-minimum-should-match
+   */
   minimum_should_match?: MinimumShouldMatch
+  /**
+   * The clause (query) must appear in matching documents and will contribute to the score.
+   */
   must?: QueryContainer | QueryContainer[]
+  /**
+   * The clause (query) must not appear in the matching documents.
+   * Because scoring is ignored, a score of `0` is returned for all documents.
+   */
   must_not?: QueryContainer | QueryContainer[]
+  /**
+   * The clause (query) should appear in the matching document.
+   */
   should?: QueryContainer | QueryContainer[]
 }
 
 export class BoostingQuery extends QueryBase {
+  /**
+   * Floating point number between 0 and 1.0 used to decrease the relevance scores of documents matching the `negative` query.
+   */
   negative_boost: double
+  /**
+   * Query used to decrease the relevance score of matching documents.
+   */
   negative: QueryContainer
+  /**
+   * Any returned documents must match this query.
+   */
   positive: QueryContainer
 }
 
 export class ConstantScoreQuery extends QueryBase {
+  /**
+   * Filter query you wish to run. Any returned documents must match this query.
+   * Filter queries do not calculate relevance scores.
+   * To speed up performance, Elasticsearch automatically caches frequently used filter queries.
+   */
   filter: QueryContainer
 }
 
 export class DisMaxQuery extends QueryBase {
+  /**
+   * One or more query clauses.
+   * Returned documents must match one or more of these queries.
+   * If a document matches multiple queries, Elasticsearch uses the highest relevance score.
+   */
   queries: QueryContainer[]
-  /** @server_default 0.0 */
+  /**
+   * Floating point number between 0 and 1.0 used to increase the relevance scores of documents matching multiple query clauses.
+   * @server_default 0.0
+   */
   tie_breaker?: double
 }
 
 export class FunctionScoreQuery extends QueryBase {
+  /**
+   * Defines how he newly computed score is combined with the score of the query
+   * @server_default multiply
+   */
   boost_mode?: FunctionBoostMode
+  /**
+   * One or more functions that compute a new score for each document returned by the query.
+   */
   functions?: FunctionScoreContainer[]
+  /**
+   * Restricts the new score to not exceed the provided limit.
+   */
   max_boost?: double
+  /**
+   * Excludes documents that do not meet the provided score threshold.
+   */
   min_score?: double
+  /**
+   * A query that determines the documents for which a new score is computed.
+   */
   query?: QueryContainer
+  /** Specifies how the computed scores are combined
+   * @server_default multiply
+   */
   score_mode?: FunctionScoreMode
 }
 
 export class ScriptScoreFunction {
+  /**
+   * A script that computes a score.
+   */
   script: Script
 }
 
@@ -68,20 +130,52 @@ export class RandomScoreFunction {
 }
 
 export class FieldValueFactorScoreFunction {
+  /**
+   * Field to be extracted from the document.
+   */
   field: Field
+  /**
+   * Optional factor to multiply the field value with.
+   * @server_default 1
+   */
   factor?: double
+  /**
+   * Value used if the document doesn’t have that field.
+   * The modifier and factor are still applied to it as though it were read from the document.
+   */
   missing?: double
+  /**
+   * Modifier to apply to the field value.
+   */
   modifier?: FieldValueFactorModifier
 }
 
 export class DecayPlacement<TOrigin, TScale> {
+  /**
+   * Defines how documents are scored at the distance given at scale.
+   * @server_default 0.5
+   */
   decay?: double
+  /**
+   * If defined, the decay function will only compute the decay function for documents with a distance greater than the defined `offset`.
+   * @server_default 0
+   */
   offset?: TScale
+  /**
+   * Defines the distance from origin + offset at which the computed score will equal `decay` parameter.
+   */
   scale?: TScale
+  /**
+   * The point of origin used for calculating distance. Must be given as a number for numeric field, date for date fields and geo point for geo fields.
+   */
   origin?: TOrigin
 }
 
 export class DecayFunctionBase {
+  /**
+   * Determines how the distance is calculated when a field used for computing the decay contains multiple values.
+   * @server_default min
+   */
   multi_value_mode?: MultiValueMode
 }
 
@@ -113,11 +207,31 @@ export type DecayFunction =
  *   which is why it needs to be registered manually here.
  */
 export class FunctionScoreContainer {
+  /**
+   * Function that scores a document with a exponential decay, depending on the distance of a numeric field value of the document from an origin.
+   */
   exp?: DecayFunction
+  /**
+   * Function that scores a document with a normal decay, depending on the distance of a numeric field value of the document from an origin.
+   */
   gauss?: DecayFunction
+  /**
+   * Function that scores a document with a linear decay, depending on the distance of a numeric field value of the document from an origin.
+   */
   linear?: DecayFunction
+  /**
+   * Function allows you to use a field from a document to influence the score.
+   * It’s similar to using the script_score function, however, it avoids the overhead of scripting.
+   */
   field_value_factor?: FieldValueFactorScoreFunction
+  /**
+   * Generates scores that are uniformly distributed from 0 up to but not including 1.
+   * In case you want scores to be reproducible, it is possible to provide a `seed` and `field`.
+   */
   random_score?: RandomScoreFunction
+  /**
+   * Enables you to wrap another query and customize the scoring of it optionally with a computation derived from other numeric field values in the doc using a script expression.
+   */
   script_score?: ScriptScoreFunction
 
   /** @variant container_property */
@@ -127,39 +241,120 @@ export class FunctionScoreContainer {
 }
 
 export enum FunctionScoreMode {
+  /**
+   * Scores are multiplied.
+   */
   multiply = 0,
+  /**
+   * Scores are summed.
+   */
   sum = 1,
+  /**
+   * Scores are averaged.
+   */
   avg = 2,
+  /**
+   * The first function that has a matching filter is applied.
+   */
   first = 3,
+  /**
+   * Maximum score is used.
+   */
   max = 4,
+  /**
+   * Minimum score is used.
+   */
   min = 5
 }
 
 export enum FunctionBoostMode {
+  /**
+   * Query score and function score are multiplied
+   */
   multiply = 0,
+  /**
+   * Only the function score is used.
+   * The query score is ignored.
+   */
   replace = 1,
+  /**
+   * Query score and function score are added
+   */
   sum = 2,
+  /**
+   * Query score and function score are averaged
+   */
   avg = 3,
+  /**
+   * Max of query score and function score
+   */
   max = 4,
+  /**
+   * Min of query score and function score
+   */
   min = 5
 }
 
 export enum FieldValueFactorModifier {
+  /**
+   * Do not apply any multiplier to the field value.
+   */
   none = 0,
+  /**
+   * Take the common logarithm of the field value.
+   * Because this function will return a negative value and cause an error if used on values between 0 and 1, it is recommended to use `log1p` instead.
+   */
   log = 1,
+  /**
+   * Add 1 to the field value and take the common logarithm.
+   */
   log1p = 2,
+  /**
+   * Add 2 to the field value and take the common logarithm.
+   */
   log2p = 3,
+  /**
+   * Take the natural logarithm of the field value.
+   * Because this function will return a negative value and cause an error if used on values between 0 and 1, it is recommended to use `ln1p` instead.
+   */
   ln = 4,
+  /**
+   * Add 1 to the field value and take the natural logarithm.
+   */
   ln1p = 5,
+  /**
+   * Add 2 to the field value and take the natural logarithm.
+   */
   ln2p = 6,
+  /**
+   * Square the field value (multiply it by itself).
+   */
   square = 7,
+  /**
+   * Take the square root of the field value.
+   */
   sqrt = 8,
+  /**
+   * Reciprocate the field value, same as `1/x` where `x` is the field’s value.
+   */
   reciprocal = 9
 }
 
 export enum MultiValueMode {
+  /**
+   * Distance is the minimum distance.
+   */
   min = 0,
+  /**
+   * Distance is the maximum distance.
+   */
   max = 1,
+  /**
+   * Distance is the average distance.
+   */
   avg = 2,
+  /**
+   * Distance is the sum of all distances.
+   */
   sum = 3
 }

--- a/specification/_types/query_dsl/geo.ts
+++ b/specification/_types/query_dsl/geo.ts
@@ -35,8 +35,17 @@ export class GeoBoundingBoxQuery
 {
   /** @deprecated 7.14.0 */
   type?: GeoExecution
-  /** @server_default 'strict' */
+  /**
+   * Set to `IGNORE_MALFORMED` to accept geo points with invalid latitude or longitude.
+   * Set to `COERCE` to also try to infer correct latitude or longitude.
+   * @server_default 'strict'
+   */
   validation_method?: GeoValidationMethod
+  /**
+   * Set to `true` to ignore an unmapped field and not match any documents for this query.
+   * Set to `false` to throw an exception if the field is not mapped.
+   * @server_default false
+   */
   ignore_unmapped?: boolean
 }
 
@@ -49,10 +58,23 @@ export class GeoDistanceQuery
   extends QueryBase
   implements AdditionalProperty<Field, GeoLocation>
 {
+  /**
+   * The radius of the circle centred on the specified location.
+   * Points which fall into this circle are considered to be matches.
+   * @doc_id distance-units
+   */
   distance: Distance
-  /** @server_default 'arc' */
+  /**
+   * How to compute the distance.
+   * Set to `plane` for a faster calculation that's inaccurate on long distances and close to the poles.
+   * @server_default 'arc'
+   */
   distance_type?: GeoDistanceType
-  /** @server_default 'strict' */
+  /**
+   * Set to `IGNORE_MALFORMED` to accept geo points with invalid latitude or longitude.
+   * Set to `COERCE` to also try to infer correct latitude or longitude.
+   * @server_default 'strict'
+   */
   validation_method?: GeoValidationMethod
 }
 
@@ -77,7 +99,14 @@ export enum GeoFormat {
 
 export class GeoShapeFieldQuery {
   shape?: GeoShape
+  /**
+   * Query using an indexed shape retrieved from the the specified document and path.
+   */
   indexed_shape?: FieldLookup
+  /**
+   * Spatial relation operator used to search a geo field.
+   * @server_default intersects
+   */
   relation?: GeoShapeRelation
 }
 
@@ -87,6 +116,11 @@ export class GeoShapeQuery
   extends QueryBase
   implements AdditionalProperty<Field, GeoShapeFieldQuery>
 {
+  /**
+   * Set to `true` to ignore an unmapped field and not match any documents for this query.
+   * Set to `false` to throw an exception if the field is not mapped.
+   * @server_default false
+   */
   ignore_unmapped?: boolean
 }
 
@@ -105,7 +139,13 @@ export enum TokenType {
 }
 
 export enum GeoValidationMethod {
+  /**
+   * Accept geo points with invalid latitude or longitude and additionally try and infer correct coordinates.
+   */
   coerce = 0,
+  /**
+   * Accept geo points with invalid latitude or longitude.
+   */
   ignore_malformed = 1,
   strict = 2
 }

--- a/specification/_types/query_dsl/specialized.ts
+++ b/specification/_types/query_dsl/specialized.ts
@@ -38,8 +38,24 @@ import { FieldLookup, QueryBase, QueryContainer } from './abstractions'
 import { AdditionalProperty } from '@spec_utils/behaviors'
 
 export class DistanceFeatureQueryBase<TOrigin, TDistance> extends QueryBase {
+  /**
+   * Date or point of origin used to calculate distances.
+   * If the `field` value is a `date` or `date_nanos` field, the `origin` value must be a date.
+   * Date Math, such as `now-1h`, is supported.
+   * If the field value is a `geo_point` field, the `origin` value must be a geopoint.
+   */
   origin: TOrigin
+  /**
+   * Distance from the `origin` at which relevance scores receive half of the `boost` value.
+   * If the `field` value is a `date` or `date_nanos` field, the `pivot` value must be a time unit, such as `1h` or `10d`. If the `field` value is a `geo_point` field, the `pivot` value must be a distance unit, such as `1km` or `12m`.
+   */
   pivot: TDistance
+  /**
+   * Name of the field used to calculate distances. This field must meet the following criteria:
+   * be a `date`, `date_nanos` or `geo_point` field;
+   * have an `index` mapping parameter value of `true`, which is the default;
+   * have an `doc_values` mapping parameter value of `true`, which is the default.
+   */
   field: Field
 }
 

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -34,16 +34,43 @@ import { QueryBase } from './abstractions'
 import { AdditionalProperty } from '@spec_utils/behaviors'
 
 export class ExistsQuery extends QueryBase {
+  /**
+   * Name of the field you wish to search.
+   */
   field: Field
 }
 
 /** @shortcut_property value */
 export class FuzzyQuery extends QueryBase {
+  /**
+   * Maximum number of variations created.
+   * @server_default 50
+   */
   max_expansions?: integer
+  /**
+   * Number of beginning characters left unchanged when creating expansions.
+   * @server_default 0
+   */
   prefix_length?: integer
+  /**
+   * Number of beginning characters left unchanged when creating expansions.
+   * @doc_id query-dsl-multi-term-rewrite
+   * @server_default constant_score
+   */
   rewrite?: MultiTermQueryRewrite
+  /**
+   * Indicates whether edits include transpositions of two adjacent characters (for example `ab` to `ba`).
+   * @server_default true
+   */
   transpositions?: boolean
+  /**
+   * Maximum edit distance allowed for matching.
+   * @doc_id fuzziness
+   */
   fuzziness?: Fuzziness
+  /**
+   * Term you wish to find in the provided field.
+   */
   // ES is lenient and accepts any primitive type, but ultimately converts it to a string.
   // Changing this field definition from UserDefinedValue to string breaks a recording produced from Nest tests,
   // but Nest is probably also overly flexible here and exposes an option that should not exist.


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/964

Adds Query DSL descriptions for queries A through G. Descriptions were sourced from https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html and subpages.