### PR TITLE
Correcting visibility of ML APIs in serverless

### DIFF
--- a/specification/ml/infer_trained_model/MlInferTrainedModelRequest.ts
+++ b/specification/ml/infer_trained_model/MlInferTrainedModelRequest.ts
@@ -28,7 +28,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * Evaluates a trained model.
  * @rest_spec_name ml.infer_trained_model
  * @availability stack since=8.3.0 stability=stable
- * @availability serverless stability=stable visibility=private
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ml/post_data/MlPostJobDataRequest.ts
+++ b/specification/ml/post_data/MlPostJobDataRequest.ts
@@ -28,7 +28,6 @@ import { DateTime } from '@_types/Time'
  * It is not currently possible to post data to multiple jobs using wildcards or a comma-separated list.
  * @rest_spec_name ml.post_data
  * @availability stack since=5.4.0 stability=stable
- * @availability serverless stability=stable visibility=private
  * @deprecated 7.11.0 Posting data directly to anomaly detection jobs is deprecated, in a future major version a datafeed will be required.
  * @cluster_privileges manage_ml
  */


### PR DESCRIPTION
Two ML APIs had the wrong serverless visibility:

1. Post data should not be visible at all in serverless
2. Infer trained model should be visible publicly

(With the infer endpoint there was confusion about the deprecated infer trained model _deployment_ API, which we want to pretend does not exist.)