### PR TITLE
Fix query `text_expansion` definition

### DIFF
--- a/specification/_types/query_dsl/TextExpansionQuery.ts
+++ b/specification/_types/query_dsl/TextExpansionQuery.ts
@@ -17,13 +17,10 @@
  * under the License.
  */
 
-import { Field } from '@_types/common'
 import { QueryBase } from './abstractions'
 
 /** @shortcut_property value */
 export class TextExpansionQuery extends QueryBase {
-  /** The name of the rank features field to search against */
-  value: Field
   /** The text expansion NLP model to use */
   model_id: string
   /** The query text */

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -208,7 +208,7 @@ export class QueryContainer {
    * @availability stack since=8.8.0
    * @availability serverless
    */
-  text_expansion?: TextExpansionQuery
+  text_expansion?: SingleKeyDictionary<Field, TextExpansionQuery>
   wildcard?: SingleKeyDictionary<Field, WildcardQuery>
   wrapper?: WrapperQuery
 


### PR DESCRIPTION
Changed the definition of `text_expansion` according to the documentation:
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-text-expansion-query.html