### PR TITLE
Introduce `PipeSeparatedFlags<T>` marker class

### DIFF
--- a/specification/_spec_utils/FlagsEnum.ts
+++ b/specification/_spec_utils/FlagsEnum.ts
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This type type marks the underlaying enum as a "flags enum". Individual members of flags enums
+ * are combined using the pipe separator ("A|B|C|...").
+ *
+ * Depending on the target language, code generators can use this hint to generate language specific
+ * flags enum constructs and the corresponding (de-)serialization code.
+ */
+export type FlagsEnum<T> = T

--- a/specification/_spec_utils/PipeSeparatedFlags.ts
+++ b/specification/_spec_utils/PipeSeparatedFlags.ts
@@ -18,10 +18,10 @@
  */
 
 /**
- * This type type marks the underlaying enum as a "flags enum". Individual members of flags enums
- * are combined using the pipe separator ("A|B|C|...").
+ * A set of flags that can be represented as a single enum value or a set of values that are encoded
+ * as a pipe-separated string
  *
  * Depending on the target language, code generators can use this hint to generate language specific
  * flags enum constructs and the corresponding (de-)serialization code.
  */
-export type FlagsEnum<T> = T
+export type PipeSeparatedFlags<T> = T | string

--- a/specification/_types/query_dsl/fulltext.ts
+++ b/specification/_types/query_dsl/fulltext.ts
@@ -29,7 +29,7 @@ import { Script } from '@_types/Scripting'
 import { QueryBase } from './abstractions'
 import { Operator } from './Operator'
 import { DateMath, TimeZone } from '@_types/Time'
-import { FlagsEnum } from '@spec_utils/FlagsEnum'
+import { FlagsEnum, PipeSeparatedFlags } from '@spec_utils/PipeSeparatedFlags'
 
 /**
  * @shortcut_property query
@@ -703,7 +703,7 @@ export class QueryStringQuery extends QueryBase {
  * Query flags can be either a single flag or a combination of flags, e.g. `OR|AND|PREFIX`
  * @doc_id supported-flags
  */
-export type SimpleQueryStringFlags = FlagsEnum<SimpleQueryStringFlag[]>
+export type SimpleQueryStringFlags = PipeSeparatedFlags<SimpleQueryStringFlag>
 
 export enum SimpleQueryStringFlag {
   /**
@@ -722,7 +722,6 @@ export enum SimpleQueryStringFlag {
    * Enables the `\|` OR operator.
    */
   OR = 1 << 2,
-  
   /**
    * Enables the `*` prefix operator.
    */

--- a/specification/_types/query_dsl/fulltext.ts
+++ b/specification/_types/query_dsl/fulltext.ts
@@ -29,6 +29,7 @@ import { Script } from '@_types/Scripting'
 import { QueryBase } from './abstractions'
 import { Operator } from './Operator'
 import { DateMath, TimeZone } from '@_types/Time'
+import { FlagsEnum } from '@spec_utils/FlagsEnum'
 
 /**
  * @shortcut_property query
@@ -701,65 +702,65 @@ export class QueryStringQuery extends QueryBase {
 /**
  * Query flags can be either a single flag or a combination of flags, e.g. `OR|AND|PREFIX`
  * @doc_id supported-flags
- * @codegen_names single, multiple
  */
-export type SimpleQueryStringFlags = SimpleQueryStringFlag | string
+export type SimpleQueryStringFlags = FlagsEnum<SimpleQueryStringFlag[]>
 
 export enum SimpleQueryStringFlag {
   /**
    * Disables all operators.
    */
-  NONE = 1,
+  NONE = 0,
   /**
    * Enables the `+` AND operator.
    */
-  AND = 2,
-  /**
-   * Enables the `\|` OR operator.
-   */
-  OR = 4,
+  AND = 1 << 0,
   /**
    * Enables the `-` NOT operator.
    */
-  NOT = 8,
+  NOT = 1 << 1,
+  /**
+   * Enables the `\|` OR operator.
+   */
+  OR = 1 << 2,
+  
   /**
    * Enables the `*` prefix operator.
    */
-  PREFIX = 16,
+  PREFIX = 1 << 3,
   /**
    * Enables the `"` quotes operator used to search for phrases.
    */
-  PHRASE = 32,
+  PHRASE = 1 << 4,
   /**
    * Enables the `(` and `)` operators to control operator precedence.
    */
-  PRECEDENCE = 64,
+  PRECEDENCE = 1 << 5,
   /**
    * Enables `\` as an escape character.
    */
-  ESCAPE = 128,
+  ESCAPE = 1 << 6,
   /**
    * Enables whitespace as split characters.
    */
-  WHITESPACE = 256,
+  WHITESPACE = 1 << 7,
   /**
    * Enables the `~N` operator after a word, where `N` is an integer denoting the allowed edit distance for matching.
    */
-  FUZZY = 512,
+  FUZZY = 1 << 8,
   /**
    * Enables the `~N` operator, after a phrase where `N` is the maximum number of positions allowed between matching tokens.
    * Synonymous to `SLOP`.
    */
-  NEAR = 1024,
+  NEAR = 1 << 9,
   /**
    * Enables the `~N` operator, after a phrase where `N` is maximum number of positions allowed between matching tokens.
    * Synonymous to `NEAR`.
    */
-  SLOP = 2048,
+  SLOP = 1 << 9,
   /**
    * Enables all optional operators.
    */
-  ALL = 4096
+  ALL = -1
 }
 
 export class SimpleQueryStringQuery extends QueryBase {


### PR DESCRIPTION
## What?

This PR introduces the `FlagsEnum<T>` marker class similar to the `Stringified<T>` concept.

Flags enums are defined as enums with a special case serialization. Values of this enum are represented as `string` (like for regular enums as well). In addition, individual enum member values can be combined using the pipe separator char (`|`) like e.g. described here:
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#supported-flags

## Why?

At the moment, this specific construct is defined in 2 parts:

1. The enum itself (`TEnum`) as a regular enum type
2. A type alias defined as `FlagsEnum = TEnum | string`

Using just a generic union makes it hard to generate correct (de-)serialization code and "hard" for the users to use properties of this type, as they have to manually craft strings when using multiple values (unintuitive, error prone, ...).

In case of C#, this marker would allow me to e.g. generate a native language construct:

```csharp
[Flags]
public enum MyEnum
{
    None = 0,
    A = 1 << 0,
    B = 1 << 1,
    ...
}
```

and allows the user to utilize the standard way of working with flags:

```csharp
var flags = MyEnum.A | MyEnum.B;
if (flags.HasFlag(MyEnum.B))
{
    ...
}
```