### PR TITLE
Add `Stringified` marker to `Tokenizer` and `TokenFilter` properties

### DIFF
--- a/specification/_types/analysis/token_filters.ts
+++ b/specification/_types/analysis/token_filters.ts
@@ -188,7 +188,7 @@ export class ElisionTokenFilter extends TokenFilterBase {
   type: 'elision'
   articles?: string[]
   articles_path?: string
-  articles_case?: boolean
+  articles_case?: Stringified<boolean>
 }
 
 export class FingerprintTokenFilter extends TokenFilterBase {

--- a/specification/_types/analysis/tokenizers.ts
+++ b/specification/_types/analysis/tokenizers.ts
@@ -22,6 +22,7 @@ import { integer } from '@_types/Numeric'
 import { IcuTokenizer } from './icu-plugin'
 import { KuromojiTokenizer } from './kuromoji-plugin'
 import { TokenFilterDefinition } from '@_types/analysis/token_filters'
+import { Stringified } from '@spec_utils/Stringified'
 
 export class TokenizerBase {
   version?: VersionString
@@ -87,11 +88,11 @@ export class NoriTokenizer extends TokenizerBase {
 
 export class PathHierarchyTokenizer extends TokenizerBase {
   type: 'path_hierarchy'
-  buffer_size: integer
+  buffer_size: Stringified<integer>
   delimiter: string
   replacement: string
-  reverse: boolean
-  skip: integer
+  reverse: Stringified<boolean>
+  skip: Stringified<integer>
 }
 
 export class PatternTokenizer extends TokenizerBase {


### PR DESCRIPTION
These properties seem to be sent as `string` sometimes. Judging from the server code, it even seems like more (all?) properties of `TokenFilterBase` and `TokenizerBase` descendants should use the `Stringified` marker.

Related to https://github.com/elastic/elasticsearch-net/issues/7870