### PR TITLE
Fix broken doc url for indices-close

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -99,7 +99,7 @@ index-modules-blocks,https://www.elastic.co/guide/en/elasticsearch/reference/{br
 indices-analyze,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-analyze.html
 indices-clearcache,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-clearcache.html
 indices-clone-index,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-clone-index.html
-indices-close,https://www.elastic.co/guide/en/elasticsearch/reference{branch}/indices-close.html
+indices-close,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-close.html
 indices-open-close,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-open-close.html
 indices-create-index,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-create-index.html
 data-streams,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams.html


### PR DESCRIPTION
CI found a broken doc link on my latest [build of the JS client](https://github.com/elastic/elasticsearch-js/pull/1946). Looks like a slash was missed in https://github.com/elastic/elasticsearch-specification/pull/2226.
