### PR TITLE
[DOCS] Update field descriptions for geogrid aggs

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -65,6 +65,7 @@
         "Request: query parameter 'pre_filter_shard_size' does not exist in the json spec",
         "Request: query parameter 'scroll' does not exist in the json spec",
         "Request: query parameter 'rest_total_hits_as_int' does not exist in the json spec",
+        "type_alias definition _spec_utils:PipeSeparatedFlags / union_of / instance_of - No type definition for '_spec_utils:T'",
         "interface definition _types:QueryVectorBuilder - Property text_embedding is a single-variant and must be required"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2016,6 +2016,8 @@ export interface SpecUtilsBaseNode {
   transport_address: TransportAddress
 }
 
+export type SpecUtilsPipeSeparatedFlags<T = unknown> = T | string
+
 export type SpecUtilsStringified<T = unknown> = T | string
 
 export type SpecUtilsVoid = void
@@ -5943,9 +5945,9 @@ export interface QueryDslShapeQueryKeys extends QueryDslQueryBase {
 export type QueryDslShapeQuery = QueryDslShapeQueryKeys
   & { [property: string]: QueryDslShapeFieldQuery | boolean | float | string }
 
-export type QueryDslSimpleQueryStringFlag = 'NONE' | 'AND' | 'OR' | 'NOT' | 'PREFIX' | 'PHRASE' | 'PRECEDENCE' | 'ESCAPE' | 'WHITESPACE' | 'FUZZY' | 'NEAR' | 'SLOP' | 'ALL'
+export type QueryDslSimpleQueryStringFlag = 'NONE' | 'AND' | 'NOT' | 'OR' | 'PREFIX' | 'PHRASE' | 'PRECEDENCE' | 'ESCAPE' | 'WHITESPACE' | 'FUZZY' | 'NEAR' | 'SLOP' | 'ALL'
 
-export type QueryDslSimpleQueryStringFlags = QueryDslSimpleQueryStringFlag | string
+export type QueryDslSimpleQueryStringFlags = SpecUtilsPipeSeparatedFlags<QueryDslSimpleQueryStringFlag>
 
 export interface QueryDslSimpleQueryStringQuery extends QueryDslQueryBase {
   analyzer?: string

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -408,7 +408,8 @@ export class GeoHashGridAggregation extends BucketAggregationBase {
    */
   bounds?: GeoBounds
   /**
-   * The name of the field.
+   * Field containing indexed `geo_point` or `geo_shape` values.
+   * If the field contains an array, `geohash_grid` aggregates all array values.
    */
   field?: Field
   /**
@@ -431,6 +432,7 @@ export class GeoHashGridAggregation extends BucketAggregationBase {
 export class GeoTileGridAggregation extends BucketAggregationBase {
   /**
    * Field containing indexed `geo_point` or `geo_shape` values.
+   * If the field contains an array, `geotile_grid` aggregates all array values.
    */
   field?: Field
   /**
@@ -457,9 +459,8 @@ export class GeoTileGridAggregation extends BucketAggregationBase {
 
 export class GeohexGridAggregation extends BucketAggregationBase {
   /**
-   * Field containing indexed geo-point values. Must be explicitly
-   * mapped as a `geo_point` field. If the field contains an array
-   * `geohex_grid` aggregates all array values.
+   * Field containing indexed `geo_point` or `geo_shape` values.
+   * If the field contains an array, `geohex_grid` aggregates all array values.
    */
   field: Field
   /**


### PR DESCRIPTION
Updates the descriptions of `field` for `geohash_grid`, `geohex_grid`, and `geotile_grid`, so they all mention support for `geo_shape` and array values.