### PR TITLE
[DOCS] Fixes a typo in the processor descriptions

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11695,7 +11695,7 @@ export interface IngestUppercaseProcessor extends IngestProcessorBase {
 
 export interface IngestUrlDecodeProcessor extends IngestProcessorBase {
   field: Field
-  ignre_missing?: boolean
+  ignore_missing?: boolean
   target_field?: Field
 }
 

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -1121,7 +1121,7 @@ export class UrlDecodeProcessor extends ProcessorBase {
    * If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
    * @server_default false
    */
-  ignre_missing?: boolean
+  ignore_missing?: boolean
   /**
    * The field to assign the converted value to.
    * By default, the field is updated in-place.


### PR DESCRIPTION
## Overview

This PR fixes a typo that was introduced by [this PR](https://github.com/elastic/elasticsearch-specification/pull/2236).