### PR TITLE
Update visibility for serverless

### DIFF
--- a/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
+++ b/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
@@ -24,6 +24,7 @@ import { float } from '@_types/Numeric'
 /**
  * @rest_spec_name delete_by_query_rethrottle
  * @availability stack since=6.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/explain/ExplainRequest.ts
+++ b/specification/_global/explain/ExplainRequest.ts
@@ -26,6 +26,7 @@ import { Operator } from '@_types/query_dsl/Operator'
 /**
  * @rest_spec_name explain
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/health_report/Request.ts
+++ b/specification/_global/health_report/Request.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name health_report
  * @availability stack since=8.7.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/reindex/ReindexRequest.ts
+++ b/specification/_global/reindex/ReindexRequest.ts
@@ -27,6 +27,7 @@ import { Destination, Source } from './types'
 /**
  * @rest_spec_name reindex
  * @availability stack since=2.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/_global/reindex_rethrottle/ReindexRethrottleRequest.ts
+++ b/specification/_global/reindex_rethrottle/ReindexRethrottleRequest.ts
@@ -24,6 +24,7 @@ import { float } from '@_types/Numeric'
 /**
  * @rest_spec_name reindex_rethrottle
  * @availability stack since=2.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/search_mvt/SearchMvtRequest.ts
+++ b/specification/_global/search_mvt/SearchMvtRequest.ts
@@ -33,6 +33,7 @@ import { TrackHits } from '@global/search/_types/hits'
 /**
  * @rest_spec_name search_mvt
  * @availability stack since=7.15.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/update_by_query_rethrottle/UpdateByQueryRethrottleRequest.ts
+++ b/specification/_global/update_by_query_rethrottle/UpdateByQueryRethrottleRequest.ts
@@ -24,6 +24,7 @@ import { float, long } from '@_types/Numeric'
 /**
  * @rest_spec_name update_by_query_rethrottle
  * @availability stack since=6.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/cat/health/CatHealthRequest.ts
+++ b/specification/cat/health/CatHealthRequest.ts
@@ -33,6 +33,7 @@ import { TimeUnit } from '@_types/Time'
  * You also can use the API to track the recovery of a large cluster over a longer period of time.
  * @rest_spec_name cat.health
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-health
  * @cluster_privileges monitor
  */

--- a/specification/cat/recovery/CatRecoveryRequest.ts
+++ b/specification/cat/recovery/CatRecoveryRequest.ts
@@ -27,6 +27,7 @@ import { Bytes, Indices } from '@_types/common'
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index recovery API.
  * @rest_spec_name cat.recovery
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-recovery
  * @cluster_privileges monitor
  * @index_privileges monitor

--- a/specification/cat/repositories/CatRepositoriesRequest.ts
+++ b/specification/cat/repositories/CatRepositoriesRequest.ts
@@ -24,6 +24,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot repository API.
  * @rest_spec_name cat.repositories
  * @availability stack since=2.1.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @doc_id cat-repositories
  * @cluster_privileges monitor_snapshot
  */

--- a/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
+++ b/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
@@ -25,7 +25,7 @@ import { Duration } from '@_types/Time'
  * By default, it returns only settings that have been explicitly defined.
  * @rest_spec_name cluster.get_settings
  * @availability stack since=0.0.0 stability=stable
- * @availability serverless stability=stable visibility=public
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor
  * @doc_id cluster-get-settings
  */

--- a/specification/cluster/pending_tasks/ClusterPendingTasksRequest.ts
+++ b/specification/cluster/pending_tasks/ClusterPendingTasksRequest.ts
@@ -27,7 +27,7 @@ import { Duration } from '@_types/Time'
  * However, if a user-initiated task such as a create index command causes a cluster state update, the activity of this task might be reported by both task api and pending cluster tasks API.
  * @rest_spec_name cluster.pending_tasks
  * @availability stack since=0.0.0 stability=stable
- * @availability serverless stability=stable visibility=public
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor
  * @doc_id cluster-pending
  */

--- a/specification/cluster/put_settings/ClusterPutSettingsRequest.ts
+++ b/specification/cluster/put_settings/ClusterPutSettingsRequest.ts
@@ -25,7 +25,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name cluster.put_settings
  * @availability stack since=0.0.0 stability=stable
- * @availability serverless stability=stable visibility=public
+ * @availability serverless stability=stable visibility=private
  * @doc_id cluster-update-settings
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/stats/ClusterStatsRequest.ts
+++ b/specification/cluster/stats/ClusterStatsRequest.ts
@@ -26,7 +26,7 @@ import { Duration } from '@_types/Time'
  * It returns basic index metrics (shard numbers, store size, memory usage) and information about the current nodes that form the cluster (number, roles, os, jvm versions, memory usage, cpu and installed plugins).
  * @rest_spec_name cluster.stats
  * @availability stack since=1.3.0 stability=stable
- * @availability serverless stability=stable visibility=public
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor
  * @doc_id cluster-stats
  */

--- a/specification/eql/delete/EqlDeleteRequest.ts
+++ b/specification/eql/delete/EqlDeleteRequest.ts
@@ -25,6 +25,7 @@ import { Id } from '@_types/common'
  * The API also deletes results for the search.
  * @rest_spec_name eql.delete
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/eql/get/EqlGetRequest.ts
+++ b/specification/eql/get/EqlGetRequest.ts
@@ -26,6 +26,7 @@ import { Duration } from '@_types/Time'
  * @doc_id eql-async-search-api
  * @rest_spec_name eql.get
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/eql/get_status/EqlGetStatusRequest.ts
+++ b/specification/eql/get_status/EqlGetStatusRequest.ts
@@ -25,6 +25,7 @@ import { Id } from '@_types/common'
  * @doc_id eql-async-search-status-api
  * @rest_spec_name eql.get_status
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/eql/search/EqlSearchRequest.ts
+++ b/specification/eql/search/EqlSearchRequest.ts
@@ -28,6 +28,7 @@ import { ResultPosition } from './types'
 /**
  * @rest_spec_name eql.search
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/features/reset_features/ResetFeaturesRequest.ts
+++ b/specification/features/reset_features/ResetFeaturesRequest.ts
@@ -22,5 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name features.reset_features
  * @availability stack since=7.12.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
  */
 export interface Request extends RequestBase {}

--- a/specification/indices/add_block/IndicesAddBlockRequest.ts
+++ b/specification/indices/add_block/IndicesAddBlockRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.add_block
  * @availability stack since=7.9.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/clear_cache/IndicesIndicesClearCacheRequest.ts
+++ b/specification/indices/clear_cache/IndicesIndicesClearCacheRequest.ts
@@ -25,6 +25,7 @@ import { ExpandWildcards, Fields, Indices } from '@_types/common'
  * For data streams, the API clears the caches of the stream’s backing indices.
  * @rest_spec_name indices.clear_cache
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/delete_template/IndicesDeleteTemplateRequest.ts
+++ b/specification/indices/delete_template/IndicesDeleteTemplateRequest.ts
@@ -25,7 +25,6 @@ import { Duration } from '@_types/Time'
  * Deletes a legacy index template.
  * @rest_spec_name indices.delete_template
  * @availability stack since=0.0.0 stability=stable
- * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_index_templates,manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/disk_usage/IndicesDiskUsageRequest.ts
+++ b/specification/indices/disk_usage/IndicesDiskUsageRequest.ts
@@ -25,7 +25,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
  * @doc_id indices-disk-usage
  * @rest_spec_name indices.disk_usage
  * @availability stack since=7.15.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability serverless stability=experimental visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/exists_template/IndicesExistsTemplateRequest.ts
+++ b/specification/indices/exists_template/IndicesExistsTemplateRequest.ts
@@ -24,7 +24,6 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name indices.exists_template
  * @availability stack since=0.0.0 stability=stable
- * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/field_usage_stats/IndicesFieldUsageStatsRequest.ts
+++ b/specification/indices/field_usage_stats/IndicesFieldUsageStatsRequest.ts
@@ -30,6 +30,7 @@ import { Duration } from '@_types/Time'
  * Returns field usage information for each shard and field of an index.
  * @rest_spec_name indices.field_usage_stats
  * @availability stack since=7.15.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
  * @index_privileges manage
  */
 export interface Request extends RequestBase {

--- a/specification/indices/flush/IndicesFlushRequest.ts
+++ b/specification/indices/flush/IndicesFlushRequest.ts
@@ -25,6 +25,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
  * @doc_id indices-flush
  * @rest_spec_name indices.flush
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/forcemerge/IndicesForceMergeRequest.ts
+++ b/specification/indices/forcemerge/IndicesForceMergeRequest.ts
@@ -24,6 +24,7 @@ import { long } from '@_types/Numeric'
 /**
  * @rest_spec_name indices.forcemerge
  * @availability stack since=2.1.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_template/IndicesGetTemplateRequest.ts
+++ b/specification/indices/get_template/IndicesGetTemplateRequest.ts
@@ -25,7 +25,6 @@ import { Duration } from '@_types/Time'
  * Retrieves information about one or more index templates.
  * @rest_spec_name indices.get_template
  * @availability stack since=0.0.0 stability=stable
- * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/refresh/IndicesRefreshRequest.ts
+++ b/specification/indices/refresh/IndicesRefreshRequest.ts
@@ -25,6 +25,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
  * For data streams, the API runs the refresh operation on the stream’s backing indices.
  * @rest_spec_name indices.refresh
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/segments/IndicesSegmentsRequest.ts
+++ b/specification/indices/segments/IndicesSegmentsRequest.ts
@@ -24,6 +24,7 @@ import { ExpandWildcards, Indices } from '@_types/common'
  * For data streams, the API returns information about the stream’s backing indices.
  * @rest_spec_name indices.segments
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/license/get/GetLicenseRequest.ts
+++ b/specification/license/get/GetLicenseRequest.ts
@@ -24,6 +24,7 @@ import { RequestBase } from '@_types/Base'
  * For more information about the different types of licenses, see https://www.elastic.co/subscriptions.
  * @rest_spec_name license.get
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/nodes/clear_repositories_metering_archive/ClearRepositoriesMeteringArchiveRequest.ts
+++ b/specification/nodes/clear_repositories_metering_archive/ClearRepositoriesMeteringArchiveRequest.ts
@@ -25,6 +25,7 @@ import { long } from '@_types/Numeric'
  * You can use this API to clear the archived repositories metering information in the cluster.
  * @rest_spec_name nodes.clear_repositories_metering_archive
  * @availability stack since=7.16.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
  * @cluster_privileges monitor, manage
  */
 export interface Request extends RequestBase {

--- a/specification/nodes/get_repositories_metering_info/GetRepositoriesMeteringInfoRequest.ts
+++ b/specification/nodes/get_repositories_metering_info/GetRepositoriesMeteringInfoRequest.ts
@@ -27,6 +27,7 @@ import { NodeIds } from '@_types/common'
  * API is volatile, meaning that it won’t be present after node restarts.
  * @rest_spec_name nodes.get_repositories_metering_info
  * @availability stack since=7.16.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
  * @cluster_privileges monitor, manage
  */
 export interface Request extends RequestBase {

--- a/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
+++ b/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
@@ -25,7 +25,7 @@ import { Ids } from '@_types/common'
  * The cache is also automatically cleared on state changes of the security index.
  * @rest_spec_name security.clear_api_key_cache
  * @availability stack since=7.10.0 stability=stable
- * @availability serverless stability=stable visibility=public
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_security
  */
 export interface Request extends RequestBase {

--- a/specification/security/has_privileges/SecurityHasPrivilegesRequest.ts
+++ b/specification/security/has_privileges/SecurityHasPrivilegesRequest.ts
@@ -25,7 +25,7 @@ import { ApplicationPrivilegesCheck, IndexPrivilegesCheck } from './types'
 /**
  * @rest_spec_name security.has_privileges
  * @availability stack since=6.4.0 stability=stable
- * @availability serverless stability=stable visibility=private
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/slm/delete_lifecycle/DeleteSnapshotLifecycleRequest.ts
+++ b/specification/slm/delete_lifecycle/DeleteSnapshotLifecycleRequest.ts
@@ -23,6 +23,7 @@ import { Name } from '@_types/common'
 /**
  * @rest_spec_name slm.delete_lifecycle
  * @availability stack since=7.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/slm/execute_lifecycle/ExecuteSnapshotLifecycleRequest.ts
+++ b/specification/slm/execute_lifecycle/ExecuteSnapshotLifecycleRequest.ts
@@ -23,6 +23,7 @@ import { Name } from '@_types/common'
 /**
  * @rest_spec_name slm.execute_lifecycle
  * @availability stack since=7.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/slm/execute_retention/ExecuteRetentionRequest.ts
+++ b/specification/slm/execute_retention/ExecuteRetentionRequest.ts
@@ -22,5 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name slm.execute_retention
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {}

--- a/specification/slm/get_lifecycle/GetSnapshotLifecycleRequest.ts
+++ b/specification/slm/get_lifecycle/GetSnapshotLifecycleRequest.ts
@@ -23,6 +23,7 @@ import { Names } from '@_types/common'
 /**
  * @rest_spec_name slm.get_lifecycle
  * @availability stack since=7.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/slm/get_stats/GetSnapshotLifecycleStatsRequest.ts
+++ b/specification/slm/get_stats/GetSnapshotLifecycleStatsRequest.ts
@@ -22,5 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name slm.get_stats
  * @availability stack since=7.5.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {}

--- a/specification/slm/get_status/GetSnapshotLifecycleManagementStatusRequest.ts
+++ b/specification/slm/get_status/GetSnapshotLifecycleManagementStatusRequest.ts
@@ -22,5 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name slm.get_status
  * @availability stack since=7.6.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {}

--- a/specification/slm/put_lifecycle/PutSnapshotLifecycleRequest.ts
+++ b/specification/slm/put_lifecycle/PutSnapshotLifecycleRequest.ts
@@ -26,6 +26,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name slm.put_lifecycle
  * @availability stack since=7.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/slm/start/StartSnapshotLifecycleManagementRequest.ts
+++ b/specification/slm/start/StartSnapshotLifecycleManagementRequest.ts
@@ -22,5 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name slm.start
  * @availability stack since=7.6.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {}

--- a/specification/slm/stop/StopSnapshotLifecycleManagementRequest.ts
+++ b/specification/slm/stop/StopSnapshotLifecycleManagementRequest.ts
@@ -22,5 +22,6 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name slm.stop
  * @availability stack since=7.6.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {}

--- a/specification/snapshot/cleanup_repository/SnapshotCleanupRepositoryRequest.ts
+++ b/specification/snapshot/cleanup_repository/SnapshotCleanupRepositoryRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
  * Triggers the review of a snapshot repository’s contents and deletes any stale data not referenced by existing snapshots.
  * @rest_spec_name snapshot.cleanup_repository
  * @availability stack since=7.4.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/clone/SnapshotCloneRequest.ts
+++ b/specification/snapshot/clone/SnapshotCloneRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name snapshot.clone
  * @availability stack since=7.10.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/create/SnapshotCreateRequest.ts
+++ b/specification/snapshot/create/SnapshotCreateRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name snapshot.create
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/create_repository/SnapshotCreateRepositoryRequest.ts
+++ b/specification/snapshot/create_repository/SnapshotCreateRepositoryRequest.ts
@@ -28,7 +28,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name snapshot.create_repository
  * @availability stack since=0.0.0 stability=stable
- *
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/delete/SnapshotDeleteRequest.ts
+++ b/specification/snapshot/delete/SnapshotDeleteRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name snapshot.delete
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/delete_repository/SnapshotDeleteRepositoryRequest.ts
+++ b/specification/snapshot/delete_repository/SnapshotDeleteRepositoryRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name snapshot.delete_repository
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/get/SnapshotGetRequest.ts
+++ b/specification/snapshot/get/SnapshotGetRequest.ts
@@ -27,6 +27,7 @@ import { SortOrder } from '@_types/sort'
 /**
  * @rest_spec_name snapshot.get
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/get_repository/SnapshotGetRepositoryRequest.ts
+++ b/specification/snapshot/get_repository/SnapshotGetRepositoryRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name snapshot.get_repository
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/restore/SnapshotRestoreRequest.ts
+++ b/specification/snapshot/restore/SnapshotRestoreRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name snapshot.restore
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/status/SnapshotStatusRequest.ts
+++ b/specification/snapshot/status/SnapshotStatusRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name snapshot.status
  * @availability stack since=7.8.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/snapshot/verify_repository/SnapshotVerifyRepositoryRequest.ts
+++ b/specification/snapshot/verify_repository/SnapshotVerifyRepositoryRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name snapshot.verify_repository
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/sql/clear_cursor/ClearSqlCursorRequest.ts
+++ b/specification/sql/clear_cursor/ClearSqlCursorRequest.ts
@@ -22,6 +22,7 @@ import { RequestBase } from '@_types/Base'
 /**
  * @rest_spec_name sql.clear_cursor
  * @availability stack since=6.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/sql/delete_async/SqlDeleteAsyncRequest.ts
+++ b/specification/sql/delete_async/SqlDeleteAsyncRequest.ts
@@ -23,6 +23,7 @@ import { Id } from '@_types/common'
 /**
  * @rest_spec_name sql.delete_async
  * @availability stack since=7.15.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/sql/get_async/SqlGetAsyncRequest.ts
+++ b/specification/sql/get_async/SqlGetAsyncRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
 /**
  * @rest_spec_name sql.get_async
  * @availability stack since=7.15.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/sql/get_async_status/SqlGetAsyncStatusRequest.ts
+++ b/specification/sql/get_async_status/SqlGetAsyncStatusRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
 /**
  * @rest_spec_name sql.get_async_status
  * @availability stack since=7.15.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/sql/query/QuerySqlRequest.ts
+++ b/specification/sql/query/QuerySqlRequest.ts
@@ -28,6 +28,7 @@ import { Duration, TimeZone } from '@_types/Time'
 /**
  * @rest_spec_name sql.query
  * @availability stack since=6.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/sql/translate/TranslateSqlRequest.ts
+++ b/specification/sql/translate/TranslateSqlRequest.ts
@@ -25,6 +25,7 @@ import { TimeZone } from '@_types/Time'
 /**
  * @rest_spec_name sql.translate
  * @availability stack since=6.3.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/tasks/cancel/CancelTasksRequest.ts
+++ b/specification/tasks/cancel/CancelTasksRequest.ts
@@ -23,6 +23,7 @@ import { TaskId } from '@_types/common'
 /**
  * @rest_spec_name tasks.cancel
  * @availability stack since=2.3.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
  * @doc_id tasks
  */
 export interface Request extends RequestBase {

--- a/specification/tasks/get/GetTaskRequest.ts
+++ b/specification/tasks/get/GetTaskRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 /**
  * @rest_spec_name tasks.get
  * @availability stack since=5.0.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
  * @doc_id tasks
  */
 export interface Request extends RequestBase {

--- a/specification/tasks/list/ListTasksRequest.ts
+++ b/specification/tasks/list/ListTasksRequest.ts
@@ -26,6 +26,7 @@ import { GroupBy } from '@tasks/_types/GroupBy'
  * The task management API returns information about tasks currently executing on one or more nodes in the cluster.
  * @rest_spec_name tasks.list
  * @availability stack since=2.3.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
  * @cluster_privileges monitor, manage
  * @doc_id tasks
  */

--- a/specification/xpack/usage/XPackUsageRequest.ts
+++ b/specification/xpack/usage/XPackUsageRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
  * This API provides information about which features are currently enabled and available under the current license and some usage statistics.
  * @rest_spec_name xpack.usage
  * @availability stack since=0.0.0 stability=stable
+ * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor,manage
  */
 export interface Request extends RequestBase {


### PR DESCRIPTION
This commit reconciles the spec against the server implementation.

The specification's '@available serverless' annotations now match the @ServerlessScope annotations in the Elasticsearch Java code.
