### PR TITLE
Update the data stream lifecycle API

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8328,7 +8328,7 @@ export interface ClusterComponentTemplateSummary {
   settings?: Record<IndexName, IndicesIndexSettings>
   mappings?: MappingTypeMapping
   aliases?: Record<string, IndicesAliasDefinition>
-  lifecycle?: IndicesDataLifecycleWithRollover
+  lifecycle?: IndicesDataStreamLifecycleWithRollover
 }
 
 export interface ClusterAllocationExplainAllocationDecision {
@@ -9631,15 +9631,6 @@ export interface IndicesCacheQueries {
   enabled: boolean
 }
 
-export interface IndicesDataLifecycle {
-  data_retention?: Duration
-}
-
-export interface IndicesDataLifecycleWithRollover {
-  data_retention?: Duration
-  rollover?: IndicesDlmRolloverConditions
-}
-
 export interface IndicesDataStream {
   _meta?: Metadata
   allow_custom_routing?: boolean
@@ -9647,7 +9638,7 @@ export interface IndicesDataStream {
   hidden: boolean
   ilm_policy?: Name
   indices: IndicesDataStreamIndex[]
-  lifecycle?: IndicesDataLifecycleWithRollover
+  lifecycle?: IndicesDataStreamLifecycleWithRollover
   name: DataStreamName
   replicated?: boolean
   status: HealthStatus
@@ -9661,15 +9652,11 @@ export interface IndicesDataStreamIndex {
   index_uuid: Uuid
 }
 
-export interface IndicesDataStreamTimestampField {
-  name: Field
+export interface IndicesDataStreamLifecycle {
+  data_retention?: Duration
 }
 
-export interface IndicesDataStreamVisibility {
-  hidden?: boolean
-}
-
-export interface IndicesDlmRolloverConditions {
+export interface IndicesDataStreamLifecycleRolloverConditions {
   min_age?: Duration
   max_age?: string
   min_docs?: long
@@ -9680,6 +9667,19 @@ export interface IndicesDlmRolloverConditions {
   max_primary_shard_size?: ByteSize
   min_primary_shard_docs?: long
   max_primary_shard_docs?: long
+}
+
+export interface IndicesDataStreamLifecycleWithRollover {
+  data_retention?: Duration
+  rollover?: IndicesDataStreamLifecycleRolloverConditions
+}
+
+export interface IndicesDataStreamTimestampField {
+  name: Field
+}
+
+export interface IndicesDataStreamVisibility {
+  hidden?: boolean
 }
 
 export interface IndicesDownsampleConfig {
@@ -9836,7 +9836,7 @@ export interface IndicesIndexState {
   settings?: IndicesIndexSettings
   defaults?: IndicesIndexSettings
   data_stream?: DataStreamName
-  lifecycle?: IndicesDataLifecycle
+  lifecycle?: IndicesDataStreamLifecycle
 }
 
 export interface IndicesIndexTemplate {
@@ -9859,7 +9859,7 @@ export interface IndicesIndexTemplateSummary {
   aliases?: Record<IndexName, IndicesAlias>
   mappings?: MappingTypeMapping
   settings?: IndicesIndexSettings
-  lifecycle?: IndicesDataLifecycleWithRollover
+  lifecycle?: IndicesDataStreamLifecycleWithRollover
 }
 
 export interface IndicesIndexVersioning {
@@ -10379,14 +10379,14 @@ export interface IndicesExistsTemplateRequest extends RequestBase {
 
 export type IndicesExistsTemplateResponse = boolean
 
-export interface IndicesExplainDataLifecycleDataLifecycleExplain {
+export interface IndicesExplainDataLifecycleDataStreamLifecycleExplain {
   index: IndexName
-  managed_by_dlm: boolean
+  managed_by_lifecycle: boolean
   index_creation_date_millis?: EpochTime<UnitMillis>
   time_since_index_creation?: Duration
   rollover_date_millis?: EpochTime<UnitMillis>
   time_since_rollover?: Duration
-  lifecycle?: IndicesDataLifecycleWithRollover
+  lifecycle?: IndicesDataStreamLifecycleWithRollover
   generation_time?: Duration
   error?: string
 }
@@ -10398,7 +10398,7 @@ export interface IndicesExplainDataLifecycleRequest extends RequestBase {
 }
 
 export interface IndicesExplainDataLifecycleResponse {
-  indices: Record<IndexName, IndicesExplainDataLifecycleDataLifecycleExplain>
+  indices: Record<IndexName, IndicesExplainDataLifecycleDataStreamLifecycleExplain>
 }
 
 export interface IndicesFieldUsageStatsFieldSummary {
@@ -10518,9 +10518,9 @@ export interface IndicesGetAliasRequest extends RequestBase {
 
 export type IndicesGetAliasResponse = Record<IndexName, IndicesGetAliasIndexAliases>
 
-export interface IndicesGetDataLifecycleDataStreamLifecycle {
+export interface IndicesGetDataLifecycleDataStreamWithLifecycle {
   name: DataStreamName
-  lifecycle?: IndicesDataLifecycle
+  lifecycle?: IndicesDataStreamLifecycle
 }
 
 export interface IndicesGetDataLifecycleRequest extends RequestBase {
@@ -10530,7 +10530,7 @@ export interface IndicesGetDataLifecycleRequest extends RequestBase {
 }
 
 export interface IndicesGetDataLifecycleResponse {
-  data_streams: IndicesGetDataLifecycleDataStreamLifecycle[]
+  data_streams: IndicesGetDataLifecycleDataStreamWithLifecycle[]
 }
 
 export interface IndicesGetDataStreamRequest extends RequestBase {
@@ -10692,7 +10692,7 @@ export interface IndicesPutIndexTemplateIndexTemplateMapping {
   aliases?: Record<IndexName, IndicesAlias>
   mappings?: MappingTypeMapping
   settings?: IndicesIndexSettings
-  lifecycle?: IndicesDataLifecycle
+  lifecycle?: IndicesDataStreamLifecycle
 }
 
 export interface IndicesPutIndexTemplateRequest extends RequestBase {

--- a/specification/_json_spec/indices.delete_data_lifecycle.json
+++ b/specification/_json_spec/indices.delete_data_lifecycle.json
@@ -1,23 +1,25 @@
 {
-  "indices.delete_data_lifecycle": {
-    "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-delete-lifecycle.html",
-      "description": "Deletes the data lifecycle of the selected data streams."
+  "indices.delete_data_lifecycle":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html",
+      "description":"Deletes the data stream lifecycle of the selected data streams."
     },
-    "stability": "experimental",
-    "visibility": "public",
-    "headers": {
-      "accept": ["application/json"]
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"]
     },
-    "url": {
-      "paths": [
+    "url":{
+      "paths":[
         {
-          "path": "/_data_stream/{name}/_lifecycle",
-          "methods": ["DELETE"],
-          "parts": {
-            "name": {
-              "type": "list",
-              "description": "A comma-separated list of data streams of which the data lifecycle will be deleted; use `*` to get all data streams"
+          "path":"/_data_stream/{name}/_lifecycle",
+          "methods":[
+            "DELETE"
+          ],
+          "parts":{
+            "name":{
+              "type":"list",
+              "description":"A comma-separated list of data streams of which the data stream lifecycle will be deleted; use `*` to get all data streams"
             }
           }
         }
@@ -26,7 +28,13 @@
     "params": {
       "expand_wildcards": {
         "type": "enum",
-        "options": ["open", "closed", "hidden", "none", "all"],
+        "options": [
+          "open",
+          "closed",
+          "hidden",
+          "none",
+          "all"
+        ],
         "default": "open",
         "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)"
       },

--- a/specification/_json_spec/indices.delete_data_lifecycle.json
+++ b/specification/_json_spec/indices.delete_data_lifecycle.json
@@ -1,25 +1,23 @@
 {
-  "indices.delete_data_lifecycle":{
-    "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html",
-      "description":"Deletes the data stream lifecycle of the selected data streams."
+  "indices.delete_data_lifecycle": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html",
+      "description": "Deletes the data stream lifecycle of the selected data streams."
     },
-    "stability":"stable",
-    "visibility":"public",
-    "headers":{
-      "accept": [ "application/json"]
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
     },
-    "url":{
-      "paths":[
+    "url": {
+      "paths": [
         {
-          "path":"/_data_stream/{name}/_lifecycle",
-          "methods":[
-            "DELETE"
-          ],
-          "parts":{
-            "name":{
-              "type":"list",
-              "description":"A comma-separated list of data streams of which the data stream lifecycle will be deleted; use `*` to get all data streams"
+          "path": "/_data_stream/{name}/_lifecycle",
+          "methods": ["DELETE"],
+          "parts": {
+            "name": {
+              "type": "list",
+              "description": "A comma-separated list of data streams of which the data stream lifecycle will be deleted; use `*` to get all data streams"
             }
           }
         }
@@ -28,13 +26,7 @@
     "params": {
       "expand_wildcards": {
         "type": "enum",
-        "options": [
-          "open",
-          "closed",
-          "hidden",
-          "none",
-          "all"
-        ],
+        "options": ["open", "closed", "hidden", "none", "all"],
         "default": "open",
         "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)"
       },

--- a/specification/_json_spec/indices.explain_data_lifecycle.json
+++ b/specification/_json_spec/indices.explain_data_lifecycle.json
@@ -7,17 +7,13 @@
     "stability": "stable",
     "visibility": "public",
     "headers": {
-      "accept": [
-        "application/json"
-      ]
+      "accept": ["application/json"]
     },
     "url": {
       "paths": [
         {
           "path": "/{index}/_lifecycle/explain",
-          "methods": [
-            "GET"
-          ],
+          "methods": ["GET"],
           "parts": {
             "index": {
               "type": "string",

--- a/specification/_json_spec/indices.explain_data_lifecycle.json
+++ b/specification/_json_spec/indices.explain_data_lifecycle.json
@@ -1,19 +1,23 @@
 {
   "indices.explain_data_lifecycle": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/dlm-explain-lifecycle.html",
-      "description": "Retrieves information about the index's current DLM lifecycle, such as any potential encountered error, time since creation etc."
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams-explain-lifecycle.html",
+      "description": "Retrieves information about the index's current data stream lifecycle, such as any potential encountered error, time since creation etc."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
-      "accept": ["application/json"]
+      "accept": [
+        "application/json"
+      ]
     },
     "url": {
       "paths": [
         {
           "path": "/{index}/_lifecycle/explain",
-          "methods": ["GET"],
+          "methods": [
+            "GET"
+          ],
           "parts": {
             "index": {
               "type": "string",

--- a/specification/_json_spec/indices.get_data_lifecycle.json
+++ b/specification/_json_spec/indices.get_data_lifecycle.json
@@ -1,46 +1,38 @@
 {
-  "indices.get_data_lifecycle":{
-    "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle.html",
-      "description":"Returns the data stream lifecycle of the selected data streams."
+  "indices.get_data_lifecycle": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle.html",
+      "description": "Returns the data stream lifecycle of the selected data streams."
     },
-    "stability":"stable",
-    "visibility":"public",
-    "headers":{
-      "accept": [ "application/json"]
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
     },
-    "url":{
-      "paths":[
+    "url": {
+      "paths": [
         {
-          "path":"/_data_stream/{name}/_lifecycle",
-          "methods":[
-            "GET"
-          ],
-          "parts":{
-            "name":{
-              "type":"list",
-              "description":"A comma-separated list of data streams to get; use `*` to get all data streams"
+          "path": "/_data_stream/{name}/_lifecycle",
+          "methods": ["GET"],
+          "parts": {
+            "name": {
+              "type": "list",
+              "description": "A comma-separated list of data streams to get; use `*` to get all data streams"
             }
           }
         }
       ]
     },
-    "params":{
-      "expand_wildcards":{
-        "type":"enum",
-        "options":[
-          "open",
-          "closed",
-          "hidden",
-          "none",
-          "all"
-        ],
-        "default":"open",
-        "description":"Whether wildcard expressions should get expanded to open or closed indices (default: open)"
+    "params": {
+      "expand_wildcards": {
+        "type": "enum",
+        "options": ["open", "closed", "hidden", "none", "all"],
+        "default": "open",
+        "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)"
       },
-      "include_defaults":{
-        "type":"boolean",
-        "description":"Return all relevant default configurations for the data stream (default: false)"
+      "include_defaults": {
+        "type": "boolean",
+        "description": "Return all relevant default configurations for the data stream (default: false)"
       }
     }
   }

--- a/specification/_json_spec/indices.get_data_lifecycle.json
+++ b/specification/_json_spec/indices.get_data_lifecycle.json
@@ -1,38 +1,46 @@
 {
-  "indices.get_data_lifecycle": {
-    "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-get-lifecycle.html",
-      "description": "Returns the data lifecycle of the selected data streams."
+  "indices.get_data_lifecycle":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle.html",
+      "description":"Returns the data stream lifecycle of the selected data streams."
     },
-    "stability": "experimental",
-    "visibility": "public",
-    "headers": {
-      "accept": ["application/json"]
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"]
     },
-    "url": {
-      "paths": [
+    "url":{
+      "paths":[
         {
-          "path": "/_data_stream/{name}/_lifecycle",
-          "methods": ["GET"],
-          "parts": {
-            "name": {
-              "type": "list",
-              "description": "A comma-separated list of data streams to get; use `*` to get all data streams"
+          "path":"/_data_stream/{name}/_lifecycle",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "name":{
+              "type":"list",
+              "description":"A comma-separated list of data streams to get; use `*` to get all data streams"
             }
           }
         }
       ]
     },
-    "params": {
-      "expand_wildcards": {
-        "type": "enum",
-        "options": ["open", "closed", "hidden", "none", "all"],
-        "default": "open",
-        "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)"
+    "params":{
+      "expand_wildcards":{
+        "type":"enum",
+        "options":[
+          "open",
+          "closed",
+          "hidden",
+          "none",
+          "all"
+        ],
+        "default":"open",
+        "description":"Whether wildcard expressions should get expanded to open or closed indices (default: open)"
       },
-      "include_defaults": {
-        "type": "boolean",
-        "description": "Return all relevant default configurations for the data stream (default: false)"
+      "include_defaults":{
+        "type":"boolean",
+        "description":"Return all relevant default configurations for the data stream (default: false)"
       }
     }
   }

--- a/specification/_json_spec/indices.put_data_lifecycle.json
+++ b/specification/_json_spec/indices.put_data_lifecycle.json
@@ -1,47 +1,54 @@
 {
-  "indices.put_data_lifecycle": {
-    "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-put-lifecycle.html",
-      "description": "Updates the data lifecycle of the selected data streams."
+  "indices.put_data_lifecycle":{
+    "documentation":{
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-put-lifecycle.html",
+      "description":"Updates the data stream lifecycle of the selected data streams."
     },
-    "stability": "experimental",
-    "visibility": "public",
-    "headers": {
-      "accept": ["application/json"]
+    "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"]
     },
     "url": {
       "paths": [
         {
-          "path": "/_data_stream/{name}/_lifecycle",
-          "methods": ["PUT"],
-          "parts": {
-            "name": {
-              "type": "list",
-              "description": "A comma-separated list of data streams whose lifecycle will be updated; use `*` to set the lifecycle to all data streams"
+          "path":"/_data_stream/{name}/_lifecycle",
+          "methods":[
+            "PUT"
+          ],
+          "parts":{
+            "name":{
+              "type":"list",
+              "description":"A comma-separated list of data streams whose lifecycle will be updated; use `*` to set the lifecycle to all data streams"
             }
           }
         }
       ]
     },
-    "params": {
-      "expand_wildcards": {
-        "type": "enum",
-        "options": ["open", "closed", "hidden", "none", "all"],
-        "default": "open",
-        "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)"
+    "params":{
+      "expand_wildcards":{
+        "type":"enum",
+        "options":[
+          "open",
+          "closed",
+          "hidden",
+          "none",
+          "all"
+        ],
+        "default":"open",
+        "description":"Whether wildcard expressions should get expanded to open or closed indices (default: open)"
       },
-      "timeout": {
-        "type": "time",
-        "description": "Explicit timestamp for the document"
+      "timeout":{
+        "type":"time",
+        "description":"Explicit timestamp for the document"
       },
-      "master_timeout": {
-        "type": "time",
-        "description": "Specify timeout for connection to master"
+      "master_timeout":{
+        "type":"time",
+        "description":"Specify timeout for connection to master"
       }
     },
-    "body": {
-      "description": "The data lifecycle configuration that consist of the data retention",
-      "required": false
+    "body":{
+      "description":"The data stream lifecycle configuration that consist of the data retention"
     }
   }
 }

--- a/specification/_json_spec/indices.put_data_lifecycle.json
+++ b/specification/_json_spec/indices.put_data_lifecycle.json
@@ -1,54 +1,46 @@
 {
-  "indices.put_data_lifecycle":{
-    "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-put-lifecycle.html",
-      "description":"Updates the data stream lifecycle of the selected data streams."
+  "indices.put_data_lifecycle": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-put-lifecycle.html",
+      "description": "Updates the data stream lifecycle of the selected data streams."
     },
-    "stability":"stable",
-    "visibility":"public",
-    "headers":{
-      "accept": [ "application/json"]
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
     },
     "url": {
       "paths": [
         {
-          "path":"/_data_stream/{name}/_lifecycle",
-          "methods":[
-            "PUT"
-          ],
-          "parts":{
-            "name":{
-              "type":"list",
-              "description":"A comma-separated list of data streams whose lifecycle will be updated; use `*` to set the lifecycle to all data streams"
+          "path": "/_data_stream/{name}/_lifecycle",
+          "methods": ["PUT"],
+          "parts": {
+            "name": {
+              "type": "list",
+              "description": "A comma-separated list of data streams whose lifecycle will be updated; use `*` to set the lifecycle to all data streams"
             }
           }
         }
       ]
     },
-    "params":{
-      "expand_wildcards":{
-        "type":"enum",
-        "options":[
-          "open",
-          "closed",
-          "hidden",
-          "none",
-          "all"
-        ],
-        "default":"open",
-        "description":"Whether wildcard expressions should get expanded to open or closed indices (default: open)"
+    "params": {
+      "expand_wildcards": {
+        "type": "enum",
+        "options": ["open", "closed", "hidden", "none", "all"],
+        "default": "open",
+        "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)"
       },
-      "timeout":{
-        "type":"time",
-        "description":"Explicit timestamp for the document"
+      "timeout": {
+        "type": "time",
+        "description": "Explicit timestamp for the document"
       },
-      "master_timeout":{
-        "type":"time",
-        "description":"Specify timeout for connection to master"
+      "master_timeout": {
+        "type": "time",
+        "description": "Specify timeout for connection to master"
       }
     },
-    "body":{
-      "description":"The data stream lifecycle configuration that consist of the data retention"
+    "body": {
+      "description": "The data lifecycle configuration that consist of the data retention"
     }
   }
 }

--- a/specification/cluster/_types/ComponentTemplate.ts
+++ b/specification/cluster/_types/ComponentTemplate.ts
@@ -47,8 +47,8 @@ export class ComponentTemplateSummary {
   mappings?: TypeMapping
   aliases?: Dictionary<string, AliasDefinition>
   /**
-   * @availability stack since=8.8.0 stability=experimental
-   * @availability serverless stability=experimental
+   * @availability stack since=8.11.0 stability=stable
+   * @availability serverless stability=stable
    */
   lifecycle?: DataStreamLifecycleWithRollover
 }

--- a/specification/cluster/_types/ComponentTemplate.ts
+++ b/specification/cluster/_types/ComponentTemplate.ts
@@ -23,9 +23,9 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { IndexName, Metadata, Name, VersionNumber } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 import {
-  DataLifecycle,
-  DataLifecycleWithRollover
-} from '@indices/_types/DataLifecycle'
+  DataStreamLifecycle,
+  DataStreamLifecycleWithRollover
+} from '@indices/_types/DataStreamLifecycle'
 
 export class ComponentTemplate {
   name: Name
@@ -50,5 +50,5 @@ export class ComponentTemplateSummary {
    * @availability stack since=8.8.0 stability=experimental
    * @availability serverless stability=experimental
    */
-  lifecycle?: DataLifecycleWithRollover
+  lifecycle?: DataStreamLifecycleWithRollover
 }

--- a/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
+++ b/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
@@ -45,8 +45,8 @@ export interface Request extends RequestBase {
     flat_settings?: boolean
     /**
      * @server_default false
-     * @availability stack since=8.8.0 stability=experimental
-     * @availability serverless stability=experimental
+     * @availability stack since=8.11.0 stability=stable
+     * @availability serverless stability=stable
      */
     include_defaults?: boolean
     /**

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -27,7 +27,7 @@ import {
   Uuid
 } from '@_types/common'
 import { integer } from '@_types/Numeric'
-import { DataLifecycleWithRollover } from '@indices/_types/DataLifecycle'
+import { DataStreamLifecycleWithRollover } from '@indices/_types/DataStreamLifecycle'
 
 export class DataStream {
   /**
@@ -64,7 +64,7 @@ export class DataStream {
    * @availability stack since=8.8.0 stability=experimental
    * @availability serverless stability=experimental
    */
-  lifecycle?: DataLifecycleWithRollover
+  lifecycle?: DataStreamLifecycleWithRollover
   /**
    * Name of the data stream.
    */

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -61,8 +61,8 @@ export class DataStream {
   indices: DataStreamIndex[]
   /**
    * Contains the configuration for the data lifecycle management of this data stream.
-   * @availability stack since=8.8.0 stability=experimental
-   * @availability serverless stability=experimental
+   * @availability stack since=8.11.0 stability=stable
+   * @availability serverless stability=stable
    */
   lifecycle?: DataStreamLifecycleWithRollover
   /**

--- a/specification/indices/_types/DataStreamLifecycle.ts
+++ b/specification/indices/_types/DataStreamLifecycle.ts
@@ -22,9 +22,9 @@ import { long } from '@_types/Numeric'
 import { ByteSize } from '@_types/common'
 
 /**
- * Data lifecycle denotes that a data stream is managed by DLM and contains the configuration.
+ * Data lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration.
  */
-export class DataLifecycle {
+export class DataStreamLifecycle {
   data_retention?: Duration
 }
 
@@ -32,7 +32,7 @@ export class DataLifecycle {
  * Data lifecycle with rollover can be used to display the configuration including the default rollover conditions,
  * if asked.
  */
-export class DataLifecycleWithRollover {
+export class DataStreamLifecycleWithRollover {
   /**
    * If defined, every document added to this data stream will be stored at least for this time frame.
    * Any time after this duration the document could be deleted.
@@ -44,10 +44,10 @@ export class DataLifecycleWithRollover {
    * This property is an implementation detail and it will only be retrieved when the query param `include_defaults` is set to true.
    * The contents of this field are subject to change.
    */
-  rollover?: DlmRolloverConditions
+  rollover?: DataStreamLifecycleRolloverConditions
 }
 
-class DlmRolloverConditions {
+class DataStreamLifecycleRolloverConditions {
   min_age?: Duration
   // max_age is a string because it can contain a label to signal that it's automatically calculated
   max_age?: string

--- a/specification/indices/_types/IndexState.ts
+++ b/specification/indices/_types/IndexState.ts
@@ -33,8 +33,8 @@ export class IndexState {
   data_stream?: DataStreamName
   /**
    * Data lifecycle applicable if this is a data stream.
-   * @availability stack since=8.8.0 stability=experimental
-   * @availability serverless stability=experimental
+   * @availability stack since=8.11.0 stability=stable
+   * @availability serverless stability=stable
    */
   lifecycle?: DataStreamLifecycle
 }

--- a/specification/indices/_types/IndexState.ts
+++ b/specification/indices/_types/IndexState.ts
@@ -22,7 +22,7 @@ import { DataStreamName, IndexName } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { Alias } from './Alias'
 import { IndexSettings } from './IndexSettings'
-import { DataLifecycle } from '@indices/_types/DataLifecycle'
+import { DataStreamLifecycle } from '@indices/_types/DataStreamLifecycle'
 
 export class IndexState {
   aliases?: Dictionary<IndexName, Alias>
@@ -36,5 +36,5 @@ export class IndexState {
    * @availability stack since=8.8.0 stability=experimental
    * @availability serverless stability=experimental
    */
-  lifecycle?: DataLifecycle
+  lifecycle?: DataStreamLifecycle
 }

--- a/specification/indices/_types/IndexTemplate.ts
+++ b/specification/indices/_types/IndexTemplate.ts
@@ -100,8 +100,8 @@ export class IndexTemplateSummary {
    */
   settings?: IndexSettings
   /**
-   * @availability stack since=8.8.0 stability=experimental
-   * @availability serverless stability=experimental
+   * @availability stack since=8.11.0 stability=stable
+   * @availability serverless stability=stable
    */
   lifecycle?: DataStreamLifecycleWithRollover
 }

--- a/specification/indices/_types/IndexTemplate.ts
+++ b/specification/indices/_types/IndexTemplate.ts
@@ -24,9 +24,9 @@ import { long } from '@_types/Numeric'
 import { Alias } from './Alias'
 import { IndexSettings } from './IndexSettings'
 import {
-  DataLifecycle,
-  DataLifecycleWithRollover
-} from '@indices/_types/DataLifecycle'
+  DataStreamLifecycle,
+  DataStreamLifecycleWithRollover
+} from '@indices/_types/DataStreamLifecycle'
 
 export class IndexTemplate {
   /**
@@ -103,5 +103,5 @@ export class IndexTemplateSummary {
    * @availability stack since=8.8.0 stability=experimental
    * @availability serverless stability=experimental
    */
-  lifecycle?: DataLifecycleWithRollover
+  lifecycle?: DataStreamLifecycleWithRollover
 }

--- a/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
+++ b/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
@@ -22,10 +22,10 @@ import { ExpandWildcards, DataStreamNames } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Removes the data lifecycle from a data stream rendering it not managed by DLM
+ * Removes the data lifecycle from a data stream rendering it not managed by the data stream lifecycle
  * @rest_spec_name indices.delete_data_lifecycle
- * @availability stack since=8.8.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.11.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts
+++ b/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts
@@ -22,10 +22,10 @@ import { Indices } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Retrieves information about the index's current DLM lifecycle, such as any potential encountered error, time since creation etc.
+ * Retrieves information about the index's current data stream lifecycle, such as any potential encountered error, time since creation etc.
  * @rest_spec_name indices.explain_data_lifecycle
- * @availability stack since=8.8.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.11.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleResponse.ts
+++ b/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleResponse.ts
@@ -20,22 +20,22 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 import { IndexName } from '@_types/common'
 import { Duration, EpochTime, UnitMillis } from '@_types/Time'
-import { DataLifecycleWithRollover } from '@indices/_types/DataLifecycle'
+import { DataStreamLifecycleWithRollover } from '@indices/_types/DataStreamLifecycle'
 
 export class Response {
   body: {
-    indices: Dictionary<IndexName, DataLifecycleExplain>
+    indices: Dictionary<IndexName, DataStreamLifecycleExplain>
   }
 }
 
-class DataLifecycleExplain {
+class DataStreamLifecycleExplain {
   index: IndexName
-  managed_by_dlm: boolean
+  managed_by_lifecycle: boolean
   index_creation_date_millis?: EpochTime<UnitMillis>
   time_since_index_creation?: Duration
   rollover_date_millis?: EpochTime<UnitMillis>
   time_since_rollover?: Duration
-  lifecycle?: DataLifecycleWithRollover
+  lifecycle?: DataStreamLifecycleWithRollover
   generation_time?: Duration
   error?: string
 }

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
@@ -21,10 +21,10 @@ import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, DataStreamNames } from '@_types/common'
 
 /**
- * Retrieves the data lifecycle configuration of one or more data streams.
+ * Retrieves the data stream lifecycle configuration of one or more data streams.
  * @rest_spec_name indices.get_data_lifecycle
- * @availability stack since=8.8.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.11.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleResponse.ts
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleResponse.ts
@@ -18,13 +18,13 @@
  */
 
 import { DataStreamName } from '@_types/common'
-import { DataLifecycle } from '@indices/_types/DataLifecycle'
+import { DataStreamLifecycle } from '@indices/_types/DataStreamLifecycle'
 
 export class Response {
-  body: { data_streams: DataStreamLifecycle[] }
+  body: { data_streams: DataStreamWithLifecycle[] }
 }
 
-class DataStreamLifecycle {
+class DataStreamWithLifecycle {
   name: DataStreamName
-  lifecycle?: DataLifecycle
+  lifecycle?: DataStreamLifecycle
 }

--- a/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
+++ b/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
@@ -45,8 +45,8 @@ export interface Request extends RequestBase {
     /**
      * If true, returns all relevant default configurations for the index template.
      * @server_default false
-     * @availability stack since=8.8.0 stability=experimental
-     * @availability serverless stability=experimental
+     * @availability stack since=8.11.0 stability=stable
+     * @availability serverless stability=stable
      */
     include_defaults?: boolean
   }

--- a/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
+++ b/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
@@ -52,8 +52,8 @@ export interface Request extends RequestBase {
     /**
      * If true, returns all relevant default configurations for the index template.
      * @server_default false
-     * @availability stack since=8.8.0 stability=experimental
-     * @availability serverless stability=experimental
+     * @availability stack since=8.11.0 stability=stable
+     * @availability serverless stability=stable
      */
     include_defaults?: boolean
   }

--- a/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
+++ b/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
@@ -24,8 +24,8 @@ import { Duration } from '@_types/Time'
 /**
  * Update the data lifecycle of the specified data streams.
  * @rest_spec_name indices.put_data_lifecycle
- * @availability stack since=8.8.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.11.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
@@ -112,8 +112,8 @@ export class IndexTemplateMapping {
    */
   settings?: IndexSettings
   /**
-   * @availability stack since=8.8.0 stability=experimental
-   * @availability serverless stability=experimental
+   * @availability stack since=8.11.0 stability=stable
+   * @availability serverless stability=stable
    */
   lifecycle?: DataStreamLifecycle
 }

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
@@ -31,7 +31,7 @@ import {
 } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { integer } from '@_types/Numeric'
-import { DataLifecycle } from '@indices/_types/DataLifecycle'
+import { DataStreamLifecycle } from '@indices/_types/DataStreamLifecycle'
 
 /**
  * Creates or updates an index template.
@@ -115,5 +115,5 @@ export class IndexTemplateMapping {
    * @availability stack since=8.8.0 stability=experimental
    * @availability serverless stability=experimental
    */
-  lifecycle?: DataLifecycle
+  lifecycle?: DataStreamLifecycle
 }

--- a/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
+++ b/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
@@ -60,8 +60,8 @@ export interface Request extends RequestBase {
     /**
      * If true, returns all relevant default configurations for the index template.
      * @server_default false
-     * @availability stack since=8.8.0 stability=experimental
-     * @availability serverless stability=experimental
+     * @availability stack since=8.11.0 stability=stable
+     * @availability serverless stability=stable
      */
     include_defaults?: boolean
   }

--- a/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
+++ b/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
@@ -51,8 +51,8 @@ export interface Request extends RequestBase {
     /**
      * If true, returns all relevant default configurations for the index template.
      * @server_default false
-     * @availability stack since=8.8.0 stability=experimental
-     * @availability serverless stability=experimental
+     * @availability stack since=8.11.0 stability=stable
+     * @availability serverless stability=stable
      */
     include_defaults?: boolean
   }


### PR DESCRIPTION
As part of https://github.com/elastic/elasticsearch/pull/98644, the data stream lifecycle API become stable. Furthermore we aligned class names to reflect the rebranding of DLM to data stream lifecycle.