### PR TITLE
[DOCS] Add descriptions for the reindex API

### DIFF
--- a/specification/_global/reindex/ReindexRequest.ts
+++ b/specification/_global/reindex/ReindexRequest.ts
@@ -30,21 +30,71 @@ import { Destination, Source } from './types'
  */
 export interface Request extends RequestBase {
   query_parameters: {
+    /**
+     * If `true`, the request refreshes affected shards to make this operation visible to search.
+     * @server_default false
+     */
     refresh?: boolean
+    /**
+     * The throttle for this request in sub-requests per second.
+     * Defaults to no throttle.
+     * @server_default -1
+     */
     requests_per_second?: float
+    /**
+     * Specifies how long a consistent view of the index should be maintained for scrolled search.
+     */
     scroll?: Duration
+    /**
+     * The number of slices this task should be divided into.
+     * Defaults to 1 slice, meaning the task isn’t sliced into subtasks.
+     * @server_default 1
+     */
     slices?: Slices
+    /**
+     * Period each indexing waits for automatic index creation, dynamic mapping updates, and waiting for active shards.
+     * @server_default 1m
+     */
     timeout?: Duration
+    /**
+     * The number of shard copies that must be active before proceeding with the operation.
+     * Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * @server_default 1
+     */
     wait_for_active_shards?: WaitForActiveShards
+    /**
+     * If `true`, the request blocks until the operation is complete.
+     * @server_default true
+     */
     wait_for_completion?: boolean
+    /**
+     * If `true`, the destination must be an index alias.
+     * @server_default false
+     */
     require_alias?: boolean
   }
   body: {
+    /**
+     * Set to proceed to continue reindexing even if there are conflicts.
+     * @server_default abort
+     */
     conflicts?: Conflicts
+    /**
+     * The destination you are copying to.
+     */
     dest: Destination
+    /**
+     * The maximum number of documents to reindex.
+     */
     max_docs?: long
+    /**
+     * The script to run to update the document source or metadata when reindexing.
+     */
     script?: Script
     size?: long
+    /**
+     * The source you are copying from.
+     */
     source: Source
   }
 }

--- a/specification/_global/reindex/types.ts
+++ b/specification/_global/reindex/types.ts
@@ -37,30 +37,89 @@ import { Duration } from '@_types/Time'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Destination {
+  /**
+   * The name of the data stream, index, or index alias you are copying to.
+   */
   index: IndexName
+  /**
+   * Set to `create` to only index documents that do not already exist.
+   * Important: To reindex to a data stream destination, this argument must be `create`.
+   * @server_default index
+   */
   op_type?: OpType
+  /**
+   * The name of the pipeline to use.
+   */
   pipeline?: string
+  /**
+   * By default, a document's routing is preserved unless it’s changed by the script.
+   * Set to `discard` to set routing to `null`,  or `=value` to route using the specified `value`.
+   * @server_default keep
+   */
   routing?: Routing
+  /**
+   *  The versioning to use for the indexing operation.
+   */
   version_type?: VersionType
 }
 
 export class Source {
+  /**
+   * The name of the data stream, index, or alias you are copying from.
+   * Accepts a comma-separated list to reindex from multiple sources.
+   */
   index: Indices
+  /**
+   * Specifies the documents to reindex using the Query DSL.
+   */
   query?: QueryContainer
+  /**
+   * A remote instance of Elasticsearch that you want to index from.
+   */
   remote?: RemoteSource
+  /**
+   * The number of documents to index per batch.
+   * Use when indexing from remote to ensure that the batches fit within the on-heap buffer, which defaults to a maximum size of 100 MB.
+   */
   size?: integer
+  /**
+   * Slice the reindex request manually using the provided slice ID and total number of slices.
+   */
   slice?: SlicedScroll
   sort?: Sort
-  /** @codegen_name source_fields */
+  /**
+   * If `true` reindexes all source fields.
+   * Set to a list to reindex select fields.
+   * @server_default true
+   * @codegen_name source_fields */
   _source?: Fields
   runtime_mappings?: RuntimeFields
 }
 
 export class RemoteSource {
+  /**
+   * The remote connection timeout.
+   * Defaults to 30 seconds.
+   */
   connect_timeout?: Duration
+  /**
+   * An object containing the headers of the request.
+   */
   headers?: Dictionary<string, string>
+  /**
+   * The URL for the remote instance of Elasticsearch that you want to index from.
+   */
   host: Host
+  /**
+   * The username to use for authentication with the remote host.
+   */
   username?: Username
+  /**
+   * The password to use for authentication with the remote host.
+   */
   password?: Password
+  /**
+   * The remote socket read timeout. Defaults to 30 seconds.
+   */
   socket_timeout?: Duration
 }

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -96,8 +96,19 @@ export type VersionNumbers = VersionNumber[]
 export type VersionString = string
 export type VersionStrings = VersionString[]
 export enum VersionType {
+  /**
+   * Use internal versioning that starts at 1 and increments with each update or delete.
+   */
   internal = 0,
+  /**
+   * Only index the document if the given version is strictly higher than the version of the stored document or if there is no existing document.
+   */
   external = 1,
+  /**
+   * Only index the document if the given version is equal or higher than the version of the stored document or if there is no existing document.
+   * Note: the external_gte version type is meant for special use cases and should be used with care.
+   * If used incorrectly, it can result in loss of data.
+   */
   external_gte = 2,
   force = 3
 }
@@ -168,7 +179,13 @@ export enum Bytes {
 }
 
 export enum Conflicts {
+  /**
+   * Stop reindexing if there are conflicts.
+   */
   abort = 0,
+  /**
+   * Continue reindexing even if there are conflicts.
+   */
   proceed = 1
 }
 
@@ -234,7 +251,13 @@ export enum Level {
 }
 
 export enum OpType {
+  /**
+   * Overwrite any documents that already exist.
+   */
   index = 0,
+  /**
+   * Only index documents that do not already exist.
+   */
   create = 1
 }
 


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/964.

Adds descriptions for the reindex API. Descriptions were sourced from https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html