### PR TITLE
Downsampling spec

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9658,7 +9658,7 @@ export interface IndicesDataStreamLifecycle {
 }
 
 export interface IndicesDataStreamLifecycleDownsampling {
-  rounds?: IndicesDownsamplingRound[]
+  rounds: IndicesDownsamplingRound[]
 }
 
 export interface IndicesDataStreamLifecycleRolloverConditions {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9654,6 +9654,11 @@ export interface IndicesDataStreamIndex {
 
 export interface IndicesDataStreamLifecycle {
   data_retention?: Duration
+  downsampling?: IndicesDataStreamLifecycleDownsampling
+}
+
+export interface IndicesDataStreamLifecycleDownsampling {
+  rounds?: IndicesDownsamplingRound[]
 }
 
 export interface IndicesDataStreamLifecycleRolloverConditions {
@@ -9671,6 +9676,7 @@ export interface IndicesDataStreamLifecycleRolloverConditions {
 
 export interface IndicesDataStreamLifecycleWithRollover {
   data_retention?: Duration
+  downsampling?: IndicesDataStreamLifecycleDownsampling
   rollover?: IndicesDataStreamLifecycleRolloverConditions
 }
 
@@ -9684,6 +9690,11 @@ export interface IndicesDataStreamVisibility {
 
 export interface IndicesDownsampleConfig {
   fixed_interval: DurationLarge
+}
+
+export interface IndicesDownsamplingRound {
+  after: Duration
+  config: IndicesDownsampleConfig
 }
 
 export interface IndicesFielddataFrequencyFilter {
@@ -10683,6 +10694,7 @@ export interface IndicesPutDataLifecycleRequest extends RequestBase {
   timeout?: Duration
   body?: {
     data_retention?: Duration
+    downsamplig?: IndicesDataStreamLifecycleDownsampling
   }
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10694,7 +10694,7 @@ export interface IndicesPutDataLifecycleRequest extends RequestBase {
   timeout?: Duration
   body?: {
     data_retention?: Duration
-    downsamplig?: IndicesDataStreamLifecycleDownsampling
+    downsampling?: IndicesDataStreamLifecycleDownsampling
   }
 }
 

--- a/specification/indices/_types/DataStreamLifecycle.ts
+++ b/specification/indices/_types/DataStreamLifecycle.ts
@@ -20,12 +20,14 @@
 import { Duration } from '@_types/Time'
 import { long } from '@_types/Numeric'
 import { ByteSize } from '@_types/common'
+import { DataStreamLifecycleDownsampling } from '@indices/_types/DataStreamLifecycleDownsampling'
 
 /**
  * Data lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration.
  */
 export class DataStreamLifecycle {
   data_retention?: Duration
+  downsampling?: DataStreamLifecycleDownsampling
 }
 
 /**
@@ -39,6 +41,11 @@ export class DataStreamLifecycleWithRollover {
    * When empty, every document in this data stream will be stored indefinitely.
    */
   data_retention?: Duration
+
+  /**
+   * The downsampling configuration to execute for the managed backing index after rollover.
+   */
+  downsampling?: DataStreamLifecycleDownsampling
   /**
    * The conditions which will trigger the rollover of a backing index as configured by the cluster setting `cluster.lifecycle.default.rollover`.
    * This property is an implementation detail and it will only be retrieved when the query param `include_defaults` is set to true.

--- a/specification/indices/_types/DataStreamLifecycleDownsampling.ts
+++ b/specification/indices/_types/DataStreamLifecycleDownsampling.ts
@@ -23,5 +23,5 @@ export class DataStreamLifecycleDownsampling {
   /**
    * The list of downsampling rounds to execute as part of this downsampling configuration
    */
-  rounds?: DownsamplingRound[]
+  rounds: DownsamplingRound[]
 }

--- a/specification/indices/_types/DataStreamLifecycleDownsampling.ts
+++ b/specification/indices/_types/DataStreamLifecycleDownsampling.ts
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { DownsamplingRound } from '@indices/_types/DownsamplingRound'
+
+export class DataStreamLifecycleDownsampling {
+  /**
+   * The list of downsampling rounds to execute as part of this downsampling configuration
+   */
+  rounds?: DownsamplingRound[]
+}

--- a/specification/indices/_types/DownsamplingRound.ts
+++ b/specification/indices/_types/DownsamplingRound.ts
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Duration } from '@_types/Time'
+import { DownsampleConfig } from '@indices/_types/Downsample'
+
+export class DownsamplingRound {
+  /**
+   * The duration since rollover when this downsampling round should execute
+   */
+  after: Duration
+  /**
+   * The downsample configuration to execute.
+   */
+  config: DownsampleConfig
+}

--- a/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
+++ b/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
@@ -20,6 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { DataStreamNames, ExpandWildcards } from '@_types/common'
 import { Duration } from '@_types/Time'
+import { DataStreamLifecycleDownsampling } from '@indices/_types/DataStreamLifecycleDownsampling'
 
 /**
  * Update the data lifecycle of the specified data streams.
@@ -65,5 +66,10 @@ export interface Request extends RequestBase {
      * When empty, every document in this data stream will be stored indefinitely.
      */
     data_retention?: Duration
+    /**
+     * If defined, every backing index will execute the configured downsampling configuration after the backing
+     * index is not the data stream write index anymore.
+     */
+    downsamplig?: DataStreamLifecycleDownsampling
   }
 }

--- a/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
+++ b/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
@@ -70,6 +70,6 @@ export interface Request extends RequestBase {
      * If defined, every backing index will execute the configured downsampling configuration after the backing
      * index is not the data stream write index anymore.
      */
-    downsamplig?: DataStreamLifecycleDownsampling
+    downsampling?: DataStreamLifecycleDownsampling
   }
 }


### PR DESCRIPTION
This adds the specification for downsampling as part of
the data stream lifecycle.

The downsampling configuration is nullable (just like
data_retention) and itself can contain a nullable list
of downsampling rounds.

Each round consists of an after duration/timevalue field
and the downsample configuration (the fixed_interval)
