### PR TITLE
Search Response has completion_time and _cluster/details

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2055,14 +2055,28 @@ export type Bytes = 'b' | 'kb' | 'mb' | 'gb' | 'tb' | 'pb'
 
 export type CategoryId = string
 
+export type ClusterAlias = string
+
+export interface ClusterDetails {
+  status: ClusterSearchStatusEnum
+  indices: string
+  took?: long
+  timed_out: boolean
+  _shards?: ShardStatistics
+  failures?: ShardFailure[]
+}
+
 export type ClusterInfoTarget = '_all' | 'http' | 'ingest' | 'thread_pool' | 'script'
 
 export type ClusterInfoTargets = ClusterInfoTarget | ClusterInfoTarget[]
+
+export type ClusterSearchStatusEnum = 'running' | 'successful' | 'partial' | 'skipped' | 'failed'
 
 export interface ClusterStatistics {
   skipped: integer
   successful: integer
   total: integer
+  details?: Record<ClusterAlias, ClusterDetails>
 }
 
 export interface CompletionStats {
@@ -6105,6 +6119,8 @@ export interface AsyncSearchAsyncSearchResponseBase {
   expiration_time_in_millis: EpochTime<UnitMillis>
   start_time?: DateTime
   start_time_in_millis: EpochTime<UnitMillis>
+  completion_time?: DateTime
+  completion_time_in_millis?: EpochTime<UnitMillis>
 }
 
 export interface AsyncSearchDeleteRequest extends RequestBase {
@@ -6130,6 +6146,7 @@ export type AsyncSearchStatusResponse = AsyncSearchStatusStatusResponseBase
 
 export interface AsyncSearchStatusStatusResponseBase extends AsyncSearchAsyncSearchResponseBase {
   _shards: ShardStatistics
+  _clusters?: ClusterStatistics
   completion_status?: integer
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2058,9 +2058,9 @@ export type CategoryId = string
 export type ClusterAlias = string
 
 export interface ClusterDetails {
-  status: ClusterSearchStatusEnum
+  status: ClusterSearchStatus
   indices: string
-  took?: long
+  took?: DurationValue<UnitMillis>
   timed_out: boolean
   _shards?: ShardStatistics
   failures?: ShardFailure[]
@@ -2070,7 +2070,7 @@ export type ClusterInfoTarget = '_all' | 'http' | 'ingest' | 'thread_pool' | 'sc
 
 export type ClusterInfoTargets = ClusterInfoTarget | ClusterInfoTarget[]
 
-export type ClusterSearchStatusEnum = 'running' | 'successful' | 'partial' | 'skipped' | 'failed'
+export type ClusterSearchStatus = 'running' | 'successful' | 'partial' | 'skipped' | 'failed'
 
 export interface ClusterStatistics {
   skipped: integer

--- a/specification/_types/Stats.ts
+++ b/specification/_types/Stats.ts
@@ -19,7 +19,7 @@
 
 import { ShardFileSizeInfo } from '@indices/stats/types'
 import { Dictionary } from '@spec_utils/Dictionary'
-import { ByteSize, Field, Name, VersionString } from './common'
+import { ByteSize, ClusterAlias, Field, Name, VersionString } from './common'
 import { ShardFailure } from './Errors'
 import { double, integer, long, uint } from './Numeric'
 import { Duration, DurationValue, UnitMillis } from '@_types/Time'
@@ -28,6 +28,26 @@ export class ClusterStatistics {
   skipped: integer
   successful: integer
   total: integer
+  details?: Dictionary<ClusterAlias, ClusterDetails>
+}
+
+enum ClusterSearchStatusEnum {
+  running = 0,
+  successful = 1,
+  partial = 2,
+  skipped = 3,
+  failed = 4
+}
+
+property: ClusterSearchStatusEnum
+
+export class ClusterDetails {
+  status: ClusterSearchStatusEnum
+  indices: string
+  took?: long
+  timed_out: boolean
+  _shards?: ShardStatistics
+  failures?: ShardFailure[]
 }
 
 export class ShardStatistics {

--- a/specification/_types/Stats.ts
+++ b/specification/_types/Stats.ts
@@ -31,7 +31,7 @@ export class ClusterStatistics {
   details?: Dictionary<ClusterAlias, ClusterDetails>
 }
 
-enum ClusterSearchStatusEnum {
+enum ClusterSearchStatus {
   running = 0,
   successful = 1,
   partial = 2,
@@ -39,12 +39,10 @@ enum ClusterSearchStatusEnum {
   failed = 4
 }
 
-property: ClusterSearchStatusEnum
-
 export class ClusterDetails {
-  status: ClusterSearchStatusEnum
+  status: ClusterSearchStatus
   indices: string
-  took?: long
+  took?: DurationValue<UnitMillis>
   timed_out: boolean
   _shards?: ShardStatistics
   failures?: ShardFailure[]

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -69,6 +69,8 @@ export type LongId = string
 export type IndexMetrics = string
 export type Metrics = string | string[]
 
+export type ClusterAlias = string
+
 export type Name = string
 export type Names = Name | Name[]
 

--- a/specification/async_search/_types/AsyncSearchResponseBase.ts
+++ b/specification/async_search/_types/AsyncSearchResponseBase.ts
@@ -40,6 +40,12 @@ export class AsyncSearchResponseBase {
   expiration_time_in_millis: EpochTime<UnitMillis>
   start_time?: DateTime
   start_time_in_millis: EpochTime<UnitMillis>
+  /**
+   * Indicates when the async search completed. Only present
+   * when the search has completed.
+   */
+  completion_time?: DateTime
+  completion_time_in_millis?: EpochTime<UnitMillis>
 }
 export class AsyncSearchDocumentResponseBase<
   TDocument

--- a/specification/async_search/status/AsyncSearchStatusResponse.ts
+++ b/specification/async_search/status/AsyncSearchStatusResponse.ts
@@ -19,11 +19,16 @@
 
 import { AsyncSearchResponseBase } from '@async_search/_types/AsyncSearchResponseBase'
 import { integer } from '@_types/Numeric'
-import { ShardStatistics } from '@_types/Stats'
+import { ClusterStatistics, ShardStatistics } from '@_types/Stats'
 
 export class StatusResponseBase extends AsyncSearchResponseBase {
   /** Indicates how many shards have run the query so far. */
   _shards: ShardStatistics
+  /**
+   * Metadata about clusters involved in the cross-cluster search.
+   * Not shown for local-only searches.
+   */
+  _clusters?: ClusterStatistics
   /**
    * If the async search completed, this field shows the status code of the search.
    * For example, 200 indicates that the async search was successfully completed.


### PR DESCRIPTION
Updates the spec for the response objects for `POST _async_search`, `GET _async_search/:id`, `GET _async_search/status/:id` and `GET _search`

Two high level changes have happened in 8.10:

1) `completion_time` and `completion_time_in_millis` (async_search only) https://github.com/elastic/elasticsearch/pull/97700

2) Adding `details` metadata to the `_clusters` section of both async and synchronous search responses https://github.com/elastic/elasticsearch/pull/97731

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
