### PR TITLE
[DOCS] Descriptions for tasks APIs

### DIFF
--- a/specification/tasks/cancel/CancelTasksRequest.ts
+++ b/specification/tasks/cancel/CancelTasksRequest.ts
@@ -27,11 +27,23 @@ import { TaskId } from '@_types/common'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * ID of the task.
+     */
     task_id?: TaskId
   }
   query_parameters: {
+    /**
+     * Comma-separated list or wildcard expression of actions used to limit the request.
+     */
     actions?: string | string[]
+    /**
+     * Comma-separated list of node IDs or names used to limit the request.
+     */
     nodes?: string[]
+    /**
+     * Parent task ID used to limit the tasks.
+     */
     parent_task_id?: string
     wait_for_completion?: boolean
   }

--- a/specification/tasks/get/GetTaskRequest.ts
+++ b/specification/tasks/get/GetTaskRequest.ts
@@ -28,10 +28,22 @@ import { Duration } from '@_types/Time'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * ID of the task.
+     */
     task_id: Id
   }
   query_parameters: {
+    /**
+     * Period to wait for a response.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
     timeout?: Duration
+    /**
+     * If `true`, the request blocks until the task has completed.
+     * @server_default false
+     */
     wait_for_completion?: boolean
   }
 }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/964.

Adds descriptions for retrieve and cancel tasks APIs. Descriptions were sourced from https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html