### PR TITLE
[DOCS] Descriptions for SQL APIs

### DIFF
--- a/specification/sql/clear_cursor/ClearSqlCursorRequest.ts
+++ b/specification/sql/clear_cursor/ClearSqlCursorRequest.ts
@@ -25,6 +25,9 @@ import { RequestBase } from '@_types/Base'
  */
 export interface Request extends RequestBase {
   body: {
+    /**
+     * Cursor to clear.
+     */
     cursor: string
   }
 }

--- a/specification/sql/delete_async/SqlDeleteAsyncRequest.ts
+++ b/specification/sql/delete_async/SqlDeleteAsyncRequest.ts
@@ -26,6 +26,9 @@ import { Id } from '@_types/common'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier for the search.
+     */
     id: Id
   }
 }

--- a/specification/sql/get_async/SqlGetAsyncRequest.ts
+++ b/specification/sql/get_async/SqlGetAsyncRequest.ts
@@ -27,6 +27,9 @@ import { Id } from '@_types/common'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier for the search.
+     */
     id: Id
   }
   query_parameters: {

--- a/specification/sql/get_async_status/SqlGetAsyncStatusRequest.ts
+++ b/specification/sql/get_async_status/SqlGetAsyncStatusRequest.ts
@@ -27,6 +27,9 @@ import { Id } from '@_types/common'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier for the search.
+     */
     id: Id
   }
 }

--- a/specification/sql/query/QuerySqlRequest.ts
+++ b/specification/sql/query/QuerySqlRequest.ts
@@ -32,6 +32,7 @@ import { Duration, TimeZone } from '@_types/Time'
 export interface Request extends RequestBase {
   query_parameters: {
     /**
+     * Format for the response.
      * @doc_id sql-rest-format
      */
     format?: string
@@ -46,6 +47,11 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     columnar?: boolean
+    /**
+     * Cursor used to retrieve a set of paginated results.
+     * If you specify a cursor, the API only uses the `columnar` and `time_zone` request body parameters.
+     * It ignores other request body parameters.
+     */
     cursor?: string
     /**
      * The maximum number of rows (or entries) to return in one response
@@ -53,13 +59,13 @@ export interface Request extends RequestBase {
      */
     fetch_size?: integer
     /**
-     * Optional Elasticsearch query DSL for additional filtering.
+     * Elasticsearch query DSL for additional filtering.
      * @doc_id sql-rest-filtering
      * @server_default none
      */
     filter?: QueryContainer
     /**
-     * SQL query to execute
+     * SQL query to run.
      */
     query?: string
     /**
@@ -73,8 +79,9 @@ export interface Request extends RequestBase {
      */
     page_timeout?: Duration
     /**
-     * Time-zone in ISO 8601 used for executing the query on the server. More information available here.
+     * ISO-8601 time zone ID for the search.
      * @doc_url https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html
+     * @server_default Z
      */
     time_zone?: TimeZone
     /**

--- a/specification/sql/translate/TranslateSqlRequest.ts
+++ b/specification/sql/translate/TranslateSqlRequest.ts
@@ -28,9 +28,26 @@ import { TimeZone } from '@_types/Time'
  */
 export interface Request extends RequestBase {
   body: {
+    /**
+     * The maximum number of rows (or entries) to return in one response
+     * @server_default 1000
+     */
     fetch_size?: integer
+    /**
+     * Elasticsearch query DSL for additional filtering.
+     * @doc_id sql-rest-filtering
+     * @server_default none
+     */
     filter?: QueryContainer
+    /**
+     * SQL query to run.
+     */
     query: string
+    /**
+     * ISO-8601 time zone ID for the search.
+     * @doc_url https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html
+     * @server_default Z
+     */
     time_zone?: TimeZone
   }
 }

--- a/specification/sql/translate/TranslateSqlRequest.ts
+++ b/specification/sql/translate/TranslateSqlRequest.ts
@@ -29,7 +29,7 @@ import { TimeZone } from '@_types/Time'
 export interface Request extends RequestBase {
   body: {
     /**
-     * The maximum number of rows (or entries) to return in one response
+     * The maximum number of rows (or entries) to return in one response.
      * @server_default 1000
      */
     fetch_size?: integer


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/964.

Adds descriptions for SQL APIs. Descriptions were sourced from https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-apis.html