### PR TITLE
[DOCS] Descriptions for the termvector/mtermvector APIs

### DIFF
--- a/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
+++ b/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
@@ -35,24 +35,75 @@ import { Operation } from './types'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Name of the index that contains the documents.
+     */
     index?: IndexName
   }
   query_parameters: {
     ids?: Id[]
+    /**
+     * Comma-separated list or wildcard expressions of fields to include in the statistics.
+     * Used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.
+     */
     fields?: Fields
+    /**
+     * If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies.
+     * @server_default true
+     */
     field_statistics?: boolean
+    /**
+     * If `true`, the response includes term offsets.
+     * @server_default true
+     */
     offsets?: boolean
+    /**
+     * If `true`, the response includes term payloads.
+     * @server_default true
+     */
     payloads?: boolean
+    /**
+     * If `true`, the response includes term positions.
+     * @server_default true
+     */
     positions?: boolean
+    /**
+     * Specifies the node or shard the operation should be performed on.
+     * Random by default.
+     */
     preference?: string
+    /**
+     * If true, the request is real-time as opposed to near-real-time.
+     * @server_default true
+     * @doc_id realtime
+     */
     realtime?: boolean
+    /**
+     * Custom value used to route operations to a specific shard.
+     */
     routing?: Routing
+    /**
+     * If true, the response includes term frequency and document frequency.
+     * @server_default false
+     */
     term_statistics?: boolean
+    /**
+     * If `true`, returns the document version as part of a hit.
+     */
     version?: VersionNumber
+    /**
+     * Specific version type.
+     */
     version_type?: VersionType
   }
   body: {
+    /**
+     * Array of existing or artificial documents.
+     */
     docs?: Operation[]
+    /**
+     * Simplified syntax to specify documents by their ID if they're in the same index.
+     */
     ids?: Id[]
   }
 }

--- a/specification/_global/mtermvectors/types.ts
+++ b/specification/_global/mtermvectors/types.ts
@@ -33,18 +33,63 @@ import { ErrorCause } from '@_types/Errors'
 import { long } from '@_types/Numeric'
 
 export class Operation {
+  /**
+   * The ID of the document.
+   */
   _id: Id
+  /**
+   * The index of the document.
+   */
   _index?: IndexName
+  /**
+   * An artificial document (a document not present in the index) for which you want to retrieve term vectors.
+   */
   doc?: UserDefinedValue
+  /**
+   * Comma-separated list or wildcard expressions of fields to include in the statistics.
+   * Used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.
+   */
   fields?: Fields
+  /**
+   * If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies.
+   * @server_default true
+   */
   field_statistics?: boolean
+  /**
+   * Filter terms based on their tf-idf scores.
+   */
   filter?: Filter
+  /**
+   * If `true`, the response includes term offsets.
+   * @server_default true
+   */
   offsets?: boolean
+  /**
+   * If `true`, the response includes term payloads.
+   * @server_default true
+   */
   payloads?: boolean
+  /**
+   * If `true`, the response includes term positions.
+   * @server_default true
+   */
   positions?: boolean
+  /**
+   * Custom value used to route operations to a specific shard.
+   */
   routing?: Routing
+  /**
+   * If true, the response includes term frequency and document frequency.
+   * @server_default false
+   */
   term_statistics?: boolean
+  /**
+   * If `true`, returns the document version as part of a hit.
+   */
   version?: VersionNumber
+  /**
+   * Specific version type.
+   */
   version_type?: VersionType
 }
 

--- a/specification/_global/termvectors/TermVectorsRequest.ts
+++ b/specification/_global/termvectors/TermVectorsRequest.ts
@@ -37,25 +37,82 @@ import { Filter } from './types'
  */
 export interface Request<TDocument> extends RequestBase {
   path_parts: {
+    /**
+     * Name of the index that contains the document.
+     */
     index: IndexName
+    /**
+     * Unique identifier of the document.
+     */
     id?: Id
   }
   query_parameters: {
+    /**
+     *  Comma-separated list or wildcard expressions of fields to include in the statistics.
+     * Used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.
+     */
     fields?: Fields
+    /**
+     * If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies.
+     * @server_default true
+     */
     field_statistics?: boolean
+    /**
+     * If `true`, the response includes term offsets.
+     * @server_default true
+     */
     offsets?: boolean
+    /**
+     * If `true`, the response includes term payloads.
+     * @server_default true
+     */
     payloads?: boolean
+    /**
+     * If `true`, the response includes term positions.
+     * @server_default true
+     */
     positions?: boolean
+    /**
+     * Specifies the node or shard the operation should be performed on.
+     * Random by default.
+     */
     preference?: string
+    /**
+     * If true, the request is real-time as opposed to near-real-time.
+     * @server_default true
+     * @doc_id realtime
+     */
     realtime?: boolean
+    /**
+     * Custom value used to route operations to a specific shard.
+     */
     routing?: Routing
+    /**
+     * If `true`, the response includes term frequency and document frequency.
+     * @server_default false
+     */
     term_statistics?: boolean
+    /**
+     * If `true`, returns the document version as part of a hit.
+     */
     version?: VersionNumber
+    /**
+     * Specific version type.
+     */
     version_type?: VersionType
   }
   body: {
+    /**
+     * An artificial document (a document not present in the index) for which you want to retrieve term vectors.
+     */
     doc?: TDocument
+    /**
+     * Filter terms based on their tf-idf scores.
+     */
     filter?: Filter
+    /**
+     * Overrides the default per-field analyzer.
+     */
     per_field_analyzer?: Dictionary<Field, string>
   }
 }

--- a/specification/_global/termvectors/types.ts
+++ b/specification/_global/termvectors/types.ts
@@ -47,11 +47,40 @@ export class Token {
 }
 
 export class Filter {
+  /**
+   * Ignore words which occur in more than this many docs.
+   * Defaults to unbounded.
+   */
   max_doc_freq?: integer
+  /**
+   * Maximum number of terms that must be returned per field.
+   * @server_default 25
+   */
   max_num_terms?: integer
+  /**
+   * Ignore words with more than this frequency in the source doc.
+   * Defaults to unbounded.
+   */
   max_term_freq?: integer
+  /**
+   * The maximum word length above which words will be ignored.
+   * Defaults to unbounded.
+   * @server_default 0
+   */
   max_word_length?: integer
+  /**
+   * Ignore terms which do not occur in at least this many docs.
+   * @server_default 1
+   */
   min_doc_freq?: integer
+  /**
+   * Ignore words with less than this frequency in the source doc.
+   * @server_default 1
+   */
   min_term_freq?: integer
+  /**
+   * The minimum word length below which words will be ignored.
+   * @server_default 0
+   */
   min_word_length?: integer
 }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/964.

Adds descriptions for the term vectors and multi term vectors APIs. Descriptions were sourced from https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-termvectors.html and https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-termvectors.html