### PR TITLE
[DOCS] Adds description to global APIs part 2

### DIFF
--- a/specification/_global/create/CreateRequest.ts
+++ b/specification/_global/create/CreateRequest.ts
@@ -30,6 +30,8 @@ import {
 import { Duration } from '@_types/Time'
 
 /**
+ * Adds a JSON document to the specified data stream or index and makes it searchable.
+ * If the target is an index and the document already exists, the request updates the document and increments its version.
  * @rest_spec_name create
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
@@ -37,18 +39,57 @@ import { Duration } from '@_types/Time'
  */
 export interface Request<TDocument> extends RequestBase {
   path_parts: {
+    /**
+     * Unique identifier for the document.
+     */
     id: Id
+    /**
+     * Name of the data stream or index to target.
+     * If the target doesn’t exist and matches the name or wildcard (`*`) pattern of an index template with a `data_stream` definition, this request creates the data stream.
+     * If the target doesn’t exist and doesn’t match a data stream template, this request creates the index.
+     */
     index: IndexName
   }
   query_parameters: {
+    /**
+     * ID of the pipeline to use to preprocess incoming documents.
+     * If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request.
+     * If a final pipeline is configured it will always run, regardless of the value of this parameter.
+     */
     pipeline?: string
+    /**
+     * If `true`, Elasticsearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
+     * Valid values: `true`, `false`, `wait_for`.
+     * @server_default false
+     */
     refresh?: Refresh
+    /**
+     * Custom value used to route operations to a specific shard.
+     */
     routing?: Routing
+    /**
+     * Period the request waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.
+     * @server_default 1m
+     */
     timeout?: Duration
+    /**
+     * Explicit version number for concurrency control.
+     * The specified version must match the current version of the document for the request to succeed.
+     */
     version?: VersionNumber
+    /**
+     * Specific version type: `external`, `external_gte`.
+     */
     version_type?: VersionType
+    /**
+     * The number of shard copies that must be active before proceeding with the operation.
+     * Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * @server_default 1
+     */
     wait_for_active_shards?: WaitForActiveShards
   }
-  /** @codegen_name document */
+  /**
+   * Request body contains the JSON source for the document data.
+   * @codegen_name document */
   body?: TDocument
 }

--- a/specification/_global/delete/DeleteRequest.ts
+++ b/specification/_global/delete/DeleteRequest.ts
@@ -32,23 +32,60 @@ import { long } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 /**
+ * Removes a JSON document from the specified index.
  * @rest_spec_name delete
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Unique identifier for the document.
+     */
     id: Id
+    /**
+     * Name of the target index.
+     */
     index: IndexName
   }
   query_parameters: {
+    /**
+     * Only perform the operation if the document has this primary term.
+     */
     if_primary_term?: long
+    /**
+     * Only perform the operation if the document has this sequence number.
+     */
     if_seq_no?: SequenceNumber
+    /**
+     * If `true`, Elasticsearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
+     * Valid values: `true`, `false`, `wait_for`.
+     * @server_default false
+     */
     refresh?: Refresh
+    /**
+     * Custom value used to route operations to a specific shard.
+     */
     routing?: Routing
+    /**
+     * Period to wait for active shards.
+     * @server_default 1m
+     */
     timeout?: Duration
+    /**
+     * Explicit version number for concurrency control.
+     * The specified version must match the current version of the document for the request to succeed.
+     */
     version?: VersionNumber
+    /**
+     * Specific version type: `external`, `external_gte`.
+     */
     version_type?: VersionType
+    /**
+     * The number of shard copies that must be active before proceeding with the operation.
+     * Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * @server_default 1
+     */
     wait_for_active_shards?: WaitForActiveShards
   }
 }

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -119,7 +119,6 @@ export interface Request extends RequestBase {
     request_cache?: boolean
     /**
      * The throttle for this request in sub-requests per second.
-     * @seerver_default -1
      */
     requests_per_second?: float
     /**
@@ -195,7 +194,7 @@ export interface Request extends RequestBase {
   }
   body: {
     /**
-     * The maximum number of documents to delete. 
+     * The maximum number of documents to delete.
      */
     max_docs?: long
     /**

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -34,47 +34,173 @@ import { Duration } from '@_types/Time'
 import { Operator } from '@_types/query_dsl/Operator'
 
 /**
+ * Deletes documents that match the specified query.
  * @rest_spec_name delete_by_query
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Comma-separated list of data streams, indices, and aliases to search.
+     * Supports wildcards (`*`).
+     * To search all data streams or indices, omit this parameter or use `*` or `_all`.
+     */
     index: Indices
   }
   query_parameters: {
+    /**
+     * If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
+     * This behavior applies even if the request targets other open indices.
+     * For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+     * @server_default true
+     */
     allow_no_indices?: boolean
+    /**
+     * Analyzer to use for the query string.
+     */
     analyzer?: string
+    /**
+     * If `true`, wildcard and prefix queries are analyzed.
+     * @server_default false
+     */
     analyze_wildcard?: boolean
+    /**
+     * What to do if delete by query hits version conflicts: `abort` or `proceed`.
+     * @server_default abort
+     */
     conflicts?: Conflicts
+    /**
+     * The default operator for query string query: `AND` or `OR`.
+     * @server_default OR
+     */
     default_operator?: Operator
+    /**
+     * Field to use as default where no field prefix is given in the query string.
+     */
     df?: string
+    /**
+     * Type of index that wildcard patterns can match.
+     * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
+     * Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards
     from?: long
+    /**
+     * If `false`, the request returns an error if it targets a missing or closed index.
+     * @server_default false
+     */
     ignore_unavailable?: boolean
+    /**
+     * If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
+     * @server_default false
+     */
     lenient?: boolean
+    /**
+     * Maximum number of documents to process.
+     * Defaults to all documents.
+     */
     max_docs?: long
+    /**
+     * Specifies the node or shard the operation should be performed on.
+     * Random by default.
+     */
     preference?: string
+    /**
+     * If `true`, Elasticsearch refreshes all shards involved in the delete by query after the request completes.
+     * @server_default false
+     */
     refresh?: boolean
+    /**
+     * If `true`, the request cache is used for this request.
+     * Defaults to the index-level setting.
+     */
     request_cache?: boolean
+    /**
+     * The throttle for this request in sub-requests per second.
+     * @seerver_default -1
+     */
     requests_per_second?: float
+    /**
+     * Custom value used to route operations to a specific shard.
+     */
     routing?: Routing
+    /**
+     * Query in the Lucene query string syntax.
+     */
     q?: string
+    /**
+     * Period to retain the search context for scrolling.
+     */
     scroll?: Duration
+    /**
+     * Size of the scroll request that powers the operation.
+     * @server_default 1000
+     */
     scroll_size?: long
+    /**
+     * Explicit timeout for each search request.
+     * Defaults to no timeout.
+     */
     search_timeout?: Duration
+    /**
+     * The type of the search operation.
+     * Available options: `query_then_fetch`, `dfs_query_then_fetch`.
+     */
     search_type?: SearchType
+    /**
+     * The number of slices this task should be divided into.
+     * @server_default 1
+     */
     slices?: Slices
+    /**
+     * A comma-separated list of <field>:<direction> pairs.
+     */
     sort?: string[]
+    /**
+     * Specific `tag` of the request for logging and statistical purposes.
+     */
     stats?: string[]
+    /**
+     * Maximum number of documents to collect for each shard.
+     * If a query reaches this limit, Elasticsearch terminates the query early.
+     * Elasticsearch collects documents before sorting.
+     * Use with caution.
+     * Elasticsearch applies this parameter to each shard handling the request.
+     * When possible, let Elasticsearch perform early termination automatically.
+     * Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
+     */
     terminate_after?: long
+    /**
+     * Period each deletion request waits for active shards.
+     * @server_default 1m
+     */
     timeout?: Duration
+    /**
+     * If `true`, returns the document version as part of a hit.
+     */
     version?: boolean
+    /**
+     * The number of shard copies that must be active before proceeding with the operation.
+     * Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * @server_default 1
+     */
     wait_for_active_shards?: WaitForActiveShards
+    /**
+     * If `true`, the request blocks until the operation is complete.
+     * @server_default true
+     */
     wait_for_completion?: boolean
   }
   body: {
+    /**
+     * The maximum number of documents to delete. 
+     */
     max_docs?: long
+    /**
+     * Specifies the documents to delete using the Query DSL.
+     */
     query?: QueryContainer
     slice?: SlicedScroll
   }

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -201,6 +201,9 @@ export interface Request extends RequestBase {
      * Specifies the documents to delete using the Query DSL.
      */
     query?: QueryContainer
+    /**
+     * Slice the request manually using the provided slice ID and total number of slices.
+     */
     slice?: SlicedScroll
   }
 }

--- a/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
+++ b/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
@@ -32,10 +32,9 @@ export interface Request extends RequestBase {
      */
     task_id: TaskId
   }
-  qery_parameters: {
+  query_parameters: {
     /**
      * The throttle for this request in sub-requests per second.
-     * @server_default -1
      */
     requests_per_second?: float
   }

--- a/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
+++ b/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
@@ -27,9 +27,16 @@ import { float } from '@_types/Numeric'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * The ID for the task.
+     */
     task_id: TaskId
   }
-  query_parameters: {
+  qery_parameters: {
+    /**
+     * The throttle for this request in sub-requests per second.
+     * @server_default -1
+     */
     requests_per_second?: float
   }
 }

--- a/specification/_global/delete_script/DeleteScriptRequest.ts
+++ b/specification/_global/delete_script/DeleteScriptRequest.ts
@@ -22,16 +22,30 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Deletes a stored script or search template.
  * @rest_spec_name delete_script
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier for the stored script or search template.
+     */
     id: Id
   }
   query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
     master_timeout?: Duration
+    /**
+     * Period to wait for a response.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
     timeout?: Duration
   }
 }

--- a/specification/_global/get_script/GetScriptRequest.ts
+++ b/specification/_global/get_script/GetScriptRequest.ts
@@ -22,12 +22,16 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Retrieves a stored script or search template.
  * @rest_spec_name get_script
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier for the stored script or search template.
+     */
     id: Id
   }
   query_parameters: {

--- a/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
+++ b/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
@@ -39,10 +39,30 @@ export interface Request extends RequestBase {
     index: Indices
   }
   query_parameters: {
+    /**
+     * Extends the time to live of the corresponding point in time.
+     */
     keep_alive: Duration
+    /**
+     * If `false`, the request returns an error if it targets a missing or closed index.
+     * @server_default false
+     */
     ignore_unavailable?: boolean
+    /**
+     * Specifies the node or shard the operation should be performed on.
+     * Random by default.
+     */
     preference?: string
+    /**
+     * Custom value used to route operations to a specific shard.
+     */
     routing?: Routing
+    /**
+     * Type of index that wildcard patterns can match.
+     * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
+     * Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards
   }
 }

--- a/specification/_global/put_script/PutScriptRequest.ts
+++ b/specification/_global/put_script/PutScriptRequest.ts
@@ -23,20 +23,42 @@ import { StoredScript } from '@_types/Scripting'
 import { Duration } from '@_types/Time'
 
 /**
+ * Creates or updates a stored script or search template.
  * @rest_spec_name put_script
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier for the stored script or search template.
+     * Must be unique within the cluster.
+     */
     id: Id
+    /**
+     * Context in which the script or search template should run.
+     * To prevent errors, the API immediately compiles the script or template in this context.
+     */
     context?: Name
   }
   query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
     master_timeout?: Duration
+    /**
+     * Period to wait for a response.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s
+     */
     timeout?: Duration
   }
   body: {
+    /**
+     * Contains the script or search template, its parameters, and its language.
+     */
     script: StoredScript
   }
 }

--- a/specification/_global/scripts_painless_execute/ExecutePainlessScriptRequest.ts
+++ b/specification/_global/scripts_painless_execute/ExecutePainlessScriptRequest.ts
@@ -22,14 +22,25 @@ import { InlineScript } from '@_types/Scripting'
 import { PainlessContextSetup } from './types'
 
 /**
+ * Runs a script and returns a result.
  * @rest_spec_name scripts_painless_execute
  * @availability stack since=6.3.0 stability=experimental
  * @availability serverless stability=experimental visibility=public
  */
 export interface Request extends RequestBase {
   body: {
+    /**
+     * The context that the script should run in.
+     * @server_default painless_test
+     */
     context?: string
+    /**
+     * Additional parameters for the `context`.
+     */
     context_setup?: PainlessContextSetup
+    /**
+     * The Painless script to execute.
+     */
     script?: InlineScript
   }
 }

--- a/specification/_global/scripts_painless_execute/types.ts
+++ b/specification/_global/scripts_painless_execute/types.ts
@@ -23,8 +23,18 @@ import { integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 
 export class PainlessContextSetup {
+  /**
+   * Document that’s temporarily indexed in-memory and accessible from the script.
+   */
   document: UserDefinedValue
+  /**
+   * Index containing a mapping that’s compatible with the indexed document.
+   * You may specify a remote index by prefixing the index with the remote cluster alias.
+   */
   index: IndexName
+  /**
+   * Use this parameter to specify a query for computing a score.
+   */
   query: QueryContainer
 }
 

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -197,7 +197,7 @@ export interface Request extends RequestBase {
   }
   body: {
     /**
-     * The maximum number of documents to update. 
+     * The maximum number of documents to update.
      */
     max_docs?: long
     /**

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -35,51 +35,184 @@ import { Duration } from '@_types/Time'
 import { Operator } from '@_types/query_dsl/Operator'
 
 /**
+ * Updates documents that match the specified query.
+ * If no query is specified, performs an update on every document in the data stream or index without modifying the source, which is useful for picking up mapping changes.
  * @rest_spec_name update_by_query
  * @availability stack since=2.4.0 stability=stable
  * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Comma-separated list of data streams, indices, and aliases to search.
+     * Supports wildcards (`*`).
+     * To search all data streams or indices, omit this parameter or use `*` or `_all`.
+     */
     index: Indices
   }
   query_parameters: {
+    /**
+     * If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
+     * This behavior applies even if the request targets other open indices.
+     * For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+     * @server_default true
+     */
     allow_no_indices?: boolean
+    /**
+     * Analyzer to use for the query string.
+     */
     analyzer?: string
+    /**
+     * If `true`, wildcard and prefix queries are analyzed.
+     * @server_default false
+     */
     analyze_wildcard?: boolean
+    /**
+     * What to do if update by query hits version conflicts: `abort` or `proceed`.
+     * @server_default abort
+     */
     conflicts?: Conflicts
+    /**
+     * The default operator for query string query: `AND` or `OR`.
+     * @server_default OR
+     */
     default_operator?: Operator
+    /**
+     * Field to use as default where no field prefix is given in the query string.
+     */
     df?: string
+    /**
+     * Type of index that wildcard patterns can match.
+     * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
+     * Supports comma-separated values, such as `open,hidden`.
+     * Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     */
     expand_wildcards?: ExpandWildcards
     from?: long
+    /**
+     * If `false`, the request returns an error if it targets a missing or closed index.
+     * @server_default false
+     */
     ignore_unavailable?: boolean
+    /**
+     * If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
+     * @server_default false
+     */
     lenient?: boolean
+    /**
+     * Maximum number of documents to process.
+     * Defaults to all documents.
+     */
     max_docs?: long
+    /**
+     * ID of the pipeline to use to preprocess incoming documents.
+     * If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request.
+     * If a final pipeline is configured it will always run, regardless of the value of this parameter.
+     */
     pipeline?: string
+    /**
+     * Specifies the node or shard the operation should be performed on.
+     * Random by default.
+     */
     preference?: string
+    /**
+     * If `true`, Elasticsearch refreshes affected shards to make the operation visible to search.
+     * @server_default false
+     */
     refresh?: boolean
+    /**
+     * If `true`, the request cache is used for this request.
+     */
     request_cache?: boolean
+    /**
+     * The throttle for this request in sub-requests per second.
+     * @server_default -1
+     */
     requests_per_second?: float
+    /**
+     * Custom value used to route operations to a specific shard.
+     */
     routing?: Routing
+    /**
+     * Period to retain the search context for scrolling.
+     */
     scroll?: Duration
+    /**
+     * Size of the scroll request that powers the operation.
+     * @server_default 1000
+     */
     scroll_size?: long
+    /**
+     * Explicit timeout for each search request.
+     */
     search_timeout?: Duration
+    /**
+     * The type of the search operation. Available options: `query_then_fetch`, `dfs_query_then_fetch`.
+     */
     search_type?: SearchType
+    /**
+     * The number of slices this task should be divided into.
+     * @server_default 1
+     */
     slices?: Slices
+    /**
+     * A comma-separated list of <field>:<direction> pairs.
+     */
     sort?: string[]
+    /**
+     * Specific `tag` of the request for logging and statistical purposes.
+     */
     stats?: string[]
+    /**
+     * Maximum number of documents to collect for each shard.
+     * If a query reaches this limit, Elasticsearch terminates the query early.
+     * Elasticsearch collects documents before sorting.
+     * Use with caution.
+     * Elasticsearch applies this parameter to each shard handling the request.
+     * When possible, let Elasticsearch perform early termination automatically.
+     * Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
+     */
     terminate_after?: long
+    /**
+     * Period each update request waits for the following operations: dynamic mapping updates, waiting for active shards.
+     * @server_default 1m
+     */
     timeout?: Duration
+    /**
+     * If `true`, returns the document version as part of a hit.
+     */
     version?: boolean
     version_type?: boolean
+    /**
+     * The number of shard copies that must be active before proceeding with the operation.
+     * Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * @server_default 1
+     */
     wait_for_active_shards?: WaitForActiveShards
+    /**
+     * If `true`, the request blocks until the operation is complete.
+     * @server_default true
+     */
     wait_for_completion?: boolean
   }
   body: {
+    /**
+     * The maximum number of documents to update. 
+     */
     max_docs?: long
+    /**
+     * Specifies the documents to update using the Query DSL.
+     */
     query?: QueryContainer
+    /**
+     * The script to run to update the document source or metadata when updating.
+     */
     script?: Script
     slice?: SlicedScroll
+    /**
+     * What to do if update by query hits version conflicts: `abort` or `proceed`.
+     * @server_default abort
+     */
     conflicts?: Conflicts
   }
 }

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -208,6 +208,9 @@ export interface Request extends RequestBase {
      * The script to run to update the document source or metadata when updating.
      */
     script?: Script
+    /**
+     * Slice the request manually using the provided slice ID and total number of slices.
+     */
     slice?: SlicedScroll
     /**
      * What to do if update by query hits version conflicts: `abort` or `proceed`.

--- a/specification/_global/update_by_query_rethrottle/UpdateByQueryRethrottleRequest.ts
+++ b/specification/_global/update_by_query_rethrottle/UpdateByQueryRethrottleRequest.ts
@@ -27,9 +27,16 @@ import { float, long } from '@_types/Numeric'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * The ID for the task.
+     */
     task_id: Id
   }
   query_parameters: {
+    /**
+     * The throttle for this request in sub-requests per second.
+     * @server_default -1
+     */
     requests_per_second?: float
   }
 }


### PR DESCRIPTION

## Overview

Related to https://github.com/elastic/elasticsearch-specification/issues/964.

Adds descriptions to the:
* create
* delete
* delete by query
* delete by query rethrottle
* delete script
* get script
* open PIT
* PUT script
* scripts painless execute
* update by query
* update by query rethrottle
APIs.

Source of info:
* https://www.elastic.co/guide/en/elasticsearch/reference/current/docs.html
* https://www.elastic.co/guide/en/elasticsearch/reference/current/script-apis.html
* https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-execute-api.html