### PR TITLE
[DOCS] Adds description to global APIs part 3

### DIFF
--- a/specification/_global/exists/DocumentExistsRequest.ts
+++ b/specification/_global/exists/DocumentExistsRequest.ts
@@ -53,7 +53,7 @@ export interface Request extends RequestBase {
      */
     preference?: string
     /**
-     * If true, the request is real-time as opposed to near-real-time.
+     * If `true`, the request is real-time as opposed to near-real-time.
      * @server_default true
      * @doc_id realtime
      */
@@ -69,7 +69,7 @@ export interface Request extends RequestBase {
      */
     routing?: Routing
     /**
-     * True or false to return the _source field or not, or a list of fields to return.
+     * `true` or `false` to return the `_source` field or not, or a list of fields to return.
      */
     _source?: SourceConfigParam
     /**

--- a/specification/_global/exists/DocumentExistsRequest.ts
+++ b/specification/_global/exists/DocumentExistsRequest.ts
@@ -29,25 +29,71 @@ import {
 import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
+ * Checks if a document in an index exists.
  * @rest_spec_name exists
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier of the document.
+     */
     id: Id
+    /**
+     * Comma-separated list of data streams, indices, and aliases.
+     * Supports wildcards (`*`).
+     */
     index: IndexName
   }
   query_parameters: {
+    /**
+     * Specifies the node or shard the operation should be performed on.
+     * Random by default.
+     */
     preference?: string
+    /**
+     * If true, the request is real-time as opposed to near-real-time.
+     * @server_default true
+     * @doc_id realtime
+     */
     realtime?: boolean
+    /**
+     * If `true`, Elasticsearch refreshes all shards involved in the delete by query after the request completes.
+     * @server_default false
+     */
     refresh?: boolean
+    /**
+     * Target the specified primary shard.
+     * @doc_id routing
+     */
     routing?: Routing
+    /**
+     * True or false to return the _source field or not, or a list of fields to return.
+     */
     _source?: SourceConfigParam
+    /**
+     * A comma-separated list of source fields to exclude in the response.
+     */
     _source_excludes?: Fields
+    /**
+     * A comma-separated list of source fields to include in the response.
+     */
     _source_includes?: Fields
+    /**
+     * List of stored fields to return as part of a hit.
+     * If no fields are specified, no stored fields are included in the response.
+     * If this field is specified, the `_source` parameter defaults to false.
+     */
     stored_fields?: Fields
+    /**
+     * Explicit version number for concurrency control.
+     * The specified version must match the current version of the document for the request to succeed.
+     */
     version?: VersionNumber
+    /**
+     * Specific version type: `external`, `external_gte`.
+     */
     version_type?: VersionType
   }
 }

--- a/specification/_global/exists_source/SourceExistsRequest.ts
+++ b/specification/_global/exists_source/SourceExistsRequest.ts
@@ -29,7 +29,7 @@ import {
 import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
- * Checks if a document is stored in the `source`.
+ * Checks if a document's `_source` is stored.
  * @rest_spec_name exists_source
  * @availability stack since=5.4.0 stability=stable
  * @availability serverless stability=stable visibility=public
@@ -69,7 +69,7 @@ export interface Request extends RequestBase {
      */
     routing?: Routing
     /**
-     * True or false to return the _source field or not, or a list of fields to return.
+     * `true` or `false` to return the `_source` field or not, or a list of fields to return.
      */
     _source?: SourceConfigParam
     /**

--- a/specification/_global/exists_source/SourceExistsRequest.ts
+++ b/specification/_global/exists_source/SourceExistsRequest.ts
@@ -29,24 +29,65 @@ import {
 import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 
 /**
+ * Checks if a document is stored in the `source`.
  * @rest_spec_name exists_source
  * @availability stack since=5.4.0 stability=stable
  * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier of the document.
+     */
     id: Id
+    /**
+     * Comma-separated list of data streams, indices, and aliases.
+     * Supports wildcards (`*`).
+     */
     index: IndexName
   }
   query_parameters: {
+    /**
+     * Specifies the node or shard the operation should be performed on.
+     * Random by default.
+     */
     preference?: string
+    /**
+     * If true, the request is real-time as opposed to near-real-time.
+     * @server_default true
+     * @doc_id realtime
+     */
     realtime?: boolean
+    /**
+     * If `true`, Elasticsearch refreshes all shards involved in the delete by query after the request completes.
+     * @server_default false
+     */
     refresh?: boolean
+    /**
+     * Target the specified primary shard.
+     * @doc_id routing
+     */
     routing?: Routing
+    /**
+     * True or false to return the _source field or not, or a list of fields to return.
+     */
     _source?: SourceConfigParam
+    /**
+     * A comma-separated list of source fields to exclude in the response.
+     */
     _source_excludes?: Fields
+    /**
+     * A comma-separated list of source fields to include in the response.
+     */
     _source_includes?: Fields
+    /**
+     * Explicit version number for concurrency control.
+     * The specified version must match the current version of the document for the request to succeed.
+     */
     version?: VersionNumber
+    /**
+     * Specific version type: `external`, `external_gte`.
+     */
     version_type?: VersionType
   }
 }

--- a/specification/_global/explain/ExplainRequest.ts
+++ b/specification/_global/explain/ExplainRequest.ts
@@ -24,29 +24,81 @@ import { SourceConfigParam } from '@global/search/_types/SourceFilter'
 import { Operator } from '@_types/query_dsl/Operator'
 
 /**
+ * Returns information about why a specific document matches (or doesn’t match) a query.
  * @rest_spec_name explain
  * @availability stack since=0.0.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Defines the document ID.
+     */
     id: Id
+    /**
+     * Index names used to limit the request.
+     * Only a single index name can be provided to this parameter.
+     */
     index: IndexName
   }
   query_parameters: {
+    /**
+     * Analyzer to use for the query string.
+     * This parameter can only be used when the `q` query string parameter is specified.
+     */
     analyzer?: string
+    /**
+     * If `true`, wildcard and prefix queries are analyzed.
+     * @server_default false
+     */
     analyze_wildcard?: boolean
+    /**
+     * The default operator for query string query: `AND` or `OR`.
+     * @server_default OR
+     */
     default_operator?: Operator
+    /**
+     * Field to use as default where no field prefix is given in the query string.
+     */
     df?: string
+    /**
+     * If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
+     * @server_default false
+     */
     lenient?: boolean
+    /**
+     * Specifies the node or shard the operation should be performed on.
+     * Random by default.
+     */
     preference?: string
+    /**
+     * Custom value used to route operations to a specific shard.
+     */
     routing?: Routing
+    /**
+     * True or false to return the `_source` field or not, or a list of fields to return.
+     */
     _source?: SourceConfigParam
+    /**
+     * A comma-separated list of source fields to exclude from the response.
+     */
     _source_excludes?: Fields
+    /**
+     * A comma-separated list of source fields to include in the response.
+     */
     _source_includes?: Fields
+    /**
+     * A comma-separated list of stored fields to return in the response.
+     */
     stored_fields?: Fields
+    /**
+     * Query in the Lucene query string syntax.
+     */
     q?: string
   }
   body: {
+    /**
+     * Defines the search definition using the Query DSL.
+     */
     query?: QueryContainer
   }
 }

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -46,7 +46,7 @@ export interface Request extends RequestBase {
      */
     preference?: string
     /**
-     *  Boolean) If true, the request is real-time as opposed to near-real-time.
+     * If true, the request is real-time as opposed to near-real-time.
      * @server_default true
      * @doc_id realtime
      */
@@ -73,6 +73,11 @@ export interface Request extends RequestBase {
      * A comma-separated list of source fields to include in the response.
      */
     _source_includes?: Fields
+    /**
+     * List of stored fields to return as part of a hit.
+     * If no fields are specified, no stored fields are included in the response.
+     * If this field is specified, the `_source` parameter defaults to false.
+     */
     stored_fields?: Fields
     /**
      * Explicit version number for concurrency control. The specified version must match the current version of the document for the request to succeed.

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -46,7 +46,7 @@ export interface Request extends RequestBase {
      */
     preference?: string
     /**
-     * If true, the request is real-time as opposed to near-real-time.
+     * If `true`, the request is real-time as opposed to near-real-time.
      * @server_default true
      * @doc_id realtime
      */

--- a/specification/_global/index/IndexRequest.ts
+++ b/specification/_global/index/IndexRequest.ts
@@ -33,28 +33,85 @@ import { long } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 /**
+ * Adds a JSON document to the specified data stream or index and makes it searchable.
+ * If the target is an index and the document already exists, the request updates the document and increments its version.
  * @rest_spec_name index
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
  */
 export interface Request<TDocument> extends RequestBase {
   path_parts: {
+    /**
+     * Unique identifier for the document.
+     */
     id?: Id
+    /**
+     * Name of the data stream or index to target.
+     */
     index: IndexName
   }
   query_parameters: {
+    /**
+     * Only perform the operation if the document has this primary term.
+     */
     if_primary_term?: long
+    /**
+     * Only perform the operation if the document has this sequence number.
+     */
     if_seq_no?: SequenceNumber
+    /**
+     * Set to create to only index the document if it does not already exist (put if absent).
+     * If a document with the specified `_id` already exists, the indexing operation will fail.
+     * Same as using the `<index>/_create` endpoint.
+     * Valid values: `index`, `create`.
+     * If document id is specified, it defaults to `index`.
+     * Otherwise, it defaults to `create`.
+     */
     op_type?: OpType
+    /**
+     * ID of the pipeline to use to preprocess incoming documents.
+     * If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request.
+     * If a final pipeline is configured it will always run, regardless of the value of this parameter.
+     */
     pipeline?: string
+    /**
+     * If `true`, Elasticsearch refreshes the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` do nothing with refreshes.
+     * Valid values: `true`, `false`, `wait_for`.
+     */
     refresh?: Refresh
+    /**
+     * Custom value used to route operations to a specific shard.
+     */
     routing?: Routing
+    /**
+     * Period the request waits for the following operations: automatic index creation, dynamic mapping updates, waiting for active shards.
+     * @server_default 1m
+     */
     timeout?: Duration
+    /**
+     * Explicit version number for concurrency control.
+     * The specified version must match the current version of the document for the request to succeed.
+     */
     version?: VersionNumber
+    /**
+     * Specific version type: `external`, `external_gte`.
+     */
     version_type?: VersionType
+    /**
+     * The number of shard copies that must be active before proceeding with the operation.
+     * Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * @server_default 1
+     */
     wait_for_active_shards?: WaitForActiveShards
+    /**
+     * If `true`, the destination must be an index alias.
+     * @server_default false
+     */
     require_alias?: boolean
   }
   /** @codegen_name document */
+  /**
+   * Request body contains the JSON source for the document data.
+   */
   body?: TDocument
 }

--- a/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
@@ -31,13 +31,38 @@ import { RequestItem } from './types'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Comma-separated list of data streams, indices, and aliases to search.
+     * Supports wildcards (`*`).
+     * To search all data streams and indices, omit this parameter or use `*`.
+     */
     index?: Indices
   }
   query_parameters: {
+    /**
+     * If `true`, network round-trips are minimized for cross-cluster search requests.
+     * @server_default true
+     */
     ccs_minimize_roundtrips?: boolean
+    /**
+     * Maximum number of concurrent searches the API can run.
+     */
     max_concurrent_searches?: long
+    /**
+     * The type of the search operation.
+     * Available options: `query_then_fetch`, `dfs_query_then_fetch`.
+     */
     search_type?: SearchType
+    /**
+     * If `true`, the response returns hits.total as an integer.
+     * If `false`, it returns hits.total as an object.
+     * @server_default false
+     */
     rest_total_hits_as_int?: boolean
+    /**
+     * If `true`, the response prefixes aggregation and suggester names with their respective types.
+     * @server_default false
+     */
     typed_keys?: boolean
   }
   /** @codegen_name search_templates */

--- a/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
@@ -54,8 +54,8 @@ export interface Request extends RequestBase {
      */
     search_type?: SearchType
     /**
-     * If `true`, the response returns hits.total as an integer.
-     * If `false`, it returns hits.total as an object.
+     * If `true`, the response returns `hits.total` as an integer.
+     * If `false`, it returns `hits.total` as an object.
      * @server_default false
      */
     rest_total_hits_as_int?: boolean

--- a/specification/_global/msearch_template/types.ts
+++ b/specification/_global/msearch_template/types.ts
@@ -26,15 +26,24 @@ import { MultisearchHeader } from '@global/msearch/types'
 export type RequestItem = MultisearchHeader | TemplateConfig
 
 export class TemplateConfig {
-  /** @server_default false */
+  /**
+   * If `true`, returns detailed information about score calculation as part of each hit.
+   * @server_default false */
   explain?: boolean
   /**
    * ID of the search template to use. If no source is specified,
    * this parameter is required.
    */
   id?: Id
+  /**
+   * Key-value pairs used to replace Mustache variables in the template.
+   * The key is the variable name.
+   * The value is the variable value.
+   */
   params?: Dictionary<string, UserDefinedValue>
-  /** @server_default false */
+  /**
+   * If `true`, the query execution is profiled.
+   * @server_default false */
   profile?: boolean
   /**
    * An inline search template. Supports the same parameters as the search API's

--- a/specification/_global/reindex_rethrottle/ReindexRethrottleRequest.ts
+++ b/specification/_global/reindex_rethrottle/ReindexRethrottleRequest.ts
@@ -22,14 +22,21 @@ import { Id } from '@_types/common'
 import { float } from '@_types/Numeric'
 
 /**
+ * Copies documents from a source to a destination.
  * @rest_spec_name reindex_rethrottle
  * @availability stack since=2.4.0 stability=stable
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Identifier for the task.
+     */
     task_id: Id
   }
   query_parameters: {
+    /**
+     * The throttle for this request in sub-requests per second.
+     */
     requests_per_second?: float
   }
 }

--- a/specification/_global/reindex_rethrottle/types.ts
+++ b/specification/_global/reindex_rethrottle/types.ts
@@ -35,18 +35,55 @@ export class ReindexNode extends BaseNode {
 }
 
 export class ReindexStatus {
+  /**
+   * The number of scroll responses pulled back by the reindex.
+   */
   batches: long
+  /**
+   * The number of documents that were successfully created.
+   */
   created: long
+  /**
+   * The number of documents that were successfully deleted.
+   */
   deleted: long
+  /**
+   * The number of documents that were ignored because the script used for the reindex returned a `noop` value for `ctx.op`.
+   */
   noops: long
+  /**
+   * The number of requests per second effectively executed during the reindex.
+   */
   requests_per_second: float
+  /**
+   * The number of retries attempted by reindex. `bulk` is the number of bulk actions retried and `search` is the number of search actions retried.
+   */
   retries: Retries
+  /**
+   *
+   */
   throttled?: Duration
+  /**
+   * Number of milliseconds the request slept to conform to `requests_per_second`.
+   */
   throttled_millis: DurationValue<UnitMillis>
   throttled_until?: Duration
+  /**
+   * This field should always be equal to zero in a `_reindex` response.
+   * It only has meaning when using the Task API, where it indicates the next time (in milliseconds since epoch) a throttled request will be executed again in order to conform to `requests_per_second`.
+   */
   throttled_until_millis: DurationValue<UnitMillis>
+  /**
+   * The number of documents that were successfully processed.
+   */
   total: long
+  /**
+   * The number of documents that were successfully updated, for example, a document with same ID already existed prior to reindex updating it.
+   */
   updated: long
+  /**
+   * The number of version conflicts that reindex hits.
+   */
   version_conflicts: long
 }
 

--- a/specification/_global/reindex_rethrottle/types.ts
+++ b/specification/_global/reindex_rethrottle/types.ts
@@ -59,9 +59,6 @@ export class ReindexStatus {
    * The number of retries attempted by reindex. `bulk` is the number of bulk actions retried and `search` is the number of search actions retried.
    */
   retries: Retries
-  /**
-   *
-   */
   throttled?: Duration
   /**
    * Number of milliseconds the request slept to conform to `requests_per_second`.

--- a/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
+++ b/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
@@ -23,17 +23,33 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
+ * Renders a search template as a search request body.
  * @rest_spec_name render_search_template
  * @availability stack since=0.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * ID of the search template to render.
+     * If no `source` is specified, this or the `id` request body parameter is required.
+     */
     id?: Id
   }
   body: {
     file?: string
+    /**
+     * Key-value pairs used to replace Mustache variables in the template.
+     * The key is the variable name.
+     * The value is the variable value.
+     */
     params?: Dictionary<string, UserDefinedValue>
+    /**
+     * An inline search template.
+     * Supports the same parameters as the search API's request body.
+     * These parameters also support Mustache variables.
+     * If no `id` or `<templated-id>` is specified, this parameter is required.
+     */
     source?: string
   }
 }

--- a/specification/_global/search_shards/SearchShardsRequest.ts
+++ b/specification/_global/search_shards/SearchShardsRequest.ts
@@ -26,14 +26,45 @@ import { ExpandWildcards, Indices, Routing } from '@_types/common'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * Returns the indices and shards that a search request would be executed against.
+     */
     index?: Indices
   }
   query_parameters: {
+    /**
+     * If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
+     * This behavior applies even if the request targets other open indices.
+     * For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+     * @server_default false
+     */
     allow_no_indices?: boolean
+    /**
+     * Type of index that wildcard patterns can match.
+     * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
+     * Supports comma-separated values, such as `open,hidden`.
+     * Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards
+    /**
+     * If `false`, the request returns an error if it targets a missing or closed index.
+     * @server_default false
+     */
     ignore_unavailable?: boolean
+    /**
+     * If `true`, the request retrieves information from the local node only.
+     * @server_default false
+     */
     local?: boolean
+    /**
+     * Specifies the node or shard the operation should be performed on.
+     * Random by default.
+     */
     preference?: string
+    /**
+     * Custom value used to route operations to a specific shard.
+     */
     routing?: Routing
   }
 }

--- a/specification/_global/search_template/SearchTemplateRequest.ts
+++ b/specification/_global/search_template/SearchTemplateRequest.ts
@@ -30,6 +30,7 @@ import {
 import { Duration } from '@_types/Time'
 
 /**
+ * Runs a search with a search template.
  * @rest_spec_name search_template
  * @availability stack since=2.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
@@ -43,19 +44,44 @@ export interface Request extends RequestBase {
     index?: Indices
   }
   query_parameters: {
-    /** @server_default true */
+    /**
+     * If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
+     * This behavior applies even if the request targets other open indices.
+     * For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+     * @server_default true
+     */
     allow_no_indices?: boolean
-    /** @server_default false */
+    /**
+     * If `true`, network round-trips are minimized for cross-cluster search requests.
+     * @server_default false */
     ccs_minimize_roundtrips?: boolean
+    /**
+     * Type of index that wildcard patterns can match.
+     * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
+     * Supports comma-separated values, such as `open,hidden`.
+     * Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     */
     expand_wildcards?: ExpandWildcards
-    /** @server_default false */
+    /**
+     * If `true`, the response includes additional details about score computation as part of a hit.
+     * @server_default false */
     explain?: boolean
-    /** @server_default true */
+    /**
+     * If `true`, specified concrete, expanded, or aliased indices are not included in the response when throttled.
+     * @server_default true */
     ignore_throttled?: boolean
-    /** @server_default false */
+    /**
+     * If `false`, the request returns an error if it targets a missing or closed index.
+     * @server_default false */
     ignore_unavailable?: boolean
+    /**
+     * Specifies the node or shard the operation should be performed on.
+     * Random by default.
+     */
     preference?: string
-    /** @server_default false */
+    /**
+     * If `true`, the query execution is profiled.
+     * @server_default false */
     profile?: boolean
     /** Custom value used to route operations to a specific shard. */
     routing?: Routing
@@ -73,19 +99,30 @@ export interface Request extends RequestBase {
      * @availability serverless
      */
     rest_total_hits_as_int?: boolean
-    /** @server_default false */
+    /**
+     * If `true`, the response prefixes aggregation and suggester names with their respective types.
+     * @server_default false */
     typed_keys?: boolean
   }
   body: {
-    /** @server_default false */
+    /**
+     * If `true`, returns detailed information about score calculation as part of each hit.
+     * @server_default false */
     explain?: boolean
     /**
      * ID of the search template to use. If no source is specified,
      * this parameter is required.
      */
     id?: Id
+    /**
+     * Key-value pairs used to replace Mustache variables in the template.
+     * The key is the variable name.
+     * The value is the variable value.
+     */
     params?: Dictionary<string, UserDefinedValue>
-    /** @server_default false */
+    /**
+     * If `true`, the query execution is profiled.
+     * @server_default false */
     profile?: boolean
     /**
      * An inline search template. Supports the same parameters as the search API's


### PR DESCRIPTION

## Overview

Related to https://github.com/elastic/elasticsearch-specification/issues/964.

Adds descriptions to the:
* document exists
* source exists
* explain
* GET
* index
* msearch template
* reindex rethrottle
* render search template
* search shards
* search template
APIs.

Source of info:
* https://www.elastic.co/guide/en/elasticsearch/reference/current/docs.html
* https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html