### PR TITLE
Fix include type in Significant Text agg

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3926,7 +3926,7 @@ export interface AggregationsSignificantTextAggregation extends AggregationsBuck
   field?: Field
   filter_duplicate_text?: boolean
   gnd?: AggregationsGoogleNormalizedDistanceHeuristic
-  include?: string | string[]
+  include?: AggregationsTermsInclude
   jlh?: EmptyObject
   min_doc_count?: long
   mutual_information?: AggregationsMutualInformationHeuristic

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -865,7 +865,7 @@ export class SignificantTextAggregation extends BucketAggregationBase {
   /**
    * Values to include.
    */
-  include?: string | string[]
+  include?: TermsInclude
   /**
    * Use JLH score as the significance score.
    */


### PR DESCRIPTION
Closes #2275 

I'm not sure where this should be backported exactly. This aggregation was introduced in Elasticsearch 6.0.