### PR TITLE
Fix include/exclude type in Frequent Items agg

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3309,8 +3309,8 @@ export type AggregationsFrequentItemSetsBucket = AggregationsFrequentItemSetsBuc
 
 export interface AggregationsFrequentItemSetsField {
   field: Field
-  exclude?: string | string[]
-  include?: string | string[]
+  exclude?: AggregationsTermsExclude
+  include?: AggregationsTermsInclude
 }
 
 export type AggregationsGapPolicy = 'skip' | 'insert_zeros' | 'keep_values'

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -1148,12 +1148,12 @@ export class FrequentItemSetsField {
    * Values to exclude.
    * Can be regular expression strings or arrays of strings of exact terms.
    */
-  exclude?: string | string[]
+  exclude?: TermsExclude
   /**
    * Values to include.
    * Can be regular expression strings or arrays of strings of exact terms.
    */
-  include?: string | string[]
+  include?: TermsInclude
 }
 
 export class FrequentItemSetsAggregation {


### PR DESCRIPTION
When working on https://github.com/elastic/elasticsearch-specification/pull/2279, I noticed that the Frequent Items set aggregation [appears to reuse](https://github.com/elastic/elasticsearch/blob/92458fcbcca2d36a2a16f98e1f91d739bbebbb98/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceValueSource.java#L24) the [standard include/exclude support](https://github.com/elastic/elasticsearch/blob/92458fcbcca2d36a2a16f98e1f91d739bbebbb98/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/IncludeExclude.java#L48), so I fixed it too.

I opened a different pull request because this aggregation is much more recent: it went GA for Elasticsearch 8.7. I would also appreciate guidance regarding the backports labels.