### PR TITLE
[Backport 8.8] Fix include/exclude type in Frequent Items agg (#2280)

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3244,8 +3244,8 @@ export type AggregationsFrequentItemSetsBucket = AggregationsFrequentItemSetsBuc
 
 export interface AggregationsFrequentItemSetsField {
   field: Field
-  exclude?: string | string[]
-  include?: string | string[]
+  exclude?: AggregationsTermsExclude
+  include?: AggregationsTermsInclude
 }
 
 export type AggregationsGapPolicy = 'skip' | 'insert_zeros' | 'keep_values'

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -544,8 +544,8 @@ export class IpPrefixAggregation extends BucketAggregationBase {
 
 export class FrequentItemSetsField {
   field: Field
-  exclude?: string | string[]
-  include?: string | string[]
+  exclude?: TermsExclude
+  include?: TermsInclude
 }
 
 export class FrequentItemSetsAggregation {


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch-specification/commit/fa57bcdbb1823eb2b62ee983f64f131f4b2fc02e from https://github.com/elastic/elasticsearch-specification/pull/2280