### PR TITLE
[Backport 7.17] Fix include type in Significant Text Agg (#2279)

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3520,7 +3520,7 @@ export interface AggregationsSignificantTextAggregation extends AggregationsBuck
   field?: Field
   filter_duplicate_text?: boolean
   gnd?: AggregationsGoogleNormalizedDistanceHeuristic
-  include?: string | string[]
+  include?: AggregationsTermsInclude
   min_doc_count?: long
   mutual_information?: AggregationsMutualInformationHeuristic
   percentage?: AggregationsPercentageScoreHeuristic

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -334,7 +334,7 @@ export class SignificantTextAggregation extends BucketAggregationBase {
   field?: Field
   filter_duplicate_text?: boolean
   gnd?: GoogleNormalizedDistanceHeuristic
-  include?: string | string[]
+  include?: TermsInclude
   min_doc_count?: long
   mutual_information?: MutualInformationHeuristic
   percentage?: PercentageScoreHeuristic


### PR DESCRIPTION
Backport ca591c5eda691a76bb5456d29637493b9a25b426 from #2279