### PR TITLE
Add additional counters in _clusters response

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2076,6 +2076,9 @@ export interface ClusterStatistics {
   skipped: integer
   successful: integer
   total: integer
+  running: integer
+  partial: integer
+  failed: integer
   details?: Record<ClusterAlias, ClusterDetails>
 }
 

--- a/specification/_types/Stats.ts
+++ b/specification/_types/Stats.ts
@@ -28,6 +28,9 @@ export class ClusterStatistics {
   skipped: integer
   successful: integer
   total: integer
+  running: integer
+  partial: integer
+  failed: integer
   details?: Dictionary<ClusterAlias, ClusterDetails>
 }
 


### PR DESCRIPTION
Updates the spec for the response objects for `POST _async_search`, `GET _async_search/:id`, `GET _async_search/status/:id` and `GET _search`.

In `8.11` we are adding counters in the `_details` section of both async and synchronous search responses. The counters added are: `running`, `partial` and `failed`. https://github.com/elastic/elasticsearch/pull/99566
