### PR TITLE
Add sparse_vector field type

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5000,7 +5000,7 @@ export interface MappingFieldNamesField {
   enabled: boolean
 }
 
-export type MappingFieldType = 'none' | 'geo_point' | 'geo_shape' | 'ip' | 'binary' | 'keyword' | 'text' | 'search_as_you_type' | 'date' | 'date_nanos' | 'boolean' | 'completion' | 'nested' | 'object' | 'murmur3' | 'token_count' | 'percolator' | 'integer' | 'long' | 'short' | 'byte' | 'float' | 'half_float' | 'scaled_float' | 'double' | 'integer_range' | 'float_range' | 'long_range' | 'double_range' | 'date_range' | 'ip_range' | 'alias' | 'join' | 'rank_feature' | 'rank_features' | 'flattened' | 'shape' | 'histogram' | 'constant_keyword' | 'aggregate_metric_double' | 'dense_vector' | 'match_only_text'
+export type MappingFieldType = 'none' | 'geo_point' | 'geo_shape' | 'ip' | 'binary' | 'keyword' | 'text' | 'search_as_you_type' | 'date' | 'date_nanos' | 'boolean' | 'completion' | 'nested' | 'object' | 'murmur3' | 'token_count' | 'percolator' | 'integer' | 'long' | 'short' | 'byte' | 'float' | 'half_float' | 'scaled_float' | 'double' | 'integer_range' | 'float_range' | 'long_range' | 'double_range' | 'date_range' | 'ip_range' | 'alias' | 'join' | 'rank_feature' | 'rank_features' | 'flattened' | 'shape' | 'histogram' | 'constant_keyword' | 'aggregate_metric_double' | 'dense_vector' | 'sparse_vector' | 'match_only_text'
 
 export interface MappingFlattenedProperty extends MappingPropertyBase {
   boost?: double

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -197,6 +197,7 @@ export enum FieldType {
   constant_keyword,
   aggregate_metric_double,
   dense_vector,
+  sparse_vector,
   match_only_text
 }
 

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -190,6 +190,10 @@ export class RankFeaturesProperty extends PropertyBase {
   type: 'rank_features'
 }
 
+export class SparseVectorProperty extends PropertyBase {
+  type: 'sparse_vector'
+}
+
 export class SearchAsYouTypeProperty extends CorePropertyBase {
   analyzer?: string
   index?: boolean

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -367,7 +367,7 @@ export class QueryContainer {
    */
   terms_set?: SingleKeyDictionary<Field, TermsSetQuery>
   /**
-   * Uses a natural language processing model to convert the query text into a list of token-weight pairs which are then used in a query against a rank features field.
+   * Uses a natural language processing model to convert the query text into a list of token-weight pairs which are then used in a query against a sparse vector or rank features field.
    * @availability stack since=8.8.0
    * @availability serverless
    * @doc_id query-dsl-text-expansion-query


### PR DESCRIPTION
Add sparse_vector field support (added to Elasticsearch https://github.com/elastic/elasticsearch/pull/98996) to mappings, and include it as usable in the docs for `text_expansion` query.