### PR TITLE
[WASM lib] Add compiler error with instructions to build the webassembly

### DIFF
--- a/compiler-rs/compiler-wasm-lib/src/lib.rs
+++ b/compiler-rs/compiler-wasm-lib/src/lib.rs
@@ -19,6 +19,10 @@ use anyhow::bail;
 use wasm_bindgen::prelude::*;
 use clients_schema::{Availabilities, Visibility};
 
+
+#[cfg(not(target_arch="wasm32"))]
+compile_error!("To build this crate use `make compiler-wasm-lib`");
+
 #[wasm_bindgen]
 pub fn convert_schema_to_openapi(json: &str, flavor: &str) -> Result<String, String> {
     set_panic_hook();


### PR DESCRIPTION
This adds a simple compilation error in case someone tries to build the lib with a direct `cargo build`.