### PR TITLE
Allow single fields in fields and _source parameters

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -26307,7 +26307,14 @@
                   "description": "Array of wildcard (`*`) patterns.\nThe request returns doc values for field names matching these patterns in the `hits.fields` property of the response.",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/_types:Field"
+                      },
+                      {
+                        "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
+                      }
+                    ]
                   }
                 },
                 "knn": {
@@ -26382,7 +26389,14 @@
                   "description": "Array of wildcard (`*`) patterns.\nThe request returns values for field names matching these patterns in the `hits.fields` property of the response.",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
+                      },
+                      {
+                        "$ref": "#/components/schemas/_types:Field"
+                      }
+                    ]
                   }
                 },
                 "suggest": {
@@ -34067,6 +34081,9 @@
         "oneOf": [
           {
             "type": "boolean"
+          },
+          {
+            "$ref": "#/components/schemas/_types:Fields"
           },
           {
             "$ref": "#/components/schemas/_global.search._types:SourceFilter"
@@ -54979,7 +54996,14 @@
             "description": "Array of wildcard (*) patterns. The request returns doc values for field\nnames matching these patterns in the hits.fields property of the response.",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/_types:Field"
+                },
+                {
+                  "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
+                }
+              ]
             }
           },
           "knn": {
@@ -55060,7 +55084,14 @@
             "description": "Array of wildcard (*) patterns. The request returns values for field names\nmatching these patterns in the hits.fields property of the response.",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/_types:Field"
+                },
+                {
+                  "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
+                }
+              ]
             }
           },
           "terminate_after": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -728,7 +728,7 @@ export interface MsearchMultisearchBody {
   explain?: boolean
   ext?: Record<string, any>
   stored_fields?: Fields
-  docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
+  docvalue_fields?: (Field | QueryDslFieldAndFormat | Field)[]
   knn?: KnnQuery | KnnQuery[]
   from?: integer
   highlight?: SearchHighlight
@@ -742,7 +742,7 @@ export interface MsearchMultisearchBody {
   size?: integer
   sort?: Sort
   _source?: SearchSourceConfig
-  fields?: (QueryDslFieldAndFormat | Field)[]
+  fields?: (Field | QueryDslFieldAndFormat | Field)[]
   terminate_after?: long
   stats?: string[]
   timeout?: string
@@ -1194,7 +1194,7 @@ export interface SearchRequest extends RequestBase {
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
     indices_boost?: Record<IndexName, double>[]
-    docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
+    docvalue_fields?: (Field | QueryDslFieldAndFormat | Field)[]
     knn?: KnnQuery | KnnQuery[]
     rank?: RankContainer
     min_score?: double
@@ -1208,7 +1208,7 @@ export interface SearchRequest extends RequestBase {
     slice?: SlicedScroll
     sort?: Sort
     _source?: SearchSourceConfig
-    fields?: (QueryDslFieldAndFormat | Field)[]
+    fields?: (QueryDslFieldAndFormat | Field | Field)[]
     suggest?: SearchSuggester
     terminate_after?: long
     timeout?: string
@@ -1632,7 +1632,7 @@ export interface SearchSmoothingModelContainer {
   stupid_backoff?: SearchStupidBackoffSmoothingModel
 }
 
-export type SearchSourceConfig = boolean | SearchSourceFilter | Fields
+export type SearchSourceConfig = boolean | Fields | SearchSourceFilter | Fields
 
 export type SearchSourceConfigParam = boolean | Fields
 

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -23,6 +23,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import {
   ExpandWildcards,
+  Field,
   Fields,
   IndexName,
   Indices,
@@ -96,7 +97,7 @@ export class MultisearchBody {
    * Array of wildcard (*) patterns. The request returns doc values for field
    * names matching these patterns in the hits.fields property of the response.
    */
-  docvalue_fields?: FieldAndFormat[]
+  docvalue_fields?: Array<Field | FieldAndFormat>
   /**
    * Defines the approximate kNN search to run.
    * @availability stack since=8.4.0
@@ -146,7 +147,7 @@ export class MultisearchBody {
    * Array of wildcard (*) patterns. The request returns values for field names
    * matching these patterns in the hits.fields property of the response.
    */
-  fields?: Array<FieldAndFormat>
+  fields?: Array<Field | FieldAndFormat>
   /**
    * Maximum number of documents to collect for each shard. If a query reaches this
    * limit, Elasticsearch terminates the query early. Elasticsearch collects documents

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -371,7 +371,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (`*`) patterns.
      * The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.
      */
-    docvalue_fields?: FieldAndFormat[]
+    docvalue_fields?: Array<Field | FieldAndFormat>
     /**
      * Defines the approximate kNN search to run.
      * @availability stack since=8.4.0
@@ -442,7 +442,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (`*`) patterns.
      * The request returns values for field names matching these patterns in the `hits.fields` property of the response.
      */
-    fields?: Array<FieldAndFormat>
+    fields?: Array<FieldAndFormat | Field>
     /**
      * Defines a suggester that provides similar looking terms based on a provided text.
      */

--- a/specification/_global/search/_types/SourceFilter.ts
+++ b/specification/_global/search/_types/SourceFilter.ts
@@ -32,9 +32,9 @@ export class SourceFilter {
 
 /**
  * Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.
- * @codegen_names fetch, filter
+ * @codegen_names fetch, fields, filter
  */
-export type SourceConfig = boolean | SourceFilter
+export type SourceConfig = boolean | Fields | SourceFilter
 
 /**
  * Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.


### PR DESCRIPTION
This was initially reported in https://github.com/elastic/elasticsearch-py/pull/2347

The `_source` body field used to work but was broken in https://github.com/elastic/elasticsearch-specification/pull/1027/files#diff-4114e335296798822015a064d77c5c6d14c797a89c76a0d08b63dcf5d4028651.

Based on https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html, I fixed `_source`, `fields` and `docvalue_fields`.