### PR TITLE
Add missing `scores` parameter in `MLPutTrainedModelVocabularyRequest`

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14314,6 +14314,7 @@ export interface MlPutTrainedModelVocabularyRequest extends RequestBase {
   body?: {
     vocabulary: string[]
     merges?: string[]
+    scores?: double[]
   }
 }
 

--- a/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
+++ b/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
@@ -19,7 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
-import {double} from "@_types/Numeric";
+import { double } from '@_types/Numeric'
 
 /**
  * Creates a trained model vocabulary.

--- a/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
+++ b/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import {double} from "@_types/Numeric";
 
 /**
  * Creates a trained model vocabulary.
@@ -54,6 +55,6 @@ export interface Request extends RequestBase {
      * @availability stack since=8.9.0
      * @availability serverless
      */
-    scores?: string[]
+    scores?: double[]
   }
 }

--- a/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
+++ b/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
@@ -48,5 +48,12 @@ export interface Request extends RequestBase {
      * @availability serverless
      */
     merges?: string[]
+
+    /**
+     * The optional vocabulary value scores if required by the tokenizer.
+     * @availability stack since=8.9.0
+     * @availability serverless
+     */
+    scores?: string[]
   }
 }


### PR DESCRIPTION
This adds the missing scores parameter that was introduced in v8.9.0.

[Docs](https://www.elastic.co/guide/en/elasticsearch/reference/8.9/put-trained-model-vocabulary.html#ml-put-trained-model-vocabulary-request-body) say:

(Optional, array) Vocabulary value scores used by sentence-piece tokenization. Must have the same length as vocabulary. Required for unigram sentence-piece tokenized models like XLMRoberta and T5.