### PR TITLE
[8.11] Allow single fields in fields and _source parameters (#2317)

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -728,7 +728,7 @@ export interface MsearchMultisearchBody {
   explain?: boolean
   ext?: Record<string, any>
   stored_fields?: Fields
-  docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
+  docvalue_fields?: (Field | QueryDslFieldAndFormat | Field)[]
   knn?: KnnQuery | KnnQuery[]
   from?: integer
   highlight?: SearchHighlight
@@ -742,7 +742,7 @@ export interface MsearchMultisearchBody {
   size?: integer
   sort?: Sort
   _source?: SearchSourceConfig
-  fields?: (QueryDslFieldAndFormat | Field)[]
+  fields?: (Field | QueryDslFieldAndFormat | Field)[]
   terminate_after?: long
   stats?: string[]
   timeout?: string
@@ -1194,7 +1194,7 @@ export interface SearchRequest extends RequestBase {
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
     indices_boost?: Record<IndexName, double>[]
-    docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
+    docvalue_fields?: (Field | QueryDslFieldAndFormat | Field)[]
     knn?: KnnQuery | KnnQuery[]
     rank?: RankContainer
     min_score?: double
@@ -1208,7 +1208,7 @@ export interface SearchRequest extends RequestBase {
     slice?: SlicedScroll
     sort?: Sort
     _source?: SearchSourceConfig
-    fields?: (QueryDslFieldAndFormat | Field)[]
+    fields?: (QueryDslFieldAndFormat | Field | Field)[]
     suggest?: SearchSuggester
     terminate_after?: long
     timeout?: string
@@ -1632,7 +1632,7 @@ export interface SearchSmoothingModelContainer {
   stupid_backoff?: SearchStupidBackoffSmoothingModel
 }
 
-export type SearchSourceConfig = boolean | SearchSourceFilter | Fields
+export type SearchSourceConfig = boolean | Fields | SearchSourceFilter | Fields
 
 export type SearchSourceConfigParam = boolean | Fields
 

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -23,6 +23,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import {
   ExpandWildcards,
+  Field,
   Fields,
   IndexName,
   Indices,
@@ -96,7 +97,7 @@ export class MultisearchBody {
    * Array of wildcard (*) patterns. The request returns doc values for field
    * names matching these patterns in the hits.fields property of the response.
    */
-  docvalue_fields?: FieldAndFormat[]
+  docvalue_fields?: Array<Field | FieldAndFormat>
   /**
    * Defines the approximate kNN search to run.
    * @availability stack since=8.4.0
@@ -146,7 +147,7 @@ export class MultisearchBody {
    * Array of wildcard (*) patterns. The request returns values for field names
    * matching these patterns in the hits.fields property of the response.
    */
-  fields?: Array<FieldAndFormat>
+  fields?: Array<Field | FieldAndFormat>
   /**
    * Maximum number of documents to collect for each shard. If a query reaches this
    * limit, Elasticsearch terminates the query early. Elasticsearch collects documents

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -371,7 +371,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (`*`) patterns.
      * The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.
      */
-    docvalue_fields?: FieldAndFormat[]
+    docvalue_fields?: Array<Field | FieldAndFormat>
     /**
      * Defines the approximate kNN search to run.
      * @availability stack since=8.4.0
@@ -442,7 +442,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (`*`) patterns.
      * The request returns values for field names matching these patterns in the `hits.fields` property of the response.
      */
-    fields?: Array<FieldAndFormat>
+    fields?: Array<FieldAndFormat | Field>
     /**
      * Defines a suggester that provides similar looking terms based on a provided text.
      */

--- a/specification/_global/search/_types/SourceFilter.ts
+++ b/specification/_global/search/_types/SourceFilter.ts
@@ -32,9 +32,9 @@ export class SourceFilter {
 
 /**
  * Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.
- * @codegen_names fetch, filter
+ * @codegen_names fetch, fields, filter
  */
-export type SourceConfig = boolean | SourceFilter
+export type SourceConfig = boolean | Fields | SourceFilter
 
 /**
  * Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.


### PR DESCRIPTION
(cherry picked from commit 9f40be8b64f80a8602c362aae25ff27be71e1b9a)

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
