### PR TITLE
Index create request should support singular 'mapping'

### DIFF
--- a/specification/indices/create/IndicesCreateRequest.ts
+++ b/specification/indices/create/IndicesCreateRequest.ts
@@ -71,6 +71,7 @@ export interface Request extends RequestBase {
      * - Field data types
      * - Mapping parameters
      * @doc_id mapping
+     * @aliases mapping
      */
     mappings?: TypeMapping
     /**


### PR DESCRIPTION
[The current indices create spec](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-settings-limit.html#mapping-settings-limit) expects the term `mapping` rather than `mappings`. Adding as an alias to avoid breaking compatibility.

See https://github.com/elastic/elasticsearch-js/issues/1753.
