### PR TITLE
Revert "[8.11] Allow single fields in fields and _source parameters (#2317)"

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -728,7 +728,7 @@ export interface MsearchMultisearchBody {
   explain?: boolean
   ext?: Record<string, any>
   stored_fields?: Fields
-  docvalue_fields?: (Field | QueryDslFieldAndFormat | Field)[]
+  docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
   knn?: KnnQuery | KnnQuery[]
   from?: integer
   highlight?: SearchHighlight
@@ -742,7 +742,7 @@ export interface MsearchMultisearchBody {
   size?: integer
   sort?: Sort
   _source?: SearchSourceConfig
-  fields?: (Field | QueryDslFieldAndFormat | Field)[]
+  fields?: (QueryDslFieldAndFormat | Field)[]
   terminate_after?: long
   stats?: string[]
   timeout?: string
@@ -1194,7 +1194,7 @@ export interface SearchRequest extends RequestBase {
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
     indices_boost?: Record<IndexName, double>[]
-    docvalue_fields?: (Field | QueryDslFieldAndFormat | Field)[]
+    docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
     knn?: KnnQuery | KnnQuery[]
     rank?: RankContainer
     min_score?: double
@@ -1208,7 +1208,7 @@ export interface SearchRequest extends RequestBase {
     slice?: SlicedScroll
     sort?: Sort
     _source?: SearchSourceConfig
-    fields?: (QueryDslFieldAndFormat | Field | Field)[]
+    fields?: (QueryDslFieldAndFormat | Field)[]
     suggest?: SearchSuggester
     terminate_after?: long
     timeout?: string
@@ -1632,7 +1632,7 @@ export interface SearchSmoothingModelContainer {
   stupid_backoff?: SearchStupidBackoffSmoothingModel
 }
 
-export type SearchSourceConfig = boolean | Fields | SearchSourceFilter | Fields
+export type SearchSourceConfig = boolean | SearchSourceFilter | Fields
 
 export type SearchSourceConfigParam = boolean | Fields
 

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -23,7 +23,6 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import {
   ExpandWildcards,
-  Field,
   Fields,
   IndexName,
   Indices,
@@ -97,7 +96,7 @@ export class MultisearchBody {
    * Array of wildcard (*) patterns. The request returns doc values for field
    * names matching these patterns in the hits.fields property of the response.
    */
-  docvalue_fields?: Array<Field | FieldAndFormat>
+  docvalue_fields?: FieldAndFormat[]
   /**
    * Defines the approximate kNN search to run.
    * @availability stack since=8.4.0
@@ -147,7 +146,7 @@ export class MultisearchBody {
    * Array of wildcard (*) patterns. The request returns values for field names
    * matching these patterns in the hits.fields property of the response.
    */
-  fields?: Array<Field | FieldAndFormat>
+  fields?: Array<FieldAndFormat>
   /**
    * Maximum number of documents to collect for each shard. If a query reaches this
    * limit, Elasticsearch terminates the query early. Elasticsearch collects documents

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -371,7 +371,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (`*`) patterns.
      * The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.
      */
-    docvalue_fields?: Array<Field | FieldAndFormat>
+    docvalue_fields?: FieldAndFormat[]
     /**
      * Defines the approximate kNN search to run.
      * @availability stack since=8.4.0
@@ -442,7 +442,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (`*`) patterns.
      * The request returns values for field names matching these patterns in the `hits.fields` property of the response.
      */
-    fields?: Array<FieldAndFormat | Field>
+    fields?: Array<FieldAndFormat>
     /**
      * Defines a suggester that provides similar looking terms based on a provided text.
      */

--- a/specification/_global/search/_types/SourceFilter.ts
+++ b/specification/_global/search/_types/SourceFilter.ts
@@ -32,9 +32,9 @@ export class SourceFilter {
 
 /**
  * Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.
- * @codegen_names fetch, fields, filter
+ * @codegen_names fetch, filter
  */
-export type SourceConfig = boolean | Fields | SourceFilter
+export type SourceConfig = boolean | SourceFilter
 
 /**
  * Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.


### PR DESCRIPTION
Reverts elastic/elasticsearch-specification#2330

It's a breaking change for typed clients and too late for 8.11.