### PR TITLE
Revert "[7.17] Allow single fields in fields and _source parameters"

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -553,7 +553,7 @@ export interface MsearchMultisearchBody {
   explain?: boolean
   ext?: Record<string, any>
   stored_fields?: Fields
-  docvalue_fields?: (Field | QueryDslFieldAndFormat | Field)[]
+  docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
   from?: integer
   highlight?: SearchHighlight
   indices_boost?: Record<IndexName, double>[]
@@ -566,7 +566,7 @@ export interface MsearchMultisearchBody {
   size?: integer
   sort?: Sort
   _source?: SearchSourceConfig
-  fields?: (Field | QueryDslFieldAndFormat | Field)[]
+  fields?: (QueryDslFieldAndFormat | Field)[]
   terminate_after?: long
   stats?: string[]
   timeout?: string
@@ -1018,7 +1018,7 @@ export interface SearchRequest extends RequestBase {
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
     indices_boost?: Record<IndexName, double>[]
-    docvalue_fields?: (Field | QueryDslFieldAndFormat | Field)[]
+    docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
     min_score?: double
     post_filter?: QueryDslQueryContainer
     profile?: boolean
@@ -1030,7 +1030,7 @@ export interface SearchRequest extends RequestBase {
     slice?: SlicedScroll
     sort?: Sort
     _source?: SearchSourceConfig
-    fields?: (QueryDslFieldAndFormat | Field | Field)[]
+    fields?: (QueryDslFieldAndFormat | Field)[]
     suggest?: SearchSuggester
     terminate_after?: long
     timeout?: string
@@ -1455,7 +1455,7 @@ export interface SearchSmoothingModelContainer {
   stupid_backoff?: SearchStupidBackoffSmoothingModel
 }
 
-export type SearchSourceConfig = boolean | Fields | SearchSourceFilter | Fields
+export type SearchSourceConfig = boolean | SearchSourceFilter | Fields
 
 export type SearchSourceConfigParam = boolean | Fields
 

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -23,7 +23,6 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import {
   ExpandWildcards,
-  Field,
   Fields,
   IndexName,
   Indices,
@@ -96,7 +95,7 @@ export class MultisearchBody {
    * Array of wildcard (*) patterns. The request returns doc values for field
    * names matching these patterns in the hits.fields property of the response.
    */
-  docvalue_fields?: Array<Field | FieldAndFormat>
+  docvalue_fields?: FieldAndFormat[]
   /**
    * Starting document offset. By default, you cannot page through more than 10,000
    * hits using the from and size parameters. To page through more hits, use the
@@ -140,7 +139,7 @@ export class MultisearchBody {
    * Array of wildcard (*) patterns. The request returns values for field names
    * matching these patterns in the hits.fields property of the response.
    */
-  fields?: Array<Field | FieldAndFormat>
+  fields?: Array<FieldAndFormat>
   /**
    * Maximum number of documents to collect for each shard. If a query reaches this
    * limit, Elasticsearch terminates the query early. Elasticsearch collects documents

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -146,7 +146,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (*) patterns. The request returns doc values for field
      * names matching these patterns in the hits.fields property of the response.
      */
-    docvalue_fields?: Array<Field | FieldAndFormat>
+    docvalue_fields?: FieldAndFormat[]
     /**
      * Minimum _score for matching documents. Documents with a lower _score are
      * not included in the search results.
@@ -183,10 +183,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (*) patterns. The request returns values for field names
      * matching these patterns in the hits.fields property of the response.
      */
-    fields?: Array<FieldAndFormat | Field>
-    /**
-     * Defines a suggester that provides similar looking terms based on a provided text.
-     */
+    fields?: Array<FieldAndFormat>
     suggest?: Suggester
     /**
      * Maximum number of documents to collect for each shard. If a query reaches this

--- a/specification/_global/search/_types/SourceFilter.ts
+++ b/specification/_global/search/_types/SourceFilter.ts
@@ -32,9 +32,9 @@ export class SourceFilter {
 
 /**
  * Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.
- * @codegen_names fetch, fields, filter
+ * @codegen_names fetch, filter
  */
-export type SourceConfig = boolean | Fields | SourceFilter
+export type SourceConfig = boolean | SourceFilter
 
 /**
  * Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.


### PR DESCRIPTION
Reverts elastic/elasticsearch-specification#2332