### PR TITLE
Revert "Allow single fields in fields and _source parameters"

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -26307,14 +26307,7 @@
                   "description": "Array of wildcard (`*`) patterns.\nThe request returns doc values for field names matching these patterns in the `hits.fields` property of the response.",
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/_types:Field"
-                      },
-                      {
-                        "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
                   }
                 },
                 "knn": {
@@ -26389,14 +26382,7 @@
                   "description": "Array of wildcard (`*`) patterns.\nThe request returns values for field names matching these patterns in the `hits.fields` property of the response.",
                   "type": "array",
                   "items": {
-                    "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
-                      },
-                      {
-                        "$ref": "#/components/schemas/_types:Field"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
                   }
                 },
                 "suggest": {
@@ -34081,9 +34067,6 @@
         "oneOf": [
           {
             "type": "boolean"
-          },
-          {
-            "$ref": "#/components/schemas/_types:Fields"
           },
           {
             "$ref": "#/components/schemas/_global.search._types:SourceFilter"
@@ -54996,14 +54979,7 @@
             "description": "Array of wildcard (*) patterns. The request returns doc values for field\nnames matching these patterns in the hits.fields property of the response.",
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/_types:Field"
-                },
-                {
-                  "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
-                }
-              ]
+              "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
             }
           },
           "knn": {
@@ -55084,14 +55060,7 @@
             "description": "Array of wildcard (*) patterns. The request returns values for field names\nmatching these patterns in the hits.fields property of the response.",
             "type": "array",
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/_types:Field"
-                },
-                {
-                  "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
-                }
-              ]
+              "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
             }
           },
           "terminate_after": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -728,7 +728,7 @@ export interface MsearchMultisearchBody {
   explain?: boolean
   ext?: Record<string, any>
   stored_fields?: Fields
-  docvalue_fields?: (Field | QueryDslFieldAndFormat | Field)[]
+  docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
   knn?: KnnQuery | KnnQuery[]
   from?: integer
   highlight?: SearchHighlight
@@ -742,7 +742,7 @@ export interface MsearchMultisearchBody {
   size?: integer
   sort?: Sort
   _source?: SearchSourceConfig
-  fields?: (Field | QueryDslFieldAndFormat | Field)[]
+  fields?: (QueryDslFieldAndFormat | Field)[]
   terminate_after?: long
   stats?: string[]
   timeout?: string
@@ -1194,7 +1194,7 @@ export interface SearchRequest extends RequestBase {
     highlight?: SearchHighlight
     track_total_hits?: SearchTrackHits
     indices_boost?: Record<IndexName, double>[]
-    docvalue_fields?: (Field | QueryDslFieldAndFormat | Field)[]
+    docvalue_fields?: (QueryDslFieldAndFormat | Field)[]
     knn?: KnnQuery | KnnQuery[]
     rank?: RankContainer
     min_score?: double
@@ -1208,7 +1208,7 @@ export interface SearchRequest extends RequestBase {
     slice?: SlicedScroll
     sort?: Sort
     _source?: SearchSourceConfig
-    fields?: (QueryDslFieldAndFormat | Field | Field)[]
+    fields?: (QueryDslFieldAndFormat | Field)[]
     suggest?: SearchSuggester
     terminate_after?: long
     timeout?: string
@@ -1632,7 +1632,7 @@ export interface SearchSmoothingModelContainer {
   stupid_backoff?: SearchStupidBackoffSmoothingModel
 }
 
-export type SearchSourceConfig = boolean | Fields | SearchSourceFilter | Fields
+export type SearchSourceConfig = boolean | SearchSourceFilter | Fields
 
 export type SearchSourceConfigParam = boolean | Fields
 

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -23,7 +23,6 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import {
   ExpandWildcards,
-  Field,
   Fields,
   IndexName,
   Indices,
@@ -97,7 +96,7 @@ export class MultisearchBody {
    * Array of wildcard (*) patterns. The request returns doc values for field
    * names matching these patterns in the hits.fields property of the response.
    */
-  docvalue_fields?: Array<Field | FieldAndFormat>
+  docvalue_fields?: FieldAndFormat[]
   /**
    * Defines the approximate kNN search to run.
    * @availability stack since=8.4.0
@@ -147,7 +146,7 @@ export class MultisearchBody {
    * Array of wildcard (*) patterns. The request returns values for field names
    * matching these patterns in the hits.fields property of the response.
    */
-  fields?: Array<Field | FieldAndFormat>
+  fields?: Array<FieldAndFormat>
   /**
    * Maximum number of documents to collect for each shard. If a query reaches this
    * limit, Elasticsearch terminates the query early. Elasticsearch collects documents

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -371,7 +371,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (`*`) patterns.
      * The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.
      */
-    docvalue_fields?: Array<Field | FieldAndFormat>
+    docvalue_fields?: FieldAndFormat[]
     /**
      * Defines the approximate kNN search to run.
      * @availability stack since=8.4.0
@@ -442,7 +442,7 @@ export interface Request extends RequestBase {
      * Array of wildcard (`*`) patterns.
      * The request returns values for field names matching these patterns in the `hits.fields` property of the response.
      */
-    fields?: Array<FieldAndFormat | Field>
+    fields?: Array<FieldAndFormat>
     /**
      * Defines a suggester that provides similar looking terms based on a provided text.
      */

--- a/specification/_global/search/_types/SourceFilter.ts
+++ b/specification/_global/search/_types/SourceFilter.ts
@@ -32,9 +32,9 @@ export class SourceFilter {
 
 /**
  * Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.
- * @codegen_names fetch, fields, filter
+ * @codegen_names fetch, filter
  */
-export type SourceConfig = boolean | Fields | SourceFilter
+export type SourceConfig = boolean | SourceFilter
 
 /**
  * Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered.


### PR DESCRIPTION
Reverts elastic/elasticsearch-specification#2317. The `FieldAndFormat` type has a `@shortcut_property` field which means that if it's a scalar value, it is equivalent to a `FieldAndFormat` with only field defined. The code generation strategy for Python should be to lift the shortcut property into a union, so that `FieldAndFormat` becomes `Field | FieldAndFormat`.