### PR TITLE
Backport 2345 to 8.11

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
 output/dangling-types/dangling.csv linguist-generated=true
 output/schema/schema.json linguist-generated=true
-output/openapi/elasticsearch-serverless-openapi.json linguist-generated=true
 output/schema/import-type-graph.json linguist-generated=true
 output/schema/import-namespace-graph-compact.json linguist-generated=true
 output/schema/import-namespace-graph-expanded.json linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 output/dangling-types/dangling.csv linguist-generated=true
 output/schema/schema.json linguist-generated=true
+output/openapi/elasticsearch-serverless-openapi.json linguist-generated=true
 output/schema/import-type-graph.json linguist-generated=true
 output/schema/import-namespace-graph-compact.json linguist-generated=true
 output/schema/import-namespace-graph-expanded.json linguist-generated=true

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5164,7 +5164,7 @@ export interface MappingPointProperty extends MappingDocValuesPropertyBase {
   type: 'point'
 }
 
-export type MappingProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDynamicProperty | MappingJoinProperty | MappingKeywordProperty | MappingMatchOnlyTextProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingSearchAsYouTypeProperty | MappingTextProperty | MappingVersionProperty | MappingWildcardProperty | MappingDateNanosProperty | MappingDateProperty | MappingAggregateMetricDoubleProperty | MappingDenseVectorProperty | MappingFlattenedProperty | MappingNestedProperty | MappingObjectProperty | MappingCompletionProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingTokenCountProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingPointProperty | MappingShapeProperty | MappingByteNumberProperty | MappingDoubleNumberProperty | MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingScaledFloatNumberProperty | MappingShortNumberProperty | MappingUnsignedLongNumberProperty | MappingDateRangeProperty | MappingDoubleRangeProperty | MappingFloatRangeProperty | MappingIntegerRangeProperty | MappingIpRangeProperty | MappingLongRangeProperty
+export type MappingProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDynamicProperty | MappingJoinProperty | MappingKeywordProperty | MappingMatchOnlyTextProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingSearchAsYouTypeProperty | MappingTextProperty | MappingVersionProperty | MappingWildcardProperty | MappingDateNanosProperty | MappingDateProperty | MappingAggregateMetricDoubleProperty | MappingDenseVectorProperty | MappingSparseVectorProperty | MappingFlattenedProperty | MappingNestedProperty | MappingObjectProperty | MappingCompletionProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingTokenCountProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingPointProperty | MappingShapeProperty | MappingByteNumberProperty | MappingDoubleNumberProperty | MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingScaledFloatNumberProperty | MappingShortNumberProperty | MappingUnsignedLongNumberProperty | MappingDateRangeProperty | MappingDoubleRangeProperty | MappingFloatRangeProperty | MappingIntegerRangeProperty | MappingIpRangeProperty | MappingLongRangeProperty
 
 export interface MappingPropertyBase {
   meta?: Record<string, string>
@@ -5257,6 +5257,10 @@ export interface MappingSourceField {
 }
 
 export type MappingSourceFieldMode = 'disabled' | 'stored' | 'synthetic'
+
+export interface MappingSparseVectorProperty extends MappingPropertyBase {
+  type: 'sparse_vector'
+}
 
 export interface MappingSuggestContext {
   name: Name

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -48,6 +48,7 @@ import {
   ScaledFloatNumberProperty,
   SearchAsYouTypeProperty,
   ShortNumberProperty,
+  SparseVectorProperty,
   TextProperty,
   UnsignedLongNumberProperty,
   VersionProperty,
@@ -117,6 +118,7 @@ export type Property =
   // complex
   | AggregateMetricDoubleProperty
   | DenseVectorProperty
+  | SparseVectorProperty
   | FlattenedProperty
   | NestedProperty
   | ObjectProperty


### PR DESCRIPTION
* Add SparseVectorProperty to Property union
* Add output/openapi/elasticsearch-serverless-openapi.json to .gitattributes

(cherry picked from commit 45873c6fd4d1695892b81aba61f42418703905c3)
