### PR TITLE
Change replacement for PathHierarchyTokenizer to be optional

### DIFF
--- a/specification/_types/analysis/tokenizers.ts
+++ b/specification/_types/analysis/tokenizers.ts
@@ -90,7 +90,7 @@ export class PathHierarchyTokenizer extends TokenizerBase {
   type: 'path_hierarchy'
   buffer_size: Stringified<integer>
   delimiter: string
-  replacement: string
+  replacement?: string
   reverse: Stringified<boolean>
   skip: Stringified<integer>
 }


### PR DESCRIPTION
As per the docs for [Path hierarchy tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-pathhierarchy-tokenizer.html#analysis-pathhierarchy-tokenizer) the replacement field should be optional.