### PR TITLE
Fix whitespace in EQL links

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -114,8 +114,8 @@ dot-expand-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{br
 drop-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/drop-processor.html
 enrich-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/enrich-processor.html
 enrich-stats-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/enrich-stats-api.html
-eql-async-search-api, https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-async-eql-search-api.html
-eql-async-search-status-api, https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-async-eql-status-api.html
+eql-async-search-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-async-eql-search-api.html
+eql-async-search-status-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-async-eql-status-api.html
 eql-basic-syntax,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/eql-syntax.html#eql-basic-syntax
 eql-search-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/eql-search-api.html
 eql-sequences,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/eql-syntax.html#eql-sequences


### PR DESCRIPTION
The current links produce errors in the Python client documentation.

```
/.../elasticsearch-py/.nox/docs/lib/python3.11/site-packages/elasticsearch/client.py:docstring of elasticsearch.client.EqlClient.get:3: ERROR: Unknown t
arget name: "< https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-eql-search-api.html>".
/.../elasticsearch-py/.nox/docs/lib/python3.11/site-packages/elasticsearch/client.py:docstring of elasticsearch.client.EqlClient.get_status:4: ERROR: Un
known target name: "< https://www.elastic.co/guide/en/elasticsearch/reference/master/get-async-eql-status-api.html>".                    
```