### PR TITLE
Initial version of ES|QL query endpoint

### DIFF
--- a/specification/esql/_types/Pragmas.ts
+++ b/specification/esql/_types/Pragmas.ts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { integer } from '@_types/Numeric'
+import { Duration } from '@_types/Time'
+
+export enum DataPartitioning {
+  SHARD,
+  SEGMENT,
+  DOC
+}
+
+export class Pragmas {
+  exchange_buffer_size?: integer
+  exchange_concurrent_clients?: integer
+  enrich_max_workers?: integer
+  task_concurrency?: integer
+  data_partitioning?: DataPartitioning
+  page_size?: integer
+  status_interval?: Duration
+}

--- a/specification/esql/query/QueryRequest.ts
+++ b/specification/esql/query/QueryRequest.ts
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { QueryContainer } from '@_types/query_dsl/abstractions'
+import { TimeZone } from '@_types/Time'
+import { Pragmas } from 'esql/_types/Pragmas'
+
+/**
+ * Executes an ESQL request
+ * @rest_spec_name esql.query
+ * @availability stack since=8.11.0 stability=experimental
+ */
+export interface Request extends RequestBase {
+  query_parameters: {
+    /**
+     * A short version of the Accept header, e.g. json, yaml.
+     */
+    format?: string
+    /**
+     * The character to use between values within a CSV row. Only valid for the csv format.
+     */
+    delimiter?: string
+  }
+  /**
+   * Use the `query` element to start a query. Use `time_zone` to specify an execution time zone and `columnar` to format the answer.
+   */
+  body: {
+    /**
+     * The ES|QL query API accepts an ES|QL query string in the query parameter, runs it, and returns the results.
+     */
+    query: string
+    /**
+     * By default, ES|QL returns results as rows. For example, FROM returns each individual document as one row. For the json, yaml, cbor and smile formats, ES|QL can return the results in a columnar fashion where one row represents all the values of a certain column in the results.
+     */
+    columnar?: boolean
+    time_zone?: TimeZone
+    /**
+     * Specify a Query DSL query in the filter parameter to filter the set of documents that an ES|QL query runs on.
+     */
+    filter?: QueryContainer
+    /**
+     * To avoid any attempts of hacking or code injection, extract the values in a separate list of parameters. Use question mark placeholders (?) in the query string for each of the parameters.
+     */
+    params?: Array<string>
+    pragmas?: Pragmas
+    locale?: string
+  }
+}

--- a/specification/esql/query/QueryResponse.ts
+++ b/specification/esql/query/QueryResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+
+export class Response {
+  body: UserDefinedValue
+}


### PR DESCRIPTION
Based on the following resources:

[ES|QL REST API](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-rest.html)
[EsqlQueryRequest.java](https://github.com/elastic/elasticsearch/blob/b08f1e4090f6dae3a582637caab9436fc471bcfb/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequest.java)
[QueryPragmas.java](https://github.com/elastic/elasticsearch/blob/5e6bf3ceb1c6b1f9df7e169a57fb648d655aa320/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/QueryPragmas.java)