### PR TITLE
Add transform-to-openapi to auto regen Github action

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -49,6 +49,7 @@ jobs:
       run: |
         make compile
         make generate
+        make transform-to-openapi
 
     - name: Check for Changed Files
       id: changes


### PR DESCRIPTION
This add the `transform-to-openapi` target to the `generate` Github Action.
