### PR TITLE
Fix FieldRule

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16071,13 +16071,14 @@ export interface SecurityCreatedStatus {
   created: boolean
 }
 
-export interface SecurityFieldRule {
-  username?: Name
+export interface SecurityFieldRuleKeys {
+  username?: Names
   dn?: Names
   groups?: Names
-  metadata?: any
-  realm?: SecurityRealm
+  'realm.name'?: Name
 }
+export type SecurityFieldRule = SecurityFieldRuleKeys
+  & { [property: string]: any }
 
 export interface SecurityFieldSecurity {
   except?: Fields
@@ -16104,10 +16105,6 @@ export type SecurityIndicesPrivilegesQuery = string | QueryDslQueryContainer | S
 
 export interface SecurityManageUserPrivileges {
   applications: string[]
-}
-
-export interface SecurityRealm {
-  name: Name
 }
 
 export interface SecurityRealmInfo {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16071,14 +16071,12 @@ export interface SecurityCreatedStatus {
   created: boolean
 }
 
-export interface SecurityFieldRuleKeys {
+export interface SecurityFieldRule {
   username?: Names
   dn?: Names
   groups?: Names
   'realm.name'?: Name
 }
-export type SecurityFieldRule = SecurityFieldRuleKeys
-  & { [property: string]: any }
 
 export interface SecurityFieldSecurity {
   except?: Fields

--- a/specification/security/_types/RoleMappingRule.ts
+++ b/specification/security/_types/RoleMappingRule.ts
@@ -35,8 +35,7 @@ export class RoleMappingRule {
  * @variants container
  * @non_exhaustive
  */
-export class FieldRule
-{
+export class FieldRule {
   username?: Names
   dn?: Names
   groups?: Names

--- a/specification/security/_types/RoleMappingRule.ts
+++ b/specification/security/_types/RoleMappingRule.ts
@@ -33,9 +33,9 @@ export class RoleMappingRule {
 
 /**
  * @variants container
+ * @non_exhaustive
  */
 export class FieldRule
-  implements AdditionalProperties<string, UserDefinedValue>
 {
   username?: Names
   dn?: Names

--- a/specification/security/_types/RoleMappingRule.ts
+++ b/specification/security/_types/RoleMappingRule.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { AdditionalProperties } from '@spec_utils/behaviors'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Name, Names } from '@_types/common'
 

--- a/specification/security/_types/RoleMappingRule.ts
+++ b/specification/security/_types/RoleMappingRule.ts
@@ -26,6 +26,9 @@ import { Name, Names } from '@_types/common'
 export class RoleMappingRule {
   any?: RoleMappingRule[]
   all?: RoleMappingRule[]
+  // `field` should have been defined as SingleKeyDictionary<String, ScalarValue|ScalarValue[]>
+  // However, this was initially defined as a container with a limited number of variants,
+  // and was later made non_exhaustive to limit breaking changes.
   field?: FieldRule
   except?: RoleMappingRule
 }
@@ -38,5 +41,4 @@ export class FieldRule {
   username?: Names
   dn?: Names
   groups?: Names
-  'realm.name'?: Name
 }

--- a/specification/security/_types/RoleMappingRule.ts
+++ b/specification/security/_types/RoleMappingRule.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { AdditionalProperties } from '@spec_utils/behaviors'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Name, Names } from '@_types/common'
 
@@ -33,14 +34,11 @@ export class RoleMappingRule {
 /**
  * @variants container
  */
-export class FieldRule {
-  username?: Name
+export class FieldRule
+  implements AdditionalProperties<string, UserDefinedValue>
+{
+  username?: Names
   dn?: Names
   groups?: Names
-  metadata?: UserDefinedValue
-  realm?: Realm
-}
-
-export class Realm {
-  name: Name
+  'realm.name'?: Name
 }


### PR DESCRIPTION
Closes #2344

This fixes three issues with `FieldRule`:

* `username` can also be a list,
* `realm.name` is the field name, using an intermediate `realm` object leads to a parsing exception,
* `metadata` is not an object: values are of the form `metadata.key = value`.

Sources:
 * https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role-mapping.html for the general documentation of `POST /_security/role_mapping/<name>`, including complete examples
 * https://www.elastic.co/guide/en/elasticsearch/reference/current/jwt-auth-realm.html#jwt-authorization-role-mapping which has a an extensive list of possible rules

I only tested in Kibana, as the Python client only exposes `rules` and does not go deeper.

Regarding the backports, `realm.name` and `metadata` are unusable today, but `username` is. Should this be separated in two pull requests, so that the `realm.name` and `metadata` get backported to 8.12, 8.11 and 7.17?