### PR TITLE
Add prefix_string config option for ML models

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -53197,6 +53197,9 @@
           },
           "location": {
             "$ref": "#/components/schemas/ml._types:TrainedModelLocation"
+          },
+          "prefix_strings": {
+            "$ref": "#/components/schemas/ml._types:TrainedModelPrefixStrings"
           }
         },
         "required": [
@@ -53667,6 +53670,23 @@
         },
         "required": [
           "name"
+        ]
+      },
+      "ml._types:TrainedModelPrefixStrings": {
+        "type": "object",
+        "properties": {
+          "ingest": {
+            "description": "String prepended to input at ingest",
+            "type": "string"
+          },
+          "search": {
+            "description": "String prepended to input at search",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ingest",
+          "search"
         ]
       },
       "ml._types:TrainedModelStats": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13233,6 +13233,7 @@ export interface MlTrainedModelConfig {
   metadata?: MlTrainedModelConfigMetadata
   model_size_bytes?: ByteSize
   location?: MlTrainedModelLocation
+  prefix_strings?: MlTrainedModelPrefixStrings
 }
 
 export interface MlTrainedModelConfigInput {
@@ -13318,6 +13319,11 @@ export interface MlTrainedModelLocation {
 
 export interface MlTrainedModelLocationIndex {
   name: IndexName
+}
+
+export interface MlTrainedModelPrefixStrings {
+  ingest: string
+  search: string
 }
 
 export interface MlTrainedModelSizeStats {

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -196,6 +196,7 @@ export class TrainedModelConfig {
   metadata?: TrainedModelConfigMetadata
   model_size_bytes?: ByteSize
   location?: TrainedModelLocation
+  prefix_strings?: TrainedModelPrefixStrings
 }
 
 export class TrainedModelConfigInput {
@@ -422,4 +423,15 @@ export class TrainedModelLocation {
 
 export class TrainedModelLocationIndex {
   name: IndexName
+}
+
+export class TrainedModelPrefixStrings {
+  /**
+   * String prepended to input at ingest
+   */
+  ingest: string
+  /**
+   * String prepended to input at search
+   */
+  search: string
 }


### PR DESCRIPTION
The `prefix_strings` option was added to support the E5 model in https://github.com/elastic/elasticsearch/pull/102089