### PR TITLE
Fix definition of `ManagedBy`

### DIFF
--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -77,11 +77,6 @@ export type Metrics = string | string[]
 
 export type ClusterAlias = string
 
-export type ManagedBy =
-  | 'Index Lifecycle Management'
-  | 'Data stream lifecycle'
-  | 'Unmanaged'
-
 export type Name = string
 export type Names = Name | Name[]
 

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -22,13 +22,18 @@ import {
   Field,
   HealthStatus,
   IndexName,
-  ManagedBy,
   Metadata,
   Name,
   Uuid
 } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { DataStreamLifecycleWithRollover } from '@indices/_types/DataStreamLifecycle'
+
+enum ManagedBy {
+  'Index Lifecycle Management',
+  'Data stream lifecycle',
+  'Unmanaged'
+}
 
 export class DataStream {
   /**


### PR DESCRIPTION
Changes the definition of `ManagedBy` to an `enum` to make consumption more idiomatic.

@andreidan 
We noticed that the string values have different casing (e.g. lowercase "stream" "lifecycle", but uppercase "Lifecycle" "Management"). Are these the exact strings returned by the ES server?