### PR TITLE
Add codegen_name annotations to ManagedBy

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository_owner == 'elastic' # this action will fail if executed from a fork
     runs-on: ubuntu-latest
     env:
-      STACK_VERSION: 8.10-SNAPSHOT
+      STACK_VERSION: 8.13-SNAPSHOT
 
     steps:
       - uses: actions/checkout@v2

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -30,9 +30,22 @@ import { integer } from '@_types/Numeric'
 import { DataStreamLifecycleWithRollover } from '@indices/_types/DataStreamLifecycle'
 
 enum ManagedBy {
+  /** @codegen_name ilm */
   'Index Lifecycle Management',
+  /** @codegen_name datastream */
   'Data stream lifecycle',
+  /** @codegen_name unmanaged */
   'Unmanaged'
+}
+
+enum Foo {
+  FirstItem,
+  SecondItem
+}
+
+enum Bar {
+  first_item,
+  second_item
 }
 
 export class DataStream {

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -38,16 +38,6 @@ enum ManagedBy {
   'Unmanaged'
 }
 
-enum Foo {
-  FirstItem,
-  SecondItem
-}
-
-enum Bar {
-  first_item,
-  second_item
-}
-
 export class DataStream {
   /**
    * Custom metadata for the stream, copied from the `_meta` object of the stream’s matching index template.


### PR DESCRIPTION
The `ManagedBy` enumeration has members containing spaces. This is uncommon, and much more verbose that the actual [values used in the server code](https://github.com/elastic/elasticsearch/blob/6fa7f600738494391b8ee2241ea8664db259cc95/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java#L151).

This PR adds `@codegen_name` to this enum's members to have shorter 'space-less' identifiers.