### PR TITLE
Add token pruning to clients for text expansion query

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6088,7 +6088,7 @@ export interface QueryDslTextExpansionQuery extends QueryDslQueryBase {
 export type QueryDslTextQueryType = 'best_fields' | 'most_fields' | 'cross_fields' | 'phrase' | 'phrase_prefix' | 'bool_prefix'
 
 export interface QueryDslTokenPruningConfig {
-  tokens_freq_ratio_threshold?: float
+  tokens_freq_ratio_threshold?: integer
   tokens_weight_threshold?: float
   only_score_pruned_tokens?: boolean
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5857,6 +5857,7 @@ export interface QueryDslQueryContainer {
   terms?: QueryDslTermsQuery
   terms_set?: Partial<Record<Field, QueryDslTermsSetQuery>>
   text_expansion?: Partial<Record<Field, QueryDslTextExpansionQuery>>
+  weighted_tokens?: Partial<Record<Field, QueryDslWeightedTokensQuery>>
   wildcard?: Partial<Record<Field, QueryDslWildcardQuery | string>>
   wrapper?: QueryDslWrapperQuery
   type?: QueryDslTypeQuery
@@ -6095,6 +6096,14 @@ export interface QueryDslTokenPruningConfig {
 export interface QueryDslTypeQuery extends QueryDslQueryBase {
   value: string
 }
+
+export interface QueryDslWeightedTokensQueryKeys extends QueryDslQueryBase {
+  value: FieldValue
+  tokens: Record<string, float>
+  pruning_config?: QueryDslTokenPruningConfig
+}
+export type QueryDslWeightedTokensQuery = QueryDslWeightedTokensQueryKeys
+  & { [property: string]: FieldValue | Record<string, float> | QueryDslTokenPruningConfig | float | string }
 
 export interface QueryDslWildcardQuery extends QueryDslQueryBase {
   case_insensitive?: boolean

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6098,7 +6098,6 @@ export interface QueryDslTypeQuery extends QueryDslQueryBase {
 }
 
 export interface QueryDslWeightedTokensQueryKeys extends QueryDslQueryBase {
-  value: FieldValue
   tokens: Record<string, float>
   pruning_config?: QueryDslTokenPruningConfig
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6097,12 +6097,10 @@ export interface QueryDslTypeQuery extends QueryDslQueryBase {
   value: string
 }
 
-export interface QueryDslWeightedTokensQueryKeys extends QueryDslQueryBase {
+export interface QueryDslWeightedTokensQuery extends QueryDslQueryBase {
   tokens: Record<string, float>
   pruning_config?: QueryDslTokenPruningConfig
 }
-export type QueryDslWeightedTokensQuery = QueryDslWeightedTokensQueryKeys
-  & { [property: string]: FieldValue | Record<string, float> | QueryDslTokenPruningConfig | float | string }
 
 export interface QueryDslWildcardQuery extends QueryDslQueryBase {
   case_insensitive?: boolean

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6081,9 +6081,16 @@ export interface QueryDslTermsSetQuery extends QueryDslQueryBase {
 export interface QueryDslTextExpansionQuery extends QueryDslQueryBase {
   model_id: string
   model_text: string
+  pruning_config?: QueryDslTokenPruningConfig
 }
 
 export type QueryDslTextQueryType = 'best_fields' | 'most_fields' | 'cross_fields' | 'phrase' | 'phrase_prefix' | 'bool_prefix'
+
+export interface QueryDslTokenPruningConfig {
+  tokens_freq_ratio_threshold?: float
+  tokens_weight_threshold?: float
+  only_score_pruned_tokens?: boolean
+}
 
 export interface QueryDslTypeQuery extends QueryDslQueryBase {
   value: string

--- a/specification/_types/query_dsl/TextExpansionQuery.ts
+++ b/specification/_types/query_dsl/TextExpansionQuery.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { TokenPruningConfig } from './TokenPruningConfig'
 import { QueryBase } from './abstractions'
 
 export class TextExpansionQuery extends QueryBase {
@@ -24,4 +25,9 @@ export class TextExpansionQuery extends QueryBase {
   model_id: string
   /** The query text */
   model_text: string
+  /** Token pruning configurations
+   * @availability stack since=8.13.0 stability=experimental
+   * @availability serverless stability=experimental
+  */
+  pruning_config?: TokenPruningConfig
 }

--- a/specification/_types/query_dsl/TextExpansionQuery.ts
+++ b/specification/_types/query_dsl/TextExpansionQuery.ts
@@ -28,6 +28,6 @@ export class TextExpansionQuery extends QueryBase {
   /** Token pruning configurations
    * @availability stack since=8.13.0 stability=experimental
    * @availability serverless stability=experimental
-  */
+   */
   pruning_config?: TokenPruningConfig
 }

--- a/specification/_types/query_dsl/TokenPruningConfig.ts
+++ b/specification/_types/query_dsl/TokenPruningConfig.ts
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-import { float } from '@_types/Numeric'
+import { float, integer } from '@_types/Numeric'
 
 export class TokenPruningConfig {
   /** Tokens whose frequency is more than this threshold times the average frequency of all tokens in the specified field are considered outliers and pruned.
    * @server_default 5
    */
-  tokens_freq_ratio_threshold?: float
+  tokens_freq_ratio_threshold?: integer
   /** Tokens whose weight is less than this threshold are considered nonsignificant and pruned.
    * @server_default 0.4
    */

--- a/specification/_types/query_dsl/TokenPruningConfig.ts
+++ b/specification/_types/query_dsl/TokenPruningConfig.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { float } from "@_types/Numeric"
+import { float } from '@_types/Numeric'
 
 export class TokenPruningConfig {
   /** Tokens whose frequency is more than this threshold times the average frequency of all tokens in the specified field are considered outliers and pruned.
@@ -26,7 +26,7 @@ export class TokenPruningConfig {
   tokens_freq_ratio_threshold?: float
   /** Tokens whose weight is less than this threshold are considered nonsignificant and pruned.
    * @server_default 0.4
-  */
+   */
   tokens_weight_threshold?: float
   /** Whether to only score pruned tokens, vs only scoring kept tokens.
    * @server_default false

--- a/specification/_types/query_dsl/TokenPruningConfig.ts
+++ b/specification/_types/query_dsl/TokenPruningConfig.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { float } from "@_types/Numeric"
+
+export class TokenPruningConfig {
+  /** Tokens whose frequency is more than this threshold times the average frequency of all tokens in the specified field are considered outliers and pruned.
+   * @server_default 5
+   */
+  tokens_freq_ratio_threshold?: float
+  /** Tokens whose weight is less than this threshold are considered nonsignificant and pruned.
+   * @server_default 0.4
+  */
+  tokens_weight_threshold?: float
+  /** Whether to only score pruned tokens, vs only scoring kept tokens.
+   * @server_default false
+   */
+  only_score_pruned_tokens?: boolean
+}

--- a/specification/_types/query_dsl/WeightedTokensQuery.ts
+++ b/specification/_types/query_dsl/WeightedTokensQuery.ts
@@ -24,9 +24,7 @@ import { Field, FieldValue } from '@_types/common'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { float } from '@_types/Numeric'
 
-export class WeightedTokensQuery
-  extends QueryBase
-{
+export class WeightedTokensQuery extends QueryBase {
   /** The tokens representing this query */
   tokens: Dictionary<string, float>
   /** Token pruning configurations */

--- a/specification/_types/query_dsl/WeightedTokensQuery.ts
+++ b/specification/_types/query_dsl/WeightedTokensQuery.ts
@@ -26,7 +26,6 @@ import { float } from '@_types/Numeric'
 
 export class WeightedTokensQuery
   extends QueryBase
-  implements AdditionalProperty<Field, FieldValue>
 {
   /** The tokens representing this query */
   tokens: Dictionary<string, float>

--- a/specification/_types/query_dsl/WeightedTokensQuery.ts
+++ b/specification/_types/query_dsl/WeightedTokensQuery.ts
@@ -28,8 +28,6 @@ export class WeightedTokensQuery
   extends QueryBase
   implements AdditionalProperty<Field, FieldValue>
 {
-  /** The field to query */
-  value: FieldValue
   /** The tokens representing this query */
   tokens: Dictionary<string, float>
   /** Token pruning configurations */

--- a/specification/_types/query_dsl/WeightedTokensQuery.ts
+++ b/specification/_types/query_dsl/WeightedTokensQuery.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AdditionalProperty } from '@spec_utils/behaviors'
+import { TokenPruningConfig } from './TokenPruningConfig'
+import { QueryBase } from './abstractions'
+import { Field, FieldValue } from '@_types/common'
+import { Dictionary } from '@spec_utils/Dictionary'
+import { float } from '@_types/Numeric'
+
+export class WeightedTokensQuery extends QueryBase implements AdditionalProperty<Field, FieldValue> {
+  /** The field to query */
+  value: FieldValue
+  /** The tokens representing this query */
+  tokens: Dictionary<string, float>
+  /** Token pruning configurations */
+  pruning_config?: TokenPruningConfig
+}

--- a/specification/_types/query_dsl/WeightedTokensQuery.ts
+++ b/specification/_types/query_dsl/WeightedTokensQuery.ts
@@ -24,7 +24,10 @@ import { Field, FieldValue } from '@_types/common'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { float } from '@_types/Numeric'
 
-export class WeightedTokensQuery extends QueryBase implements AdditionalProperty<Field, FieldValue> {
+export class WeightedTokensQuery
+  extends QueryBase
+  implements AdditionalProperty<Field, FieldValue>
+{
   /** The field to query */
   value: FieldValue
   /** The tokens representing this query */

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -375,7 +375,7 @@ export class QueryContainer {
    */
   text_expansion?: SingleKeyDictionary<Field, TextExpansionQuery>
   /**
-   * Supports prototyping text_expansion query results by sending in precomputed tokens with the query. Not intended for production workflows.
+   * Supports returning text_expansion query results by sending in precomputed tokens with the query.
    * @availability stack since=8.13.0
    * @availability serverless
    * @doc_id query-dsl-weighted-tokens-query

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -94,6 +94,7 @@ import {
   WildcardQuery
 } from './term'
 import { TextExpansionQuery } from './TextExpansionQuery'
+import { WeightedTokensQuery } from './WeightedTokensQuery'
 
 /**
  * @variants container
@@ -373,6 +374,13 @@ export class QueryContainer {
    * @doc_id query-dsl-text-expansion-query
    */
   text_expansion?: SingleKeyDictionary<Field, TextExpansionQuery>
+  /**
+   * Supports prototyping text_expansion query results by sending in precomputed tokens with the query. Not intended for production workflows.
+   * @availability stack since=8.13.0
+   * @availability serverless
+   * @doc_id query-dsl-weighted-tokens-query
+   */
+  weighted_tokens?: SingleKeyDictionary<Field, WeightedTokensQuery>
   /**
    * Returns documents that contain terms matching a wildcard pattern.
    * @doc_id query-dsl-wildcard-query


### PR DESCRIPTION
Adds the following specification after merging https://github.com/elastic/elasticsearch/pull/102862: 

- Optional `pruning_config` added to the `text_expansion` query 
- New `weighted_tokens` query