### PR TITLE
Remove unknown setting index.shard

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -41405,9 +41405,6 @@
           "time_series": {
             "$ref": "#/components/schemas/indices._types:IndexSettingsTimeSeries"
           },
-          "shards": {
-            "type": "number"
-          },
           "queries": {
             "$ref": "#/components/schemas/indices._types:Queries"
           },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9852,7 +9852,7 @@ export interface IndicesIndexSettingsKeys {
   analysis?: IndicesIndexSettingsAnalysis
   settings?: IndicesIndexSettings
   time_series?: IndicesIndexSettingsTimeSeries
-  shards?: integer//from here too?
+  shards?: integer
   queries?: IndicesQueries
   similarity?: IndicesSettingsSimilarity
   mapping?: IndicesMappingLimitSettings

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9852,7 +9852,6 @@ export interface IndicesIndexSettingsKeys {
   analysis?: IndicesIndexSettingsAnalysis
   settings?: IndicesIndexSettings
   time_series?: IndicesIndexSettingsTimeSeries
-  shards?: integer
   queries?: IndicesQueries
   similarity?: IndicesSettingsSimilarity
   mapping?: IndicesMappingLimitSettings

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9852,7 +9852,7 @@ export interface IndicesIndexSettingsKeys {
   analysis?: IndicesIndexSettingsAnalysis
   settings?: IndicesIndexSettings
   time_series?: IndicesIndexSettingsTimeSeries
-  shards?: integer
+  shards?: integer//from here too?
   queries?: IndicesQueries
   similarity?: IndicesSettingsSimilarity
   mapping?: IndicesMappingLimitSettings

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -146,7 +146,6 @@ export class IndexSettings
   analysis?: IndexSettingsAnalysis
   settings?: IndexSettings
   time_series?: IndexSettingsTimeSeries
-  shards?: integer
   queries?: Queries
   /**
    * Configure custom similarity settings to customize how search results are scored.


### PR DESCRIPTION
The Java client has a `.shard()` method in the Index API  that returns `illegal_argument_exception` when called, with reason `unknown setting [index.shards]`.

For example:

```
esClient.indices().create(c -> c
        .index("test")
       .settings(st -> st
       .shards(1)
```

Trying the same call in Kibana yields the same result:

```
PUT test/
{
  "settings": {
      "shards": 1
  }
}
```

Given that `number_of_shards` exists, I suspect `shards` shouldn't be part of the IndexSettings type.