### PR TITLE
Update total property of HitsMetadata

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -29890,15 +29890,7 @@
         "type": "object",
         "properties": {
           "total": {
-            "description": "Total hit count information, present only if `track_total_hits` wasn't `false` in the search request.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/_global.search._types:TotalHits"
-              },
-              {
-                "type": "number"
-              }
-            ]
+            "$ref": "#/components/schemas/_global.search._types:TotalHits"
           },
           "hits": {
             "type": "array",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1469,7 +1469,7 @@ export interface SearchHit<TDocument = unknown> {
 }
 
 export interface SearchHitsMetadata<T = unknown> {
-  total?: SearchTotalHits | long
+  total?: SearchTotalHits
   hits: SearchHit<T>[]
   max_score?: double | null
 }

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -65,7 +65,7 @@ export class Hit<TDocument> {
 
 export class HitsMetadata<T> {
   /** Total hit count information, present only if `track_total_hits` wasn't `false` in the search request. */
-  total?: TotalHits | long
+  total?: TotalHits
   hits: Hit<T>[]
 
   max_score?: double | null


### PR DESCRIPTION
The documentation, and my experience working with Elasticsearch at runtime, indicate that this property is never of type `long` and is always of type `TotalHits` (if it is defined).  It would be nice if this was reflected in the types!

Maybe there's a reason this change is inappropriate (I don't know how this type might be used internally), but it was simple enough that fixing it seemed easier for everyone than writing an issue.

Thank you for considering this change!
