### PR TITLE
[ML] Adding signed byte support to support Cohere integration

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11464,7 +11464,7 @@ export interface IndicesValidateQueryResponse {
   error?: string
 }
 
-export type InferenceDenseVector = float[]
+export type InferenceDenseVector = float[] | byte[]
 
 export interface InferenceInferenceResult {
   text_embedding?: InferenceTextEmbeddingResult[]

--- a/specification/inference/_types/Results.ts
+++ b/specification/inference/_types/Results.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { float } from '@_types/Numeric'
+import { float, byte } from '@_types/Numeric'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 /**
@@ -28,9 +28,9 @@ export type SparseVector = Dictionary<string, float>
 
 /**
  * Text Embedding results are represented as Dense Vectors
- * of floats.
+ * of floats or signed bytes.
  */
-export type DenseVector = Array<float>
+export type DenseVector = Array<float> | Array<byte>
 
 export class SparseEmbeddingResult {
   embedding: SparseVector


### PR DESCRIPTION
This PR is to reflect the proposed changes included in this PR: https://github.com/elastic/elasticsearch/pull/104559 which adds support for the Cohere 3rd party service. By adding Cohere we also would like to support signed bytes as a response format for dense vector.

I'll leave this in draft until the elasticsearch PR is merged.