### PR TITLE
Fix script definition in processorcontainer

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -49276,7 +49276,7 @@
             "$ref": "#/components/schemas/ingest._types:RerouteProcessor"
           },
           "script": {
-            "$ref": "#/components/schemas/_types:Script"
+            "$ref": "#/components/schemas/ingest._types:ScriptProcessor"
           },
           "set": {
             "$ref": "#/components/schemas/ingest._types:SetProcessor"
@@ -50115,6 +50115,36 @@
                     }
                   }
                 ]
+              }
+            }
+          }
+        ]
+      },
+      "ingest._types:ScriptProcessor": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ingest._types:ProcessorBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "$ref": "#/components/schemas/_types:Id"
+              },
+              "lang": {
+                "description": "Script language.",
+                "type": "string"
+              },
+              "params": {
+                "description": "Object containing parameters for the script.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
+              "source": {
+                "description": "Inline script.\nIf no `id` is specified, this parameter is required.",
+                "type": "string"
               }
             }
           }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11770,7 +11770,7 @@ export interface IngestProcessorContainer {
   remove?: IngestRemoveProcessor
   rename?: IngestRenameProcessor
   reroute?: IngestRerouteProcessor
-  script?: Script
+  script?: IngestScriptProcessor
   set?: IngestSetProcessor
   sort?: IngestSortProcessor
   split?: IngestSplitProcessor
@@ -11801,6 +11801,13 @@ export interface IngestRerouteProcessor extends IngestProcessorBase {
   destination?: string
   dataset?: string | string[]
   namespace?: string | string[]
+}
+
+export interface IngestScriptProcessor extends IngestProcessorBase {
+  id?: Id
+  lang?: string
+  params?: Record<string, any>
+  source?: string
 }
 
 export interface IngestSetProcessor extends IngestProcessorBase {

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -23,7 +23,6 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Field, Fields, Id, Name } from '@_types/common'
 import { GeoShapeRelation } from '@_types/Geo'
 import { double, integer, long } from '@_types/Numeric'
-import { Script } from '@_types/Scripting'
 
 /**
  * @variants container
@@ -159,7 +158,7 @@ export class ProcessorContainer {
    * The script runs in the `ingest` context.
    * @doc_id script-processor
    */
-  script?: Script
+  script?: ScriptProcessor
   /**
    * Adds a field with the specified value.
    * If the field already exists, its value will be replaced with the provided one.


### PR DESCRIPTION
Fixes [Issue 500](https://github.com/elastic/elasticsearch-java/issues/500)
ProcessorContainer class was referring to Script instead of ScriptProcessor