### PR TITLE
Make `PathHierarchyTokenizer` properties optional

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -44343,11 +44343,7 @@
               }
             },
             "required": [
-              "type",
-              "buffer_size",
-              "delimiter",
-              "reverse",
-              "skip"
+              "type"
             ]
           }
         ]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4580,11 +4580,11 @@ export type AnalysisNormalizer = AnalysisLowercaseNormalizer | AnalysisCustomNor
 
 export interface AnalysisPathHierarchyTokenizer extends AnalysisTokenizerBase {
   type: 'path_hierarchy'
-  buffer_size: SpecUtilsStringified<integer>
-  delimiter: string
+  buffer_size?: SpecUtilsStringified<integer>
+  delimiter?: string
   replacement?: string
-  reverse: SpecUtilsStringified<boolean>
-  skip: SpecUtilsStringified<integer>
+  reverse?: SpecUtilsStringified<boolean>
+  skip?: SpecUtilsStringified<integer>
 }
 
 export interface AnalysisPatternAnalyzer {

--- a/specification/_types/analysis/tokenizers.ts
+++ b/specification/_types/analysis/tokenizers.ts
@@ -88,11 +88,11 @@ export class NoriTokenizer extends TokenizerBase {
 
 export class PathHierarchyTokenizer extends TokenizerBase {
   type: 'path_hierarchy'
-  buffer_size: Stringified<integer>
-  delimiter: string
+  buffer_size?: Stringified<integer>
+  delimiter?: string
   replacement?: string
-  reverse: Stringified<boolean>
-  skip: Stringified<integer>
+  reverse?: Stringified<boolean>
+  skip?: Stringified<integer>
 }
 
 export class PatternTokenizer extends TokenizerBase {


### PR DESCRIPTION
When attempting to configure the path hierarchy tokenizer from a .NET app, I noticed that many of the fields are serialized with their defaults when unset, and this is incorrect. They are all optional.