### PR TITLE
Change `total_count` from `int` -> `long`

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2470,7 +2470,7 @@ export interface QueryCacheStats {
   memory_size?: ByteSize
   memory_size_in_bytes: long
   miss_count: integer
-  total_count: integer
+  total_count: long
 }
 
 export type QueryVector = float[]


### PR DESCRIPTION
Change type of `QueryCacheStats.total_count` from `int` -> `long`. This was incorrectly typed just for this class. All other places are already using `long` for `total_count` properties.

Related to https://github.com/elastic/elasticsearch-net/issues/8015