### PR TITLE
Fix synonyms/put_synonym_rule body

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -16622,10 +16622,7 @@
                 "type": "object",
                 "properties": {
                   "synonyms": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/synonyms._types:SynonymString"
-                    }
+                    "$ref": "#/components/schemas/synonyms._types:SynonymString"
                   }
                 },
                 "required": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17668,7 +17668,7 @@ export interface SynonymsPutSynonymRuleRequest extends RequestBase {
   set_id: Id
   rule_id: Id
   body?: {
-    synonyms: SynonymsSynonymString[]
+    synonyms: SynonymsSynonymString
   }
 }
 

--- a/specification/synonyms/put_synonym_rule/SynonymRulePutRequest.ts
+++ b/specification/synonyms/put_synonym_rule/SynonymRulePutRequest.ts
@@ -42,6 +42,6 @@ export interface Request extends RequestBase {
    * The synonym rule information to update
    */
   body: {
-    synonyms: SynonymString[]
+    synonyms: SynonymString
   }
 }


### PR DESCRIPTION
synonyms is not a list, but a string in Solr format.