### PR TITLE
Fix synonyms/put_synonym_rule body (#2407)

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17544,7 +17544,7 @@ export interface SynonymsPutSynonymRuleRequest extends RequestBase {
   set_id: Id
   rule_id: Id
   body?: {
-    synonyms: SynonymsSynonymString[]
+    synonyms: SynonymsSynonymString
   }
 }
 

--- a/specification/synonyms/put_synonym_rule/SynonymRulePutRequest.ts
+++ b/specification/synonyms/put_synonym_rule/SynonymRulePutRequest.ts
@@ -42,6 +42,6 @@ export interface Request extends RequestBase {
    * The synonym rule information to update
    */
   body: {
-    synonyms: SynonymString[]
+    synonyms: SynonymString
   }
 }


### PR DESCRIPTION
synonyms is not a list, but a string in Solr format.

(cherry picked from commit 90b09673b22aa4537a2339470dc123d03f167f3b)