### PR TITLE
[ML] Adding text embedding byte representation

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11464,9 +11464,12 @@ export interface IndicesValidateQueryResponse {
   error?: string
 }
 
+export type InferenceDenseByteVector = byte[]
+
 export type InferenceDenseVector = float[]
 
 export interface InferenceInferenceResult {
+  text_embedding_bytes?: InferenceTextEmbeddingByteResult[]
   text_embedding?: InferenceTextEmbeddingResult[]
   sparse_embedding?: InferenceSparseEmbeddingResult[]
 }
@@ -11493,6 +11496,10 @@ export type InferenceSparseVector = Record<string, float>
 export type InferenceTaskSettings = any
 
 export type InferenceTaskType = 'sparse_embedding' | 'text_embedding'
+
+export interface InferenceTextEmbeddingByteResult {
+  embedding: InferenceDenseByteVector
+}
 
 export interface InferenceTextEmbeddingResult {
   embedding: InferenceDenseVector

--- a/specification/inference/_types/Results.ts
+++ b/specification/inference/_types/Results.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { float } from '@_types/Numeric'
+import { float, byte } from '@_types/Numeric'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 /**
@@ -37,6 +37,19 @@ export class SparseEmbeddingResult {
 }
 
 /**
+ * Text Embedding results containing bytes are represented as Dense
+ * Vectors of bytes.
+ */
+export type DenseByteVector = Array<byte>;
+
+/**
+ * The text embedding result object for byte representation
+ */
+export class TextEmbeddingByteResult {
+  embedding: DenseByteVector
+}
+
+/**
  * The text embedding result object
  */
 export class TextEmbeddingResult {
@@ -48,6 +61,7 @@ export class TextEmbeddingResult {
  * @variants container
  */
 export class InferenceResult {
+  text_embedding_bytes?: Array<TextEmbeddingByteResult>
   text_embedding?: Array<TextEmbeddingResult>
   sparse_embedding?: Array<SparseEmbeddingResult>
 }

--- a/specification/inference/_types/Results.ts
+++ b/specification/inference/_types/Results.ts
@@ -40,7 +40,7 @@ export class SparseEmbeddingResult {
  * Text Embedding results containing bytes are represented as Dense
  * Vectors of bytes.
  */
-export type DenseByteVector = Array<byte>;
+export type DenseByteVector = Array<byte>
 
 /**
  * The text embedding result object for byte representation


### PR DESCRIPTION
This PR adds the text embedding byte representation. This is to resolve the problems with the original PR: https://github.com/elastic/elasticsearch-specification/pull/2398 which caused the client generates to fail because it was unable to deduce the response format.

These changes coincide with the server changes here: https://github.com/elastic/elasticsearch/pull/105290 