### PR TITLE
Batch from java issues

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -18166,8 +18166,8 @@
         "tags": [
           "update_by_query"
         ],
-        "summary": "Performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change.",
-        "description": "Performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change.",
+        "summary": "Updates documents that match the specified query. If no query is specified,\n performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change.",
+        "description": "Updates documents that match the specified query. If no query is specified,\n performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html"
         },
@@ -44547,7 +44547,9 @@
           "scripted_tfidf": {
             "$ref": "#/components/schemas/indices._types:SettingsSimilarityScriptedTfidf"
           }
-        }
+        },
+        "minProperties": 1,
+        "maxProperties": 1
       },
       "indices._types:SettingsSimilarityBm25": {
         "type": "object",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -49346,6 +49346,10 @@
               "target_field": {
                 "$ref": "#/components/schemas/_types:Field"
               },
+              "remove_binary": {
+                "description": "If true, the binary field will be removed from the document",
+                "type": "boolean"
+              },
               "resource_name": {
                 "description": "Field containing the name of the resource to decode.\nIf specified, the processor passes this resource name to the underlying Tika library to enable Resource Name Based Detection.",
                 "type": "string"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15289,9 +15289,13 @@ export interface NodesInfoNodeInfoClient {
   type: string
 }
 
-export interface NodesInfoNodeInfoDiscover {
-  seed_hosts?: string
+export interface NodesInfoNodeInfoDiscoverKeys {
+  seed_hosts?: string[]
+  type?: string
+  seed_providers?: string[]
 }
+export type NodesInfoNodeInfoDiscover = NodesInfoNodeInfoDiscoverKeys
+  & { [property: string]: any }
 
 export interface NodesInfoNodeInfoHttp {
   bound_address: string[]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15406,7 +15406,7 @@ export interface NodesInfoNodeInfoSettingsCluster {
   name: Name
   routing?: IndicesIndexRouting
   election: NodesInfoNodeInfoSettingsClusterElection
-  initial_master_nodes?: string
+  initial_master_nodes?: string[]
   deprecation_indexing?: NodesInfoDeprecationIndexing
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11546,6 +11546,7 @@ export interface IngestAttachmentProcessor extends IngestProcessorBase {
   indexed_chars_field?: Field
   properties?: string[]
   target_field?: Field
+  remove_binary?: boolean
   resource_name?: string
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15357,9 +15357,9 @@ export interface NodesInfoNodeInfoOSCPU {
 }
 
 export interface NodesInfoNodeInfoPath {
-  logs: string
-  home: string
-  repo: string[]
+  logs?: string
+  home?: string
+  repo?: string[]
   data?: string[]
 }
 
@@ -15387,7 +15387,7 @@ export interface NodesInfoNodeInfoSearchRemote {
 export interface NodesInfoNodeInfoSettings {
   cluster: NodesInfoNodeInfoSettingsCluster
   node: NodesInfoNodeInfoSettingsNode
-  path: NodesInfoNodeInfoPath
+  path?: NodesInfoNodeInfoPath
   repositories?: NodesInfoNodeInfoRepositories
   discovery?: NodesInfoNodeInfoDiscover
   action?: NodesInfoNodeInfoAction

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15290,7 +15290,7 @@ export interface NodesInfoNodeInfoClient {
 }
 
 export interface NodesInfoNodeInfoDiscover {
-  seed_hosts: string
+  seed_hosts?: string
 }
 
 export interface NodesInfoNodeInfoHttp {

--- a/specification/_json_spec/update_by_query.json
+++ b/specification/_json_spec/update_by_query.json
@@ -2,7 +2,7 @@
   "update_by_query": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html",
-      "description": "Performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change."
+      "description": "Updates documents that match the specified query. If no query is specified,\n performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change."
     },
     "stability": "stable",
     "visibility": "public",

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -166,6 +166,10 @@ export class IndexSettings
   store?: Storage
 }
 
+/**
+ * @variants container
+ * @non_exhaustive
+ */
 export class SettingsSimilarity {
   bm25?: SettingsSimilarityBm25
   dfi?: SettingsSimilarityDfi

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -325,6 +325,11 @@ export class AttachmentProcessor extends ProcessorBase {
    */
   target_field?: Field
   /**
+   * If true, the binary field will be removed from the document
+   * @server_default false
+   */
+  remove_binary?: boolean
+  /**
    * Field containing the name of the resource to decode.
    * If specified, the processor passes this resource name to the underlying Tika library to enable Resource Name Based Detection.
    */

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -68,7 +68,7 @@ export class NodeInfo {
 export class NodeInfoSettings {
   cluster: NodeInfoSettingsCluster
   node: NodeInfoSettingsNode
-  path: NodeInfoPath
+  path?: NodeInfoPath
   repositories?: NodeInfoRepositories
   discovery?: NodeInfoDiscover
   action?: NodeInfoAction
@@ -155,9 +155,9 @@ export class NodeInfoSettingsNode {
 }
 
 export class NodeInfoPath {
-  logs: string
-  home: string
-  repo: string[]
+  logs?: string
+  home?: string
+  repo?: string[]
   data?: string[]
 }
 

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -132,7 +132,7 @@ export class NodeInfoSettingsCluster {
   name: Name
   routing?: IndexRouting
   election: NodeInfoSettingsClusterElection
-  initial_master_nodes?: string
+  initial_master_nodes?: string[]
   /**
    * @availability stack since=7.16.0
    * @availability serverless

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -26,6 +26,8 @@ import { integer, long } from '@_types/Numeric'
 import { PluginStats } from '@_types/Stats'
 import { NodeRoles } from '@_types/Node'
 import { Duration, DurationValue, EpochTime, UnitMillis } from '@_types/Time'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { AdditionalProperties } from '@spec_utils/behaviors'
 
 export class NodeInfo {
   attributes: Dictionary<string, string>
@@ -169,8 +171,12 @@ export class NodeInfoRepositoriesUrl {
   allowed_urls: string
 }
 
-export class NodeInfoDiscover {
-  seed_hosts?: string
+export class NodeInfoDiscover
+  implements AdditionalProperties<string, UserDefinedValue>
+{
+  seed_hosts?: string[]
+  type?: string
+  seed_providers?: string[]
 }
 
 export class NodeInfoAction {

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -170,7 +170,7 @@ export class NodeInfoRepositoriesUrl {
 }
 
 export class NodeInfoDiscover {
-  seed_hosts: string
+  seed_hosts?: string
 }
 
 export class NodeInfoAction {


### PR DESCRIPTION
Fixes provided in this PR:

- [727](https://github.com/elastic/elasticsearch-java/issues/727) added `remove_binary` to AttachmentProcessor
- [242](https://github.com/elastic/elasticsearch-java/issues/242) made NodeInfoPath and `seed_hosts` optional to make the method `.nodes().info()` work properly, also made `initial_master_nodes` a string array, since the documentation allows for both a single string and an array, also added additional properties for NodeInfoDiscover
- [315](https://github.com/elastic/elasticsearch-java/issues/315) fixed description for update by query
- [299](https://github.com/elastic/elasticsearch-java/issues/299) allowed custom options for IndexSettings Similarity (via custom plugin)
