### PR TITLE
Add optional query param in _field_caps to return only fields with value in index

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -4229,6 +4229,9 @@
           },
           {
             "$ref": "#/components/parameters/field_caps#types"
+          },
+          {
+            "$ref": "#/components/parameters/field_caps#include_empty_fields"
           }
         ],
         "requestBody": {
@@ -4271,6 +4274,9 @@
           },
           {
             "$ref": "#/components/parameters/field_caps#types"
+          },
+          {
+            "$ref": "#/components/parameters/field_caps#include_empty_fields"
           }
         ],
         "requestBody": {
@@ -4318,6 +4324,9 @@
           },
           {
             "$ref": "#/components/parameters/field_caps#types"
+          },
+          {
+            "$ref": "#/components/parameters/field_caps#include_empty_fields"
           }
         ],
         "requestBody": {
@@ -4363,6 +4372,9 @@
           },
           {
             "$ref": "#/components/parameters/field_caps#types"
+          },
+          {
+            "$ref": "#/components/parameters/field_caps#include_empty_fields"
           }
         ],
         "requestBody": {
@@ -21918,6 +21930,16 @@
           "items": {
             "type": "string"
           }
+        },
+        "style": "form"
+      },
+      "field_caps#include_empty_fields": {
+        "in": "query",
+        "name": "include_empty_fields",
+        "description": "If false, empty fields are not included in the response.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
         },
         "style": "form"
       },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -349,6 +349,7 @@ export interface FieldCapsRequest extends RequestBase {
   include_unmapped?: boolean
   filters?: string
   types?: string[]
+  include_empty_fields?: boolean
   body?: {
     fields?: Fields
     index_filter?: QueryDslQueryContainer

--- a/specification/_global/field_caps/FieldCapabilitiesRequest.ts
+++ b/specification/_global/field_caps/FieldCapabilitiesRequest.ts
@@ -78,6 +78,7 @@ export interface Request extends RequestBase {
     /**
      * If false, empty fields are not included in the response.
      * @availability stack since=8.13.0
+     * @availability serverless
      * @server_default true
      */
     include_empty_fields?: boolean

--- a/specification/_global/field_caps/FieldCapabilitiesRequest.ts
+++ b/specification/_global/field_caps/FieldCapabilitiesRequest.ts
@@ -75,6 +75,12 @@ export interface Request extends RequestBase {
      * @availability serverless
      */
     types?: string[]
+    /**
+     * If false, empty fields are not included in the response.
+     * @availability stack since=8.13.0
+     * @server_default true
+     */
+    include_empty_fields?: boolean
   }
   body: {
     /**

--- a/specification/_json_spec/field_caps.json
+++ b/specification/_json_spec/field_caps.json
@@ -59,6 +59,11 @@
       "types": {
         "type": "list",
         "description": "Only return results for fields that have one of the types in the list"
+      },
+      "include_empty_fields": {
+        "type": "boolean",
+        "default": true,
+        "description": "Indicates whether empty fields should be included in the response."
       }
     },
     "body": {


### PR DESCRIPTION
Updates the spec for the request object for all `_field_caps` endpoints.
In `8.13` we are adding a new optional query parameter `include_empty_fields` that defaults to `true`. If `false` empty fields are not included in the response. This change will not alter the `_field_caps` response schema.
https://github.com/elastic/elasticsearch/pull/103651