### PR TITLE
Make Inference APIs public in Serverless

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -7551,6 +7551,247 @@
         }
       }
     },
+    "/_inference/{task_type}/{model_id}": {
+      "get": {
+        "tags": [
+          "inference.get_model"
+        ],
+        "summary": "Get a model in the Inference API",
+        "description": "Get a model in the Inference API",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-inference-api.html"
+        },
+        "operationId": "inference-get-model",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_type",
+            "description": "The model task type",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/inference._types:TaskType"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "model_id",
+            "description": "The unique identifier of the inference model.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "models": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/inference._types:ModelConfigContainer"
+                      }
+                    }
+                  },
+                  "required": [
+                    "models"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "inference.put_model"
+        ],
+        "summary": "Configure a model for use in the Inference API",
+        "description": "Configure a model for use in the Inference API",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-inference-api.html"
+        },
+        "operationId": "inference-put-model",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_type",
+            "description": "The model task type",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/inference._types:TaskType"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "model_id",
+            "description": "The unique identifier of the inference model.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/inference._types:ModelConfig"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/inference._types:ModelConfigContainer"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "inference.inference"
+        ],
+        "summary": "Perform inference on a model",
+        "description": "Perform inference on a model",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/post-inference-api.html"
+        },
+        "operationId": "inference-inference",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_type",
+            "description": "The model task type",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/inference._types:TaskType"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "model_id",
+            "description": "The unique identifier of the inference model.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "input": {
+                    "description": "Text input to the model.\nEither a string or an array of strings.",
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  },
+                  "task_settings": {
+                    "$ref": "#/components/schemas/inference._types:TaskSettings"
+                  }
+                },
+                "required": [
+                  "input"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/inference._types:InferenceResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "inference.delete_model"
+        ],
+        "summary": "Delete model in the Inference API",
+        "description": "Delete model in the Inference API",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-inference-api.html"
+        },
+        "operationId": "inference-delete-model",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_type",
+            "description": "The model task type",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/inference._types:TaskType"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "model_id",
+            "description": "The unique identifier of the inference model.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_types:AcknowledgedResponseBase"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "tags": [
@@ -49148,6 +49389,142 @@
           "index",
           "valid"
         ]
+      },
+      "inference._types:TaskType": {
+        "type": "string",
+        "enum": [
+          "sparse_embedding",
+          "text_embedding"
+        ]
+      },
+      "inference._types:ModelConfigContainer": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/inference._types:ModelConfig"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "model_id": {
+                "description": "The model Id",
+                "type": "string"
+              },
+              "task_type": {
+                "$ref": "#/components/schemas/inference._types:TaskType"
+              }
+            },
+            "required": [
+              "model_id",
+              "task_type"
+            ]
+          }
+        ]
+      },
+      "inference._types:ModelConfig": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "description": "The service type",
+            "type": "string"
+          },
+          "service_settings": {
+            "$ref": "#/components/schemas/inference._types:ServiceSettings"
+          },
+          "task_settings": {
+            "$ref": "#/components/schemas/inference._types:TaskSettings"
+          }
+        },
+        "required": [
+          "service",
+          "service_settings",
+          "task_settings"
+        ]
+      },
+      "inference._types:ServiceSettings": {
+        "type": "object"
+      },
+      "inference._types:TaskSettings": {
+        "type": "object"
+      },
+      "inference._types:InferenceResult": {
+        "description": "InferenceResult is an aggregation of mutually exclusive variants",
+        "type": "object",
+        "properties": {
+          "text_embedding_bytes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/inference._types:TextEmbeddingByteResult"
+            }
+          },
+          "text_embedding": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/inference._types:TextEmbeddingResult"
+            }
+          },
+          "sparse_embedding": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/inference._types:SparseEmbeddingResult"
+            }
+          }
+        },
+        "minProperties": 1,
+        "maxProperties": 1
+      },
+      "inference._types:TextEmbeddingByteResult": {
+        "type": "object",
+        "properties": {
+          "embedding": {
+            "$ref": "#/components/schemas/inference._types:DenseByteVector"
+          }
+        },
+        "required": [
+          "embedding"
+        ]
+      },
+      "inference._types:DenseByteVector": {
+        "description": "Text Embedding results containing bytes are represented as Dense\nVectors of bytes.",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/_types:byte"
+        }
+      },
+      "inference._types:TextEmbeddingResult": {
+        "type": "object",
+        "properties": {
+          "embedding": {
+            "$ref": "#/components/schemas/inference._types:DenseVector"
+          }
+        },
+        "required": [
+          "embedding"
+        ]
+      },
+      "inference._types:DenseVector": {
+        "description": "Text Embedding results are represented as Dense Vectors\nof floats.",
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      },
+      "inference._types:SparseEmbeddingResult": {
+        "type": "object",
+        "properties": {
+          "embedding": {
+            "$ref": "#/components/schemas/inference._types:SparseVector"
+          }
+        },
+        "required": [
+          "embedding"
+        ]
+      },
+      "inference._types:SparseVector": {
+        "description": "Sparse Embedding tokens are represented as a dictionary\nof string to double.",
+        "type": "object",
+        "additionalProperties": {
+          "type": "number"
+        }
       },
       "_types:ElasticsearchVersionInfo": {
         "type": "object",

--- a/specification/inference/delete_model/DeleteModelRequest.ts
+++ b/specification/inference/delete_model/DeleteModelRequest.ts
@@ -25,7 +25,7 @@ import { TaskType } from '@inference/_types/TaskType'
  * Delete an inference service model
  * @rest_spec_name inference.delete_model
  * @availability stack since=8.11.0 stability=experimental visibility=public
- * @availability serverless stability=experimental visibility=private
+ * @availability serverless stability=experimental visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/inference/get_model/GetModelRequest.ts
+++ b/specification/inference/get_model/GetModelRequest.ts
@@ -25,7 +25,7 @@ import { TaskType } from '@inference/_types/TaskType'
  * Get an inference service model
  * @rest_spec_name inference.get_model
  * @availability stack since=8.11.0 stability=experimental visibility=public
- * @availability serverless stability=experimental visibility=private
+ * @availability serverless stability=experimental visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/inference/inference/InferenceRequest.ts
+++ b/specification/inference/inference/InferenceRequest.ts
@@ -26,7 +26,7 @@ import { TaskSettings } from '@inference/_types/Services'
  * Perform inference on the service
  * @rest_spec_name inference.inference
  * @availability stack since=8.11.0 stability=experimental visibility=public
- * @availability serverless stability=experimental visibility=private
+ * @availability serverless stability=experimental visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/inference/put_model/PutModelRequest.ts
+++ b/specification/inference/put_model/PutModelRequest.ts
@@ -26,7 +26,7 @@ import { TaskType } from '@inference/_types/TaskType'
  * Create an inference service model
  * @rest_spec_name inference.put_model
  * @availability stack since=8.11.0 stability=experimental visibility=public
- * @availability serverless stability=experimental visibility=private
+ * @availability serverless stability=experimental visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {


### PR DESCRIPTION
The _inference APIs were made public in https://github.com/elastic/elasticsearch/pull/105190 and are now available in serverless. This updates the serverless visibility to `public`. 

