### PR TITLE
Remove `IcuTokenizer` from `TokenFilterDefinition` variants union

### DIFF
--- a/specification/_types/analysis/token_filters.ts
+++ b/specification/_types/analysis/token_filters.ts
@@ -392,7 +392,6 @@ export type TokenFilterDefinition =
   | KuromojiStemmerTokenFilter
   | KuromojiReadingFormTokenFilter
   | KuromojiPartOfSpeechTokenFilter
-  | IcuTokenizer
   | IcuCollationTokenFilter
   | IcuFoldingTokenFilter
   | IcuNormalizationTokenFilter


### PR DESCRIPTION
`IcuTokenizer` was accidentally added to the `TokenFilterDefinition` variants union a while ago. This PR removes the variant.

This as well removes a special case where `IcuTokenizer` is a variant of both, `Tokenizer` and `TokenFilterDefinition` and might allow for simplification of the code generators. cc @elastic/clients-team 