### PR TITLE
Java client issues fixes backport

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10571,6 +10571,7 @@ export interface IngestAttachmentProcessor extends IngestProcessorBase {
   indexed_chars_field?: Field
   properties?: string[]
   target_field?: Field
+  remove_binary?: boolean
   resource_name?: string
 }
 
@@ -13777,9 +13778,13 @@ export interface NodesInfoNodeInfoClient {
   type: string
 }
 
-export interface NodesInfoNodeInfoDiscover {
-  seed_hosts?: string
+export interface NodesInfoNodeInfoDiscoverKeys {
+  seed_hosts?: string[]
+  type?: string
+  seed_providers?: string[]
 }
+export type NodesInfoNodeInfoDiscover = NodesInfoNodeInfoDiscoverKeys
+  & { [property: string]: any }
 
 export interface NodesInfoNodeInfoHttp {
   bound_address: string[]
@@ -13845,9 +13850,9 @@ export interface NodesInfoNodeInfoOSCPU {
 }
 
 export interface NodesInfoNodeInfoPath {
-  logs: string
-  home: string
-  repo: string[]
+  logs?: string
+  home?: string
+  repo?: string[]
   data?: string[]
 }
 
@@ -13875,7 +13880,7 @@ export interface NodesInfoNodeInfoSearchRemote {
 export interface NodesInfoNodeInfoSettings {
   cluster: NodesInfoNodeInfoSettingsCluster
   node: NodesInfoNodeInfoSettingsNode
-  path: NodesInfoNodeInfoPath
+  path?: NodesInfoNodeInfoPath
   repositories?: NodesInfoNodeInfoRepositories
   discovery?: NodesInfoNodeInfoDiscover
   action?: NodesInfoNodeInfoAction
@@ -13894,7 +13899,7 @@ export interface NodesInfoNodeInfoSettingsCluster {
   name: Name
   routing?: IndicesIndexRouting
   election: NodesInfoNodeInfoSettingsClusterElection
-  initial_master_nodes?: string
+  initial_master_nodes?: string[]
   deprecation_indexing?: NodesInfoDeprecationIndexing
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13778,7 +13778,7 @@ export interface NodesInfoNodeInfoClient {
 }
 
 export interface NodesInfoNodeInfoDiscover {
-  seed_hosts: string
+  seed_hosts?: string
 }
 
 export interface NodesInfoNodeInfoHttp {

--- a/specification/_json_spec/update_by_query.json
+++ b/specification/_json_spec/update_by_query.json
@@ -2,7 +2,7 @@
   "update_by_query": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html",
-      "description": "Performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change."
+      "description": "Updates documents that match the specified query. If no query is specified,\n performs an update on every document in the index without changing the source,\nfor example to pick up a mapping change."
     },
     "stability": "stable",
     "visibility": "public",

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -99,6 +99,7 @@ export class AttachmentProcessor extends ProcessorBase {
   indexed_chars_field?: Field
   properties?: string[]
   target_field?: Field
+  remove_binary?: boolean
   resource_name?: string
 }
 

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -166,7 +166,7 @@ export class NodeInfoRepositoriesUrl {
 }
 
 export class NodeInfoDiscover {
-  seed_hosts: string
+  seed_hosts?: string
 }
 
 export class NodeInfoAction {

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -25,6 +25,9 @@ import { Host, Ip, TransportAddress } from '@_types/Networking'
 import { integer, long } from '@_types/Numeric'
 import { PluginStats } from '@_types/Stats'
 import { NodeRoles } from '@_types/Node'
+import { Duration, DurationValue, EpochTime, UnitMillis } from '@_types/Time'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { AdditionalProperties } from '@spec_utils/behaviors'
 
 export class NodeInfo {
   attributes: Dictionary<string, string>
@@ -165,8 +168,12 @@ export class NodeInfoRepositoriesUrl {
   allowed_urls: string
 }
 
-export class NodeInfoDiscover {
-  seed_hosts?: string
+export class NodeInfoDiscover
+  implements AdditionalProperties<string, UserDefinedValue>
+{
+  seed_hosts?: string[]
+  type?: string
+  seed_providers?: string[]
 }
 
 export class NodeInfoAction {

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -131,7 +131,7 @@ export class NodeInfoSettingsCluster {
   name: Name
   routing?: IndexRouting
   election: NodeInfoSettingsClusterElection
-  initial_master_nodes?: string
+  initial_master_nodes?: string[]
   /** @since 7.16.0 */
   deprecation_indexing?: DeprecationIndexing
 }

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -67,7 +67,7 @@ export class NodeInfo {
 export class NodeInfoSettings {
   cluster: NodeInfoSettingsCluster
   node: NodeInfoSettingsNode
-  path: NodeInfoPath
+  path?: NodeInfoPath
   repositories?: NodeInfoRepositories
   discovery?: NodeInfoDiscover
   action?: NodeInfoAction
@@ -151,9 +151,9 @@ export class NodeInfoSettingsNode {
 }
 
 export class NodeInfoPath {
-  logs: string
-  home: string
-  repo: string[]
+  logs?: string
+  home?: string
+  repo?: string[]
   data?: string[]
 }
 


### PR DESCRIPTION
Fixes backported in this PR:

[727](https://github.com/elastic/elasticsearch-java/issues/727) added remove_binary to AttachmentProcessor
[242](https://github.com/elastic/elasticsearch-java/issues/242) made NodeInfoPath and seed_hosts optional to make the method .nodes().info() work properly, also made initial_master_nodes a string array, since the documentation allows for both a single string and an array, also added additional properties for NodeInfoDiscover
[315](https://github.com/elastic/elasticsearch-java/issues/315) fixed description for update by query
