### PR TITLE
Add inner_hits field to KnnQuery within search

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -39380,6 +39380,9 @@
           "similarity": {
             "description": "The minimum similarity for a vector to be considered a match",
             "type": "number"
+          },
+          "inner_hits": {
+            "$ref": "#/components/schemas/_global.search._types:InnerHits"
           }
         },
         "required": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2346,6 +2346,7 @@ export interface KnnQuery {
   boost?: float
   filter?: QueryDslQueryContainer | QueryDslQueryContainer[]
   similarity?: float
+  inner_hits?: SearchInnerHits
 }
 
 export interface LatLonGeoLocation {
@@ -2471,7 +2472,7 @@ export interface QueryCacheStats {
   memory_size?: ByteSize
   memory_size_in_bytes: long
   miss_count: integer
-  total_count: long
+  total_count: integer
 }
 
 export type QueryVector = float[]

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -219,6 +219,7 @@ json-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/
 k-precision,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#k-precision
 k-recall,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#k-recall
 kv-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/kv-processor.html
+knn-inner-hits,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/knn-search.html#nested-knn-search-inner-hits
 logstash-api-delete-pipeline,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/logstash-api-delete-pipeline.html
 logstash-api-get-pipeline,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/logstash-api-get-pipeline.html
 logstash-api-put-pipeline,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/logstash-api-put-pipeline.html

--- a/specification/_types/Knn.ts
+++ b/specification/_types/Knn.ts
@@ -20,6 +20,7 @@
 import { Field } from '@_types/common'
 import { long, float } from '@_types/Numeric'
 import { QueryContainer } from './query_dsl/abstractions'
+import { InnerHits } from '@global/search/_types/hits'
 
 export type QueryVector = float[]
 
@@ -40,6 +41,11 @@ export interface KnnQuery {
   filter?: QueryContainer | QueryContainer[]
   /** The minimum similarity for a vector to be considered a match */
   similarity?: float
+  /**
+   * If defined, each search hit will contain inner hits.
+   * @doc_id knn-inner-hits
+   */
+  inner_hits?: InnerHits
 }
 
 /** @variants container */


### PR DESCRIPTION
`KnnQuery` reuses the same `InnerHits` as `NestedQuery`. [source](https://github.com/elastic/elasticsearch/blob/b5828fbb671cae81a9f9818fe3370a00628a1a62/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java#L119)

Fixes #2406