### PR TITLE
Add support for subobjects property

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -45364,6 +45364,9 @@
           "enabled": {
             "type": "boolean"
           },
+          "subobjects": {
+            "type": "boolean"
+          },
           "_data_stream_timestamp": {
             "$ref": "#/components/schemas/_types.mapping:DataStreamTimestamp"
           }
@@ -46526,6 +46529,9 @@
             "type": "object",
             "properties": {
               "enabled": {
+                "type": "boolean"
+              },
+              "subobjects": {
                 "type": "boolean"
               },
               "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5164,6 +5164,7 @@ export interface MappingNumberPropertyBase extends MappingDocValuesPropertyBase 
 
 export interface MappingObjectProperty extends MappingCorePropertyBase {
   enabled?: boolean
+  subobjects?: boolean
   type?: 'object'
 }
 
@@ -5338,6 +5339,7 @@ export interface MappingTypeMapping {
   _source?: MappingSourceField
   runtime?: Record<string, MappingRuntimeField>
   enabled?: boolean
+  subobjects?: boolean
   _data_stream_timestamp?: MappingDataStreamTimestamp
 }
 

--- a/specification/_types/mapping/TypeMapping.ts
+++ b/specification/_types/mapping/TypeMapping.ts
@@ -48,6 +48,7 @@ export class TypeMapping {
   _source?: SourceField
   runtime?: Dictionary<string, RuntimeField>
   enabled?: boolean
+  subobjects?: boolean
   /**
    * @availability stack since=7.16.0
    * @availability serverless

--- a/specification/_types/mapping/complex.ts
+++ b/specification/_types/mapping/complex.ts
@@ -45,6 +45,7 @@ export class NestedProperty extends CorePropertyBase {
 
 export class ObjectProperty extends CorePropertyBase {
   enabled?: boolean
+  subobjects?: boolean
   type?: 'object'
 }
 


### PR DESCRIPTION
Closes #1714 

Per https://www.elastic.co/guide/en/elasticsearch/reference/current/subobjects.html, `subobjects` is allowed at the top level and in object properties.
