### PR TITLE
Add prefix strings to PUT model request

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -10027,6 +10027,9 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "prefix_strings": {
+                    "$ref": "#/components/schemas/ml._types:TrainedModelPrefixStrings"
                   }
                 }
               }
@@ -54358,11 +54361,7 @@
             "description": "String prepended to input at search",
             "type": "string"
           }
-        },
-        "required": [
-          "ingest",
-          "search"
-        ]
+        }
       },
       "ml._types:TrainedModelStats": {
         "type": "object",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13391,8 +13391,8 @@ export interface MlTrainedModelLocationIndex {
 }
 
 export interface MlTrainedModelPrefixStrings {
-  ingest: string
-  search: string
+  ingest?: string
+  search?: string
 }
 
 export interface MlTrainedModelSizeStats {
@@ -14415,6 +14415,7 @@ export interface MlPutTrainedModelRequest extends RequestBase {
     model_size_bytes?: long
     platform_architecture?: string
     tags?: string[]
+    prefix_strings?: MlTrainedModelPrefixStrings
   }
 }
 

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -429,9 +429,9 @@ export class TrainedModelPrefixStrings {
   /**
    * String prepended to input at ingest
    */
-  ingest: string
+  ingest?: string
   /**
    * String prepended to input at search
    */
-  search: string
+  search?: string
 }

--- a/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
@@ -22,6 +22,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { Definition, Input } from './types'
+import { TrainedModelPrefixStrings } from '../_types/TrainedModel'
 import { TrainedModelType } from '../_types/TrainedModel'
 import { InferenceConfigCreateContainer } from '@ml/_types/inference'
 
@@ -102,5 +103,11 @@ export interface Request extends RequestBase {
      * An array of tags to organize the model.
      */
     tags?: string[]
+    /**
+     * Optional prefix strings applied at inference
+     * @availability stack since=8.12.0
+     * @availability serverless since=8.12.0
+     */
+    prefix_strings?: TrainedModelPrefixStrings
   }
 }

--- a/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
@@ -106,7 +106,7 @@ export interface Request extends RequestBase {
     /**
      * Optional prefix strings applied at inference
      * @availability stack since=8.12.0
-     * @availability serverless since=8.12.0
+     * @availability serverless
      */
     prefix_strings?: TrainedModelPrefixStrings
   }


### PR DESCRIPTION
The `prefix_string` option was added to the model configuration in #2363 but the PUT request does not use the same config and needs to be added explicitly. 

The model config as defined in `TrainedModels.ts` cannot be used in the PUT request because it contains many fields that are automatically generated by the server and those fields should not be optional in the config but would have to be optional if used in the PUT request.


Closes #2448