### PR TITLE
Add summaries for machine learning APIs

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -16705,8 +16705,8 @@
         "tags": [
           "ml.close_job"
         ],
-        "summary": "Close anomaly detection jobs A job can be opened and closed multiple times throughout its lifecycle",
-        "description": "A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results. When you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data. If you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request. When a datafeed that has a specified end date stops, it automatically closes its associated job.",
+        "summary": "Close anomaly detection jobs",
+        "description": "A job can be opened and closed multiple times throughout its lifecycle. A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results. When you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data. If you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request. When a datafeed that has a specified end date stops, it automatically closes its associated job.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html"
         },
@@ -18044,7 +18044,7 @@
         "tags": [
           "ml.put_job"
         ],
-        "summary": "Instantiates an anomaly detection job",
+        "summary": "Create an anomaly detection job",
         "description": "If you include a `datafeed_config`, you must have read index privileges on the source index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html"
@@ -18229,7 +18229,7 @@
         "tags": [
           "ml.delete_job"
         ],
-        "summary": "Deletes an anomaly detection job.",
+        "summary": "Delete an anomaly detection job",
         "description": "All job configuration, model state and results are deleted. It is not currently possible to delete multiple jobs using wildcards or a comma separated list. If you delete a job that has a datafeed, the request first tries to delete the datafeed. This behavior is equivalent to calling the delete datafeed API with the same timeout and force parameters as the delete job request.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html"
@@ -20630,7 +20630,7 @@
         "tags": [
           "ml.open_job"
         ],
-        "summary": "Opens one or more anomaly detection jobs",
+        "summary": "Open anomaly detection jobs",
         "description": "An anomaly detection job must be opened in order for it to be ready to receive and analyze data. It can be opened and closed multiple times throughout its lifecycle. When you open a new job, it starts with an empty model. When you open an existing job, the most recent model state is automatically loaded. The job is ready to resume its analysis from where it left off, once new data is received.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -10079,8 +10079,8 @@
         "tags": [
           "ml.close_job"
         ],
-        "summary": "Close anomaly detection jobs A job can be opened and closed multiple times throughout its lifecycle",
-        "description": "A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results. When you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data. If you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request. When a datafeed that has a specified end date stops, it automatically closes its associated job.",
+        "summary": "Close anomaly detection jobs",
+        "description": "A job can be opened and closed multiple times throughout its lifecycle. A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results. When you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data. If you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request. When a datafeed that has a specified end date stops, it automatically closes its associated job.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html"
         },
@@ -11197,7 +11197,7 @@
         "tags": [
           "ml.put_job"
         ],
-        "summary": "Instantiates an anomaly detection job",
+        "summary": "Create an anomaly detection job",
         "description": "If you include a `datafeed_config`, you must have read index privileges on the source index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html"
@@ -11382,7 +11382,7 @@
         "tags": [
           "ml.delete_job"
         ],
-        "summary": "Deletes an anomaly detection job.",
+        "summary": "Delete an anomaly detection job",
         "description": "All job configuration, model state and results are deleted. It is not currently possible to delete multiple jobs using wildcards or a comma separated list. If you delete a job that has a datafeed, the request first tries to delete the datafeed. This behavior is equivalent to calling the delete datafeed API with the same timeout and force parameters as the delete job request.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html"
@@ -12747,7 +12747,7 @@
         "tags": [
           "ml.open_job"
         ],
-        "summary": "Opens one or more anomaly detection jobs",
+        "summary": "Open anomaly detection jobs",
         "description": "An anomaly detection job must be opened in order for it to be ready to receive and analyze data. It can be opened and closed multiple times throughout its lifecycle. When you open a new job, it starts with an empty model. When you open an existing job, the most recent model state is automatically loaded. The job is ready to resume its analysis from where it left off, once new data is received.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html"

--- a/specification/ml/close_job/MlCloseJobRequest.ts
+++ b/specification/ml/close_job/MlCloseJobRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Close anomaly detection jobs
+ * Close anomaly detection jobs.
  * A job can be opened and closed multiple times throughout its lifecycle. A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results.
  * When you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data.
  * If you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request.

--- a/specification/ml/delete_job/MlDeleteJobRequest.ts
+++ b/specification/ml/delete_job/MlDeleteJobRequest.ts
@@ -21,8 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes an anomaly detection job.
- *
+ * Delete an anomaly detection job.
  * All job configuration, model state and results are deleted.
  * It is not currently possible to delete multiple jobs using wildcards or a
  * comma separated list. If you delete a job that has a datafeed, the request

--- a/specification/ml/open_job/MlOpenJobRequest.ts
+++ b/specification/ml/open_job/MlOpenJobRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Opens one or more anomaly detection jobs.
+ * Open anomaly detection jobs.
  * An anomaly detection job must be opened in order for it to be ready to
  * receive and analyze data. It can be opened and closed multiple times
  * throughout its lifecycle.

--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -28,7 +28,8 @@ import { Duration } from '@_types/Time'
 import { DatafeedConfig } from '@ml/_types/Datafeed'
 
 /**
- * Instantiates an anomaly detection job. If you include a `datafeed_config`, you must have read index privileges on the source index.
+ * Create an anomaly detection job.
+ * If you include a `datafeed_config`, you must have read index privileges on the source index.
  * @rest_spec_name ml.put_job
  * @availability stack since=5.4.0 stability=stable
  * @availability serverless stability=stable visibility=public


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR fixes the operation summaries for a handful of machine learning anomaly detection APIs (ending period is necessary per https://github.com/elastic/elasticsearch-specification/blob/main/docs/doc-comments-guide.md), then runs the `make generate` and `make transform-to-openapi` commands to refresh the output.