### PR TITLE
Rewrite similarity definition

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -41879,7 +41879,11 @@
             "$ref": "#/components/schemas/indices._types:Queries"
           },
           "similarity": {
-            "$ref": "#/components/schemas/indices._types:SettingsSimilarity"
+            "description": "Configure custom similarity settings to customize how search results are scored.",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/indices._types:SettingsSimilarity"
+            }
           },
           "mapping": {
             "$ref": "#/components/schemas/indices._types:MappingLimitSettings"
@@ -44923,36 +44927,45 @@
         ]
       },
       "indices._types:SettingsSimilarity": {
-        "type": "object",
-        "properties": {
-          "bm25": {
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
             "$ref": "#/components/schemas/indices._types:SettingsSimilarityBm25"
           },
-          "dfi": {
+          {
+            "$ref": "#/components/schemas/indices._types:SettingsSimilarityBoolean"
+          },
+          {
             "$ref": "#/components/schemas/indices._types:SettingsSimilarityDfi"
           },
-          "dfr": {
+          {
             "$ref": "#/components/schemas/indices._types:SettingsSimilarityDfr"
           },
-          "ib": {
+          {
             "$ref": "#/components/schemas/indices._types:SettingsSimilarityIb"
           },
-          "lmd": {
+          {
             "$ref": "#/components/schemas/indices._types:SettingsSimilarityLmd"
           },
-          "lmj": {
+          {
             "$ref": "#/components/schemas/indices._types:SettingsSimilarityLmj"
           },
-          "scripted_tfidf": {
-            "$ref": "#/components/schemas/indices._types:SettingsSimilarityScriptedTfidf"
+          {
+            "$ref": "#/components/schemas/indices._types:SettingsSimilarityScripted"
           }
-        },
-        "minProperties": 1,
-        "maxProperties": 1
+        ]
       },
       "indices._types:SettingsSimilarityBm25": {
         "type": "object",
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "BM25"
+            ]
+          },
           "b": {
             "type": "number"
           },
@@ -44961,37 +44974,42 @@
           },
           "k1": {
             "type": "number"
-          },
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "indices._types:SettingsSimilarityBoolean": {
+        "type": "object",
+        "properties": {
           "type": {
             "type": "string",
             "enum": [
-              "BM25"
+              "boolean"
             ]
           }
         },
         "required": [
-          "b",
-          "discount_overlaps",
-          "k1",
           "type"
         ]
       },
       "indices._types:SettingsSimilarityDfi": {
         "type": "object",
         "properties": {
-          "independence_measure": {
-            "$ref": "#/components/schemas/_types:DFIIndependenceMeasure"
-          },
           "type": {
             "type": "string",
             "enum": [
               "DFI"
             ]
+          },
+          "independence_measure": {
+            "$ref": "#/components/schemas/_types:DFIIndependenceMeasure"
           }
         },
         "required": [
-          "independence_measure",
-          "type"
+          "type",
+          "independence_measure"
         ]
       },
       "_types:DFIIndependenceMeasure": {
@@ -45005,6 +45023,12 @@
       "indices._types:SettingsSimilarityDfr": {
         "type": "object",
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "DFR"
+            ]
+          },
           "after_effect": {
             "$ref": "#/components/schemas/_types:DFRAfterEffect"
           },
@@ -45013,19 +45037,13 @@
           },
           "normalization": {
             "$ref": "#/components/schemas/_types:Normalization"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "DFR"
-            ]
           }
         },
         "required": [
+          "type",
           "after_effect",
           "basic_model",
-          "normalization",
-          "type"
+          "normalization"
         ]
       },
       "_types:DFRAfterEffect": {
@@ -45061,6 +45079,12 @@
       "indices._types:SettingsSimilarityIb": {
         "type": "object",
         "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "IB"
+            ]
+          },
           "distribution": {
             "$ref": "#/components/schemas/_types:IBDistribution"
           },
@@ -45069,19 +45093,13 @@
           },
           "normalization": {
             "$ref": "#/components/schemas/_types:Normalization"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "IB"
-            ]
           }
         },
         "required": [
+          "type",
           "distribution",
           "lambda",
-          "normalization",
-          "type"
+          "normalization"
         ]
       },
       "_types:IBDistribution": {
@@ -45101,55 +45119,56 @@
       "indices._types:SettingsSimilarityLmd": {
         "type": "object",
         "properties": {
-          "mu": {
-            "type": "number"
-          },
           "type": {
             "type": "string",
             "enum": [
               "LMDirichlet"
             ]
+          },
+          "mu": {
+            "type": "number"
           }
         },
         "required": [
-          "mu",
           "type"
         ]
       },
       "indices._types:SettingsSimilarityLmj": {
         "type": "object",
         "properties": {
-          "lambda": {
-            "type": "number"
-          },
           "type": {
             "type": "string",
             "enum": [
               "LMJelinekMercer"
             ]
+          },
+          "lambda": {
+            "type": "number"
           }
         },
         "required": [
-          "lambda",
           "type"
         ]
       },
-      "indices._types:SettingsSimilarityScriptedTfidf": {
+      "indices._types:SettingsSimilarityScripted": {
         "type": "object",
         "properties": {
-          "script": {
-            "$ref": "#/components/schemas/_types:Script"
-          },
           "type": {
             "type": "string",
             "enum": [
               "scripted"
             ]
+          },
+          "script": {
+            "$ref": "#/components/schemas/_types:Script"
+          },
+          "weight_script": {
+            "$ref": "#/components/schemas/_types:Script"
           }
         },
         "required": [
-          "script",
-          "type"
+          "type",
+          "script"
         ]
       },
       "indices._types:MappingLimitSettings": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9883,7 +9883,7 @@ export interface IndicesIndexSettingsKeys {
   settings?: IndicesIndexSettings
   time_series?: IndicesIndexSettingsTimeSeries
   queries?: IndicesQueries
-  similarity?: IndicesSettingsSimilarity
+  similarity?: Record<string, IndicesSettingsSimilarity>
   mapping?: IndicesMappingLimitSettings
   'indexing.slowlog'?: IndicesIndexingSlowlogSettings
   indexing_pressure?: IndicesIndexingPressure
@@ -10061,55 +10061,52 @@ export interface IndicesSettingsSearch {
   slowlog?: IndicesSlowlogSettings
 }
 
-export interface IndicesSettingsSimilarity {
-  bm25?: IndicesSettingsSimilarityBm25
-  dfi?: IndicesSettingsSimilarityDfi
-  dfr?: IndicesSettingsSimilarityDfr
-  ib?: IndicesSettingsSimilarityIb
-  lmd?: IndicesSettingsSimilarityLmd
-  lmj?: IndicesSettingsSimilarityLmj
-  scripted_tfidf?: IndicesSettingsSimilarityScriptedTfidf
-}
+export type IndicesSettingsSimilarity = IndicesSettingsSimilarityBm25 | IndicesSettingsSimilarityBoolean | IndicesSettingsSimilarityDfi | IndicesSettingsSimilarityDfr | IndicesSettingsSimilarityIb | IndicesSettingsSimilarityLmd | IndicesSettingsSimilarityLmj | IndicesSettingsSimilarityScripted
 
 export interface IndicesSettingsSimilarityBm25 {
-  b: double
-  discount_overlaps: boolean
-  k1: double
   type: 'BM25'
+  b?: double
+  discount_overlaps?: boolean
+  k1?: double
+}
+
+export interface IndicesSettingsSimilarityBoolean {
+  type: 'boolean'
 }
 
 export interface IndicesSettingsSimilarityDfi {
-  independence_measure: DFIIndependenceMeasure
   type: 'DFI'
+  independence_measure: DFIIndependenceMeasure
 }
 
 export interface IndicesSettingsSimilarityDfr {
+  type: 'DFR'
   after_effect: DFRAfterEffect
   basic_model: DFRBasicModel
   normalization: Normalization
-  type: 'DFR'
 }
 
 export interface IndicesSettingsSimilarityIb {
+  type: 'IB'
   distribution: IBDistribution
   lambda: IBLambda
   normalization: Normalization
-  type: 'IB'
 }
 
 export interface IndicesSettingsSimilarityLmd {
-  mu: integer
   type: 'LMDirichlet'
+  mu?: double
 }
 
 export interface IndicesSettingsSimilarityLmj {
-  lambda: double
   type: 'LMJelinekMercer'
+  lambda?: double
 }
 
-export interface IndicesSettingsSimilarityScriptedTfidf {
-  script: Script
+export interface IndicesSettingsSimilarityScripted {
   type: 'scripted'
+  script: Script
+  weight_script?: Script
 }
 
 export interface IndicesSlowlogSettings {

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -30,7 +30,7 @@ import {
   Uuid,
   VersionString
 } from '@_types/common'
-import { double, integer, long } from '@_types/Numeric'
+import { double, float, integer, long } from '@_types/Numeric'
 import { DateTime, Duration, EpochTime, UnitMillis } from '@_types/Time'
 import { Tokenizer } from '@_types/analysis/tokenizers'
 import { IndexSegmentSort } from './IndexSegmentSort'
@@ -150,7 +150,7 @@ export class IndexSettings
   /**
    * Configure custom similarity settings to customize how search results are scored.
    */
-  similarity?: SettingsSimilarity
+  similarity?: Dictionary<string, SettingsSimilarity>
   /**
    * Enable or disable dynamic mapping for an index.
    */
@@ -167,58 +167,62 @@ export class IndexSettings
 }
 
 /**
- * @variants container
- * @non_exhaustive
+ * @variants internal tag='type'
  */
-export class SettingsSimilarity {
-  bm25?: SettingsSimilarityBm25
-  dfi?: SettingsSimilarityDfi
-  dfr?: SettingsSimilarityDfr
-  ib?: SettingsSimilarityIb
-  lmd?: SettingsSimilarityLmd
-  lmj?: SettingsSimilarityLmj
-  scripted_tfidf?: SettingsSimilarityScriptedTfidf
+export type SettingsSimilarity =
+  | SettingsSimilarityBm25
+  | SettingsSimilarityBoolean
+  | SettingsSimilarityDfi
+  | SettingsSimilarityDfr
+  | SettingsSimilarityIb
+  | SettingsSimilarityLmd
+  | SettingsSimilarityLmj
+  | SettingsSimilarityScripted
+
+export class SettingsSimilarityBoolean {
+  type: 'boolean'
 }
 
 export class SettingsSimilarityBm25 {
-  b: double
-  discount_overlaps: boolean
-  k1: double
   type: 'BM25'
+  b?: double
+  discount_overlaps?: boolean
+  k1?: double
 }
 
 export class SettingsSimilarityDfi {
-  independence_measure: DFIIndependenceMeasure
   type: 'DFI'
+  independence_measure: DFIIndependenceMeasure
 }
 
 export class SettingsSimilarityDfr {
+  type: 'DFR'
   after_effect: DFRAfterEffect
   basic_model: DFRBasicModel
   normalization: Normalization
-  type: 'DFR'
 }
 
 export class SettingsSimilarityIb {
+  type: 'IB'
   distribution: IBDistribution
   lambda: IBLambda
   normalization: Normalization
-  type: 'IB'
 }
 
 export class SettingsSimilarityLmd {
-  mu: integer
   type: 'LMDirichlet'
+  mu?: double
 }
 
 export class SettingsSimilarityLmj {
-  lambda: double
   type: 'LMJelinekMercer'
+  lambda?: double
 }
 
-export class SettingsSimilarityScriptedTfidf {
-  script: Script
+export class SettingsSimilarityScripted {
   type: 'scripted'
+  script: Script
+  weight_script?: Script
 }
 
 export class SettingsHighlight {

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -30,7 +30,7 @@ import {
   Uuid,
   VersionString
 } from '@_types/common'
-import { double, float, integer, long } from '@_types/Numeric'
+import { double, integer, long } from '@_types/Numeric'
 import { DateTime, Duration, EpochTime, UnitMillis } from '@_types/Time'
 import { Tokenizer } from '@_types/analysis/tokenizers'
 import { IndexSegmentSort } from './IndexSegmentSort'


### PR DESCRIPTION
Rewrites the index similarity definition: this is a dictionary and not a container, as users can define several similarities. The name is also user-defined, indicating a dictionary.

Also adds the boolean similarity that was missing and makes some of the configuration properties optional after inspection of [the ES code base](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java).