### PR TITLE
Support for aggregations in Security's Query API Key Information API

### DIFF
--- a/specification/security/query_api_keys/APIKeyAggregationContainer.ts
+++ b/specification/security/query_api_keys/APIKeyAggregationContainer.ts
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Dictionary } from '@spec_utils/Dictionary'
+import { Metadata } from '@_types/common'
+import { QueryContainer } from '@_types/query_dsl/abstractions'
+import {
+  CompositeAggregation,
+  DateRangeAggregation,
+  FiltersAggregation,
+  MissingAggregation,
+  RangeAggregation,
+  TermsAggregation,
+} from '@_types/aggregations/bucket'
+import {
+  CardinalityAggregation,
+  ValueCountAggregation,
+} from '@_types/aggregations/metric'
+
+/**
+ * @variants container
+ * @non_exhaustive
+ */
+export class APIKeyAggregationContainer {
+  /**
+   * Sub-aggregations for this aggregation.
+   * Only applies to bucket aggregations.
+   * @variant container_property
+   * @aliases aggs
+   */
+  aggregations?: Dictionary<string, APIKeyAggregationContainer>
+  /**
+   * @variant container_property
+   */
+  meta?: Metadata
+  /**
+   * A single-value metrics aggregation that calculates an approximate count of distinct values.
+   * @doc_id search-aggregations-metrics-cardinality-aggregation
+   */
+  cardinality?: CardinalityAggregation
+  /**
+   * A multi-bucket aggregation that creates composite buckets from different sources.
+   * Unlike the other multi-bucket aggregations, you can use the `composite` aggregation to paginate *all* buckets from a multi-level aggregation efficiently.
+   */
+  composite?: CompositeAggregation
+  /**
+   * A multi-bucket value source based aggregation that enables the user to define a set of date ranges - each representing a bucket.
+   * @doc_id search-aggregations-bucket-daterange-aggregation
+   */
+  date_range?: DateRangeAggregation
+  /**
+   * A single bucket aggregation that narrows the set of documents to those that match a query.
+   * @doc_id search-aggregations-bucket-filter-aggregation
+   */
+  filter?: QueryContainer
+  /**
+   * A multi-bucket aggregation where each bucket contains the documents that match a query.
+   * @doc_id search-aggregations-bucket-filters-aggregation
+   */
+  filters?: FiltersAggregation
+  missing?: MissingAggregation
+  /**
+   * A multi-bucket value source based aggregation that enables the user to define a set of ranges - each representing a bucket.
+   * @doc_id search-aggregations-bucket-range-aggregation
+   */
+  range?: RangeAggregation
+  /**
+   * A multi-bucket value source based aggregation where buckets are dynamically built - one per unique value.
+   * @doc_id search-aggregations-bucket-terms-aggregation
+   */
+  terms?: TermsAggregation
+  /**
+   * A single-value metrics aggregation that counts the number of values that are extracted from the aggregated documents.
+   * @doc_id search-aggregations-metrics-valuecount-aggregation
+   */
+  value_count?: ValueCountAggregation
+}

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -51,7 +51,7 @@ export interface Request extends RequestBase {
      * Additionally, aggregations only run over the same subset of fields that query works with.
      * @aliases aggs */
     aggregations?: Dictionary<string, APIKeyAggregationContainer>
-		/**
+    /**
      * A query to filter which API keys to return.
      * If the query parameter is missing, it is equivalent to a `match_all` query.
      * The query supports a subset of query types, including `match_all`, `bool`, `term`, `terms`, `match`,

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -18,10 +18,11 @@
  */
 
 import { Dictionary } from '@spec_utils/Dictionary'
-import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
+import { APIKeyAggregationContainer } from 'APIKeyAggregationContainer'
 import { RequestBase } from '@_types/Base'
 import { integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
+import { Sort, SortResults } from '@_types/sort'
 import { Sort, SortResults } from '@_types/sort'
 
 /**
@@ -50,7 +51,7 @@ export interface Request extends RequestBase {
      * `cardinality`, `value_count`, `composite`, `filter`, and `filters`.
      * Additionally, aggregations only run over the same subset of fields that query works with.
      * @aliases aggs */
-    aggregations?: Dictionary<string, AggregationContainer>
+    aggregations?: Dictionary<string, APIKeyAggregationContainer>
 		/**
      * A query to filter which API keys to return.
      * If the query parameter is missing, it is equivalent to a `match_all` query.

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+import { Dictionary } from '@spec_utils/Dictionary'
+import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import { RequestBase } from '@_types/Base'
 import { integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
@@ -42,9 +44,20 @@ export interface Request extends RequestBase {
   }
   body: {
     /**
+     * Any aggregations to run over the corpus of returned API keys.
+     * Aggregations and queries work together. Aggregations are computed only on the API keys that match the query.
+     * This supports only a subset of aggregation types, namely: `terms`, `range`, `date_range`, `missing`,
+     * `cardinality`, `value_count`, `composite`, `filter`, and `filters`.
+     * Additionally, aggregations only run over the same subset of fields that query works with.
+     * @aliases aggs */
+    aggregations?: Dictionary<string, AggregationContainer>
+		/**
      * A query to filter which API keys to return.
-     * The query supports a subset of query types, including `match_all`, `bool`, `term`, `terms`, `ids`, `prefix`, `wildcard`, and `range`.
-     * You can query all public information associated with an API key.
+     * If the query parameter is missing, it is equivalent to a `match_all` query.
+     * The query supports a subset of query types, including `match_all`, `bool`, `term`, `terms`, `match`,
+     * `ids`, `prefix`, `wildcard`, `exists`, `range`, and `simple_query_string`.
+     * You can query the following public information associated with an API key: `id`, `type`, `name`,
+     * `creation`, `expiration`, `invalidated`, `invalidation`, `username`, `realm`, and `metadata`.
      */
     query?: QueryContainer
     /**

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -18,11 +18,10 @@
  */
 
 import { Dictionary } from '@spec_utils/Dictionary'
-import { APIKeyAggregationContainer } from 'APIKeyAggregationContainer'
+import { APIKeyAggregationContainer } from './types'
 import { RequestBase } from '@_types/Base'
 import { integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
-import { Sort, SortResults } from '@_types/sort'
 import { Sort, SortResults } from '@_types/sort'
 
 /**
@@ -35,7 +34,7 @@ import { Sort, SortResults } from '@_types/sort'
 export interface Request extends RequestBase {
   query_parameters: {
     /**
-     * Return the snapshot of the owner user's role descriptors associated with the API key. 
+     * Return the snapshot of the owner user's role descriptors associated with the API key.
      * An API key's actual permission is the intersection of its assigned role descriptors and the owner user's role descriptors.
      * @availability stack since=8.5.0
      * @availability serverless

--- a/specification/security/query_api_keys/QueryApiKeysResponse.ts
+++ b/specification/security/query_api_keys/QueryApiKeysResponse.ts
@@ -20,8 +20,22 @@
 import { ApiKey } from '@security/_types/ApiKey'
 import { integer } from '@_types/Numeric'
 import { Dictionary } from '@spec_utils/Dictionary'
-import { Aggregate } from '@_types/aggregations/Aggregate'
-import { AggregateName, Id, ScrollId, SuggestionName } from '@_types/common'
+import { AggregateName } from '@_types/common'
+import {
+  CardinalityAggregate,
+  ValueCountAggregate,
+  StringTermsAggregate,
+  LongTermsAggregate,
+  DoubleTermsAggregate,
+  UnmappedTermsAggregate,
+  MultiTermsAggregate,
+  MissingAggregate,
+  FilterAggregate,
+  RangeAggregate,
+  DateRangeAggregate,
+  FiltersAggregate,
+  CompositeAggregate,
+} from '@_types/aggregations/Aggregate'
 
 export class Response {
   body: {
@@ -40,6 +54,26 @@ export class Response {
     /**
      * The aggregations result, if requested.
      */
-    aggregations?: Dictionary<AggregateName, Aggregate>
+    aggregations?: Dictionary<AggregateName, APIKeyAggregate>
   }
 }
+
+/**
+ * @variants external
+ * @non_exhaustive
+ */
+export type APIKeyAggregate =
+  | CardinalityAggregate
+  | ValueCountAggregate
+  | StringTermsAggregate
+  | LongTermsAggregate
+  | DoubleTermsAggregate
+  | UnmappedTermsAggregate
+  | MultiTermsAggregate
+  | MissingAggregate
+  | FilterAggregate
+  | FiltersAggregate
+  | RangeAggregate
+  | DateRangeAggregate
+  | CompositeAggregate
+

--- a/specification/security/query_api_keys/QueryApiKeysResponse.ts
+++ b/specification/security/query_api_keys/QueryApiKeysResponse.ts
@@ -21,21 +21,7 @@ import { ApiKey } from '@security/_types/ApiKey'
 import { integer } from '@_types/Numeric'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregateName } from '@_types/common'
-import {
-  CardinalityAggregate,
-  ValueCountAggregate,
-  StringTermsAggregate,
-  LongTermsAggregate,
-  DoubleTermsAggregate,
-  UnmappedTermsAggregate,
-  MultiTermsAggregate,
-  MissingAggregate,
-  FilterAggregate,
-  RangeAggregate,
-  DateRangeAggregate,
-  FiltersAggregate,
-  CompositeAggregate,
-} from '@_types/aggregations/Aggregate'
+import { APIKeyAggregate } from './types'
 
 export class Response {
   body: {
@@ -57,23 +43,3 @@ export class Response {
     aggregations?: Dictionary<AggregateName, APIKeyAggregate>
   }
 }
-
-/**
- * @variants external
- * @non_exhaustive
- */
-export type APIKeyAggregate =
-  | CardinalityAggregate
-  | ValueCountAggregate
-  | StringTermsAggregate
-  | LongTermsAggregate
-  | DoubleTermsAggregate
-  | UnmappedTermsAggregate
-  | MultiTermsAggregate
-  | MissingAggregate
-  | FilterAggregate
-  | FiltersAggregate
-  | RangeAggregate
-  | DateRangeAggregate
-  | CompositeAggregate
-

--- a/specification/security/query_api_keys/QueryApiKeysResponse.ts
+++ b/specification/security/query_api_keys/QueryApiKeysResponse.ts
@@ -19,6 +19,9 @@
 
 import { ApiKey } from '@security/_types/ApiKey'
 import { integer } from '@_types/Numeric'
+import { Dictionary } from '@spec_utils/Dictionary'
+import { Aggregate } from '@_types/aggregations/Aggregate'
+import { AggregateName, Id, ScrollId, SuggestionName } from '@_types/common'
 
 export class Response {
   body: {
@@ -34,5 +37,9 @@ export class Response {
      * A list of API key information.
      */
     api_keys: ApiKey[]
+    /**
+     * The aggregations result, if requested.
+     */
+    aggregations?: Dictionary<AggregateName, Aggregate>
   }
 }

--- a/specification/security/query_api_keys/types.ts
+++ b/specification/security/query_api_keys/types.ts
@@ -26,11 +26,11 @@ import {
   FiltersAggregation,
   MissingAggregation,
   RangeAggregation,
-  TermsAggregation,
+  TermsAggregation
 } from '@_types/aggregations/bucket'
 import {
   CardinalityAggregation,
-  ValueCountAggregation,
+  ValueCountAggregation
 } from '@_types/aggregations/metric'
 import {
   CardinalityAggregate,
@@ -45,7 +45,7 @@ import {
   RangeAggregate,
   DateRangeAggregate,
   FiltersAggregate,
-  CompositeAggregate,
+  CompositeAggregate
 } from '@_types/aggregations/Aggregate'
 
 /**

--- a/specification/security/query_api_keys/types.ts
+++ b/specification/security/query_api_keys/types.ts
@@ -32,6 +32,21 @@ import {
   CardinalityAggregation,
   ValueCountAggregation,
 } from '@_types/aggregations/metric'
+import {
+  CardinalityAggregate,
+  ValueCountAggregate,
+  StringTermsAggregate,
+  LongTermsAggregate,
+  DoubleTermsAggregate,
+  UnmappedTermsAggregate,
+  MultiTermsAggregate,
+  MissingAggregate,
+  FilterAggregate,
+  RangeAggregate,
+  DateRangeAggregate,
+  FiltersAggregate,
+  CompositeAggregate,
+} from '@_types/aggregations/Aggregate'
 
 /**
  * @variants container
@@ -91,3 +106,22 @@ export class APIKeyAggregationContainer {
    */
   value_count?: ValueCountAggregation
 }
+
+/**
+ * @variants external
+ * @non_exhaustive
+ */
+export type APIKeyAggregate =
+  | CardinalityAggregate
+  | ValueCountAggregate
+  | StringTermsAggregate
+  | LongTermsAggregate
+  | DoubleTermsAggregate
+  | UnmappedTermsAggregate
+  | MultiTermsAggregate
+  | MissingAggregate
+  | FilterAggregate
+  | FiltersAggregate
+  | RangeAggregate
+  | DateRangeAggregate
+  | CompositeAggregate


### PR DESCRIPTION
In 8.13 ES's [Query API Key Information API](https://www.elastic.co/guide/en/elasticsearch/reference/8.13/security-api-query-api-key.html#_response_2) added support for [aggregations](https://github.com/elastic/elasticsearch/issues/101691).
This should reflect that change in the request/response of the specification.