### PR TITLE
Add missing `codegen_name` annotations to all value bodied responses

### DIFF
--- a/specification/_global/get_source/SourceResponse.ts
+++ b/specification/_global/get_source/SourceResponse.ts
@@ -18,5 +18,6 @@
  */
 
 export class Response<TDocument> {
+  /** @codegen_name source */
   body: TDocument
 }

--- a/specification/_global/search_mvt/SearchMvtResponse.ts
+++ b/specification/_global/search_mvt/SearchMvtResponse.ts
@@ -20,5 +20,6 @@
 import { MapboxVectorTiles } from '@_types/Binary'
 
 export class Response {
+  /** @codegen_name vector_tiles */
   body: MapboxVectorTiles
 }

--- a/specification/cluster/remote_info/ClusterRemoteInfoResponse.ts
+++ b/specification/cluster/remote_info/ClusterRemoteInfoResponse.ts
@@ -22,6 +22,7 @@ import { integer, long } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 export class Response {
+  /** @codegen_name infos */
   body: Dictionary<string, ClusterRemoteInfo>
 }
 

--- a/specification/esql/query/QueryResponse.ts
+++ b/specification/esql/query/QueryResponse.ts
@@ -20,5 +20,6 @@
 import { EsqlColumns } from '@_types/Binary'
 
 export class Response {
+  /** @codegen_name data */
   body: EsqlColumns
 }

--- a/specification/ilm/get_lifecycle/GetLifecycleResponse.ts
+++ b/specification/ilm/get_lifecycle/GetLifecycleResponse.ts
@@ -21,5 +21,6 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Lifecycle } from './types'
 
 export class Response {
+  /** @codegen_name lifecycles */
   body: Dictionary<string, Lifecycle>
 }

--- a/specification/indices/disk_usage/IndicesDiskUsageResponse.ts
+++ b/specification/indices/disk_usage/IndicesDiskUsageResponse.ts
@@ -20,5 +20,6 @@
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
+  /** @codegen_name disk_usage */
   body: UserDefinedValue
 }

--- a/specification/indices/downsample/Response.ts
+++ b/specification/indices/downsample/Response.ts
@@ -20,5 +20,6 @@
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
+  /** @codegen_name result */
   body: UserDefinedValue // TODO: This API is experimental and no docs exist describing it. Requires reverse engineering if made stable
 }

--- a/specification/indices/get/IndicesGetResponse.ts
+++ b/specification/indices/get/IndicesGetResponse.ts
@@ -22,5 +22,6 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { IndexName } from '@_types/common'
 
 export class Response {
+  /** @codegen_name indices */
   body: Dictionary<IndexName, IndexState>
 }

--- a/specification/indices/get_alias/IndicesGetAliasResponse.ts
+++ b/specification/indices/get_alias/IndicesGetAliasResponse.ts
@@ -24,6 +24,7 @@ import { ErrorResponseBase } from '@_types/Base'
 import { IndexName } from '@_types/common'
 
 export class Response {
+  /** @codegen_name aliases */
   body: Dictionary<IndexName, IndexAliases>
   exceptions: [
     {

--- a/specification/indices/get_field_mapping/IndicesGetFieldMappingResponse.ts
+++ b/specification/indices/get_field_mapping/IndicesGetFieldMappingResponse.ts
@@ -22,5 +22,6 @@ import { IndexName } from '@_types/common'
 import { TypeFieldMappings } from './types'
 
 export class Response {
+  /** @codegen_name field_mappings */
   body: Dictionary<IndexName, TypeFieldMappings>
 }

--- a/specification/indices/get_mapping/IndicesGetMappingResponse.ts
+++ b/specification/indices/get_mapping/IndicesGetMappingResponse.ts
@@ -22,6 +22,7 @@ import { IndexName } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 
 export class Response {
+  /** @codegen_name index_mappings */
   body: Dictionary<IndexName, IndexMappingRecord>
 }
 

--- a/specification/indices/get_mapping/IndicesGetMappingResponse.ts
+++ b/specification/indices/get_mapping/IndicesGetMappingResponse.ts
@@ -22,7 +22,7 @@ import { IndexName } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 
 export class Response {
-  /** @codegen_name index_mappings */
+  /** @codegen_name mappings */
   body: Dictionary<IndexName, IndexMappingRecord>
 }
 

--- a/specification/indices/get_settings/IndicesGetSettingsResponse.ts
+++ b/specification/indices/get_settings/IndicesGetSettingsResponse.ts
@@ -22,5 +22,6 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { IndexName } from '@_types/common'
 
 export class Response {
+  /** @codegen_name settings */
   body: Dictionary<IndexName, IndexState>
 }

--- a/specification/indices/get_template/IndicesGetTemplateResponse.ts
+++ b/specification/indices/get_template/IndicesGetTemplateResponse.ts
@@ -21,6 +21,6 @@ import { TemplateMapping } from '@indices/_types/TemplateMapping'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  /** @codegen_name template_mappings */
+  /** @codegen_name templates */
   body: Dictionary<string, TemplateMapping>
 }

--- a/specification/indices/get_template/IndicesGetTemplateResponse.ts
+++ b/specification/indices/get_template/IndicesGetTemplateResponse.ts
@@ -21,5 +21,6 @@ import { TemplateMapping } from '@indices/_types/TemplateMapping'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
+  /** @codegen_name template_mappings */
   body: Dictionary<string, TemplateMapping>
 }

--- a/specification/indices/promote_data_stream/IndicesPromoteDataStreamResponse.ts
+++ b/specification/indices/promote_data_stream/IndicesPromoteDataStreamResponse.ts
@@ -20,5 +20,6 @@
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
+  /** @codegen_name result */
   body: UserDefinedValue
 }

--- a/specification/indices/recovery/IndicesRecoveryResponse.ts
+++ b/specification/indices/recovery/IndicesRecoveryResponse.ts
@@ -22,5 +22,6 @@ import { IndexName } from '@_types/common'
 import { RecoveryStatus } from './types'
 
 export class Response {
+  /** @codegen_name statuses */
   body: Dictionary<IndexName, RecoveryStatus>
 }

--- a/specification/indices/resolve_cluster/ResolveClusterResponse.ts
+++ b/specification/indices/resolve_cluster/ResolveClusterResponse.ts
@@ -22,6 +22,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { ElasticsearchVersionMinInfo } from '@_types/Base'
 
 export class Response {
+  /** @codegen_name infos */
   body: Dictionary<ClusterAlias, ResolveClusterInfo>
 }
 

--- a/specification/ingest/get_pipeline/GetPipelineResponse.ts
+++ b/specification/ingest/get_pipeline/GetPipelineResponse.ts
@@ -21,5 +21,6 @@ import { Pipeline } from '@ingest/_types/Pipeline'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
+  /** @codegen_name pipelines */
   body: Dictionary<string, Pipeline>
 }

--- a/specification/logstash/get_pipeline/LogstashGetPipelineResponse.ts
+++ b/specification/logstash/get_pipeline/LogstashGetPipelineResponse.ts
@@ -22,5 +22,6 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Id } from '@_types/common'
 
 export class Response {
+  /** @codegen_name pipelines */
   body: Dictionary<Id, Pipeline>
 }

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedResponse.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedResponse.ts
@@ -18,5 +18,6 @@
  */
 
 export class Response<TDocument> {
+  /** @codegen_name documents */
   body: Array<TDocument>
 }

--- a/specification/rollup/get_rollup_caps/GetRollupCapabilitiesResponse.ts
+++ b/specification/rollup/get_rollup_caps/GetRollupCapabilitiesResponse.ts
@@ -22,5 +22,6 @@ import { IndexName } from '@_types/common'
 import { RollupCapabilities } from './types'
 
 export class Response {
+  /** @codegen_name capabilities */
   body: Dictionary<IndexName, RollupCapabilities>
 }

--- a/specification/rollup/get_rollup_index_caps/GetRollupIndexCapabilitiesResponse.ts
+++ b/specification/rollup/get_rollup_index_caps/GetRollupIndexCapabilitiesResponse.ts
@@ -22,5 +22,6 @@ import { IndexName } from '@_types/common'
 import { IndexCapabilities } from './types'
 
 export class Response {
+  /** @codegen_name capabilities */
   body: Dictionary<IndexName, IndexCapabilities>
 }

--- a/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetResponse.ts
+++ b/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetResponse.ts
@@ -22,5 +22,6 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Name } from '@_types/common'
 
 export class Response {
+  /** @codegen_name analytics */
   body: Dictionary<Name, AnalyticsCollection>
 }

--- a/specification/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheResponse.ts
+++ b/specification/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheResponse.ts
@@ -20,5 +20,6 @@
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class Response {
+  /** @codegen_name result */
   body: UserDefinedValue
 }

--- a/specification/security/delete_privileges/SecurityDeletePrivilegesResponse.ts
+++ b/specification/security/delete_privileges/SecurityDeletePrivilegesResponse.ts
@@ -21,5 +21,6 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { FoundStatus } from './types'
 
 export class Response {
+  /** @codegen_name result */
   body: Dictionary<string, Dictionary<string, FoundStatus>>
 }

--- a/specification/security/get_privileges/SecurityGetPrivilegesResponse.ts
+++ b/specification/security/get_privileges/SecurityGetPrivilegesResponse.ts
@@ -21,5 +21,6 @@ import { Actions } from '@security/put_privileges/types'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
+  /** @codegen_name privileges */
   body: Dictionary<string, Dictionary<string, Actions>>
 }

--- a/specification/security/get_role/SecurityGetRoleResponse.ts
+++ b/specification/security/get_role/SecurityGetRoleResponse.ts
@@ -21,5 +21,6 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Role } from './types'
 
 export class Response {
+  /** @codegen_name roles */
   body: Dictionary<string, Role>
 }

--- a/specification/security/get_role_mapping/SecurityGetRoleMappingResponse.ts
+++ b/specification/security/get_role_mapping/SecurityGetRoleMappingResponse.ts
@@ -21,5 +21,6 @@ import { RoleMapping } from '@security/_types/RoleMapping'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
+  /** @codegen_name role_mappings */
   body: Dictionary<string, RoleMapping>
 }

--- a/specification/security/get_service_accounts/GetServiceAccountsResponse.ts
+++ b/specification/security/get_service_accounts/GetServiceAccountsResponse.ts
@@ -21,5 +21,6 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { RoleDescriptorWrapper } from './types'
 
 export class Response {
+  /** @codegen_name service_accoutns */
   body: Dictionary<string, RoleDescriptorWrapper>
 }

--- a/specification/security/get_user/SecurityGetUserResponse.ts
+++ b/specification/security/get_user/SecurityGetUserResponse.ts
@@ -21,5 +21,6 @@ import { User } from '@security/_types/User'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
+  /** @codegen_name users */
   body: Dictionary<string, User>
 }

--- a/specification/security/put_privileges/SecurityPutPrivilegesResponse.ts
+++ b/specification/security/put_privileges/SecurityPutPrivilegesResponse.ts
@@ -21,5 +21,6 @@ import { CreatedStatus } from '@security/_types/CreatedStatus'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
+  /** @codegen_name result */
   body: Dictionary<string, Dictionary<string, CreatedStatus>>
 }

--- a/specification/slm/get_lifecycle/GetSnapshotLifecycleResponse.ts
+++ b/specification/slm/get_lifecycle/GetSnapshotLifecycleResponse.ts
@@ -22,5 +22,6 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Id } from '@_types/common'
 
 export class Response {
+  /** @codegen_name lifecycles */
   body: Dictionary<Id, SnapshotLifecycle>
 }


### PR DESCRIPTION
In the .NET client, these value-type bodies will be wrapped in a common response type like e.g.:

```csharp
public partial class EsqlQueryResponse : 
    ElasticsearchResponse
{
    public byte[] Data { init; }
}
````

In order to properly auto-generate the required body property (e.g. `Data` in this case) with a meaningful name, all of these bodies must be annotated with `codegen_name` attributes.

It would be nice having a compiler check for this rule in the future.