### PR TITLE
Use consistent naming for API when used in a word

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -20320,7 +20320,7 @@
                   "description": "The aggregations result, if requested.",
                   "type": "object",
                   "additionalProperties": {
-                    "$ref": "#/components/schemas/security.query_api_keys:APIKeyAggregate"
+                    "$ref": "#/components/schemas/security.query_api_keys:ApiKeyAggregate"
                   }
                 }
               },
@@ -27048,7 +27048,7 @@
                   "description": "Any aggregations to run over the corpus of returned API keys.\nAggregations and queries work together. Aggregations are computed only on the API keys that match the query.\nThis supports only a subset of aggregation types, namely: `terms`, `range`, `date_range`, `missing`,\n`cardinality`, `value_count`, `composite`, `filter`, and `filters`.\nAdditionally, aggregations only run over the same subset of fields that query works with.",
                   "type": "object",
                   "additionalProperties": {
-                    "$ref": "#/components/schemas/security.query_api_keys:APIKeyAggregationContainer"
+                    "$ref": "#/components/schemas/security.query_api_keys:ApiKeyAggregationContainer"
                   }
                 },
                 "query": {
@@ -57372,7 +57372,7 @@
           "type": "boolean"
         }
       },
-      "security.query_api_keys:APIKeyAggregationContainer": {
+      "security.query_api_keys:ApiKeyAggregationContainer": {
         "allOf": [
           {
             "type": "object",
@@ -57381,7 +57381,7 @@
                 "description": "Sub-aggregations for this aggregation.\nOnly applies to bucket aggregations.",
                 "type": "object",
                 "additionalProperties": {
-                  "$ref": "#/components/schemas/security.query_api_keys:APIKeyAggregationContainer"
+                  "$ref": "#/components/schemas/security.query_api_keys:ApiKeyAggregationContainer"
                 }
               },
               "meta": {
@@ -57554,7 +57554,7 @@
           }
         ]
       },
-      "security.query_api_keys:APIKeyAggregate": {
+      "security.query_api_keys:ApiKeyAggregate": {
         "oneOf": [
           {
             "$ref": "#/components/schemas/_types.aggregations:CardinalityAggregate"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -27052,7 +27052,7 @@
                   }
                 },
                 "query": {
-                  "$ref": "#/components/schemas/security.query_api_keys:APIKeyQueryContainer"
+                  "$ref": "#/components/schemas/security.query_api_keys:ApiKeyQueryContainer"
                 },
                 "from": {
                   "description": "Starting document offset.\nBy default, you cannot page through more than 10,000 hits using the from and size parameters.\nTo page through more hits, use the `search_after` parameter.",
@@ -57402,10 +57402,10 @@
                 "$ref": "#/components/schemas/_types.aggregations:DateRangeAggregation"
               },
               "filter": {
-                "$ref": "#/components/schemas/security.query_api_keys:APIKeyQueryContainer"
+                "$ref": "#/components/schemas/security.query_api_keys:ApiKeyQueryContainer"
               },
               "filters": {
-                "$ref": "#/components/schemas/security.query_api_keys:APIKeyFiltersAggregation"
+                "$ref": "#/components/schemas/security.query_api_keys:ApiKeyFiltersAggregation"
               },
               "missing": {
                 "$ref": "#/components/schemas/_types.aggregations:MissingAggregation"
@@ -57425,7 +57425,7 @@
           }
         ]
       },
-      "security.query_api_keys:APIKeyQueryContainer": {
+      "security.query_api_keys:ApiKeyQueryContainer": {
         "type": "object",
         "properties": {
           "bool": {
@@ -57510,7 +57510,7 @@
         "minProperties": 1,
         "maxProperties": 1
       },
-      "security.query_api_keys:APIKeyFiltersAggregation": {
+      "security.query_api_keys:ApiKeyFiltersAggregation": {
         "allOf": [
           {
             "$ref": "#/components/schemas/_types.aggregations:BucketAggregationBase"
@@ -57519,7 +57519,7 @@
             "type": "object",
             "properties": {
               "filters": {
-                "$ref": "#/components/schemas/_types.aggregations:BucketsAPIKeyQueryContainer"
+                "$ref": "#/components/schemas/_types.aggregations:BucketsApiKeyQueryContainer"
               },
               "other_bucket": {
                 "description": "Set to `true` to add a bucket to the response which will contain all documents that do not match any of the given filters.",
@@ -57537,19 +57537,19 @@
           }
         ]
       },
-      "_types.aggregations:BucketsAPIKeyQueryContainer": {
+      "_types.aggregations:BucketsApiKeyQueryContainer": {
         "description": "Aggregation buckets. By default they are returned as an array, but if the aggregation has keys configured for\nthe different buckets, the result is a dictionary.",
         "oneOf": [
           {
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/components/schemas/security.query_api_keys:APIKeyQueryContainer"
+              "$ref": "#/components/schemas/security.query_api_keys:ApiKeyQueryContainer"
             }
           },
           {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/security.query_api_keys:APIKeyQueryContainer"
+              "$ref": "#/components/schemas/security.query_api_keys:ApiKeyQueryContainer"
             }
           }
         ]

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1317,7 +1317,7 @@
     "security.query_api_keys": {
       "request": [],
       "response": [
-        "type_alias definition security.query_api_keys:APIKeyAggregate / instance_of - Non-leaf type cannot be used here: '_types.aggregations:RangeAggregate'"
+        "type_alias definition security.query_api_keys:ApiKeyAggregate / instance_of - Non-leaf type cannot be used here: '_types.aggregations:RangeAggregate'"
       ]
     },
     "security.suggest_user_profiles": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16887,22 +16887,22 @@ export interface SecurityQueryApiKeysAPIKeyAggregationContainer {
   cardinality?: AggregationsCardinalityAggregation
   composite?: AggregationsCompositeAggregation
   date_range?: AggregationsDateRangeAggregation
-  filter?: SecurityQueryApiKeysAPIKeyQueryContainer
-  filters?: SecurityQueryApiKeysAPIKeyFiltersAggregation
+  filter?: SecurityQueryApiKeysApiKeyQueryContainer
+  filters?: SecurityQueryApiKeysApiKeyFiltersAggregation
   missing?: AggregationsMissingAggregation
   range?: AggregationsRangeAggregation
   terms?: AggregationsTermsAggregation
   value_count?: AggregationsValueCountAggregation
 }
 
-export interface SecurityQueryApiKeysAPIKeyFiltersAggregation extends AggregationsBucketAggregationBase {
-  filters?: AggregationsBuckets<SecurityQueryApiKeysAPIKeyQueryContainer>
+export interface SecurityQueryApiKeysApiKeyFiltersAggregation extends AggregationsBucketAggregationBase {
+  filters?: AggregationsBuckets<SecurityQueryApiKeysApiKeyQueryContainer>
   other_bucket?: boolean
   other_bucket_key?: string
   keyed?: boolean
 }
 
-export interface SecurityQueryApiKeysAPIKeyQueryContainer {
+export interface SecurityQueryApiKeysApiKeyQueryContainer {
   bool?: QueryDslBoolQuery
   exists?: QueryDslExistsQuery
   ids?: QueryDslIdsQuery
@@ -16921,7 +16921,7 @@ export interface SecurityQueryApiKeysRequest extends RequestBase {
   body?: {
     aggregations?: Record<string, SecurityQueryApiKeysAPIKeyAggregationContainer>
     aggs?: Record<string, SecurityQueryApiKeysAPIKeyAggregationContainer>
-    query?: SecurityQueryApiKeysAPIKeyQueryContainer
+    query?: SecurityQueryApiKeysApiKeyQueryContainer
     from?: integer
     sort?: Sort
     size?: integer

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16878,11 +16878,11 @@ export interface SecurityPutUserResponse {
   created: boolean
 }
 
-export type SecurityQueryApiKeysAPIKeyAggregate = AggregationsCardinalityAggregate | AggregationsValueCountAggregate | AggregationsStringTermsAggregate | AggregationsLongTermsAggregate | AggregationsDoubleTermsAggregate | AggregationsUnmappedTermsAggregate | AggregationsMultiTermsAggregate | AggregationsMissingAggregate | AggregationsFilterAggregate | AggregationsFiltersAggregate | AggregationsRangeAggregate | AggregationsDateRangeAggregate | AggregationsCompositeAggregate
+export type SecurityQueryApiKeysApiKeyAggregate = AggregationsCardinalityAggregate | AggregationsValueCountAggregate | AggregationsStringTermsAggregate | AggregationsLongTermsAggregate | AggregationsDoubleTermsAggregate | AggregationsUnmappedTermsAggregate | AggregationsMultiTermsAggregate | AggregationsMissingAggregate | AggregationsFilterAggregate | AggregationsFiltersAggregate | AggregationsRangeAggregate | AggregationsDateRangeAggregate | AggregationsCompositeAggregate
 
-export interface SecurityQueryApiKeysAPIKeyAggregationContainer {
-  aggregations?: Record<string, SecurityQueryApiKeysAPIKeyAggregationContainer>
-  aggs?: Record<string, SecurityQueryApiKeysAPIKeyAggregationContainer>
+export interface SecurityQueryApiKeysApiKeyAggregationContainer {
+  aggregations?: Record<string, SecurityQueryApiKeysApiKeyAggregationContainer>
+  aggs?: Record<string, SecurityQueryApiKeysApiKeyAggregationContainer>
   meta?: Metadata
   cardinality?: AggregationsCardinalityAggregation
   composite?: AggregationsCompositeAggregation
@@ -16919,8 +16919,8 @@ export interface SecurityQueryApiKeysApiKeyQueryContainer {
 export interface SecurityQueryApiKeysRequest extends RequestBase {
   with_limited_by?: boolean
   body?: {
-    aggregations?: Record<string, SecurityQueryApiKeysAPIKeyAggregationContainer>
-    aggs?: Record<string, SecurityQueryApiKeysAPIKeyAggregationContainer>
+    aggregations?: Record<string, SecurityQueryApiKeysApiKeyAggregationContainer>
+    aggs?: Record<string, SecurityQueryApiKeysApiKeyAggregationContainer>
     query?: SecurityQueryApiKeysApiKeyQueryContainer
     from?: integer
     sort?: Sort
@@ -16933,7 +16933,7 @@ export interface SecurityQueryApiKeysResponse {
   total: integer
   count: integer
   api_keys: SecurityApiKey[]
-  aggregations?: Record<AggregateName, SecurityQueryApiKeysAPIKeyAggregate>
+  aggregations?: Record<AggregateName, SecurityQueryApiKeysApiKeyAggregate>
 }
 
 export interface SecuritySamlAuthenticateRequest extends RequestBase {

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { Dictionary } from '@spec_utils/Dictionary'
-import { APIKeyAggregationContainer, APIKeyQueryContainer } from './types'
+import { APIKeyAggregationContainer, ApiKeyQueryContainer } from './types'
 import { RequestBase } from '@_types/Base'
 import { integer } from '@_types/Numeric'
 import { Sort, SortResults } from '@_types/sort'
@@ -58,7 +58,7 @@ export interface Request extends RequestBase {
      * You can query the following public information associated with an API key: `id`, `type`, `name`,
      * `creation`, `expiration`, `invalidated`, `invalidation`, `username`, `realm`, and `metadata`.
      */
-    query?: APIKeyQueryContainer
+    query?: ApiKeyQueryContainer
     /**
      * Starting document offset.
      * By default, you cannot page through more than 10,000 hits using the from and size parameters.

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { Dictionary } from '@spec_utils/Dictionary'
-import { APIKeyAggregationContainer, ApiKeyQueryContainer } from './types'
+import { ApiKeyAggregationContainer, ApiKeyQueryContainer } from './types'
 import { RequestBase } from '@_types/Base'
 import { integer } from '@_types/Numeric'
 import { Sort, SortResults } from '@_types/sort'
@@ -49,7 +49,7 @@ export interface Request extends RequestBase {
      * `cardinality`, `value_count`, `composite`, `filter`, and `filters`.
      * Additionally, aggregations only run over the same subset of fields that query works with.
      * @aliases aggs */
-    aggregations?: Dictionary<string, APIKeyAggregationContainer>
+    aggregations?: Dictionary<string, ApiKeyAggregationContainer>
     /**
      * A query to filter which API keys to return.
      * If the query parameter is missing, it is equivalent to a `match_all` query.

--- a/specification/security/query_api_keys/QueryApiKeysResponse.ts
+++ b/specification/security/query_api_keys/QueryApiKeysResponse.ts
@@ -21,7 +21,7 @@ import { ApiKey } from '@security/_types/ApiKey'
 import { integer } from '@_types/Numeric'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregateName } from '@_types/common'
-import { APIKeyAggregate } from './types'
+import { ApiKeyAggregate } from './types'
 
 export class Response {
   body: {
@@ -40,6 +40,6 @@ export class Response {
     /**
      * The aggregations result, if requested.
      */
-    aggregations?: Dictionary<AggregateName, APIKeyAggregate>
+    aggregations?: Dictionary<AggregateName, ApiKeyAggregate>
   }
 }

--- a/specification/security/query_api_keys/types.ts
+++ b/specification/security/query_api_keys/types.ts
@@ -96,12 +96,12 @@ export class APIKeyAggregationContainer {
    * A single bucket aggregation that narrows the set of documents to those that match a query.
    * @doc_id search-aggregations-bucket-filter-aggregation
    */
-  filter?: APIKeyQueryContainer
+  filter?: ApiKeyQueryContainer
   /**
    * A multi-bucket aggregation where each bucket contains the documents that match a query.
    * @doc_id search-aggregations-bucket-filters-aggregation
    */
-  filters?: APIKeyFiltersAggregation
+  filters?: ApiKeyFiltersAggregation
   missing?: MissingAggregation
   /**
    * A multi-bucket value source based aggregation that enables the user to define a set of ranges - each representing a bucket.
@@ -143,7 +143,7 @@ export type APIKeyAggregate =
  * @variants container
  * @non_exhaustive
  */
-export class APIKeyQueryContainer {
+export class ApiKeyQueryContainer {
   /**
    * matches documents matching boolean combinations of other queries.
    * @doc_id query-dsl-bool-query
@@ -205,11 +205,11 @@ export class APIKeyQueryContainer {
   wildcard?: SingleKeyDictionary<Field, WildcardQuery>
 }
 
-export class APIKeyFiltersAggregation extends BucketAggregationBase {
+export class ApiKeyFiltersAggregation extends BucketAggregationBase {
   /**
    * Collection of queries from which to build buckets.
    */
-  filters?: Buckets<APIKeyQueryContainer>
+  filters?: Buckets<ApiKeyQueryContainer>
   /**
    * Set to `true` to add a bucket to the response which will contain all documents that do not match any of the given filters.
    */

--- a/specification/security/query_api_keys/types.ts
+++ b/specification/security/query_api_keys/types.ts
@@ -65,14 +65,14 @@ import {
  * @variants container
  * @non_exhaustive
  */
-export class APIKeyAggregationContainer {
+export class ApiKeyAggregationContainer {
   /**
    * Sub-aggregations for this aggregation.
    * Only applies to bucket aggregations.
    * @variant container_property
    * @aliases aggs
    */
-  aggregations?: Dictionary<string, APIKeyAggregationContainer>
+  aggregations?: Dictionary<string, ApiKeyAggregationContainer>
   /**
    * @variant container_property
    */
@@ -124,7 +124,7 @@ export class APIKeyAggregationContainer {
  * @variants external
  * @non_exhaustive
  */
-export type APIKeyAggregate =
+export type ApiKeyAggregate =
   | CardinalityAggregate
   | ValueCountAggregate
   | StringTermsAggregate


### PR DESCRIPTION
Renames `APIKeyQueryContainer` and `APIKeyFiltersAggregation` to use the same casing convention as the existing `ApiKey`, `ApiKeyAuthorization`, etc.