### PR TITLE
Add Completion result and task type to the Inference API spec

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -26365,7 +26365,8 @@
               "$ref": "#/components/schemas/inference._types:ModelConfig"
             }
           }
-        }
+        },
+        "required": true
       },
       "ingest.simulate": {
         "content": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11495,6 +11495,12 @@ export interface IndicesValidateQueryResponse {
   error?: string
 }
 
+export type InferenceCompletion = string
+
+export interface InferenceCompletionResult {
+  result: InferenceCompletion
+}
+
 export type InferenceDenseByteVector = byte[]
 
 export type InferenceDenseVector = float[]
@@ -11503,6 +11509,7 @@ export interface InferenceInferenceResult {
   text_embedding_bytes?: InferenceTextEmbeddingByteResult[]
   text_embedding?: InferenceTextEmbeddingResult[]
   sparse_embedding?: InferenceSparseEmbeddingResult[]
+  completion?: InferenceCompletionResult[]
 }
 
 export interface InferenceModelConfig {
@@ -11526,7 +11533,7 @@ export type InferenceSparseVector = Record<string, float>
 
 export type InferenceTaskSettings = any
 
-export type InferenceTaskType = 'sparse_embedding' | 'text_embedding'
+export type InferenceTaskType = 'sparse_embedding' | 'text_embedding' | 'completion'
 
 export interface InferenceTextEmbeddingByteResult {
   embedding: InferenceDenseByteVector

--- a/specification/inference/_types/Results.ts
+++ b/specification/inference/_types/Results.ts
@@ -32,6 +32,11 @@ export type SparseVector = Dictionary<string, float>
  */
 export type DenseVector = Array<float>
 
+/**
+ * A Completion result is represented as a string.
+ */
+export type Completion = string
+
 export class SparseEmbeddingResult {
   embedding: SparseVector
 }
@@ -57,6 +62,13 @@ export class TextEmbeddingResult {
 }
 
 /**
+ * The completion result object
+ */
+export class CompletionResult {
+  result: Completion
+}
+
+/**
  * InferenceResult is an aggregation of mutually exclusive variants
  * @variants container
  */
@@ -64,4 +76,5 @@ export class InferenceResult {
   text_embedding_bytes?: Array<TextEmbeddingByteResult>
   text_embedding?: Array<TextEmbeddingResult>
   sparse_embedding?: Array<SparseEmbeddingResult>
+  completion?: Array<CompletionResult>
 }

--- a/specification/inference/_types/TaskType.ts
+++ b/specification/inference/_types/TaskType.ts
@@ -22,5 +22,6 @@
  */
 export enum TaskType {
   sparse_embedding,
-  text_embedding
+  text_embedding,
+  completion
 }


### PR DESCRIPTION
This PR adds the new completion task type and the result to the specification.

Completion result example:

```
{ 
  "completion": [ 
     { 
       "result": "..." 
      } 
   ] 
} 