### PR TITLE
Add Completion result and task type to the Inference API spec

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11495,6 +11495,10 @@ export interface IndicesValidateQueryResponse {
   error?: string
 }
 
+export interface InferenceCompletionResult {
+  result: string
+}
+
 export type InferenceDenseByteVector = byte[]
 
 export type InferenceDenseVector = float[]
@@ -11503,6 +11507,7 @@ export interface InferenceInferenceResult {
   text_embedding_bytes?: InferenceTextEmbeddingByteResult[]
   text_embedding?: InferenceTextEmbeddingResult[]
   sparse_embedding?: InferenceSparseEmbeddingResult[]
+  completion?: InferenceCompletionResult[]
 }
 
 export interface InferenceModelConfig {

--- a/specification/inference/_types/Results.ts
+++ b/specification/inference/_types/Results.ts
@@ -60,7 +60,7 @@ export class TextEmbeddingResult {
  * The completion result object
  */
 export class CompletionResult {
-  result: string;
+  result: string
 }
 
 /**

--- a/specification/inference/_types/Results.ts
+++ b/specification/inference/_types/Results.ts
@@ -57,6 +57,13 @@ export class TextEmbeddingResult {
 }
 
 /**
+ * The completion result object
+ */
+export class CompletionResult {
+  result: string;
+}
+
+/**
  * InferenceResult is an aggregation of mutually exclusive variants
  * @variants container
  */
@@ -64,4 +71,5 @@ export class InferenceResult {
   text_embedding_bytes?: Array<TextEmbeddingByteResult>
   text_embedding?: Array<TextEmbeddingResult>
   sparse_embedding?: Array<SparseEmbeddingResult>
+  completion?: Array<CompletionResult>
 }


### PR DESCRIPTION
This PR adds the new completion task type and the result to the specification.

Completion result example:

```
{ 
  "completion": [ 
     { 
       "result": "..." 
      } 
   ] 
} 