### PR TITLE
Add force_synthethic_source parameter

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -650,12 +650,6 @@
       ],
       "response": []
     },
-    "get": {
-      "request": [
-        "Request: missing json spec query parameter 'force_synthetic_source'"
-      ],
-      "response": []
-    },
     "get_source": {
       "request": [
         "Request: query parameter 'stored_fields' does not exist in the json spec"
@@ -929,9 +923,7 @@
       "response": []
     },
     "mget": {
-      "request": [
-        "Request: missing json spec query parameter 'force_synthetic_source'"
-      ],
+      "request": [],
       "response": [
         "type_alias definition _global.mget:ResponseItem / union_of / instance_of / Generics / instance_of - No type definition for '_global.mget:TDocument'"
       ]
@@ -1171,7 +1163,6 @@
     },
     "search": {
       "request": [
-        "Request: missing json spec query parameter 'force_synthetic_source'",
         "Request: missing json spec query parameter 'include_named_queries_score'",
         "interface definition _types:RankContainer - Property rrf is a single-variant and must be required"
       ],

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -377,6 +377,7 @@ export interface GetGetResult<TDocument = unknown> {
 export interface GetRequest extends RequestBase {
   id: Id
   index: IndexName
+  force_synthetic_source?: boolean
   preference?: string
   realtime?: boolean
   refresh?: boolean
@@ -692,6 +693,7 @@ export interface MgetOperation {
 
 export interface MgetRequest extends RequestBase {
   index?: IndexName
+  force_synthetic_source?: boolean
   preference?: string
   realtime?: boolean
   refresh?: boolean
@@ -1185,6 +1187,7 @@ export interface SearchRequest extends RequestBase {
   size?: integer
   from?: integer
   sort?: string | string[]
+  force_synthetic_source?: boolean
   body?: {
     aggregations?: Record<string, AggregationsAggregationContainer>
     aggs?: Record<string, AggregationsAggregationContainer>

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -42,6 +42,13 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
+     * Should this request force synthetic _source?
+     * Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance.
+     * Fetches with this enabled will be slower the enabling synthetic source natively in the index.
+     * @availability stack since=8.4.0 visibility=feature_flag feature_flag=es.index_mode_feature_flag_registered
+     */
+    force_synthetic_source?: boolean
+    /**
      * Specifies the node or shard the operation should be performed on. Random by default.
      */
     preference?: string

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -37,6 +37,13 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
+     * Should this request force synthetic _source?
+     * Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance.
+     * Fetches with this enabled will be slower the enabling synthetic source natively in the index.
+     * @availability stack since=8.4.0 visibility=feature_flag feature_flag=es.index_mode_feature_flag_registered
+     */
+    force_synthetic_source?: boolean
+    /**
      * Specifies the node or shard the operation should be performed on. Random by default.
      */
     preference?: string

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -324,6 +324,13 @@ export interface Request extends RequestBase {
      * @doc_id sort-search-results
      */
     sort?: string | string[]
+    /**
+     * Should this request force synthetic _source?
+     * Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance.
+     * Fetches with this enabled will be slower the enabling synthetic source natively in the index.
+     * @availability stack since=8.4.0 visibility=feature_flag feature_flag=es.index_mode_feature_flag_registered
+     */
+    force_synthetic_source?: boolean
   }
   // We should keep this in sync with the multi search request body.
   body: {


### PR DESCRIPTION
I noticed that `force_synthetic_source` was missing from this report: https://github.com/elastic/elasticsearch-specification/blob/071b2f79d37b92150d8ce42e3bd77951aa917f4f/output/schema/validation-errors.json#L655. Do we typically add fields behind feature flags?

I checked the following things:

 * this parameter is not accepted as body parameter, either in get, mget or search
 * this parameter is not accepted in msearch at all