### PR TITLE
Query and Get API Key Information endpoints support for profile uid

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -15833,6 +15833,16 @@
               "type": "boolean"
             },
             "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "with_profile_uid",
+            "description": "Determines whether to also retrieve the profile uid, for the API key owner principal, if it exists.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
           }
         ],
         "responses": {
@@ -16099,6 +16109,12 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/security.query_api_keys#with_limited_by"
+          },
+          {
+            "$ref": "#/components/parameters/security.query_api_keys#with_profile_uid"
+          },
+          {
+            "$ref": "#/components/parameters/security.query_api_keys#typed_keys"
           }
         ],
         "requestBody": {
@@ -16123,6 +16139,12 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/security.query_api_keys#with_limited_by"
+          },
+          {
+            "$ref": "#/components/parameters/security.query_api_keys#with_profile_uid"
+          },
+          {
+            "$ref": "#/components/parameters/security.query_api_keys#typed_keys"
           }
         ],
         "requestBody": {
@@ -25378,6 +25400,26 @@
         "in": "query",
         "name": "with_limited_by",
         "description": "Return the snapshot of the owner user's role descriptors associated with the API key.\nAn API key's actual permission is the intersection of its assigned role descriptors and the owner user's role descriptors.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
+      "security.query_api_keys#with_profile_uid": {
+        "in": "query",
+        "name": "with_profile_uid",
+        "description": "Determines whether to also retrieve the profile uid, for the API key owner principal, if it exists.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
+      "security.query_api_keys#typed_keys": {
+        "in": "query",
+        "name": "typed_keys",
+        "description": "Determines whether aggregation names are prefixed by their respective types in the response.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -57001,8 +57043,16 @@
             "description": "Realm name of the principal for which this API key was created.",
             "type": "string"
           },
+          "realm_type": {
+            "description": "Realm type of the principal for which this API key was created",
+            "type": "string"
+          },
           "username": {
             "$ref": "#/components/schemas/_types:Username"
+          },
+          "profile_uid": {
+            "description": "The profile uid for the API key owner principal, if requested and if it exists",
+            "type": "string"
           },
           "metadata": {
             "$ref": "#/components/schemas/_types:Metadata"

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1245,7 +1245,8 @@
     },
     "security.get_api_key": {
       "request": [
-        "Request: query parameter 'active_only' does not exist in the json spec"
+        "Request: query parameter 'active_only' does not exist in the json spec",
+        "Request: query parameter 'with_profile_uid' does not exist in the json spec"
       ],
       "response": []
     },
@@ -1300,7 +1301,10 @@
       "response": []
     },
     "security.query_api_keys": {
-      "request": [],
+      "request": [
+        "Request: query parameter 'with_profile_uid' does not exist in the json spec",
+        "Request: query parameter 'typed_keys' does not exist in the json spec"
+      ],
       "response": [
         "type_alias definition security.query_api_keys:ApiKeyAggregate / instance_of - Non-leaf type cannot be used here: '_types.aggregations:RangeAggregate'"
       ]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16138,7 +16138,9 @@ export interface SecurityApiKey {
   invalidated?: boolean
   name: Name
   realm?: string
+  realm_type?: string
   username?: Username
+  profile_uid?: string
   metadata?: Metadata
   role_descriptors?: Record<string, SecurityRoleDescriptor>
   limited_by?: Record<string, SecurityRoleDescriptor>[]
@@ -16554,6 +16556,7 @@ export interface SecurityGetApiKeyRequest extends RequestBase {
   username?: Username
   with_limited_by?: boolean
   active_only?: boolean
+  with_profile_uid?: boolean
 }
 
 export interface SecurityGetApiKeyResponse {
@@ -16935,6 +16938,8 @@ export interface SecurityQueryApiKeysApiKeyQueryContainer {
 
 export interface SecurityQueryApiKeysRequest extends RequestBase {
   with_limited_by?: boolean
+  with_profile_uid?: boolean
+  typed_keys?: boolean
   body?: {
     aggregations?: Record<string, SecurityQueryApiKeysApiKeyAggregationContainer>
     aggs?: Record<string, SecurityQueryApiKeysApiKeyAggregationContainer>

--- a/specification/security/_types/ApiKey.ts
+++ b/specification/security/_types/ApiKey.ts
@@ -51,9 +51,21 @@ export class ApiKey {
    */
   realm?: string
   /**
+   * Realm type of the principal for which this API key was created
+   * @availability stack since=8.14.0
+   * @availability serverless
+   */
+  realm_type?: string
+  /**
    * Principal for which this API key was created
    */
   username?: Username
+  /**
+   * The profile uid for the API key owner principal, if requested and if it exists
+   * @availability stack since=8.14.0
+   * @availability serverless
+   */
+  profile_uid?: string
   /**
    * Metadata of the API key
    * @availability stack since=7.13.0

--- a/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
+++ b/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
@@ -75,5 +75,12 @@ export interface Request extends RequestBase {
      * @availability serverless
      */
     active_only?: boolean
+     /**
+      * Determines whether to also retrieve the profile uid, for the API key owner principal, if it exists.
+      * @server_default false
+      * @availability stack since=8.14.0
+      * @availability serverless
+      */
+    with_profile_uid?: boolean
   }
 }

--- a/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
+++ b/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
@@ -75,12 +75,12 @@ export interface Request extends RequestBase {
      * @availability serverless
      */
     active_only?: boolean
-     /**
-      * Determines whether to also retrieve the profile uid, for the API key owner principal, if it exists.
-      * @server_default false
-      * @availability stack since=8.14.0
-      * @availability serverless
-      */
+    /**
+     * Determines whether to also retrieve the profile uid, for the API key owner principal, if it exists.
+     * @server_default false
+     * @availability stack since=8.14.0
+     * @availability serverless
+     */
     with_profile_uid?: boolean
   }
 }

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -37,9 +37,22 @@ export interface Request extends RequestBase {
      * An API key's actual permission is the intersection of its assigned role descriptors and the owner user's role descriptors.
      * @availability stack since=8.5.0
      * @availability serverless
-
      */
     with_limited_by?: boolean
+     /**
+      * Determines whether to also retrieve the profile uid, for the API key owner principal, if it exists.
+      * @server_default false
+      * @availability stack since=8.14.0
+      * @availability serverless
+      */
+    with_profile_uid?: boolean
+     /**
+      * Determines whether aggregation names are prefixed by their respective types in the response.
+      * @server_default false
+      * @availability stack since=8.14.0
+      * @availability serverless
+      */
+    typed_keys?: boolean
   }
   body: {
     /**

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -39,19 +39,19 @@ export interface Request extends RequestBase {
      * @availability serverless
      */
     with_limited_by?: boolean
-     /**
-      * Determines whether to also retrieve the profile uid, for the API key owner principal, if it exists.
-      * @server_default false
-      * @availability stack since=8.14.0
-      * @availability serverless
-      */
+    /**
+     * Determines whether to also retrieve the profile uid, for the API key owner principal, if it exists.
+     * @server_default false
+     * @availability stack since=8.14.0
+     * @availability serverless
+     */
     with_profile_uid?: boolean
-     /**
-      * Determines whether aggregation names are prefixed by their respective types in the response.
-      * @server_default false
-      * @availability stack since=8.14.0
-      * @availability serverless
-      */
+    /**
+     * Determines whether aggregation names are prefixed by their respective types in the response.
+     * @server_default false
+     * @availability stack since=8.14.0
+     * @availability serverless
+     */
     typed_keys?: boolean
   }
   body: {


### PR DESCRIPTION
This PR changes the client spec to support the new
`with_profile_uid` request parameter, as well as the
corresponding `profile_uid` response field in the returned API key information,
for the Get and Query API key endpoints, from https://github.com/elastic/elasticsearch/pull/106531 .

Separately it adds support for the `typed_keys` request parameter to
the Query API key endpoint, from https://github.com/elastic/elasticsearch/pull/106873

It also exposes the `realm_type` field in the returned API key information,
from https://github.com/elastic/elasticsearch/pull/105629