### PR TITLE
Get Role Mappings optional roles field

### DIFF
--- a/specification/security/_types/RoleMapping.ts
+++ b/specification/security/_types/RoleMapping.ts
@@ -25,7 +25,9 @@ import { RoleTemplate } from './RoleTemplate'
 export class RoleMapping {
   enabled: boolean
   metadata: Metadata
+  // Exactly one of roles or role_templates should be set
   roles?: string[]
-  rules: RoleMappingRule
+  // Exactly one of roles or role_templates should be set
   role_templates?: RoleTemplate[]
+  rules: RoleMappingRule
 }

--- a/specification/security/_types/RoleMapping.ts
+++ b/specification/security/_types/RoleMapping.ts
@@ -25,7 +25,7 @@ import { RoleTemplate } from './RoleTemplate'
 export class RoleMapping {
   enabled: boolean
   metadata: Metadata
-  roles: string[]
+  roles?: string[]
   rules: RoleMappingRule
   role_templates?: RoleTemplate[]
 }

--- a/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
+++ b/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
@@ -37,7 +37,9 @@ export interface Request extends RequestBase {
   body: {
     enabled?: boolean
     metadata?: Metadata
+    // Exactly one of roles or role_templates must be specified
     roles?: string[]
+    // Exactly one of roles or role_templates must be specified
     role_templates?: RoleTemplate[]
     rules?: RoleMappingRule
     run_as?: string[]


### PR DESCRIPTION
The `roles` is optional the same way as `role_templates` is.
ES in both 7.17 [https://github.com/elastic/elasticsearch/blob/92f290e9537478f85ff3fe3ab39945c1a49a[…]k/core/security/authc/support/mapper/ExpressionRoleMapping.java](https://github.com/elastic/elasticsearch/blob/92f290e9537478f85ff3fe3ab39945c1a49a6c1a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java#L236) and master (8.13) [https://github.com/elastic/elasticsearch/blob/09df99393193b2c53d92899662a8b8b3c55b[…]k/core/security/authc/support/mapper/ExpressionRoleMapping.java](https://github.com/elastic/elasticsearch/blob/09df99393193b2c53d92899662a8b8b3c55b45cd/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java#L237)
would only show the `roles` and `roles_templates` fields in the response if they are non-empty.