### PR TITLE
Adding the API design guidelines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
-# Elasticsearch Specification
+# Elasticsearch API Specification
 
-This repository contains the Elasticsearch request/response definitions in TypeScript,
-you can find them inside [`/specification`](./specification).
-The [`/compiler`](./compiler) folder contains a TypeScript program that compiles the entire definition
-in a JSON representation that can be used for generating language clients.
+The **Elasticsearch API Specification** provides the contract for communication between client and server components within the Elasticsearch stack.
+With almost 500 API endpoints and around 3000 data types across the entire API surface, this project is vitally important for sustaining our engineering efforts at scale.
+
+The repository has the following structure:
+
+| Path | Description |
+| -------- | ------- |
+| [`api-design-guidelines/`](api-design-guidelines/) | Knowledge base of best practices for API design. |
+| [`compiler/`](compiler/) | TypeScript compiler for specification definition to JSON. |
+| [`compiler-rs/`](compiler-rs/) | |
+| [`docs/`](docs/) | |
+| [`output/`](output/) | |
+| [`specification/`](specification/) | Elasticsearch request/response definitions in TypeScript. |
+| [`typescript-generator/`](typescript-generator/) | |
 
 This JSON representation is formally defined by [a set of TypeScript definitions (a meta-model)](./compiler/src/model/metamodel.ts)
 that also explains the various properties and their values.
+
 
 ## Prepare the environment
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Elasticsearch API Specification
 
 The **Elasticsearch API Specification** provides the contract for communication between client and server components within the Elasticsearch stack.
-With almost 500 API endpoints and around 3000 data types across the entire API surface, this project is vitally important for sustaining our engineering efforts at scale.
+With almost 500 API endpoints and around 3000 data types across the entire API surface, this project is a vitally important part of sustaining our engineering efforts at scale.
 
 The repository has the following structure:
 

--- a/api-design-guidelines/README.md
+++ b/api-design-guidelines/README.md
@@ -1,0 +1,11 @@
+# Elasticsearch API design guidelines
+
+This document aims to provide a set of design guidelines for drawing up HTTP APIs in a way that is consistent and easy to consume. These concerns are becoming ever more important, as the number of API consumers grows, and as new systems are built upon these lower layers. One such project involves the automatic generation of API documentation, the existence of which is crucial for the effective communication of the Elastic product surface to users.
+
+While it is also desirable and beneficial to align existing APIs with these design principles, this is very much recognised as a complex secondary concern, which can only happen gradually over a longer period of time.
+
+All guidelines are just that: guidelines. These should not be read as hard rules, but as a set of best practices distilled from our collective experience. As such, deviation from these guidelines is acceptable, but must be accompanied by a solid reasoning for that deviation.
+
+* [Naming](naming.md)
+* [Data modelling](data-modelling.md)
+* [Requests and responses](requests-responses.md)

--- a/api-design-guidelines/data-modelling.md
+++ b/api-design-guidelines/data-modelling.md
@@ -1,12 +1,4 @@
----
-id: esTmApiGuidelinesDataModelling
-slug: /elasticsearch-team/api-guidelines/data-modelling
-title: Data modelling
-image: https://source.unsplash.com/400x175/?Nature
-description: API guidelines - Data modelling
-date: 2022-06-26
-tags: ['elasticsearch','internal docs']
----
+# API guidelines - Data modelling
 
 Request and response bodies are typically encoded in JSON. The full JSON specification is defined in [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259).
 

--- a/api-design-guidelines/data-modelling.md
+++ b/api-design-guidelines/data-modelling.md
@@ -1,0 +1,275 @@
+---
+id: esTmApiGuidelinesDataModelling
+slug: /elasticsearch-team/api-guidelines/data-modelling
+title: Data modelling
+image: https://source.unsplash.com/400x175/?Nature
+description: API guidelines - Data modelling
+date: 2022-06-26
+tags: ['elasticsearch','internal docs']
+---
+
+Request and response bodies are typically encoded in JSON. The full JSON specification is defined in [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259).
+
+## JSON objects are not ordered
+
+JSON objects must be conceptually treated as **unordered**. Maintaining order of deserialized JSON objects is not supported in general, and isn’t possible in some programming languages.
+
+If preservation of order is important, such ordering information should be represented separately. The examples below shows a plain (unordered) object alongside three alternative representations which also provide ordering detail.
+
+```json
+// Plain object (unordered)
+{
+  "one": "eins",
+  "two": "zwei",
+  "three": "drei"
+}
+
+// List of single key objects
+[
+  {"one": "eins"},
+  {"two": "zwei"},
+  {"three": "drei"}
+]
+
+// List of key-value lists
+[
+  ["one", "eins"],
+  ["two", "zwei"],
+  ["three", "drei"]
+]
+
+// List of key-value objects
+[
+  {"key": "one", "value": "eins"},
+  {"key": "two", "value": "zwei"},
+  {"key": "three", "value": "drei"}
+]
+```
+
+Ordering of keys in JSON objects should be consistent when serialized into a response body to avoid being confusing to human viewers.
+
+## JSON objects and query parameters must not have duplicate keys
+
+JSON objects and query string parameters must not use duplicate keys. The behaviour of most JSON libraries and language modules is undefined in this regard, and therefore unexpected consequences are likely to occur if duplicate keys are passed.
+
+## Avoid null and empty string to mark a value as missing
+
+Nulls are sometimes used to mark a value as "missing" or "not available". Instead of returning `null` as a value in JSON prefer to omit the field in the response. Empty strings (`""`) should similarly not be used to denote a missing string value as they can be confused for an explicit value of the empty string. It is fine to accept `null` in the request if they have special semantics such as unsetting a value. Otherwise fields that would have null or empty string values should also be omitted in the request.
+
+- DON'T:
+  ```json
+  {"key1": 1, "key2": null} 
+  ```
+- DON'T:
+  ```json
+  {"key1": 1, "key2": ""}
+  ```
+- DO:
+  ```json
+  {"key1": 1}
+  ```
+
+## Consider the portability of numeric values over JSON
+
+Numeric values can be subject to a couple of limitations that exist in some JSON parsers:
+
+- Values with more than 53 bits of precision are not guaranteed to be interpreted losslessly due to the limitations of the IEEE 64-bit floating point number format, which is used by some parsers. This most notably affects large integer values within the int64 and uint64 ranges.
+
+- Special floating point values (NaN, Infinity and negative zero) are not included in the official JSON spec and, as such, are not reliably understood by all JSON parsers.
+
+In general, a solution to both of these problems is to permit numeric values to be encoded as either JSON strings or JSON numbers for certain cases. However, this solution should only be employed in conjunction with the corresponding API specification, wherein the correct data type and numeric range for a particular field can be denoted. It is the responsibility of the API designer to ensure that ambiguity does not occur between numeric values passed as strings and true string values.
+
+### Integer values
+
+If the API specification defines a field as having a type of int8, int16 or int32 (or equivalent numeric range) then corresponding values should always be encoded as JSON numbers, as no lossiness can occur within these ranges.
+
+If the API specification defines a field as having a type of int64 or uint64 (or equivalent numeric range) then corresponding values may be passed as either JSON numbers or JSON strings. Note that the smallest positive integer that is subject to potential lossiness is (2^53 + 1) and the smallest equivalent negative integer is (-2^53 - 1).
+
+```python
+>>> 2**53+1, int(float(2**53+1))
+(9007199254740993, 9007199254740992)
+
+>>> -2**53-1, int(float(-2**53-1))
+(-9007199254740993, -9007199254740992)
+```
+
+In all integer cases, JSON numbers and equivalent JSON strings should only ever be written as digits with an optional sign prefix. A decimal point should never be written for integer fields (even if the fractional component is "`.0`") as JSON parsers that distinguish between numeric types will typically interpret such a value as a floating point number rather than as an integer.
+
+### Floating point values
+
+If the API specification defines a field as having a type of float32 or float64 then corresponding values may be passed as either JSON numbers or JSON strings. All such values should be written with a decimal point and fractional component, even if that fractional component is ".0". If a field is likely to need to pass special values, consider always encoding the values as strings, for simpler client-side processing.
+
+To ensure maximum portability, all special values must be passed as JSON strings and must be encoded precisely according to the table below, including casing.
+
+| JSON output   | Description       |
+|---------------|-------------------|
+| `"-0.0"`      | Negative zero     |
+| `"NaN"`       | Not a number      |
+| `"Infinity"`  | Positive infinity |
+| `"+Infinity"` | Positive infinity |
+| `"-Infinity"` | Negative infinity |
+
+### Don't mix static and dynamic keys in JSON objects
+
+Modelling objects that are a mix between static and dynamic keys is more complex to parse and extend as an API as you need to provide a hash/dictionary-like structure for arbitrary key access in addition to a structure that has properties. To avoid this problem **dynamic values like names and IDs shouldn’t be mixed with static keys in objects**.
+
+An example of mixed static and dynamic keys can be seen in the `indices.field_usage_stats` endpoint response:
+
+```json
+{
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "failed": 0
+  },
+  "my-index": { ... }
+}
+```
+
+The key `"my-index"` is user-defined wheras `"_shards"` is static. This API would be easier to model by keeping all dynamic keys in their own object:
+
+```json
+{
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "failed": 0
+  },
+  "indices": {
+     "my-index": { ... }
+  }
+}
+```
+
+Or better yet, to completely avoid using dynamic keys the user-defined value can be a property value within the object itself:
+
+```json
+{
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "failed": 0
+  },
+  "indices": [
+    {"name": "my-index", ...}
+  ]
+}
+```
+
+### Model object variants in a consumable way
+
+Sometimes an API accepts an object but the keys are determined by what "kind/variant" of the object is intended. An example of this is aggregations, queries, and pipeline steps. There are two ways the Elasticsearch API handles this situation. The first method is using an **internal variant type** property like "type" with analyzers:
+
+```json
+{
+  "type": "snowball",
+  "stopwords": ["if", "and", "but"]
+}
+```
+
+The second is using **external variants** where the inner object is wrapped with an object with a single key containing the kind of the inner object. This example changes the analyzer from above to use an external variant:
+
+```json
+{
+  "snowball": {
+    "stopwords": ["if", "and", "but"]
+  }
+}
+```
+
+When choosing between these two possibilities **favor using external variants** as it removes the requirement to buffer key-value pairs until the internal variant property is found. Using external variants also improves traversability of the API (ie auto-complete) as properties can be anticipated without waiting for the discriminant property.
+
+## Model enumerations in a portable way
+
+Enumerations should be modelled in a way that is most portable across programming languages. The following guidelines apply:
+
+- Always use string values
+- Values should be case-sensitive and casing should be consistent across the enumeration.
+- Values should only use basic characters
+
+**Note that booleans and enumerations are distinct types**. Historically, some enum values have evolved from booleans, but where the original boolean form remains, a clumsy mixture of accepted values sometimes results. For example:
+
+```ts
+enum DynamicMapping {strict, runtime, true, false}
+```
+
+Where the above type describes the value accepted by the "dynamic_mapping" parameter. While this may be useful for backwards compatibility, this arguably actually introduces a new value which has been conflated with the original. Additionally, changing a value from `boolean -> union[bool|enum]` isn’t backwards compatible for clients. An alternative might be:
+
+```ts
+bool DynamicMappingEnabled {true, false}
+// only use DynamicMapping if the first value is true
+enum DynamicMapping {simple, strict, runtime}
+```
+
+Or adding a "disabled" value to the enum:
+
+```ts
+enum DynamicMapping {simple, strict, runtime, disabled}
+```
+
+## Units
+
+Below is the complete set of units that are accepted by Elasticsearch along with their canonicalized suffix or abbreviation. Note that these units are case-sensitive as there can be collisions within a category (e.g. minute versus month)
+
+| Category  | Unit                    | Suffix(es) / Abbreviation |
+|-----------|-------------------------|---------------------------|
+| Duration  | Nanosecond              | ns, nanos¹                |
+| Duration  | Microsecond             | us, micros                |
+| Duration  | Millisecond             | ms, millis¹               |
+| Duration  | Second                  | s, seconds                |
+| Duration  | Minute                  | m, minutes                |
+| Duration  | Hour                    | h, hours                  |
+| Duration  | Day                     | d, days                   |
+| Duration  | Month                   | M, months                 |
+| Duration  | Year                    | y, years                  |
+| Distance  | Millimeter              | mm, millimeters           |
+| Distance  | Centimeter              | cm, centimeters           |
+| Distance  | Meter                   | m, meters                 |
+| Distance  | Kilometer               | km, kilometers            |
+| Distance  | Inch                    | in, inches                |
+| Distance  | Foot                    | ft, feet                  |
+| Distance  | Mile                    | mi, miles                 |
+| Distance  | Nautical Mile           | nmi, nautical_miles       |
+| Byte size | Byte                    | b, bytes                  |
+| Byte size | Kilobyte ("kibibyte") ² | kb                        |
+| Byte size | Metabyte ("mibibyte") ² | mb                        |
+| Byte size | Gigabyte ("gibibyte") ² | gb                        |
+| Byte size | Terabyte ("tebibyte") ² | tb                        |
+| Byte size | Petabyte ("pebibyte") ² | pb                        |
+
+¹ "millis" and "nanos" are used already in the API as a suffix for field names to either represent a datetime value in terms of "units since the epoch" or a duration of time.
+For example: `{"start_date_in_millis": 1652296510000}` or `{"duration_in_millis": 10}`
+
+² Note that Elasticsearch uses suffixes like "kb" (Kilobytes) instead of "kib" (Kibibytes) despite scaling bytes values by factors of 1,024 instead of 1,000. Also note that the suffixes for these units in prose use an uppercase "B" to represent bytes (ie kB, not kb) as lowercase "b" means bits instead of bytes.
+
+For the following measures consider using the default unit in order to be consistent with other areas in the API:
+
+| Metric    | Recommended unit | Suffix examples      |
+|-----------|------------------|----------------------|
+| Duration  | milliseconds     | "duration_in_millis" |
+| Byte size | bytes            | "memory_in_bytes"    |
+
+Values which have a unit should be explicit by specifying the name in the property, name in the value, or unit as a separate property in the same object.
+
+- DO: `{"took_in_millis": 3}`
+- DO: `{"took": "3ms"}`
+- DO: `{"took": {"value": 3, "unit": "ms"}}`
+- DON'T:  `{"took": 3}`
+
+## Formats
+
+Many of our APIs support users supplying values in multiple different formats. For example, a duration can be specified either as an integer value (10000) or as a string value ("10s") and mean the same thing assuming the default unit is "milliseconds" for this value. This is especially true for APIs accepting dates and times.
+
+For the sake of user experience we should accept values in different formats. For values that accept multiple formats the format should be explicitly set by users so Elasticsearch can interpret and validate the value based on the given format. For example:
+
+```json
+{"type": "date", "format": "yyyy-MM-dd HH:mm:ss"}
+```
+
+Values that are returned in responses (with the exception of user-specified values) must always be in the same format. Below is the set of formats to use to be consistent with other APIs:
+
+| Metric    | Format   | Example(s)            |
+|-----------|----------|-----------------------|
+| Date      | ISO 8601 | "2022-05-10"          |
+| Datetime  | ISO 8601 | "2022-05-10 16:00:00" |
+| Time zone | ISO 8601 | "Z", "-05:00"         |

--- a/api-design-guidelines/naming.md
+++ b/api-design-guidelines/naming.md
@@ -1,12 +1,4 @@
----
-id: esTmApiGuidelinesNaming
-slug: /elasticsearch-team/api-guidelines/naming
-title: Naming
-image: https://source.unsplash.com/400x175/?Nature
-description: API guidelines - Naming
-date: 2022-06-26
-tags: ['elasticsearch','internal docs']
----
+# API guidelines - Naming
 
 Names are everywhere when designing an API. This section applies to:
 

--- a/api-design-guidelines/naming.md
+++ b/api-design-guidelines/naming.md
@@ -1,0 +1,170 @@
+---
+id: esTmApiGuidelinesNaming
+slug: /elasticsearch-team/api-guidelines/naming
+title: Naming
+image: https://source.unsplash.com/400x175/?Nature
+description: API guidelines - Naming
+date: 2022-06-26
+tags: ['elasticsearch','internal docs']
+---
+
+Names are everywhere when designing an API. This section applies to:
+
+- Endpoint namespaces
+- Endpoint names
+- Path and query parameter names
+- Properties in a JSON object that aren't user defined or generated (like IDs)
+- Enum values
+
+## Use basic characters for names
+
+Names should only consist of the following characters:
+
+- Basic Latin letters: `A-Z` and `a-z`
+- Arabic numerals: `0-9`
+- Underscores: `_`
+
+Additionally the first character of a name should not be numeric.
+
+- DO: `name`
+- DONT: `1name`
+
+In general lowercase letters should be favored over uppercase letters in names. An example of when uppercase characters should be used is when there's disambiguation required between two different casings (such as (`M`)onth versus (`m`)inute).
+
+## Use underscores for readability
+
+Words within a name should be separated by an underscore. Phrases that are hyphenated will usually be combined into a single string of characters without an underscore between them. Favor readability over strict adherence to rules. Names and phrases that already have a representation in use within the Elasticsearch API should be used as they are for consistency.
+
+In the below examples the phrase being transformed into a name for the API is "searchable snapshot":
+
+- DO: `searchable_snapshot`
+- DON'T: `search_able_snapshot` (even if it were "search-able snapshot" this isn't correct)
+- DON'T: `searchablesnapshot`
+- DON'T: `searchable_snap_shot` ("snapshot" is one word)
+
+## Avoid reserved words when choosing names
+
+Care should be given when naming to avoid using keywords that are reserved in common programming languages. While some automation does exist to protect against this in some situations, it is not foolproof. Therefore API designers should carry out due diligence on this matter before committing to particular naming.
+
+The primary languages officially supported by Elastic are C#, Go, Java, JavaScript, PHP, Python, and Ruby. More information on which languages use which keywords can be [found here](https://nige.tech/keywords.html).
+
+## Name uniqueness
+
+Leading and trailing underscores and casing shouldn't be taken into account when considering the uniqueness of names within the same context. For example, the following names should all be considered equivalent in terms of uniqueness:
+
+- `nodes`
+- `Nodes`
+- `_nodes`
+- `__nodes`
+- `__NODES__`
+
+Some programming languages place special meaning on underscore prefixes and suffixes. Casing rules and conventions are not flexible across languages in general. Prefer instead to use completely separate names and terms for distinct cases.
+
+See the below example with a JSON object with two properties `nodes` and `_nodes`:
+
+```json
+{
+  "nodes": {...},
+  "_nodes": {...}
+}
+```
+
+For this API the generated structure in some programming languages would have a clash between the names of the two properties which would require inventing a name for one of the properties. Diversions from the API as it is on the wire are likely to cause confusion for users and should be avoided if possible. Instead these properties could be named more semantically as follows:
+
+```json
+{
+  "nodes": {...},
+  "node_info": {...}
+}
+```
+
+## Nesting and dots
+
+Dots are permitted as separators when nesting, but these should not be considered part of the name itself. Instead dotted keys should be considered an alternate method of specifying nested structures across multiple names. The two below are equivalent:
+
+- `{"index.settings.number_of_shards": 1}`
+- `{"index": {"settings": {"number_of_shards": 1}}`
+
+If an API supports specifying a structure with dotted notation that API must also allow specifying the same structure via nested objects. Language clients do not generate APIs and structures for dotted notation, they only support the nested object notation.
+
+The rules for dotted keys only apply to API-specified structures. Dots are allowed within a "name" when the name is user-specified, such as a field name, without requiring nesting rules in every part of the API using fields.
+
+## Naming endpoints
+
+Endpoint names and namespaces should only use lowercase Latin letters and underscores. Ideally endpoint names combined with their namespace (if any) should be visually mappable to the corresponding HTTP request method and path.
+
+- `search` -> `POST /_search` and `POST /<index>/_search`
+- `cluster.health` -> `GET /_cluster/health`
+- `ccr.get_auto_follow_pattern` -> `GET /_ccr/auto_follow/<name>`
+
+### Choosing the right endpoint namespace
+
+Namespaces are useful to separate and contain related pieces of functionality. They are an abstraction that allows users to organize and locate parts of the product surface and reduce mental overhead.
+
+As such, there is no requirement for the organization of the product surface to reflect the structure of the underlying implementation. A module of code may expose APIs over multiple namespaces. Conversely, multiple modules may collaborate within the same namespace.
+
+Care should be given to ensure that:
+
+- All member APIs of a given namespace are logically related and form a coherent set.
+- Related functionality is not distributed across multiple arbitrary namespaces
+
+### Use the global namespace sparingly
+
+The top-level global namespace should be treated with particular care. It is traditionally reserved for search and document endpoints only. A case should be made and a broader discussion carried out before new endpoints unrelated to these functions are added to the global namespace.
+
+## Use consistent naming conventions for endpoints
+
+Certain endpoint name prefixes have established meaning by convention. For consistency these should be maintained for all new endpoints:
+
+| Prefix    | Meaning                                                         |
+|-----------|-----------------------------------------------------------------|
+| `get_`    | CRUD read                                                       |
+| `put_`    | Create or replace                                               |
+| `update_` | CRUD or patch update                                            |
+| `delete_` | CRUD delete                                                     |
+| `create_` | CRUD create                                                     |
+| `search_` | Ask an index for a set of documents that match given criteria   |
+| `query_`  | Higher-level search abstraction which protects internal indices |
+
+The following parameters are conventionally used for pagination:
+
+| Prefix | Meaning                                                             |
+|--------|---------------------------------------------------------------------|
+| `from` | The offset into the list of objects to start adding to the response |
+| `size` | The maximum number of objects to include in the response            |
+
+## Choosing the request path
+
+Every endpoint must have a request path that uniquely identifies the endpoint from other endpoints. A request path is made up of zero or more path segments delimited by a forward slash character (`/`). Path segments will either be a set value (like `_search`) or will be a dynamic segment which are referred to as "path parameters" where a value can be supplied to target specific resources on the server.
+
+If the endpoint belongs to a namespace (e.g. `async_search.submit` belongs to the `async_search` namespace) then the endpoint must have it's first path segment be the namespace prefixed with an underscore:
+
+- `async_search` namespace → `/_async_search/` path prefix
+
+Path segments should only have an underscore prefix in the following conditions:
+
+- The first or "root" path segment in a endpoint with a namespace.
+- The path shares a prefix with an existing endpoint that at the same path segment index has a path parameter.
+
+Underscores should be avoided if the above conditions aren't met to avoid adding underscores to path segments when they aren't necessary.
+
+To avoid causing future cases of the second condition, path segments that are a path parameter should always be preceded by a path segment that describes the resource being identified. This advice applies to child resource identifiers too.
+
+- DO: `/_ilm/policy/<policy_name>`
+- DON'T: `/_ilm/<policy_name>`
+- DON'T: `/_ilm/_policy/<policy_name>`
+
+- DO: `/_snapshot/<repository>/snapshot/<snapshot>`
+- DON'T: `/_snapshot/<repository>/<snapshot>`
+- DON'T: `/_snapshot/<repository>/_snapshot/<snapshot>`
+
+Model names within the path should be in singular form, not pluralized, even when the endpoint is capable of returning more than one of the model.
+
+- DO: `/_ingest/pipeline`
+- DON'T: `/_ingest/pipelines`
+
+If a path prefix has a path parameter to request a given resource (like an ID or name) and includes an option to request "all" of a resource, instead of omitting the path parameter from the path for the "all" case the path parameter should be required to be set to "`*`" or a wildcard pattern ("`*foo`") to keep the number of path segments consistent:
+
+- DO: `/_searchable_snapshots/<id>/cache/stats`
+- DO: `/_searchable_snapshots/*/cache/stats`
+- DON'T: `/_searchable_snapshots/cache/stats`

--- a/api-design-guidelines/requests-responses.md
+++ b/api-design-guidelines/requests-responses.md
@@ -1,0 +1,157 @@
+# API guidelines - Requests and reponses
+
+## Denote endpoints intended for only human usage
+
+Some API functionality is designed for machines to consume while other functionality is intended to be used directly by humans. The former typically returns structured data, whereas the latter returns human readable information.
+
+Human and machine interfaces are also sometimes mixed together within the same endpoint.
+
+- [Where a parameter exists to switch the output from structured to human readable](https://github.com/elastic/elasticsearch-net/issues/5953)
+- Where syntactic sugar is added as a simpler way to make a request
+
+In these cases, **the API creator should always clearly denote which pieces of functionality are intended for direct human usage**. This allows tool authors to choose how or whether to support this functionality.
+
+## Use HTTP methods correctly
+
+Methods such as GET and POST must be used consistently in adherance to HTTP standards. Failing to do this can result in third-party network hardware and software being unable to correctly route or handle requests and responses.
+
+For example, if your request has an optional or required body then do not use GET as a method. From RFC 9110 Section 9.3.1:
+
+> Although request message framing is independent of the method used, content received in a GET request has no generally defined semantics, cannot alter the meaning or target of the request, and might lead some implementations to reject the request and close the connection because of its potential as a request smuggling attack.
+
+Use instead an alternative method which does support a request body such as POST.
+
+[RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110) also defines a number of terms relating to the expected behavior of HTTP methods:
+
+- [Safe](https://datatracker.ietf.org/doc/html/rfc9110#section-9.2.1): a method is **safe** if it is read-only, and makes no state change on the server.
+- [Idempotent](https://datatracker.ietf.org/doc/html/rfc9110#section-9.2.2): a method is **idempotent** if the effect of a single request is identical to the effect of multiple identical requests.
+- [Cacheable](https://datatracker.ietf.org/doc/html/rfc9110#section-9.2.3): a method is **cacheable** if its response may be stored by browsers/proxies/clients for future reuse.
+
+The table shows which properties apply to which HTTP methods:
+
+| Method    | Safe | Idempotent | Cacheable | Request body allowed | Response body allowed |
+|-----------|------|------------|-----------|----------------------|-----------------------|
+| `GET`     | Y    | Y          | Y         | N                    | Y                     |
+| `HEAD`    | Y    | Y          | Y         | N                    | N                     |
+| `POST`    | N    | N          | Y/N¹      | Y                    | Y                     |
+| `PUT`     | N    | Y          | N         | Y                    | Y                     |
+| `DELETE`  | N    | Y          | N         | N                    | Y                     |
+| `PATCH`   | N    | Y/N²       | N         | Y                    | Y                     |
+| `OPTIONS` | Y    | Y          | N         | N                    | N³                    |
+
+- ¹ A POST response is not HTTP cacheable by peers unless explicit freshness information is included. The server-side implementation may still make use of caching.
+- ² PATCH is not idemptotent as defined in RFC 2616, but a note on idempotent use of PATCH can be found in RFC 5789
+- ³ RFC 7231 does not strictly disallow a response body for OPTIONS, but does not define its purpose either. A Content-Length header must be included in the response, however.
+
+## Use appropriate HTTP methods and status codes
+
+When designing an endpoint, consider which style of interaction is most appropriate and adhere to convention accordingly. Common endpoint styles include:
+
+- Representational State Transfer (REST)
+- Blocking Remote Procedure Call (Blocking RPC)
+- Asynchronous Remote Procedure Call (Async RPC)
+
+### Representational State Transfer (REST)
+
+Under REST each endpoint is treated as a remote resource or collection of resources and HTTP methods are employed similarly to CRUD operations.
+
+Many REST GET endpoints support fetching models using a single identifier, a comma-separated list of identifiers, and sometimes identififer patterns including wildcards. In order to avoid running into problems with maximum response sizes, consider adding support for fetching results over multiple requests using pagination (`size`/`from`) or a cursor (`scroll`, `search_after`).
+
+| Behavior                    | Method | Status Codes                                                  |
+|-----------------------------|--------|---------------------------------------------------------------|
+| Fetch one or more resources | GET    | 200 OK, 404 Not Found                                         |
+| Check resource exists       | HEAD   | 200 OK, 404 Not Found                                         |
+| Create resource             | POST   | 201 Created, 400 Bad Request, 409 Conflict (already exists)   |
+| Create or replace resource  | PUT    | 200 OK (on replace), 201 Created (on create), 400 Bad Request |
+| Delete resource             | DELETE | 200 OK, 404 Not Found                                         |
+
+### Blocking Remote Procedure Call (Blocking RPC)
+
+Blocking RPC is a style which treats the endpoint as a foreground data processor. Inputs are provided and proceeded and outputs are returned directly in the HTTP response. While the response may begin streaming back bto the client before processing has been completed it is expected that completion have occurred by the time the response hnas been fully transmitted.
+
+Given the wide variety of functionality that an RPC endpoint may undertake, there is no clear way to map status codes meaningfully. Therefore, only a small selection of status codes should be used with other detailed summary information (for success or failure) included within the error response body.
+
+| Behavior               | Method | Status Codes            |
+|------------------------|--------|-------------------------|
+| Execute a blocking RPC | `POST` | 200 OK, 400 Bad Request |
+
+### Async Remote Procedure Call (Async RPC)
+
+Async RPC is a style which treatts the endpoint as a background data processor. Inputs are provided and processed is passed to a background task with only the acknowledgement of acceptance or rejection returned in the HTTP response. Following up on the background task and obtaining results from that task will require further exchanges between client and server. The exact nature of these exchanges is not defined here.
+
+Given the wide variety of functionality that an RPC endpoint may potentially undertake there is no clear way to map status codes meaningfully. Therefore, only a small selection of status codes should be used, with other detailed summary information for success or failure included within the response body.
+
+**Note that unlike blocking RPC endpoints async RPC endpoints should return 202 Accepted to indicate that the work has been successfully accepted.**
+
+| Behavior           | Method | Status Codes                                 |
+|--------------------|--------|----------------------------------------------|
+| Start an async RPC | `POST` | 202 Accepted, 400 Bad Request, 404 Not Found |
+
+## Avoid defining the same request parameter in path, query string, and body
+
+There should be only a single canonical way to pass each request parameter. Allowing the same parameter to be supplied in the path, the query string, and the body adds complexity and ambiguity to the API definition wherein custom rules must be defined for resolving conflicts.
+
+It's best to use the body for large or high cardinality variable-length request components, such as lists of fields, query definitions, etc. Servers often place a limit on the URI length, which can prevent users from passing this data through a path or query string. Some examples of values that should be sent in the request bodies are given below:
+
+- Large values (Scroll ID, Point in Time ID)
+- Large objects (Query DSL, aggregations, machine learning models)
+- High cardinality variable length values (list of fields, indices, shards, document IDs)
+
+## Adhere to the robustness principle
+
+The robustness principle states:
+
+> "be conservative in what you do, be liberal in what you accept from others"
+
+This principle can apply in a number of ways, but in particular it can determine the design of API requests and responses. An API request may be built flexibly so as to allow both verbose detailed payloads and terse convenience payloads. The corresponding response, however, should always be structured predictably, and not depend on a particular syntax used within the request.
+
+As an example, consider an API that looks up entities based on their ID. The request may be structured to allow either a single ID or a collection of IDs to be passed in. However, the API response should always return a collection of entities, even if that collection only contains one entity.
+
+This principle allows for simpler consumer code that neither has to remember state between request and response, nor needs to "sniff" the output to determine its structure. If multiple variants of the response are truly desired, this may suggest that multiple API endpoints should be introduced, for example called `get_single_entity` and `get_multiple_entities`.
+
+An example of this is the datafeeds API which accepts either a string or list of strings for indices but always returns a list of strings:
+
+```json
+PUT /_ml/datafeeds/feed-id
+{
+  "indices": "index-name", // Input is a string.
+  ...
+}
+
+GET /_ml/datafeeds/feed-id
+{
+  "indices": ["index-name"], // Always returns a list of strings.
+  ...
+}
+```
+
+## Consider how client functions would wrap the API endpoint
+
+It is common within client-side architecture to provide a one-to-one mapping between API endpoint and client language function. This simplifies implementation and documentation, provides good developer experience, and makes tracking of endpoint usage straightforward.
+
+The semantics of HTTP and language functions typically differ in a number of ways, however, with HTTP generally allowing a broader range of functionality. The available semantics are constrained further when portability across multiple languages is concerned. It is therefore useful to consider these differences during API design in order to create a programmatic interface that is sympathetic to available client-side functionality.
+
+The generic form of a language client function is:
+
+`name(arguments) -> success response | error response`
+
+The `name` of the function is typically restricted to alphanumeric characters and underscores. Naming is discussed in detail elsewhere in the guidelines.
+
+Functions also only allow a single return / response type which is the "nominal successful response". Error responses can vary based on status code but at a minimum should match the following structure:
+
+```json
+{
+  "type": "error type",
+  "reason": "<human readable message>",
+  "stack_trace": "<optional stack trace if error_trace=true is used>",
+  ...
+}
+```
+
+### Single vs. Multiple endpoints
+
+While dynamically-typed languages can support typing variation and union types with relative ease, doing so is much more complex for statically-typed languages, such as Java, and often leads to a poor developer experience.
+
+On this basis, if an endpoint can return multiple 2xx (success) responses, then all corresponding payloads **must be structurally compatible**. In other words, it should be possible to comfortably store the body of any possible 2xx response within the same data structure. If this is not feasible, then multiple endpoints should be considered instead.
+
+Consequently, if it is desired that an operation can be carried out both synchronously and asynchronously, then each of these methods should be implemented as separate endpoints, since function signatures for these two approaches will necessarily be quite different.


### PR DESCRIPTION
This PR introduces the API Design Guidelines into this repository, giving them greater visibility. The content of these has not been changed, beyond conversion from `.mdx` to `.md`, which allows them to be viewed inline within GitHub (which is useful given that GitHub is a major part of the workflow for users of these).

The top-level README has also been updated to include reference to this new subdirectory, and a table of repo structure has been included.