### PR TITLE
Add null value and Setting type

### DIFF
--- a/specification/_spec_utils/utils.ts
+++ b/specification/_spec_utils/utils.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Stringified } from '@spec_utils/Stringified'
+
+/**
+ * A `null` value that is to be interpreted as an actual value, unless other uses of `null` that are equivalent
+ * to a missing value. It is used for exemple in settings, where using the `NullValue` for a setting will reset
+ * it to its default value.
+ */
+type NullValue = null
+
+/**
+ * Settings in Elasticsearch are values that can be reset to their default by setting them to the `null` value.
+ *
+ * @es_quirk Because of how they are implemented internally, settings are always returned as strings, even
+ *           if their value has been set using a primitive type.
+ */
+type Setting<T> = Stringified<T> | NullValue


### PR DESCRIPTION
This PR adds a `NullValue` type that is an alias to `null`, meant to represent "meaningful" null values, i.e. nulls that are not equivalent to missing value.

It also introduces a `Settings` type that represent a setting. Elasticsearch handles settings in very specific ways:
* setting their value to `null` resets the setting to its default value
* because of how they're implementing on the server, setting values are always returned as strings.

This PR does not uses these new types and value in the API specification. They first need to be implemented in code generators where relevant (a separate issue will track this).

Fixes #2049 - from the proposals in this issue, we introduce a specific type for meaningful nulls, but keep the standard typescript `null` for "null as optional".