### PR TITLE
Rerank renamed id to index

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -49756,7 +49756,7 @@
       "inference._types:RankedDocument": {
         "type": "object",
         "properties": {
-          "id": {
+          "index": {
             "type": "string"
           },
           "score": {
@@ -49767,7 +49767,7 @@
           }
         },
         "required": [
-          "id",
+          "index",
           "score"
         ]
       },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11523,7 +11523,7 @@ export interface InferenceModelConfigContainer extends InferenceModelConfig {
 }
 
 export interface InferenceRankedDocument {
-  id: string
+  index: string
   score: string
   text?: string
 }

--- a/specification/inference/_types/Results.ts
+++ b/specification/inference/_types/Results.ts
@@ -70,7 +70,7 @@ export class CompletionResult {
  * text: Optional, the text of the document, if requested
  */
 export class RankedDocument {
-  id: string
+  index: string
   score: string
   text?: string
 }


### PR DESCRIPTION
Following on the review of this PR, I am renaming the rerank parameter `id` to `index`. https://github.com/elastic/elasticsearch-specification/pull/2479