### PR TITLE
Query API Key Information API support for the typed_keys request parameter

### DIFF
--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -40,6 +40,13 @@ export interface Request extends RequestBase {
 
      */
     with_limited_by?: boolean
+    /**
+     * Determines whether aggregation names are prefixed by their respective types in the response.
+     * @server_default false
+     * @availability stack since=8.13.2
+     * @availability serverless
+     */
+    typed_keys?: boolean
   }
   body: {
     /**


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/pull/106873
Backported in https://github.com/elastic/elasticsearch/pull/107110