### PR TITLE
Fix 404 links in "add new api "docs

### DIFF
--- a/docs/add-new-api.md
+++ b/docs/add-new-api.md
@@ -20,7 +20,7 @@ Once you have added a new endpoint definition, the next step is to add its type 
 First of all, you should find the most approariate place inside [`/specification`](../specification)
 where to put the new definition. The content of [`/specification`](../specification)
 tryied to mimic the Elasticsearch online documentation, so you can use it as inspiration.
-For example, the index document defintion can be found in [`/specification/__global/index`](../specification/__global/index).
+For example, the index document defintion can be found in [`/specification/_global/index`](../specification/_global/index).
 
 Once you have found the best place for the new definition, you should create a new file for it.
 The filename should be the same of the type definition you are writing, for example:
@@ -98,7 +98,7 @@ interface Request<Generic> extends RequestBase {
 }
 ```
 And the generic will be used somewhere inside the definition.
-There are cases where the generic might be the entire body, see [`IndexRequest`](../specification/__global/index/IndexRequest.ts).
+There are cases where the generic might be the entire body, see [`IndexRequest`](../specification/_global/index/IndexRequest.ts).
 
 ### Add the endpoint response definition
 


### PR DESCRIPTION
Changing `__global` to `_global` in add new api docs

https://github.com/elastic/elasticsearch-specification/blob/main/specification/__global doesn't exist
<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
