### PR TITLE
Make NullValue and Setting public

### DIFF
--- a/specification/_spec_utils/utils.ts
+++ b/specification/_spec_utils/utils.ts
@@ -24,7 +24,7 @@ import { Stringified } from '@spec_utils/Stringified'
  * to a missing value. It is used for exemple in settings, where using the `NullValue` for a setting will reset
  * it to its default value.
  */
-type NullValue = null
+export type NullValue = null
 
 /**
  * Settings in Elasticsearch are values that can be reset to their default by setting them to the `null` value.
@@ -32,4 +32,4 @@ type NullValue = null
  * @es_quirk Because of how they are implemented internally, settings are always returned as strings, even
  *           if their value has been set using a primitive type.
  */
-type Setting<T> = Stringified<T> | NullValue
+export type Setting<T> = Stringified<T> | NullValue


### PR DESCRIPTION
PR #2478 introduced `NullValue` and `Settings` but was not exporting these types, and this went unnoticed as they were not used by other modules as part of that PR.