### PR TITLE
Index settings lifecycle name should be optional, not ILM policy name

### DIFF
--- a/specification/ilm/put_lifecycle/PutLifecycleRequest.ts
+++ b/specification/ilm/put_lifecycle/PutLifecycleRequest.ts
@@ -35,7 +35,7 @@ export interface Request extends RequestBase {
      * Identifier for the policy.
      * @codegen_name name
      */
-    policy?: Name
+    policy: Name
   }
   query_parameters: {
     /**

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -275,7 +275,7 @@ export class IndexSettingsLifecycle {
   /**
    * The name of the policy to use to manage the index. For information about how Elasticsearch applies policy changes, see Policy updates.
    */
-  name: Name
+  name?: Name
   /**
    * Indicates whether or not the index has been rolled over. Automatically set to true when ILM completes the rollover action.
    * You can explicitly set it to skip rollover.


### PR DESCRIPTION
JavaScript codegen [started failing](https://github.com/elastic/clients-team/actions/runs/8611069657/job/23597614947#step:3:205) for me after [this PR](https://github.com/elastic/elasticsearch-specification/pull/2485) merged the other day, specifically breaking on the "policy name in ILM should be optional" change. [The docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html#ilm-put-lifecycle-path-params) say `policy_id` is a required parameter, since it is part of the URL path. 

I'm fairly certain the optional name that [the original issue](https://github.com/elastic/elasticsearch-java/issues/456) was referring to was for `IndexSettingsLifecycle` rather than `PutLifecycleRequest`.
