### PR TITLE
Make SpanQuery non exhaustive, as they can be extended with plugins

### DIFF
--- a/specification/_types/query_dsl/span.ts
+++ b/specification/_types/query_dsl/span.ts
@@ -128,7 +128,10 @@ export class SpanWithinQuery extends QueryBase {
   little: SpanQuery
 }
 
-/** @variants container */
+/**
+ * @variants container
+ * @non_exhaustive
+ */
 export class SpanQuery {
   /**
    * Accepts a list of span queries, but only returns those spans which also match a second span query.


### PR DESCRIPTION
Span queries are a subset of queries, and as such can be extended through plugins.

Reported in https://github.com/elastic/elasticsearch-java/issues/780