### PR TITLE
Knn already inherits boost field

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -36117,10 +36117,6 @@
                 "description": "The number of nearest neighbor candidates to consider per shard",
                 "type": "number"
               },
-              "boost": {
-                "description": "Boost value to apply to kNN scores",
-                "type": "number"
-              },
               "filter": {
                 "description": "Filters for the kNN search query",
                 "oneOf": [

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -66,7 +66,6 @@
         "Request: query parameter 'scroll' does not exist in the json spec",
         "Request: query parameter 'rest_total_hits_as_int' does not exist in the json spec",
         "interface definition _types:QueryVectorBuilder - Property text_embedding is a single-variant and must be required",
-        "interface definition _types:KnnQuery - Property 'boost' is already defined in an ancestor class",
         "type_alias definition _spec_utils:PipeSeparatedFlags / union_of / instance_of - No type definition for '_spec_utils:T'"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2362,7 +2362,6 @@ export interface KnnQuery extends QueryDslQueryBase {
   query_vector?: QueryVector
   query_vector_builder?: QueryVectorBuilder
   num_candidates?: long
-  boost?: float
   filter?: QueryDslQueryContainer | QueryDslQueryContainer[]
   similarity?: float
 }

--- a/specification/_types/Knn.ts
+++ b/specification/_types/Knn.ts
@@ -60,8 +60,6 @@ export interface KnnQuery extends QueryBase {
   query_vector_builder?: QueryVectorBuilder
   /** The number of nearest neighbor candidates to consider per shard */
   num_candidates?: long
-  /** Boost value to apply to kNN scores */
-  boost?: float
   /** Filters for the kNN search query */
   filter?: QueryContainer | QueryContainer[]
   /** The minimum similarity for a vector to be considered a match */


### PR DESCRIPTION
removing boost from knn query, querybase already has it