### PR TITLE
Add esql version

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9686,7 +9686,7 @@ export type EqlSearchResponse<TEvent = unknown> = EqlEqlSearchResponseBase<TEven
 
 export type EqlSearchResultPosition = 'tail' | 'head'
 
-export type EsqlVersion = '2024.04.01' | 'snapshot'
+export type EsqlVersion = '2024.04.01'
 
 export interface EsqlQueryRequest extends RequestBase {
   format?: string

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9686,6 +9686,8 @@ export type EqlSearchResponse<TEvent = unknown> = EqlEqlSearchResponseBase<TEven
 
 export type EqlSearchResultPosition = 'tail' | 'head'
 
+export type EsqlVersion = '2024.04.01' | 'snapshot'
+
 export interface EsqlQueryRequest extends RequestBase {
   format?: string
   delimiter?: string
@@ -9695,6 +9697,7 @@ export interface EsqlQueryRequest extends RequestBase {
     locale?: string
     params?: ScalarValue[]
     query: string
+    version: EsqlVersion
   }
 }
 

--- a/specification/esql/_types/Version.ts
+++ b/specification/esql/_types/Version.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { integer } from '@_types/Numeric'
+import { Duration } from '@_types/Time'
+
+export enum Version {
+    /**
+     * Run against the first version of ESQL.
+     */
+    '2024.04.01',
+    /**
+     * Run against the unreleased version of the ESQL language. This will
+     * contain any changes staged for release that have yet to be included
+     * in a version.
+     */
+    snapshot
+}

--- a/specification/esql/_types/Version.ts
+++ b/specification/esql/_types/Version.ts
@@ -24,8 +24,8 @@ import { Duration } from '@_types/Time'
  * The version of the ES|QL language in which the "query" field was written.
  */
 export enum Version {
-    /**
-     * Run against the first version of ES|QL.
-     */
-    '2024.04.01',
+  /**
+   * Run against the first version of ES|QL.
+   */
+  '2024.04.01'
 }

--- a/specification/esql/_types/Version.ts
+++ b/specification/esql/_types/Version.ts
@@ -20,15 +20,12 @@
 import { integer } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
+/**
+ * The version of the ES|QL language in which the "query" field was written.
+ */
 export enum Version {
     /**
-     * Run against the first version of ESQL.
+     * Run against the first version of ES|QL.
      */
     '2024.04.01',
-    /**
-     * Run against the unreleased version of the ESQL language. This will
-     * contain any changes staged for release that have yet to be included
-     * in a version.
-     */
-    snapshot
 }

--- a/specification/esql/query/QueryRequest.ts
+++ b/specification/esql/query/QueryRequest.ts
@@ -62,7 +62,7 @@ export interface Request extends RequestBase {
      */
     query: string,
     /**
-     * The version of the ES|QL language in which the "query" field uses was written.
+     * The version of the ES|QL language in which the "query" field was written.
      */
     version: Version
   }

--- a/specification/esql/query/QueryRequest.ts
+++ b/specification/esql/query/QueryRequest.ts
@@ -60,7 +60,7 @@ export interface Request extends RequestBase {
     /**
      * The ES|QL query API accepts an ES|QL query string in the query parameter, runs it, and returns the results.
      */
-    query: string,
+    query: string
     /**
      * The version of the ES|QL language in which the "query" field was written.
      */

--- a/specification/esql/query/QueryRequest.ts
+++ b/specification/esql/query/QueryRequest.ts
@@ -20,6 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { ScalarValue } from '@_types/common'
+import { Version } from '@esql/_types/Version'
 
 /**
  * Executes an ES|QL request
@@ -59,6 +60,10 @@ export interface Request extends RequestBase {
     /**
      * The ES|QL query API accepts an ES|QL query string in the query parameter, runs it, and returns the results.
      */
-    query: string
+    query: string,
+    /**
+     * The version of the ES|QL language in which the "query" field uses was written.
+     */
+    version: Version
   }
 }


### PR DESCRIPTION
Adds a `version` parameter to the ESQL `_query` request endpoint. We'll do some work to give this a default value in the generated clients soon, but for 8.14+ this'll be a required parameter.
