### PR TITLE
Change `QueryCacheStats` field types from `int` -> `long`

### DIFF
--- a/specification/_types/Stats.ts
+++ b/specification/_types/Stats.ts
@@ -194,19 +194,19 @@ export class QueryCacheStats {
    * Total number of entries added to the query cache across all shards assigned to selected nodes.
    * This number includes current and evicted entries.
    */
-  cache_count: integer
+  cache_count: long
   /**
    * Total number of entries currently in the query cache across all shards assigned to selected nodes.
    */
-  cache_size: integer
+  cache_size: long
   /**
    * Total number of query cache evictions across all shards assigned to selected nodes.
    */
-  evictions: integer
+  evictions: long
   /**
    * Total count of query cache hits across all shards assigned to selected nodes.
    */
-  hit_count: integer
+  hit_count: long
   /**
    * Total amount of memory used for the query cache across all shards assigned to selected nodes.
    */
@@ -218,11 +218,11 @@ export class QueryCacheStats {
   /**
    * Total count of query cache misses across all shards assigned to selected nodes.
    */
-  miss_count: integer
+  miss_count: long
   /**
    * Total count of hits and misses in the query cache across all shards assigned to selected nodes.
    */
-  total_count: integer
+  total_count: long
 }
 
 export class RecoveryStats {


### PR DESCRIPTION
Server class: https://github.com/elastic/elasticsearch/blob/08a2f7991e214f2ac8e8b274ac51a540c30b6f3c/server/src/main/java/org/elasticsearch/index/cache/query/QueryCacheStats.java#L23

Related to: https://github.com/elastic/elasticsearch-net/issues/8015