### PR TITLE
Adding synonyms set to filters

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -45045,6 +45045,9 @@
               "synonyms_path": {
                 "type": "string"
               },
+              "synonyms_set": {
+                "type": "string"
+              },
               "tokenizer": {
                 "type": "string"
               },
@@ -45095,6 +45098,9 @@
                 }
               },
               "synonyms_path": {
+                "type": "string"
+              },
+              "synonyms_set": {
                 "type": "string"
               },
               "tokenizer": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4770,6 +4770,7 @@ export interface AnalysisSynonymGraphTokenFilter extends AnalysisTokenFilterBase
   lenient?: boolean
   synonyms?: string[]
   synonyms_path?: string
+  synonyms_set?: string
   tokenizer?: string
   updateable?: boolean
 }
@@ -4781,6 +4782,7 @@ export interface AnalysisSynonymTokenFilter extends AnalysisTokenFilterBase {
   lenient?: boolean
   synonyms?: string[]
   synonyms_path?: string
+  synonyms_set?: string
   tokenizer?: string
   updateable?: boolean
 }

--- a/specification/_types/analysis/token_filters.ts
+++ b/specification/_types/analysis/token_filters.ts
@@ -114,6 +114,7 @@ export class SynonymGraphTokenFilter extends TokenFilterBase {
   lenient?: boolean
   synonyms?: string[]
   synonyms_path?: string
+  synonyms_set?: string
   tokenizer?: string
   updateable?: boolean
 }
@@ -125,6 +126,7 @@ export class SynonymTokenFilter extends TokenFilterBase {
   lenient?: boolean
   synonyms?: string[]
   synonyms_path?: string
+  synonyms_set?: string
   tokenizer?: string
   updateable?: boolean
 }


### PR DESCRIPTION
SynonymGraphTokenFilter and SynonymTokenFilter should have the `synonyms_set` field.

- SynonymGraphTokenFilter [server code](https://github.com/elastic/elasticsearch/blob/4cca544ccb0c12e9c35cd7f1ba49c65d84456ba0/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java#L28)
- SynonymTokenFilter [server code](https://github.com/elastic/elasticsearch/blob/4cca544ccb0c12e9c35cd7f1ba49c65d84456ba0/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java#L169)
