### PR TITLE
Add `TermsRangeQuery`

### DIFF
--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -163,9 +163,30 @@ export class NumberRangeQuery extends RangeQueryBase {
   to?: double | null
 }
 
-/** @codegen_names date, number */
+export class TermsRangeQuery extends RangeQueryBase {
+  /**
+   * Greater than.
+   */
+  gt?: string
+  /**
+   * Greater than or equal to.
+   */
+  gte?: string
+  /**
+   * Less than.
+   */
+  lt?: string
+  /**
+   * Less than or equal to.
+   */
+  lte?: string
+  from?: string | null
+  to?: string | null
+}
+
+/** @codegen_names date, number, terms */
 // Note: deserialization depends on value types
-export type RangeQuery = DateRangeQuery | NumberRangeQuery
+export type RangeQuery = DateRangeQuery | NumberRangeQuery | TermsRangeQuery
 
 export enum RangeRelation {
   /**


### PR DESCRIPTION
Currently, we only support `DateRangeQuery` and `NumberRangeQuery`. According to the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html#ranges-on-text-and-keyword), range queries can as well be used with `text` and `keyword` fields.

Related to: https://github.com/elastic/elasticsearch-net/issues/8004