### PR TITLE
[8.14] Use alias types in connectors API where it makes sense (#2507)

### DIFF
--- a/specification/connector/_types/Connector.ts
+++ b/specification/connector/_types/Connector.ts
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Id, ScalarValue } from '@_types/common'
+import { Field, Id, IndexName, ScalarValue } from '@_types/common'
 import { double, integer, long } from '@_types/Numeric'
+import { DateTime } from '@_types/Time'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
@@ -120,7 +121,7 @@ interface CustomScheduling {
   configuration_overrides: CustomSchedulingConfigurationOverrides
   enabled: boolean
   interval: string
-  last_synced?: string
+  last_synced?: DateTime
   name: string
 }
 
@@ -167,18 +168,18 @@ enum FilteringRuleRule {
 }
 
 interface FilteringRule {
-  created_at: string
-  field: string
-  id: string
+  created_at: DateTime
+  field: Field
+  id: Id
   order: integer
   policy: FilteringPolicy
   rule: FilteringRuleRule
-  updated_at: string
+  updated_at: DateTime
   value: string
 }
 
 interface FilteringValidation {
-  ids: string[]
+  ids: Id[]
   messages: string[]
 }
 
@@ -189,8 +190,8 @@ enum FilteringValidationState {
 }
 
 interface FilteringAdvancedSnippet {
-  created_at: string
-  updated_at: string
+  created_at: DateTime
+  updated_at: DateTime
   value: Dictionary<string, UserDefinedValue>
 }
 
@@ -243,20 +244,20 @@ export interface Connector {
   features: ConnectorFeatures
   filtering: FilteringConfig[]
   id?: Id
-  index_name?: string
+  index_name?: IndexName
   is_native: boolean
   language?: string
   last_access_control_sync_error?: string
-  last_access_control_sync_scheduled_at?: string
+  last_access_control_sync_scheduled_at?: DateTime
   last_access_control_sync_status?: SyncStatus
   last_deleted_document_count?: long
-  last_incremental_sync_scheduled_at?: string
+  last_incremental_sync_scheduled_at?: DateTime
   last_indexed_document_count?: long
-  last_seen?: string
+  last_seen?: DateTime
   last_sync_error?: string
-  last_sync_scheduled_at?: string
+  last_sync_scheduled_at?: DateTime
   last_sync_status?: SyncStatus
-  last_synced?: string
+  last_synced?: DateTime
   name?: string
   pipeline?: IngestPipelineParams
   scheduling: SchedulingConfiguration

--- a/specification/connector/last_sync/ConnectorUpdateLastSyncRequest.ts
+++ b/specification/connector/last_sync/ConnectorUpdateLastSyncRequest.ts
@@ -21,6 +21,7 @@ import { Id } from '@_types/common'
 import { SyncStatus } from '../_types/Connector'
 import { long } from '@_types/Numeric'
 import { WithNullValue } from '@spec_utils/utils'
+import { DateTime } from '@_types/Time'
 
 /**
  * Updates last sync stats in the connector document
@@ -41,15 +42,15 @@ export interface Request extends RequestBase {
    */
   body: {
     last_access_control_sync_error?: WithNullValue<string>
-    last_access_control_sync_scheduled_at?: string
+    last_access_control_sync_scheduled_at?: DateTime
     last_access_control_sync_status?: SyncStatus
     last_deleted_document_count?: long
-    last_incremental_sync_scheduled_at?: string
+    last_incremental_sync_scheduled_at?: DateTime
     last_indexed_document_count?: long
-    last_seen?: WithNullValue<string>
+    last_seen?: WithNullValue<DateTime>
     last_sync_error?: WithNullValue<string>
-    last_sync_scheduled_at?: string
+    last_sync_scheduled_at?: DateTime
     last_sync_status?: SyncStatus
-    last_synced?: string
+    last_synced?: DateTime
   }
 }

--- a/specification/connector/post/ConnectorPostRequest.ts
+++ b/specification/connector/post/ConnectorPostRequest.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 import { RequestBase } from '@_types/Base'
+import { IndexName } from '@_types/common'
 import { WithNullValue } from '@spec_utils/utils'
 
 /**
@@ -33,7 +34,7 @@ export interface Request extends RequestBase {
   /** @codegen_name connector */
   body: {
     description?: string
-    index_name: WithNullValue<string>
+    index_name: WithNullValue<IndexName>
     is_native?: boolean
     language?: string
     name?: string

--- a/specification/connector/put/ConnectorPutRequest.ts
+++ b/specification/connector/put/ConnectorPutRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
+import { Id, IndexName } from '@_types/common'
 import { WithNullValue } from '@spec_utils/utils'
 
 /**
@@ -40,7 +40,7 @@ export interface Request extends RequestBase {
   /** @codegen_name connector */
   body: {
     description?: string
-    index_name: WithNullValue<string>
+    index_name: WithNullValue<IndexName>
     is_native?: boolean
     language?: string
     name?: string

--- a/specification/connector/update_index_name/ConnectorUpdateIndexNameRequest.ts
+++ b/specification/connector/update_index_name/ConnectorUpdateIndexNameRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
+import { Id, IndexName } from '@_types/common'
 import { WithNullValue } from '@spec_utils/utils'
 
 /**
@@ -38,6 +38,6 @@ export interface Request extends RequestBase {
    * The connector index name
    */
   body: {
-    index_name: WithNullValue<string>
+    index_name: WithNullValue<IndexName>
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [Use alias types in connectors API where it makes sense (#2507)](https://github.com/elastic/elasticsearch-specification/pull/2507)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)