### PR TITLE
[8.14] [Connector API] Add missing 8.14 changes (#2527)

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -1997,6 +1997,17 @@
               "$ref": "#/components/schemas/_types:Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "delete_sync_jobs",
+            "description": "Determines whether associated sync jobs are also deleted.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
           }
         ],
         "responses": {
@@ -2540,6 +2551,52 @@
         }
       }
     },
+    "/_connector/{connector_id}/_filtering/_activate": {
+      "put": {
+        "tags": [
+          "connector.update_active_filtering"
+        ],
+        "summary": "Activates the draft filtering rules if they are in a validated state.",
+        "description": "Activates the draft filtering rules if they are in a validated state.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-filtering-api.html"
+        },
+        "operationId": "connector-update-active-filtering",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_id",
+            "description": "The unique identifier of the connector to be updated",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "$ref": "#/components/schemas/_types:Result"
+                    }
+                  },
+                  "required": [
+                    "result"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/_connector/{connector_id}/_api_key_id": {
       "put": {
         "tags": [
@@ -2770,10 +2827,80 @@
                     "items": {
                       "$ref": "#/components/schemas/connector._types:FilteringConfig"
                     }
+                  },
+                  "rules": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/connector._types:FilteringRule"
+                    }
+                  },
+                  "advanced_snippet": {
+                    "$ref": "#/components/schemas/connector._types:FilteringAdvancedSnippet"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "$ref": "#/components/schemas/_types:Result"
+                    }
+                  },
+                  "required": [
+                    "result"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/_connector/{connector_id}/_filtering/_validation": {
+      "put": {
+        "tags": [
+          "connector.update_filtering_validation"
+        ],
+        "summary": "Updates the validation info of the draft filtering rules.",
+        "description": "Updates the validation info of the draft filtering rules.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-filtering-validation-api.html"
+        },
+        "operationId": "connector-update-filtering-validation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_id",
+            "description": "The unique identifier of the connector to be updated",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "validation": {
+                    "$ref": "#/components/schemas/connector._types:FilteringRulesValidation"
                   }
                 },
                 "required": [
-                  "filtering"
+                  "validation"
                 ]
               }
             }
@@ -49659,7 +49786,6 @@
         "required": [
           "configuration",
           "custom_scheduling",
-          "features",
           "filtering",
           "is_native",
           "scheduling",
@@ -49847,7 +49973,7 @@
           "type": {
             "type": "string",
             "enum": [
-              "less_than"
+              "\"less_than\""
             ]
           },
           "constraint": {
@@ -49865,7 +49991,7 @@
           "type": {
             "type": "string",
             "enum": [
-              "greater_than"
+              "\"greater_than\""
             ]
           },
           "constraint": {
@@ -49883,7 +50009,7 @@
           "type": {
             "type": "string",
             "enum": [
-              "list_type"
+              "\"list_type\""
             ]
           },
           "constraint": {
@@ -49904,7 +50030,7 @@
           "type": {
             "type": "string",
             "enum": [
-              "included_in"
+              "\"included_in\""
             ]
           },
           "constraint": {
@@ -49922,7 +50048,7 @@
           "type": {
             "type": "string",
             "enum": [
-              "regex"
+              "\"regex\""
             ]
           },
           "constraint": {
@@ -50095,8 +50221,6 @@
           }
         },
         "required": [
-          "created_at",
-          "updated_at",
           "value"
         ]
       },
@@ -50129,13 +50253,11 @@
           }
         },
         "required": [
-          "created_at",
           "field",
           "id",
           "order",
           "policy",
           "rule",
-          "updated_at",
           "value"
         ]
       },
@@ -50400,7 +50522,7 @@
             "$ref": "#/components/schemas/connector._types:ConnectorConfiguration"
           },
           "filtering": {
-            "$ref": "#/components/schemas/connector._types:FilteringConfig"
+            "$ref": "#/components/schemas/connector._types:FilteringRules"
           },
           "id": {
             "$ref": "#/components/schemas/_types:Id"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9089,7 +9089,7 @@ export interface ConnectorConnector {
   custom_scheduling: ConnectorConnectorCustomScheduling
   description?: string
   error?: string
-  features: ConnectorConnectorFeatures
+  features?: ConnectorConnectorFeatures
   filtering: ConnectorFilteringConfig[]
   id?: Id
   index_name?: IndexName
@@ -9202,8 +9202,8 @@ export interface ConnectorFeatureEnabled {
 }
 
 export interface ConnectorFilteringAdvancedSnippet {
-  created_at: DateTime
-  updated_at: DateTime
+  created_at?: DateTime
+  updated_at?: DateTime
   value: Record<string, any>
 }
 
@@ -9216,13 +9216,13 @@ export interface ConnectorFilteringConfig {
 export type ConnectorFilteringPolicy = 'exclude' | 'include'
 
 export interface ConnectorFilteringRule {
-  created_at: DateTime
+  created_at?: DateTime
   field: Field
   id: Id
   order: integer
   policy: ConnectorFilteringPolicy
   rule: ConnectorFilteringRuleRule
-  updated_at: DateTime
+  updated_at?: DateTime
   value: string
 }
 
@@ -9247,12 +9247,12 @@ export interface ConnectorFilteringValidation {
 export type ConnectorFilteringValidationState = 'edited' | 'invalid' | 'valid'
 
 export interface ConnectorGreaterThanValidation {
-  type: 'greater_than'
+  type: '"greater_than"'
   constraint: double
 }
 
 export interface ConnectorIncludedInValidation {
-  type: 'included_in'
+  type: '"included_in"'
   constraint: string
 }
 
@@ -9264,17 +9264,17 @@ export interface ConnectorIngestPipelineParams {
 }
 
 export interface ConnectorLessThanValidation {
-  type: 'less_than'
+  type: '"less_than"'
   constraint: double
 }
 
 export interface ConnectorListTypeValidation {
-  type: 'list_type'
+  type: '"list_type"'
   constraint: ScalarValue[]
 }
 
 export interface ConnectorRegexValidation {
-  type: 'regex'
+  type: '"regex"'
   constraint: string
 }
 
@@ -9291,7 +9291,7 @@ export interface ConnectorSelectOption {
 
 export interface ConnectorSyncJobConnectorReference {
   configuration: ConnectorConnectorConfiguration
-  filtering: ConnectorFilteringConfig
+  filtering: ConnectorFilteringRules
   id: Id
   index_name: string
   language?: string
@@ -9322,6 +9322,7 @@ export interface ConnectorCheckInResponse {
 
 export interface ConnectorDeleteRequest extends RequestBase {
   connector_id: Id
+  delete_sync_jobs: boolean
 }
 
 export type ConnectorDeleteResponse = AcknowledgedResponseBase
@@ -9443,6 +9444,14 @@ export interface ConnectorSyncJobPostResponse {
   id: Id
 }
 
+export interface ConnectorUpdateActiveFilteringRequest extends RequestBase {
+  connector_id: Id
+}
+
+export interface ConnectorUpdateActiveFilteringResponse {
+  result: Result
+}
+
 export interface ConnectorUpdateApiKeyIdRequest extends RequestBase {
   connector_id: Id
   body?: {
@@ -9481,11 +9490,24 @@ export interface ConnectorUpdateErrorResponse {
 export interface ConnectorUpdateFilteringRequest extends RequestBase {
   connector_id: Id
   body?: {
-    filtering: ConnectorFilteringConfig[]
+    filtering?: ConnectorFilteringConfig[]
+    rules?: ConnectorFilteringRule[]
+    advanced_snippet?: ConnectorFilteringAdvancedSnippet
   }
 }
 
 export interface ConnectorUpdateFilteringResponse {
+  result: Result
+}
+
+export interface ConnectorUpdateFilteringValidationRequest extends RequestBase {
+  connector_id: Id
+  body?: {
+    validation: ConnectorFilteringRulesValidation
+  }
+}
+
+export interface ConnectorUpdateFilteringValidationResponse {
   result: Result
 }
 

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -94,6 +94,7 @@ connector-configuration,https://www.elastic.co/guide/en/elasticsearch/reference/
 connector-update-api-key-id,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-connector-api-key-id-api.html
 connector-update-error,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-connector-error-api.html
 connector-update-filtering,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-connector-filtering-api.html
+connector-update-filtering-validation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-connector-filtering-validation-api.html
 connector-update-index-name,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-connector-index-name-api.html
 connector-update-name,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-connector-name-description-api.html
 connector-update-native,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-connector-native-api.html

--- a/specification/_json_spec/connector.delete.json
+++ b/specification/_json_spec/connector.delete.json
@@ -22,6 +22,13 @@
           }
         }
       ]
+    },
+    "params": {
+      "delete_sync_jobs": {
+        "type": "boolean",
+        "default": false,
+        "description": "Determines whether associated sync jobs are also deleted."
+      }
     }
   }
 }

--- a/specification/_json_spec/connector.update_active_filtering.json
+++ b/specification/_json_spec/connector.update_active_filtering.json
@@ -1,0 +1,28 @@
+{
+  "connector.update_active_filtering": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-filtering-api.html",
+      "description": "Activates the draft filtering rules if they are in a validated state."
+    },
+    "stability": "experimental",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_connector/{connector_id}/_filtering/_activate",
+          "methods": ["PUT"],
+          "parts": {
+            "connector_id": {
+              "type": "string",
+              "description": "The unique identifier of the connector to be updated."
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/specification/_json_spec/connector.update_filtering_validation.json
+++ b/specification/_json_spec/connector.update_filtering_validation.json
@@ -1,0 +1,32 @@
+{
+  "connector.update_filtering_validation": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-filtering-api.html",
+      "description": "Updates the validation info of the draft filtering rules."
+    },
+    "stability": "experimental",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_connector/{connector_id}/_filtering/_validation",
+          "methods": ["PUT"],
+          "parts": {
+            "connector_id": {
+              "type": "string",
+              "description": "The unique identifier of the connector to be updated."
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "Validation info for the draft filtering rules",
+      "required": true
+    }
+  }
+}

--- a/specification/connector/_types/Connector.ts
+++ b/specification/connector/_types/Connector.ts
@@ -167,14 +167,14 @@ enum FilteringRuleRule {
   less_than = '<'
 }
 
-interface FilteringRule {
-  created_at: DateTime
+export interface FilteringRule {
+  created_at?: DateTime
   field: Field
   id: Id
   order: integer
   policy: FilteringPolicy
   rule: FilteringRuleRule
-  updated_at: DateTime
+  updated_at?: DateTime
   value: string
 }
 
@@ -189,18 +189,18 @@ enum FilteringValidationState {
   valid
 }
 
-interface FilteringAdvancedSnippet {
-  created_at: DateTime
-  updated_at: DateTime
+export interface FilteringAdvancedSnippet {
+  created_at?: DateTime
+  updated_at?: DateTime
   value: Dictionary<string, UserDefinedValue>
 }
 
-interface FilteringRulesValidation {
+export interface FilteringRulesValidation {
   errors: FilteringValidation[]
   state: FilteringValidationState
 }
 
-interface FilteringRules {
+export interface FilteringRules {
   advanced_snippet: FilteringAdvancedSnippet
   rules: FilteringRule[]
   validation: FilteringRulesValidation
@@ -241,7 +241,7 @@ export interface Connector {
   custom_scheduling: ConnectorCustomScheduling
   description?: string
   error?: string
-  features: ConnectorFeatures
+  features?: ConnectorFeatures
   filtering: FilteringConfig[]
   id?: Id
   index_name?: IndexName

--- a/specification/connector/_types/SyncJob.ts
+++ b/specification/connector/_types/SyncJob.ts
@@ -23,14 +23,14 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import {
   ConnectorConfiguration,
-  FilteringConfig,
+  FilteringRules,
   IngestPipelineParams,
   SyncStatus
 } from './Connector'
 
 interface SyncJobConnectorReference {
   configuration: ConnectorConfiguration
-  filtering: FilteringConfig
+  filtering: FilteringRules
   id: Id
   index_name: string
   language?: string

--- a/specification/connector/delete/ConnectorDeleteRequest.ts
+++ b/specification/connector/delete/ConnectorDeleteRequest.ts
@@ -33,4 +33,7 @@ export interface Request extends RequestBase {
      */
     connector_id: Id
   }
+  query_parameters: {
+    delete_sync_jobs: boolean
+  }
 }

--- a/specification/connector/update_active_filtering/ConnectorUpdateActiveFilteringRequest.ts
+++ b/specification/connector/update_active_filtering/ConnectorUpdateActiveFilteringRequest.ts
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+
+/**
+ * Activates the valid draft filtering for a connector.
+ * @rest_spec_name connector.update_active_filtering
+ * @availability stack since=8.12.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
+ * @doc_id connector-update-filtering
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the connector to be updated
+     */
+    connector_id: Id
+  }
+}

--- a/specification/connector/update_active_filtering/ConnectorUpdateActiveFilteringResponse.ts
+++ b/specification/connector/update_active_filtering/ConnectorUpdateActiveFilteringResponse.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Result } from '@_types/Result'
+
+export class Response {
+  body: {
+    result: Result
+  }
+}

--- a/specification/connector/update_filtering/ConnectorUpdateFilteringRequest.ts
+++ b/specification/connector/update_filtering/ConnectorUpdateFilteringRequest.ts
@@ -18,7 +18,11 @@
  */
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
-import { FilteringConfig } from '../_types/Connector'
+import {
+  FilteringAdvancedSnippet,
+  FilteringConfig,
+  FilteringRule
+} from '../_types/Connector'
 
 /**
  * Updates the filtering field in the connector document
@@ -35,10 +39,12 @@ export interface Request extends RequestBase {
     connector_id: Id
   }
   /**
-   * The connector filtering configuration
+   * The connector draft filtering configuration
    */
   /** @codegen_name filtering */
   body: {
-    filtering: FilteringConfig[]
+    filtering?: FilteringConfig[]
+    rules?: FilteringRule[]
+    advanced_snippet?: FilteringAdvancedSnippet
   }
 }

--- a/specification/connector/update_filtering_validation/ConnectorUpdateFilteringValidationRequest.ts
+++ b/specification/connector/update_filtering_validation/ConnectorUpdateFilteringValidationRequest.ts
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+import { FilteringRulesValidation } from 'connector/_types/Connector'
+
+/**
+ * Updates the draft filtering validation info for a connector.
+ * @rest_spec_name connector.update_filtering_validation
+ * @availability stack since=8.12.0 stability=experimental
+ * @availability serverless stability=experimental visibility=public
+ * @doc_id connector-update-filtering-validation
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the connector to be updated
+     */
+    connector_id: Id
+  }
+  body: {
+    validation: FilteringRulesValidation
+  }
+}

--- a/specification/connector/update_filtering_validation/ConnectorUpdateFilteringValidationResponse.ts
+++ b/specification/connector/update_filtering_validation/ConnectorUpdateFilteringValidationResponse.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Result } from '@_types/Result'
+
+export class Response {
+  body: {
+    result: Result
+  }
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Connector API] Add missing 8.14 changes (#2527)](https://github.com/elastic/elasticsearch-specification/pull/2527)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)