### PR TITLE
Add dangling types to the generic-less schema

### DIFF
--- a/compiler/src/transform/expand-generics.ts
+++ b/compiler/src/transform/expand-generics.ts
@@ -135,6 +135,24 @@ export function expandGenerics (inputModel: Model): Model {
   }
 
   /**
+   * Add dangling types like CommonQueryParameters & BaseEsqlVersion to the generic less schema.
+   * @param type the type definition
+   */
+  function addDanglingTypeIfNotSeen(type: TypeDefinition) {
+    switch (type.kind) {
+      case "type_alias":
+        if (type.generics !== undefined && type.generics.length > 0) {
+          return;
+        }
+      case "interface":
+        if (type.generics !== undefined && type.generics.length > 0) {
+          return;
+        }
+    }
+    addIfNotSeen(type.name, () => type)
+  }
+
+  /**
    * Expand an interface definition.
    *
    * @param type the type definition
@@ -359,6 +377,10 @@ export function expandGenerics (inputModel: Model): Model {
   for (const endpoint of inputModel.endpoints) {
     expandRootType(endpoint.request)
     expandRootType(endpoint.response)
+  }
+
+  for (const type of inputModel.types) {
+    addDanglingTypeIfNotSeen(type);
   }
 
   sortTypeDefinitions(types)

--- a/compiler/src/transform/expand-generics.ts
+++ b/compiler/src/transform/expand-generics.ts
@@ -174,7 +174,7 @@ export function expandGenerics (inputModel: Model): Model {
       if (result.behaviors != null) {
         result.behaviors.forEach(b => {
           if (b.generics == null) {
-            var type = getType(b.type)
+            const type = getType(b.type)
             addIfNotSeen(b.type, () => type)
           }
         })

--- a/compiler/src/transform/expand-generics.ts
+++ b/compiler/src/transform/expand-generics.ts
@@ -168,6 +168,18 @@ export function expandGenerics (inputModel: Model): Model {
 
       result.inherits = expandInherits(result.inherits, mappings)
 
+      // We add to the schema the non generics behaviors
+      // CommonQueryParameters
+      // CommonCatQueryParameters
+      if (result.behaviors != null) {
+        result.behaviors.forEach(b => {
+          if (b.generics == null) {
+            var type = getType(b.type)
+            addIfNotSeen(b.type, () => type)
+          }
+        })
+      }
+
       if (result.behaviors != null) {
         // We keep the generic parameters, but expand their value
         result.behaviors = result.behaviors.map(b => {
@@ -381,6 +393,7 @@ export function expandGenerics (inputModel: Model): Model {
     expandRootType(endpoint.response)
   }
 
+  // Allows to retrieve EsqlBase*EsqlVersion
   for (const type of inputModel.types) {
     addDanglingTypeIfNotSeen(type)
   }

--- a/compiler/src/transform/expand-generics.ts
+++ b/compiler/src/transform/expand-generics.ts
@@ -138,16 +138,18 @@ export function expandGenerics (inputModel: Model): Model {
    * Add dangling types like CommonQueryParameters & BaseEsqlVersion to the generic less schema.
    * @param type the type definition
    */
-  function addDanglingTypeIfNotSeen(type: TypeDefinition) {
+  function addDanglingTypeIfNotSeen (type: TypeDefinition): void {
     switch (type.kind) {
-      case "type_alias":
+      case 'type_alias':
         if (type.generics !== undefined && type.generics.length > 0) {
-          return;
+          return
         }
-      case "interface":
+        break
+      case 'interface':
         if (type.generics !== undefined && type.generics.length > 0) {
-          return;
+          return
         }
+        break
     }
     addIfNotSeen(type.name, () => type)
   }
@@ -380,7 +382,7 @@ export function expandGenerics (inputModel: Model): Model {
   }
 
   for (const type of inputModel.types) {
-    addDanglingTypeIfNotSeen(type);
+    addDanglingTypeIfNotSeen(type)
   }
 
   sortTypeDefinitions(types)


### PR DESCRIPTION
This parses the leftovers from the expansion which are tied to no `Request` nor `Response` and adds the missing behaviors without generics to the processed schema.

It allows the generic-less schema to know about:
* `CommonCatQueryParameters`
* `CommonQueryParameters`
* `BaseServerlessEsqlVersion`
* `BaseStatefulEsqlVersion`