### PR TITLE
Changed inference name to avoid duplicate

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -21125,7 +21125,7 @@
                 "endpoints": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/inference._types:InferenceEndpointContainer"
+                    "$ref": "#/components/schemas/inference._types:InferenceEndpointInfo"
                   }
                 }
               },
@@ -21151,7 +21151,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/inference._types:InferenceEndpointContainer"
+              "$ref": "#/components/schemas/inference._types:InferenceEndpointInfo"
             }
           }
         }
@@ -52291,7 +52291,7 @@
           "completion"
         ]
       },
-      "inference._types:InferenceEndpointContainer": {
+      "inference._types:InferenceEndpointInfo": {
         "allOf": [
           {
             "$ref": "#/components/schemas/inference._types:InferenceEndpoint"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12064,7 +12064,7 @@ export interface InferenceInferenceEndpoint {
   task_settings: InferenceTaskSettings
 }
 
-export interface InferenceInferenceEndpointContainer extends InferenceInferenceEndpoint {
+export interface InferenceInferenceEndpointInfo extends InferenceInferenceEndpoint {
   inference_id: string
   task_type: InferenceTaskType
 }
@@ -12116,7 +12116,7 @@ export interface InferenceGetRequest extends RequestBase {
 }
 
 export interface InferenceGetResponse {
-  endpoints: InferenceInferenceEndpointContainer[]
+  endpoints: InferenceInferenceEndpointInfo[]
 }
 
 export interface InferenceInferenceRequest extends RequestBase {
@@ -12138,7 +12138,7 @@ export interface InferencePutRequest extends RequestBase {
   body?: InferenceInferenceEndpoint
 }
 
-export type InferencePutResponse = InferenceInferenceEndpointContainer
+export type InferencePutResponse = InferenceInferenceEndpointInfo
 
 export interface IngestAppendProcessor extends IngestProcessorBase {
   field: Field

--- a/specification/inference/_types/Services.ts
+++ b/specification/inference/_types/Services.ts
@@ -41,7 +41,7 @@ export class InferenceEndpoint {
 /**
  * Represents an inference endpoint as returned by the GET API
  */
-export class InferenceEndpointContainer extends InferenceEndpoint {
+export class InferenceEndpointInfo extends InferenceEndpoint {
   /**
    * The inference Id
    */

--- a/specification/inference/get/GetResponse.ts
+++ b/specification/inference/get/GetResponse.ts
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-import { InferenceEndpointContainer } from '@inference/_types/Services'
+import { InferenceEndpointInfo } from '@inference/_types/Services'
 
 export class Response {
   body: {
-    endpoints: Array<InferenceEndpointContainer>
+    endpoints: Array<InferenceEndpointInfo>
   }
 }

--- a/specification/inference/put/PutResponse.ts
+++ b/specification/inference/put/PutResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointContainer } from '@inference/_types/Services'
+import { InferenceEndpointInfo } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointContainer
+  body: InferenceEndpointInfo
 }


### PR DESCRIPTION
The java generator was complaining about types `InferenceEndpointContainer` and `InferenceEndpoint`, changed the first one's name since it's not technically a container class. 