### PR TITLE
Improve declaration of untagged unions to allow for generator optimizations

### DIFF
--- a/compiler-rs/clients_schema/src/lib.rs
+++ b/compiler-rs/clients_schema/src/lib.rs
@@ -380,6 +380,7 @@ pub enum ServerDefault {
 pub enum Variants {
     ExternalTag(ExternalTag),
     InternalTag(InternalTag),
+    Untagged(Untagged),
     Container(Container),
 }
 
@@ -402,6 +403,13 @@ pub struct InternalTag {
     /// Default value for the variant tag if it's missing
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_tag: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Untagged {
+    #[serde(default)]
+    pub non_exhaustive: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -799,6 +807,7 @@ impl TypeAlias {
 pub enum TypeAliasVariants {
     ExternalTag(ExternalTag),
     InternalTag(InternalTag),
+    Untagged(Untagged),
 }
 
 //------------------------------------------------------------------------------------------------------------

--- a/compiler-rs/clients_schema_to_openapi/src/main.rs
+++ b/compiler-rs/clients_schema_to_openapi/src/main.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::path::{Path, PathBuf};
+use anyhow::bail;
 
 use clap::{Parser, ValueEnum};
 use clients_schema::{Availabilities, Visibility};
@@ -71,7 +72,10 @@ impl Cli {
             std::fs::read_to_string(self.schema)?
         };
 
-        let mut model: clients_schema::IndexedModel = serde_json::from_str(&json)?;
+        let mut model: clients_schema::IndexedModel = match serde_json::from_str(&json) {
+            Ok(indexed_model) => indexed_model,
+            Err(e) => bail!("cannot parse schema json: {}", e)
+        };
 
         if let Some(flavor) = self.flavor {
             if flavor != SchemaFlavor::All {

--- a/compiler-rs/clients_schema_to_openapi/src/schemas.rs
+++ b/compiler-rs/clients_schema_to_openapi/src/schemas.rs
@@ -395,6 +395,8 @@ impl<'a> TypesAndComponents<'a> {
                     extensions: Default::default(),
                 });
             }
+            Some(TypeAliasVariants::Untagged(_tag)) => {
+            }
         };
 
         Ok(schema)

--- a/compiler-rs/openapi_to_clients_schema/src/types.rs
+++ b/compiler-rs/openapi_to_clients_schema/src/types.rs
@@ -323,7 +323,7 @@ fn generate_schema_kind_one_of(
     let mut variants: Option<TypeAliasVariants> = None;
 
     // TODO: do we want to allow untagged unions (those that are disambiguated by inspecting property names)?
-
+    
     if let Some(discriminator) = discriminator {
         variants = Some(TypeAliasVariants::InternalTag(InternalTag {
             default_tag: None,

--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -180,7 +180,7 @@ export abstract class BaseType {
   specLocation: string
 }
 
-export type Variants = ExternalTag | InternalTag | Container
+export type Variants = ExternalTag | InternalTag | Container | Untagged
 
 export class VariantBase {
   /**
@@ -205,6 +205,10 @@ export class InternalTag extends VariantBase {
 
 export class Container extends VariantBase {
   kind: 'container'
+}
+
+export class Untagged extends VariantBase {
+  kind: 'untagged'
 }
 
 /**
@@ -364,8 +368,11 @@ export class TypeAlias extends BaseType {
   type: ValueOf
   /** generic parameters: either concrete types or open parameters from the enclosing type */
   generics?: TypeName[]
-  /** Only applicable to `union_of` aliases: identify typed_key unions (external) and variant inventories (internal) */
-  variants?: InternalTag | ExternalTag
+  /**
+   * Only applicable to `union_of` aliases: identify typed_key unions (external), variant inventories (internal)
+   * and untagged variants
+   */
+  variants?: InternalTag | ExternalTag | Untagged
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -209,6 +209,7 @@ export class Container extends VariantBase {
 
 export class Untagged extends VariantBase {
   kind: 'untagged'
+  untypedVariant: Inherits
 }
 
 /**

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -1110,24 +1110,34 @@ export function parseVariantsTag (jsDoc: JSDoc[]): model.Variants | undefined {
     }
   }
 
-  if (type === 'untagged') {
+  if (type === 'internal') {
+    const pairs = parseKeyValues(jsDoc, values, 'tag', 'default')
+    assert(jsDoc, typeof pairs.tag === 'string', 'Internal variant requires a tag definition')
     return {
-      kind: 'untagged',
-      nonExhaustive: nonExhaustive
+      kind: 'internal_tag',
+      nonExhaustive: nonExhaustive,
+      tag: pairs.tag,
+      defaultTag: pairs.default
     }
   }
 
-  assert(jsDoc, type === 'internal', `Bad variant type: ${type}`)
-
-  const pairs = parseKeyValues(jsDoc, values, 'tag', 'default')
-  assert(jsDoc, typeof pairs.tag === 'string', 'Internal variant requires a tag definition')
-
-  return {
-    kind: 'internal_tag',
-    nonExhaustive: nonExhaustive,
-    tag: pairs.tag,
-    defaultTag: pairs.default
+  if (type === 'untagged') {
+    const pairs = parseKeyValues(jsDoc, values, 'untyped')
+    assert(jsDoc, typeof pairs.untyped === 'string', 'Untagged variant requires an untyped definition')
+    const fqn = pairs.untyped.split('.')
+    return {
+      kind: 'untagged',
+      nonExhaustive: nonExhaustive,
+      untypedVariant: {
+        type: {
+          namespace: fqn.slice(0, fqn.length - 1).join('.'),
+          name: fqn[fqn.length - 1]
+        }
+      }
+    }
   }
+
+  assert(jsDoc, false, `Bad variant type: ${type}`)
 }
 
 /**

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -536,8 +536,8 @@ export function modelTypeAlias (declaration: TypeAliasDeclaration): model.TypeAl
     if (variants != null) {
       assert(
         declaration.getJsDocs(),
-        variants.kind === 'internal_tag' || variants.kind === 'external_tag',
-        'Type Aliases can only have internal or external variants'
+        variants.kind === 'internal_tag' || variants.kind === 'external_tag' || variants.kind === 'untagged',
+        'Type Aliases can only have internal, external or untagged variants'
       )
       typeAlias.variants = variants
     }
@@ -1106,6 +1106,13 @@ export function parseVariantsTag (jsDoc: JSDoc[]): model.Variants | undefined {
   if (type === 'container') {
     return {
       kind: 'container',
+      nonExhaustive: nonExhaustive
+    }
+  }
+
+  if (type === 'untagged') {
+    return {
+      kind: 'untagged',
       nonExhaustive: nonExhaustive
     }
   }

--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -455,16 +455,17 @@ For example:
 ```ts
 export class MyTypeBase<T1, T2, ...> { ... }
 
+export class MyTypeUntyped extends MyTypeBase<UserDefinedValue> {}
 export class MyTypeSpecialized1 extends MyTypeBase<int> {}
 export class MyTypeSpecialized2 extends MyTypeBase<string> {}
 export class MyTypeSpecialized3 extends MyTypeBase<bool> {}
 
 /**
- * @codegen_names mytype1, mytypet2, mytype3 
- * @variant untagged
+ * @codegen_names untyped, mytype1, mytypet2, mytype3 
+ * @variant untagged untyped=_types.MyTypeUntyped
  */
 // Note: deserialization depends on value types
-export type MyType = MyTypeSpecialized1 | MyTypeSpecialized2 | MyTypeSpecialized3 
+export type MyType = MyTypeUntyped | MyTypeSpecialized1 | MyTypeSpecialized2 | MyTypeSpecialized3 
 ```
 
 ### Shortcut properties

--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -418,7 +418,7 @@ An annotation allows distinguishing these properties from container variants:
 
 For example:
 
-```
+```ts
 /**
  * @variants container
  */
@@ -433,6 +433,38 @@ class AggregationContainer {
   auto_date_histogram?: AutoDateHistogramAggregation
   avg?: AverageAggregation
   ...
+```
+
+#### Untagged
+
+The untagged variant is used for unions that can only be distinguished by the type of one or more fields.
+
+> [!WARNING]
+> This variant should only be used for legacy types and should otherwise be avoided as far as possible, as it leads to less optimal code generation in the client libraries.
+
+The syntax is:
+
+```ts
+/** @variants untagged */
+```
+
+Untagged variants must exactly follow a defined pattern.
+
+For example:
+
+```ts
+export class MyTypeBase<T1, T2, ...> { ... }
+
+export class MyTypeSpecialized1 extends MyTypeBase<int> {}
+export class MyTypeSpecialized2 extends MyTypeBase<string> {}
+export class MyTypeSpecialized3 extends MyTypeBase<bool> {}
+
+/**
+ * @codegen_names mytype1, mytypet2, mytype3 
+ * @variant untagged
+ */
+// Note: deserialization depends on value types
+export type MyType = MyTypeSpecialized1 | MyTypeSpecialized2 | MyTypeSpecialized3 
 ```
 
 ### Shortcut properties

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -35094,14 +35094,14 @@
       "_types.query_dsl:DateDecayFunction": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/_types.query_dsl:DecayFunctionBase"
+            "$ref": "#/components/schemas/_types.query_dsl:DecayFunctionBaseDateMathDuration"
           },
           {
             "type": "object"
           }
         ]
       },
-      "_types.query_dsl:DecayFunctionBase": {
+      "_types.query_dsl:DecayFunctionBaseDateMathDuration": {
         "type": "object",
         "properties": {
           "multi_value_mode": {
@@ -35121,22 +35121,38 @@
       "_types.query_dsl:NumericDecayFunction": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/_types.query_dsl:DecayFunctionBase"
+            "$ref": "#/components/schemas/_types.query_dsl:DecayFunctionBasedoubledouble"
           },
           {
             "type": "object"
           }
         ]
       },
+      "_types.query_dsl:DecayFunctionBasedoubledouble": {
+        "type": "object",
+        "properties": {
+          "multi_value_mode": {
+            "$ref": "#/components/schemas/_types.query_dsl:MultiValueMode"
+          }
+        }
+      },
       "_types.query_dsl:GeoDecayFunction": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/_types.query_dsl:DecayFunctionBase"
+            "$ref": "#/components/schemas/_types.query_dsl:DecayFunctionBaseGeoLocationDistance"
           },
           {
             "type": "object"
           }
         ]
+      },
+      "_types.query_dsl:DecayFunctionBaseGeoLocationDistance": {
+        "type": "object",
+        "properties": {
+          "multi_value_mode": {
+            "$ref": "#/components/schemas/_types.query_dsl:MultiValueMode"
+          }
+        }
       },
       "_types.query_dsl:FieldValueFactorScoreFunction": {
         "type": "object",
@@ -37685,18 +37701,31 @@
             "$ref": "#/components/schemas/_types.query_dsl:NumberRangeQuery"
           },
           {
-            "$ref": "#/components/schemas/_types.query_dsl:TermsRangeQuery"
+            "$ref": "#/components/schemas/_types.query_dsl:TermRangeQuery"
           }
         ]
       },
       "_types.query_dsl:DateRangeQuery": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/_types.query_dsl:RangeQueryBase"
+            "$ref": "#/components/schemas/_types.query_dsl:RangeQueryBaseDateMath"
+          },
+          {
+            "type": "object"
+          }
+        ]
+      },
+      "_types.query_dsl:RangeQueryBaseDateMath": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/_types.query_dsl:QueryBase"
           },
           {
             "type": "object",
             "properties": {
+              "relation": {
+                "$ref": "#/components/schemas/_types.query_dsl:RangeRelation"
+              },
               "gt": {
                 "$ref": "#/components/schemas/_types:DateMath"
               },
@@ -37741,13 +37770,31 @@
           }
         ]
       },
+      "_types.query_dsl:RangeRelation": {
+        "type": "string",
+        "enum": [
+          "within",
+          "contains",
+          "intersects"
+        ]
+      },
       "_types:DateFormat": {
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html"
         },
         "type": "string"
       },
-      "_types.query_dsl:RangeQueryBase": {
+      "_types.query_dsl:NumberRangeQuery": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/_types.query_dsl:RangeQueryBasedouble"
+          },
+          {
+            "type": "object"
+          }
+        ]
+      },
+      "_types.query_dsl:RangeQueryBasedouble": {
         "allOf": [
           {
             "$ref": "#/components/schemas/_types.query_dsl:QueryBase"
@@ -37757,27 +37804,7 @@
             "properties": {
               "relation": {
                 "$ref": "#/components/schemas/_types.query_dsl:RangeRelation"
-              }
-            }
-          }
-        ]
-      },
-      "_types.query_dsl:RangeRelation": {
-        "type": "string",
-        "enum": [
-          "within",
-          "contains",
-          "intersects"
-        ]
-      },
-      "_types.query_dsl:NumberRangeQuery": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/_types.query_dsl:RangeQueryBase"
-          },
-          {
-            "type": "object",
-            "properties": {
+              },
               "gt": {
                 "description": "Greater than.",
                 "type": "number"
@@ -37815,19 +37842,38 @@
                     "type": "string"
                   }
                 ]
+              },
+              "format": {
+                "$ref": "#/components/schemas/_types:DateFormat"
+              },
+              "time_zone": {
+                "$ref": "#/components/schemas/_types:TimeZone"
               }
             }
           }
         ]
       },
-      "_types.query_dsl:TermsRangeQuery": {
+      "_types.query_dsl:TermRangeQuery": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/_types.query_dsl:RangeQueryBase"
+            "$ref": "#/components/schemas/_types.query_dsl:RangeQueryBasestring"
+          },
+          {
+            "type": "object"
+          }
+        ]
+      },
+      "_types.query_dsl:RangeQueryBasestring": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/_types.query_dsl:QueryBase"
           },
           {
             "type": "object",
             "properties": {
+              "relation": {
+                "$ref": "#/components/schemas/_types.query_dsl:RangeRelation"
+              },
               "gt": {
                 "description": "Greater than.",
                 "type": "string"
@@ -37865,6 +37911,12 @@
                     "type": "string"
                   }
                 ]
+              },
+              "format": {
+                "$ref": "#/components/schemas/_types:DateFormat"
+              },
+              "time_zone": {
+                "$ref": "#/components/schemas/_types:TimeZone"
               }
             }
           }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5492,28 +5492,20 @@ export interface QueryDslConstantScoreQuery extends QueryDslQueryBase {
   filter: QueryDslQueryContainer
 }
 
-export interface QueryDslDateDecayFunctionKeys extends QueryDslDecayFunctionBase {
+export interface QueryDslDateDecayFunctionKeys extends QueryDslDecayFunctionBase<DateMath, Duration> {
 }
 export type QueryDslDateDecayFunction = QueryDslDateDecayFunctionKeys
-  & { [property: string]: QueryDslDecayPlacement<DateMath, Duration> | QueryDslMultiValueMode }
+  & { [property: string]: QueryDslDecayPlacement<QueryDslTOrigin, QueryDslTScale> | QueryDslMultiValueMode }
 
 export interface QueryDslDateDistanceFeatureQuery extends QueryDslDistanceFeatureQueryBase<DateMath, Duration> {
 }
 
-export interface QueryDslDateRangeQuery extends QueryDslRangeQueryBase {
-  gt?: DateMath
-  gte?: DateMath
-  lt?: DateMath
-  lte?: DateMath
-  from?: DateMath | null
-  to?: DateMath | null
-  format?: DateFormat
-  time_zone?: TimeZone
+export interface QueryDslDateRangeQuery extends QueryDslRangeQueryBase<DateMath> {
 }
 
 export type QueryDslDecayFunction = QueryDslDateDecayFunction | QueryDslNumericDecayFunction | QueryDslGeoDecayFunction
 
-export interface QueryDslDecayFunctionBase {
+export interface QueryDslDecayFunctionBase<TOrigin = unknown, TScale = unknown> {
   multi_value_mode?: QueryDslMultiValueMode
 }
 
@@ -5604,10 +5596,10 @@ export interface QueryDslGeoBoundingBoxQueryKeys extends QueryDslQueryBase {
 export type QueryDslGeoBoundingBoxQuery = QueryDslGeoBoundingBoxQueryKeys
   & { [property: string]: GeoBounds | QueryDslGeoExecution | QueryDslGeoValidationMethod | boolean | float | string }
 
-export interface QueryDslGeoDecayFunctionKeys extends QueryDslDecayFunctionBase {
+export interface QueryDslGeoDecayFunctionKeys extends QueryDslDecayFunctionBase<GeoLocation, Distance> {
 }
 export type QueryDslGeoDecayFunction = QueryDslGeoDecayFunctionKeys
-  & { [property: string]: QueryDslDecayPlacement<GeoLocation, Distance> | QueryDslMultiValueMode }
+  & { [property: string]: QueryDslDecayPlacement<QueryDslTOrigin, QueryDslTScale> | QueryDslMultiValueMode }
 
 export interface QueryDslGeoDistanceFeatureQuery extends QueryDslDistanceFeatureQueryBase<GeoLocation, Distance> {
 }
@@ -5855,19 +5847,13 @@ export interface QueryDslNestedQuery extends QueryDslQueryBase {
   score_mode?: QueryDslChildScoreMode
 }
 
-export interface QueryDslNumberRangeQuery extends QueryDslRangeQueryBase {
-  gt?: double
-  gte?: double
-  lt?: double
-  lte?: double
-  from?: double | null
-  to?: double | null
+export interface QueryDslNumberRangeQuery extends QueryDslRangeQueryBase<double> {
 }
 
-export interface QueryDslNumericDecayFunctionKeys extends QueryDslDecayFunctionBase {
+export interface QueryDslNumericDecayFunctionKeys extends QueryDslDecayFunctionBase<double, double> {
 }
 export type QueryDslNumericDecayFunction = QueryDslNumericDecayFunctionKeys
-  & { [property: string]: QueryDslDecayPlacement<double, double> | QueryDslMultiValueMode }
+  & { [property: string]: QueryDslDecayPlacement<QueryDslTOrigin, QueryDslTScale> | QueryDslMultiValueMode }
 
 export type QueryDslOperator = 'and' | 'AND' | 'or' | 'OR'
 
@@ -6007,10 +5993,18 @@ export interface QueryDslRandomScoreFunction {
   seed?: long | string
 }
 
-export type QueryDslRangeQuery = QueryDslDateRangeQuery | QueryDslNumberRangeQuery | QueryDslTermsRangeQuery
+export type QueryDslRangeQuery = QueryDslDateRangeQuery | QueryDslNumberRangeQuery | QueryDslTermRangeQuery
 
-export interface QueryDslRangeQueryBase extends QueryDslQueryBase {
+export interface QueryDslRangeQueryBase<T = unknown> extends QueryDslQueryBase {
   relation?: QueryDslRangeRelation
+  gt?: T
+  gte?: T
+  lt?: T
+  lte?: T
+  from?: T | null
+  to?: T | null
+  format?: DateFormat
+  time_zone?: TimeZone
 }
 
 export type QueryDslRangeRelation = 'within' | 'contains' | 'intersects'
@@ -6184,6 +6178,9 @@ export interface QueryDslTermQuery extends QueryDslQueryBase {
   case_insensitive?: boolean
 }
 
+export interface QueryDslTermRangeQuery extends QueryDslRangeQueryBase<string> {
+}
+
 export interface QueryDslTermsLookup {
   index: IndexName
   id: Id
@@ -6197,15 +6194,6 @@ export type QueryDslTermsQuery = QueryDslTermsQueryKeys
   & { [property: string]: QueryDslTermsQueryField | float | string }
 
 export type QueryDslTermsQueryField = FieldValue[] | QueryDslTermsLookup
-
-export interface QueryDslTermsRangeQuery extends QueryDslRangeQueryBase {
-  gt?: string
-  gte?: string
-  lt?: string
-  lte?: string
-  from?: string | null
-  to?: string | null
-}
 
 export interface QueryDslTermsSetQuery extends QueryDslQueryBase {
   minimum_should_match_field?: Field

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5495,7 +5495,7 @@ export interface QueryDslConstantScoreQuery extends QueryDslQueryBase {
 export interface QueryDslDateDecayFunctionKeys extends QueryDslDecayFunctionBase<DateMath, Duration> {
 }
 export type QueryDslDateDecayFunction = QueryDslDateDecayFunctionKeys
-  & { [property: string]: QueryDslDecayPlacement<QueryDslTOrigin, QueryDslTScale> | QueryDslMultiValueMode }
+  & { [property: string]: QueryDslDecayPlacement<DateMath, Duration> | QueryDslMultiValueMode }
 
 export interface QueryDslDateDistanceFeatureQuery extends QueryDslDistanceFeatureQueryBase<DateMath, Duration> {
 }
@@ -5599,7 +5599,7 @@ export type QueryDslGeoBoundingBoxQuery = QueryDslGeoBoundingBoxQueryKeys
 export interface QueryDslGeoDecayFunctionKeys extends QueryDslDecayFunctionBase<GeoLocation, Distance> {
 }
 export type QueryDslGeoDecayFunction = QueryDslGeoDecayFunctionKeys
-  & { [property: string]: QueryDslDecayPlacement<QueryDslTOrigin, QueryDslTScale> | QueryDslMultiValueMode }
+  & { [property: string]: QueryDslDecayPlacement<GeoLocation, Distance> | QueryDslMultiValueMode }
 
 export interface QueryDslGeoDistanceFeatureQuery extends QueryDslDistanceFeatureQueryBase<GeoLocation, Distance> {
 }
@@ -5853,7 +5853,7 @@ export interface QueryDslNumberRangeQuery extends QueryDslRangeQueryBase<double>
 export interface QueryDslNumericDecayFunctionKeys extends QueryDslDecayFunctionBase<double, double> {
 }
 export type QueryDslNumericDecayFunction = QueryDslNumericDecayFunctionKeys
-  & { [property: string]: QueryDslDecayPlacement<QueryDslTOrigin, QueryDslTScale> | QueryDslMultiValueMode }
+  & { [property: string]: QueryDslDecayPlacement<double, double> | QueryDslMultiValueMode }
 
 export type QueryDslOperator = 'and' | 'AND' | 'or' | 'OR'
 

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -24,6 +24,7 @@ import { double, float, long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 import { DateMath, Duration } from '@_types/Time'
 import { QueryBase, QueryContainer } from './abstractions'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class BoolQuery extends QueryBase {
   /**
@@ -171,7 +172,12 @@ export class DecayPlacement<TOrigin, TScale> {
   origin?: TOrigin
 }
 
-export class DecayFunctionBase {
+/**
+ * @behavior_meta AdditionalProperty key=field value=placement
+ */
+export class DecayFunctionBase<TOrigin, TScale>
+  implements AdditionalProperty<TOrigin, TScale>
+{
   /**
    * Determines how the distance is calculated when a field used for computing the decay contains multiple values.
    * @server_default min
@@ -179,30 +185,30 @@ export class DecayFunctionBase {
   multi_value_mode?: MultiValueMode
 }
 
-/**
- * @behavior_meta AdditionalProperty key=field value=placement
- */
-export class NumericDecayFunction
-  extends DecayFunctionBase
-  implements AdditionalProperty<Field, DecayPlacement<double, double>> {}
+export class UntypedDecayFunction extends DecayFunctionBase<
+  Field,
+  UserDefinedValue
+> {}
+export class NumericDecayFunction extends DecayFunctionBase<
+  Field,
+  DecayPlacement<double, double>
+> {}
+export class DateDecayFunction extends DecayFunctionBase<
+  Field,
+  DecayPlacement<DateMath, Duration>
+> {}
+export class GeoDecayFunction extends DecayFunctionBase<
+  Field,
+  DecayPlacement<GeoLocation, Distance>
+> {}
 
 /**
- * @behavior_meta AdditionalProperty key=field value=placement
+ * @codegen_names untyped, date, numeric, geo
+ * @variants untagged untyped=_types.query_dsl.UntypedDecayFunction
  */
-export class DateDecayFunction
-  extends DecayFunctionBase
-  implements AdditionalProperty<Field, DecayPlacement<DateMath, Duration>> {}
-
-/**
- * @behavior_meta AdditionalProperty key=field value=placement
- */
-export class GeoDecayFunction
-  extends DecayFunctionBase
-  implements AdditionalProperty<Field, DecayPlacement<GeoLocation, Distance>> {}
-
-/** @codegen_names date, numeric, geo */
 // Note: deserialization depends on value types
 export type DecayFunction =
+  | UntypedDecayFunction
   | DateDecayFunction
   | NumericDecayFunction
   | GeoDecayFunction

--- a/specification/_types/query_dsl/specialized.ts
+++ b/specification/_types/query_dsl/specialized.ts
@@ -59,6 +59,11 @@ export class DistanceFeatureQueryBase<TOrigin, TDistance> extends QueryBase {
   field: Field
 }
 
+export class UntypedDistanceFeatureQuery extends DistanceFeatureQueryBase<
+  UserDefinedValue,
+  UserDefinedValue
+> {}
+
 export class GeoDistanceFeatureQuery extends DistanceFeatureQueryBase<
   GeoLocation,
   Distance
@@ -70,11 +75,12 @@ export class DateDistanceFeatureQuery extends DistanceFeatureQueryBase<
 > {}
 
 /**
- * @codegen_names geo, date
- * @variants untagged
+ * @codegen_names untyped, geo, date
+ * @variants untagged untyped=_types.query_dsl.UntypedDistanceFeatureQuery
  */
 // Note: deserialization depends on value types
 export type DistanceFeatureQuery =
+  | UntypedDistanceFeatureQuery
   | GeoDistanceFeatureQuery
   | DateDistanceFeatureQuery
 

--- a/specification/_types/query_dsl/specialized.ts
+++ b/specification/_types/query_dsl/specialized.ts
@@ -69,7 +69,10 @@ export class DateDistanceFeatureQuery extends DistanceFeatureQueryBase<
   Duration
 > {}
 
-/** @codegen_names geo, date */
+/**
+ * @codegen_names geo, date
+ * @variants untagged
+ */
 // Note: deserialization depends on value types
 export type DistanceFeatureQuery =
   | GeoDistanceFeatureQuery

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -105,33 +105,30 @@ export class PrefixQuery extends QueryBase {
   case_insensitive?: boolean
 }
 
-export class RangeQueryBase extends QueryBase {
+export class RangeQueryBase<T> extends QueryBase {
   /**
    * Indicates how the range query matches values for `range` fields.
    * @server_default intersects
    */
   relation?: RangeRelation
-}
-
-export class DateRangeQuery extends RangeQueryBase {
   /**
    * Greater than.
    */
-  gt?: DateMath
+  gt?: T
   /**
    * Greater than or equal to.
    */
-  gte?: DateMath
+  gte?: T
   /**
    * Less than.
    */
-  lt?: DateMath
+  lt?: T
   /**
    * Less than or equal to.
    */
-  lte?: DateMath
-  from?: DateMath | null
-  to?: DateMath | null
+  lte?: T
+  from?: T | null
+  to?: T | null
   /**
    * Date format used to convert `date` values in the query.
    */
@@ -142,51 +139,18 @@ export class DateRangeQuery extends RangeQueryBase {
   time_zone?: TimeZone
 }
 
-export class NumberRangeQuery extends RangeQueryBase {
-  /**
-   * Greater than.
-   */
-  gt?: double
-  /**
-   * Greater than or equal to.
-   */
-  gte?: double
-  /**
-   * Less than.
-   */
-  lt?: double
-  /**
-   * Less than or equal to.
-   */
-  lte?: double
-  from?: double | null
-  to?: double | null
-}
+export class DateRangeQuery extends RangeQueryBase<DateMath> {}
 
-export class TermsRangeQuery extends RangeQueryBase {
-  /**
-   * Greater than.
-   */
-  gt?: string
-  /**
-   * Greater than or equal to.
-   */
-  gte?: string
-  /**
-   * Less than.
-   */
-  lt?: string
-  /**
-   * Less than or equal to.
-   */
-  lte?: string
-  from?: string | null
-  to?: string | null
-}
+export class NumberRangeQuery extends RangeQueryBase<double> {}
 
-/** @codegen_names date, number, terms */
+export class TermRangeQuery extends RangeQueryBase<string> {}
+
+/**
+ * @codegen_names date, number, term
+ * @variants untagged
+ */
 // Note: deserialization depends on value types
-export type RangeQuery = DateRangeQuery | NumberRangeQuery | TermsRangeQuery
+export type RangeQuery = DateRangeQuery | NumberRangeQuery | TermRangeQuery
 
 export enum RangeRelation {
   /**

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -32,6 +32,7 @@ import { Script } from '@_types/Scripting'
 import { DateFormat, DateMath, TimeZone } from '@_types/Time'
 import { QueryBase } from './abstractions'
 import { AdditionalProperty } from '@spec_utils/behaviors'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class ExistsQuery extends QueryBase {
   /**
@@ -129,6 +130,9 @@ export class RangeQueryBase<T> extends QueryBase {
   lte?: T
   from?: T | null
   to?: T | null
+}
+
+export class UntypedRangeQuery extends RangeQueryBase<UserDefinedValue> {
   /**
    * Date format used to convert `date` values in the query.
    */
@@ -139,18 +143,31 @@ export class RangeQueryBase<T> extends QueryBase {
   time_zone?: TimeZone
 }
 
-export class DateRangeQuery extends RangeQueryBase<DateMath> {}
+export class DateRangeQuery extends RangeQueryBase<DateMath> {
+  /**
+   * Date format used to convert `date` values in the query.
+   */
+  format?: DateFormat
+  /**
+   *  Coordinated Universal Time (UTC) offset or IANA time zone used to convert `date` values in the query to UTC.
+   */
+  time_zone?: TimeZone
+}
 
 export class NumberRangeQuery extends RangeQueryBase<double> {}
 
 export class TermRangeQuery extends RangeQueryBase<string> {}
 
 /**
- * @codegen_names date, number, term
- * @variants untagged
+ * @codegen_names untyped, date, number, term
+ * @variants untagged untyped=_types.query_dsl.UntypedRangeQuery
  */
 // Note: deserialization depends on value types
-export type RangeQuery = DateRangeQuery | NumberRangeQuery | TermRangeQuery
+export type RangeQuery =
+  | UntypedRangeQuery
+  | DateRangeQuery
+  | NumberRangeQuery
+  | TermRangeQuery
 
 export enum RangeRelation {
   /**

--- a/typescript-generator/src/index.ts
+++ b/typescript-generator/src/index.ts
@@ -283,8 +283,21 @@ function buildBehaviorInterface (type: M.Interface): string {
 // The main difference with this approaches comes when you are actually using the types. 1 and 2 are good when
 // you are reading an object of that type, while 3 is good when you are writing an object of that type.
 function serializeAdditionalPropertiesType (type: M.Interface): string {
-  const dictionaryOf = lookupBehavior(type, 'AdditionalProperties') ?? lookupBehavior(type, 'AdditionalProperty')
+  let dictionaryOf = lookupBehavior(type, 'AdditionalProperties') ?? lookupBehavior(type, 'AdditionalProperty')
   if (dictionaryOf == null) throw new Error(`Unknown implements ${type.name.name}`)
+
+  const parent = model.types.find(t => t.name.name === type.inherits?.type.name)
+  if (parent != null && parent.kind === 'interface' && parent.generics != null && parent.generics.length === type.inherits?.generics?.length) {
+    const map = new Map<M.TypeName, M.ValueOf>();
+    for (let i = 0; i < parent.generics.length; i++) {
+      map.set(parent.generics[i], type.inherits.generics[i])
+    }
+    dictionaryOf = {
+      type: dictionaryOf.type,
+      generics: dictionaryOf.generics?.map(x => replaceGenerics(x, map))
+    }
+  }
+
   const extendedPropertyTypes = getAllExtendedPropertyTypes(type.inherits)
   const openGenerics = type.generics?.map(t => t.name) ?? []
   let code = `export interface ${createName(type.name)}Keys${buildGenerics(type.generics)}${buildInherits(type)} {\n`
@@ -322,6 +335,27 @@ function serializeAdditionalPropertiesType (type: M.Interface): string {
 
   function required (property: M.Property): string {
     return property.required ? '' : '?'
+  }
+}
+
+function replaceGenerics(value: M.ValueOf, map: Map<M.TypeName, M.ValueOf>): M.ValueOf {
+  if (value.kind !== 'instance_of') {
+    return value
+  }
+
+  if (value.generics == null || value.generics.length === 0) {
+    for (const entry of map) {
+      if (entry[0].namespace === value.type.namespace && entry[0].name === value.type.name) {
+        return entry[1]
+      }
+    }
+    return value
+  }
+
+  return {
+    kind: 'instance_of',
+    type: value.type,
+    generics: value.generics.map(x => replaceGenerics(x, map))
   }
 }
 

--- a/typescript-generator/src/index.ts
+++ b/typescript-generator/src/index.ts
@@ -288,7 +288,7 @@ function serializeAdditionalPropertiesType (type: M.Interface): string {
 
   const parent = model.types.find(t => t.name.name === type.inherits?.type.name)
   if (parent != null && parent.kind === 'interface' && parent.generics != null && parent.generics.length === type.inherits?.generics?.length) {
-    const map = new Map<M.TypeName, M.ValueOf>();
+    const map = new Map<M.TypeName, M.ValueOf>()
     for (let i = 0; i < parent.generics.length; i++) {
       map.set(parent.generics[i], type.inherits.generics[i])
     }
@@ -338,7 +338,7 @@ function serializeAdditionalPropertiesType (type: M.Interface): string {
   }
 }
 
-function replaceGenerics(value: M.ValueOf, map: Map<M.TypeName, M.ValueOf>): M.ValueOf {
+function replaceGenerics (value: M.ValueOf, map: Map<M.TypeName, M.ValueOf>): M.ValueOf {
   if (value.kind !== 'instance_of') {
     return value
   }

--- a/typescript-generator/src/metamodel.ts
+++ b/typescript-generator/src/metamodel.ts
@@ -180,7 +180,7 @@ export abstract class BaseType {
   specLocation: string
 }
 
-export type Variants = ExternalTag | InternalTag | Container
+export type Variants = ExternalTag | InternalTag | Container | Untagged
 
 export class VariantBase {
   /**
@@ -205,6 +205,10 @@ export class InternalTag extends VariantBase {
 
 export class Container extends VariantBase {
   kind: 'container'
+}
+
+export class Untagged extends VariantBase {
+  kind: 'untagged'
 }
 
 /**
@@ -364,8 +368,11 @@ export class TypeAlias extends BaseType {
   type: ValueOf
   /** generic parameters: either concrete types or open parameters from the enclosing type */
   generics?: TypeName[]
-  /** Only applicable to `union_of` aliases: identify typed_key unions (external) and variant inventories (internal) */
-  variants?: InternalTag | ExternalTag
+  /**
+   * Only applicable to `union_of` aliases: identify typed_key unions (external), variant inventories (internal)
+   * and untagged variants
+   */
+  variants?: InternalTag | ExternalTag | Untagged
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/typescript-generator/src/metamodel.ts
+++ b/typescript-generator/src/metamodel.ts
@@ -209,6 +209,7 @@ export class Container extends VariantBase {
 
 export class Untagged extends VariantBase {
   kind: 'untagged'
+  untypedVariant: Inherits
 }
 
 /**


### PR DESCRIPTION
## Problem

`RangeQuery` is currently declared as:

```ts
/** @codegen_names date, number, terms */
// Note: deserialization depends on value types
export type RangeQuery = DateRangeQuery | NumberRangeQuery | TermsRangeQuery
```

This declaration is highly problematic for statically typed clients as there is no way to correctly **de**serialize into the correct union variant, because for example the following variants share the same underlying JSON type:

```ts
export class TermsRangeQuery extends RangeQueryBase {
  gt?: string
```

```ts
export class DateRangeQuery extends RangeQueryBase {
  gt?: DateMath // string
```

There are more types for which the same issue applies, for example:

```ts
/** @codegen_names date, numeric, geo */
// Note: deserialization depends on value types
export type DecayFunction =
  | DateDecayFunction
  | NumericDecayFunction
  | GeoDecayFunction
```

```ts
/** @codegen_names geo, date */
// Note: deserialization depends on value types
export type DistanceFeatureQuery =
  | GeoDistanceFeatureQuery
  | DateDistanceFeatureQuery
```

## Proposal

Rearrange and mark these kind of untagged unions, that only differ by the type of some fields, in a specific way so that code generators can drive specialized generation to allow for asymmetric (de-)serialization:

```ts
export class MyTypeBase<T1, T2, ...> { ... }

export class MyTypeSpecialized1 extends MyTypeBase<int> {}
export class MyTypeSpecialized2 extends MyTypeBase<string> {}
export class MyTypeSpecialized3 extends MyTypeBase<bool> {}

/**
 * @codegen_names 1, 2, 3 
 * @variant untagged
 */
// Note: deserialization depends on value types
export type MyType = MyTypeSpecialized1 | MyTypeSpecialized2 | MyTypeSpecialized3 
```

In .NET world, the resulting class design could look like this:

```csharp
// Untyped/any variant always used for deserialization; can optionally be used by the user when building queries
public class RangeQuery
{
    public object? Gt { get; set; }
}

public abstract class GenericRangeQuery<T> : RangeQuery
{
    public new T? Gt { get; set; }
}

// Specialized range query for numbers
public sealed class NumberRangeQuery : GenericRangeQuery<double> { }

// Specialized range query for dates
public sealed class DateRangeQuery : GenericRangeQuery<DateMath> { }
```

---

Motivation and initial discussion: #2545