### PR TITLE
Java issues batch 4

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -1567,9 +1567,6 @@
           },
           {
             "$ref": "#/components/parameters/cluster.put_component_template#master_timeout"
-          },
-          {
-            "$ref": "#/components/parameters/cluster.put_component_template#cause"
           }
         ],
         "requestBody": {
@@ -1600,9 +1597,6 @@
           },
           {
             "$ref": "#/components/parameters/cluster.put_component_template#master_timeout"
-          },
-          {
-            "$ref": "#/components/parameters/cluster.put_component_template#cause"
           }
         ],
         "requestBody": {
@@ -23230,15 +23224,6 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
-        },
-        "style": "form"
-      },
-      "cluster.put_component_template#cause": {
-        "in": "query",
-        "name": "cause",
-        "deprecated": false,
-        "schema": {
-          "type": "string"
         },
         "style": "form"
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -48243,6 +48243,9 @@
                   "dense_vector"
                 ]
               },
+              "element_type": {
+                "type": "string"
+              },
               "dims": {
                 "type": "number"
               },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -53351,6 +53351,9 @@
               "field": {
                 "$ref": "#/components/schemas/_types:Fields"
               },
+              "keep": {
+                "$ref": "#/components/schemas/_types:Fields"
+              },
               "ignore_missing": {
                 "description": "If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.",
                 "type": "boolean"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -50651,7 +50651,6 @@
           "_id",
           "_index",
           "result",
-          "_seq_no",
           "_shards",
           "_version"
         ]

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -34045,6 +34045,10 @@
                 "additionalProperties": {
                   "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
                 }
+              },
+              "separator": {
+                "description": "Separator used to concatenate filter names. Defaults to &.",
+                "type": "string"
               }
             }
           }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -475,7 +475,6 @@
     },
     "cluster.put_component_template": {
       "request": [
-        "Request: query parameter 'cause' does not exist in the json spec",
         "Request: missing json spec query parameter 'timeout'",
         "request definition cluster.put_component_template:Request / body / Property 'template' / instance_of - Non-leaf type cannot be used here: 'indices._types:IndexState'"
       ],

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2855,6 +2855,7 @@ export interface AggregationsAdjacencyMatrixAggregate extends AggregationsMultiB
 
 export interface AggregationsAdjacencyMatrixAggregation extends AggregationsBucketAggregationBase {
   filters?: Record<string, QueryDslQueryContainer>
+  separator?: string
 }
 
 export interface AggregationsAdjacencyMatrixBucketKeys extends AggregationsMultiBucketBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8691,7 +8691,6 @@ export interface ClusterPutComponentTemplateRequest extends RequestBase {
   name: Name
   create?: boolean
   master_timeout?: Duration
-  cause?: string
   body?: {
     template: IndicesIndexState
     version?: VersionNumber

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12395,6 +12395,7 @@ export interface IngestProcessorContainer {
 
 export interface IngestRemoveProcessor extends IngestProcessorBase {
   field: Fields
+  keep?: Fields
   ignore_missing?: boolean
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2828,7 +2828,7 @@ export interface WriteResponseBase {
   _index: IndexName
   _primary_term?: long
   result: Result
-  _seq_no: SequenceNumber
+  _seq_no?: SequenceNumber
   _shards: ShardStatistics
   _version: VersionNumber
   forced_refresh?: boolean

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4973,6 +4973,7 @@ export interface MappingDenseVectorIndexOptions {
 
 export interface MappingDenseVectorProperty extends MappingPropertyBase {
   type: 'dense_vector'
+  element_type?: string
   dims?: integer
   similarity?: string
   index?: boolean

--- a/specification/_types/Base.ts
+++ b/specification/_types/Base.ts
@@ -38,7 +38,7 @@ export class WriteResponseBase {
   _index: IndexName
   _primary_term?: long
   result: Result
-  _seq_no: SequenceNumber
+  _seq_no?: SequenceNumber
   _shards: ShardStatistics
   _version: VersionNumber
   forced_refresh?: boolean

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -58,6 +58,10 @@ export class AdjacencyMatrixAggregation extends BucketAggregationBase {
    * At least one filter is required.
    */
   filters?: Dictionary<string, QueryContainer>
+  /**
+   * Separator used to concatenate filter names. Defaults to &.
+   */
+  separator?: string
 }
 
 export class AutoDateHistogramAggregation extends BucketAggregationBase {

--- a/specification/_types/mapping/complex.ts
+++ b/specification/_types/mapping/complex.ts
@@ -51,6 +51,7 @@ export class ObjectProperty extends CorePropertyBase {
 
 export class DenseVectorProperty extends PropertyBase {
   type: 'dense_vector'
+  element_type?: string
   dims?: integer
   similarity?: string
   index?: boolean

--- a/specification/cluster/put_component_template/ClusterPutComponentTemplateRequest.ts
+++ b/specification/cluster/put_component_template/ClusterPutComponentTemplateRequest.ts
@@ -65,12 +65,6 @@ export interface Request extends RequestBase {
      * If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s */
     master_timeout?: Duration
-
-    /**
-     * Only used for logging, to determine if a component template is from the API (default) or file-based settings.
-     * Should not be documented or exposed.
-     cause?: string
-     */
   }
   body: {
     /**

--- a/specification/cluster/put_component_template/ClusterPutComponentTemplateRequest.ts
+++ b/specification/cluster/put_component_template/ClusterPutComponentTemplateRequest.ts
@@ -21,7 +21,6 @@ import { IndexState } from '@indices/_types/IndexState'
 import { RequestBase } from '@_types/Base'
 import { Metadata, Name, VersionNumber } from '@_types/common'
 import { Duration } from '@_types/Time'
-import { ErrorCause } from '@_types/Errors'
 
 /**
  * Creates or updates a component template.
@@ -67,7 +66,11 @@ export interface Request extends RequestBase {
      * @server_default 30s */
     master_timeout?: Duration
 
-    cause?: string
+    /**
+     * Only used for logging, to determine if a component template is from the API (default) or file-based settings.
+     * Should not be documented or exposed.
+     cause?: string
+     */
   }
   body: {
     /**

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -944,6 +944,10 @@ export class RemoveProcessor extends ProcessorBase {
    */
   field: Fields
   /**
+   * Fields to be kept. When set, all fields other than those specified are removed.
+   */
+  keep?: Fields
+  /**
    * If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document.
    * @server_default false
    */


### PR DESCRIPTION
Fixes provided in this PR:

- commenting `cause` from PutComponentTemplateRequest, it's an internal parameter and should not be exposed 
- [472](https://github.com/elastic/elasticsearch-java/issues/472): `seq_no` should be optional too, like `primary_term`
- [610](https://github.com/elastic/elasticsearch-java/issues/610): RemoveProcessor is missing `keep` field. [docs]( https://www.elastic.co/guide/en/elasticsearch/reference/current/remove-processor.html#remove-processor) + [server code](https://github.com/elastic/elasticsearch/blob/b44ce50f64435d0738426551b42c950fbd59ed12/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RemoveProcessor.java#L32)
- [629](https://github.com/elastic/elasticsearch-java/issues/629): AdjacencyMatrixAggregation is missing the `separator` field. [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-adjacency-matrix-aggregation.html#adjacency-matrix-agg-params) + [server code]( https://github.com/elastic/elasticsearch/blob/ead585f9620e94819a6c83d6c953422ed0a311e0/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/AdjacencyMatrixAggregationBuilder.java#L44)
- [632](https://github.com/elastic/elasticsearch-java/issues/632): DenseVectorProperty missing `element_type`. [docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/dense-vector.html#dense-vector-params) + [server code](https://github.com/elastic/elasticsearch/blob/ead585f9620e94819a6c83d6c953422ed0a311e0/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java#L127)

