### PR TITLE
Java issues batch 5

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -39537,18 +39537,7 @@
         "properties": {
           "from": {
             "description": "Start of the range (inclusive).",
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "nullable": true,
-                "type": "string"
-              }
-            ]
+            "type": "number"
           },
           "key": {
             "description": "Custom key to return the range with.",
@@ -39556,18 +39545,7 @@
           },
           "to": {
             "description": "End of the range (exclusive).",
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "nullable": true,
-                "type": "string"
-              }
-            ]
+            "type": "number"
           }
         }
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -47267,30 +47267,107 @@
         ]
       },
       "_types.mapping:DynamicTemplate": {
-        "type": "object",
-        "properties": {
-          "mapping": {
-            "$ref": "#/components/schemas/_types.mapping:Property"
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "match": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              },
+              "path_match": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              },
+              "unmatch": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              },
+              "path_unmatch": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              },
+              "match_mapping_type": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              },
+              "unmatch_mapping_type": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              },
+              "match_pattern": {
+                "$ref": "#/components/schemas/_types.mapping:MatchType"
+              }
+            }
           },
-          "match": {
-            "type": "string"
-          },
-          "match_mapping_type": {
-            "type": "string"
-          },
-          "match_pattern": {
-            "$ref": "#/components/schemas/_types.mapping:MatchType"
-          },
-          "path_match": {
-            "type": "string"
-          },
-          "path_unmatch": {
-            "type": "string"
-          },
-          "unmatch": {
-            "type": "string"
+          {
+            "type": "object",
+            "properties": {
+              "mapping": {
+                "$ref": "#/components/schemas/_types.mapping:Property"
+              },
+              "runtime": {
+                "$ref": "#/components/schemas/_types.mapping:Property"
+              }
+            },
+            "minProperties": 1,
+            "maxProperties": 1
           }
-        }
+        ]
       },
       "_types.mapping:Property": {
         "discriminator": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -47781,6 +47781,12 @@
               "index_options": {
                 "$ref": "#/components/schemas/_types.mapping:IndexOptions"
               },
+              "script": {
+                "$ref": "#/components/schemas/_types:Script"
+              },
+              "on_script_error": {
+                "$ref": "#/components/schemas/_types.mapping:OnScriptError"
+              },
               "normalizer": {
                 "type": "string"
               },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5045,7 +5045,7 @@ export interface MappingFieldNamesField {
   enabled: boolean
 }
 
-export type MappingFieldType = 'none' | 'geo_point' | 'geo_shape' | 'ip' | 'binary' | 'keyword' | 'text' | 'search_as_you_type' | 'date' | 'date_nanos' | 'boolean' | 'completion' | 'nested' | 'object' | 'murmur3' | 'token_count' | 'percolator' | 'integer' | 'long' | 'short' | 'byte' | 'float' | 'half_float' | 'scaled_float' | 'double' | 'integer_range' | 'float_range' | 'long_range' | 'double_range' | 'date_range' | 'ip_range' | 'alias' | 'join' | 'rank_feature' | 'rank_features' | 'flattened' | 'shape' | 'histogram' | 'constant_keyword' | 'aggregate_metric_double' | 'dense_vector' | 'sparse_vector' | 'match_only_text'
+export type MappingFieldType = 'none' | 'geo_point' | 'geo_shape' | 'ip' | 'binary' | 'keyword' | 'text' | 'search_as_you_type' | 'date' | 'date_nanos' | 'boolean' | 'completion' | 'nested' | 'object' | 'version' | 'murmur3' | 'token_count' | 'percolator' | 'integer' | 'long' | 'short' | 'byte' | 'float' | 'half_float' | 'scaled_float' | 'double' | 'integer_range' | 'float_range' | 'long_range' | 'double_range' | 'date_range' | 'ip_range' | 'alias' | 'join' | 'rank_feature' | 'rank_features' | 'flattened' | 'shape' | 'histogram' | 'constant_keyword' | 'aggregate_metric_double' | 'dense_vector' | 'sparse_vector' | 'match_only_text'
 
 export interface MappingFlattenedProperty extends MappingPropertyBase {
   boost?: double

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5143,6 +5143,8 @@ export interface MappingKeywordProperty extends MappingDocValuesPropertyBase {
   eager_global_ordinals?: boolean
   index?: boolean
   index_options?: MappingIndexOptions
+  script?: Script
+  on_script_error?: MappingOnScriptError
   normalizer?: string
   norms?: boolean
   null_value?: string

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2959,9 +2959,9 @@ export interface AggregationsAggregationContainer {
 }
 
 export interface AggregationsAggregationRange {
-  from?: double | string | null
+  from?: double
   key?: string
-  to?: double | string | null
+  to?: double
 }
 
 export interface AggregationsArrayPercentilesItem {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5023,12 +5023,14 @@ export interface MappingDynamicProperty extends MappingDocValuesPropertyBase {
 
 export interface MappingDynamicTemplate {
   mapping?: MappingProperty
-  match?: string
-  match_mapping_type?: string
+  runtime?: MappingProperty
+  match?: string | string[]
+  path_match?: string | string[]
+  unmatch?: string | string[]
+  path_unmatch?: string | string[]
+  match_mapping_type?: string | string[]
+  unmatch_mapping_type?: string | string[]
   match_pattern?: MappingMatchType
-  path_match?: string
-  path_unmatch?: string
-  unmatch?: string
 }
 
 export interface MappingFieldAliasProperty extends MappingPropertyBase {

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -675,7 +675,7 @@ export class AggregationRange {
   /**
    * Start of the range (inclusive).
    */
-  from?: double | string | null
+  from?: double
   /**
    * Custom key to return the range with.
    */
@@ -683,7 +683,7 @@ export class AggregationRange {
   /**
    * End of the range (exclusive).
    */
-  to?: double | string | null
+  to?: double
 }
 
 export class RareTermsAggregation extends BucketAggregationBase {

--- a/specification/_types/analysis/normalizers.ts
+++ b/specification/_types/analysis/normalizers.ts
@@ -18,7 +18,7 @@
  */
 
 /**
- * @variants internal tag='type'
+ * @variants internal tag='type' default='custom'
  * @doc_id analysis-normalizers
  */
 export type Normalizer = LowercaseNormalizer | CustomNormalizer

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -172,6 +172,7 @@ export enum FieldType {
   completion,
   nested,
   object,
+  version,
   murmur3,
   token_count,
   percolator,

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -91,6 +91,8 @@ export class KeywordProperty extends DocValuesPropertyBase {
   eager_global_ordinals?: boolean
   index?: boolean
   index_options?: IndexOptions
+  script?: Script
+  on_script_error?: OnScriptError
   normalizer?: string
   norms?: boolean
   null_value?: string

--- a/specification/_types/mapping/dynamic-template.ts
+++ b/specification/_types/mapping/dynamic-template.ts
@@ -19,14 +19,26 @@
 
 import { Property } from './Property'
 
+/**
+ * @variants container
+ */
 export class DynamicTemplate {
   mapping?: Property
-  match?: string
-  match_mapping_type?: string
+  runtime?: Property
+  /** @variant container_property */
+  match?: string | string[]
+  /** @variant container_property */
+  path_match?: string | string[]
+  /** @variant container_property */
+  unmatch?: string | string[]
+  /** @variant container_property */
+  path_unmatch?: string | string[]
+  /** @variant container_property */
+  match_mapping_type?: string | string[]
+  /** @variant container_property */
+  unmatch_mapping_type?: string | string[]
+  /** @variant container_property */
   match_pattern?: MatchType
-  path_match?: string
-  path_unmatch?: string
-  unmatch?: string
 }
 
 export enum MatchType {


### PR DESCRIPTION
Fixes provided in this PR:

- [666](https://github.com/elastic/elasticsearch-java/issues/666): [AggregationRange](https://github.com/elastic/elasticsearch-specification/blob/02109140a64ce247fbb3fc0e6e4dd7b4b0d98da6/specification/_types/aggregations/bucket.ts#L674) accepting both double and string was probably established because at some point it was also used for RangeQuery, which accepts Objects for parameters `to` and `from`. But in the spec we just use it in [GeoDistanceAggregation](https://github.com/elastic/elasticsearch/blob/8864058f83bc485ce6c89a196e9d64b04e79b1cf/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java#L98) and [RangeAggregation](https://github.com/elastic/elasticsearch/blob/8864058f83bc485ce6c89a196e9d64b04e79b1cf/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java#L98), both accepting only doubles. Since the java client generalizes `string | double` as just string, this results in the server throwing exceptions when called. 
- [673](https://github.com/elastic/elasticsearch-java/issues/673): [FieldType](https://github.com/elastic/elasticsearch-specification/blob/53edb7836cd4d15fc15c1341a5eb7bf9dfb5d50a/specification/_types/mapping/Property.ts#L160) enum missing `version`. [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html)
- [690](https://github.com/elastic/elasticsearch-java/issues/690): [KeywordProperty](https://github.com/elastic/elasticsearch-specification/blob/53edb7836cd4d15fc15c1341a5eb7bf9dfb5d50a/specification/_types/mapping/core.ts#L89) missing `script` and `onScriptError` fields. [server code](https://github.com/elastic/elasticsearch/blob/e7350dce291921bded600cf306e4dca6138fdb25/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java#L179)
- [696](https://github.com/elastic/elasticsearch-java/issues/696): [Normalizer](https://github.com/elastic/elasticsearch-specification/blob/53edb7836cd4d15fc15c1341a5eb7bf9dfb5d50a/specification/_types/analysis/normalizers.ts#L24) is missing a default type, which for the java client means deserialization error whenever any normalizer was not created through the client (because of the missing `type` field).
-  [648](https://github.com/elastic/elasticsearch-java/issues/648): [DynamicTemplate](https://github.com/elastic/elasticsearch-specification/blob/53edb7836cd4d15fc15c1341a5eb7bf9dfb5d50a/specification/_types/mapping/dynamic-template.ts#L22) remodeled to match the current [server code](https://github.com/elastic/elasticsearch/blob/7e38ee13d593984406c9192c5ee31b6b351e99e7/server/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java#L256). `mapping` and `runtime` can be used alternatively (it's explained in the [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-templates.html)) so both fields are maps and only one must be set (therefore the container variant). 
