### PR TITLE
Renaming window_size to rank_window_size for RRF in retrievers API

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -59787,7 +59787,7 @@
                 "description": "This value determines how much influence documents in individual result sets per query have over the final ranked result set.",
                 "type": "number"
               },
-              "window_size": {
+              "rank_window_size": {
                 "description": "This value determines the size of the individual result sets per query.",
                 "type": "number"
               }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2523,7 +2523,7 @@ export interface QueryVectorBuilder {
 export interface RRFRetriever extends RetrieverBase {
   retrievers: RetrieverContainer[]
   rank_constant?: integer
-  window_size?: integer
+  rank_window_size?: integer
 }
 
 export interface RankBase {

--- a/specification/_types/Retriever.ts
+++ b/specification/_types/Retriever.ts
@@ -76,5 +76,5 @@ export class RRFRetriever extends RetrieverBase {
   /** This value determines how much influence documents in individual result sets per query have over the final ranked result set. */
   rank_constant?: integer
   /** This value determines the size of the individual result sets per query.  */
-  window_size?: integer
+  rank_window_size?: integer
 }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/pull/2551