### PR TITLE
Remove empty alias from StorageType

### DIFF
--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -513,8 +513,6 @@ export enum StorageType {
   /**
    * Default file system implementation. This will pick the best implementation depending on the operating environment, which
    * is currently hybridfs on all supported systems but is subject to change.
-   *
-   * @aliases ''
    */
   fs,
   /**


### PR DESCRIPTION
This remove what seems to be a leftover alias on the `StorageType` enum.