### PR TITLE
GA the update trained model action

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -15336,6 +15336,7 @@ export interface MlUpdateModelSnapshotResponse {
 
 export interface MlUpdateTrainedModelDeploymentRequest extends RequestBase {
   model_id: Id
+  number_of_allocations?: integer
   body?: {
     number_of_allocations?: integer
   }

--- a/specification/_json_spec/ml.update_trained_model_deployment.json
+++ b/specification/_json_spec/ml.update_trained_model_deployment.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-trained-model-deployment.html",
       "description": "Updates certain properties of trained model deployment."
     },
-    "stability": "beta",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"],
@@ -24,9 +24,16 @@
         }
       ]
     },
+    "params": {
+      "number_of_allocations": {
+        "type": "int",
+        "required": false,
+        "description": "Update the model deployment to this number of allocations."
+      }
+    },
     "body": {
       "description": "The updated trained model deployment settings",
-      "required": true
+      "required": false
     }
   }
 }

--- a/specification/ml/update_trained_model_deployment/MlUpdateTrainedModelDeploymentRequest.ts
+++ b/specification/ml/update_trained_model_deployment/MlUpdateTrainedModelDeploymentRequest.ts
@@ -46,7 +46,7 @@ export interface Request extends RequestBase {
      * @server_default 1
      */
     number_of_allocations?: integer
-  },
+  }
   body: {
     /**
      * The number of model allocations on each node where the model is deployed.

--- a/specification/ml/update_trained_model_deployment/MlUpdateTrainedModelDeploymentRequest.ts
+++ b/specification/ml/update_trained_model_deployment/MlUpdateTrainedModelDeploymentRequest.ts
@@ -35,6 +35,18 @@ export interface Request extends RequestBase {
      */
     model_id: Id
   }
+  query_parameters: {
+    /**
+     * The number of model allocations on each node where the model is deployed.
+     * All allocations on a node share the same copy of the model in memory but use
+     * a separate set of threads to evaluate the model.
+     * Increasing this value generally increases the throughput.
+     * If this setting is greater than the number of hardware threads
+     * it will automatically be changed to a value less than the number of hardware threads.
+     * @server_default 1
+     */
+    number_of_allocations?: integer
+  },
   body: {
     /**
      * The number of model allocations on each node where the model is deployed.


### PR DESCRIPTION
Follow-up of https://github.com/elastic/elasticsearch-specification/pull/2564

Reflects the change made in https://github.com/elastic/elasticsearch/pull/108868. Per our [backporting guidelines](https://github.com/elastic/elasticsearch-specification/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1), this should not be backported into 8.14, as the API is usable in 8.14 and fix is on the request side.