### PR TITLE
Fix deserialization for putsynonymresponse

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -18418,7 +18418,7 @@ export interface SynonymsPutSynonymRequest extends RequestBase {
 
 export interface SynonymsPutSynonymResponse {
   result: Result
-  reload_analyzers_details: IndicesReloadSearchAnalyzersReloadDetails
+  reload_analyzers_details: IndicesReloadSearchAnalyzersReloadResult
 }
 
 export interface SynonymsPutSynonymRuleRequest extends RequestBase {

--- a/specification/synonyms/put_synonym/SynonymsPutResponse.ts
+++ b/specification/synonyms/put_synonym/SynonymsPutResponse.ts
@@ -18,12 +18,11 @@
  */
 
 import { Result } from '@_types/Result'
-import { ReloadDetails } from '@indices/reload_search_analyzers/types'
-import { ShardStatistics } from '@_types/Stats'
+import { ReloadResult } from '@indices/reload_search_analyzers/types'
 
 export class Response {
   body: {
     result: Result
-    reload_analyzers_details: ReloadDetails
+    reload_analyzers_details: ReloadResult
   }
 }


### PR DESCRIPTION
Initially opened by @GeorgeCiachir in https://github.com/elastic/elasticsearch-specification/pull/2577, but pull requests have to opened from branches.

The ReloadResult should be a member of the PutResponseSynonym, instead of the ReloadDetails, so that the PutResponseSynonym is properly serialized.
Current behavior is that it throws a [MissingRequiredPropertyException](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.13/missing-required-property.html)

This PR fixes https://github.com/elastic/elasticsearch-java/issues/784