### PR TITLE
Remove duplicate schema.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ report
 output/schema/import-*
 output/schema/schema-no-generics.json
 output/schema/routes.go
+output/schema/schema
 .github/**/package-lock.json
 
 # Editor lockfiles


### PR DESCRIPTION
- Removed a duplicate `output/schema/schema/schema.json` file that was committed by mistake. 
- Added `output/schema/schema` to `.gitignore` to prevent this from happening again.