### PR TITLE
Fail explicitly with pull requests opened from forks

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check pull request was opened from branch
-        if: ${{ github.event.pull_request.head.repo.full_name != 'elastic/elasticsearch-specification' }}
+        if: github.event.pull_request.head.repo.full_name != 'elastic/elasticsearch-specification'
         run: echo "Validation is not supported from forks"; exit 1
         
       - uses: actions/checkout@v4

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -15,10 +15,13 @@ on:
 jobs:
   validate-pr:
     name: build
-    if: github.repository_owner == 'elastic' # this action will fail if executed from a fork
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check pull request was opened from branch
+        if: ${{ github.event.pull_request.head.repo.full_name != 'elastic/elasticsearch-specification' }}
+        run: echo "Validation is not supported from forks"; exit 1
+        
       - uses: actions/checkout@v4
         with:
           path: ./elasticsearch-specification


### PR DESCRIPTION
This is a common problem, see #2555 and #2577 for recent examples. But not *that* common, and I tend to forget about it after a few months. Indeed, the current condition does not actually skip validation, and we don't want that anyway: we want to fail when we should have run validation but could not do it. And explain *why* we failed.

If the pull request was from an Elastic employee (95% of cases), then they can reopen it from a branch. If it was community-contributed, we need to do it for them (without closing the original pull request, thus preserving attribution when merging).

From a branch, the build was correctly triggered: https://github.com/elastic/elasticsearch-specification/actions/runs/9250931808/job/25445405796?pr=2580 (and failed as expected due to the extra file I have now removed).