### PR TITLE
Fix `PhoneticTokenFilter`

### DIFF
--- a/specification/_types/analysis/phonetic-plugin.ts
+++ b/specification/_types/analysis/phonetic-plugin.ts
@@ -64,7 +64,7 @@ export enum PhoneticRuleType {
 export class PhoneticTokenFilter extends TokenFilterBase {
   type: 'phonetic'
   encoder: PhoneticEncoder
-  languageset: PhoneticLanguage[]
+  languageset: PhoneticLanguage | PhoneticLanguage[]
   max_code_len?: integer
   name_type: PhoneticNameType
   replace?: boolean


### PR DESCRIPTION
The `languageset` array sometimes gets serialized as `string`, if it only contains a single element.

Related to: https://github.com/elastic/sdh-enterprise-search/issues/1360