### PR TITLE
Optional field id in hit class

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -32350,8 +32350,7 @@
           }
         },
         "required": [
-          "_index",
-          "_id"
+          "_index"
         ]
       },
       "_types:IndexName": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1453,7 +1453,7 @@ export type SearchHighlighterType = 'plain' | 'fvh' | 'unified'| string
 
 export interface SearchHit<TDocument = unknown> {
   _index: IndexName
-  _id: Id
+  _id?: Id
   _score?: double | null
   _explanation?: ExplainExplanation
   fields?: Record<string, any>

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -43,7 +43,7 @@ export class Hit<TDocument> {
    * @es_quirk '_id' is not available when using 'stored_fields: _none_'
    * on a search request. Otherwise the field is always present on hits.
    */
-  _id: Id
+  _id?: Id
   _score?: double | null
   _explanation?: Explanation
   fields?: Dictionary<string, UserDefinedValue>


### PR DESCRIPTION
as the comment just above the field says: 

> '_id' is not available when using 'stored_fields: `_none_`'
