### PR TITLE
Java client issues batch 6

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -59356,10 +59356,7 @@
           "version_type": {
             "$ref": "#/components/schemas/_types:VersionType"
           }
-        },
-        "required": [
-          "_id"
-        ]
+        }
       },
       "_global.termvectors:Filter": {
         "type": "object",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -30689,7 +30689,7 @@
           {
             "type": "object",
             "properties": {
-              "doc_count_error": {
+              "doc_count_error_upper_bound": {
                 "type": "number"
               }
             }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -818,7 +818,7 @@ export interface MsearchTemplateTemplateConfig {
 }
 
 export interface MtermvectorsOperation {
-  _id: Id
+  _id?: Id
   _index?: IndexName
   doc?: any
   fields?: Fields

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4164,7 +4164,7 @@ export type AggregationsTermsAggregationCollectMode = 'depth_first' | 'breadth_f
 export type AggregationsTermsAggregationExecutionHint = 'map' | 'global_ordinals' | 'global_ordinals_hash' | 'global_ordinals_low_cardinality'
 
 export interface AggregationsTermsBucketBase extends AggregationsMultiBucketBase {
-  doc_count_error?: long
+  doc_count_error_upper_bound?: long
 }
 
 export type AggregationsTermsExclude = string | string[]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16031,7 +16031,7 @@ export interface NodesInfoNodeInfoRepositoriesUrl {
 
 export interface NodesInfoNodeInfoScript {
   allowed_types: string
-  disable_max_compilations_rate: string
+  disable_max_compilations_rate?: string
 }
 
 export interface NodesInfoNodeInfoSearch {
@@ -16049,7 +16049,7 @@ export interface NodesInfoNodeInfoSettings {
   repositories?: NodesInfoNodeInfoRepositories
   discovery?: NodesInfoNodeInfoDiscover
   action?: NodesInfoNodeInfoAction
-  client: NodesInfoNodeInfoClient
+  client?: NodesInfoNodeInfoClient
   http: NodesInfoNodeInfoSettingsHttp
   bootstrap?: NodesInfoNodeInfoBootstrap
   transport: NodesInfoNodeInfoSettingsTransport
@@ -16121,7 +16121,7 @@ export interface NodesInfoNodeInfoSettingsIngest {
 }
 
 export interface NodesInfoNodeInfoSettingsNetwork {
-  host: Host
+  host?: Host
 }
 
 export interface NodesInfoNodeInfoSettingsNode {

--- a/specification/_global/mtermvectors/types.ts
+++ b/specification/_global/mtermvectors/types.ts
@@ -36,7 +36,7 @@ export class Operation {
   /**
    * The ID of the document.
    */
-  _id: Id
+  _id?: Id
   /**
    * The index of the document.
    */

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -703,7 +703,7 @@ export class StringStatsAggregate extends AggregateBase {
   avg_length_as_string?: string
 }
 
-/** @variant name=box_plot */
+/** @variant name=boxplot */
 export class BoxPlotAggregate extends AggregateBase {
   min: double
   max: double

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -389,7 +389,7 @@ export class TermsAggregateBase<
 export class StringTermsAggregate extends TermsAggregateBase<StringTermsBucket> {}
 
 export class TermsBucketBase extends MultiBucketBase {
-  doc_count_error?: long
+  doc_count_error_upper_bound?: long
 }
 
 export class StringTermsBucket extends TermsBucketBase {

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -73,7 +73,7 @@ export class NodeInfoSettings {
   repositories?: NodeInfoRepositories
   discovery?: NodeInfoDiscover
   action?: NodeInfoAction
-  client: NodeInfoClient
+  client?: NodeInfoClient
   http: NodeInfoSettingsHttp
   bootstrap?: NodeInfoBootstrap
   transport: NodeInfoSettingsTransport
@@ -218,7 +218,7 @@ export class NodeInfoSettingsTransportFeatures {
 }
 
 export class NodeInfoSettingsNetwork {
-  host: Host
+  host?: Host
 }
 
 export class NodeInfoIngest {
@@ -280,7 +280,7 @@ export class NodeInfoXpackLicenseType {
 
 export class NodeInfoScript {
   allowed_types: string
-  disable_max_compilations_rate: string
+  disable_max_compilations_rate?: string
 }
 
 export class NodeInfoSearch {


### PR DESCRIPTION
- [558](https://github.com/elastic/elasticsearch-java/issues/558): box_plot should be boxplot. [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-boxplot-aggregation.html)
- [785](https://github.com/elastic/elasticsearch-java/issues/785): `doc_count_error` should be `doc_count_error_upper_bound`. [server code](https://github.com/elastic/elasticsearch/blob/ef12b99284785b5877bf62193bdb6f40a0bde66f/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java#L28) (it's the only match when searching)
- [716](https://github.com/elastic/elasticsearch-java/issues/716), [783](https://github.com/elastic/elasticsearch-java/issues/783): multi term vector can take both `_id` or `doc`, with `doc` being an artificial document which has not been indexed. [server code](https://github.com/elastic/elasticsearch/blob/98e02c3c878c11c2802da039bb74f47710ce6651/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java#L234), [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-termvectors.html#docs-multi-termvectors-artificial-doc)
- [707](https://github.com/elastic/elasticsearch-java/issues/707): some optional types around NodeInfo and subclasses, to make the nodes.info() endpoint work. 