### PR TITLE
[ML] Update Delete Inference Endpoint for dry_run and force options

### DIFF
--- a/specification/_json_spec/inference.delete.json
+++ b/specification/_json_spec/inference.delete.json
@@ -7,13 +7,17 @@
     "stability": "experimental",
     "visibility": "public",
     "headers": {
-      "accept": ["application/json"]
+      "accept": [
+        "application/json"
+      ]
     },
     "url": {
       "paths": [
         {
           "path": "/_inference/{inference_id}",
-          "methods": ["DELETE"],
+          "methods": [
+            "DELETE"
+          ],
           "parts": {
             "inference_id": {
               "type": "string",
@@ -23,7 +27,9 @@
         },
         {
           "path": "/_inference/{task_type}/{inference_id}",
-          "methods": ["DELETE"],
+          "methods": [
+            "DELETE"
+          ],
           "parts": {
             "task_type": {
               "type": "string",
@@ -36,6 +42,18 @@
           }
         }
       ]
+    },
+    "params": {
+      "dry_run": {
+        "type": "boolean",
+        "description": "If true the endpoint will not be deleted and a list of ingest processors which reference this endpoint will be returned.",
+        "required": false
+      },
+      "force": {
+        "type": "boolean",
+        "description": "True if the endpoint should be forcefully stopped (regardless of whether or not it is referenced by any ingest processors or semantic text fields).",
+        "required": false
+      }
     }
   }
 }

--- a/specification/_json_spec/inference.delete.json
+++ b/specification/_json_spec/inference.delete.json
@@ -7,17 +7,13 @@
     "stability": "experimental",
     "visibility": "public",
     "headers": {
-      "accept": [
-        "application/json"
-      ]
+      "accept": ["application/json"]
     },
     "url": {
       "paths": [
         {
           "path": "/_inference/{inference_id}",
-          "methods": [
-            "DELETE"
-          ],
+          "methods": ["DELETE"],
           "parts": {
             "inference_id": {
               "type": "string",
@@ -27,9 +23,7 @@
         },
         {
           "path": "/_inference/{task_type}/{inference_id}",
-          "methods": [
-            "DELETE"
-          ],
+          "methods": ["DELETE"],
           "parts": {
             "task_type": {
               "type": "string",

--- a/specification/inference/_types/Results.ts
+++ b/specification/inference/_types/Results.ts
@@ -19,7 +19,7 @@
 
 import { float, byte, integer } from '@_types/Numeric'
 import { Dictionary } from '@spec_utils/Dictionary'
-import {AcknowledgedResponseBase} from "@_types/Base";
+import { AcknowledgedResponseBase } from '@_types/Base'
 
 /**
  * Sparse Embedding tokens are represented as a dictionary
@@ -92,5 +92,5 @@ export class InferenceResult {
  * Acknowledged response. For dry_run, contains the list of ingest processors which reference the inference endpoint
  */
 export class DeleteInferenceEndpointResult extends AcknowledgedResponseBase {
-    ingest_processors: Array<string>
+  ingest_processors: Array<string>
 }

--- a/specification/inference/_types/Results.ts
+++ b/specification/inference/_types/Results.ts
@@ -19,6 +19,7 @@
 
 import { float, byte, integer } from '@_types/Numeric'
 import { Dictionary } from '@spec_utils/Dictionary'
+import {AcknowledgedResponseBase} from "@_types/Base";
 
 /**
  * Sparse Embedding tokens are represented as a dictionary
@@ -74,6 +75,7 @@ export class RankedDocument {
   score: float
   text?: string
 }
+
 /**
  * InferenceResult is an aggregation of mutually exclusive variants
  * @variants container
@@ -84,4 +86,11 @@ export class InferenceResult {
   sparse_embedding?: Array<SparseEmbeddingResult>
   completion?: Array<CompletionResult>
   rerank?: Array<RankedDocument>
+}
+
+/**
+ * Acknowledged response. For dry_run, contains the list of ingest processors which reference the inference endpoint
+ */
+export class DeleteInferenceEndpointResult extends AcknowledgedResponseBase {
+    ingest_processors: Array<string>
 }

--- a/specification/inference/_types/Results.ts
+++ b/specification/inference/_types/Results.ts
@@ -89,8 +89,8 @@ export class InferenceResult {
 }
 
 /**
- * Acknowledged response. For dry_run, contains the list of ingest processors which reference the inference endpoint
+ * Acknowledged response. For dry_run, contains the list of pipelines which reference the inference endpoint
  */
 export class DeleteInferenceEndpointResult extends AcknowledgedResponseBase {
-  ingest_processors: Array<string>
+  pipelines: Array<string>
 }

--- a/specification/inference/delete/DeleteRequest.ts
+++ b/specification/inference/delete/DeleteRequest.ts
@@ -38,7 +38,8 @@ export interface Request extends RequestBase {
      * The inference Id
      */
     inference_id: Id
-query_parameters: {
+  }
+  query_parameters: {
     /**
      * When true, the endpoint is not deleted, and a list of ingest processors which reference this endpoint is returned
      * @server_default false

--- a/specification/inference/delete/DeleteRequest.ts
+++ b/specification/inference/delete/DeleteRequest.ts
@@ -38,7 +38,7 @@ export interface Request extends RequestBase {
      * The inference Id
      */
     inference_id: Id
-
+query_parameters: {
     /**
      * When true, the endpoint is not deleted, and a list of ingest processors which reference this endpoint is returned
      * @server_default false

--- a/specification/inference/delete/DeleteRequest.ts
+++ b/specification/inference/delete/DeleteRequest.ts
@@ -33,9 +33,22 @@ export interface Request extends RequestBase {
      * The task type
      */
     task_type?: TaskType
+
     /**
      * The inference Id
      */
     inference_id: Id
+
+    /**
+     * When true, the endpoint is not deleted, and a list of ingest processors which reference this endpoint is returned
+     * @server_default false
+     */
+    dry_run?: Boolean
+
+    /**
+     * When true, the inference endpoint is forcefully deleted even if it is still being used by ingest processors or semantic text fields
+     * @server_default false
+     */
+    force?: Boolean
   }
 }

--- a/specification/inference/delete/DeleteResponse.ts
+++ b/specification/inference/delete/DeleteResponse.ts
@@ -20,7 +20,5 @@
 import { DeleteInferenceEndpointResult } from '@inference/_types/Results'
 
 export class Response {
-  body: {
-    dryRunResult: DeleteInferenceEndpointResult
-  }
+  body: DeleteInferenceEndpointResult
 }

--- a/specification/inference/delete/DeleteResponse.ts
+++ b/specification/inference/delete/DeleteResponse.ts
@@ -17,8 +17,11 @@
  * under the License.
  */
 
-import { AcknowledgedResponseBase } from '@_types/Base'
+
+import {DeleteInferenceEndpointResult} from "@inference/_types/Results";
 
 export class Response {
-  body: AcknowledgedResponseBase
+  body: {
+    dryRunResult: DeleteInferenceEndpointResult
+  }
 }

--- a/specification/inference/delete/DeleteResponse.ts
+++ b/specification/inference/delete/DeleteResponse.ts
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-
-import {DeleteInferenceEndpointResult} from "@inference/_types/Results";
+import { DeleteInferenceEndpointResult } from '@inference/_types/Results'
 
 export class Response {
   body: {


### PR DESCRIPTION
Following on  https://github.com/elastic/elasticsearch/pull/109123 and https://github.com/elastic/elasticsearch/pull/109384, this change updates the elasticsearch specification to include the dry_run and force options for the Delete Inference Endpoint API.