### PR TITLE
`InferenceResponseResult.predicted_value` is single-or-many

### DIFF
--- a/specification/ml/_types/inference.ts
+++ b/specification/ml/_types/inference.ts
@@ -475,7 +475,7 @@ export class InferenceResponseResult {
    * For regression models, its a numerical value
    * For classification models, it may be an integer, double, boolean or string depending on prediction type
    */
-  predicted_value?: PredictedValue[]
+  predicted_value?: PredictedValue | PredictedValue[]
   /**
    * For fill mask tasks, the response contains the input text sequence with the mask token replaced by the predicted
    * value.


### PR DESCRIPTION
Some examples of singular predicted values are documented here:
https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-trained-model.html#infer-trained-model-example

Related to: https://github.com/elastic/elasticsearch-net/issues/8218