### PR TITLE
Fix generation output type check

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -51,6 +51,11 @@ jobs:
           npm install --prefix .github/validate-pr
           make setup
 
+      - name: Generate specification and check generated types
+        working-directory: ./elasticsearch-specification
+        run: |
+          make generate
+
       - name: Download artifacts
         working-directory: ./clients-flight-recorder
         run: |

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -2,13 +2,6 @@ name: Validate APIs
 
 on:
   pull_request:
-    paths:
-      - 'specification/**'
-      - '!specification/_types/**'
-      - '!specification/_spec_utils/**'
-      - '!specification/_doc_ids/**'
-      - '!specification/_json_spec/**'
-
     branches:
       - main
 

--- a/typescript-generator/package.json
+++ b/typescript-generator/package.json
@@ -10,7 +10,7 @@
     "kibana": "KIBANA=true ts-node src/client.ts",
     "lint": "ts-standard src",
     "lint:fix": "ts-standard --fix src",
-    "is-valid-output": "tsc --noEmit",
+    "is-valid-output": "tsc --noEmit ../output/typescript/types.ts",
     "test": "npm run lint",
     "build": "rm -rf lib && tsc"
   },


### PR DESCRIPTION
Without https://github.com/elastic/elasticsearch-specification/pull/2612, the generated `types.ts` are not valid TypeScript. But we did not notice because the `tsc --noEmit` call was not looking at the actual output which is in a different directory. I'm not including #2612 on purpose here to make sure the CI breaks with that fix.