### PR TITLE
Attach generic type parameters to the declaring type

### DIFF
--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -444,7 +444,7 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
     for (const typeParameter of declaration.getTypeParameters()) {
       type.generics = (type.generics ?? []).concat({
         name: modelGenerics(typeParameter),
-        namespace: type.name.namespace
+        namespace: type.name.namespace + '.' + type.name.name 
       })
     }
 
@@ -532,7 +532,7 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
     for (const typeParameter of declaration.getTypeParameters()) {
       type.generics = (type.generics ?? []).concat({
         name: modelGenerics(typeParameter),
-        namespace: type.name.namespace
+        namespace: type.name.namespace + '.' + type.name.name 
       })
     }
 

--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -444,7 +444,7 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
     for (const typeParameter of declaration.getTypeParameters()) {
       type.generics = (type.generics ?? []).concat({
         name: modelGenerics(typeParameter),
-        namespace: type.name.namespace + '.' + type.name.name 
+        namespace: type.name.namespace + '.' + type.name.name
       })
     }
 
@@ -532,7 +532,7 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
     for (const typeParameter of declaration.getTypeParameters()) {
       type.generics = (type.generics ?? []).concat({
         name: modelGenerics(typeParameter),
-        namespace: type.name.namespace + '.' + type.name.name 
+        namespace: type.name.namespace + '.' + type.name.name
       })
     }
 

--- a/compiler/src/model/json-spec.ts
+++ b/compiler/src/model/json-spec.ts
@@ -67,12 +67,13 @@ export default function buildJsonSpec (): Map<string, JsonSpec> {
   const files = readdirSync(jsonSpecPath)
     .filter(file => file.endsWith('.json'))
 
-  const map = new Map()
+  const map: Map<string, JsonSpec> = new Map()
   for (const file of files) {
     const json = require(join(jsonSpecPath, file))
     const name = Object.keys(json)[0]
     map.set(name, json[name])
   }
 
-  return map
+  // Ensure deterministic ordering
+  return new Map([...map.entries()].sort((a, b) => a[0].localeCompare(b[0])))
 }

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -351,7 +351,7 @@ export function modelType (node: Node): model.ValueOf {
               Node.isClassDeclaration(parent) ||
               Node.isInterfaceDeclaration(parent) ||
               Node.isTypeAliasDeclaration(parent),
-              'It should be a class, interface, enum, type alias, or type parameter declaration'
+              'It should be a class, interface, or type alias declaration'
             )
 
             type.type.namespace = `${type.type.namespace}.${parent.getName() as string}`

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -343,20 +343,20 @@ export function modelType (node: Node): model.ValueOf {
               namespace: getNameSpace(node)
             }
           }
-          
+
           if (Node.isTypeParameterDeclaration(declaration)) {
-            const parent = declaration.getParent();
+            const parent = declaration.getParent()
             assert(
-                parent,
-                Node.isClassDeclaration(parent) ||
-                Node.isInterfaceDeclaration(parent) ||
-                Node.isTypeAliasDeclaration(parent),
-                'It should be a class, interface, enum, type alias, or type parameter declaration'
+              parent,
+              Node.isClassDeclaration(parent) ||
+              Node.isInterfaceDeclaration(parent) ||
+              Node.isTypeAliasDeclaration(parent),
+              'It should be a class, interface, enum, type alias, or type parameter declaration'
             )
-            
-            type.type.namespace += '.' + parent.getName() as string;
+
+            type.type.namespace = `${type.type.namespace}.${parent.getName() as string}`
           }
-          
+
           return type
         }
       }
@@ -489,10 +489,9 @@ export function modelEnumDeclaration (declaration: EnumDeclaration): model.Enum 
 export function modelTypeAlias (declaration: TypeAliasDeclaration): model.TypeAlias {
   const type = declaration.getTypeNode()
   assert(declaration, type != null, 'Type alias without a referenced type')
-  
   const generics = declaration.getTypeParameters().map(typeParameter => ({
     name: modelGenerics(typeParameter),
-    namespace: getNameSpace(typeParameter) + '.' + declaration.getName() as string
+    namespace: getNameSpace(typeParameter) + '.' + declaration.getName()
   }))
 
   const alias = modelType(type)

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -731,7 +731,7 @@ export function hoistTypeAnnotations (type: model.TypeDefinition, jsDocs: JSDoc[
         '@codegen_names must have the number of items as the union definition'
       )
     } else if (tag === 'es_quirk') {
-      type.esQuirk = value
+      type.esQuirk = value.replace(/\r/g, '')
     } else {
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on type ${type.name.name}`)
     }

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -343,6 +343,20 @@ export function modelType (node: Node): model.ValueOf {
               namespace: getNameSpace(node)
             }
           }
+          
+          if (Node.isTypeParameterDeclaration(declaration)) {
+            const parent = declaration.getParent();
+            assert(
+                parent,
+                Node.isClassDeclaration(parent) ||
+                Node.isInterfaceDeclaration(parent) ||
+                Node.isTypeAliasDeclaration(parent),
+                'It should be a class, interface, enum, type alias, or type parameter declaration'
+            )
+            
+            type.type.namespace += '.' + parent.getName() as string;
+          }
+          
           return type
         }
       }
@@ -475,9 +489,10 @@ export function modelEnumDeclaration (declaration: EnumDeclaration): model.Enum 
 export function modelTypeAlias (declaration: TypeAliasDeclaration): model.TypeAlias {
   const type = declaration.getTypeNode()
   assert(declaration, type != null, 'Type alias without a referenced type')
+  
   const generics = declaration.getTypeParameters().map(typeParameter => ({
     name: modelGenerics(typeParameter),
-    namespace: getNameSpace(typeParameter)
+    namespace: getNameSpace(typeParameter) + '.' + declaration.getName() as string
   }))
 
   const alias = modelType(type)

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -45,16 +45,16 @@
     "async_search.get": {
       "request": [],
       "response": [
-        "type_alias definition _types:EpochTime / instance_of - No type definition for '_types:Unit'",
+        "type_alias definition _types:EpochTime / instance_of - No type definition for '_types.EpochTime:Unit'",
         "type_alias definition _types.aggregations:Aggregate / instance_of - Non-leaf type cannot be used here: '_types.aggregations:StatsAggregate'",
         "type_alias definition _types.aggregations:Aggregate / instance_of - Non-leaf type cannot be used here: '_types.aggregations:ExtendedStatsAggregate'",
-        "type_alias definition _types.aggregations:Buckets / union_of / dictionary_of / instance_of - No type definition for '_types.aggregations:TBucket'",
-        "type_alias definition _types.aggregations:Buckets / union_of / array_of / instance_of - No type definition for '_types.aggregations:TBucket'",
+        "type_alias definition _types.aggregations:Buckets / union_of / dictionary_of / instance_of - No type definition for '_types.aggregations.Buckets:TBucket'",
+        "type_alias definition _types.aggregations:Buckets / union_of / array_of / instance_of - No type definition for '_types.aggregations.Buckets:TBucket'",
         "type_alias definition _spec_utils:Void / instance_of - No type definition for '_builtins:void'",
         "type_alias definition _types.aggregations:Aggregate / instance_of - Non-leaf type cannot be used here: '_types.aggregations:RangeAggregate'",
-        "type_alias definition _types:DurationValue / instance_of - No type definition for '_types:Unit'",
+        "type_alias definition _types:DurationValue / instance_of - No type definition for '_types.DurationValue:Unit'",
         "type_alias definition _global.search._types:Suggest - A tagged union should not have generic parameters",
-        "type_alias definition _global.search._types:Suggest / instance_of / Generics / instance_of - No type definition for '_global.search._types:TDocument'",
+        "type_alias definition _global.search._types:Suggest / instance_of / Generics / instance_of - No type definition for '_global.search._types.Suggest:TDocument'",
         "type_alias definition _global.search._types:Suggest - Expected 1 generic parameters but got 0"
       ]
     },
@@ -66,7 +66,7 @@
         "Request: query parameter 'scroll' does not exist in the json spec",
         "Request: query parameter 'rest_total_hits_as_int' does not exist in the json spec",
         "interface definition _types:QueryVectorBuilder - Property text_embedding is a single-variant and must be required",
-        "type_alias definition _spec_utils:PipeSeparatedFlags / union_of / instance_of - No type definition for '_spec_utils:T'"
+        "type_alias definition _spec_utils:PipeSeparatedFlags / union_of / instance_of - No type definition for '_spec_utils.PipeSeparatedFlags:T'"
       ],
       "response": []
     },
@@ -136,7 +136,7 @@
         "request definition cat.count:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": [
-        "type_alias definition _spec_utils:Stringified / union_of / instance_of - No type definition for '_spec_utils:T'"
+        "type_alias definition _spec_utils:Stringified / union_of / instance_of - No type definition for '_spec_utils.Stringified:T'"
       ]
     },
     "cat.fielddata": {
@@ -490,7 +490,7 @@
     },
     "connector.last_sync": {
       "request": [
-        "type_alias definition _spec_utils:WithNullValue / union_of / instance_of - No type definition for '_spec_utils:T'"
+        "type_alias definition _spec_utils:WithNullValue / union_of / instance_of - No type definition for '_spec_utils.WithNullValue:T'"
       ],
       "response": []
     },
@@ -611,7 +611,7 @@
         "Request: query parameter 'allow_partial_search_results' does not exist in the json spec"
       ],
       "response": [
-        "type_alias definition _global.msearch:ResponseItem / union_of / instance_of / Generics / instance_of - No type definition for '_global.msearch:TDocument'"
+        "type_alias definition _global.msearch:ResponseItem / union_of / instance_of / Generics / instance_of - No type definition for '_global.msearch.ResponseItem:TDocument'"
       ]
     },
     "fleet.post_secret": {
@@ -934,7 +934,7 @@
     "mget": {
       "request": [],
       "response": [
-        "type_alias definition _global.mget:ResponseItem / union_of / instance_of / Generics / instance_of - No type definition for '_global.mget:TDocument'"
+        "type_alias definition _global.mget:ResponseItem / union_of / instance_of / Generics / instance_of - No type definition for '_global.mget.ResponseItem:TDocument'"
       ]
     },
     "ml.delete_calendar": {


### PR DESCRIPTION
Attach generic type parameters to the declaring type instead of the parent namespace.

This more precisely reflects the actual declaration hierarchy and allows type parameters to be uniquely identified by their FQNs.

The following definition:

```ts
export class A<T> { }
```

caused a type parameter with the FQN `some.namespace.T` to get emitted.

The same type parameter is now emitted as `some.namespace.A.T` instead.