### PR TITLE
Add semantic_text and semantic query

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5338,7 +5338,6 @@ export interface MappingSemanticTextProperty {
   type: 'semantic_text'
   meta?: Record<string, string>
   inference_id: Id
-  copy_to?: Fields
 }
 
 export interface MappingShapeProperty extends MappingDocValuesPropertyBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5080,7 +5080,7 @@ export interface MappingFieldNamesField {
   enabled: boolean
 }
 
-export type MappingFieldType = 'none' | 'geo_point' | 'geo_shape' | 'ip' | 'binary' | 'keyword' | 'text' | 'search_as_you_type' | 'date' | 'date_nanos' | 'boolean' | 'completion' | 'nested' | 'object' | 'version' | 'murmur3' | 'token_count' | 'percolator' | 'integer' | 'long' | 'short' | 'byte' | 'float' | 'half_float' | 'scaled_float' | 'double' | 'integer_range' | 'float_range' | 'long_range' | 'double_range' | 'date_range' | 'ip_range' | 'alias' | 'join' | 'rank_feature' | 'rank_features' | 'flattened' | 'shape' | 'histogram' | 'constant_keyword' | 'aggregate_metric_double' | 'dense_vector' | 'sparse_vector' | 'match_only_text' | 'icu_collation_keyword'
+export type MappingFieldType = 'none' | 'geo_point' | 'geo_shape' | 'ip' | 'binary' | 'keyword' | 'text' | 'search_as_you_type' | 'date' | 'date_nanos' | 'boolean' | 'completion' | 'nested' | 'object' | 'version' | 'murmur3' | 'token_count' | 'percolator' | 'integer' | 'long' | 'short' | 'byte' | 'float' | 'half_float' | 'scaled_float' | 'double' | 'integer_range' | 'float_range' | 'long_range' | 'double_range' | 'date_range' | 'ip_range' | 'alias' | 'join' | 'rank_feature' | 'rank_features' | 'flattened' | 'shape' | 'histogram' | 'constant_keyword' | 'aggregate_metric_double' | 'dense_vector' | 'semantic_text' | 'sparse_vector' | 'match_only_text' | 'icu_collation_keyword'
 
 export interface MappingFlattenedProperty extends MappingPropertyBase {
   boost?: double
@@ -5267,7 +5267,7 @@ export interface MappingPointProperty extends MappingDocValuesPropertyBase {
   type: 'point'
 }
 
-export type MappingProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDynamicProperty | MappingJoinProperty | MappingKeywordProperty | MappingMatchOnlyTextProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingSearchAsYouTypeProperty | MappingTextProperty | MappingVersionProperty | MappingWildcardProperty | MappingDateNanosProperty | MappingDateProperty | MappingAggregateMetricDoubleProperty | MappingDenseVectorProperty | MappingSparseVectorProperty | MappingFlattenedProperty | MappingNestedProperty | MappingObjectProperty | MappingCompletionProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingTokenCountProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingPointProperty | MappingShapeProperty | MappingByteNumberProperty | MappingDoubleNumberProperty | MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingScaledFloatNumberProperty | MappingShortNumberProperty | MappingUnsignedLongNumberProperty | MappingDateRangeProperty | MappingDoubleRangeProperty | MappingFloatRangeProperty | MappingIntegerRangeProperty | MappingIpRangeProperty | MappingLongRangeProperty | MappingIcuCollationProperty
+export type MappingProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDynamicProperty | MappingJoinProperty | MappingKeywordProperty | MappingMatchOnlyTextProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingSearchAsYouTypeProperty | MappingTextProperty | MappingVersionProperty | MappingWildcardProperty | MappingDateNanosProperty | MappingDateProperty | MappingAggregateMetricDoubleProperty | MappingDenseVectorProperty | MappingFlattenedProperty | MappingNestedProperty | MappingObjectProperty | MappingSemanticTextProperty | MappingSparseVectorProperty | MappingCompletionProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingTokenCountProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingPointProperty | MappingShapeProperty | MappingByteNumberProperty | MappingDoubleNumberProperty | MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingScaledFloatNumberProperty | MappingShortNumberProperty | MappingUnsignedLongNumberProperty | MappingDateRangeProperty | MappingDoubleRangeProperty | MappingFloatRangeProperty | MappingIntegerRangeProperty | MappingIpRangeProperty | MappingLongRangeProperty | MappingIcuCollationProperty
 
 export interface MappingPropertyBase {
   meta?: Record<string, string>
@@ -5332,6 +5332,13 @@ export interface MappingSearchAsYouTypeProperty extends MappingCorePropertyBase 
   search_quote_analyzer?: string
   term_vector?: MappingTermVectorOption
   type: 'search_as_you_type'
+}
+
+export interface MappingSemanticTextProperty {
+  type: 'semantic_text'
+  meta?: Record<string, string>
+  inference_id: Id
+  copy_to?: Fields
 }
 
 export interface MappingShapeProperty extends MappingDocValuesPropertyBase {
@@ -5944,6 +5951,7 @@ export interface QueryDslQueryContainer {
   rule_query?: QueryDslRuleQuery
   script?: QueryDslScriptQuery
   script_score?: QueryDslScriptScoreQuery
+  semantic?: QueryDslSemanticQuery
   shape?: QueryDslShapeQuery
   simple_query_string?: QueryDslSimpleQueryStringQuery
   span_containing?: QueryDslSpanContainingQuery
@@ -6061,6 +6069,11 @@ export interface QueryDslScriptScoreQuery extends QueryDslQueryBase {
   min_score?: float
   query: QueryDslQueryContainer
   script: Script
+}
+
+export interface QueryDslSemanticQuery extends QueryDslQueryBase {
+  field: string
+  query: string
 }
 
 export interface QueryDslShapeFieldQuery {

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -48,6 +48,7 @@ import {
   ScaledFloatNumberProperty,
   SearchAsYouTypeProperty,
   ShortNumberProperty,
+  SemanticTextProperty,
   SparseVectorProperty,
   TextProperty,
   UnsignedLongNumberProperty,
@@ -119,10 +120,11 @@ export type Property =
   // complex
   | AggregateMetricDoubleProperty
   | DenseVectorProperty
-  | SparseVectorProperty
   | FlattenedProperty
   | NestedProperty
   | ObjectProperty
+  | SemanticTextProperty
+  | SparseVectorProperty
 
   // structured
   | CompletionProperty
@@ -204,6 +206,7 @@ export enum FieldType {
   constant_keyword,
   aggregate_metric_double,
   dense_vector,
+  semantic_text,
   sparse_vector,
   match_only_text,
   icu_collation_keyword

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -20,7 +20,13 @@
 import { FielddataFrequencyFilter } from '@indices/_types/FielddataFrequencyFilter'
 import { NumericFielddata } from '@indices/_types/NumericFielddata'
 import { Dictionary } from '@spec_utils/Dictionary'
-import { Fields, FieldValue, PropertyName, RelationName } from '@_types/common'
+import {
+  Fields,
+  FieldValue,
+  Id,
+  PropertyName,
+  RelationName
+} from '@_types/common'
 import {
   byte,
   double,
@@ -195,6 +201,13 @@ export class RankFeaturesProperty extends PropertyBase {
 
 export class SparseVectorProperty extends PropertyBase {
   type: 'sparse_vector'
+}
+
+export class SemanticTextProperty {
+  type: 'semantic_text'
+  meta?: Dictionary<string, string>
+  inference_id: Id
+  copy_to?: Fields
 }
 
 export class SearchAsYouTypeProperty extends CorePropertyBase {

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -207,7 +207,6 @@ export class SemanticTextProperty {
   type: 'semantic_text'
   meta?: Dictionary<string, string>
   inference_id: Id
-  copy_to?: Fields
 }
 
 export class SearchAsYouTypeProperty extends CorePropertyBase {

--- a/specification/_types/query_dsl/SemanticQuery.ts
+++ b/specification/_types/query_dsl/SemanticQuery.ts
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { QueryBase } from './abstractions'
+
+export class SemanticQuery extends QueryBase {
+  /** The field to query, which must be a semantic_text field type */
+  field: string
+  /** The query text */
+  query: string
+}

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -96,6 +96,7 @@ import {
 import { TextExpansionQuery } from './TextExpansionQuery'
 import { WeightedTokensQuery } from './WeightedTokensQuery'
 import { KnnQuery } from '@_types/Knn'
+import { SemanticQuery } from './SemanticQuery'
 
 /**
  * @variants container
@@ -301,6 +302,12 @@ export class QueryContainer {
    * @doc_id query-dsl-script-score-query
    */
   script_score?: ScriptScoreQuery
+  /**
+   * A semantic query to semantic_text field types
+   * @availability stack since=8.15.0
+   * @availability serverless
+   */
+  semantic?: SemanticQuery
   /**
    * Queries documents that contain fields indexed using the `shape` type.
    * @doc_id query-dsl-shape-query


### PR DESCRIPTION
Add support for the upcoming [semantic_text](https://www.elastic.co/guide/en/elasticsearch/reference/master/semantic-text.html) and [semantic query](https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-semantic-query.html).