### PR TITLE
Fix errors around arrays in ML requests

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13088,8 +13088,8 @@ export interface MlDatafeedConfig {
   datafeed_id?: Id
   delayed_data_check_config?: MlDelayedDataCheckConfig
   frequency?: Duration
-  indices?: string[]
-  indexes?: string[]
+  indices?: Indices
+  indexes?: Indices
   indices_options?: IndicesOptions
   job_id?: Id
   max_empty_searches?: integer
@@ -14669,14 +14669,14 @@ export interface MlGetRecordsResponse {
 }
 
 export interface MlGetTrainedModelsRequest extends RequestBase {
-  model_id?: Id
+  model_id?: Ids
   allow_no_match?: boolean
   decompress_definition?: boolean
   exclude_generated?: boolean
   from?: integer
   include?: MlInclude
   size?: integer
-  tags?: string
+  tags?: string | string[]
 }
 
 export interface MlGetTrainedModelsResponse {
@@ -14843,7 +14843,7 @@ export interface MlPutCalendarResponse {
 
 export interface MlPutCalendarJobRequest extends RequestBase {
   calendar_id: Id
-  job_id: Id
+  job_id: Ids
 }
 
 export interface MlPutCalendarJobResponse {
@@ -14941,7 +14941,7 @@ export interface MlPutFilterResponse {
 }
 
 export interface MlPutJobRequest extends RequestBase {
-  job_id: Id
+  job_id: Ids
   body?: {
     allow_lazy_open?: boolean
     analysis_config: MlAnalysisConfig

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -19,7 +19,7 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
-import { Id, IndicesOptions } from '@_types/common'
+import { Id, Indices, IndicesOptions } from '@_types/common'
 import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { integer, long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
@@ -82,7 +82,7 @@ export class DatafeedConfig {
    * An array of index names. Wildcards are supported. If any indices are in remote clusters, the machine learning nodes must have the `remote_cluster_client` role.
    * @aliases indexes
    */
-  indices?: string[]
+  indices?: Indices
   /**
    * Specifies index expansion options that are used during search.
    */

--- a/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
+++ b/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
+import { Ids } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { Include } from '@ml/_types/Include'
 
@@ -32,9 +32,13 @@ import { Include } from '@ml/_types/Include'
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * The unique identifier of the trained model.
+     * The unique identifier of the trained model or a model alias.
+     *
+     * You can get information for multiple trained models in a single API
+     * request by using a comma-separated list of model IDs or a wildcard
+     * expression.
      */
-    model_id?: Id
+    model_id?: Ids
   }
   query_parameters: {
     /**
@@ -82,6 +86,6 @@ export interface Request extends RequestBase {
      * none. When supplied, only trained models that contain all the supplied
      * tags are returned.
      */
-    tags?: string
+    tags?: string | string[]
   }
 }

--- a/specification/ml/put_calendar_job/MlPutCalendarJobRequest.ts
+++ b/specification/ml/put_calendar_job/MlPutCalendarJobRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
+import { Id, Ids } from '@_types/common'
 
 /**
  * Adds an anomaly detection job to a calendar.
@@ -32,6 +32,6 @@ export interface Request extends RequestBase {
     /** A string that uniquely identifies a calendar. */
     calendar_id: Id
     /** An identifier for the anomaly detection jobs. It can be a job identifier, a group name, or a comma-separated list of jobs or groups. */
-    job_id: Id
+    job_id: Ids
   }
 }


### PR DESCRIPTION
Relates #2621 

When query parameters accept comma-separated strings, we should type them as `string | string[]` (which is what `Ids` and `Indices` are), so that clients can offer nicer list-based APIs. In fact, it's currently mandated for validation to pass, and I did not realize it when listing issues in #2621, so I am fixing those unlisted issues.

This fixes `ml.put_calendar_job`, fixes `ml.preview_datafeed` and improves `ml.get_trained_models` (fixed 5 examples, one example left).