### PR TITLE
Prioritize request descriptions over rest-spec for endpoint descriptions

### DIFF
--- a/compiler/src/steps/add-description.ts
+++ b/compiler/src/steps/add-description.ts
@@ -22,9 +22,8 @@ import * as model from '../model/metamodel'
 import { JsonSpec } from '../model/json-spec'
 
 /**
- * Adds the `description` field to every path and query property
- * from the rest-api-spec. If a description for a property
- * does not exists, the `description` key will not be added.
+ * Adds the description from the rest-api-spec to every endpoint, path and query property
+ * if not already present (i.e. missing in the TypeScript definition)
  */
 export default async function addDescription (model: model.Model, jsonSpec: Map<string, JsonSpec>): Promise<model.Model> {
   for (const endpoint of model.endpoints) {
@@ -55,9 +54,9 @@ export default async function addDescription (model: model.Model, jsonSpec: Map<
       }
     }
 
-    if (spec.documentation.description != null) {
-      requestDefinition.description = requestDefinition.description ?? spec.documentation.description
-    }
+    // An API endpoint is defined by an endpoint object (paths and http methods) and a request
+    // type (parameters and structure).
+    endpoint.description = requestDefinition.description ?? spec.documentation.description
   }
 
   return model

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -14,7 +14,8 @@
         "tags": [
           "async_search.get"
         ],
-        "summary": "Retrieves the results of a previously submitted async search request given its ID",
+        "summary": "Retrieves the results of a previously submitted async search request given its identifier",
+        "description": "If the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html"
         },
@@ -79,8 +80,8 @@
         "tags": [
           "async_search.delete"
         ],
-        "summary": "Deletes an async search by ID",
-        "description": "If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.",
+        "summary": "Deletes an async search by identifier",
+        "description": "If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted. If the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html"
         },
@@ -117,7 +118,8 @@
         "tags": [
           "async_search.status"
         ],
-        "summary": "Retrieves the status of a previously submitted async search request given its ID",
+        "summary": "Get async search status Retrieves the status of a previously submitted async search request given its identifier, without retrieving search results",
+        "description": "If the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html"
         },
@@ -154,7 +156,8 @@
         "tags": [
           "async_search.submit"
         ],
-        "summary": "Executes a search request asynchronously",
+        "summary": "Runs a search request asynchronously",
+        "description": "When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field, hence partial results become available following the sort criteria that was requested. Warning: Async search does not support scroll nor search requests that only include the suggest section. By default, Elasticsearch doesn’t allow you to store an async search response larger than 10Mb and an attempt to do this results in an error. The maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html"
         },
@@ -314,7 +317,8 @@
         "tags": [
           "async_search.submit"
         ],
-        "summary": "Executes a search request asynchronously",
+        "summary": "Runs a search request asynchronously",
+        "description": "When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field, hence partial results become available following the sort criteria that was requested. Warning: Async search does not support scroll nor search requests that only include the suggest section. By default, Elasticsearch doesn’t allow you to store an async search response larger than 10Mb and an attempt to do this results in an error. The maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html"
         },
@@ -633,7 +637,8 @@
         "tags": [
           "bulk"
         ],
-        "summary": "Allows to perform multiple index/update/delete operations in a single request",
+        "summary": "Performs multiple indexing or delete operations in a single API call",
+        "description": "This reduces overhead and can greatly increase indexing speed.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html"
         },
@@ -680,7 +685,8 @@
         "tags": [
           "bulk"
         ],
-        "summary": "Allows to perform multiple index/update/delete operations in a single request",
+        "summary": "Performs multiple indexing or delete operations in a single API call",
+        "description": "This reduces overhead and can greatly increase indexing speed.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html"
         },
@@ -729,7 +735,8 @@
         "tags": [
           "bulk"
         ],
-        "summary": "Allows to perform multiple index/update/delete operations in a single request",
+        "summary": "Performs multiple indexing or delete operations in a single API call",
+        "description": "This reduces overhead and can greatly increase indexing speed.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html"
         },
@@ -779,7 +786,8 @@
         "tags": [
           "bulk"
         ],
-        "summary": "Allows to perform multiple index/update/delete operations in a single request",
+        "summary": "Performs multiple indexing or delete operations in a single API call",
+        "description": "This reduces overhead and can greatly increase indexing speed.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html"
         },
@@ -831,7 +839,8 @@
         "tags": [
           "cat.aliases"
         ],
-        "summary": "Shows information about currently configured aliases to indices including filter and routing infos",
+        "summary": "Retrieves the cluster’s index aliases, including filter and routing information",
+        "description": "The API does not return data stream aliases. IMPORTANT: cat APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-alias.html"
         },
@@ -853,7 +862,8 @@
         "tags": [
           "cat.aliases"
         ],
-        "summary": "Shows information about currently configured aliases to indices including filter and routing infos",
+        "summary": "Retrieves the cluster’s index aliases, including filter and routing information",
+        "description": "The API does not return data stream aliases. IMPORTANT: cat APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-alias.html"
         },
@@ -878,7 +888,8 @@
         "tags": [
           "cat.allocation"
         ],
-        "summary": "Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using",
+        "summary": "Provides a snapshot of the number of shards allocated to each data node and their disk space",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html"
         },
@@ -900,7 +911,8 @@
         "tags": [
           "cat.allocation"
         ],
-        "summary": "Provides a snapshot of how many shards are allocated to each data node and how much disk space they are using",
+        "summary": "Provides a snapshot of the number of shards allocated to each data node and their disk space",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html"
         },
@@ -925,7 +937,8 @@
         "tags": [
           "cat.component_templates"
         ],
-        "summary": "Returns information about existing component_templates templates",
+        "summary": "Returns information about component templates in a cluster",
+        "description": "Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get component template API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html"
         },
@@ -942,7 +955,8 @@
         "tags": [
           "cat.component_templates"
         ],
-        "summary": "Returns information about existing component_templates templates",
+        "summary": "Returns information about component templates in a cluster",
+        "description": "Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get component template API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html"
         },
@@ -964,7 +978,8 @@
         "tags": [
           "cat.count"
         ],
-        "summary": "Provides quick access to the document count of the entire cluster, or individual indices",
+        "summary": "Provides quick access to a document count for a data stream, an index, or an entire cluster",
+        "description": "NOTE: The document count only includes live documents, not deleted documents which have not yet been removed by the merge process. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the count API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-count.html"
         },
@@ -981,7 +996,8 @@
         "tags": [
           "cat.count"
         ],
-        "summary": "Provides quick access to the document count of the entire cluster, or individual indices",
+        "summary": "Provides quick access to a document count for a data stream, an index, or an entire cluster",
+        "description": "NOTE: The document count only includes live documents, not deleted documents which have not yet been removed by the merge process. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the count API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-count.html"
         },
@@ -1003,7 +1019,8 @@
         "tags": [
           "cat.fielddata"
         ],
-        "summary": "Shows how much heap memory is currently being used by fielddata on every data node in the cluster",
+        "summary": "Returns the amount of heap memory currently used by the field data cache on every data node in the cluster",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes stats API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-fielddata.html"
         },
@@ -1028,7 +1045,8 @@
         "tags": [
           "cat.fielddata"
         ],
-        "summary": "Shows how much heap memory is currently being used by fielddata on every data node in the cluster",
+        "summary": "Returns the amount of heap memory currently used by the field data cache on every data node in the cluster",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes stats API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-fielddata.html"
         },
@@ -1056,7 +1074,8 @@
         "tags": [
           "cat.health"
         ],
-        "summary": "Returns a concise representation of the cluster health",
+        "summary": "Returns the health status of a cluster, similar to the cluster health API",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the cluster health API. This API is often used to check malfunctioning clusters. To help you track cluster health alongside log files and alerting systems, the API returns timestamps in two formats: `HH:MM:SS`, which is human-readable but includes no date information; `Unix epoch time`, which is machine-sortable and includes date information. The latter format is useful for cluster recoveries that take multiple days. You can use the cat health API to verify cluster health across multiple nodes. You also can use the API to track the recovery of a large cluster over a longer period of time.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-health.html"
         },
@@ -1132,7 +1151,8 @@
         "tags": [
           "cat.indices"
         ],
-        "summary": "Returns information about indices: number of primaries and replicas, document counts, disk size, ..",
+        "summary": "Returns high-level information about indices in a cluster, including backing indices for data streams",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index API. Use the cat indices API to get the following information for each index in a cluster: shard count; document count; deleted document count; primary store size; total store size of all shards, including shard replicas. These metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents. To get an accurate count of Elasticsearch documents, use the cat count or count APIs.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html"
         },
@@ -1169,7 +1189,8 @@
         "tags": [
           "cat.indices"
         ],
-        "summary": "Returns information about indices: number of primaries and replicas, document counts, disk size, ..",
+        "summary": "Returns high-level information about indices in a cluster, including backing indices for data streams",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index API. Use the cat indices API to get the following information for each index in a cluster: shard count; document count; deleted document count; primary store size; total store size of all shards, including shard replicas. These metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents. To get an accurate count of Elasticsearch documents, use the cat count or count APIs.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html"
         },
@@ -1209,7 +1230,8 @@
         "tags": [
           "cat.master"
         ],
-        "summary": "Returns information about the master node",
+        "summary": "Returns information about the master node, including the ID, bound IP address, and name",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-master.html"
         },
@@ -1236,7 +1258,8 @@
         "tags": [
           "cat.ml_data_frame_analytics"
         ],
-        "summary": "Gets configuration and usage information about data frame analytics jobs",
+        "summary": "Returns configuration and usage information about data frame analytics jobs.",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get data frame analytics jobs statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-dfanalytics.html"
         },
@@ -1270,7 +1293,8 @@
         "tags": [
           "cat.ml_data_frame_analytics"
         ],
-        "summary": "Gets configuration and usage information about data frame analytics jobs",
+        "summary": "Returns configuration and usage information about data frame analytics jobs.",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get data frame analytics jobs statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-dfanalytics.html"
         },
@@ -1307,7 +1331,8 @@
         "tags": [
           "cat.ml_datafeeds"
         ],
-        "summary": "Gets configuration and usage information about datafeeds",
+        "summary": "Returns configuration and usage information about datafeeds",
+        "description": "This API returns a maximum of 10,000 datafeeds. If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.. IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get datafeed statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-datafeeds.html"
         },
@@ -1338,7 +1363,8 @@
         "tags": [
           "cat.ml_datafeeds"
         ],
-        "summary": "Gets configuration and usage information about datafeeds",
+        "summary": "Returns configuration and usage information about datafeeds",
+        "description": "This API returns a maximum of 10,000 datafeeds. If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.. IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get datafeed statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-datafeeds.html"
         },
@@ -1372,7 +1398,8 @@
         "tags": [
           "cat.ml_jobs"
         ],
-        "summary": "Gets configuration and usage information about anomaly detection jobs",
+        "summary": "Returns configuration and usage information for anomaly detection jobs",
+        "description": "This API returns a maximum of 10,000 jobs. If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.. IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get anomaly detection job statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-anomaly-detectors.html"
         },
@@ -1406,7 +1433,8 @@
         "tags": [
           "cat.ml_jobs"
         ],
-        "summary": "Gets configuration and usage information about anomaly detection jobs",
+        "summary": "Returns configuration and usage information for anomaly detection jobs",
+        "description": "This API returns a maximum of 10,000 jobs. If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.. IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get anomaly detection job statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-anomaly-detectors.html"
         },
@@ -1443,7 +1471,8 @@
         "tags": [
           "cat.ml_trained_models"
         ],
-        "summary": "Gets configuration and usage information about inference trained models",
+        "summary": "Returns configuration and usage information about inference trained models.",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get trained models statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-trained-model.html"
         },
@@ -1480,7 +1509,8 @@
         "tags": [
           "cat.ml_trained_models"
         ],
-        "summary": "Gets configuration and usage information about inference trained models",
+        "summary": "Returns configuration and usage information about inference trained models.",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get trained models statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-trained-model.html"
         },
@@ -1521,6 +1551,7 @@
           "cat.nodeattrs"
         ],
         "summary": "Returns information about custom node attributes",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-nodeattrs.html"
         },
@@ -1547,7 +1578,8 @@
         "tags": [
           "cat.nodes"
         ],
-        "summary": "Returns basic statistics about performance of cluster nodes",
+        "summary": "Returns information about the nodes in a cluster",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-nodes.html"
         },
@@ -1613,7 +1645,8 @@
         "tags": [
           "cat.pending_tasks"
         ],
-        "summary": "Returns a concise representation of the cluster pending tasks",
+        "summary": "Returns cluster-level changes that have not yet been executed",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the pending cluster tasks API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-pending-tasks.html"
         },
@@ -1640,7 +1673,8 @@
         "tags": [
           "cat.plugins"
         ],
-        "summary": "Returns information about installed plugins across nodes node",
+        "summary": "Returns a list of plugins running on each node of a cluster",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-plugins.html"
         },
@@ -1667,7 +1701,8 @@
         "tags": [
           "cat.recovery"
         ],
-        "summary": "Returns information about index shard recoveries, both on-going completed",
+        "summary": "Returns information about ongoing and completed shard recoveries",
+        "description": "Shard recovery is the process of initializing a shard copy, such as restoring a primary shard from a snapshot or syncing a replica shard from a primary shard. When a shard recovery completes, the recovered shard is available for search and indexing. For data streams, the API returns information about the stream’s backing indices. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index recovery API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-recovery.html"
         },
@@ -1695,7 +1730,8 @@
         "tags": [
           "cat.recovery"
         ],
-        "summary": "Returns information about index shard recoveries, both on-going completed",
+        "summary": "Returns information about ongoing and completed shard recoveries",
+        "description": "Shard recovery is the process of initializing a shard copy, such as restoring a primary shard from a snapshot or syncing a replica shard from a primary shard. When a shard recovery completes, the recovered shard is available for search and indexing. For data streams, the API returns information about the stream’s backing indices. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index recovery API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-recovery.html"
         },
@@ -1726,7 +1762,8 @@
         "tags": [
           "cat.repositories"
         ],
-        "summary": "Returns information about snapshot repositories registered in the cluster",
+        "summary": "Returns the snapshot repositories for a cluster",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot repository API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-repositories.html"
         },
@@ -1753,7 +1790,8 @@
         "tags": [
           "cat.segments"
         ],
-        "summary": "Provides low-level information about the segments in the shards of an index",
+        "summary": "Returns low-level information about the Lucene segments in index shards",
+        "description": "For data streams, the API returns information about the backing indices. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index segments API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-segments.html"
         },
@@ -1775,7 +1813,8 @@
         "tags": [
           "cat.segments"
         ],
-        "summary": "Provides low-level information about the segments in the shards of an index",
+        "summary": "Returns low-level information about the Lucene segments in index shards",
+        "description": "For data streams, the API returns information about the backing indices. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index segments API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-segments.html"
         },
@@ -1800,7 +1839,8 @@
         "tags": [
           "cat.shards"
         ],
-        "summary": "Provides a detailed view of shard allocation on nodes",
+        "summary": "Returns information about the shards in a cluster",
+        "description": "For data streams, the API returns information about the backing indices. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-shards.html"
         },
@@ -1822,7 +1862,8 @@
         "tags": [
           "cat.shards"
         ],
-        "summary": "Provides a detailed view of shard allocation on nodes",
+        "summary": "Returns information about the shards in a cluster",
+        "description": "For data streams, the API returns information about the backing indices. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-shards.html"
         },
@@ -1847,7 +1888,8 @@
         "tags": [
           "cat.snapshots"
         ],
-        "summary": "Returns all snapshots in a specific repository",
+        "summary": "Returns information about the snapshots stored in one or more repositories",
+        "description": "A snapshot is a backup of an index or running Elasticsearch cluster. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-snapshots.html"
         },
@@ -1869,7 +1911,8 @@
         "tags": [
           "cat.snapshots"
         ],
-        "summary": "Returns all snapshots in a specific repository",
+        "summary": "Returns information about the snapshots stored in one or more repositories",
+        "description": "A snapshot is a backup of an index or running Elasticsearch cluster. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-snapshots.html"
         },
@@ -1894,7 +1937,8 @@
         "tags": [
           "cat.tasks"
         ],
-        "summary": "Returns information about the tasks currently executing on one or more nodes in the cluster",
+        "summary": "Returns information about tasks currently executing in the cluster",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the task management API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html"
         },
@@ -1969,7 +2013,8 @@
         "tags": [
           "cat.templates"
         ],
-        "summary": "Returns information about existing templates",
+        "summary": "Returns information about index templates in a cluster",
+        "description": "You can use index templates to apply index settings and field mappings to new indices at creation. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index template API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-templates.html"
         },
@@ -1986,7 +2031,8 @@
         "tags": [
           "cat.templates"
         ],
-        "summary": "Returns information about existing templates",
+        "summary": "Returns information about index templates in a cluster",
+        "description": "You can use index templates to apply index settings and field mappings to new indices at creation. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index template API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-templates.html"
         },
@@ -2008,8 +2054,8 @@
         "tags": [
           "cat.thread_pool"
         ],
-        "summary": "Returns cluster-wide thread pool statistics per node",
-        "description": "By default the active, queue and rejected statistics are returned for all thread pools.",
+        "summary": "Returns thread pool statistics for each node in a cluster",
+        "description": "Returned information includes all built-in thread pools and custom thread pools. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-thread-pool.html"
         },
@@ -2031,8 +2077,8 @@
         "tags": [
           "cat.thread_pool"
         ],
-        "summary": "Returns cluster-wide thread pool statistics per node",
-        "description": "By default the active, queue and rejected statistics are returned for all thread pools.",
+        "summary": "Returns thread pool statistics for each node in a cluster",
+        "description": "Returned information includes all built-in thread pools and custom thread pools. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-thread-pool.html"
         },
@@ -2057,7 +2103,8 @@
         "tags": [
           "cat.transforms"
         ],
-        "summary": "Gets configuration and usage information about transforms",
+        "summary": "Returns configuration and usage information about transforms.",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get transform statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-transforms.html"
         },
@@ -2094,7 +2141,8 @@
         "tags": [
           "cat.transforms"
         ],
-        "summary": "Gets configuration and usage information about transforms",
+        "summary": "Returns configuration and usage information about transforms.",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get transform statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-transforms.html"
         },
@@ -2916,7 +2964,7 @@
         "tags": [
           "clear_scroll"
         ],
-        "summary": "Explicitly clears the search context for a scroll",
+        "summary": "Clears the search context and results for a scrolling search",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html"
         },
@@ -3000,7 +3048,7 @@
         "tags": [
           "clear_scroll"
         ],
-        "summary": "Explicitly clears the search context for a scroll",
+        "summary": "Clears the search context and results for a scrolling search",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html"
         },
@@ -3025,7 +3073,7 @@
         "tags": [
           "close_point_in_time"
         ],
-        "summary": "Close a point in time",
+        "summary": "Closes a point-in-time",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html"
         },
@@ -3132,7 +3180,7 @@
         "tags": [
           "cluster.get_component_template"
         ],
-        "summary": "Returns one or more component templates",
+        "summary": "Retrieves information about component templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html"
         },
@@ -3165,6 +3213,7 @@
           "cluster.put_component_template"
         ],
         "summary": "Creates or updates a component template",
+        "description": "Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.. An index template can be composed of multiple component templates. To use a component template, specify it in an index template’s `composed_of` list. Component templates are only applied to new data streams and indices as part of a matching index template.. Settings and mappings specified directly in the index template or the create index request override any settings or mappings specified in a component template.. Component templates are only used during index creation. For data streams, this includes data stream creation and the creation of a stream’s backing indices. Changes to component templates do not affect existing indices, including a stream’s backing indices.. You can use C-style `/* *\\/` block comments in component templates. You can include comments anywhere in the request body except before the opening curly bracket.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html"
         },
@@ -3194,6 +3243,7 @@
           "cluster.put_component_template"
         ],
         "summary": "Creates or updates a component template",
+        "description": "Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.. An index template can be composed of multiple component templates. To use a component template, specify it in an index template’s `composed_of` list. Component templates are only applied to new data streams and indices as part of a matching index template.. Settings and mappings specified directly in the index template or the create index request override any settings or mappings specified in a component template.. Component templates are only used during index creation. For data streams, this includes data stream creation and the creation of a stream’s backing indices. Changes to component templates do not affect existing indices, including a stream’s backing indices.. You can use C-style `/* *\\/` block comments in component templates. You can include comments anywhere in the request body except before the opening curly bracket.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html"
         },
@@ -3222,7 +3272,8 @@
         "tags": [
           "cluster.delete_component_template"
         ],
-        "summary": "Deletes a component template",
+        "summary": "Deletes component templates",
+        "description": "Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html"
         },
@@ -3412,7 +3463,7 @@
         "tags": [
           "cluster.get_component_template"
         ],
-        "summary": "Returns one or more component templates",
+        "summary": "Retrieves information about component templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html"
         },
@@ -3443,7 +3494,8 @@
         "tags": [
           "cluster.get_settings"
         ],
-        "summary": "Returns cluster settings",
+        "summary": "Returns cluster-wide settings",
+        "description": "By default, it returns only settings that have been explicitly defined.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-get-settings.html"
         },
@@ -3633,7 +3685,8 @@
         "tags": [
           "cluster.health"
         ],
-        "summary": "Returns basic information about the health of the cluster",
+        "summary": "The cluster health API returns a simple status on the health of the cluster",
+        "description": "You can also use the API to get the health status of only specified data streams and indices. For data streams, the API retrieves the health status of the stream’s backing indices. The cluster health status is: green, yellow or red. On the shard level, a red status indicates that the specific shard is not allocated in the cluster, yellow means that the primary shard is allocated but replicas are not, and green means that all shards are allocated. The index level status is controlled by the worst shard status. The cluster status is controlled by the worst index status.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html"
         },
@@ -3685,7 +3738,8 @@
         "tags": [
           "cluster.health"
         ],
-        "summary": "Returns basic information about the health of the cluster",
+        "summary": "The cluster health API returns a simple status on the health of the cluster",
+        "description": "You can also use the API to get the health status of only specified data streams and indices. For data streams, the API retrieves the health status of the stream’s backing indices. The cluster health status is: green, yellow or red. On the shard level, a red status indicates that the specific shard is not allocated in the cluster, yellow means that the primary shard is allocated but replicas are not, and green means that all shards are allocated. The index level status is controlled by the worst shard status. The cluster status is controlled by the worst index status.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html"
         },
@@ -3800,7 +3854,8 @@
         "tags": [
           "cluster.pending_tasks"
         ],
-        "summary": "Returns a list of any cluster-level changes (e.g. create index, update mapping, allocate or fail shard) which have not yet been executed",
+        "summary": "Returns cluster-level changes (such as create index, update mapping, allocate or fail shard) that have not yet been executed",
+        "description": "NOTE: This API returns a list of any pending updates to the cluster state. These are distinct from the tasks reported by the Task Management API which include periodic tasks and tasks initiated by the user, such as node stats, search queries, or create index requests. However, if a user-initiated task such as a create index command causes a cluster state update, the activity of this task might be reported by both task api and pending cluster tasks API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-pending.html"
         },
@@ -3857,7 +3912,8 @@
         "tags": [
           "cluster.remote_info"
         ],
-        "summary": "Returns the information about configured remote clusters",
+        "summary": "The cluster remote info API allows you to retrieve all of the configured remote cluster information",
+        "description": "It returns connection and endpoint information keyed by the configured remote cluster alias.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-remote-info.html"
         },
@@ -4144,7 +4200,8 @@
         "tags": [
           "cluster.stats"
         ],
-        "summary": "Returns high-level overview of cluster statistics",
+        "summary": "Returns cluster statistics",
+        "description": "It returns basic index metrics (shard numbers, store size, memory usage) and information about the current nodes that form the cluster (number, roles, os, jvm versions, memory usage, cpu and installed plugins).",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-stats.html"
         },
@@ -4169,7 +4226,8 @@
         "tags": [
           "cluster.stats"
         ],
-        "summary": "Returns high-level overview of cluster statistics",
+        "summary": "Returns cluster statistics",
+        "description": "It returns basic index metrics (shard numbers, store size, memory usage) and information about the current nodes that form the cluster (number, roles, os, jvm versions, memory usage, cpu and installed plugins).",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-stats.html"
         },
@@ -4197,7 +4255,7 @@
         "tags": [
           "connector.check_in"
         ],
-        "summary": "Updates the last_seen timestamp in the connector document",
+        "summary": "Updates the last_seen field in the connector, and sets it to current timestamp",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/check-in-connector-api.html"
         },
@@ -4242,7 +4300,7 @@
         "tags": [
           "connector.get"
         ],
-        "summary": "Returns the details about a connector",
+        "summary": "Retrieves a connector",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-connector-api.html"
         },
@@ -4408,7 +4466,7 @@
         "tags": [
           "connector.last_sync"
         ],
-        "summary": "Updates the stats of last sync in the connector document",
+        "summary": "Updates last sync stats in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-last-sync-api.html"
         },
@@ -4519,7 +4577,7 @@
         "tags": [
           "connector.list"
         ],
-        "summary": "Lists all connectors",
+        "summary": "Returns existing connectors",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/list-connector-api.html"
         },
@@ -4735,7 +4793,7 @@
         "tags": [
           "connector.sync_job_get"
         ],
-        "summary": "Returns the details about a connector sync job",
+        "summary": "Retrieves a connector sync job",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-connector-sync-job-api.html"
         },
@@ -4807,7 +4865,7 @@
         "tags": [
           "connector.sync_job_list"
         ],
-        "summary": "Lists all connector sync jobs",
+        "summary": "Lists connector sync jobs",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/list-connector-sync-jobs-api.html"
         },
@@ -4955,7 +5013,7 @@
         "tags": [
           "connector.update_active_filtering"
         ],
-        "summary": "Activates the draft filtering rules if they are in a validated state",
+        "summary": "Activates the valid draft filtering for a connector",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-filtering-api.html"
         },
@@ -5000,7 +5058,7 @@
         "tags": [
           "connector.update_api_key_id"
         ],
-        "summary": "Updates the API key id and/or API key secret id fields in the connector document",
+        "summary": "Updates the API key id in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-api-key-id-api.html"
         },
@@ -5077,7 +5135,7 @@
         "tags": [
           "connector.update_configuration"
         ],
-        "summary": "Updates the connector configuration",
+        "summary": "Updates the configuration field in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-configuration-api.html"
         },
@@ -5143,7 +5201,7 @@
         "tags": [
           "connector.update_error"
         ],
-        "summary": "Updates the error field in the connector document",
+        "summary": "Updates the filtering field in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-error-api.html"
         },
@@ -5285,7 +5343,7 @@
         "tags": [
           "connector.update_filtering_validation"
         ],
-        "summary": "Updates the validation info of the draft filtering rules",
+        "summary": "Updates the draft filtering validation info for a connector",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-filtering-validation-api.html"
         },
@@ -5348,7 +5406,7 @@
         "tags": [
           "connector.update_index_name"
         ],
-        "summary": "Updates the index name of the connector",
+        "summary": "Updates the index_name in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-index-name-api.html"
         },
@@ -5418,7 +5476,7 @@
         "tags": [
           "connector.update_name"
         ],
-        "summary": "Updates the name and/or description fields in the connector document",
+        "summary": "Updates the name and description fields in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-name-description-api.html"
         },
@@ -5484,7 +5542,7 @@
         "tags": [
           "connector.update_native"
         ],
-        "summary": "Updates the is_native flag of the connector",
+        "summary": "Updates the is_native flag in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-native-api.html"
         },
@@ -6057,8 +6115,8 @@
         "tags": [
           "create"
         ],
-        "summary": "Creates a new document in the index.",
-        "description": "Returns a 409 response when a document with a same ID already exists in the index.",
+        "summary": "Adds a JSON document to the specified data stream or index and makes it searchable",
+        "description": "If the target is an index and the document already exists, the request updates the document and increments its version.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html"
         },
@@ -6105,8 +6163,8 @@
         "tags": [
           "create"
         ],
-        "summary": "Creates a new document in the index.",
-        "description": "Returns a 409 response when a document with a same ID already exists in the index.",
+        "summary": "Adds a JSON document to the specified data stream or index and makes it searchable",
+        "description": "If the target is an index and the document already exists, the request updates the document and increments its version.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html"
         },
@@ -6480,7 +6538,8 @@
         "tags": [
           "index"
         ],
-        "summary": "Creates or updates a document in an index",
+        "summary": "Adds a JSON document to the specified data stream or index and makes it searchable",
+        "description": "If the target is an index and the document already exists, the request updates the document and increments its version.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html"
         },
@@ -6539,7 +6598,8 @@
         "tags": [
           "index"
         ],
-        "summary": "Creates or updates a document in an index",
+        "summary": "Adds a JSON document to the specified data stream or index and makes it searchable",
+        "description": "If the target is an index and the document already exists, the request updates the document and increments its version.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html"
         },
@@ -6598,7 +6658,7 @@
         "tags": [
           "delete"
         ],
-        "summary": "Removes a document from the index",
+        "summary": "Removes a JSON document from the specified index",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html"
         },
@@ -6724,7 +6784,7 @@
         "tags": [
           "exists"
         ],
-        "summary": "Returns information about whether a document exists in an index",
+        "summary": "Checks if a document in an index exists",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html"
         },
@@ -6868,7 +6928,7 @@
         "tags": [
           "delete_by_query"
         ],
-        "summary": "Deletes documents matching the provided query",
+        "summary": "Deletes documents that match the specified query",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html"
         },
@@ -7323,7 +7383,7 @@
         "tags": [
           "get_script"
         ],
-        "summary": "Returns a script",
+        "summary": "Retrieves a stored script or search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html"
         },
@@ -7383,7 +7443,7 @@
         "tags": [
           "put_script"
         ],
-        "summary": "Creates or updates a script",
+        "summary": "Creates or updates a stored script or search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html"
         },
@@ -7412,7 +7472,7 @@
         "tags": [
           "put_script"
         ],
-        "summary": "Creates or updates a script",
+        "summary": "Creates or updates a stored script or search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html"
         },
@@ -7441,7 +7501,7 @@
         "tags": [
           "delete_script"
         ],
-        "summary": "Deletes a script",
+        "summary": "Deletes a stored script or search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html"
         },
@@ -7498,7 +7558,7 @@
         "tags": [
           "enrich.get_policy"
         ],
-        "summary": "Gets information about an enrich policy",
+        "summary": "Returns information about an enrich policy",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-enrich-policy-api.html"
         },
@@ -7518,7 +7578,7 @@
         "tags": [
           "enrich.put_policy"
         ],
-        "summary": "Creates a new enrich policy",
+        "summary": "Creates an enrich policy",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-enrich-policy-api.html"
         },
@@ -7666,7 +7726,7 @@
         "tags": [
           "enrich.get_policy"
         ],
-        "summary": "Gets information about an enrich policy",
+        "summary": "Returns information about an enrich policy",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-enrich-policy-api.html"
         },
@@ -7683,7 +7743,7 @@
         "tags": [
           "enrich.stats"
         ],
-        "summary": "Gets enrich coordinator statistics and information about enrich policies that are currently executing",
+        "summary": "Returns enrich coordinator statistics and information about enrich policies that are currently executing",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-stats-api.html"
         },
@@ -7734,7 +7794,7 @@
         "tags": [
           "eql.get"
         ],
-        "summary": "Returns async results from previously executed Event Query Language (EQL) search",
+        "summary": "Returns the current status and available results for an async EQL search or a stored synchronous EQL search",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-async-eql-search-api.html"
         },
@@ -7789,8 +7849,8 @@
         "tags": [
           "eql.delete"
         ],
-        "summary": "Deletes an async EQL search by ID",
-        "description": "If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.",
+        "summary": "Deletes an async EQL search or a stored synchronous EQL search",
+        "description": "The API also deletes results for the search.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html"
         },
@@ -7827,7 +7887,7 @@
         "tags": [
           "eql.get_status"
         ],
-        "summary": "Returns the status of a previously submitted async or stored Event Query Language (EQL) search",
+        "summary": "Returns the current status for an async EQL search or a stored synchronous EQL search without returning results",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-async-eql-status-api.html"
         },
@@ -7976,7 +8036,7 @@
         "tags": [
           "esql.query"
         ],
-        "summary": "Executes an ESQL request",
+        "summary": "Executes an ES|QL request",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-rest.html"
         },
@@ -8206,7 +8266,7 @@
         "tags": [
           "exists_source"
         ],
-        "summary": "Returns information about whether a document source exists in an index",
+        "summary": "Checks if a document's `_source` is stored",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html"
         },
@@ -8340,7 +8400,7 @@
         "tags": [
           "explain"
         ],
-        "summary": "Returns information about why a specific matches (or doesn't match) a query",
+        "summary": "Returns information about why a specific document matches (or doesn’t match) a query",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html"
         },
@@ -8402,7 +8462,7 @@
         "tags": [
           "explain"
         ],
-        "summary": "Returns information about why a specific matches (or doesn't match) a query",
+        "summary": "Returns information about why a specific document matches (or doesn’t match) a query",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html"
         },
@@ -8536,7 +8596,8 @@
         "tags": [
           "field_caps"
         ],
-        "summary": "Returns the information about the capabilities of fields among multiple indices",
+        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
+        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type of keyword is returned as any other field that belongs to the `keyword` family.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html"
         },
@@ -8580,7 +8641,8 @@
         "tags": [
           "field_caps"
         ],
-        "summary": "Returns the information about the capabilities of fields among multiple indices",
+        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
+        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type of keyword is returned as any other field that belongs to the `keyword` family.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html"
         },
@@ -8626,7 +8688,8 @@
         "tags": [
           "field_caps"
         ],
-        "summary": "Returns the information about the capabilities of fields among multiple indices",
+        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
+        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type of keyword is returned as any other field that belongs to the `keyword` family.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html"
         },
@@ -8673,7 +8736,8 @@
         "tags": [
           "field_caps"
         ],
-        "summary": "Returns the information about the capabilities of fields among multiple indices",
+        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
+        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type of keyword is returned as any other field that belongs to the `keyword` family.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html"
         },
@@ -8825,8 +8889,8 @@
         "tags": [
           "fleet.msearch"
         ],
-        "summary": "Multi Search API where the search will only be executed after specified checkpoints are available due to a refresh",
-        "description": "This API is designed for internal use by the fleet server project.",
+        "summary": "Executes several [fleet searches](https://www.elastic.co/guide/en/elasticsearch/reference/current/fleet-search.html) with a single API request",
+        "description": "The API follows the same structure as the [multi search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html) API. However, similar to the fleet search API, it supports the wait_for_checkpoints parameter.",
         "operationId": "fleet-msearch",
         "parameters": [
           {
@@ -8882,8 +8946,8 @@
         "tags": [
           "fleet.msearch"
         ],
-        "summary": "Multi Search API where the search will only be executed after specified checkpoints are available due to a refresh",
-        "description": "This API is designed for internal use by the fleet server project.",
+        "summary": "Executes several [fleet searches](https://www.elastic.co/guide/en/elasticsearch/reference/current/fleet-search.html) with a single API request",
+        "description": "The API follows the same structure as the [multi search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html) API. However, similar to the fleet search API, it supports the wait_for_checkpoints parameter.",
         "operationId": "fleet-msearch-1",
         "parameters": [
           {
@@ -8941,8 +9005,8 @@
         "tags": [
           "fleet.msearch"
         ],
-        "summary": "Multi Search API where the search will only be executed after specified checkpoints are available due to a refresh",
-        "description": "This API is designed for internal use by the fleet server project.",
+        "summary": "Executes several [fleet searches](https://www.elastic.co/guide/en/elasticsearch/reference/current/fleet-search.html) with a single API request",
+        "description": "The API follows the same structure as the [multi search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html) API. However, similar to the fleet search API, it supports the wait_for_checkpoints parameter.",
         "operationId": "fleet-msearch-2",
         "parameters": [
           {
@@ -9001,8 +9065,8 @@
         "tags": [
           "fleet.msearch"
         ],
-        "summary": "Multi Search API where the search will only be executed after specified checkpoints are available due to a refresh",
-        "description": "This API is designed for internal use by the fleet server project.",
+        "summary": "Executes several [fleet searches](https://www.elastic.co/guide/en/elasticsearch/reference/current/fleet-search.html) with a single API request",
+        "description": "The API follows the same structure as the [multi search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html) API. However, similar to the fleet search API, it supports the wait_for_checkpoints parameter.",
         "operationId": "fleet-msearch-3",
         "parameters": [
           {
@@ -9063,8 +9127,7 @@
         "tags": [
           "fleet.search"
         ],
-        "summary": "Search API where the search will only be executed after specified checkpoints are available due to a refresh",
-        "description": "This API is designed for internal use by the fleet server project.",
+        "summary": "The purpose of the fleet search api is to provide a search api where the search will only be executed after provided checkpoint has been processed and is visible for searches inside of Elasticsearch",
         "operationId": "fleet-search",
         "parameters": [
           {
@@ -9216,8 +9279,7 @@
         "tags": [
           "fleet.search"
         ],
-        "summary": "Search API where the search will only be executed after specified checkpoints are available due to a refresh",
-        "description": "This API is designed for internal use by the fleet server project.",
+        "summary": "The purpose of the fleet search api is to provide a search api where the search will only be executed after provided checkpoint has been processed and is visible for searches inside of Elasticsearch",
         "operationId": "fleet-search-1",
         "parameters": [
           {
@@ -9448,7 +9510,7 @@
         "tags": [
           "graph.explore"
         ],
-        "summary": "Explore extracted and summarized information about the documents and terms in an index",
+        "summary": "Extracts and summarizes information about the documents and terms in an Elasticsearch data stream or index",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html"
         },
@@ -9477,7 +9539,7 @@
         "tags": [
           "graph.explore"
         ],
-        "summary": "Explore extracted and summarized information about the documents and terms in an index",
+        "summary": "Extracts and summarizes information about the documents and terms in an Elasticsearch data stream or index",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html"
         },
@@ -9567,8 +9629,7 @@
         "tags": [
           "ilm.get_lifecycle"
         ],
-        "summary": "Returns the specified policy definition",
-        "description": "Includes the policy version and last modified date.",
+        "summary": "Retrieves a lifecycle policy",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html"
         },
@@ -9595,6 +9656,7 @@
           "ilm.put_lifecycle"
         ],
         "summary": "Creates a lifecycle policy",
+        "description": "If the specified policy exists, the policy is replaced and the policy version is incremented.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-put-lifecycle.html"
         },
@@ -9664,7 +9726,7 @@
           "ilm.delete_lifecycle"
         ],
         "summary": "Deletes the specified lifecycle policy definition",
-        "description": "A currently used policy cannot be deleted.",
+        "description": "You cannot delete policies that are currently in use. If the policy is being used to manage any indices, the request fails and returns an error.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-delete-lifecycle.html"
         },
@@ -9721,7 +9783,8 @@
         "tags": [
           "ilm.explain_lifecycle"
         ],
-        "summary": "Retrieves information about the index's current lifecycle state, such as the currently executing phase, action, and step",
+        "summary": "Retrieves information about the index’s current lifecycle state, such as the currently executing phase, action, and step",
+        "description": "Shows when the index entered each one, the definition of the running phase, and information about any failures.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html"
         },
@@ -9809,8 +9872,7 @@
         "tags": [
           "ilm.get_lifecycle"
         ],
-        "summary": "Returns the specified policy definition",
-        "description": "Includes the policy version and last modified date.",
+        "summary": "Retrieves a lifecycle policy",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-get-lifecycle.html"
         },
@@ -9867,7 +9929,8 @@
         "tags": [
           "ilm.migrate_to_data_tiers"
         ],
-        "summary": "Migrates the indices and ILM policies away from custom node attribute allocation routing to data tiers routing",
+        "summary": "Switches the indices, ILM policies, and legacy, composable and component templates from using custom node attributes and attribute-based allocation filters to using data tiers, and optionally deletes one legacy index template",
+        "description": "+ Using node roles enables ILM to automatically move the indices between data tiers.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-migrate-to-data-tiers.html"
         },
@@ -10195,7 +10258,8 @@
         "tags": [
           "index"
         ],
-        "summary": "Creates or updates a document in an index",
+        "summary": "Adds a JSON document to the specified data stream or index and makes it searchable",
+        "description": "If the target is an index and the document already exists, the request updates the document and increments its version.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html"
         },
@@ -10370,7 +10434,7 @@
         "tags": [
           "indices.analyze"
         ],
-        "summary": "Performs the analysis process on a text and return the tokens breakdown of the text",
+        "summary": "Performs analysis on a text string and returns the resulting tokens",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html"
         },
@@ -10388,7 +10452,7 @@
         "tags": [
           "indices.analyze"
         ],
-        "summary": "Performs the analysis process on a text and return the tokens breakdown of the text",
+        "summary": "Performs analysis on a text string and returns the resulting tokens",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html"
         },
@@ -10408,7 +10472,7 @@
         "tags": [
           "indices.analyze"
         ],
-        "summary": "Performs the analysis process on a text and return the tokens breakdown of the text",
+        "summary": "Performs analysis on a text string and returns the resulting tokens",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html"
         },
@@ -10431,7 +10495,7 @@
         "tags": [
           "indices.analyze"
         ],
-        "summary": "Performs the analysis process on a text and return the tokens breakdown of the text",
+        "summary": "Performs analysis on a text string and returns the resulting tokens",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html"
         },
@@ -10456,7 +10520,8 @@
         "tags": [
           "indices.clear_cache"
         ],
-        "summary": "Clears all or specific caches for one or more indices",
+        "summary": "Clears the caches of one or more indices",
+        "description": "For data streams, the API clears the caches of the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html"
         },
@@ -10496,7 +10561,8 @@
         "tags": [
           "indices.clear_cache"
         ],
-        "summary": "Clears all or specific caches for one or more indices",
+        "summary": "Clears the caches of one or more indices",
+        "description": "For data streams, the API clears the caches of the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clearcache.html"
         },
@@ -10539,7 +10605,7 @@
         "tags": [
           "indices.clone"
         ],
-        "summary": "Clones an index",
+        "summary": "Clones an existing index",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html"
         },
@@ -10574,7 +10640,7 @@
         "tags": [
           "indices.clone"
         ],
-        "summary": "Clones an index",
+        "summary": "Clones an existing index",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html"
         },
@@ -10728,6 +10794,7 @@
           "indices.get"
         ],
         "summary": "Returns information about one or more indices",
+        "description": "For data streams, the API returns information about the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html"
         },
@@ -10845,7 +10912,7 @@
         "tags": [
           "indices.create"
         ],
-        "summary": "Creates an index with optional settings and mappings",
+        "summary": "Creates a new index",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html"
         },
@@ -10950,7 +11017,7 @@
         "tags": [
           "indices.delete"
         ],
-        "summary": "Deletes an index",
+        "summary": "Deletes one or more indices",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html"
         },
@@ -11035,7 +11102,7 @@
         "tags": [
           "indices.exists"
         ],
-        "summary": "Returns information about whether a particular index exists",
+        "summary": "Checks if a data stream, index, or alias exists",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html"
         },
@@ -11128,7 +11195,7 @@
         "tags": [
           "indices.get_data_stream"
         ],
-        "summary": "Returns data streams",
+        "summary": "Retrieves information about one or more data streams",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -11155,6 +11222,7 @@
           "indices.create_data_stream"
         ],
         "summary": "Creates a data stream",
+        "description": "You must have a matching index template with data stream enabled.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -11189,7 +11257,7 @@
         "tags": [
           "indices.delete_data_stream"
         ],
-        "summary": "Deletes a data stream",
+        "summary": "Deletes one or more data streams and their backing indices",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -11236,7 +11304,7 @@
         "tags": [
           "indices.data_streams_stats"
         ],
-        "summary": "Provides statistics on operations happening in a data stream",
+        "summary": "Retrieves statistics for one or more data streams",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -11258,7 +11326,7 @@
         "tags": [
           "indices.data_streams_stats"
         ],
-        "summary": "Provides statistics on operations happening in a data stream",
+        "summary": "Retrieves statistics for one or more data streams",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -11283,7 +11351,7 @@
         "tags": [
           "indices.get_alias"
         ],
-        "summary": "Returns an alias",
+        "summary": "Retrieves information for one or more aliases",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -11318,7 +11386,7 @@
         "tags": [
           "indices.put_alias"
         ],
-        "summary": "Creates or updates an alias",
+        "summary": "Adds a data stream or index to an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -11350,7 +11418,7 @@
         "tags": [
           "indices.put_alias"
         ],
-        "summary": "Creates or updates an alias",
+        "summary": "Adds a data stream or index to an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -11382,7 +11450,7 @@
         "tags": [
           "indices.delete_alias"
         ],
-        "summary": "Deletes an alias",
+        "summary": "Removes a data stream or index from an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -11411,7 +11479,7 @@
         "tags": [
           "indices.exists_alias"
         ],
-        "summary": "Returns information about whether a particular alias exists",
+        "summary": "Checks if an alias exists",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -11448,7 +11516,7 @@
         "tags": [
           "indices.put_alias"
         ],
-        "summary": "Creates or updates an alias",
+        "summary": "Adds a data stream or index to an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -11480,7 +11548,7 @@
         "tags": [
           "indices.put_alias"
         ],
-        "summary": "Creates or updates an alias",
+        "summary": "Adds a data stream or index to an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -11512,7 +11580,7 @@
         "tags": [
           "indices.delete_alias"
         ],
-        "summary": "Deletes an alias",
+        "summary": "Removes a data stream or index from an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -11543,7 +11611,7 @@
         "tags": [
           "indices.get_data_lifecycle"
         ],
-        "summary": "Returns the data stream lifecycle of the selected data streams",
+        "summary": "Retrieves the data stream lifecycle configuration of one or more data streams",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle.html"
         },
@@ -11609,7 +11677,7 @@
         "tags": [
           "indices.put_data_lifecycle"
         ],
-        "summary": "Updates the data stream lifecycle of the selected data streams",
+        "summary": "Update the data lifecycle of the specified data streams",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-put-lifecycle.html"
         },
@@ -11691,7 +11759,7 @@
         "tags": [
           "indices.delete_data_lifecycle"
         ],
-        "summary": "Deletes the data stream lifecycle of the selected data streams",
+        "summary": "Removes the data lifecycle from a data stream rendering it not managed by the data stream lifecycle",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html"
         },
@@ -11758,7 +11826,7 @@
         "tags": [
           "indices.get_index_template"
         ],
-        "summary": "Returns an index template",
+        "summary": "Returns information about one or more index templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html"
         },
@@ -11791,6 +11859,7 @@
           "indices.put_index_template"
         ],
         "summary": "Creates or updates an index template",
+        "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-template.html"
         },
@@ -11823,6 +11892,7 @@
           "indices.put_index_template"
         ],
         "summary": "Creates or updates an index template",
+        "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-template.html"
         },
@@ -11854,7 +11924,8 @@
         "tags": [
           "indices.delete_index_template"
         ],
-        "summary": "Deletes an index template",
+        "summary": "The provided <index-template> may contain multiple template names separated by a comma",
+        "description": "If multiple template names are specified then there is no wildcard support and the provided names should match completely with existing templates.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-template.html"
         },
@@ -11952,7 +12023,7 @@
         "tags": [
           "indices.get_template"
         ],
-        "summary": "Returns an index template",
+        "summary": "Retrieves information about one or more index templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template-v1.html"
         },
@@ -11982,6 +12053,7 @@
           "indices.put_template"
         ],
         "summary": "Creates or updates an index template",
+        "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html"
         },
@@ -12017,6 +12089,7 @@
           "indices.put_template"
         ],
         "summary": "Creates or updates an index template",
+        "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html"
         },
@@ -12051,7 +12124,7 @@
         "tags": [
           "indices.delete_template"
         ],
-        "summary": "Deletes an index template",
+        "summary": "Deletes a legacy index template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-template-v1.html"
         },
@@ -12256,7 +12329,7 @@
         "tags": [
           "indices.downsample"
         ],
-        "summary": "Downsample an index",
+        "summary": "Aggregates a time series (TSDS) index and stores pre-computed statistical summaries (`min`, `max`, `sum`, `value_count` and `avg`) for each metric field grouped by a configured time interval",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-downsample-data-stream.html"
         },
@@ -12314,7 +12387,7 @@
         "tags": [
           "indices.get_alias"
         ],
-        "summary": "Returns an alias",
+        "summary": "Retrieves information for one or more aliases",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -12346,7 +12419,7 @@
         "tags": [
           "indices.exists_alias"
         ],
-        "summary": "Returns information about whether a particular alias exists",
+        "summary": "Checks if an alias exists",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -12448,7 +12521,7 @@
         "tags": [
           "indices.field_usage_stats"
         ],
-        "summary": "Returns the field usage stats for each field of an index",
+        "summary": "Returns field usage information for each shard and field of an index",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/field-usage-stats.html"
         },
@@ -12555,7 +12628,7 @@
         "tags": [
           "indices.flush"
         ],
-        "summary": "Performs the flush operation on one or more indices",
+        "summary": "Flushes one or more data streams or indices",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-flush.html"
         },
@@ -12587,7 +12660,7 @@
         "tags": [
           "indices.flush"
         ],
-        "summary": "Performs the flush operation on one or more indices",
+        "summary": "Flushes one or more data streams or indices",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-flush.html"
         },
@@ -12621,7 +12694,7 @@
         "tags": [
           "indices.flush"
         ],
-        "summary": "Performs the flush operation on one or more indices",
+        "summary": "Flushes one or more data streams or indices",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-flush.html"
         },
@@ -12656,7 +12729,7 @@
         "tags": [
           "indices.flush"
         ],
-        "summary": "Performs the flush operation on one or more indices",
+        "summary": "Flushes one or more data streams or indices",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-flush.html"
         },
@@ -12776,7 +12849,7 @@
         "tags": [
           "indices.get_alias"
         ],
-        "summary": "Returns an alias",
+        "summary": "Retrieves information for one or more aliases",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -12807,7 +12880,7 @@
         "tags": [
           "indices.get_alias"
         ],
-        "summary": "Returns an alias",
+        "summary": "Retrieves information for one or more aliases",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -12841,7 +12914,7 @@
         "tags": [
           "indices.get_data_stream"
         ],
-        "summary": "Returns data streams",
+        "summary": "Retrieves information about one or more data streams",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -12866,7 +12939,8 @@
         "tags": [
           "indices.get_field_mapping"
         ],
-        "summary": "Returns mapping for one or more fields",
+        "summary": "Retrieves mapping definitions for one or more fields",
+        "description": "For data streams, the API retrieves field mappings for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html"
         },
@@ -12903,7 +12977,8 @@
         "tags": [
           "indices.get_field_mapping"
         ],
-        "summary": "Returns mapping for one or more fields",
+        "summary": "Retrieves mapping definitions for one or more fields",
+        "description": "For data streams, the API retrieves field mappings for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-field-mapping.html"
         },
@@ -12943,7 +13018,7 @@
         "tags": [
           "indices.get_index_template"
         ],
-        "summary": "Returns an index template",
+        "summary": "Returns information about one or more index templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html"
         },
@@ -12974,7 +13049,8 @@
         "tags": [
           "indices.get_mapping"
         ],
-        "summary": "Returns mappings for one or more indices",
+        "summary": "Retrieves mapping definitions for one or more indices",
+        "description": "For data streams, the API retrieves mappings for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html"
         },
@@ -13008,7 +13084,8 @@
         "tags": [
           "indices.get_mapping"
         ],
-        "summary": "Returns mappings for one or more indices",
+        "summary": "Retrieves mapping definitions for one or more indices",
+        "description": "For data streams, the API retrieves mappings for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html"
         },
@@ -13043,7 +13120,8 @@
         "tags": [
           "indices.put_mapping"
         ],
-        "summary": "Updates the index mappings",
+        "summary": "Adds new fields to an existing data stream or index",
+        "description": "You can also use this API to change the search settings of existing fields. For data streams, these changes are applied to all backing indices by default.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html"
         },
@@ -13084,7 +13162,8 @@
         "tags": [
           "indices.put_mapping"
         ],
-        "summary": "Updates the index mappings",
+        "summary": "Adds new fields to an existing data stream or index",
+        "description": "You can also use this API to change the search settings of existing fields. For data streams, these changes are applied to all backing indices by default.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html"
         },
@@ -13127,7 +13206,8 @@
         "tags": [
           "indices.get_settings"
         ],
-        "summary": "Returns settings for one or more indices",
+        "summary": "Returns setting information for one or more indices",
+        "description": "For data streams, returns setting information for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html"
         },
@@ -13165,7 +13245,8 @@
         "tags": [
           "indices.put_settings"
         ],
-        "summary": "Updates the index settings",
+        "summary": "Changes a dynamic index setting in real time",
+        "description": "For data streams, index setting changes are applied to all backing indices by default.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html"
         },
@@ -13208,7 +13289,8 @@
         "tags": [
           "indices.get_settings"
         ],
-        "summary": "Returns settings for one or more indices",
+        "summary": "Returns setting information for one or more indices",
+        "description": "For data streams, returns setting information for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html"
         },
@@ -13249,7 +13331,8 @@
         "tags": [
           "indices.put_settings"
         ],
-        "summary": "Updates the index settings",
+        "summary": "Changes a dynamic index setting in real time",
+        "description": "For data streams, index setting changes are applied to all backing indices by default.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html"
         },
@@ -13295,7 +13378,8 @@
         "tags": [
           "indices.get_settings"
         ],
-        "summary": "Returns settings for one or more indices",
+        "summary": "Returns setting information for one or more indices",
+        "description": "For data streams, returns setting information for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html"
         },
@@ -13341,7 +13425,8 @@
         "tags": [
           "indices.get_settings"
         ],
-        "summary": "Returns settings for one or more indices",
+        "summary": "Returns setting information for one or more indices",
+        "description": "For data streams, returns setting information for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html"
         },
@@ -13384,7 +13469,7 @@
         "tags": [
           "indices.get_template"
         ],
-        "summary": "Returns an index template",
+        "summary": "Retrieves information about one or more index templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template-v1.html"
         },
@@ -13412,7 +13497,8 @@
         "tags": [
           "indices.migrate_to_data_stream"
         ],
-        "summary": "Migrates an alias to a data stream",
+        "summary": "Converts an index alias to a data stream",
+        "description": "You must have a matching index template that is data stream enabled. The alias must meet the following criteria: The alias must have a write index; All indices for the alias must have a `@timestamp` field mapping of a `date` or `date_nanos` field type; The alias must not have any filters; The alias must not use custom routing. If successful, the request removes the alias and creates a data stream with the same name. The indices for the alias become hidden backing indices for the stream. The write index for the alias becomes the write index for the stream.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -13449,7 +13535,7 @@
         "tags": [
           "indices.modify_data_stream"
         ],
-        "summary": "Modifies a data stream",
+        "summary": "Performs one or more data stream modification actions in a single atomic operation",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -13495,7 +13581,8 @@
         "tags": [
           "indices.open"
         ],
-        "summary": "Opens an index",
+        "summary": "Opens a closed index",
+        "description": "For data streams, the API opens any closed backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html"
         },
@@ -13641,7 +13728,8 @@
         "tags": [
           "indices.recovery"
         ],
-        "summary": "Returns information about ongoing index shard recoveries",
+        "summary": "Returns information about ongoing and completed shard recoveries for one or more indices",
+        "description": "For data streams, the API returns information for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html"
         },
@@ -13666,7 +13754,8 @@
         "tags": [
           "indices.recovery"
         ],
-        "summary": "Returns information about ongoing index shard recoveries",
+        "summary": "Returns information about ongoing and completed shard recoveries for one or more indices",
+        "description": "For data streams, the API returns information for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-recovery.html"
         },
@@ -13694,7 +13783,8 @@
         "tags": [
           "indices.refresh"
         ],
-        "summary": "Performs the refresh operation in one or more indices",
+        "summary": "A refresh makes recent operations performed on one or more indices available for search",
+        "description": "For data streams, the API runs the refresh operation on the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html"
         },
@@ -13720,7 +13810,8 @@
         "tags": [
           "indices.refresh"
         ],
-        "summary": "Performs the refresh operation in one or more indices",
+        "summary": "A refresh makes recent operations performed on one or more indices available for search",
+        "description": "For data streams, the API runs the refresh operation on the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html"
         },
@@ -13748,7 +13839,8 @@
         "tags": [
           "indices.refresh"
         ],
-        "summary": "Performs the refresh operation in one or more indices",
+        "summary": "A refresh makes recent operations performed on one or more indices available for search",
+        "description": "For data streams, the API runs the refresh operation on the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html"
         },
@@ -13777,7 +13869,8 @@
         "tags": [
           "indices.refresh"
         ],
-        "summary": "Performs the refresh operation in one or more indices",
+        "summary": "A refresh makes recent operations performed on one or more indices available for search",
+        "description": "For data streams, the API runs the refresh operation on the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html"
         },
@@ -13869,6 +13962,7 @@
           "indices.resolve_cluster"
         ],
         "summary": "Resolves the specified index expressions to return information about each cluster, including the local cluster, if included",
+        "description": "Multiple patterns and remote clusters are supported.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-cluster-api.html"
         },
@@ -13948,7 +14042,8 @@
         "tags": [
           "indices.resolve_index"
         ],
-        "summary": "Returns information about any matching indices, aliases, and data streams",
+        "summary": "Resolves the specified name(s) and/or index patterns for indices, aliases, and data streams",
+        "description": "Multiple patterns and remote clusters are supported.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html"
         },
@@ -14020,7 +14115,7 @@
         "tags": [
           "indices.rollover"
         ],
-        "summary": "Updates an alias to point to a new index when the existing index is considered to be too large or too old",
+        "summary": "Creates a new index for a data stream or index alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html"
         },
@@ -14057,7 +14152,7 @@
         "tags": [
           "indices.rollover"
         ],
-        "summary": "Updates an alias to point to a new index when the existing index is considered to be too large or too old",
+        "summary": "Creates a new index for a data stream or index alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html"
         },
@@ -14097,7 +14192,8 @@
         "tags": [
           "indices.segments"
         ],
-        "summary": "Provides low-level information about segments in a Lucene index",
+        "summary": "Returns low-level information about the Lucene segments in index shards",
+        "description": "For data streams, the API returns information about the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html"
         },
@@ -14128,7 +14224,8 @@
         "tags": [
           "indices.segments"
         ],
-        "summary": "Provides low-level information about segments in a Lucene index",
+        "summary": "Returns low-level information about the Lucene segments in index shards",
+        "description": "For data streams, the API returns information about the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-segments.html"
         },
@@ -14162,7 +14259,8 @@
         "tags": [
           "indices.shard_stores"
         ],
-        "summary": "Provides store information for shard copies of indices",
+        "summary": "Retrieves store information about replica shards in one or more indices",
+        "description": "For data streams, the API retrieves store information for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html"
         },
@@ -14193,7 +14291,8 @@
         "tags": [
           "indices.shard_stores"
         ],
-        "summary": "Provides store information for shard copies of indices",
+        "summary": "Retrieves store information about replica shards in one or more indices",
+        "description": "For data streams, the API retrieves store information for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-shards-stores.html"
         },
@@ -14227,7 +14326,7 @@
         "tags": [
           "indices.shrink"
         ],
-        "summary": "Allow to shrink an existing index into a new index with fewer primary shards",
+        "summary": "Shrinks an existing index into a new index with fewer primary shards",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-shrink-index.html"
         },
@@ -14262,7 +14361,7 @@
         "tags": [
           "indices.shrink"
         ],
-        "summary": "Allow to shrink an existing index into a new index with fewer primary shards",
+        "summary": "Shrinks an existing index into a new index with fewer primary shards",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-shrink-index.html"
         },
@@ -14299,7 +14398,6 @@
         "tags": [
           "indices.simulate_index_template"
         ],
-        "summary": "Simulate matching the given index name against the index templates in the system",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-index.html"
         },
@@ -14370,7 +14468,7 @@
         "tags": [
           "indices.simulate_template"
         ],
-        "summary": "Simulate resolving the given template name or body",
+        "summary": "Returns the index configuration that would be applied by a particular index template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html"
         },
@@ -14401,7 +14499,7 @@
         "tags": [
           "indices.simulate_template"
         ],
-        "summary": "Simulate resolving the given template name or body",
+        "summary": "Returns the index configuration that would be applied by a particular index template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html"
         },
@@ -14435,7 +14533,7 @@
         "tags": [
           "indices.split"
         ],
-        "summary": "Allows you to split an existing index into a new index with more primary shards",
+        "summary": "Splits an existing index into a new index with more primary shards",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-split-index.html"
         },
@@ -14470,7 +14568,7 @@
         "tags": [
           "indices.split"
         ],
-        "summary": "Allows you to split an existing index into a new index with more primary shards",
+        "summary": "Splits an existing index into a new index with more primary shards",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-split-index.html"
         },
@@ -14507,7 +14605,8 @@
         "tags": [
           "indices.stats"
         ],
-        "summary": "Provides statistics on operations happening in an index",
+        "summary": "Returns statistics for one or more indices",
+        "description": "For data streams, the API retrieves statistics for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html"
         },
@@ -14553,7 +14652,8 @@
         "tags": [
           "indices.stats"
         ],
-        "summary": "Provides statistics on operations happening in an index",
+        "summary": "Returns statistics for one or more indices",
+        "description": "For data streams, the API retrieves statistics for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html"
         },
@@ -14602,7 +14702,8 @@
         "tags": [
           "indices.stats"
         ],
-        "summary": "Provides statistics on operations happening in an index",
+        "summary": "Returns statistics for one or more indices",
+        "description": "For data streams, the API retrieves statistics for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html"
         },
@@ -14651,7 +14752,8 @@
         "tags": [
           "indices.stats"
         ],
-        "summary": "Provides statistics on operations happening in an index",
+        "summary": "Returns statistics for one or more indices",
+        "description": "For data streams, the API retrieves statistics for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html"
         },
@@ -14704,7 +14806,6 @@
           "indices.unfreeze"
         ],
         "summary": "Unfreezes an index",
-        "description": "When a frozen index is unfrozen, the index goes through the normal recovery process and becomes writeable again.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/unfreeze-index-api.html"
         },
@@ -14813,7 +14914,7 @@
         "tags": [
           "indices.update_aliases"
         ],
-        "summary": "Updates index aliases",
+        "summary": "Adds a data stream or index to an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -14878,7 +14979,7 @@
         "tags": [
           "indices.validate_query"
         ],
-        "summary": "Allows a user to validate a potentially expensive query without executing it",
+        "summary": "Validates a potentially expensive query without executing it",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html"
         },
@@ -14934,7 +15035,7 @@
         "tags": [
           "indices.validate_query"
         ],
-        "summary": "Allows a user to validate a potentially expensive query without executing it",
+        "summary": "Validates a potentially expensive query without executing it",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html"
         },
@@ -14992,7 +15093,7 @@
         "tags": [
           "indices.validate_query"
         ],
-        "summary": "Allows a user to validate a potentially expensive query without executing it",
+        "summary": "Validates a potentially expensive query without executing it",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html"
         },
@@ -15051,7 +15152,7 @@
         "tags": [
           "indices.validate_query"
         ],
-        "summary": "Allows a user to validate a potentially expensive query without executing it",
+        "summary": "Validates a potentially expensive query without executing it",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html"
         },
@@ -15132,7 +15233,7 @@
         "tags": [
           "inference.put"
         ],
-        "summary": "Configure an inference endpoint for use in the Inference API",
+        "summary": "Create an inference endpoint",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-inference-api.html"
         },
@@ -15155,7 +15256,7 @@
         "tags": [
           "inference.inference"
         ],
-        "summary": "Perform inference",
+        "summary": "Perform inference on the service",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/post-inference-api.html"
         },
@@ -15232,7 +15333,7 @@
         "tags": [
           "inference.put"
         ],
-        "summary": "Configure an inference endpoint for use in the Inference API",
+        "summary": "Create an inference endpoint",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-inference-api.html"
         },
@@ -15258,7 +15359,7 @@
         "tags": [
           "inference.inference"
         ],
-        "summary": "Perform inference",
+        "summary": "Perform inference on the service",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/post-inference-api.html"
         },
@@ -15401,7 +15502,8 @@
         "tags": [
           "ingest.get_pipeline"
         ],
-        "summary": "Returns a pipeline",
+        "summary": "Returns information about one or more ingest pipelines",
+        "description": "This API returns a local reference of the pipeline.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html"
         },
@@ -15427,7 +15529,8 @@
         "tags": [
           "ingest.put_pipeline"
         ],
-        "summary": "Creates or updates a pipeline",
+        "summary": "Creates or updates an ingest pipeline",
+        "description": "Changes made using this API take effect immediately.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html"
         },
@@ -15528,7 +15631,7 @@
         "tags": [
           "ingest.delete_pipeline"
         ],
-        "summary": "Deletes a pipeline",
+        "summary": "Deletes one or more existing ingest pipeline",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html"
         },
@@ -15585,7 +15688,7 @@
         "tags": [
           "ingest.geo_ip_stats"
         ],
-        "summary": "Returns statistical information about geoip databases",
+        "summary": "Gets download statistics for GeoIP2 databases used with the geoip processor",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/geoip-processor.html"
         },
@@ -15625,7 +15728,8 @@
         "tags": [
           "ingest.get_pipeline"
         ],
-        "summary": "Returns a pipeline",
+        "summary": "Returns information about one or more ingest pipelines",
+        "description": "This API returns a local reference of the pipeline.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html"
         },
@@ -15650,7 +15754,8 @@
         "tags": [
           "ingest.processor_grok"
         ],
-        "summary": "Returns a list of the built-in patterns",
+        "summary": "Extracts structured fields out of a single text field within a document",
+        "description": "You choose which field to extract matched fields from, as well as the grok pattern you expect will match. A grok pattern is like a regular expression that supports aliased expressions that can be reused.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/grok-processor.html"
         },
@@ -15685,7 +15790,7 @@
         "tags": [
           "ingest.simulate"
         ],
-        "summary": "Allows to simulate a pipeline with example documents",
+        "summary": "Executes an ingest pipeline against a set of provided documents",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html"
         },
@@ -15708,7 +15813,7 @@
         "tags": [
           "ingest.simulate"
         ],
-        "summary": "Allows to simulate a pipeline with example documents",
+        "summary": "Executes an ingest pipeline against a set of provided documents",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html"
         },
@@ -15733,7 +15838,7 @@
         "tags": [
           "ingest.simulate"
         ],
-        "summary": "Allows to simulate a pipeline with example documents",
+        "summary": "Executes an ingest pipeline against a set of provided documents",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html"
         },
@@ -15759,7 +15864,7 @@
         "tags": [
           "ingest.simulate"
         ],
-        "summary": "Allows to simulate a pipeline with example documents",
+        "summary": "Executes an ingest pipeline against a set of provided documents",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html"
         },
@@ -15841,7 +15946,8 @@
         "tags": [
           "license.get"
         ],
-        "summary": "Retrieves licensing information for the cluster",
+        "summary": "This API returns information about the type of license, when it was issued, and when it expires, for example",
+        "description": "For more information about the different types of licenses, see https://www.elastic.co/subscriptions.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html"
         },
@@ -16027,7 +16133,8 @@
         "tags": [
           "license.post_start_basic"
         ],
-        "summary": "Starts an indefinite basic license",
+        "summary": "The start basic API enables you to initiate an indefinite basic license, which gives access to all the basic features",
+        "description": "If the basic license does not support all of the features that are available with your current license, however, you are notified in the response. You must then re-submit the API request with the acknowledge parameter set to true. To check the status of your basic license, use the following API: [Get basic status](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-basic-status.html).",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/start-basic.html"
         },
@@ -16097,7 +16204,7 @@
         "tags": [
           "license.post_start_trial"
         ],
-        "summary": "starts a limited time trial license",
+        "summary": "The start trial API enables you to start a 30-day trial, which gives access to all subscription features",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trial.html"
         },
@@ -16160,7 +16267,7 @@
         "tags": [
           "logstash.get_pipeline"
         ],
-        "summary": "Retrieves Logstash Pipelines used by Central Management",
+        "summary": "Retrieves pipelines used for Logstash Central Management",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-get-pipeline.html"
         },
@@ -16180,7 +16287,7 @@
         "tags": [
           "logstash.put_pipeline"
         ],
-        "summary": "Adds and updates Logstash Pipelines used for Central Management",
+        "summary": "Creates or updates a pipeline used for Logstash Central Management",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-put-pipeline.html"
         },
@@ -16221,7 +16328,7 @@
         "tags": [
           "logstash.delete_pipeline"
         ],
-        "summary": "Deletes Logstash Pipelines used by Central Management",
+        "summary": "Deletes a pipeline used for Logstash Central Management",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-delete-pipeline.html"
         },
@@ -16254,7 +16361,7 @@
         "tags": [
           "logstash.get_pipeline"
         ],
-        "summary": "Retrieves Logstash Pipelines used by Central Management",
+        "summary": "Retrieves pipelines used for Logstash Central Management",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-get-pipeline.html"
         },
@@ -16584,7 +16691,8 @@
         "tags": [
           "ml.clear_trained_model_deployment_cache"
         ],
-        "summary": "Clear the cached results from a trained model deployment",
+        "summary": "Clears a trained model deployment cache on all nodes where the trained model is assigned",
+        "description": "A trained model deployment may have an inference cache enabled. As requests are handled by each allocated node, their responses may be cached on that individual node. Calling this API clears the caches without restarting the deployment.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-trained-model-deployment-cache.html"
         },
@@ -16629,8 +16737,8 @@
         "tags": [
           "ml.close_job"
         ],
-        "summary": "Closes one or more anomaly detection jobs",
-        "description": "A job can be opened and closed multiple times throughout its lifecycle.",
+        "summary": "Close anomaly detection jobs A job can be opened and closed multiple times throughout its lifecycle",
+        "description": "A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results. When you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data. If you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request. When a datafeed that has a specified end date stops, it automatically closes its associated job.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html"
         },
@@ -16756,7 +16864,7 @@
         "tags": [
           "ml.put_calendar"
         ],
-        "summary": "Instantiates a calendar",
+        "summary": "Creates a calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-calendar.html"
         },
@@ -16858,7 +16966,7 @@
         "tags": [
           "ml.delete_calendar"
         ],
-        "summary": "Deletes a calendar",
+        "summary": "Removes all scheduled events from a calendar, then deletes it",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar.html"
         },
@@ -17070,6 +17178,7 @@
           "ml.get_data_frame_analytics"
         ],
         "summary": "Retrieves configuration information for data frame analytics jobs",
+        "description": "You can get information for multiple data frame analytics jobs in a single API request by using a comma-separated list of data frame analytics jobs or a wildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html"
         },
@@ -17102,6 +17211,7 @@
           "ml.put_data_frame_analytics"
         ],
         "summary": "Instantiates a data frame analytics job",
+        "description": "This API creates a data frame analytics job that performs an analysis on the source indices and stores the outcome in a destination index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html"
         },
@@ -17239,7 +17349,7 @@
         "tags": [
           "ml.delete_data_frame_analytics"
         ],
-        "summary": "Deletes an existing data frame analytics job",
+        "summary": "Deletes a data frame analytics job",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html"
         },
@@ -17297,6 +17407,7 @@
           "ml.get_datafeeds"
         ],
         "summary": "Retrieves configuration information for datafeeds",
+        "description": "You can get information for multiple datafeeds in a single API request by using a comma-separated list of datafeeds or a wildcard expression. You can get information for all datafeeds by using `_all`, by specifying `*` as the `<feed_id>`, or by omitting the `<feed_id>`. This API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html"
         },
@@ -17323,6 +17434,7 @@
           "ml.put_datafeed"
         ],
         "summary": "Instantiates a datafeed",
+        "description": "Datafeeds retrieve data from Elasticsearch for analysis by an anomaly detection job. You can associate only one datafeed with each anomaly detection job. The datafeed contains a query that runs at a defined interval (`frequency`). If you are concerned about delayed data, you can add a delay (`query_delay') at each interval. When Elasticsearch security features are enabled, your datafeed remembers which roles the user who created it had at the time of creation and runs the query using those same roles. If you provide secondary authorization headers, those credentials are used instead. You must use Kibana, this API, or the create anomaly detection jobs API to create a datafeed. Do not add a datafeed directly to the `.ml-config` index. Do not give users `write` privileges on the `.ml-config` index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html"
         },
@@ -17574,6 +17686,7 @@
           "ml.delete_expired_data"
         ],
         "summary": "Deletes expired and unused machine learning data",
+        "description": "Deletes all job results, model snapshots and forecast data that have exceeded their retention days period. Machine learning state documents that are not associated with any job are also deleted. You can limit the request to a single or set of anomaly detection jobs by using a job identifier, a group name, a comma-separated list of jobs, or a wildcard expression. You can delete expired data for all anomaly detection jobs by using _all, by specifying * as the <job_id>, or by omitting the <job_id>.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-expired-data.html"
         },
@@ -17605,6 +17718,7 @@
           "ml.delete_expired_data"
         ],
         "summary": "Deletes expired and unused machine learning data",
+        "description": "Deletes all job results, model snapshots and forecast data that have exceeded their retention days period. Machine learning state documents that are not associated with any job are also deleted. You can limit the request to a single or set of anomaly detection jobs by using a job identifier, a group name, a comma-separated list of jobs, or a wildcard expression. You can delete expired data for all anomaly detection jobs by using _all, by specifying * as the <job_id>, or by omitting the <job_id>.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-expired-data.html"
         },
@@ -17633,6 +17747,7 @@
           "ml.get_filters"
         ],
         "summary": "Retrieves filters",
+        "description": "You can get a single filter or all filters.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-filter.html"
         },
@@ -17659,6 +17774,7 @@
           "ml.put_filter"
         ],
         "summary": "Instantiates a filter",
+        "description": "A filter contains a list of strings. It can be used by one or more anomaly detection jobs. Specifically, filters are referenced in the `custom_rules` property of detector configuration objects.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-filter.html"
         },
@@ -17736,6 +17852,7 @@
           "ml.delete_filter"
         ],
         "summary": "Deletes a filter",
+        "description": "If an anomaly detection job references the filter, you cannot delete the filter. You must update or delete the job before you can delete the filter.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-filter.html"
         },
@@ -17772,7 +17889,8 @@
         "tags": [
           "ml.forecast"
         ],
-        "summary": "Predicts the future behavior of a time series by using its historical behavior",
+        "summary": "Predicts the future behavior of a time series by using its historical behavior.",
+        "description": "Forecasts are not supported for jobs that perform population analysis; an error occurs if you try to create a forecast for a job that has an `over_field_name` in its configuration.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-forecast.html"
         },
@@ -17871,6 +17989,7 @@
           "ml.delete_forecast"
         ],
         "summary": "Deletes forecasts from a machine learning job",
+        "description": "By default, forecasts are retained for 14 days. You can specify a different retention period with the `expires_in` parameter in the forecast jobs API. The delete forecast API enables you to delete one or more forecasts before they expire.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html"
         },
@@ -17899,6 +18018,7 @@
           "ml.delete_forecast"
         ],
         "summary": "Deletes forecasts from a machine learning job",
+        "description": "By default, forecasts are retained for 14 days. You can specify a different retention period with the `expires_in` parameter in the forecast jobs API. The delete forecast API enables you to delete one or more forecasts before they expire.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html"
         },
@@ -17930,6 +18050,7 @@
           "ml.get_jobs"
         ],
         "summary": "Retrieves configuration information for anomaly detection jobs",
+        "description": "You can get information for multiple anomaly detection jobs in a single API request by using a group name, a comma-separated list of jobs, or a wildcard expression. You can get information for all anomaly detection jobs by using `_all`, by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html"
         },
@@ -17956,6 +18077,7 @@
           "ml.put_job"
         ],
         "summary": "Instantiates an anomaly detection job",
+        "description": "If you include a `datafeed_config`, you must have read index privileges on the source index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html"
         },
@@ -18139,7 +18261,8 @@
         "tags": [
           "ml.delete_job"
         ],
-        "summary": "Deletes an existing anomaly detection job",
+        "summary": "Deletes an anomaly detection job.",
+        "description": "All job configuration, model state and results are deleted. It is not currently possible to delete multiple jobs using wildcards or a comma separated list. If you delete a job that has a datafeed, the request first tries to delete the datafeed. This behavior is equivalent to calling the delete datafeed API with the same timeout and force parameters as the delete job request.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html"
         },
@@ -18295,6 +18418,7 @@
           "ml.delete_model_snapshot"
         ],
         "summary": "Deletes an existing model snapshot",
+        "description": "You cannot delete the active model snapshot. To delete that snapshot, first revert to a different one. To identify the active model snapshot, refer to the `model_snapshot_id` in the results from the get jobs API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html"
         },
@@ -18342,7 +18466,7 @@
         "tags": [
           "ml.get_trained_models"
         ],
-        "summary": "Retrieves configuration information for a trained inference model",
+        "summary": "Retrieves configuration information for a trained model",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models.html"
         },
@@ -18383,7 +18507,7 @@
         "tags": [
           "ml.put_trained_model"
         ],
-        "summary": "Creates an inference trained model",
+        "summary": "Enables you to supply a trained model that is not created by data frame analytics",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-models.html"
         },
@@ -18539,7 +18663,8 @@
         "tags": [
           "ml.put_trained_model_alias"
         ],
-        "summary": "Creates a new model alias (or reassigns an existing one) to refer to the trained model",
+        "summary": "Creates or updates a trained model alias",
+        "description": "A trained model alias is a logical name used to reference a single trained model. You can use aliases instead of trained model identifiers to make it easier to reference your models. For example, you can use aliases in inference aggregations and processors. An alias must be unique and refer to only a single trained model. However, you can have multiple aliases for each trained model. If you use this API to update an alias such that it references a different trained model ID and the model uses a different type of data frame analytics, an error occurs. For example, this situation occurs if you have a trained model for regression analysis and a trained model for classification analysis; you cannot reassign an alias from one type of trained model to another. If you use this API to update an alias and there are very few input fields in common between the old and new trained models for the model alias, the API returns a warning.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-models-aliases.html"
         },
@@ -18595,7 +18720,8 @@
         "tags": [
           "ml.delete_trained_model_alias"
         ],
-        "summary": "Deletes a model alias that refers to the trained model",
+        "summary": "Deletes a trained model alias",
+        "description": "This API deletes an existing model alias that refers to a trained model. If the model alias is missing or refers to a model other than the one identified by the `model_id`, this API returns an error.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-trained-models-aliases.html"
         },
@@ -18643,7 +18769,8 @@
         "tags": [
           "ml.estimate_model_memory"
         ],
-        "summary": "Estimates the model memory",
+        "summary": "Makes an estimation of the memory usage for an anomaly detection job model",
+        "description": "It is based on analysis configuration details for the job and cardinality estimates for the fields it references.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-apis.html"
         },
@@ -18705,6 +18832,7 @@
           "ml.evaluate_data_frame"
         ],
         "summary": "Evaluates the data frame analytics for an annotated index",
+        "description": "The API packages together commonly used evaluation metrics for various types of machine learning features. This has been designed for use on indexes created by data frame analytics. Evaluation requires both a ground truth field and an analytics result field to be present.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/evaluate-dfanalytics.html"
         },
@@ -18765,6 +18893,7 @@
           "ml.explain_data_frame_analytics"
         ],
         "summary": "Explains a data frame analytics config",
+        "description": "This API provides explanations for a data frame analytics config that either exists already or one that has not been created yet. The following explanations are provided: * which fields are included or not in the analysis and why, * how much memory is estimated to be required. The estimate can be used when deciding the appropriate value for model_memory_limit setting later on. If you have object fields or fields that are excluded via source filtering, they are not included in the explanation.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html"
         },
@@ -18783,6 +18912,7 @@
           "ml.explain_data_frame_analytics"
         ],
         "summary": "Explains a data frame analytics config",
+        "description": "This API provides explanations for a data frame analytics config that either exists already or one that has not been created yet. The following explanations are provided: * which fields are included or not in the analysis and why, * how much memory is estimated to be required. The estimate can be used when deciding the appropriate value for model_memory_limit setting later on. If you have object fields or fields that are excluded via source filtering, they are not included in the explanation.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html"
         },
@@ -18803,6 +18933,7 @@
           "ml.explain_data_frame_analytics"
         ],
         "summary": "Explains a data frame analytics config",
+        "description": "This API provides explanations for a data frame analytics config that either exists already or one that has not been created yet. The following explanations are provided: * which fields are included or not in the analysis and why, * how much memory is estimated to be required. The estimate can be used when deciding the appropriate value for model_memory_limit setting later on. If you have object fields or fields that are excluded via source filtering, they are not included in the explanation.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html"
         },
@@ -18826,6 +18957,7 @@
           "ml.explain_data_frame_analytics"
         ],
         "summary": "Explains a data frame analytics config",
+        "description": "This API provides explanations for a data frame analytics config that either exists already or one that has not been created yet. The following explanations are provided: * which fields are included or not in the analysis and why, * how much memory is estimated to be required. The estimate can be used when deciding the appropriate value for model_memory_limit setting later on. If you have object fields or fields that are excluded via source filtering, they are not included in the explanation.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html"
         },
@@ -18851,6 +18983,7 @@
           "ml.flush_job"
         ],
         "summary": "Forces any buffered data to be processed by the job",
+        "description": "The flush jobs API is only applicable when sending data for analysis using the post data API. Depending on the content of the buffer, then it might additionally calculate new results. Both flush and close operations are similar, however the flush is more efficient if you are expecting to send more data for analysis. When flushing, the job remains open and is available to continue analyzing data. A close operation additionally prunes and persists the model state to disk and the job must be opened again before analyzing further data.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html"
         },
@@ -18977,6 +19110,7 @@
           "ml.get_buckets"
         ],
         "summary": "Retrieves anomaly detection job results for one or more buckets",
+        "description": "The API presents a chronological view of the records, grouped by bucket.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html"
         },
@@ -19030,6 +19164,7 @@
           "ml.get_buckets"
         ],
         "summary": "Retrieves anomaly detection job results for one or more buckets",
+        "description": "The API presents a chronological view of the records, grouped by bucket.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html"
         },
@@ -19085,6 +19220,7 @@
           "ml.get_buckets"
         ],
         "summary": "Retrieves anomaly detection job results for one or more buckets",
+        "description": "The API presents a chronological view of the records, grouped by bucket.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html"
         },
@@ -19135,6 +19271,7 @@
           "ml.get_buckets"
         ],
         "summary": "Retrieves anomaly detection job results for one or more buckets",
+        "description": "The API presents a chronological view of the records, grouped by bucket.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html"
         },
@@ -19286,7 +19423,7 @@
         "tags": [
           "ml.post_calendar_events"
         ],
-        "summary": "Posts scheduled events in a calendar",
+        "summary": "Adds scheduled events to a calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-calendar-event.html"
         },
@@ -19549,6 +19686,7 @@
           "ml.get_data_frame_analytics"
         ],
         "summary": "Retrieves configuration information for data frame analytics jobs",
+        "description": "You can get information for multiple data frame analytics jobs in a single API request by using a comma-separated list of data frame analytics jobs or a wildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html"
         },
@@ -19645,6 +19783,7 @@
           "ml.get_datafeed_stats"
         ],
         "summary": "Retrieves usage information for datafeeds",
+        "description": "You can get statistics for multiple datafeeds in a single API request by using a comma-separated list of datafeeds or a wildcard expression. You can get statistics for all datafeeds by using `_all`, by specifying `*` as the `<feed_id>`, or by omitting the `<feed_id>`. If the datafeed is stopped, the only information you receive is the `datafeed_id` and the `state`. This API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html"
         },
@@ -19670,6 +19809,7 @@
           "ml.get_datafeed_stats"
         ],
         "summary": "Retrieves usage information for datafeeds",
+        "description": "You can get statistics for multiple datafeeds in a single API request by using a comma-separated list of datafeeds or a wildcard expression. You can get statistics for all datafeeds by using `_all`, by specifying `*` as the `<feed_id>`, or by omitting the `<feed_id>`. If the datafeed is stopped, the only information you receive is the `datafeed_id` and the `state`. This API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html"
         },
@@ -19692,6 +19832,7 @@
           "ml.get_datafeeds"
         ],
         "summary": "Retrieves configuration information for datafeeds",
+        "description": "You can get information for multiple datafeeds in a single API request by using a comma-separated list of datafeeds or a wildcard expression. You can get information for all datafeeds by using `_all`, by specifying `*` as the `<feed_id>`, or by omitting the `<feed_id>`. This API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html"
         },
@@ -19717,6 +19858,7 @@
           "ml.get_filters"
         ],
         "summary": "Retrieves filters",
+        "description": "You can get a single filter or all filters.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-filter.html"
         },
@@ -19742,6 +19884,7 @@
           "ml.get_influencers"
         ],
         "summary": "Retrieves anomaly detection job results for one or more influencers",
+        "description": "Influencers are the entities that have contributed to, or are to blame for, the anomalies. Influencer results are available only if an `influencer_field_name` is specified in the job configuration.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html"
         },
@@ -19789,6 +19932,7 @@
           "ml.get_influencers"
         ],
         "summary": "Retrieves anomaly detection job results for one or more influencers",
+        "description": "Influencers are the entities that have contributed to, or are to blame for, the anomalies. Influencer results are available only if an `influencer_field_name` is specified in the job configuration.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html"
         },
@@ -19885,6 +20029,7 @@
           "ml.get_jobs"
         ],
         "summary": "Retrieves configuration information for anomaly detection jobs",
+        "description": "You can get information for multiple anomaly detection jobs in a single API request by using a group name, a comma-separated list of jobs, or a wildcard expression. You can get information for all anomaly detection jobs by using `_all`, by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html"
         },
@@ -19909,7 +20054,7 @@
         "tags": [
           "ml.get_memory_stats"
         ],
-        "summary": "Returns information on how ML is using memory",
+        "summary": "Get information about how machine learning jobs and trained models are using memory, on each node, both within the JVM heap, and natively, outside of the JVM",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-ml-memory.html"
         },
@@ -19937,7 +20082,7 @@
         "tags": [
           "ml.get_memory_stats"
         ],
-        "summary": "Returns information on how ML is using memory",
+        "summary": "Get information about how machine learning jobs and trained models are using memory, on each node, both within the JVM heap, and natively, outside of the JVM",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-ml-memory.html"
         },
@@ -19968,7 +20113,7 @@
         "tags": [
           "ml.get_model_snapshot_upgrade_stats"
         ],
-        "summary": "Gets stats for anomaly detection job model snapshot upgrades that are in progress",
+        "summary": "Retrieves usage information for anomaly detection job model snapshot upgrades",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-model-snapshot-upgrade-stats.html"
         },
@@ -20125,7 +20270,8 @@
         "tags": [
           "ml.get_overall_buckets"
         ],
-        "summary": "Retrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs",
+        "summary": "Retrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs.",
+        "description": "The `overall_score` is calculated by combining the scores of all the buckets within the overall bucket span. First, the maximum `anomaly_score` per anomaly detection job in the overall bucket is calculated. Then the `top_n` of those scores are averaged to result in the `overall_score`. This means that you can fine-tune the `overall_score` so that it is more or less sensitive to the number of jobs that detect an anomaly at the same time. For example, if you set `top_n` to `1`, the `overall_score` is the maximum bucket score in the overall bucket. Alternatively, if you set `top_n` to the number of jobs, the `overall_score` is high only when all jobs detect anomalies in that overall bucket. If you set the `bucket_span` parameter (to a value greater than its default), the `overall_score` is the maximum `overall_score` of the overall buckets that have a span equal to the jobs' largest bucket span.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html"
         },
@@ -20169,7 +20315,8 @@
         "tags": [
           "ml.get_overall_buckets"
         ],
-        "summary": "Retrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs",
+        "summary": "Retrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs.",
+        "description": "The `overall_score` is calculated by combining the scores of all the buckets within the overall bucket span. First, the maximum `anomaly_score` per anomaly detection job in the overall bucket is calculated. Then the `top_n` of those scores are averaged to result in the `overall_score`. This means that you can fine-tune the `overall_score` so that it is more or less sensitive to the number of jobs that detect an anomaly at the same time. For example, if you set `top_n` to `1`, the `overall_score` is the maximum bucket score in the overall bucket. Alternatively, if you set `top_n` to the number of jobs, the `overall_score` is high only when all jobs detect anomalies in that overall bucket. If you set the `bucket_span` parameter (to a value greater than its default), the `overall_score` is the maximum `overall_score` of the overall buckets that have a span equal to the jobs' largest bucket span.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html"
         },
@@ -20216,6 +20363,7 @@
           "ml.get_records"
         ],
         "summary": "Retrieves anomaly records for an anomaly detection job",
+        "description": "Records contain the detailed analytical results. They describe the anomalous activity that has been identified in the input data based on the detector configuration. There can be many anomaly records depending on the characteristics and size of the input data. In practice, there are often too many to be able to manually process them. The machine learning features therefore perform a sophisticated aggregation of the anomaly records into buckets. The number of record results depends on the number of anomalies found in each bucket, which relates to the number of time series being modeled and the number of detectors.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html"
         },
@@ -20263,6 +20411,7 @@
           "ml.get_records"
         ],
         "summary": "Retrieves anomaly records for an anomaly detection job",
+        "description": "Records contain the detailed analytical results. They describe the anomalous activity that has been identified in the input data based on the detector configuration. There can be many anomaly records depending on the characteristics and size of the input data. In practice, there are often too many to be able to manually process them. The machine learning features therefore perform a sophisticated aggregation of the anomaly records into buckets. The number of record results depends on the number of anomalies found in each bucket, which relates to the number of time series being modeled and the number of detectors.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html"
         },
@@ -20311,7 +20460,7 @@
         "tags": [
           "ml.get_trained_models"
         ],
-        "summary": "Retrieves configuration information for a trained inference model",
+        "summary": "Retrieves configuration information for a trained model",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models.html"
         },
@@ -20351,7 +20500,8 @@
         "tags": [
           "ml.get_trained_models_stats"
         ],
-        "summary": "Retrieves usage information for trained inference models",
+        "summary": "Retrieves usage information for trained models",
+        "description": "You can get usage information for multiple trained models in a single API request by using a comma-separated list of model IDs or a wildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models-stats.html"
         },
@@ -20382,7 +20532,8 @@
         "tags": [
           "ml.get_trained_models_stats"
         ],
-        "summary": "Retrieves usage information for trained inference models",
+        "summary": "Retrieves usage information for trained models",
+        "description": "You can get usage information for multiple trained models in a single API request by using a comma-separated list of model IDs or a wildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models-stats.html"
         },
@@ -20410,7 +20561,7 @@
         "tags": [
           "ml.infer_trained_model"
         ],
-        "summary": "Evaluate a trained model",
+        "summary": "Evaluates a trained model",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html"
         },
@@ -20438,7 +20589,7 @@
         "tags": [
           "ml.infer_trained_model"
         ],
-        "summary": "Evaluate a trained model",
+        "summary": "Evaluates a trained model",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html"
         },
@@ -20467,6 +20618,7 @@
           "ml.info"
         ],
         "summary": "Returns defaults and limits used by machine learning",
+        "description": "This endpoint is designed to be used by a user interface that needs to fully understand machine learning configurations where some options are not specified, meaning that the defaults should be used. This endpoint may be used to find out what those defaults are. It also provides information about the maximum size of machine learning jobs that could run in the current cluster configuration.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-ml-info.html"
         },
@@ -20511,6 +20663,7 @@
           "ml.open_job"
         ],
         "summary": "Opens one or more anomaly detection jobs",
+        "description": "An anomaly detection job must be opened in order for it to be ready to receive and analyze data. It can be opened and closed multiple times throughout its lifecycle. When you open a new job, it starts with an empty model. When you open an existing job, the most recent model state is automatically loaded. The job is ready to resume its analysis from where it left off, once new data is received.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html"
         },
@@ -20583,7 +20736,8 @@
         "tags": [
           "ml.post_data"
         ],
-        "summary": "Sends data to an anomaly detection job for analysis",
+        "summary": "Sends data to an anomaly detection job for analysis.",
+        "description": "IMPORTANT: For each job, data can be accepted from only a single connection at a time. It is not currently possible to post data to multiple jobs using wildcards or a comma-separated list.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html"
         },
@@ -20717,7 +20871,7 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews that will be analyzed given a data frame analytics config",
+        "summary": "Previews the extracted features used by a data frame analytics config",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -20735,7 +20889,7 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews that will be analyzed given a data frame analytics config",
+        "summary": "Previews the extracted features used by a data frame analytics config",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -20755,7 +20909,7 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews that will be analyzed given a data frame analytics config",
+        "summary": "Previews the extracted features used by a data frame analytics config",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -20778,7 +20932,7 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews that will be analyzed given a data frame analytics config",
+        "summary": "Previews the extracted features used by a data frame analytics config",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -20804,6 +20958,7 @@
           "ml.preview_datafeed"
         ],
         "summary": "Previews a datafeed",
+        "description": "This API returns the first \"page\" of search results from a datafeed. You can preview an existing datafeed or provide configuration details for a datafeed and anomaly detection job in the API. The preview shows the structure of the data that will be passed to the anomaly detection engine. IMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that called the API. However, when the datafeed starts it uses the roles of the last user that created or updated the datafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials. You can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
         },
@@ -20833,6 +20988,7 @@
           "ml.preview_datafeed"
         ],
         "summary": "Previews a datafeed",
+        "description": "This API returns the first \"page\" of search results from a datafeed. You can preview an existing datafeed or provide configuration details for a datafeed and anomaly detection job in the API. The preview shows the structure of the data that will be passed to the anomaly detection engine. IMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that called the API. However, when the datafeed starts it uses the roles of the last user that created or updated the datafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials. You can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
         },
@@ -20864,6 +21020,7 @@
           "ml.preview_datafeed"
         ],
         "summary": "Previews a datafeed",
+        "description": "This API returns the first \"page\" of search results from a datafeed. You can preview an existing datafeed or provide configuration details for a datafeed and anomaly detection job in the API. The preview shows the structure of the data that will be passed to the anomaly detection engine. IMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that called the API. However, when the datafeed starts it uses the roles of the last user that created or updated the datafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials. You can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
         },
@@ -20890,6 +21047,7 @@
           "ml.preview_datafeed"
         ],
         "summary": "Previews a datafeed",
+        "description": "This API returns the first \"page\" of search results from a datafeed. You can preview an existing datafeed or provide configuration details for a datafeed and anomaly detection job in the API. The preview shows the structure of the data that will be passed to the anomaly detection engine. IMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that called the API. However, when the datafeed starts it uses the roles of the last user that created or updated the datafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials. You can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
         },
@@ -20995,6 +21153,7 @@
           "ml.put_trained_model_vocabulary"
         ],
         "summary": "Creates a trained model vocabulary",
+        "description": "This API is supported only for natural language processing (NLP) models. The vocabulary is stored in the index as described in `inference_config.*.vocabulary` of the trained model definition.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-model-vocabulary.html"
         },
@@ -21067,7 +21226,8 @@
         "tags": [
           "ml.reset_job"
         ],
-        "summary": "Resets an existing anomaly detection job",
+        "summary": "Resets an anomaly detection job",
+        "description": "All model state and results are deleted. The job is ready to start over as if it had just been created. It is not currently possible to reset multiple jobs using wildcards or a comma separated list.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-reset-job.html"
         },
@@ -21125,6 +21285,7 @@
           "ml.revert_model_snapshot"
         ],
         "summary": "Reverts to a specific snapshot",
+        "description": "The machine learning features react quickly to anomalous input, learning new behaviors in data. Highly anomalous input increases the variance in the models whilst the system learns whether this is a new step-change in behavior or a one-off event. In the case where this anomalous input is known to be a one-off, then it might be appropriate to reset the model state to a time before this event. For example, you might consider reverting to a saved snapshot after Black Friday or a critical system failure.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html"
         },
@@ -21206,6 +21367,7 @@
           "ml.set_upgrade_mode"
         ],
         "summary": "Sets a cluster wide upgrade_mode setting that prepares machine learning indices for an upgrade",
+        "description": "When upgrading your cluster, in some circumstances you must restart your nodes and reindex your machine learning indices. In those circumstances, there must be no machine learning jobs running. You can close the machine learning jobs, do the upgrade, then open all the jobs again. Alternatively, you can use this API to temporarily halt tasks associated with the jobs and datafeeds and prevent new jobs from opening. You can also use this API during upgrades that do not require you to reindex your machine learning indices, though stopping jobs is not a requirement in that case. You can see the current value for the upgrade_mode setting by using the get machine learning info API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-set-upgrade-mode.html"
         },
@@ -21252,6 +21414,7 @@
           "ml.start_data_frame_analytics"
         ],
         "summary": "Starts a data frame analytics job",
+        "description": "A data frame analytics job can be started and stopped multiple times throughout its lifecycle. If the destination index does not exist, it is created automatically the first time you start the data frame analytics job. The `index.number_of_shards` and `index.number_of_replicas` settings for the destination index are copied from the source index. If there are multiple source indices, the destination index copies the highest setting values. The mappings for the destination index are also copied from the source indices. If there are any mapping conflicts, the job fails to start. If the destination index exists, it is used as is. You can therefore set up the destination index in advance with custom settings and mappings.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/start-dfanalytics.html"
         },
@@ -21310,7 +21473,8 @@
         "tags": [
           "ml.start_datafeed"
         ],
-        "summary": "Starts one or more datafeeds",
+        "summary": "Starts one or more datafeeds.",
+        "description": "A datafeed must be started in order to retrieve data from Elasticsearch. A datafeed can be started and stopped multiple times throughout its lifecycle.. Before you can start a datafeed, the anomaly detection job must be open. Otherwise, an error occurs.. If you restart a stopped datafeed, it continues processing input data from the next millisecond after it was stopped. If new data was indexed for that exact millisecond between stopping and starting, it will be ignored.. When Elasticsearch security features are enabled, your datafeed remembers which roles the last user to create or update it had at the time of creation or update and runs the query using those same roles. If you provided secondary authorization headers when you created or updated the datafeed, those credentials are used instead.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html"
         },
@@ -21410,7 +21574,7 @@
         "tags": [
           "ml.start_trained_model_deployment"
         ],
-        "summary": "Start a trained model deployment",
+        "summary": "Starts a trained model deployment, which allocates the model to every machine learning node",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trained-model-deployment.html"
         },
@@ -21536,6 +21700,7 @@
           "ml.stop_data_frame_analytics"
         ],
         "summary": "Stops one or more data frame analytics jobs",
+        "description": "A data frame analytics job can be started and stopped multiple times throughout its lifecycle.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-dfanalytics.html"
         },
@@ -21611,6 +21776,7 @@
           "ml.stop_datafeed"
         ],
         "summary": "Stops one or more datafeeds",
+        "description": "A datafeed that is stopped ceases to retrieve data from Elasticsearch. A datafeed can be started and stopped multiple times throughout its lifecycle.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html"
         },
@@ -21707,7 +21873,7 @@
         "tags": [
           "ml.stop_trained_model_deployment"
         ],
-        "summary": "Stop a trained model deployment",
+        "summary": "Stops a trained model deployment",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-trained-model-deployment.html"
         },
@@ -21772,7 +21938,7 @@
         "tags": [
           "ml.update_data_frame_analytics"
         ],
-        "summary": "Updates certain properties of a data frame analytics job",
+        "summary": "Updates an existing data frame analytics job",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-dfanalytics.html"
         },
@@ -21892,7 +22058,8 @@
         "tags": [
           "ml.update_datafeed"
         ],
-        "summary": "Updates certain properties of a datafeed",
+        "summary": "Updates the properties of a datafeed",
+        "description": "You must stop and start the datafeed for the changes to be applied. When Elasticsearch security features are enabled, your datafeed remembers which roles the user who updated it had at the time of the update and runs the query using those same roles. If you provide secondary authorization headers, those credentials are used instead.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html"
         },
@@ -22099,7 +22266,7 @@
         "tags": [
           "ml.update_filter"
         ],
-        "summary": "Updates the description of a filter, adds items, or removes items",
+        "summary": "Updates the description of a filter, adds items, or removes items from the list",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-filter.html"
         },
@@ -22473,7 +22640,7 @@
         "tags": [
           "ml.update_trained_model_deployment"
         ],
-        "summary": "Updates certain properties of trained model deployment",
+        "summary": "Starts a trained model deployment, which allocates the model to every machine learning node",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-trained-model-deployment.html"
         },
@@ -22543,7 +22710,8 @@
         "tags": [
           "ml.upgrade_job_snapshot"
         ],
-        "summary": "Upgrades a given job snapshot to the current major version",
+        "summary": "Upgrades an anomaly detection model snapshot to the latest major version",
+        "description": "Over time, older snapshot formats are deprecated and removed. Anomaly detection jobs support only snapshots that are from the current or previous major version. This API provides a means to upgrade a snapshot to the current major version. This aids in preparing the cluster for an upgrade to the next major version. Only one snapshot per anomaly detection job can be upgraded at a time and the upgraded snapshot cannot be the current snapshot of the anomaly detection job.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-upgrade-job-model-snapshot.html"
         },
@@ -23081,7 +23249,7 @@
         "tags": [
           "msearch_template"
         ],
-        "summary": "Allows to execute several search template operations in one request",
+        "summary": "Runs multiple templated searches with a single request",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html"
         },
@@ -23116,7 +23284,7 @@
         "tags": [
           "msearch_template"
         ],
-        "summary": "Allows to execute several search template operations in one request",
+        "summary": "Runs multiple templated searches with a single request",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html"
         },
@@ -23153,7 +23321,7 @@
         "tags": [
           "msearch_template"
         ],
-        "summary": "Allows to execute several search template operations in one request",
+        "summary": "Runs multiple templated searches with a single request",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html"
         },
@@ -23191,7 +23359,7 @@
         "tags": [
           "msearch_template"
         ],
-        "summary": "Allows to execute several search template operations in one request",
+        "summary": "Runs multiple templated searches with a single request",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html"
         },
@@ -23465,7 +23633,7 @@
         "tags": [
           "nodes.clear_repositories_metering_archive"
         ],
-        "summary": "Removes the archived repositories metering information present in the cluster",
+        "summary": "You can use this API to clear the archived repositories metering information in the cluster",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-repositories-metering-archive-api.html"
         },
@@ -23513,7 +23681,8 @@
         "tags": [
           "nodes.get_repositories_metering_info"
         ],
-        "summary": "Returns cluster repositories metering information",
+        "summary": "You can use the cluster repositories metering API to retrieve repositories metering information in a cluster",
+        "description": "This API exposes monotonically non-decreasing counters and it’s expected that clients would durably store the information needed to compute aggregations over a period of time. Additionally, the information exposed by this API is volatile, meaning that it won’t be present after node restarts.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-repositories-metering-api.html"
         },
@@ -23550,7 +23719,8 @@
         "tags": [
           "nodes.hot_threads"
         ],
-        "summary": "Returns information about hot threads on each node in the cluster",
+        "summary": "This API yields a breakdown of the hot threads on each selected node in the cluster",
+        "description": "The output is plain text with a breakdown of each node’s top hot threads.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-hot-threads.html"
         },
@@ -23593,7 +23763,8 @@
         "tags": [
           "nodes.hot_threads"
         ],
-        "summary": "Returns information about hot threads on each node in the cluster",
+        "summary": "This API yields a breakdown of the hot threads on each selected node in the cluster",
+        "description": "The output is plain text with a breakdown of each node’s top hot threads.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-hot-threads.html"
         },
@@ -23639,7 +23810,7 @@
         "tags": [
           "nodes.info"
         ],
-        "summary": "Returns information about nodes in the cluster",
+        "summary": "Returns cluster nodes information",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html"
         },
@@ -23667,7 +23838,7 @@
         "tags": [
           "nodes.info"
         ],
-        "summary": "Returns information about nodes in the cluster",
+        "summary": "Returns cluster nodes information",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html"
         },
@@ -23698,7 +23869,7 @@
         "tags": [
           "nodes.info"
         ],
-        "summary": "Returns information about nodes in the cluster",
+        "summary": "Returns cluster nodes information",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html"
         },
@@ -23729,7 +23900,7 @@
         "tags": [
           "nodes.info"
         ],
-        "summary": "Returns information about nodes in the cluster",
+        "summary": "Returns cluster nodes information",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-info.html"
         },
@@ -23763,7 +23934,7 @@
         "tags": [
           "nodes.reload_secure_settings"
         ],
-        "summary": "Reloads secure settings",
+        "summary": "Reloads the keystore on nodes in the cluster",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings"
         },
@@ -23788,7 +23959,7 @@
         "tags": [
           "nodes.reload_secure_settings"
         ],
-        "summary": "Reloads secure settings",
+        "summary": "Reloads the keystore on nodes in the cluster",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/secure-settings.html#reloadable-secure-settings"
         },
@@ -23816,7 +23987,7 @@
         "tags": [
           "nodes.stats"
         ],
-        "summary": "Returns statistical information about nodes in the cluster",
+        "summary": "Returns cluster nodes statistics",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html"
         },
@@ -23865,7 +24036,7 @@
         "tags": [
           "nodes.stats"
         ],
-        "summary": "Returns statistical information about nodes in the cluster",
+        "summary": "Returns cluster nodes statistics",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html"
         },
@@ -23917,7 +24088,7 @@
         "tags": [
           "nodes.stats"
         ],
-        "summary": "Returns statistical information about nodes in the cluster",
+        "summary": "Returns cluster nodes statistics",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html"
         },
@@ -23969,7 +24140,7 @@
         "tags": [
           "nodes.stats"
         ],
-        "summary": "Returns statistical information about nodes in the cluster",
+        "summary": "Returns cluster nodes statistics",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html"
         },
@@ -24024,7 +24195,7 @@
         "tags": [
           "nodes.stats"
         ],
-        "summary": "Returns statistical information about nodes in the cluster",
+        "summary": "Returns cluster nodes statistics",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html"
         },
@@ -24079,7 +24250,7 @@
         "tags": [
           "nodes.stats"
         ],
-        "summary": "Returns statistical information about nodes in the cluster",
+        "summary": "Returns cluster nodes statistics",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-stats.html"
         },
@@ -24137,7 +24308,7 @@
         "tags": [
           "nodes.usage"
         ],
-        "summary": "Returns low-level information about REST actions usage on nodes",
+        "summary": "Returns information on the usage of features",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-usage.html"
         },
@@ -24159,7 +24330,7 @@
         "tags": [
           "nodes.usage"
         ],
-        "summary": "Returns low-level information about REST actions usage on nodes",
+        "summary": "Returns information on the usage of features",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-usage.html"
         },
@@ -24184,7 +24355,7 @@
         "tags": [
           "nodes.usage"
         ],
-        "summary": "Returns low-level information about REST actions usage on nodes",
+        "summary": "Returns information on the usage of features",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-usage.html"
         },
@@ -24209,7 +24380,7 @@
         "tags": [
           "nodes.usage"
         ],
-        "summary": "Returns low-level information about REST actions usage on nodes",
+        "summary": "Returns information on the usage of features",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-nodes-usage.html"
         },
@@ -24237,7 +24408,8 @@
         "tags": [
           "open_point_in_time"
         ],
-        "summary": "Open a point in time that can be used in subsequent searches",
+        "summary": "A search request by default executes against the most recent visible data of the target indices, which is called point in time",
+        "description": "Elasticsearch pit (point in time) is a lightweight view into the state of the data as it existed when initiated. In some cases, it’s preferred to perform multiple search requests using the same point in time. For example, if refreshes happen between `search_after` requests, then the results of those requests might not be consistent as changes happening between searches are only visible to the more recent point in time.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html"
         },
@@ -24333,7 +24505,7 @@
         "tags": [
           "put_script"
         ],
-        "summary": "Creates or updates a script",
+        "summary": "Creates or updates a stored script or search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html"
         },
@@ -24365,7 +24537,7 @@
         "tags": [
           "put_script"
         ],
-        "summary": "Creates or updates a script",
+        "summary": "Creates or updates a stored script or search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html"
         },
@@ -24535,7 +24707,7 @@
         "tags": [
           "query_ruleset.list"
         ],
-        "summary": "Lists query rulesets",
+        "summary": "Returns summarized information about existing query rulesets",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-query-rulesets.html"
         },
@@ -24596,7 +24768,7 @@
         "tags": [
           "rank_eval"
         ],
-        "summary": "Allows to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html"
         },
@@ -24628,7 +24800,7 @@
         "tags": [
           "rank_eval"
         ],
-        "summary": "Allows to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html"
         },
@@ -24662,7 +24834,7 @@
         "tags": [
           "rank_eval"
         ],
-        "summary": "Allows to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html"
         },
@@ -24697,7 +24869,7 @@
         "tags": [
           "rank_eval"
         ],
-        "summary": "Allows to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html"
         },
@@ -24928,7 +25100,7 @@
         "tags": [
           "reindex_rethrottle"
         ],
-        "summary": "Changes the number of requests per second for a particular Reindex operation",
+        "summary": "Copies documents from a source to a destination",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html"
         },
@@ -24986,7 +25158,7 @@
         "tags": [
           "render_search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Renders a search template as a search request body",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/render-search-template-api.html"
         },
@@ -25004,7 +25176,7 @@
         "tags": [
           "render_search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Renders a search template as a search request body",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/render-search-template-api.html"
         },
@@ -25024,7 +25196,7 @@
         "tags": [
           "render_search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Renders a search template as a search request body",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/render-search-template-api.html"
         },
@@ -25047,7 +25219,7 @@
         "tags": [
           "render_search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Renders a search template as a search request body",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/render-search-template-api.html"
         },
@@ -25284,7 +25456,7 @@
         "tags": [
           "rollup.get_rollup_index_caps"
         ],
-        "summary": "Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the index where rollup data is stored)",
+        "summary": "Returns the rollup capabilities of all jobs inside of a rollup index (for example, the index where rollup data is stored)",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-get-rollup-index-caps.html"
         },
@@ -25324,7 +25496,7 @@
         "tags": [
           "rollup.rollup_search"
         ],
-        "summary": "Enables searching rolled-up data using the standard query DSL",
+        "summary": "Enables searching rolled-up data using the standard Query DSL",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-search.html"
         },
@@ -25353,7 +25525,7 @@
         "tags": [
           "rollup.rollup_search"
         ],
-        "summary": "Enables searching rolled-up data using the standard query DSL",
+        "summary": "Enables searching rolled-up data using the standard Query DSL",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-search.html"
         },
@@ -25494,7 +25666,7 @@
         "tags": [
           "scripts_painless_execute"
         ],
-        "summary": "Allows an arbitrary script to be executed and a result to be returned",
+        "summary": "Runs a script and returns a result",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html"
         },
@@ -25512,7 +25684,7 @@
         "tags": [
           "scripts_painless_execute"
         ],
-        "summary": "Allows an arbitrary script to be executed and a result to be returned",
+        "summary": "Runs a script and returns a result",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html"
         },
@@ -25532,7 +25704,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns results matching a query",
+        "summary": "Returns search hits that match the query defined in the request",
+        "description": "You can provide search queries using the `q` query string parameter or the request body. If both are specified, only the query parameter is used.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html"
         },
@@ -25684,7 +25857,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns results matching a query",
+        "summary": "Returns search hits that match the query defined in the request",
+        "description": "You can provide search queries using the `q` query string parameter or the request body. If both are specified, only the query parameter is used.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html"
         },
@@ -25838,7 +26012,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns results matching a query",
+        "summary": "Returns search hits that match the query defined in the request",
+        "description": "You can provide search queries using the `q` query string parameter or the request body. If both are specified, only the query parameter is used.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html"
         },
@@ -25993,7 +26168,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns results matching a query",
+        "summary": "Returns search hits that match the query defined in the request",
+        "description": "You can provide search queries using the `q` query string parameter or the request body. If both are specified, only the query parameter is used.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html"
         },
@@ -26785,7 +26961,7 @@
         "tags": [
           "search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Runs a search with a search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -26844,7 +27020,7 @@
         "tags": [
           "search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Runs a search with a search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -26905,7 +27081,7 @@
         "tags": [
           "search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Runs a search with a search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -26967,7 +27143,7 @@
         "tags": [
           "search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Runs a search with a search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -27315,7 +27491,7 @@
         "tags": [
           "security.activate_user_profile"
         ],
-        "summary": "Creates or updates the user profile on behalf of another user",
+        "summary": "Creates or updates a user profile on behalf of another user",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-activate-user-profile.html"
         },
@@ -27366,7 +27542,8 @@
         "tags": [
           "security.authenticate"
         ],
-        "summary": "Enables authentication as a user and retrieve information about the authenticated user",
+        "summary": "Enables you to submit a request with a basic auth header to authenticate a user and retrieve information about the authenticated user",
+        "description": "A successful call returns a JSON structure that shows user information such as their username, the roles that are assigned to the user, any assigned metadata, and information about the realms that authenticated and authorized the user. If the user cannot be authenticated, this API returns a 401 status code.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html"
         },
@@ -27555,7 +27732,8 @@
         "tags": [
           "security.clear_api_key_cache"
         ],
-        "summary": "Clear a subset or all entries from the API key cache",
+        "summary": "Evicts a subset of all entries from the API key cache",
+        "description": "The cache is also automatically cleared on state changes of the security index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html"
         },
@@ -27872,6 +28050,7 @@
           "security.get_api_key"
         ],
         "summary": "Retrieves information for one or more API keys",
+        "description": "NOTE: If you have only the `manage_own_api_key` privilege, this API returns only the API keys that you own. If you have `read_security`, `manage_api_key` or greater privileges (including `manage_security`), this API returns all API keys regardless of ownership.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html"
         },
@@ -27987,6 +28166,7 @@
           "security.create_api_key"
         ],
         "summary": "Creates an API key for access without requiring basic authentication",
+        "description": "A successful request returns a JSON structure that contains the API key, its unique id, and its name. If applicable, it also returns expiration information for the API key in milliseconds. NOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html"
         },
@@ -28010,6 +28190,7 @@
           "security.create_api_key"
         ],
         "summary": "Creates an API key for access without requiring basic authentication",
+        "description": "A successful request returns a JSON structure that contains the API key, its unique id, and its name. If applicable, it also returns expiration information for the API key in milliseconds. NOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html"
         },
@@ -28033,6 +28214,7 @@
           "security.invalidate_api_key"
         ],
         "summary": "Invalidates one or more API keys",
+        "description": "The `manage_api_key` privilege allows deleting any API keys. The `manage_own_api_key` only allows deleting API keys that are owned by the user. In addition, with the `manage_own_api_key` privilege, an invalidation request must be issued in one of the three formats: - Set the parameter `owner=true`. - Or, set both `username` and `realm_name` to match the user’s identity. - Or, if the request is issued by an API key, i.e. an API key invalidates itself, specify its ID in the `ids` field.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html"
         },
@@ -28120,7 +28302,7 @@
         "tags": [
           "security.create_service_token"
         ],
-        "summary": "Creates a service account token for access without requiring basic authentication",
+        "summary": "Creates a service accounts token for access without requiring basic authentication",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-service-token.html"
         },
@@ -28149,7 +28331,7 @@
         "tags": [
           "security.create_service_token"
         ],
-        "summary": "Creates a service account token for access without requiring basic authentication",
+        "summary": "Creates a service accounts token for access without requiring basic authentication",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-service-token.html"
         },
@@ -28255,7 +28437,7 @@
         "tags": [
           "security.create_service_token"
         ],
-        "summary": "Creates a service account token for access without requiring basic authentication",
+        "summary": "Creates a service accounts token for access without requiring basic authentication",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-service-token.html"
         },
@@ -28370,7 +28552,8 @@
         "tags": [
           "security.get_role"
         ],
-        "summary": "Retrieves roles in the native realm",
+        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
+        "description": "The get roles API cannot retrieve roles that are defined in roles files.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html"
         },
@@ -28390,7 +28573,8 @@
         "tags": [
           "security.put_role"
         ],
-        "summary": "Adds and updates roles in the native realm",
+        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
+        "description": "The create or update roles API cannot update roles that are defined in roles files.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html"
         },
@@ -28416,7 +28600,8 @@
         "tags": [
           "security.put_role"
         ],
-        "summary": "Adds and updates roles in the native realm",
+        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
+        "description": "The create or update roles API cannot update roles that are defined in roles files.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html"
         },
@@ -28948,7 +29133,7 @@
         "tags": [
           "security.enroll_kibana"
         ],
-        "summary": "Allows a kibana instance to configure itself to communicate with a secured elasticsearch cluster",
+        "summary": "Enables a Kibana instance to configure itself for communication with a secured Elasticsearch cluster",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-kibana-enrollment.html"
         },
@@ -28984,7 +29169,7 @@
         "tags": [
           "security.enroll_node"
         ],
-        "summary": "Allows a new node to enroll to an existing cluster with security enabled",
+        "summary": "Allows a new node to join an existing cluster with security features enabled",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-node-enrollment.html"
         },
@@ -29163,7 +29348,8 @@
         "tags": [
           "security.get_role"
         ],
-        "summary": "Retrieves roles in the native realm",
+        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
+        "description": "The get roles API cannot retrieve roles that are defined in roles files.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html"
         },
@@ -29197,7 +29383,7 @@
         "tags": [
           "security.get_service_accounts"
         ],
-        "summary": "Retrieves information about service accounts",
+        "summary": "This API returns a list of service accounts that match the provided path parameter(s)",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-service-accounts.html"
         },
@@ -29222,7 +29408,7 @@
         "tags": [
           "security.get_service_accounts"
         ],
-        "summary": "Retrieves information about service accounts",
+        "summary": "This API returns a list of service accounts that match the provided path parameter(s)",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-service-accounts.html"
         },
@@ -29244,7 +29430,7 @@
         "tags": [
           "security.get_service_accounts"
         ],
-        "summary": "Retrieves information about service accounts",
+        "summary": "This API returns a list of service accounts that match the provided path parameter(s)",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-service-accounts.html"
         },
@@ -29607,7 +29793,7 @@
         "tags": [
           "security.get_user_profile"
         ],
-        "summary": "Retrieves user profiles for the given unique ID(s)",
+        "summary": "Retrieves a user's profile using the unique profile ID",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user-profile.html"
         },
@@ -29689,6 +29875,7 @@
           "security.grant_api_key"
         ],
         "summary": "Creates an API key on behalf of another user",
+        "description": "This API is similar to Create API keys, however it creates the API key for a user that is different than the user that runs the API. The caller must have authentication credentials (either an access token, or a username and password) for the user on whose behalf the API key will be created. It is not possible to use this API to create an API key without that user’s credentials. The user, for whom the authentication credentials is provided, can optionally \"run as\" (impersonate) another user. In this case, the API key will be created on behalf of the impersonated user.. This API is intended be used by applications that need to create and manage API keys for end users, but cannot guarantee that those users have permission to create API keys on their own behalf.. A successful grant API key API call returns a JSON structure that contains the API key, its unique id, and its name. If applicable, it also returns expiration information for the API key in milliseconds.. By default, API keys never expire. You can specify expiration information when you create the API keys.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-grant-api-key.html"
         },
@@ -29894,7 +30081,8 @@
         "tags": [
           "security.query_api_keys"
         ],
-        "summary": "Retrieves information for API keys using a subset of query DSL",
+        "summary": "Retrieves information for API keys in a paginated manner",
+        "description": "You can optionally filter the results with a query.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-query-api-key.html"
         },
@@ -29923,7 +30111,8 @@
         "tags": [
           "security.query_api_keys"
         ],
-        "summary": "Retrieves information for API keys using a subset of query DSL",
+        "summary": "Retrieves information for API keys in a paginated manner",
+        "description": "You can optionally filter the results with a query.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-query-api-key.html"
         },
@@ -29954,7 +30143,7 @@
         "tags": [
           "security.saml_authenticate"
         ],
-        "summary": "Exchanges a SAML Response message for an Elasticsearch access token and refresh token pair",
+        "summary": "Submits a SAML Response message to Elasticsearch for consumption",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-saml-authenticate.html"
         },
@@ -30080,7 +30269,7 @@
         "tags": [
           "security.saml_invalidate"
         ],
-        "summary": "Consumes a SAML LogoutRequest",
+        "summary": "Submits a SAML LogoutRequest message to Elasticsearch for consumption",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-saml-invalidate.html"
         },
@@ -30147,7 +30336,7 @@
         "tags": [
           "security.saml_logout"
         ],
-        "summary": "Invalidates an access token and a refresh token that were generated via the SAML Authenticate API",
+        "summary": "Submits a request to invalidate an access token and refresh token",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-saml-logout.html"
         },
@@ -30202,7 +30391,7 @@
         "tags": [
           "security.saml_prepare_authentication"
         ],
-        "summary": "Creates a SAML authentication request",
+        "summary": "Creates a SAML authentication request (<AuthnRequest>) as a URL string, based on the configuration of the respective SAML realm in Elasticsearch",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-saml-prepare-authentication.html"
         },
@@ -30266,7 +30455,7 @@
         "tags": [
           "security.saml_service_provider_metadata"
         ],
-        "summary": "Generates SAML metadata for the Elastic stack SAML 2.0 Service Provider",
+        "summary": "Generate SAML metadata for a SAML 2.0 Service Provider",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-saml-sp-metadata.html"
         },
@@ -30360,6 +30549,7 @@
           "security.update_api_key"
         ],
         "summary": "Updates attributes of an existing API key",
+        "description": "Users can only update API keys that they created or that were granted to them. Use this API to update API keys created by the create API Key or grant API Key APIs. If you need to apply the same update to many API keys, you can use bulk update API Keys to reduce overhead. It’s not possible to update expired API keys, or API keys that have been invalidated by invalidate API Key. This API supports updates to an API key’s access scope and metadata. The access scope of an API key is derived from the `role_descriptors` you specify in the request, and a snapshot of the owner user’s permissions at the time of the request. The snapshot of the owner’s permissions is updated automatically on every call. If you don’t specify `role_descriptors` in the request, a call to this API might still change the API key’s access scope. This change can occur if the owner user’s permissions have changed since the API key was created or last modified. To update another user’s API key, use the `run_as` feature to submit a request on behalf of another user. IMPORTANT: It’s not possible to use an API key as the authentication credential for this API. To update an API key, the owner user’s credentials are required.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-update-api-key.html"
         },
@@ -30432,7 +30622,7 @@
         "tags": [
           "security.update_user_profile_data"
         ],
-        "summary": "Update application specific data for the user profile of the given unique ID",
+        "summary": "Updates specific data for the user profile that's associated with the specified unique ID",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-update-user-profile-data.html"
         },
@@ -30464,7 +30654,7 @@
         "tags": [
           "security.update_user_profile_data"
         ],
-        "summary": "Update application specific data for the user profile of the given unique ID",
+        "summary": "Updates specific data for the user profile that's associated with the specified unique ID",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-update-user-profile-data.html"
         },
@@ -31072,7 +31262,7 @@
         "tags": [
           "snapshot.cleanup_repository"
         ],
-        "summary": "Removes stale data from repository",
+        "summary": "Triggers the review of a snapshot repository’s contents and deletes any stale data not referenced by existing snapshots",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/clean-up-snapshot-repo-api.html"
         },
@@ -32457,7 +32647,7 @@
         "tags": [
           "synonyms.put_synonym"
         ],
-        "summary": "Creates or updates a synonyms set",
+        "summary": "Creates or updates a synonym set",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-synonyms-set.html"
         },
@@ -32922,7 +33112,7 @@
         "tags": [
           "tasks.list"
         ],
-        "summary": "Returns a list of tasks",
+        "summary": "The task management API returns information about tasks currently executing on one or more nodes in the cluster",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/tasks.html"
         },
@@ -33690,7 +33880,8 @@
         "tags": [
           "transform.put_transform"
         ],
-        "summary": "Instantiates a transform",
+        "summary": "Creates a transform.",
+        "description": "A transform copies data from source indices, transforms it, and persists it into an entity-centric destination index. You can also think of the destination index as a two-dimensional tabular data structure (known as a data frame). The ID for each document in the data frame is generated from a hash of the entity, so there is a unique row per entity.. You must choose either the latest or pivot method for your transform; you cannot use both in a single transform. If you choose to use the pivot method for your transform, the entities are defined by the set of `group_by` fields in the pivot object. If you choose to use the latest method, the entities are defined by the `unique_key` field values in the latest object.. You must have `create_index`, `index`, and `read` privileges on the destination index and `read` and `view_index_metadata` privileges on the source indices. When Elasticsearch security features are enabled, the transform remembers which roles the user that created it had at the time of creation and uses those same roles. If those roles do not have the required privileges on the source and destination indices, the transform fails when it attempts unauthorized operations.. NOTE: You must use Kibana or this API to create a transform. Do not add a transform directly into any `.transform-internal*` indices using the Elasticsearch index API. If Elasticsearch security features are enabled, do not give users any privileges on `.transform-internal*` indices. If you used transforms prior to 7.5, also do not give users any privileges on `.data-frame-internal*` indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html"
         },
@@ -33792,7 +33983,7 @@
         "tags": [
           "transform.delete_transform"
         ],
-        "summary": "Deletes an existing transform",
+        "summary": "Deletes a transform",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-transform.html"
         },
@@ -33982,7 +34173,8 @@
         "tags": [
           "transform.preview_transform"
         ],
-        "summary": "Previews a transform",
+        "summary": "Previews a transform.",
+        "description": "It returns a maximum of 100 results. The calculations are based on all the current data in the source index. It also generates a list of mappings and settings for the destination index. These values are determined based on the field types of the source index and the transform aggregations.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html"
         },
@@ -34008,7 +34200,8 @@
         "tags": [
           "transform.preview_transform"
         ],
-        "summary": "Previews a transform",
+        "summary": "Previews a transform.",
+        "description": "It returns a maximum of 100 results. The calculations are based on all the current data in the source index. It also generates a list of mappings and settings for the destination index. These values are determined based on the field types of the source index and the transform aggregations.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html"
         },
@@ -34036,7 +34229,8 @@
         "tags": [
           "transform.preview_transform"
         ],
-        "summary": "Previews a transform",
+        "summary": "Previews a transform.",
+        "description": "It returns a maximum of 100 results. The calculations are based on all the current data in the source index. It also generates a list of mappings and settings for the destination index. These values are determined based on the field types of the source index and the transform aggregations.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html"
         },
@@ -34059,7 +34253,8 @@
         "tags": [
           "transform.preview_transform"
         ],
-        "summary": "Previews a transform",
+        "summary": "Previews a transform.",
+        "description": "It returns a maximum of 100 results. The calculations are based on all the current data in the source index. It also generates a list of mappings and settings for the destination index. These values are determined based on the field types of the source index and the transform aggregations.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html"
         },
@@ -34084,7 +34279,8 @@
         "tags": [
           "transform.reset_transform"
         ],
-        "summary": "Resets an existing transform",
+        "summary": "Resets a transform",
+        "description": "Before you can reset it, you must stop it; alternatively, use the `force` query parameter. If the destination index was created by the transform, it is deleted.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/reset-transform.html"
         },
@@ -34131,7 +34327,8 @@
         "tags": [
           "transform.schedule_now_transform"
         ],
-        "summary": "Schedules now a transform",
+        "summary": "Schedules now a transform.",
+        "description": "If you _schedule_now a transform, it will process the new data instantly, without waiting for the configured frequency interval. After _schedule_now API is called, the transform will be processed again at now + frequency unless _schedule_now API is called again in the meantime.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/schedule-now-transform.html"
         },
@@ -34178,7 +34375,8 @@
         "tags": [
           "transform.start_transform"
         ],
-        "summary": "Starts one or more transforms",
+        "summary": "Starts a transform.",
+        "description": "When you start a transform, it creates the destination index if it does not already exist. The `number_of_shards` is set to `1` and the `auto_expand_replicas` is set to `0-1`. If it is a pivot transform, it deduces the mapping definitions for the destination index from the source indices and the transform aggregations. If fields in the destination index are derived from scripts (as in the case of `scripted_metric` or `bucket_script` aggregations), the transform uses dynamic mappings unless an index template exists. If it is a latest transform, it does not deduce mapping definitions; it uses dynamic mappings. To use explicit mappings, create the destination index before you start the transform. Alternatively, you can create an index template, though it does not affect the deduced mappings in a pivot transform.. When the transform starts, a series of validations occur to ensure its success. If you deferred validation when you created the transform, they occur when you start the transform—​with the exception of privilege checks. When Elasticsearch security features are enabled, the transform remembers which roles the user that created it had at the time of creation and uses those same roles. If those roles do not have the required privileges on the source and destination indices, the transform fails when it attempts unauthorized operations.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/start-transform.html"
         },
@@ -34322,7 +34520,8 @@
         "tags": [
           "transform.update_transform"
         ],
-        "summary": "Updates certain properties of a transform",
+        "summary": "Updates certain properties of a transform.",
+        "description": "All updated properties except `description` do not take effect until after the transform starts the next checkpoint, thus there is data consistency in each checkpoint. To use this API, you must have `read` and `view_index_metadata` privileges for the source indices. You must also have `index` and `read` privileges for the destination index. When Elasticsearch security features are enabled, the transform remembers which roles the user who updated it had at the time of update and runs with those privileges.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-transform.html"
         },
@@ -34479,6 +34678,7 @@
           "transform.upgrade_transforms"
         ],
         "summary": "Upgrades all transforms",
+        "description": "This API identifies transforms that have a legacy configuration format and upgrades them to the latest version. It also cleans up the internal data structures that store the transform state and checkpoints. The upgrade does not affect the source and destination indices. The upgrade also does not affect the roles that transforms use when Elasticsearch security features are enabled; the role used to read source data and write to the destination index remains unchanged.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/upgrade-transforms.html"
         },
@@ -34750,7 +34950,7 @@
           "update_by_query"
         ],
         "summary": "Updates documents that match the specified query",
-        "description": "If no query is specified,  performs an update on every document in the index without changing the source, for example to pick up a mapping change.",
+        "description": "If no query is specified, performs an update on every document in the data stream or index without modifying the source, which is useful for picking up mapping changes.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html"
         },
@@ -35590,7 +35790,8 @@
         "tags": [
           "watcher.execute_watch"
         ],
-        "summary": "Forces the execution of a stored watch",
+        "summary": "This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes",
+        "description": "For testing and debugging purposes, you also have fine-grained control on how the watch runs. You can execute the watch without executing all of its actions or alternatively by simulating them. You can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after execution.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html"
         },
@@ -35616,7 +35817,8 @@
         "tags": [
           "watcher.execute_watch"
         ],
-        "summary": "Forces the execution of a stored watch",
+        "summary": "This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes",
+        "description": "For testing and debugging purposes, you also have fine-grained control on how the watch runs. You can execute the watch without executing all of its actions or alternatively by simulating them. You can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after execution.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html"
         },
@@ -35644,7 +35846,8 @@
         "tags": [
           "watcher.execute_watch"
         ],
-        "summary": "Forces the execution of a stored watch",
+        "summary": "This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes",
+        "description": "For testing and debugging purposes, you also have fine-grained control on how the watch runs. You can execute the watch without executing all of its actions or alternatively by simulating them. You can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after execution.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html"
         },
@@ -35667,7 +35870,8 @@
         "tags": [
           "watcher.execute_watch"
         ],
-        "summary": "Forces the execution of a stored watch",
+        "summary": "This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes",
+        "description": "For testing and debugging purposes, you also have fine-grained control on how the watch runs. You can execute the watch without executing all of its actions or alternatively by simulating them. You can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after execution.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/watcher-api-execute-watch.html"
         },
@@ -35831,7 +36035,7 @@
         "tags": [
           "xpack.info"
         ],
-        "summary": "Retrieves information about the installed X-Pack features",
+        "summary": "Provides general information about the installed X-Pack features",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/info-api.html"
         },
@@ -35910,7 +36114,7 @@
         "tags": [
           "xpack.usage"
         ],
-        "summary": "Retrieves usage information about the installed X-Pack features",
+        "summary": "This API provides information about which features are currently enabled and available under the current license and some usage statistics",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/usage-api.html"
         },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -14,7 +14,8 @@
         "tags": [
           "async_search.get"
         ],
-        "summary": "Retrieves the results of a previously submitted async search request given its ID",
+        "summary": "Retrieves the results of a previously submitted async search request given its identifier",
+        "description": "If the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html"
         },
@@ -79,8 +80,8 @@
         "tags": [
           "async_search.delete"
         ],
-        "summary": "Deletes an async search by ID",
-        "description": "If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.",
+        "summary": "Deletes an async search by identifier",
+        "description": "If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted. If the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html"
         },
@@ -117,7 +118,8 @@
         "tags": [
           "async_search.status"
         ],
-        "summary": "Retrieves the status of a previously submitted async search request given its ID",
+        "summary": "Get async search status Retrieves the status of a previously submitted async search request given its identifier, without retrieving search results",
+        "description": "If the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html"
         },
@@ -154,7 +156,8 @@
         "tags": [
           "async_search.submit"
         ],
-        "summary": "Executes a search request asynchronously",
+        "summary": "Runs a search request asynchronously",
+        "description": "When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field, hence partial results become available following the sort criteria that was requested. Warning: Async search does not support scroll nor search requests that only include the suggest section. By default, Elasticsearch doesn’t allow you to store an async search response larger than 10Mb and an attempt to do this results in an error. The maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html"
         },
@@ -314,7 +317,8 @@
         "tags": [
           "async_search.submit"
         ],
-        "summary": "Executes a search request asynchronously",
+        "summary": "Runs a search request asynchronously",
+        "description": "When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field, hence partial results become available following the sort criteria that was requested. Warning: Async search does not support scroll nor search requests that only include the suggest section. By default, Elasticsearch doesn’t allow you to store an async search response larger than 10Mb and an attempt to do this results in an error. The maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html"
         },
@@ -477,7 +481,8 @@
         "tags": [
           "bulk"
         ],
-        "summary": "Allows to perform multiple index/update/delete operations in a single request",
+        "summary": "Performs multiple indexing or delete operations in a single API call",
+        "description": "This reduces overhead and can greatly increase indexing speed.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html"
         },
@@ -524,7 +529,8 @@
         "tags": [
           "bulk"
         ],
-        "summary": "Allows to perform multiple index/update/delete operations in a single request",
+        "summary": "Performs multiple indexing or delete operations in a single API call",
+        "description": "This reduces overhead and can greatly increase indexing speed.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html"
         },
@@ -573,7 +579,8 @@
         "tags": [
           "bulk"
         ],
-        "summary": "Allows to perform multiple index/update/delete operations in a single request",
+        "summary": "Performs multiple indexing or delete operations in a single API call",
+        "description": "This reduces overhead and can greatly increase indexing speed.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html"
         },
@@ -623,7 +630,8 @@
         "tags": [
           "bulk"
         ],
-        "summary": "Allows to perform multiple index/update/delete operations in a single request",
+        "summary": "Performs multiple indexing or delete operations in a single API call",
+        "description": "This reduces overhead and can greatly increase indexing speed.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html"
         },
@@ -675,7 +683,8 @@
         "tags": [
           "cat.aliases"
         ],
-        "summary": "Shows information about currently configured aliases to indices including filter and routing infos",
+        "summary": "Retrieves the cluster’s index aliases, including filter and routing information",
+        "description": "The API does not return data stream aliases. IMPORTANT: cat APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-alias.html"
         },
@@ -697,7 +706,8 @@
         "tags": [
           "cat.aliases"
         ],
-        "summary": "Shows information about currently configured aliases to indices including filter and routing infos",
+        "summary": "Retrieves the cluster’s index aliases, including filter and routing information",
+        "description": "The API does not return data stream aliases. IMPORTANT: cat APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-alias.html"
         },
@@ -722,7 +732,8 @@
         "tags": [
           "cat.component_templates"
         ],
-        "summary": "Returns information about existing component_templates templates",
+        "summary": "Returns information about component templates in a cluster",
+        "description": "Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get component template API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html"
         },
@@ -739,7 +750,8 @@
         "tags": [
           "cat.component_templates"
         ],
-        "summary": "Returns information about existing component_templates templates",
+        "summary": "Returns information about component templates in a cluster",
+        "description": "Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get component template API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html"
         },
@@ -761,7 +773,8 @@
         "tags": [
           "cat.count"
         ],
-        "summary": "Provides quick access to the document count of the entire cluster, or individual indices",
+        "summary": "Provides quick access to a document count for a data stream, an index, or an entire cluster",
+        "description": "NOTE: The document count only includes live documents, not deleted documents which have not yet been removed by the merge process. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the count API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-count.html"
         },
@@ -778,7 +791,8 @@
         "tags": [
           "cat.count"
         ],
-        "summary": "Provides quick access to the document count of the entire cluster, or individual indices",
+        "summary": "Provides quick access to a document count for a data stream, an index, or an entire cluster",
+        "description": "NOTE: The document count only includes live documents, not deleted documents which have not yet been removed by the merge process. IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the count API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-count.html"
         },
@@ -827,7 +841,8 @@
         "tags": [
           "cat.indices"
         ],
-        "summary": "Returns information about indices: number of primaries and replicas, document counts, disk size, ..",
+        "summary": "Returns high-level information about indices in a cluster, including backing indices for data streams",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index API. Use the cat indices API to get the following information for each index in a cluster: shard count; document count; deleted document count; primary store size; total store size of all shards, including shard replicas. These metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents. To get an accurate count of Elasticsearch documents, use the cat count or count APIs.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html"
         },
@@ -864,7 +879,8 @@
         "tags": [
           "cat.indices"
         ],
-        "summary": "Returns information about indices: number of primaries and replicas, document counts, disk size, ..",
+        "summary": "Returns high-level information about indices in a cluster, including backing indices for data streams",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index API. Use the cat indices API to get the following information for each index in a cluster: shard count; document count; deleted document count; primary store size; total store size of all shards, including shard replicas. These metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents. To get an accurate count of Elasticsearch documents, use the cat count or count APIs.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html"
         },
@@ -904,7 +920,8 @@
         "tags": [
           "cat.ml_data_frame_analytics"
         ],
-        "summary": "Gets configuration and usage information about data frame analytics jobs",
+        "summary": "Returns configuration and usage information about data frame analytics jobs.",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get data frame analytics jobs statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-dfanalytics.html"
         },
@@ -938,7 +955,8 @@
         "tags": [
           "cat.ml_data_frame_analytics"
         ],
-        "summary": "Gets configuration and usage information about data frame analytics jobs",
+        "summary": "Returns configuration and usage information about data frame analytics jobs.",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get data frame analytics jobs statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-dfanalytics.html"
         },
@@ -975,7 +993,8 @@
         "tags": [
           "cat.ml_datafeeds"
         ],
-        "summary": "Gets configuration and usage information about datafeeds",
+        "summary": "Returns configuration and usage information about datafeeds",
+        "description": "This API returns a maximum of 10,000 datafeeds. If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.. IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get datafeed statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-datafeeds.html"
         },
@@ -1006,7 +1025,8 @@
         "tags": [
           "cat.ml_datafeeds"
         ],
-        "summary": "Gets configuration and usage information about datafeeds",
+        "summary": "Returns configuration and usage information about datafeeds",
+        "description": "This API returns a maximum of 10,000 datafeeds. If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.. IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get datafeed statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-datafeeds.html"
         },
@@ -1040,7 +1060,8 @@
         "tags": [
           "cat.ml_jobs"
         ],
-        "summary": "Gets configuration and usage information about anomaly detection jobs",
+        "summary": "Returns configuration and usage information for anomaly detection jobs",
+        "description": "This API returns a maximum of 10,000 jobs. If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.. IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get anomaly detection job statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-anomaly-detectors.html"
         },
@@ -1074,7 +1095,8 @@
         "tags": [
           "cat.ml_jobs"
         ],
-        "summary": "Gets configuration and usage information about anomaly detection jobs",
+        "summary": "Returns configuration and usage information for anomaly detection jobs",
+        "description": "This API returns a maximum of 10,000 jobs. If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.. IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get anomaly detection job statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-anomaly-detectors.html"
         },
@@ -1111,7 +1133,8 @@
         "tags": [
           "cat.ml_trained_models"
         ],
-        "summary": "Gets configuration and usage information about inference trained models",
+        "summary": "Returns configuration and usage information about inference trained models.",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get trained models statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-trained-model.html"
         },
@@ -1148,7 +1171,8 @@
         "tags": [
           "cat.ml_trained_models"
         ],
-        "summary": "Gets configuration and usage information about inference trained models",
+        "summary": "Returns configuration and usage information about inference trained models.",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get trained models statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-trained-model.html"
         },
@@ -1188,7 +1212,8 @@
         "tags": [
           "cat.transforms"
         ],
-        "summary": "Gets configuration and usage information about transforms",
+        "summary": "Returns configuration and usage information about transforms.",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get transform statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-transforms.html"
         },
@@ -1225,7 +1250,8 @@
         "tags": [
           "cat.transforms"
         ],
-        "summary": "Gets configuration and usage information about transforms",
+        "summary": "Returns configuration and usage information about transforms.",
+        "description": "IMPORTANT: cat APIs are only intended for human consumption using the Kibana console or command line. They are not intended for use by applications. For application consumption, use the get transform statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-transforms.html"
         },
@@ -1323,7 +1349,7 @@
         "tags": [
           "clear_scroll"
         ],
-        "summary": "Explicitly clears the search context for a scroll",
+        "summary": "Clears the search context and results for a scrolling search",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html"
         },
@@ -1407,7 +1433,7 @@
         "tags": [
           "clear_scroll"
         ],
-        "summary": "Explicitly clears the search context for a scroll",
+        "summary": "Clears the search context and results for a scrolling search",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/clear-scroll-api.html"
         },
@@ -1432,7 +1458,7 @@
         "tags": [
           "close_point_in_time"
         ],
-        "summary": "Close a point in time",
+        "summary": "Closes a point-in-time",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html"
         },
@@ -1485,7 +1511,7 @@
         "tags": [
           "cluster.get_component_template"
         ],
-        "summary": "Returns one or more component templates",
+        "summary": "Retrieves information about component templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html"
         },
@@ -1518,6 +1544,7 @@
           "cluster.put_component_template"
         ],
         "summary": "Creates or updates a component template",
+        "description": "Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.. An index template can be composed of multiple component templates. To use a component template, specify it in an index template’s `composed_of` list. Component templates are only applied to new data streams and indices as part of a matching index template.. Settings and mappings specified directly in the index template or the create index request override any settings or mappings specified in a component template.. Component templates are only used during index creation. For data streams, this includes data stream creation and the creation of a stream’s backing indices. Changes to component templates do not affect existing indices, including a stream’s backing indices.. You can use C-style `/* *\\/` block comments in component templates. You can include comments anywhere in the request body except before the opening curly bracket.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html"
         },
@@ -1547,6 +1574,7 @@
           "cluster.put_component_template"
         ],
         "summary": "Creates or updates a component template",
+        "description": "Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.. An index template can be composed of multiple component templates. To use a component template, specify it in an index template’s `composed_of` list. Component templates are only applied to new data streams and indices as part of a matching index template.. Settings and mappings specified directly in the index template or the create index request override any settings or mappings specified in a component template.. Component templates are only used during index creation. For data streams, this includes data stream creation and the creation of a stream’s backing indices. Changes to component templates do not affect existing indices, including a stream’s backing indices.. You can use C-style `/* *\\/` block comments in component templates. You can include comments anywhere in the request body except before the opening curly bracket.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html"
         },
@@ -1575,7 +1603,8 @@
         "tags": [
           "cluster.delete_component_template"
         ],
-        "summary": "Deletes a component template",
+        "summary": "Deletes component templates",
+        "description": "Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html"
         },
@@ -1683,7 +1712,7 @@
         "tags": [
           "cluster.get_component_template"
         ],
-        "summary": "Returns one or more component templates",
+        "summary": "Retrieves information about component templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-component-template.html"
         },
@@ -1774,7 +1803,7 @@
         "tags": [
           "connector.check_in"
         ],
-        "summary": "Updates the last_seen timestamp in the connector document",
+        "summary": "Updates the last_seen field in the connector, and sets it to current timestamp",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/check-in-connector-api.html"
         },
@@ -1819,7 +1848,7 @@
         "tags": [
           "connector.get"
         ],
-        "summary": "Returns the details about a connector",
+        "summary": "Retrieves a connector",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-connector-api.html"
         },
@@ -1985,7 +2014,7 @@
         "tags": [
           "connector.last_sync"
         ],
-        "summary": "Updates the stats of last sync in the connector document",
+        "summary": "Updates last sync stats in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-last-sync-api.html"
         },
@@ -2096,7 +2125,7 @@
         "tags": [
           "connector.list"
         ],
-        "summary": "Lists all connectors",
+        "summary": "Returns existing connectors",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/list-connector-api.html"
         },
@@ -2312,7 +2341,7 @@
         "tags": [
           "connector.sync_job_get"
         ],
-        "summary": "Returns the details about a connector sync job",
+        "summary": "Retrieves a connector sync job",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-connector-sync-job-api.html"
         },
@@ -2384,7 +2413,7 @@
         "tags": [
           "connector.sync_job_list"
         ],
-        "summary": "Lists all connector sync jobs",
+        "summary": "Lists connector sync jobs",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/list-connector-sync-jobs-api.html"
         },
@@ -2532,7 +2561,7 @@
         "tags": [
           "connector.update_active_filtering"
         ],
-        "summary": "Activates the draft filtering rules if they are in a validated state",
+        "summary": "Activates the valid draft filtering for a connector",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-filtering-api.html"
         },
@@ -2577,7 +2606,7 @@
         "tags": [
           "connector.update_api_key_id"
         ],
-        "summary": "Updates the API key id and/or API key secret id fields in the connector document",
+        "summary": "Updates the API key id in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-api-key-id-api.html"
         },
@@ -2654,7 +2683,7 @@
         "tags": [
           "connector.update_configuration"
         ],
-        "summary": "Updates the connector configuration",
+        "summary": "Updates the configuration field in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-configuration-api.html"
         },
@@ -2720,7 +2749,7 @@
         "tags": [
           "connector.update_error"
         ],
-        "summary": "Updates the error field in the connector document",
+        "summary": "Updates the filtering field in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-error-api.html"
         },
@@ -2862,7 +2891,7 @@
         "tags": [
           "connector.update_filtering_validation"
         ],
-        "summary": "Updates the validation info of the draft filtering rules",
+        "summary": "Updates the draft filtering validation info for a connector",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-filtering-validation-api.html"
         },
@@ -2925,7 +2954,7 @@
         "tags": [
           "connector.update_index_name"
         ],
-        "summary": "Updates the index name of the connector",
+        "summary": "Updates the index_name in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-index-name-api.html"
         },
@@ -2995,7 +3024,7 @@
         "tags": [
           "connector.update_name"
         ],
-        "summary": "Updates the name and/or description fields in the connector document",
+        "summary": "Updates the name and description fields in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-name-description-api.html"
         },
@@ -3061,7 +3090,7 @@
         "tags": [
           "connector.update_native"
         ],
-        "summary": "Updates the is_native flag of the connector",
+        "summary": "Updates the is_native flag in the connector document",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-native-api.html"
         },
@@ -3634,8 +3663,8 @@
         "tags": [
           "create"
         ],
-        "summary": "Creates a new document in the index.",
-        "description": "Returns a 409 response when a document with a same ID already exists in the index.",
+        "summary": "Adds a JSON document to the specified data stream or index and makes it searchable",
+        "description": "If the target is an index and the document already exists, the request updates the document and increments its version.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html"
         },
@@ -3682,8 +3711,8 @@
         "tags": [
           "create"
         ],
-        "summary": "Creates a new document in the index.",
-        "description": "Returns a 409 response when a document with a same ID already exists in the index.",
+        "summary": "Adds a JSON document to the specified data stream or index and makes it searchable",
+        "description": "If the target is an index and the document already exists, the request updates the document and increments its version.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html"
         },
@@ -3878,7 +3907,8 @@
         "tags": [
           "index"
         ],
-        "summary": "Creates or updates a document in an index",
+        "summary": "Adds a JSON document to the specified data stream or index and makes it searchable",
+        "description": "If the target is an index and the document already exists, the request updates the document and increments its version.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html"
         },
@@ -3937,7 +3967,8 @@
         "tags": [
           "index"
         ],
-        "summary": "Creates or updates a document in an index",
+        "summary": "Adds a JSON document to the specified data stream or index and makes it searchable",
+        "description": "If the target is an index and the document already exists, the request updates the document and increments its version.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html"
         },
@@ -3996,7 +4027,7 @@
         "tags": [
           "delete"
         ],
-        "summary": "Removes a document from the index",
+        "summary": "Removes a JSON document from the specified index",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete.html"
         },
@@ -4122,7 +4153,7 @@
         "tags": [
           "exists"
         ],
-        "summary": "Returns information about whether a document exists in an index",
+        "summary": "Checks if a document in an index exists",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html"
         },
@@ -4266,7 +4297,7 @@
         "tags": [
           "delete_by_query"
         ],
-        "summary": "Deletes documents matching the provided query",
+        "summary": "Deletes documents that match the specified query",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html"
         },
@@ -4674,7 +4705,7 @@
         "tags": [
           "get_script"
         ],
-        "summary": "Returns a script",
+        "summary": "Retrieves a stored script or search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html"
         },
@@ -4734,7 +4765,7 @@
         "tags": [
           "put_script"
         ],
-        "summary": "Creates or updates a script",
+        "summary": "Creates or updates a stored script or search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html"
         },
@@ -4763,7 +4794,7 @@
         "tags": [
           "put_script"
         ],
-        "summary": "Creates or updates a script",
+        "summary": "Creates or updates a stored script or search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html"
         },
@@ -4792,7 +4823,7 @@
         "tags": [
           "delete_script"
         ],
-        "summary": "Deletes a script",
+        "summary": "Deletes a stored script or search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html"
         },
@@ -4849,7 +4880,7 @@
         "tags": [
           "enrich.get_policy"
         ],
-        "summary": "Gets information about an enrich policy",
+        "summary": "Returns information about an enrich policy",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-enrich-policy-api.html"
         },
@@ -4869,7 +4900,7 @@
         "tags": [
           "enrich.put_policy"
         ],
-        "summary": "Creates a new enrich policy",
+        "summary": "Creates an enrich policy",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-enrich-policy-api.html"
         },
@@ -5017,7 +5048,7 @@
         "tags": [
           "enrich.get_policy"
         ],
-        "summary": "Gets information about an enrich policy",
+        "summary": "Returns information about an enrich policy",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-enrich-policy-api.html"
         },
@@ -5034,7 +5065,7 @@
         "tags": [
           "enrich.stats"
         ],
-        "summary": "Gets enrich coordinator statistics and information about enrich policies that are currently executing",
+        "summary": "Returns enrich coordinator statistics and information about enrich policies that are currently executing",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/enrich-stats-api.html"
         },
@@ -5085,7 +5116,7 @@
         "tags": [
           "eql.get"
         ],
-        "summary": "Returns async results from previously executed Event Query Language (EQL) search",
+        "summary": "Returns the current status and available results for an async EQL search or a stored synchronous EQL search",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-async-eql-search-api.html"
         },
@@ -5140,8 +5171,8 @@
         "tags": [
           "eql.delete"
         ],
-        "summary": "Deletes an async EQL search by ID",
-        "description": "If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.",
+        "summary": "Deletes an async EQL search or a stored synchronous EQL search",
+        "description": "The API also deletes results for the search.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html"
         },
@@ -5178,7 +5209,7 @@
         "tags": [
           "eql.get_status"
         ],
-        "summary": "Returns the status of a previously submitted async or stored Event Query Language (EQL) search",
+        "summary": "Returns the current status for an async EQL search or a stored synchronous EQL search without returning results",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-async-eql-status-api.html"
         },
@@ -5327,7 +5358,7 @@
         "tags": [
           "esql.query"
         ],
-        "summary": "Executes an ESQL request",
+        "summary": "Executes an ES|QL request",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-rest.html"
         },
@@ -5557,7 +5588,7 @@
         "tags": [
           "exists_source"
         ],
-        "summary": "Returns information about whether a document source exists in an index",
+        "summary": "Checks if a document's `_source` is stored",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-get.html"
         },
@@ -5691,7 +5722,7 @@
         "tags": [
           "explain"
         ],
-        "summary": "Returns information about why a specific matches (or doesn't match) a query",
+        "summary": "Returns information about why a specific document matches (or doesn’t match) a query",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html"
         },
@@ -5753,7 +5784,7 @@
         "tags": [
           "explain"
         ],
-        "summary": "Returns information about why a specific matches (or doesn't match) a query",
+        "summary": "Returns information about why a specific document matches (or doesn’t match) a query",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-explain.html"
         },
@@ -5817,7 +5848,8 @@
         "tags": [
           "field_caps"
         ],
-        "summary": "Returns the information about the capabilities of fields among multiple indices",
+        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
+        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type of keyword is returned as any other field that belongs to the `keyword` family.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html"
         },
@@ -5861,7 +5893,8 @@
         "tags": [
           "field_caps"
         ],
-        "summary": "Returns the information about the capabilities of fields among multiple indices",
+        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
+        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type of keyword is returned as any other field that belongs to the `keyword` family.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html"
         },
@@ -5907,7 +5940,8 @@
         "tags": [
           "field_caps"
         ],
-        "summary": "Returns the information about the capabilities of fields among multiple indices",
+        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
+        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type of keyword is returned as any other field that belongs to the `keyword` family.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html"
         },
@@ -5954,7 +5988,8 @@
         "tags": [
           "field_caps"
         ],
-        "summary": "Returns the information about the capabilities of fields among multiple indices",
+        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
+        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type of keyword is returned as any other field that belongs to the `keyword` family.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-field-caps.html"
         },
@@ -6003,7 +6038,7 @@
         "tags": [
           "graph.explore"
         ],
-        "summary": "Explore extracted and summarized information about the documents and terms in an index",
+        "summary": "Extracts and summarizes information about the documents and terms in an Elasticsearch data stream or index",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html"
         },
@@ -6032,7 +6067,7 @@
         "tags": [
           "graph.explore"
         ],
-        "summary": "Explore extracted and summarized information about the documents and terms in an index",
+        "summary": "Extracts and summarizes information about the documents and terms in an Elasticsearch data stream or index",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html"
         },
@@ -6063,7 +6098,8 @@
         "tags": [
           "index"
         ],
-        "summary": "Creates or updates a document in an index",
+        "summary": "Adds a JSON document to the specified data stream or index and makes it searchable",
+        "description": "If the target is an index and the document already exists, the request updates the document and increments its version.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html"
         },
@@ -6238,7 +6274,7 @@
         "tags": [
           "indices.analyze"
         ],
-        "summary": "Performs the analysis process on a text and return the tokens breakdown of the text",
+        "summary": "Performs analysis on a text string and returns the resulting tokens",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html"
         },
@@ -6256,7 +6292,7 @@
         "tags": [
           "indices.analyze"
         ],
-        "summary": "Performs the analysis process on a text and return the tokens breakdown of the text",
+        "summary": "Performs analysis on a text string and returns the resulting tokens",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html"
         },
@@ -6276,7 +6312,7 @@
         "tags": [
           "indices.analyze"
         ],
-        "summary": "Performs the analysis process on a text and return the tokens breakdown of the text",
+        "summary": "Performs analysis on a text string and returns the resulting tokens",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html"
         },
@@ -6299,7 +6335,7 @@
         "tags": [
           "indices.analyze"
         ],
-        "summary": "Performs the analysis process on a text and return the tokens breakdown of the text",
+        "summary": "Performs analysis on a text string and returns the resulting tokens",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html"
         },
@@ -6325,6 +6361,7 @@
           "indices.get"
         ],
         "summary": "Returns information about one or more indices",
+        "description": "For data streams, the API returns information about the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-index.html"
         },
@@ -6442,7 +6479,7 @@
         "tags": [
           "indices.create"
         ],
-        "summary": "Creates an index with optional settings and mappings",
+        "summary": "Creates a new index",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html"
         },
@@ -6547,7 +6584,7 @@
         "tags": [
           "indices.delete"
         ],
-        "summary": "Deletes an index",
+        "summary": "Deletes one or more indices",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-index.html"
         },
@@ -6632,7 +6669,7 @@
         "tags": [
           "indices.exists"
         ],
-        "summary": "Returns information about whether a particular index exists",
+        "summary": "Checks if a data stream, index, or alias exists",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-exists.html"
         },
@@ -6725,7 +6762,7 @@
         "tags": [
           "indices.get_data_stream"
         ],
-        "summary": "Returns data streams",
+        "summary": "Retrieves information about one or more data streams",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -6752,6 +6789,7 @@
           "indices.create_data_stream"
         ],
         "summary": "Creates a data stream",
+        "description": "You must have a matching index template with data stream enabled.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -6786,7 +6824,7 @@
         "tags": [
           "indices.delete_data_stream"
         ],
-        "summary": "Deletes a data stream",
+        "summary": "Deletes one or more data streams and their backing indices",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -6833,7 +6871,7 @@
         "tags": [
           "indices.data_streams_stats"
         ],
-        "summary": "Provides statistics on operations happening in a data stream",
+        "summary": "Retrieves statistics for one or more data streams",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -6855,7 +6893,7 @@
         "tags": [
           "indices.data_streams_stats"
         ],
-        "summary": "Provides statistics on operations happening in a data stream",
+        "summary": "Retrieves statistics for one or more data streams",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -6880,7 +6918,7 @@
         "tags": [
           "indices.get_alias"
         ],
-        "summary": "Returns an alias",
+        "summary": "Retrieves information for one or more aliases",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -6915,7 +6953,7 @@
         "tags": [
           "indices.put_alias"
         ],
-        "summary": "Creates or updates an alias",
+        "summary": "Adds a data stream or index to an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -6947,7 +6985,7 @@
         "tags": [
           "indices.put_alias"
         ],
-        "summary": "Creates or updates an alias",
+        "summary": "Adds a data stream or index to an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -6979,7 +7017,7 @@
         "tags": [
           "indices.delete_alias"
         ],
-        "summary": "Deletes an alias",
+        "summary": "Removes a data stream or index from an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -7008,7 +7046,7 @@
         "tags": [
           "indices.exists_alias"
         ],
-        "summary": "Returns information about whether a particular alias exists",
+        "summary": "Checks if an alias exists",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -7045,7 +7083,7 @@
         "tags": [
           "indices.put_alias"
         ],
-        "summary": "Creates or updates an alias",
+        "summary": "Adds a data stream or index to an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -7077,7 +7115,7 @@
         "tags": [
           "indices.put_alias"
         ],
-        "summary": "Creates or updates an alias",
+        "summary": "Adds a data stream or index to an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -7109,7 +7147,7 @@
         "tags": [
           "indices.delete_alias"
         ],
-        "summary": "Deletes an alias",
+        "summary": "Removes a data stream or index from an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -7140,7 +7178,7 @@
         "tags": [
           "indices.get_data_lifecycle"
         ],
-        "summary": "Returns the data stream lifecycle of the selected data streams",
+        "summary": "Retrieves the data stream lifecycle configuration of one or more data streams",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle.html"
         },
@@ -7206,7 +7244,7 @@
         "tags": [
           "indices.put_data_lifecycle"
         ],
-        "summary": "Updates the data stream lifecycle of the selected data streams",
+        "summary": "Update the data lifecycle of the specified data streams",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-put-lifecycle.html"
         },
@@ -7288,7 +7326,7 @@
         "tags": [
           "indices.delete_data_lifecycle"
         ],
-        "summary": "Deletes the data stream lifecycle of the selected data streams",
+        "summary": "Removes the data lifecycle from a data stream rendering it not managed by the data stream lifecycle",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html"
         },
@@ -7355,7 +7393,7 @@
         "tags": [
           "indices.get_index_template"
         ],
-        "summary": "Returns an index template",
+        "summary": "Returns information about one or more index templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html"
         },
@@ -7388,6 +7426,7 @@
           "indices.put_index_template"
         ],
         "summary": "Creates or updates an index template",
+        "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-template.html"
         },
@@ -7420,6 +7459,7 @@
           "indices.put_index_template"
         ],
         "summary": "Creates or updates an index template",
+        "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-template.html"
         },
@@ -7451,7 +7491,8 @@
         "tags": [
           "indices.delete_index_template"
         ],
-        "summary": "Deletes an index template",
+        "summary": "The provided <index-template> may contain multiple template names separated by a comma",
+        "description": "If multiple template names are specified then there is no wildcard support and the provided names should match completely with existing templates.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-template.html"
         },
@@ -7549,7 +7590,7 @@
         "tags": [
           "indices.get_alias"
         ],
-        "summary": "Returns an alias",
+        "summary": "Retrieves information for one or more aliases",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -7581,7 +7622,7 @@
         "tags": [
           "indices.exists_alias"
         ],
-        "summary": "Returns information about whether a particular alias exists",
+        "summary": "Checks if an alias exists",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -7683,7 +7724,7 @@
         "tags": [
           "indices.get_alias"
         ],
-        "summary": "Returns an alias",
+        "summary": "Retrieves information for one or more aliases",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -7714,7 +7755,7 @@
         "tags": [
           "indices.get_alias"
         ],
-        "summary": "Returns an alias",
+        "summary": "Retrieves information for one or more aliases",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -7748,7 +7789,7 @@
         "tags": [
           "indices.get_data_stream"
         ],
-        "summary": "Returns data streams",
+        "summary": "Retrieves information about one or more data streams",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -7773,7 +7814,7 @@
         "tags": [
           "indices.get_index_template"
         ],
-        "summary": "Returns an index template",
+        "summary": "Returns information about one or more index templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html"
         },
@@ -7804,7 +7845,8 @@
         "tags": [
           "indices.get_mapping"
         ],
-        "summary": "Returns mappings for one or more indices",
+        "summary": "Retrieves mapping definitions for one or more indices",
+        "description": "For data streams, the API retrieves mappings for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html"
         },
@@ -7838,7 +7880,8 @@
         "tags": [
           "indices.get_mapping"
         ],
-        "summary": "Returns mappings for one or more indices",
+        "summary": "Retrieves mapping definitions for one or more indices",
+        "description": "For data streams, the API retrieves mappings for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-mapping.html"
         },
@@ -7873,7 +7916,8 @@
         "tags": [
           "indices.put_mapping"
         ],
-        "summary": "Updates the index mappings",
+        "summary": "Adds new fields to an existing data stream or index",
+        "description": "You can also use this API to change the search settings of existing fields. For data streams, these changes are applied to all backing indices by default.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html"
         },
@@ -7914,7 +7958,8 @@
         "tags": [
           "indices.put_mapping"
         ],
-        "summary": "Updates the index mappings",
+        "summary": "Adds new fields to an existing data stream or index",
+        "description": "You can also use this API to change the search settings of existing fields. For data streams, these changes are applied to all backing indices by default.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-mapping.html"
         },
@@ -7957,7 +8002,8 @@
         "tags": [
           "indices.get_settings"
         ],
-        "summary": "Returns settings for one or more indices",
+        "summary": "Returns setting information for one or more indices",
+        "description": "For data streams, returns setting information for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html"
         },
@@ -7995,7 +8041,8 @@
         "tags": [
           "indices.put_settings"
         ],
-        "summary": "Updates the index settings",
+        "summary": "Changes a dynamic index setting in real time",
+        "description": "For data streams, index setting changes are applied to all backing indices by default.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html"
         },
@@ -8038,7 +8085,8 @@
         "tags": [
           "indices.get_settings"
         ],
-        "summary": "Returns settings for one or more indices",
+        "summary": "Returns setting information for one or more indices",
+        "description": "For data streams, returns setting information for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html"
         },
@@ -8079,7 +8127,8 @@
         "tags": [
           "indices.put_settings"
         ],
-        "summary": "Updates the index settings",
+        "summary": "Changes a dynamic index setting in real time",
+        "description": "For data streams, index setting changes are applied to all backing indices by default.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-update-settings.html"
         },
@@ -8125,7 +8174,8 @@
         "tags": [
           "indices.get_settings"
         ],
-        "summary": "Returns settings for one or more indices",
+        "summary": "Returns setting information for one or more indices",
+        "description": "For data streams, returns setting information for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html"
         },
@@ -8171,7 +8221,8 @@
         "tags": [
           "indices.get_settings"
         ],
-        "summary": "Returns settings for one or more indices",
+        "summary": "Returns setting information for one or more indices",
+        "description": "For data streams, returns setting information for the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html"
         },
@@ -8214,7 +8265,8 @@
         "tags": [
           "indices.migrate_to_data_stream"
         ],
-        "summary": "Migrates an alias to a data stream",
+        "summary": "Converts an index alias to a data stream",
+        "description": "You must have a matching index template that is data stream enabled. The alias must meet the following criteria: The alias must have a write index; All indices for the alias must have a `@timestamp` field mapping of a `date` or `date_nanos` field type; The alias must not have any filters; The alias must not use custom routing. If successful, the request removes the alias and creates a data stream with the same name. The indices for the alias become hidden backing indices for the stream. The write index for the alias becomes the write index for the stream.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -8251,7 +8303,7 @@
         "tags": [
           "indices.modify_data_stream"
         ],
-        "summary": "Modifies a data stream",
+        "summary": "Performs one or more data stream modification actions in a single atomic operation",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -8298,6 +8350,7 @@
           "indices.put_template"
         ],
         "summary": "Creates or updates an index template",
+        "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html"
         },
@@ -8333,6 +8386,7 @@
           "indices.put_template"
         ],
         "summary": "Creates or updates an index template",
+        "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html"
         },
@@ -8369,7 +8423,8 @@
         "tags": [
           "indices.refresh"
         ],
-        "summary": "Performs the refresh operation in one or more indices",
+        "summary": "A refresh makes recent operations performed on one or more indices available for search",
+        "description": "For data streams, the API runs the refresh operation on the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html"
         },
@@ -8395,7 +8450,8 @@
         "tags": [
           "indices.refresh"
         ],
-        "summary": "Performs the refresh operation in one or more indices",
+        "summary": "A refresh makes recent operations performed on one or more indices available for search",
+        "description": "For data streams, the API runs the refresh operation on the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html"
         },
@@ -8423,7 +8479,8 @@
         "tags": [
           "indices.refresh"
         ],
-        "summary": "Performs the refresh operation in one or more indices",
+        "summary": "A refresh makes recent operations performed on one or more indices available for search",
+        "description": "For data streams, the API runs the refresh operation on the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html"
         },
@@ -8452,7 +8509,8 @@
         "tags": [
           "indices.refresh"
         ],
-        "summary": "Performs the refresh operation in one or more indices",
+        "summary": "A refresh makes recent operations performed on one or more indices available for search",
+        "description": "For data streams, the API runs the refresh operation on the stream’s backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-refresh.html"
         },
@@ -8483,7 +8541,8 @@
         "tags": [
           "indices.resolve_index"
         ],
-        "summary": "Returns information about any matching indices, aliases, and data streams",
+        "summary": "Resolves the specified name(s) and/or index patterns for indices, aliases, and data streams",
+        "description": "Multiple patterns and remote clusters are supported.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-resolve-index-api.html"
         },
@@ -8555,7 +8614,7 @@
         "tags": [
           "indices.rollover"
         ],
-        "summary": "Updates an alias to point to a new index when the existing index is considered to be too large or too old",
+        "summary": "Creates a new index for a data stream or index alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html"
         },
@@ -8592,7 +8651,7 @@
         "tags": [
           "indices.rollover"
         ],
-        "summary": "Updates an alias to point to a new index when the existing index is considered to be too large or too old",
+        "summary": "Creates a new index for a data stream or index alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html"
         },
@@ -8632,7 +8691,6 @@
         "tags": [
           "indices.simulate_index_template"
         ],
-        "summary": "Simulate matching the given index name against the index templates in the system",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-index.html"
         },
@@ -8703,7 +8761,7 @@
         "tags": [
           "indices.simulate_template"
         ],
-        "summary": "Simulate resolving the given template name or body",
+        "summary": "Returns the index configuration that would be applied by a particular index template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html"
         },
@@ -8734,7 +8792,7 @@
         "tags": [
           "indices.simulate_template"
         ],
-        "summary": "Simulate resolving the given template name or body",
+        "summary": "Returns the index configuration that would be applied by a particular index template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html"
         },
@@ -8768,7 +8826,7 @@
         "tags": [
           "indices.update_aliases"
         ],
-        "summary": "Updates index aliases",
+        "summary": "Adds a data stream or index to an alias",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html"
         },
@@ -8833,7 +8891,7 @@
         "tags": [
           "indices.validate_query"
         ],
-        "summary": "Allows a user to validate a potentially expensive query without executing it",
+        "summary": "Validates a potentially expensive query without executing it",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html"
         },
@@ -8889,7 +8947,7 @@
         "tags": [
           "indices.validate_query"
         ],
-        "summary": "Allows a user to validate a potentially expensive query without executing it",
+        "summary": "Validates a potentially expensive query without executing it",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html"
         },
@@ -8947,7 +9005,7 @@
         "tags": [
           "indices.validate_query"
         ],
-        "summary": "Allows a user to validate a potentially expensive query without executing it",
+        "summary": "Validates a potentially expensive query without executing it",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html"
         },
@@ -9006,7 +9064,7 @@
         "tags": [
           "indices.validate_query"
         ],
-        "summary": "Allows a user to validate a potentially expensive query without executing it",
+        "summary": "Validates a potentially expensive query without executing it",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-validate.html"
         },
@@ -9087,7 +9145,7 @@
         "tags": [
           "inference.put"
         ],
-        "summary": "Configure an inference endpoint for use in the Inference API",
+        "summary": "Create an inference endpoint",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-inference-api.html"
         },
@@ -9110,7 +9168,7 @@
         "tags": [
           "inference.inference"
         ],
-        "summary": "Perform inference",
+        "summary": "Perform inference on the service",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/post-inference-api.html"
         },
@@ -9187,7 +9245,7 @@
         "tags": [
           "inference.put"
         ],
-        "summary": "Configure an inference endpoint for use in the Inference API",
+        "summary": "Create an inference endpoint",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-inference-api.html"
         },
@@ -9213,7 +9271,7 @@
         "tags": [
           "inference.inference"
         ],
-        "summary": "Perform inference",
+        "summary": "Perform inference on the service",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/post-inference-api.html"
         },
@@ -9356,7 +9414,8 @@
         "tags": [
           "ingest.get_pipeline"
         ],
-        "summary": "Returns a pipeline",
+        "summary": "Returns information about one or more ingest pipelines",
+        "description": "This API returns a local reference of the pipeline.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html"
         },
@@ -9382,7 +9441,8 @@
         "tags": [
           "ingest.put_pipeline"
         ],
-        "summary": "Creates or updates a pipeline",
+        "summary": "Creates or updates an ingest pipeline",
+        "description": "Changes made using this API take effect immediately.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html"
         },
@@ -9483,7 +9543,7 @@
         "tags": [
           "ingest.delete_pipeline"
         ],
-        "summary": "Deletes a pipeline",
+        "summary": "Deletes one or more existing ingest pipeline",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-pipeline-api.html"
         },
@@ -9540,7 +9600,8 @@
         "tags": [
           "ingest.get_pipeline"
         ],
-        "summary": "Returns a pipeline",
+        "summary": "Returns information about one or more ingest pipelines",
+        "description": "This API returns a local reference of the pipeline.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-pipeline-api.html"
         },
@@ -9565,7 +9626,8 @@
         "tags": [
           "ingest.processor_grok"
         ],
-        "summary": "Returns a list of the built-in patterns",
+        "summary": "Extracts structured fields out of a single text field within a document",
+        "description": "You choose which field to extract matched fields from, as well as the grok pattern you expect will match. A grok pattern is like a regular expression that supports aliased expressions that can be reused.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/grok-processor.html"
         },
@@ -9600,7 +9662,7 @@
         "tags": [
           "ingest.simulate"
         ],
-        "summary": "Allows to simulate a pipeline with example documents",
+        "summary": "Executes an ingest pipeline against a set of provided documents",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html"
         },
@@ -9623,7 +9685,7 @@
         "tags": [
           "ingest.simulate"
         ],
-        "summary": "Allows to simulate a pipeline with example documents",
+        "summary": "Executes an ingest pipeline against a set of provided documents",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html"
         },
@@ -9648,7 +9710,7 @@
         "tags": [
           "ingest.simulate"
         ],
-        "summary": "Allows to simulate a pipeline with example documents",
+        "summary": "Executes an ingest pipeline against a set of provided documents",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html"
         },
@@ -9674,7 +9736,7 @@
         "tags": [
           "ingest.simulate"
         ],
-        "summary": "Allows to simulate a pipeline with example documents",
+        "summary": "Executes an ingest pipeline against a set of provided documents",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html"
         },
@@ -9702,7 +9764,8 @@
         "tags": [
           "license.get"
         ],
-        "summary": "Retrieves licensing information for the cluster",
+        "summary": "This API returns information about the type of license, when it was issued, and when it expires, for example",
+        "description": "For more information about the different types of licenses, see https://www.elastic.co/subscriptions.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html"
         },
@@ -9756,7 +9819,7 @@
         "tags": [
           "logstash.get_pipeline"
         ],
-        "summary": "Retrieves Logstash Pipelines used by Central Management",
+        "summary": "Retrieves pipelines used for Logstash Central Management",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-get-pipeline.html"
         },
@@ -9776,7 +9839,7 @@
         "tags": [
           "logstash.put_pipeline"
         ],
-        "summary": "Adds and updates Logstash Pipelines used for Central Management",
+        "summary": "Creates or updates a pipeline used for Logstash Central Management",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-put-pipeline.html"
         },
@@ -9817,7 +9880,7 @@
         "tags": [
           "logstash.delete_pipeline"
         ],
-        "summary": "Deletes Logstash Pipelines used by Central Management",
+        "summary": "Deletes a pipeline used for Logstash Central Management",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-delete-pipeline.html"
         },
@@ -9850,7 +9913,7 @@
         "tags": [
           "logstash.get_pipeline"
         ],
-        "summary": "Retrieves Logstash Pipelines used by Central Management",
+        "summary": "Retrieves pipelines used for Logstash Central Management",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-get-pipeline.html"
         },
@@ -10053,8 +10116,8 @@
         "tags": [
           "ml.close_job"
         ],
-        "summary": "Closes one or more anomaly detection jobs",
-        "description": "A job can be opened and closed multiple times throughout its lifecycle.",
+        "summary": "Close anomaly detection jobs A job can be opened and closed multiple times throughout its lifecycle",
+        "description": "A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results. When you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data. If you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request. When a datafeed that has a specified end date stops, it automatically closes its associated job.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-close-job.html"
         },
@@ -10180,7 +10243,7 @@
         "tags": [
           "ml.put_calendar"
         ],
-        "summary": "Instantiates a calendar",
+        "summary": "Creates a calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-calendar.html"
         },
@@ -10282,7 +10345,7 @@
         "tags": [
           "ml.delete_calendar"
         ],
-        "summary": "Deletes a calendar",
+        "summary": "Removes all scheduled events from a calendar, then deletes it",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar.html"
         },
@@ -10494,6 +10557,7 @@
           "ml.get_data_frame_analytics"
         ],
         "summary": "Retrieves configuration information for data frame analytics jobs",
+        "description": "You can get information for multiple data frame analytics jobs in a single API request by using a comma-separated list of data frame analytics jobs or a wildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html"
         },
@@ -10526,6 +10590,7 @@
           "ml.put_data_frame_analytics"
         ],
         "summary": "Instantiates a data frame analytics job",
+        "description": "This API creates a data frame analytics job that performs an analysis on the source indices and stores the outcome in a destination index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html"
         },
@@ -10663,7 +10728,7 @@
         "tags": [
           "ml.delete_data_frame_analytics"
         ],
-        "summary": "Deletes an existing data frame analytics job",
+        "summary": "Deletes a data frame analytics job",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html"
         },
@@ -10721,6 +10786,7 @@
           "ml.get_datafeeds"
         ],
         "summary": "Retrieves configuration information for datafeeds",
+        "description": "You can get information for multiple datafeeds in a single API request by using a comma-separated list of datafeeds or a wildcard expression. You can get information for all datafeeds by using `_all`, by specifying `*` as the `<feed_id>`, or by omitting the `<feed_id>`. This API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html"
         },
@@ -10747,6 +10813,7 @@
           "ml.put_datafeed"
         ],
         "summary": "Instantiates a datafeed",
+        "description": "Datafeeds retrieve data from Elasticsearch for analysis by an anomaly detection job. You can associate only one datafeed with each anomaly detection job. The datafeed contains a query that runs at a defined interval (`frequency`). If you are concerned about delayed data, you can add a delay (`query_delay') at each interval. When Elasticsearch security features are enabled, your datafeed remembers which roles the user who created it had at the time of creation and runs the query using those same roles. If you provide secondary authorization headers, those credentials are used instead. You must use Kibana, this API, or the create anomaly detection jobs API to create a datafeed. Do not add a datafeed directly to the `.ml-config` index. Do not give users `write` privileges on the `.ml-config` index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html"
         },
@@ -10998,6 +11065,7 @@
           "ml.get_filters"
         ],
         "summary": "Retrieves filters",
+        "description": "You can get a single filter or all filters.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-filter.html"
         },
@@ -11024,6 +11092,7 @@
           "ml.put_filter"
         ],
         "summary": "Instantiates a filter",
+        "description": "A filter contains a list of strings. It can be used by one or more anomaly detection jobs. Specifically, filters are referenced in the `custom_rules` property of detector configuration objects.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-filter.html"
         },
@@ -11101,6 +11170,7 @@
           "ml.delete_filter"
         ],
         "summary": "Deletes a filter",
+        "description": "If an anomaly detection job references the filter, you cannot delete the filter. You must update or delete the job before you can delete the filter.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-filter.html"
         },
@@ -11138,6 +11208,7 @@
           "ml.get_jobs"
         ],
         "summary": "Retrieves configuration information for anomaly detection jobs",
+        "description": "You can get information for multiple anomaly detection jobs in a single API request by using a group name, a comma-separated list of jobs, or a wildcard expression. You can get information for all anomaly detection jobs by using `_all`, by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html"
         },
@@ -11164,6 +11235,7 @@
           "ml.put_job"
         ],
         "summary": "Instantiates an anomaly detection job",
+        "description": "If you include a `datafeed_config`, you must have read index privileges on the source index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html"
         },
@@ -11347,7 +11419,8 @@
         "tags": [
           "ml.delete_job"
         ],
-        "summary": "Deletes an existing anomaly detection job",
+        "summary": "Deletes an anomaly detection job.",
+        "description": "All job configuration, model state and results are deleted. It is not currently possible to delete multiple jobs using wildcards or a comma separated list. If you delete a job that has a datafeed, the request first tries to delete the datafeed. This behavior is equivalent to calling the delete datafeed API with the same timeout and force parameters as the delete job request.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-job.html"
         },
@@ -11414,7 +11487,7 @@
         "tags": [
           "ml.get_trained_models"
         ],
-        "summary": "Retrieves configuration information for a trained inference model",
+        "summary": "Retrieves configuration information for a trained model",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models.html"
         },
@@ -11455,7 +11528,7 @@
         "tags": [
           "ml.put_trained_model"
         ],
-        "summary": "Creates an inference trained model",
+        "summary": "Enables you to supply a trained model that is not created by data frame analytics",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-models.html"
         },
@@ -11611,7 +11684,8 @@
         "tags": [
           "ml.put_trained_model_alias"
         ],
-        "summary": "Creates a new model alias (or reassigns an existing one) to refer to the trained model",
+        "summary": "Creates or updates a trained model alias",
+        "description": "A trained model alias is a logical name used to reference a single trained model. You can use aliases instead of trained model identifiers to make it easier to reference your models. For example, you can use aliases in inference aggregations and processors. An alias must be unique and refer to only a single trained model. However, you can have multiple aliases for each trained model. If you use this API to update an alias such that it references a different trained model ID and the model uses a different type of data frame analytics, an error occurs. For example, this situation occurs if you have a trained model for regression analysis and a trained model for classification analysis; you cannot reassign an alias from one type of trained model to another. If you use this API to update an alias and there are very few input fields in common between the old and new trained models for the model alias, the API returns a warning.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-models-aliases.html"
         },
@@ -11667,7 +11741,8 @@
         "tags": [
           "ml.delete_trained_model_alias"
         ],
-        "summary": "Deletes a model alias that refers to the trained model",
+        "summary": "Deletes a trained model alias",
+        "description": "This API deletes an existing model alias that refers to a trained model. If the model alias is missing or refers to a model other than the one identified by the `model_id`, this API returns an error.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-trained-models-aliases.html"
         },
@@ -11715,7 +11790,8 @@
         "tags": [
           "ml.estimate_model_memory"
         ],
-        "summary": "Estimates the model memory",
+        "summary": "Makes an estimation of the memory usage for an anomaly detection job model",
+        "description": "It is based on analysis configuration details for the job and cardinality estimates for the fields it references.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-apis.html"
         },
@@ -11777,6 +11853,7 @@
           "ml.evaluate_data_frame"
         ],
         "summary": "Evaluates the data frame analytics for an annotated index",
+        "description": "The API packages together commonly used evaluation metrics for various types of machine learning features. This has been designed for use on indexes created by data frame analytics. Evaluation requires both a ground truth field and an analytics result field to be present.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/evaluate-dfanalytics.html"
         },
@@ -11837,6 +11914,7 @@
           "ml.flush_job"
         ],
         "summary": "Forces any buffered data to be processed by the job",
+        "description": "The flush jobs API is only applicable when sending data for analysis using the post data API. Depending on the content of the buffer, then it might additionally calculate new results. Both flush and close operations are similar, however the flush is more efficient if you are expecting to send more data for analysis. When flushing, the job remains open and is available to continue analyzing data. A close operation additionally prunes and persists the model state to disk and the job must be opened again before analyzing further data.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html"
         },
@@ -12062,7 +12140,7 @@
         "tags": [
           "ml.post_calendar_events"
         ],
-        "summary": "Posts scheduled events in a calendar",
+        "summary": "Adds scheduled events to a calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-calendar-event.html"
         },
@@ -12187,6 +12265,7 @@
           "ml.get_data_frame_analytics"
         ],
         "summary": "Retrieves configuration information for data frame analytics jobs",
+        "description": "You can get information for multiple data frame analytics jobs in a single API request by using a comma-separated list of data frame analytics jobs or a wildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html"
         },
@@ -12283,6 +12362,7 @@
           "ml.get_datafeed_stats"
         ],
         "summary": "Retrieves usage information for datafeeds",
+        "description": "You can get statistics for multiple datafeeds in a single API request by using a comma-separated list of datafeeds or a wildcard expression. You can get statistics for all datafeeds by using `_all`, by specifying `*` as the `<feed_id>`, or by omitting the `<feed_id>`. If the datafeed is stopped, the only information you receive is the `datafeed_id` and the `state`. This API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html"
         },
@@ -12308,6 +12388,7 @@
           "ml.get_datafeed_stats"
         ],
         "summary": "Retrieves usage information for datafeeds",
+        "description": "You can get statistics for multiple datafeeds in a single API request by using a comma-separated list of datafeeds or a wildcard expression. You can get statistics for all datafeeds by using `_all`, by specifying `*` as the `<feed_id>`, or by omitting the `<feed_id>`. If the datafeed is stopped, the only information you receive is the `datafeed_id` and the `state`. This API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html"
         },
@@ -12330,6 +12411,7 @@
           "ml.get_datafeeds"
         ],
         "summary": "Retrieves configuration information for datafeeds",
+        "description": "You can get information for multiple datafeeds in a single API request by using a comma-separated list of datafeeds or a wildcard expression. You can get information for all datafeeds by using `_all`, by specifying `*` as the `<feed_id>`, or by omitting the `<feed_id>`. This API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html"
         },
@@ -12355,6 +12437,7 @@
           "ml.get_filters"
         ],
         "summary": "Retrieves filters",
+        "description": "You can get a single filter or all filters.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-filter.html"
         },
@@ -12427,6 +12510,7 @@
           "ml.get_jobs"
         ],
         "summary": "Retrieves configuration information for anomaly detection jobs",
+        "description": "You can get information for multiple anomaly detection jobs in a single API request by using a group name, a comma-separated list of jobs, or a wildcard expression. You can get information for all anomaly detection jobs by using `_all`, by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html"
         },
@@ -12451,7 +12535,8 @@
         "tags": [
           "ml.get_overall_buckets"
         ],
-        "summary": "Retrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs",
+        "summary": "Retrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs.",
+        "description": "The `overall_score` is calculated by combining the scores of all the buckets within the overall bucket span. First, the maximum `anomaly_score` per anomaly detection job in the overall bucket is calculated. Then the `top_n` of those scores are averaged to result in the `overall_score`. This means that you can fine-tune the `overall_score` so that it is more or less sensitive to the number of jobs that detect an anomaly at the same time. For example, if you set `top_n` to `1`, the `overall_score` is the maximum bucket score in the overall bucket. Alternatively, if you set `top_n` to the number of jobs, the `overall_score` is high only when all jobs detect anomalies in that overall bucket. If you set the `bucket_span` parameter (to a value greater than its default), the `overall_score` is the maximum `overall_score` of the overall buckets that have a span equal to the jobs' largest bucket span.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html"
         },
@@ -12495,7 +12580,8 @@
         "tags": [
           "ml.get_overall_buckets"
         ],
-        "summary": "Retrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs",
+        "summary": "Retrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs.",
+        "description": "The `overall_score` is calculated by combining the scores of all the buckets within the overall bucket span. First, the maximum `anomaly_score` per anomaly detection job in the overall bucket is calculated. Then the `top_n` of those scores are averaged to result in the `overall_score`. This means that you can fine-tune the `overall_score` so that it is more or less sensitive to the number of jobs that detect an anomaly at the same time. For example, if you set `top_n` to `1`, the `overall_score` is the maximum bucket score in the overall bucket. Alternatively, if you set `top_n` to the number of jobs, the `overall_score` is high only when all jobs detect anomalies in that overall bucket. If you set the `bucket_span` parameter (to a value greater than its default), the `overall_score` is the maximum `overall_score` of the overall buckets that have a span equal to the jobs' largest bucket span.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html"
         },
@@ -12541,7 +12627,7 @@
         "tags": [
           "ml.get_trained_models"
         ],
-        "summary": "Retrieves configuration information for a trained inference model",
+        "summary": "Retrieves configuration information for a trained model",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models.html"
         },
@@ -12581,7 +12667,8 @@
         "tags": [
           "ml.get_trained_models_stats"
         ],
-        "summary": "Retrieves usage information for trained inference models",
+        "summary": "Retrieves usage information for trained models",
+        "description": "You can get usage information for multiple trained models in a single API request by using a comma-separated list of model IDs or a wildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models-stats.html"
         },
@@ -12612,7 +12699,8 @@
         "tags": [
           "ml.get_trained_models_stats"
         ],
-        "summary": "Retrieves usage information for trained inference models",
+        "summary": "Retrieves usage information for trained models",
+        "description": "You can get usage information for multiple trained models in a single API request by using a comma-separated list of model IDs or a wildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models-stats.html"
         },
@@ -12640,7 +12728,7 @@
         "tags": [
           "ml.infer_trained_model"
         ],
-        "summary": "Evaluate a trained model",
+        "summary": "Evaluates a trained model",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html"
         },
@@ -12668,7 +12756,7 @@
         "tags": [
           "ml.infer_trained_model"
         ],
-        "summary": "Evaluate a trained model",
+        "summary": "Evaluates a trained model",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html"
         },
@@ -12697,6 +12785,7 @@
           "ml.open_job"
         ],
         "summary": "Opens one or more anomaly detection jobs",
+        "description": "An anomaly detection job must be opened in order for it to be ready to receive and analyze data. It can be opened and closed multiple times throughout its lifecycle. When you open a new job, it starts with an empty model. When you open an existing job, the most recent model state is automatically loaded. The job is ready to resume its analysis from where it left off, once new data is received.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html"
         },
@@ -12769,7 +12858,7 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews that will be analyzed given a data frame analytics config",
+        "summary": "Previews the extracted features used by a data frame analytics config",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -12787,7 +12876,7 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews that will be analyzed given a data frame analytics config",
+        "summary": "Previews the extracted features used by a data frame analytics config",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -12807,7 +12896,7 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews that will be analyzed given a data frame analytics config",
+        "summary": "Previews the extracted features used by a data frame analytics config",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -12830,7 +12919,7 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews that will be analyzed given a data frame analytics config",
+        "summary": "Previews the extracted features used by a data frame analytics config",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -12856,6 +12945,7 @@
           "ml.preview_datafeed"
         ],
         "summary": "Previews a datafeed",
+        "description": "This API returns the first \"page\" of search results from a datafeed. You can preview an existing datafeed or provide configuration details for a datafeed and anomaly detection job in the API. The preview shows the structure of the data that will be passed to the anomaly detection engine. IMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that called the API. However, when the datafeed starts it uses the roles of the last user that created or updated the datafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials. You can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
         },
@@ -12885,6 +12975,7 @@
           "ml.preview_datafeed"
         ],
         "summary": "Previews a datafeed",
+        "description": "This API returns the first \"page\" of search results from a datafeed. You can preview an existing datafeed or provide configuration details for a datafeed and anomaly detection job in the API. The preview shows the structure of the data that will be passed to the anomaly detection engine. IMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that called the API. However, when the datafeed starts it uses the roles of the last user that created or updated the datafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials. You can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
         },
@@ -12916,6 +13007,7 @@
           "ml.preview_datafeed"
         ],
         "summary": "Previews a datafeed",
+        "description": "This API returns the first \"page\" of search results from a datafeed. You can preview an existing datafeed or provide configuration details for a datafeed and anomaly detection job in the API. The preview shows the structure of the data that will be passed to the anomaly detection engine. IMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that called the API. However, when the datafeed starts it uses the roles of the last user that created or updated the datafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials. You can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
         },
@@ -12942,6 +13034,7 @@
           "ml.preview_datafeed"
         ],
         "summary": "Previews a datafeed",
+        "description": "This API returns the first \"page\" of search results from a datafeed. You can preview an existing datafeed or provide configuration details for a datafeed and anomaly detection job in the API. The preview shows the structure of the data that will be passed to the anomaly detection engine. IMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that called the API. However, when the datafeed starts it uses the roles of the last user that created or updated the datafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials. You can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
         },
@@ -13047,6 +13140,7 @@
           "ml.put_trained_model_vocabulary"
         ],
         "summary": "Creates a trained model vocabulary",
+        "description": "This API is supported only for natural language processing (NLP) models. The vocabulary is stored in the index as described in `inference_config.*.vocabulary` of the trained model definition.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-model-vocabulary.html"
         },
@@ -13119,7 +13213,8 @@
         "tags": [
           "ml.reset_job"
         ],
-        "summary": "Resets an existing anomaly detection job",
+        "summary": "Resets an anomaly detection job",
+        "description": "All model state and results are deleted. The job is ready to start over as if it had just been created. It is not currently possible to reset multiple jobs using wildcards or a comma separated list.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-reset-job.html"
         },
@@ -13177,6 +13272,7 @@
           "ml.start_data_frame_analytics"
         ],
         "summary": "Starts a data frame analytics job",
+        "description": "A data frame analytics job can be started and stopped multiple times throughout its lifecycle. If the destination index does not exist, it is created automatically the first time you start the data frame analytics job. The `index.number_of_shards` and `index.number_of_replicas` settings for the destination index are copied from the source index. If there are multiple source indices, the destination index copies the highest setting values. The mappings for the destination index are also copied from the source indices. If there are any mapping conflicts, the job fails to start. If the destination index exists, it is used as is. You can therefore set up the destination index in advance with custom settings and mappings.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/start-dfanalytics.html"
         },
@@ -13235,7 +13331,8 @@
         "tags": [
           "ml.start_datafeed"
         ],
-        "summary": "Starts one or more datafeeds",
+        "summary": "Starts one or more datafeeds.",
+        "description": "A datafeed must be started in order to retrieve data from Elasticsearch. A datafeed can be started and stopped multiple times throughout its lifecycle.. Before you can start a datafeed, the anomaly detection job must be open. Otherwise, an error occurs.. If you restart a stopped datafeed, it continues processing input data from the next millisecond after it was stopped. If new data was indexed for that exact millisecond between stopping and starting, it will be ignored.. When Elasticsearch security features are enabled, your datafeed remembers which roles the last user to create or update it had at the time of creation or update and runs the query using those same roles. If you provided secondary authorization headers when you created or updated the datafeed, those credentials are used instead.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html"
         },
@@ -13335,7 +13432,7 @@
         "tags": [
           "ml.start_trained_model_deployment"
         ],
-        "summary": "Start a trained model deployment",
+        "summary": "Starts a trained model deployment, which allocates the model to every machine learning node",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trained-model-deployment.html"
         },
@@ -13451,6 +13548,7 @@
           "ml.stop_data_frame_analytics"
         ],
         "summary": "Stops one or more data frame analytics jobs",
+        "description": "A data frame analytics job can be started and stopped multiple times throughout its lifecycle.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-dfanalytics.html"
         },
@@ -13526,6 +13624,7 @@
           "ml.stop_datafeed"
         ],
         "summary": "Stops one or more datafeeds",
+        "description": "A datafeed that is stopped ceases to retrieve data from Elasticsearch. A datafeed can be started and stopped multiple times throughout its lifecycle.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html"
         },
@@ -13622,7 +13721,7 @@
         "tags": [
           "ml.stop_trained_model_deployment"
         ],
-        "summary": "Stop a trained model deployment",
+        "summary": "Stops a trained model deployment",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-trained-model-deployment.html"
         },
@@ -13687,7 +13786,7 @@
         "tags": [
           "ml.update_data_frame_analytics"
         ],
-        "summary": "Updates certain properties of a data frame analytics job",
+        "summary": "Updates an existing data frame analytics job",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-dfanalytics.html"
         },
@@ -13807,7 +13906,8 @@
         "tags": [
           "ml.update_datafeed"
         ],
-        "summary": "Updates certain properties of a datafeed",
+        "summary": "Updates the properties of a datafeed",
+        "description": "You must stop and start the datafeed for the changes to be applied. When Elasticsearch security features are enabled, your datafeed remembers which roles the user who updated it had at the time of the update and runs the query using those same roles. If you provide secondary authorization headers, those credentials are used instead.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html"
         },
@@ -14014,7 +14114,7 @@
         "tags": [
           "ml.update_filter"
         ],
-        "summary": "Updates the description of a filter, adds items, or removes items",
+        "summary": "Updates the description of a filter, adds items, or removes items from the list",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-filter.html"
         },
@@ -14308,7 +14408,7 @@
         "tags": [
           "ml.update_trained_model_deployment"
         ],
-        "summary": "Updates certain properties of trained model deployment",
+        "summary": "Starts a trained model deployment, which allocates the model to every machine learning node",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-trained-model-deployment.html"
         },
@@ -14612,7 +14712,7 @@
         "tags": [
           "msearch_template"
         ],
-        "summary": "Allows to execute several search template operations in one request",
+        "summary": "Runs multiple templated searches with a single request",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html"
         },
@@ -14647,7 +14747,7 @@
         "tags": [
           "msearch_template"
         ],
-        "summary": "Allows to execute several search template operations in one request",
+        "summary": "Runs multiple templated searches with a single request",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html"
         },
@@ -14684,7 +14784,7 @@
         "tags": [
           "msearch_template"
         ],
-        "summary": "Allows to execute several search template operations in one request",
+        "summary": "Runs multiple templated searches with a single request",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html"
         },
@@ -14722,7 +14822,7 @@
         "tags": [
           "msearch_template"
         ],
-        "summary": "Allows to execute several search template operations in one request",
+        "summary": "Runs multiple templated searches with a single request",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html"
         },
@@ -14996,7 +15096,8 @@
         "tags": [
           "open_point_in_time"
         ],
-        "summary": "Open a point in time that can be used in subsequent searches",
+        "summary": "A search request by default executes against the most recent visible data of the target indices, which is called point in time",
+        "description": "Elasticsearch pit (point in time) is a lightweight view into the state of the data as it existed when initiated. In some cases, it’s preferred to perform multiple search requests using the same point in time. For example, if refreshes happen between `search_after` requests, then the results of those requests might not be consistent as changes happening between searches are only visible to the more recent point in time.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html"
         },
@@ -15092,7 +15193,7 @@
         "tags": [
           "put_script"
         ],
-        "summary": "Creates or updates a script",
+        "summary": "Creates or updates a stored script or search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html"
         },
@@ -15124,7 +15225,7 @@
         "tags": [
           "put_script"
         ],
-        "summary": "Creates or updates a script",
+        "summary": "Creates or updates a stored script or search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html"
         },
@@ -15294,7 +15395,7 @@
         "tags": [
           "query_ruleset.list"
         ],
-        "summary": "Lists query rulesets",
+        "summary": "Returns summarized information about existing query rulesets",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-query-rulesets.html"
         },
@@ -15355,7 +15456,7 @@
         "tags": [
           "rank_eval"
         ],
-        "summary": "Allows to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html"
         },
@@ -15387,7 +15488,7 @@
         "tags": [
           "rank_eval"
         ],
-        "summary": "Allows to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html"
         },
@@ -15421,7 +15522,7 @@
         "tags": [
           "rank_eval"
         ],
-        "summary": "Allows to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html"
         },
@@ -15456,7 +15557,7 @@
         "tags": [
           "rank_eval"
         ],
-        "summary": "Allows to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-rank-eval.html"
         },
@@ -15687,7 +15788,7 @@
         "tags": [
           "render_search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Renders a search template as a search request body",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/render-search-template-api.html"
         },
@@ -15705,7 +15806,7 @@
         "tags": [
           "render_search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Renders a search template as a search request body",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/render-search-template-api.html"
         },
@@ -15725,7 +15826,7 @@
         "tags": [
           "render_search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Renders a search template as a search request body",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/render-search-template-api.html"
         },
@@ -15748,7 +15849,7 @@
         "tags": [
           "render_search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Renders a search template as a search request body",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/render-search-template-api.html"
         },
@@ -15773,7 +15874,7 @@
         "tags": [
           "scripts_painless_execute"
         ],
-        "summary": "Allows an arbitrary script to be executed and a result to be returned",
+        "summary": "Runs a script and returns a result",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html"
         },
@@ -15791,7 +15892,7 @@
         "tags": [
           "scripts_painless_execute"
         ],
-        "summary": "Allows an arbitrary script to be executed and a result to be returned",
+        "summary": "Runs a script and returns a result",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/painless/master/painless-execute-api.html"
         },
@@ -15811,7 +15912,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns results matching a query",
+        "summary": "Returns search hits that match the query defined in the request",
+        "description": "You can provide search queries using the `q` query string parameter or the request body. If both are specified, only the query parameter is used.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html"
         },
@@ -15960,7 +16062,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns results matching a query",
+        "summary": "Returns search hits that match the query defined in the request",
+        "description": "You can provide search queries using the `q` query string parameter or the request body. If both are specified, only the query parameter is used.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html"
         },
@@ -16111,7 +16214,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns results matching a query",
+        "summary": "Returns search hits that match the query defined in the request",
+        "description": "You can provide search queries using the `q` query string parameter or the request body. If both are specified, only the query parameter is used.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html"
         },
@@ -16263,7 +16367,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns results matching a query",
+        "summary": "Returns search hits that match the query defined in the request",
+        "description": "You can provide search queries using the `q` query string parameter or the request body. If both are specified, only the query parameter is used.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html"
         },
@@ -16902,7 +17007,7 @@
         "tags": [
           "search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Runs a search with a search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -16961,7 +17066,7 @@
         "tags": [
           "search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Runs a search with a search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -17022,7 +17127,7 @@
         "tags": [
           "search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Runs a search with a search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -17084,7 +17189,7 @@
         "tags": [
           "search_template"
         ],
-        "summary": "Allows to use the Mustache language to pre-render a search definition",
+        "summary": "Runs a search with a search template",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -17148,7 +17253,8 @@
         "tags": [
           "security.authenticate"
         ],
-        "summary": "Enables authentication as a user and retrieve information about the authenticated user",
+        "summary": "Enables you to submit a request with a basic auth header to authenticate a user and retrieve information about the authenticated user",
+        "description": "A successful call returns a JSON structure that shows user information such as their username, the roles that are assigned to the user, any assigned metadata, and information about the realms that authenticated and authorized the user. If the user cannot be authenticated, this API returns a 401 status code.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-authenticate.html"
         },
@@ -17236,6 +17342,7 @@
           "security.get_api_key"
         ],
         "summary": "Retrieves information for one or more API keys",
+        "description": "NOTE: If you have only the `manage_own_api_key` privilege, this API returns only the API keys that you own. If you have `read_security`, `manage_api_key` or greater privileges (including `manage_security`), this API returns all API keys regardless of ownership.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html"
         },
@@ -17351,6 +17458,7 @@
           "security.create_api_key"
         ],
         "summary": "Creates an API key for access without requiring basic authentication",
+        "description": "A successful request returns a JSON structure that contains the API key, its unique id, and its name. If applicable, it also returns expiration information for the API key in milliseconds. NOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html"
         },
@@ -17374,6 +17482,7 @@
           "security.create_api_key"
         ],
         "summary": "Creates an API key for access without requiring basic authentication",
+        "description": "A successful request returns a JSON structure that contains the API key, its unique id, and its name. If applicable, it also returns expiration information for the API key in milliseconds. NOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html"
         },
@@ -17397,6 +17506,7 @@
           "security.invalidate_api_key"
         ],
         "summary": "Invalidates one or more API keys",
+        "description": "The `manage_api_key` privilege allows deleting any API keys. The `manage_own_api_key` only allows deleting API keys that are owned by the user. In addition, with the `manage_own_api_key` privilege, an invalidation request must be issued in one of the three formats: - Set the parameter `owner=true`. - Or, set both `username` and `realm_name` to match the user’s identity. - Or, if the request is issued by an API key, i.e. an API key invalidates itself, specify its ID in the `ids` field.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-invalidate-api-key.html"
         },
@@ -17570,7 +17680,8 @@
         "tags": [
           "security.query_api_keys"
         ],
-        "summary": "Retrieves information for API keys using a subset of query DSL",
+        "summary": "Retrieves information for API keys in a paginated manner",
+        "description": "You can optionally filter the results with a query.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-query-api-key.html"
         },
@@ -17599,7 +17710,8 @@
         "tags": [
           "security.query_api_keys"
         ],
-        "summary": "Retrieves information for API keys using a subset of query DSL",
+        "summary": "Retrieves information for API keys in a paginated manner",
+        "description": "You can optionally filter the results with a query.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-query-api-key.html"
         },
@@ -17631,6 +17743,7 @@
           "security.update_api_key"
         ],
         "summary": "Updates attributes of an existing API key",
+        "description": "Users can only update API keys that they created or that were granted to them. Use this API to update API keys created by the create API Key or grant API Key APIs. If you need to apply the same update to many API keys, you can use bulk update API Keys to reduce overhead. It’s not possible to update expired API keys, or API keys that have been invalidated by invalidate API Key. This API supports updates to an API key’s access scope and metadata. The access scope of an API key is derived from the `role_descriptors` you specify in the request, and a snapshot of the owner user’s permissions at the time of the request. The snapshot of the owner’s permissions is updated automatically on every call. If you don’t specify `role_descriptors` in the request, a call to this API might still change the API key’s access scope. This change can occur if the owner user’s permissions have changed since the API key was created or last modified. To update another user’s API key, use the `run_as` feature to submit a request on behalf of another user. IMPORTANT: It’s not possible to use an API key as the authentication credential for this API. To update an API key, the owner user’s credentials are required.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-update-api-key.html"
         },
@@ -18129,7 +18242,7 @@
         "tags": [
           "synonyms.put_synonym"
         ],
-        "summary": "Creates or updates a synonyms set",
+        "summary": "Creates or updates a synonym set",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-synonyms-set.html"
         },
@@ -18845,7 +18958,8 @@
         "tags": [
           "transform.put_transform"
         ],
-        "summary": "Instantiates a transform",
+        "summary": "Creates a transform.",
+        "description": "A transform copies data from source indices, transforms it, and persists it into an entity-centric destination index. You can also think of the destination index as a two-dimensional tabular data structure (known as a data frame). The ID for each document in the data frame is generated from a hash of the entity, so there is a unique row per entity.. You must choose either the latest or pivot method for your transform; you cannot use both in a single transform. If you choose to use the pivot method for your transform, the entities are defined by the set of `group_by` fields in the pivot object. If you choose to use the latest method, the entities are defined by the `unique_key` field values in the latest object.. You must have `create_index`, `index`, and `read` privileges on the destination index and `read` and `view_index_metadata` privileges on the source indices. When Elasticsearch security features are enabled, the transform remembers which roles the user that created it had at the time of creation and uses those same roles. If those roles do not have the required privileges on the source and destination indices, the transform fails when it attempts unauthorized operations.. NOTE: You must use Kibana or this API to create a transform. Do not add a transform directly into any `.transform-internal*` indices using the Elasticsearch index API. If Elasticsearch security features are enabled, do not give users any privileges on `.transform-internal*` indices. If you used transforms prior to 7.5, also do not give users any privileges on `.data-frame-internal*` indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html"
         },
@@ -18947,7 +19061,7 @@
         "tags": [
           "transform.delete_transform"
         ],
-        "summary": "Deletes an existing transform",
+        "summary": "Deletes a transform",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-transform.html"
         },
@@ -19137,7 +19251,8 @@
         "tags": [
           "transform.preview_transform"
         ],
-        "summary": "Previews a transform",
+        "summary": "Previews a transform.",
+        "description": "It returns a maximum of 100 results. The calculations are based on all the current data in the source index. It also generates a list of mappings and settings for the destination index. These values are determined based on the field types of the source index and the transform aggregations.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html"
         },
@@ -19163,7 +19278,8 @@
         "tags": [
           "transform.preview_transform"
         ],
-        "summary": "Previews a transform",
+        "summary": "Previews a transform.",
+        "description": "It returns a maximum of 100 results. The calculations are based on all the current data in the source index. It also generates a list of mappings and settings for the destination index. These values are determined based on the field types of the source index and the transform aggregations.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html"
         },
@@ -19191,7 +19307,8 @@
         "tags": [
           "transform.preview_transform"
         ],
-        "summary": "Previews a transform",
+        "summary": "Previews a transform.",
+        "description": "It returns a maximum of 100 results. The calculations are based on all the current data in the source index. It also generates a list of mappings and settings for the destination index. These values are determined based on the field types of the source index and the transform aggregations.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html"
         },
@@ -19214,7 +19331,8 @@
         "tags": [
           "transform.preview_transform"
         ],
-        "summary": "Previews a transform",
+        "summary": "Previews a transform.",
+        "description": "It returns a maximum of 100 results. The calculations are based on all the current data in the source index. It also generates a list of mappings and settings for the destination index. These values are determined based on the field types of the source index and the transform aggregations.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/preview-transform.html"
         },
@@ -19239,7 +19357,8 @@
         "tags": [
           "transform.reset_transform"
         ],
-        "summary": "Resets an existing transform",
+        "summary": "Resets a transform",
+        "description": "Before you can reset it, you must stop it; alternatively, use the `force` query parameter. If the destination index was created by the transform, it is deleted.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/reset-transform.html"
         },
@@ -19286,7 +19405,8 @@
         "tags": [
           "transform.schedule_now_transform"
         ],
-        "summary": "Schedules now a transform",
+        "summary": "Schedules now a transform.",
+        "description": "If you _schedule_now a transform, it will process the new data instantly, without waiting for the configured frequency interval. After _schedule_now API is called, the transform will be processed again at now + frequency unless _schedule_now API is called again in the meantime.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/schedule-now-transform.html"
         },
@@ -19333,7 +19453,8 @@
         "tags": [
           "transform.start_transform"
         ],
-        "summary": "Starts one or more transforms",
+        "summary": "Starts a transform.",
+        "description": "When you start a transform, it creates the destination index if it does not already exist. The `number_of_shards` is set to `1` and the `auto_expand_replicas` is set to `0-1`. If it is a pivot transform, it deduces the mapping definitions for the destination index from the source indices and the transform aggregations. If fields in the destination index are derived from scripts (as in the case of `scripted_metric` or `bucket_script` aggregations), the transform uses dynamic mappings unless an index template exists. If it is a latest transform, it does not deduce mapping definitions; it uses dynamic mappings. To use explicit mappings, create the destination index before you start the transform. Alternatively, you can create an index template, though it does not affect the deduced mappings in a pivot transform.. When the transform starts, a series of validations occur to ensure its success. If you deferred validation when you created the transform, they occur when you start the transform—​with the exception of privilege checks. When Elasticsearch security features are enabled, the transform remembers which roles the user that created it had at the time of creation and uses those same roles. If those roles do not have the required privileges on the source and destination indices, the transform fails when it attempts unauthorized operations.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/start-transform.html"
         },
@@ -19477,7 +19598,8 @@
         "tags": [
           "transform.update_transform"
         ],
-        "summary": "Updates certain properties of a transform",
+        "summary": "Updates certain properties of a transform.",
+        "description": "All updated properties except `description` do not take effect until after the transform starts the next checkpoint, thus there is data consistency in each checkpoint. To use this API, you must have `read` and `view_index_metadata` privileges for the source indices. You must also have `index` and `read` privileges for the destination index. When Elasticsearch security features are enabled, the transform remembers which roles the user who updated it had at the time of update and runs with those privileges.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-transform.html"
         },
@@ -19840,7 +19962,7 @@
           "update_by_query"
         ],
         "summary": "Updates documents that match the specified query",
-        "description": "If no query is specified,  performs an update on every document in the index without changing the source, for example to pick up a mapping change.",
+        "description": "If no query is specified, performs an update on every document in the data stream or index without modifying the source, which is useful for picking up mapping changes.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-update-by-query.html"
         },


### PR DESCRIPTION
Changes the endpoint description lookup strategy to prioritize the description from request objects (i.e. in the TypeScript API) over the description from the rest-spec json file.
