### PR TITLE
Restore request descriptions fallback to json-rest-spec

### DIFF
--- a/compiler/src/steps/add-description.ts
+++ b/compiler/src/steps/add-description.ts
@@ -57,7 +57,6 @@ export default async function addDescription (model: model.Model, jsonSpec: Map<
     if (spec.documentation.description != null) {
       requestDefinition.description = requestDefinition.description ?? spec.documentation.description
     }
-    
     // An API endpoint is defined by an endpoint object (paths and http methods) and a request
     // type (parameters and structure).
     endpoint.description = requestDefinition.description ?? spec.documentation.description

--- a/compiler/src/steps/add-description.ts
+++ b/compiler/src/steps/add-description.ts
@@ -57,6 +57,7 @@ export default async function addDescription (model: model.Model, jsonSpec: Map<
     if (spec.documentation.description != null) {
       requestDefinition.description = requestDefinition.description ?? spec.documentation.description
     }
+
     // An API endpoint is defined by an endpoint object (paths and http methods) and a request
     // type (parameters and structure).
     endpoint.description = requestDefinition.description ?? spec.documentation.description

--- a/compiler/src/steps/add-description.ts
+++ b/compiler/src/steps/add-description.ts
@@ -54,6 +54,10 @@ export default async function addDescription (model: model.Model, jsonSpec: Map<
       }
     }
 
+    if (spec.documentation.description != null) {
+      requestDefinition.description = requestDefinition.description ?? spec.documentation.description
+    }
+    
     // An API endpoint is defined by an endpoint object (paths and http methods) and a request
     // type (parameters and structure).
     endpoint.description = requestDefinition.description ?? spec.documentation.description


### PR DESCRIPTION
Follow-up to PR #2625 that incorrectly removed the fallback mechanism to rest-spec-json for request descriptions. This PR restores it.
