### PR TITLE
[Backport 7.7] Add missing shard_min_doc_count to TermsAggregation

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3671,6 +3671,7 @@ export interface AggregationsTermsAggregation extends AggregationsBucketAggregat
   value_type?: string
   order?: AggregationsAggregateOrder
   script?: Script
+  shard_min_doc_count?: long
   shard_size?: integer
   show_term_doc_count_error?: boolean
   size?: integer

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -358,6 +358,15 @@ export class TermsAggregation extends BucketAggregationBase {
   value_type?: string
   order?: AggregateOrder
   script?: Script
+  /**
+   * Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`.
+   * Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.
+   */
+  shard_min_doc_count?: long
+  /**
+   * The number of candidate terms produced by each shard.
+   * By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.
+   */
   shard_size?: integer
   show_term_doc_count_error?: boolean
   size?: integer


### PR DESCRIPTION
Co-authored-by: Quentin Pradet <quentin.pradet@elastic.co>
(cherry picked from commit 2bb4d0cc61ca56099a1dd4e1dee4bdb1bf7e4362)
