### PR TITLE
Add operation summaries for index template APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ contrib: | generate license-check spec-format-fix transform-to-openapi ## Pre co
 lint-docs: ## Lint the OpenAPI documents
 	@npx @stoplight/spectral-cli lint output/openapi/*.json --ruleset .spectral.yaml
 
+lint-docs-serverless: ## Lint only the serverless OpenAPI document
+	@npx @stoplight/spectral-cli lint output/openapi/elasticsearch-serverless-openapi.json --ruleset .spectral.yaml
+
 help:  ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 #------------- <https://suva.sh/posts/well-documented-makefiles> --------------

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ dump-routes: ## Create a new schema with all generics expanded
 contrib: | generate license-check spec-format-fix transform-to-openapi ## Pre contribution target
 
 lint-docs: ## Lint the OpenAPI documents
-	@npx @stoplight/spectral-cli lint output/openapi/elasticsearch-serverless-openapi.json
+	@npx @stoplight/spectral-cli lint output/openapi/*.json --ruleset .spectral.yaml
 
 help:  ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,12 @@ Usage:
   spec-dangling-types  Generate the dangling types rreport
   setup            Install dependencies for contrib target
   clean-dep        Clean npm dependencies
+  transform-expand-generics  Create a new schema with all generics expanded
+  transform-to-openapi  Generate the OpenAPI definition from the compiled schema
+  filter-for-serverless  Generate the serverless version from the compiled schema
+  dump-routes      Create a new schema with all generics expanded
   contrib          Pre contribution target
+  lint-docs        Lint the OpenAPI documents
   help             Display help
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Usage:
   dump-routes      Create a new schema with all generics expanded
   contrib          Pre contribution target
   lint-docs        Lint the OpenAPI documents
+  lint-docs-serverless  Lint only the serverless OpenAPI document
   help             Display help
 ```
 

--- a/docs/doc-comments-guide.md
+++ b/docs/doc-comments-guide.md
@@ -4,12 +4,17 @@ A specification is not only about formalizing data structures, it's also about e
 
 Documentation of the TypeScript specification is made using [JSDoc](https://jsdoc.app/) comments, i.e. multiline comments starting with `/**` above a type or field declaration.
 
+The first phrase is used as the mandatory operation summary in the OpenAPI document.
+Refer to [API documentation guidelines](https://docs.elastic.dev/content-architecture/oas#summaries)
+NOTE: You must add a period at the end of the phrase for it to parse correctly, but the period will be properly omitted from the output OpenAPI document.
+
 Additional lines start with a `*` followed by a space. Long lines are allowed but it's better if text is formatted to a maximum of 120 characters per line.
 
 ## Example
 
 ```ts
 /**
+ * Get ranking evaluation.
  * Enables you to evaluate the quality of ranked search results over a set of typical search queries.
  * @rest_spec_name rank_eval
  * @availability stack since=6.2.0 stability=stable

--- a/docs/doc-comments-guide.md
+++ b/docs/doc-comments-guide.md
@@ -7,7 +7,8 @@ Documentation of the TypeScript specification is made using [JSDoc](https://jsdo
 The first phrase is used as the mandatory operation summary in the OpenAPI document.
 Refer to [API documentation guidelines](https://docs.elastic.dev/content-architecture/oas#summaries).
 
-NOTE: You must add a period at the end of the phrase for it to parse correctly, but the period will be properly omitted from the output OpenAPI document.
+NOTE: You must add a period or `\n` at the end of the phrase for it to parse correctly.
+The period will be properly omitted from the output OpenAPI document.
 
 Additional lines start with a `*` followed by a space. Long lines are allowed but it's better if text is formatted to a maximum of 120 characters per line.
 

--- a/docs/doc-comments-guide.md
+++ b/docs/doc-comments-guide.md
@@ -5,7 +5,8 @@ A specification is not only about formalizing data structures, it's also about e
 Documentation of the TypeScript specification is made using [JSDoc](https://jsdoc.app/) comments, i.e. multiline comments starting with `/**` above a type or field declaration.
 
 The first phrase is used as the mandatory operation summary in the OpenAPI document.
-Refer to [API documentation guidelines](https://docs.elastic.dev/content-architecture/oas#summaries)
+Refer to [API documentation guidelines](https://docs.elastic.dev/content-architecture/oas#summaries).
+
 NOTE: You must add a period at the end of the phrase for it to parse correctly, but the period will be properly omitted from the output OpenAPI document.
 
 Additional lines start with a `*` followed by a space. Long lines are allowed but it's better if text is formatted to a maximum of 120 characters per line.

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -11783,7 +11783,7 @@
         "tags": [
           "indices.get_index_template"
         ],
-        "summary": "Returns information about one or more index templates",
+        "summary": "Get index templates Returns information about one or more index templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html"
         },
@@ -12975,7 +12975,7 @@
         "tags": [
           "indices.get_index_template"
         ],
-        "summary": "Returns information about one or more index templates",
+        "summary": "Get index templates Returns information about one or more index templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html"
         },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -11783,7 +11783,8 @@
         "tags": [
           "indices.get_index_template"
         ],
-        "summary": "Get index templates Returns information about one or more index templates",
+        "summary": "Get index templates",
+        "description": "Returns information about one or more index templates.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html"
         },
@@ -11815,7 +11816,7 @@
         "tags": [
           "indices.put_index_template"
         ],
-        "summary": "Creates or updates an index template",
+        "summary": "Create or update an index template",
         "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-template.html"
@@ -11848,7 +11849,7 @@
         "tags": [
           "indices.put_index_template"
         ],
-        "summary": "Creates or updates an index template",
+        "summary": "Create or update an index template",
         "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-template.html"
@@ -11881,8 +11882,8 @@
         "tags": [
           "indices.delete_index_template"
         ],
-        "summary": "The provided <index-template> may contain multiple template names separated by a comma",
-        "description": "If multiple template names are specified then there is no wildcard support and the provided names should match completely with existing templates.",
+        "summary": "Delete an index template",
+        "description": "The provided <index-template> may contain multiple template names separated by a comma. If multiple template names are specified then there is no wildcard support and the provided names should match completely with existing templates.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-template.html"
         },
@@ -11980,7 +11981,8 @@
         "tags": [
           "indices.get_template"
         ],
-        "summary": "Retrieves information about one or more index templates",
+        "summary": "Get index templates",
+        "description": "Retrieves information about one or more index templates.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template-v1.html"
         },
@@ -12009,7 +12011,7 @@
         "tags": [
           "indices.put_template"
         ],
-        "summary": "Creates or updates an index template",
+        "summary": "Create or update an index template",
         "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html"
@@ -12045,7 +12047,7 @@
         "tags": [
           "indices.put_template"
         ],
-        "summary": "Creates or updates an index template",
+        "summary": "Create or update an index template",
         "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html"
@@ -12136,7 +12138,8 @@
         "tags": [
           "indices.exists_template"
         ],
-        "summary": "Returns information about whether a particular index template exists",
+        "summary": "Check existence of index templates",
+        "description": "Returns information about whether a particular index template exists.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-template-exists-v1.html"
         },
@@ -12975,7 +12978,8 @@
         "tags": [
           "indices.get_index_template"
         ],
-        "summary": "Get index templates Returns information about one or more index templates",
+        "summary": "Get index templates",
+        "description": "Returns information about one or more index templates.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html"
         },
@@ -13426,7 +13430,8 @@
         "tags": [
           "indices.get_template"
         ],
-        "summary": "Retrieves information about one or more index templates",
+        "summary": "Get index templates",
+        "description": "Retrieves information about one or more index templates.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template-v1.html"
         },
@@ -14355,7 +14360,7 @@
         "tags": [
           "indices.simulate_index_template"
         ],
-        "summary": "Simulate index",
+        "summary": "Simulate an index",
         "description": "Returns the index configuration that would be applied to the specified index from an existing index template.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-index.html"
@@ -14427,7 +14432,8 @@
         "tags": [
           "indices.simulate_template"
         ],
-        "summary": "Returns the index configuration that would be applied by a particular index template",
+        "summary": "Simulate an index template",
+        "description": "Returns the index configuration that would be applied by a particular index template.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html"
         },
@@ -14458,7 +14464,8 @@
         "tags": [
           "indices.simulate_template"
         ],
-        "summary": "Returns the index configuration that would be applied by a particular index template",
+        "summary": "Simulate an index template",
+        "description": "Returns the index configuration that would be applied by a particular index template.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html"
         },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -14355,6 +14355,8 @@
         "tags": [
           "indices.simulate_index_template"
         ],
+        "summary": "Simulate index",
+        "description": "Returns the index configuration that would be applied to the specified index from an existing index template.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-index.html"
         },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -7350,7 +7350,7 @@
         "tags": [
           "indices.get_index_template"
         ],
-        "summary": "Returns information about one or more index templates",
+        "summary": "Get index templates Returns information about one or more index templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html"
         },
@@ -7771,7 +7771,7 @@
         "tags": [
           "indices.get_index_template"
         ],
-        "summary": "Returns information about one or more index templates",
+        "summary": "Get index templates Returns information about one or more index templates",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html"
         },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -7350,7 +7350,8 @@
         "tags": [
           "indices.get_index_template"
         ],
-        "summary": "Get index templates Returns information about one or more index templates",
+        "summary": "Get index templates",
+        "description": "Returns information about one or more index templates.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html"
         },
@@ -7382,7 +7383,7 @@
         "tags": [
           "indices.put_index_template"
         ],
-        "summary": "Creates or updates an index template",
+        "summary": "Create or update an index template",
         "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-template.html"
@@ -7415,7 +7416,7 @@
         "tags": [
           "indices.put_index_template"
         ],
-        "summary": "Creates or updates an index template",
+        "summary": "Create or update an index template",
         "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-put-template.html"
@@ -7448,8 +7449,8 @@
         "tags": [
           "indices.delete_index_template"
         ],
-        "summary": "The provided <index-template> may contain multiple template names separated by a comma",
-        "description": "If multiple template names are specified then there is no wildcard support and the provided names should match completely with existing templates.",
+        "summary": "Delete an index template",
+        "description": "The provided <index-template> may contain multiple template names separated by a comma. If multiple template names are specified then there is no wildcard support and the provided names should match completely with existing templates.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-delete-template.html"
         },
@@ -7771,7 +7772,8 @@
         "tags": [
           "indices.get_index_template"
         ],
-        "summary": "Get index templates Returns information about one or more index templates",
+        "summary": "Get index templates",
+        "description": "Returns information about one or more index templates.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-template.html"
         },
@@ -8306,7 +8308,7 @@
         "tags": [
           "indices.put_template"
         ],
-        "summary": "Creates or updates an index template",
+        "summary": "Create or update an index template",
         "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html"
@@ -8342,7 +8344,7 @@
         "tags": [
           "indices.put_template"
         ],
-        "summary": "Creates or updates an index template",
+        "summary": "Create or update an index template",
         "description": "Index templates define settings, mappings, and aliases that can be applied automatically to new indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html"
@@ -8648,7 +8650,7 @@
         "tags": [
           "indices.simulate_index_template"
         ],
-        "summary": "Simulate index",
+        "summary": "Simulate an index",
         "description": "Returns the index configuration that would be applied to the specified index from an existing index template.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-index.html"
@@ -8720,7 +8722,8 @@
         "tags": [
           "indices.simulate_template"
         ],
-        "summary": "Returns the index configuration that would be applied by a particular index template",
+        "summary": "Simulate an index template",
+        "description": "Returns the index configuration that would be applied by a particular index template.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html"
         },
@@ -8751,7 +8754,8 @@
         "tags": [
           "indices.simulate_template"
         ],
-        "summary": "Returns the index configuration that would be applied by a particular index template",
+        "summary": "Simulate an index template",
+        "description": "Returns the index configuration that would be applied by a particular index template.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html"
         },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -8648,6 +8648,8 @@
         "tags": [
           "indices.simulate_index_template"
         ],
+        "summary": "Simulate index",
+        "description": "Returns the index configuration that would be applied to the specified index from an existing index template.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-index.html"
         },

--- a/specification/indices/delete_index_template/IndicesDeleteIndexTemplateRequest.ts
+++ b/specification/indices/delete_index_template/IndicesDeleteIndexTemplateRequest.ts
@@ -22,6 +22,7 @@ import { Names } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Delete an index template.
  * The provided <index-template> may contain multiple template names separated by a comma. If multiple template
  * names are specified then there is no wildcard support and the provided names should match completely with
  * existing templates.

--- a/specification/indices/exists_template/IndicesExistsTemplateRequest.ts
+++ b/specification/indices/exists_template/IndicesExistsTemplateRequest.ts
@@ -22,6 +22,8 @@ import { Names } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Check existence of index templates.
+ * Returns information about whether a particular index template exists.
  * @rest_spec_name indices.exists_template
  * @availability stack since=0.0.0 stability=stable
  */

--- a/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
+++ b/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
@@ -22,6 +22,7 @@ import { Name } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Get index templates
  * Returns information about one or more index templates.
  * @rest_spec_name indices.get_index_template
  * @availability stack since=7.9.0 stability=stable

--- a/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
+++ b/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
@@ -22,7 +22,7 @@ import { Name } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Get index templates
+ * Get index templates.
  * Returns information about one or more index templates.
  * @rest_spec_name indices.get_index_template
  * @availability stack since=7.9.0 stability=stable

--- a/specification/indices/get_template/IndicesGetTemplateRequest.ts
+++ b/specification/indices/get_template/IndicesGetTemplateRequest.ts
@@ -22,6 +22,7 @@ import { Names } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Get index templates.
  * Retrieves information about one or more index templates.
  * @rest_spec_name indices.get_template
  * @availability stack since=0.0.0 stability=stable

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
@@ -35,7 +35,7 @@ import { DataStreamLifecycle } from '@indices/_types/DataStreamLifecycle'
 import { Duration } from '@_types/Time'
 
 /**
- * Creates or updates an index template.
+ * Create or update an index template.
  * Index templates define settings, mappings, and aliases that can be applied automatically to new indices.
  * @rest_spec_name indices.put_index_template
  * @availability stack since=7.9.0 stability=stable

--- a/specification/indices/put_template/IndicesPutTemplateRequest.ts
+++ b/specification/indices/put_template/IndicesPutTemplateRequest.ts
@@ -27,7 +27,7 @@ import { Duration } from '@_types/Time'
 import { IndexSettings } from '@indices/_types/IndexSettings'
 
 /**
- * Creates or updates an index template.
+ * Create or update an index template.
  * Index templates define settings, mappings, and aliases that can be applied automatically to new indices.
  * @rest_spec_name indices.put_template
  * @availability stack since=0.0.0 stability=stable

--- a/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
+++ b/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
@@ -22,7 +22,8 @@ import { Name } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- *
+ * Simulate index.
+ * Returns the index configuration that would be applied to the specified index from an existing index template.
  * @rest_spec_name indices.simulate_index_template
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
+++ b/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
@@ -22,7 +22,7 @@ import { Name } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Simulate index.
+ * Simulate an index.
  * Returns the index configuration that would be applied to the specified index from an existing index template.
  * @rest_spec_name indices.simulate_index_template
  * @availability stack since=7.9.0 stability=stable

--- a/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
+++ b/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
@@ -25,6 +25,7 @@ import { DataStreamVisibility } from '@indices/_types/DataStream'
 import { long } from '@_types/Numeric'
 
 /**
+ * Simulate an index template.
  * Returns the index configuration that would be applied by a particular index template.
  * @rest_spec_name indices.simulate_template
  * @availability stack since=0.0.0 stability=stable


### PR DESCRIPTION
This PR adds the sumarries for the index template APIs (using text from the appropriate pages under https://www.elastic.co/guide/en/elasticsearch/reference/current/indices.html).

It also updates the `make lint-docs` command to lint all the `*.json` files in the output folder and updates the readme to include the other new make commands.