### PR TITLE
Maintain "behavior" meta-data in specification

### DIFF
--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -459,7 +459,8 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
       properties: new Array<model.Property>()
     }
 
-    hoistTypeAnnotations(type, declaration.getJsDocs())
+    const jsDocs = declaration.getJsDocs()
+    hoistTypeAnnotations(type, jsDocs)
 
     const variant = parseVariantNameTag(declaration.getJsDocs())
     if (typeof variant === 'string') {
@@ -532,7 +533,7 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
     if (Node.isClassDeclaration(declaration)) {
       for (const implement of declaration.getImplements()) {
         if (isKnownBehavior(implement)) {
-          type.behaviors = (type.behaviors ?? []).concat(modelBehaviors(implement))
+          type.behaviors = (type.behaviors ?? []).concat(modelBehaviors(implement, jsDocs))
         } else {
           type.implements = (type.implements ?? []).concat(modelImplements(implement))
         }

--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -213,7 +213,7 @@ export class Container extends VariantBase {
 export class Inherits {
   type: TypeName
   generics?: ValueOf[]
-  meta?: string[]
+  meta?: { [p: string]: string }
 }
 
 /**

--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -213,6 +213,11 @@ export class Container extends VariantBase {
 export class Inherits {
   type: TypeName
   generics?: ValueOf[]
+}
+
+export class Behavior {
+  type: TypeName
+  generics?: ValueOf[]
   meta?: { [p: string]: string }
 }
 
@@ -232,7 +237,7 @@ export class Interface extends BaseType {
   /**
    * Behaviors directly implemented by this interface
    */
-  behaviors?: Inherits[]
+  behaviors?: Behavior[]
 
   /**
    * Behaviors attached to this interface, coming from the interface itself (see `behaviors`)
@@ -276,7 +281,7 @@ export class Request extends BaseType {
    * that don't have a body.
    */
   body: Body
-  behaviors?: Inherits[]
+  behaviors?: Behavior[]
   attachedBehaviors?: string[]
 }
 
@@ -287,7 +292,7 @@ export class Response extends BaseType {
   kind: 'response'
   generics?: TypeName[]
   body: Body
-  behaviors?: Inherits[]
+  behaviors?: Behavior[]
   attachedBehaviors?: string[]
   exceptions?: ResponseException[]
 }

--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -213,6 +213,7 @@ export class Container extends VariantBase {
 export class Inherits {
   type: TypeName
   generics?: ValueOf[]
+  meta?: string[]
 }
 
 /**

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -414,7 +414,7 @@ export function modelImplements (node: ExpressionWithTypeArguments): model.Inher
  * A class could have multiple behaviors from multiple classes,
  * which are defined inside the node typeArguments.
  */
-export function modelBehaviors (node: ExpressionWithTypeArguments, jsDocs: JSDoc[]): model.Inherits {
+export function modelBehaviors (node: ExpressionWithTypeArguments, jsDocs: JSDoc[]): model.Behavior {
   const behaviorName = node.getExpression().getText()
   const generics = node.getTypeArguments().map(node => modelType(node))
 

--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -643,6 +643,13 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
       context.push('Behaviors')
       for (const parent of typeDef.behaviors) {
         validateTypeRef(parent.type, parent.generics, openGenerics)
+
+        if (parent.type.name === 'AdditionalProperty' && (parent.meta == null || parent.meta.length < 2 || parent.meta.length > 3)) {
+          modelError(`AdditionalProperty behavior for type '${fqn(typeDef.name)}' requires a 'behavior_meta' decorator with at least 2 arguments (name of name, name of value, description)`)
+        }
+        if (parent.type.name === 'AdditionalProperties' && (parent.meta == null || parent.meta.length !== 2)) {
+          modelError(`AdditionalProperties behavior for type '${fqn(typeDef.name)}' requires a 'behavior_meta' decorator with exactly 2 arguments (name, description)`)
+        }
       }
       context.pop()
     }

--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -644,11 +644,11 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
       for (const parent of typeDef.behaviors) {
         validateTypeRef(parent.type, parent.generics, openGenerics)
 
-        if (parent.type.name === 'AdditionalProperty' && (parent.meta == null || parent.meta.name == null || parent.meta.value == null)) {
-          modelError(`AdditionalProperty behavior for type '${fqn(typeDef.name)}' requires a 'behavior_meta' decorator with at least 2 arguments (name of name, name of value, description)`)
+        if (parent.type.name === 'AdditionalProperty' && (parent.meta == null || parent.meta.key == null || parent.meta.value == null)) {
+          modelError(`AdditionalProperty behavior for type '${fqn(typeDef.name)}' requires a 'behavior_meta' decorator with at least 2 arguments (key, value)`)
         }
-        if (parent.type.name === 'AdditionalProperties' && (parent.meta == null || parent.meta.name == null || parent.meta.description == null)) {
-          modelError(`AdditionalProperties behavior for type '${fqn(typeDef.name)}' requires a 'behavior_meta' decorator with exactly 2 arguments (name, description)`)
+        if (parent.type.name === 'AdditionalProperties' && (parent.meta == null || parent.meta.fieldname == null || parent.meta.description == null)) {
+          modelError(`AdditionalProperties behavior for type '${fqn(typeDef.name)}' requires a 'behavior_meta' decorator with exactly 2 arguments (fieldname, description)`)
         }
       }
       context.pop()

--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -644,10 +644,10 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
       for (const parent of typeDef.behaviors) {
         validateTypeRef(parent.type, parent.generics, openGenerics)
 
-        if (parent.type.name === 'AdditionalProperty' && (parent.meta == null || parent.meta.length < 2 || parent.meta.length > 3)) {
+        if (parent.type.name === 'AdditionalProperty' && (parent.meta == null || parent.meta.name == null || parent.meta.value == null)) {
           modelError(`AdditionalProperty behavior for type '${fqn(typeDef.name)}' requires a 'behavior_meta' decorator with at least 2 arguments (name of name, name of value, description)`)
         }
-        if (parent.type.name === 'AdditionalProperties' && (parent.meta == null || parent.meta.length !== 2)) {
+        if (parent.type.name === 'AdditionalProperties' && (parent.meta == null || parent.meta.name == null || parent.meta.description == null)) {
           modelError(`AdditionalProperties behavior for type '${fqn(typeDef.name)}' requires a 'behavior_meta' decorator with exactly 2 arguments (name, description)`)
         }
       }

--- a/docs/behaviors.md
+++ b/docs/behaviors.md
@@ -16,7 +16,7 @@ We therefore document the requirement to behave like a dictionary for unknown pr
 
 ```ts
 /**
- * @behavior_meta AdditionalProperties name=sub_aggregations
+ * @behavior_meta AdditionalProperties fieldname=sub_aggregations
  */
 class IpRangeBucket implements AdditionalProperties<AggregateName, Aggregate> {}
 ```
@@ -25,7 +25,7 @@ There are also many places where we expect only one runtime-defined property, su
 
 ```ts
 /**
- * @behavior_meta AdditionalProperty name=field value=bounding_box
+ * @behavior_meta AdditionalProperty key=field value=bounding_box
  */
 class GeoBoundingBoxQuery extends QueryBase
   implements AdditionalProperty<Field, BoundingBox>

--- a/docs/behaviors.md
+++ b/docs/behaviors.md
@@ -16,7 +16,7 @@ We therefore document the requirement to behave like a dictionary for unknown pr
 
 ```ts
 /**
- * @behavior_meta AdditionalProperties sub_aggregations
+ * @behavior_meta AdditionalProperties name=sub_aggregations
  */
 class IpRangeBucket implements AdditionalProperties<AggregateName, Aggregate> {}
 ```
@@ -25,7 +25,7 @@ There are also many places where we expect only one runtime-defined property, su
 
 ```ts
 /**
- * @behavior_meta AdditionalProperty field, bounding_box
+ * @behavior_meta AdditionalProperty name=field value=bounding_box
  */
 class GeoBoundingBoxQuery extends QueryBase
   implements AdditionalProperty<Field, BoundingBox>

--- a/docs/behaviors.md
+++ b/docs/behaviors.md
@@ -15,12 +15,18 @@ This puts it into a bin that needs a client specific solution.
 We therefore document the requirement to behave like a dictionary for unknown properties with this interface.
 
 ```ts
+/**
+ * @behavior_meta AdditionalProperties sub_aggregations
+ */
 class IpRangeBucket implements AdditionalProperties<AggregateName, Aggregate> {}
 ```
 
 There are also many places where we expect only one runtime-defined property, such as in field-related queries. To capture that uniqueness constraint, we can use the `AdditionalProperty` (singular) behavior.
 
 ```ts
+/**
+ * @behavior_meta AdditionalProperty field, bounding_box
+ */
 class GeoBoundingBoxQuery extends QueryBase
   implements AdditionalProperty<Field, BoundingBox>
 ```

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -99,7 +99,7 @@ export class TermSuggestOption {
 }
 
 /**
- * @behavior_meta AdditionalProperties name=suggesters description="The named suggesters"
+ * @behavior_meta AdditionalProperties fieldname=suggesters description="The named suggesters"
  */
 export class Suggester implements AdditionalProperties<string, FieldSuggester> {
   /** Global suggest text, to avoid repetition when the same text is used in several suggesters */

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -98,6 +98,9 @@ export class TermSuggestOption {
   collate_match?: boolean
 }
 
+/**
+ * @behavior_meta AdditionalProperties suggesters, "The named suggesters"
+ */
 export class Suggester implements AdditionalProperties<string, FieldSuggester> {
   /** Global suggest text, to avoid repetition when the same text is used in several suggesters */
   text?: string

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -99,7 +99,7 @@ export class TermSuggestOption {
 }
 
 /**
- * @behavior_meta AdditionalProperties suggesters, "The named suggesters"
+ * @behavior_meta AdditionalProperties name=suggesters description="The named suggesters"
  */
 export class Suggester implements AdditionalProperties<string, FieldSuggester> {
   /** Global suggest text, to avoid repetition when the same text is used in several suggesters */

--- a/specification/_types/Errors.ts
+++ b/specification/_types/Errors.ts
@@ -26,7 +26,7 @@ import { AdditionalProperties } from '@spec_utils/behaviors'
  * Cause and details about a request failure. This class defines the properties common to all error types.
  * Additional details are also provided, that depend on the error type.
  *
- * @behavior_meta AdditionalProperties name=metadata description="Additional details about the error"
+ * @behavior_meta AdditionalProperties fieldname=metadata description="Additional details about the error"
  */
 export class ErrorCause
   implements AdditionalProperties<string, UserDefinedValue>

--- a/specification/_types/Errors.ts
+++ b/specification/_types/Errors.ts
@@ -25,6 +25,8 @@ import { AdditionalProperties } from '@spec_utils/behaviors'
 /**
  * Cause and details about a request failure. This class defines the properties common to all error types.
  * Additional details are also provided, that depend on the error type.
+ *
+ * @behavior_meta AdditionalProperties metadata, "Additional details about the error"
  */
 export class ErrorCause
   implements AdditionalProperties<string, UserDefinedValue>

--- a/specification/_types/Errors.ts
+++ b/specification/_types/Errors.ts
@@ -26,7 +26,7 @@ import { AdditionalProperties } from '@spec_utils/behaviors'
  * Cause and details about a request failure. This class defines the properties common to all error types.
  * Additional details are also provided, that depend on the error type.
  *
- * @behavior_meta AdditionalProperties metadata, "Additional details about the error"
+ * @behavior_meta AdditionalProperties name=metadata description="Additional details about the error"
  */
 export class ErrorCause
   implements AdditionalProperties<string, UserDefinedValue>

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -331,7 +331,7 @@ export class MultiBucketAggregateBase<TBucket> extends AggregateBase {
 /**
  * Base type for multi-bucket aggregation results that can hold sub-aggregations results.
  *
- * @behavior_meta AdditionalProperties aggregations, "Nested aggregations"
+ * @behavior_meta AdditionalProperties name=aggregations description="Nested aggregations"
  */
 export class MultiBucketBase
   implements AdditionalProperties<AggregateName, Aggregate>
@@ -475,7 +475,7 @@ export class MultiTermsBucket extends MultiBucketBase {
 /**
  * Base type for single-bucket aggregation results that can hold sub-aggregations results.
  *
- * @behavior_meta AdditionalProperties aggregations, "Nested aggregations"
+ * @behavior_meta AdditionalProperties name=aggregations description="Nested aggregations"
  */
 export class SingleBucketAggregateBase
   extends AggregateBase
@@ -662,7 +662,7 @@ export class TopHitsAggregate extends AggregateBase {
 
 /**
  * @variant name=inference
- * @behavior_meta AdditionalProperties data, "Additional data"
+ * @behavior_meta AdditionalProperties name=data description="Additional data"
  */
 // This is a union with widely different fields, many of them being runtime-defined. We mimic below the few fields
 // present in `ParsedInference` with an additional properties spillover to not loose any data.

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -331,7 +331,7 @@ export class MultiBucketAggregateBase<TBucket> extends AggregateBase {
 /**
  * Base type for multi-bucket aggregation results that can hold sub-aggregations results.
  *
- * @behavior_meta AdditionalProperties name=aggregations description="Nested aggregations"
+ * @behavior_meta AdditionalProperties fieldname=aggregations description="Nested aggregations"
  */
 export class MultiBucketBase
   implements AdditionalProperties<AggregateName, Aggregate>
@@ -475,7 +475,7 @@ export class MultiTermsBucket extends MultiBucketBase {
 /**
  * Base type for single-bucket aggregation results that can hold sub-aggregations results.
  *
- * @behavior_meta AdditionalProperties name=aggregations description="Nested aggregations"
+ * @behavior_meta AdditionalProperties fieldname=aggregations description="Nested aggregations"
  */
 export class SingleBucketAggregateBase
   extends AggregateBase
@@ -662,7 +662,7 @@ export class TopHitsAggregate extends AggregateBase {
 
 /**
  * @variant name=inference
- * @behavior_meta AdditionalProperties name=data description="Additional data"
+ * @behavior_meta AdditionalProperties fieldname=data description="Additional data"
  */
 // This is a union with widely different fields, many of them being runtime-defined. We mimic below the few fields
 // present in `ParsedInference` with an additional properties spillover to not loose any data.

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -330,6 +330,8 @@ export class MultiBucketAggregateBase<TBucket> extends AggregateBase {
 
 /**
  * Base type for multi-bucket aggregation results that can hold sub-aggregations results.
+ *
+ * @behavior_meta AdditionalProperties aggregations, "Nested aggregations"
  */
 export class MultiBucketBase
   implements AdditionalProperties<AggregateName, Aggregate>
@@ -472,6 +474,8 @@ export class MultiTermsBucket extends MultiBucketBase {
 
 /**
  * Base type for single-bucket aggregation results that can hold sub-aggregations results.
+ *
+ * @behavior_meta AdditionalProperties aggregations, "Nested aggregations"
  */
 export class SingleBucketAggregateBase
   extends AggregateBase
@@ -656,7 +660,10 @@ export class TopHitsAggregate extends AggregateBase {
   hits: HitsMetadata<UserDefinedValue>
 }
 
-/** @variant name=inference */
+/**
+ * @variant name=inference
+ * @behavior_meta AdditionalProperties data, "Additional data"
+ */
 // This is a union with widely different fields, many of them being runtime-defined. We mimic below the few fields
 // present in `ParsedInference` with an additional properties spillover to not loose any data.
 export class InferenceAggregate

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -317,6 +317,9 @@ export enum WaitForEvents {
   languid
 }
 
+/**
+ * @behavior_meta AdditionalProperties metadata, "Document metadata"
+ */
 // Additional properties are the meta fields
 export class InlineGet<TDocument>
   implements AdditionalProperties<string, UserDefinedValue>

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -318,7 +318,7 @@ export enum WaitForEvents {
 }
 
 /**
- * @behavior_meta AdditionalProperties metadata, "Document metadata"
+ * @behavior_meta AdditionalProperties name=metadata description="Document metadata"
  */
 // Additional properties are the meta fields
 export class InlineGet<TDocument>

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -318,7 +318,7 @@ export enum WaitForEvents {
 }
 
 /**
- * @behavior_meta AdditionalProperties name=metadata description="Document metadata"
+ * @behavior_meta AdditionalProperties fieldname=metadata description="Document metadata"
  */
 // Additional properties are the meta fields
 export class InlineGet<TDocument>

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -179,14 +179,23 @@ export class DecayFunctionBase {
   multi_value_mode?: MultiValueMode
 }
 
+/**
+ * @behavior_meta AdditionalProperty field, placement
+ */
 export class NumericDecayFunction
   extends DecayFunctionBase
   implements AdditionalProperty<Field, DecayPlacement<double, double>> {}
 
+/**
+ * @behavior_meta AdditionalProperty field, placement
+ */
 export class DateDecayFunction
   extends DecayFunctionBase
   implements AdditionalProperty<Field, DecayPlacement<DateMath, Duration>> {}
 
+/**
+ * @behavior_meta AdditionalProperty field, placement
+ */
 export class GeoDecayFunction
   extends DecayFunctionBase
   implements AdditionalProperty<Field, DecayPlacement<GeoLocation, Distance>> {}

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -180,21 +180,21 @@ export class DecayFunctionBase {
 }
 
 /**
- * @behavior_meta AdditionalProperty field, placement
+ * @behavior_meta AdditionalProperty name=field value=placement
  */
 export class NumericDecayFunction
   extends DecayFunctionBase
   implements AdditionalProperty<Field, DecayPlacement<double, double>> {}
 
 /**
- * @behavior_meta AdditionalProperty field, placement
+ * @behavior_meta AdditionalProperty name=field value=placement
  */
 export class DateDecayFunction
   extends DecayFunctionBase
   implements AdditionalProperty<Field, DecayPlacement<DateMath, Duration>> {}
 
 /**
- * @behavior_meta AdditionalProperty field, placement
+ * @behavior_meta AdditionalProperty name=field value=placement
  */
 export class GeoDecayFunction
   extends DecayFunctionBase

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -180,21 +180,21 @@ export class DecayFunctionBase {
 }
 
 /**
- * @behavior_meta AdditionalProperty name=field value=placement
+ * @behavior_meta AdditionalProperty key=field value=placement
  */
 export class NumericDecayFunction
   extends DecayFunctionBase
   implements AdditionalProperty<Field, DecayPlacement<double, double>> {}
 
 /**
- * @behavior_meta AdditionalProperty name=field value=placement
+ * @behavior_meta AdditionalProperty key=field value=placement
  */
 export class DateDecayFunction
   extends DecayFunctionBase
   implements AdditionalProperty<Field, DecayPlacement<DateMath, Duration>> {}
 
 /**
- * @behavior_meta AdditionalProperty name=field value=placement
+ * @behavior_meta AdditionalProperty key=field value=placement
  */
 export class GeoDecayFunction
   extends DecayFunctionBase

--- a/specification/_types/query_dsl/geo.ts
+++ b/specification/_types/query_dsl/geo.ts
@@ -29,6 +29,9 @@ import {
 import { FieldLookup, QueryBase } from './abstractions'
 import { Field } from '@_types/common'
 
+/**
+ * @behavior_meta AdditionalProperty field, bounding_box
+ */
 export class GeoBoundingBoxQuery
   extends QueryBase
   implements AdditionalProperty<Field, GeoBounds>
@@ -54,6 +57,9 @@ export enum GeoExecution {
   indexed
 }
 
+/**
+ * @behavior_meta AdditionalProperty field, location
+ */
 export class GeoDistanceQuery
   extends QueryBase
   implements AdditionalProperty<Field, GeoLocation>
@@ -88,7 +94,10 @@ export class GeoPolygonPoints {
   points: GeoLocation[]
 }
 
-/** @deprecated 7.12.0 Use geo-shape instead. */
+/**
+ * @deprecated 7.12.0 Use geo-shape instead.
+ * @behavior_meta AdditionalProperty field, polygon
+ */
 export class GeoPolygonQuery
   extends QueryBase
   implements AdditionalProperty<Field, GeoPolygonPoints>
@@ -116,6 +125,9 @@ export class GeoShapeFieldQuery {
   relation?: GeoShapeRelation
 }
 
+/**
+ * @behavior_meta AdditionalProperty field, shape
+ */
 // GeoShape query doesn't follow the common pattern of having a single field-name property
 // holding also the query base fields (boost and _name)
 export class GeoShapeQuery

--- a/specification/_types/query_dsl/geo.ts
+++ b/specification/_types/query_dsl/geo.ts
@@ -30,7 +30,7 @@ import { FieldLookup, QueryBase } from './abstractions'
 import { Field } from '@_types/common'
 
 /**
- * @behavior_meta AdditionalProperty name=field value=bounding_box
+ * @behavior_meta AdditionalProperty key=field value=bounding_box
  */
 export class GeoBoundingBoxQuery
   extends QueryBase
@@ -58,7 +58,7 @@ export enum GeoExecution {
 }
 
 /**
- * @behavior_meta AdditionalProperty name=field value=location
+ * @behavior_meta AdditionalProperty key=field value=location
  */
 export class GeoDistanceQuery
   extends QueryBase
@@ -96,7 +96,7 @@ export class GeoPolygonPoints {
 
 /**
  * @deprecated 7.12.0 Use geo-shape instead.
- * @behavior_meta AdditionalProperty name=field value=polygon
+ * @behavior_meta AdditionalProperty key=field value=polygon
  */
 export class GeoPolygonQuery
   extends QueryBase
@@ -126,7 +126,7 @@ export class GeoShapeFieldQuery {
 }
 
 /**
- * @behavior_meta AdditionalProperty name=field value=shape
+ * @behavior_meta AdditionalProperty key=field value=shape
  */
 // GeoShape query doesn't follow the common pattern of having a single field-name property
 // holding also the query base fields (boost and _name)

--- a/specification/_types/query_dsl/geo.ts
+++ b/specification/_types/query_dsl/geo.ts
@@ -30,7 +30,7 @@ import { FieldLookup, QueryBase } from './abstractions'
 import { Field } from '@_types/common'
 
 /**
- * @behavior_meta AdditionalProperty field, bounding_box
+ * @behavior_meta AdditionalProperty name=field value=bounding_box
  */
 export class GeoBoundingBoxQuery
   extends QueryBase
@@ -58,7 +58,7 @@ export enum GeoExecution {
 }
 
 /**
- * @behavior_meta AdditionalProperty field, location
+ * @behavior_meta AdditionalProperty name=field value=location
  */
 export class GeoDistanceQuery
   extends QueryBase
@@ -96,7 +96,7 @@ export class GeoPolygonPoints {
 
 /**
  * @deprecated 7.12.0 Use geo-shape instead.
- * @behavior_meta AdditionalProperty field, polygon
+ * @behavior_meta AdditionalProperty name=field value=polygon
  */
 export class GeoPolygonQuery
   extends QueryBase
@@ -126,7 +126,7 @@ export class GeoShapeFieldQuery {
 }
 
 /**
- * @behavior_meta AdditionalProperty field, shape
+ * @behavior_meta AdditionalProperty name=field value=shape
  */
 // GeoShape query doesn't follow the common pattern of having a single field-name property
 // holding also the query base fields (boost and _name)

--- a/specification/_types/query_dsl/specialized.ts
+++ b/specification/_types/query_dsl/specialized.ts
@@ -340,7 +340,7 @@ export class ScriptScoreQuery extends QueryBase {
 }
 
 /**
- * @behavior_meta AdditionalProperty name=field value=shape
+ * @behavior_meta AdditionalProperty key=field value=shape
  */
 // Shape query doesn't follow the common pattern of having a single field-name property
 // holding also the query base fields (boost and _name)

--- a/specification/_types/query_dsl/specialized.ts
+++ b/specification/_types/query_dsl/specialized.ts
@@ -339,6 +339,9 @@ export class ScriptScoreQuery extends QueryBase {
   script: Script
 }
 
+/**
+ * @behavior_meta AdditionalProperty field, shape
+ */
 // Shape query doesn't follow the common pattern of having a single field-name property
 // holding also the query base fields (boost and _name)
 export class ShapeQuery

--- a/specification/_types/query_dsl/specialized.ts
+++ b/specification/_types/query_dsl/specialized.ts
@@ -340,7 +340,7 @@ export class ScriptScoreQuery extends QueryBase {
 }
 
 /**
- * @behavior_meta AdditionalProperty field, shape
+ * @behavior_meta AdditionalProperty name=field value=shape
  */
 // Shape query doesn't follow the common pattern of having a single field-name property
 // holding also the query base fields (boost and _name)

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -252,7 +252,7 @@ export class TermQuery extends QueryBase {
 }
 
 /**
- * @behavior_meta AdditionalProperty name=field value=term
+ * @behavior_meta AdditionalProperty key=field value=term
  */
 export class TermsQuery
   extends QueryBase

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -252,7 +252,7 @@ export class TermQuery extends QueryBase {
 }
 
 /**
- * @behavior_meta AdditionalProperty field, term
+ * @behavior_meta AdditionalProperty name=field value=term
  */
 export class TermsQuery
   extends QueryBase

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -251,6 +251,9 @@ export class TermQuery extends QueryBase {
   case_insensitive?: boolean
 }
 
+/**
+ * @behavior_meta AdditionalProperty field, term
+ */
 export class TermsQuery
   extends QueryBase
   implements AdditionalProperty<Field, TermsQueryField> {}

--- a/specification/_types/sort.ts
+++ b/specification/_types/sort.ts
@@ -55,6 +55,10 @@ export class FieldSort {
 export class ScoreSort {
   order?: SortOrder
 }
+
+/**
+ * @behavior_meta AdditionalProperty field, location
+ */
 export class GeoDistanceSort
   implements AdditionalProperty<Field, GeoLocation | GeoLocation[]>
 {
@@ -82,6 +86,7 @@ export enum ScriptSortType {
 /**
  * @doc_id sort-search-results
  * @variants container
+ * @behavior_meta AdditionalProperty field, sort
  */
 export class SortOptions implements AdditionalProperty<Field, FieldSort> {
   _score?: ScoreSort

--- a/specification/_types/sort.ts
+++ b/specification/_types/sort.ts
@@ -57,7 +57,7 @@ export class ScoreSort {
 }
 
 /**
- * @behavior_meta AdditionalProperty field, location
+ * @behavior_meta AdditionalProperty name=field value=location
  */
 export class GeoDistanceSort
   implements AdditionalProperty<Field, GeoLocation | GeoLocation[]>
@@ -86,7 +86,7 @@ export enum ScriptSortType {
 /**
  * @doc_id sort-search-results
  * @variants container
- * @behavior_meta AdditionalProperty field, sort
+ * @behavior_meta AdditionalProperty name=field value=sort
  */
 export class SortOptions implements AdditionalProperty<Field, FieldSort> {
   _score?: ScoreSort

--- a/specification/_types/sort.ts
+++ b/specification/_types/sort.ts
@@ -57,7 +57,7 @@ export class ScoreSort {
 }
 
 /**
- * @behavior_meta AdditionalProperty name=field value=location
+ * @behavior_meta AdditionalProperty key=field value=location
  */
 export class GeoDistanceSort
   implements AdditionalProperty<Field, GeoLocation | GeoLocation[]>
@@ -86,7 +86,7 @@ export enum ScriptSortType {
 /**
  * @doc_id sort-search-results
  * @variants container
- * @behavior_meta AdditionalProperty name=field value=sort
+ * @behavior_meta AdditionalProperty key=field value=sort
  */
 export class SortOptions implements AdditionalProperty<Field, FieldSort> {
   _score?: ScoreSort

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -69,7 +69,7 @@ export class RetentionLease {
 /**
  * @doc_id index-modules-settings
  *
- * @behavior_meta AdditionalProperties name=other_settings description="Additional settings not covered in this type."
+ * @behavior_meta AdditionalProperties fieldname=other_settings description="Additional settings not covered in this type."
  */
 export class IndexSettings
   implements AdditionalProperties<string, UserDefinedValue>

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -68,6 +68,8 @@ export class RetentionLease {
 
 /**
  * @doc_id index-modules-settings
+ *
+ * @behavior_meta AdditionalProperties other_settings, "Additional settings not covered in this type.
  */
 export class IndexSettings
   implements AdditionalProperties<string, UserDefinedValue>

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -69,7 +69,7 @@ export class RetentionLease {
 /**
  * @doc_id index-modules-settings
  *
- * @behavior_meta AdditionalProperties other_settings, "Additional settings not covered in this type.
+ * @behavior_meta AdditionalProperties name=other_settings description="Additional settings not covered in this type."
  */
 export class IndexSettings
   implements AdditionalProperties<string, UserDefinedValue>

--- a/specification/indices/analyze/types.ts
+++ b/specification/indices/analyze/types.ts
@@ -50,7 +50,7 @@ export class CharFilterDetail {
 
 // Additional properties are attributes that can be set by plugin-defined tokenizers
 /**
- * @behavior_meta AdditionalProperties attributes, "Additional tokenizer-specific attributes"
+ * @behavior_meta AdditionalProperties name=attributes description="Additional tokenizer-specific attributes"
  */
 export class ExplainAnalyzeToken
   implements AdditionalProperties<string, UserDefinedValue>

--- a/specification/indices/analyze/types.ts
+++ b/specification/indices/analyze/types.ts
@@ -49,6 +49,9 @@ export class CharFilterDetail {
 }
 
 // Additional properties are attributes that can be set by plugin-defined tokenizers
+/**
+ * @behavior_meta AdditionalProperties attributes, "Additional tokenizer-specific attributes"
+ */
 export class ExplainAnalyzeToken
   implements AdditionalProperties<string, UserDefinedValue>
 {

--- a/specification/indices/analyze/types.ts
+++ b/specification/indices/analyze/types.ts
@@ -50,7 +50,7 @@ export class CharFilterDetail {
 
 // Additional properties are attributes that can be set by plugin-defined tokenizers
 /**
- * @behavior_meta AdditionalProperties name=attributes description="Additional tokenizer-specific attributes"
+ * @behavior_meta AdditionalProperties fieldname=attributes description="Additional tokenizer-specific attributes"
  */
 export class ExplainAnalyzeToken
   implements AdditionalProperties<string, UserDefinedValue>

--- a/specification/indices/field_usage_stats/IndicesFieldUsageStatsResponse.ts
+++ b/specification/indices/field_usage_stats/IndicesFieldUsageStatsResponse.ts
@@ -30,7 +30,7 @@ export class Response {
 }
 
 /**
- * @behavior_meta AdditionalProperties stats, "Per index statistics"
+ * @behavior_meta AdditionalProperties name=stats description="Per index statistics"
  */
 export class FieldsUsageBody
   implements AdditionalProperties<IndexName, UsageStatsIndex>

--- a/specification/indices/field_usage_stats/IndicesFieldUsageStatsResponse.ts
+++ b/specification/indices/field_usage_stats/IndicesFieldUsageStatsResponse.ts
@@ -29,6 +29,9 @@ export class Response {
   body: FieldsUsageBody
 }
 
+/**
+ * @behavior_meta AdditionalProperties stats, "Per index statistics"
+ */
 export class FieldsUsageBody
   implements AdditionalProperties<IndexName, UsageStatsIndex>
 {

--- a/specification/indices/field_usage_stats/IndicesFieldUsageStatsResponse.ts
+++ b/specification/indices/field_usage_stats/IndicesFieldUsageStatsResponse.ts
@@ -30,7 +30,7 @@ export class Response {
 }
 
 /**
- * @behavior_meta AdditionalProperties name=stats description="Per index statistics"
+ * @behavior_meta AdditionalProperties fieldname=stats description="Per index statistics"
  */
 export class FieldsUsageBody
   implements AdditionalProperties<IndexName, UsageStatsIndex>

--- a/specification/indices/shard_stores/types.ts
+++ b/specification/indices/shard_stores/types.ts
@@ -28,7 +28,7 @@ export class IndicesShardStores {
 }
 
 /**
- * @behavior_meta AdditionalProperty node_id, node
+ * @behavior_meta AdditionalProperty name=node_id value=node
  */
 export class ShardStore implements AdditionalProperty<NodeId, ShardStoreNode> {
   allocation: ShardStoreAllocation

--- a/specification/indices/shard_stores/types.ts
+++ b/specification/indices/shard_stores/types.ts
@@ -27,6 +27,9 @@ export class IndicesShardStores {
   shards: Dictionary<string, ShardStoreWrapper>
 }
 
+/**
+ * @behavior_meta AdditionalProperty node_id, node
+ */
 export class ShardStore implements AdditionalProperty<NodeId, ShardStoreNode> {
   allocation: ShardStoreAllocation
   allocation_id?: Id

--- a/specification/indices/shard_stores/types.ts
+++ b/specification/indices/shard_stores/types.ts
@@ -28,7 +28,7 @@ export class IndicesShardStores {
 }
 
 /**
- * @behavior_meta AdditionalProperty name=node_id value=node
+ * @behavior_meta AdditionalProperty key=node_id value=node
  */
 export class ShardStore implements AdditionalProperty<NodeId, ShardStoreNode> {
   allocation: ShardStoreAllocation

--- a/specification/ingest/simulate/types.ts
+++ b/specification/ingest/simulate/types.ts
@@ -57,7 +57,7 @@ export class Document {
 /**
  * The simulated document, with optional metadata.
  *
- * @behavior_meta AdditionalProperties name=metadata description="Additional metadata"
+ * @behavior_meta AdditionalProperties fieldname=metadata description="Additional metadata"
  */
 export class DocumentSimulation
   implements AdditionalProperties<string, string>

--- a/specification/ingest/simulate/types.ts
+++ b/specification/ingest/simulate/types.ts
@@ -57,7 +57,7 @@ export class Document {
 /**
  * The simulated document, with optional metadata.
  *
- * @behavior_meta AdditionalProperties metadata, "Additional metadata"
+ * @behavior_meta AdditionalProperties name=metadata description="Additional metadata"
  */
 export class DocumentSimulation
   implements AdditionalProperties<string, string>

--- a/specification/ingest/simulate/types.ts
+++ b/specification/ingest/simulate/types.ts
@@ -56,6 +56,8 @@ export class Document {
 
 /**
  * The simulated document, with optional metadata.
+ *
+ * @behavior_meta AdditionalProperties metadata, "Additional metadata"
  */
 export class DocumentSimulation
   implements AdditionalProperties<string, string>

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -171,7 +171,7 @@ export class NodeInfoRepositoriesUrl {
 }
 
 /**
- * @behavior_meta AdditionalProperties settings, "Additional or alternative settings"
+ * @behavior_meta AdditionalProperties name=settings description="Additional or alternative settings"
  */
 export class NodeInfoDiscover
   implements AdditionalProperties<string, UserDefinedValue>

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -171,7 +171,7 @@ export class NodeInfoRepositoriesUrl {
 }
 
 /**
- * @behavior_meta AdditionalProperties name=settings description="Additional or alternative settings"
+ * @behavior_meta AdditionalProperties fieldname=settings description="Additional or alternative settings"
  */
 export class NodeInfoDiscover
   implements AdditionalProperties<string, UserDefinedValue>

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -170,6 +170,9 @@ export class NodeInfoRepositoriesUrl {
   allowed_urls: string
 }
 
+/**
+ * @behavior_meta AdditionalProperties settings, "Additional or alternative settings"
+ */
 export class NodeInfoDiscover
   implements AdditionalProperties<string, UserDefinedValue>
 {

--- a/specification/watcher/_types/Conditions.ts
+++ b/specification/watcher/_types/Conditions.ts
@@ -29,6 +29,9 @@ export class ArrayCompareOpParams {
   value: FieldValue
 }
 
+/**
+ * @behavior_meta AdditionalProperty operator, params
+ */
 export class ArrayCompareCondition
   implements AdditionalProperty<ConditionOp, ArrayCompareOpParams>
 {

--- a/specification/watcher/_types/Conditions.ts
+++ b/specification/watcher/_types/Conditions.ts
@@ -30,7 +30,7 @@ export class ArrayCompareOpParams {
 }
 
 /**
- * @behavior_meta AdditionalProperty operator, params
+ * @behavior_meta AdditionalProperty name=operator value=params
  */
 export class ArrayCompareCondition
   implements AdditionalProperty<ConditionOp, ArrayCompareOpParams>

--- a/specification/watcher/_types/Conditions.ts
+++ b/specification/watcher/_types/Conditions.ts
@@ -30,7 +30,7 @@ export class ArrayCompareOpParams {
 }
 
 /**
- * @behavior_meta AdditionalProperty name=operator value=params
+ * @behavior_meta AdditionalProperty key=operator value=params
  */
 export class ArrayCompareCondition
   implements AdditionalProperty<ConditionOp, ArrayCompareOpParams>

--- a/typescript-generator/src/metamodel.ts
+++ b/typescript-generator/src/metamodel.ts
@@ -213,7 +213,7 @@ export class Container extends VariantBase {
 export class Inherits {
   type: TypeName
   generics?: ValueOf[]
-  meta?: string[]
+  meta?: { [p: string]: string }
 }
 
 /**

--- a/typescript-generator/src/metamodel.ts
+++ b/typescript-generator/src/metamodel.ts
@@ -213,6 +213,11 @@ export class Container extends VariantBase {
 export class Inherits {
   type: TypeName
   generics?: ValueOf[]
+}
+
+export class Behavior {
+  type: TypeName
+  generics?: ValueOf[]
   meta?: { [p: string]: string }
 }
 
@@ -232,7 +237,7 @@ export class Interface extends BaseType {
   /**
    * Behaviors directly implemented by this interface
    */
-  behaviors?: Inherits[]
+  behaviors?: Behavior[]
 
   /**
    * Behaviors attached to this interface, coming from the interface itself (see `behaviors`)
@@ -276,7 +281,7 @@ export class Request extends BaseType {
    * that don't have a body.
    */
   body: Body
-  behaviors?: Inherits[]
+  behaviors?: Behavior[]
   attachedBehaviors?: string[]
 }
 
@@ -287,7 +292,7 @@ export class Response extends BaseType {
   kind: 'response'
   generics?: TypeName[]
   body: Body
-  behaviors?: Inherits[]
+  behaviors?: Behavior[]
   attachedBehaviors?: string[]
   exceptions?: ResponseException[]
 }

--- a/typescript-generator/src/metamodel.ts
+++ b/typescript-generator/src/metamodel.ts
@@ -213,6 +213,7 @@ export class Container extends VariantBase {
 export class Inherits {
   type: TypeName
   generics?: ValueOf[]
+  meta?: string[]
 }
 
 /**


### PR DESCRIPTION
Adds a new `behavior_meta` decorator that allows to specify supplementary meta-data per implemented behavior.

Closes #2637