### PR TITLE
[Query Rules] Update Query Rules API for 8.15

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -24523,6 +24523,183 @@
         }
       }
     },
+    "/_query_rules/{ruleset_id}/_rule/{rule_id}": {
+      "get": {
+        "tags": [
+          "query_rule.get"
+        ],
+        "summary": "Returns the details about a query rule within a query ruleset",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-rule.html"
+        },
+        "operationId": "query-rule-get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ruleset_id",
+            "description": "The unique identifier of the query ruleset containing the rule to retrieve",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "rule_id",
+            "description": "The unique identifier of the query rule within the specified ruleset to retrieve",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/query_ruleset._types:QueryRule"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "query_rule.put"
+        ],
+        "summary": "Creates or updates a query rule within a query ruleset",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-rule.html"
+        },
+        "operationId": "query-rule-put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ruleset_id",
+            "description": "The unique identifier of the query ruleset containing the rule to be created or updated",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "rule_id",
+            "description": "The unique identifier of the query rule within the specified ruleset to be created or updated",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "$ref": "#/components/schemas/query_ruleset._types:QueryRuleType"
+                  },
+                  "criteria": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/query_ruleset._types:QueryRuleCriteria"
+                    }
+                  },
+                  "actions": {
+                    "$ref": "#/components/schemas/query_ruleset._types:QueryRuleActions"
+                  }
+                },
+                "required": [
+                  "type",
+                  "criteria",
+                  "actions"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "$ref": "#/components/schemas/_types:Result"
+                    }
+                  },
+                  "required": [
+                    "result"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "query_rule.delete"
+        ],
+        "summary": "Deletes a query rule within a query ruleset",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-rule.html"
+        },
+        "operationId": "query-rule-delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ruleset_id",
+            "description": "The unique identifier of the query ruleset containing the rule to delete",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "rule_id",
+            "description": "The unique identifier of the query rule within the specified ruleset to delete",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_types:AcknowledgedResponseBase"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/_query_rules/{ruleset_id}": {
       "get": {
         "tags": [
@@ -56991,7 +57168,7 @@
             "minProperties": 1,
             "maxProperties": 1
           },
-          "rule_query": {
+          "rule": {
             "$ref": "#/components/schemas/_types.query_dsl:RuleQuery"
           },
           "script": {
@@ -60508,8 +60685,11 @@
               "organic": {
                 "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
               },
-              "ruleset_id": {
-                "$ref": "#/components/schemas/_types:Id"
+              "ruleset_ids": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/_types:Id"
+                }
               },
               "match_criteria": {
                 "type": "object"
@@ -60517,7 +60697,7 @@
             },
             "required": [
               "organic",
-              "ruleset_id",
+              "ruleset_ids",
               "match_criteria"
             ]
           }
@@ -92718,25 +92898,6 @@
           "aggregations"
         ]
       },
-      "query_ruleset._types:QueryRuleset": {
-        "type": "object",
-        "properties": {
-          "ruleset_id": {
-            "$ref": "#/components/schemas/_types:Id"
-          },
-          "rules": {
-            "description": "Rules associated with the query ruleset",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/query_ruleset._types:QueryRule"
-            }
-          }
-        },
-        "required": [
-          "ruleset_id",
-          "rules"
-        ]
-      },
       "query_ruleset._types:QueryRule": {
         "type": "object",
         "properties": {
@@ -92786,8 +92947,7 @@
           }
         },
         "required": [
-          "type",
-          "metadata"
+          "type"
         ]
       },
       "query_ruleset._types:QueryRuleCriteriaType": {
@@ -92802,7 +92962,8 @@
           "lt",
           "lte",
           "gt",
-          "gte"
+          "gte",
+          "always"
         ]
       },
       "query_ruleset._types:QueryRuleActions": {
@@ -92822,6 +92983,25 @@
           }
         }
       },
+      "query_ruleset._types:QueryRuleset": {
+        "type": "object",
+        "properties": {
+          "ruleset_id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "rules": {
+            "description": "Rules associated with the query ruleset",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/query_ruleset._types:QueryRule"
+            }
+          }
+        },
+        "required": [
+          "ruleset_id",
+          "rules"
+        ]
+      },
       "query_ruleset.list:QueryRulesetListItem": {
         "type": "object",
         "properties": {
@@ -92831,11 +93011,19 @@
           "rules_count": {
             "description": "The number of rules associated with this ruleset",
             "type": "number"
+          },
+          "rule_criteria_type_counts": {
+            "description": "A map of criteria type to the number of rules of that type",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         },
         "required": [
           "ruleset_id",
-          "rules_count"
+          "rules_count",
+          "rule_criteria_type_counts"
         ]
       },
       "_global.rank_eval:RankEvalRequestItem": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -93008,11 +93008,11 @@
           "ruleset_id": {
             "$ref": "#/components/schemas/_types:Id"
           },
-          "rules_count": {
+          "rule_total_count": {
             "description": "The number of rules associated with this ruleset",
             "type": "number"
           },
-          "rule_criteria_type_counts": {
+          "rule_criteria_types_counts": {
             "description": "A map of criteria type to the number of rules of that type",
             "type": "object",
             "additionalProperties": {
@@ -93022,8 +93022,8 @@
         },
         "required": [
           "ruleset_id",
-          "rules_count",
-          "rule_criteria_type_counts"
+          "rule_total_count",
+          "rule_criteria_types_counts"
         ]
       },
       "_global.rank_eval:RankEvalRequestItem": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -15211,6 +15211,183 @@
         }
       }
     },
+    "/_query_rules/{ruleset_id}/_rule/{rule_id}": {
+      "get": {
+        "tags": [
+          "query_rule.get"
+        ],
+        "summary": "Returns the details about a query rule within a query ruleset",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-rule.html"
+        },
+        "operationId": "query-rule-get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ruleset_id",
+            "description": "The unique identifier of the query ruleset containing the rule to retrieve",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "rule_id",
+            "description": "The unique identifier of the query rule within the specified ruleset to retrieve",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/query_ruleset._types:QueryRule"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "query_rule.put"
+        ],
+        "summary": "Creates or updates a query rule within a query ruleset",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-rule.html"
+        },
+        "operationId": "query-rule-put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ruleset_id",
+            "description": "The unique identifier of the query ruleset containing the rule to be created or updated",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "rule_id",
+            "description": "The unique identifier of the query rule within the specified ruleset to be created or updated",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "$ref": "#/components/schemas/query_ruleset._types:QueryRuleType"
+                  },
+                  "criteria": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/query_ruleset._types:QueryRuleCriteria"
+                    }
+                  },
+                  "actions": {
+                    "$ref": "#/components/schemas/query_ruleset._types:QueryRuleActions"
+                  }
+                },
+                "required": [
+                  "type",
+                  "criteria",
+                  "actions"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "result": {
+                      "$ref": "#/components/schemas/_types:Result"
+                    }
+                  },
+                  "required": [
+                    "result"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "query_rule.delete"
+        ],
+        "summary": "Deletes a query rule within a query ruleset",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-rule.html"
+        },
+        "operationId": "query-rule-delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ruleset_id",
+            "description": "The unique identifier of the query ruleset containing the rule to delete",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "rule_id",
+            "description": "The unique identifier of the query rule within the specified ruleset to delete",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_types:AcknowledgedResponseBase"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/_query_rules/{ruleset_id}": {
       "get": {
         "tags": [
@@ -34318,7 +34495,7 @@
             "minProperties": 1,
             "maxProperties": 1
           },
-          "rule_query": {
+          "rule": {
             "$ref": "#/components/schemas/_types.query_dsl:RuleQuery"
           },
           "script": {
@@ -37835,8 +38012,11 @@
               "organic": {
                 "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
               },
-              "ruleset_id": {
-                "$ref": "#/components/schemas/_types:Id"
+              "ruleset_ids": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/_types:Id"
+                }
               },
               "match_criteria": {
                 "type": "object"
@@ -37844,7 +38024,7 @@
             },
             "required": [
               "organic",
-              "ruleset_id",
+              "ruleset_ids",
               "match_criteria"
             ]
           }
@@ -59499,25 +59679,6 @@
           "position"
         ]
       },
-      "query_ruleset._types:QueryRuleset": {
-        "type": "object",
-        "properties": {
-          "ruleset_id": {
-            "$ref": "#/components/schemas/_types:Id"
-          },
-          "rules": {
-            "description": "Rules associated with the query ruleset",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/query_ruleset._types:QueryRule"
-            }
-          }
-        },
-        "required": [
-          "ruleset_id",
-          "rules"
-        ]
-      },
       "query_ruleset._types:QueryRule": {
         "type": "object",
         "properties": {
@@ -59567,8 +59728,7 @@
           }
         },
         "required": [
-          "type",
-          "metadata"
+          "type"
         ]
       },
       "query_ruleset._types:QueryRuleCriteriaType": {
@@ -59583,7 +59743,8 @@
           "lt",
           "lte",
           "gt",
-          "gte"
+          "gte",
+          "always"
         ]
       },
       "query_ruleset._types:QueryRuleActions": {
@@ -59603,6 +59764,25 @@
           }
         }
       },
+      "query_ruleset._types:QueryRuleset": {
+        "type": "object",
+        "properties": {
+          "ruleset_id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "rules": {
+            "description": "Rules associated with the query ruleset",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/query_ruleset._types:QueryRule"
+            }
+          }
+        },
+        "required": [
+          "ruleset_id",
+          "rules"
+        ]
+      },
       "query_ruleset.list:QueryRulesetListItem": {
         "type": "object",
         "properties": {
@@ -59612,11 +59792,19 @@
           "rules_count": {
             "description": "The number of rules associated with this ruleset",
             "type": "number"
+          },
+          "rule_criteria_type_counts": {
+            "description": "A map of criteria type to the number of rules of that type",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         },
         "required": [
           "ruleset_id",
-          "rules_count"
+          "rules_count",
+          "rule_criteria_type_counts"
         ]
       },
       "_global.rank_eval:RankEvalRequestItem": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -59789,11 +59789,11 @@
           "ruleset_id": {
             "$ref": "#/components/schemas/_types:Id"
           },
-          "rules_count": {
+          "rule_total_count": {
             "description": "The number of rules associated with this ruleset",
             "type": "number"
           },
-          "rule_criteria_type_counts": {
+          "rule_criteria_types_counts": {
             "description": "A map of criteria type to the number of rules of that type",
             "type": "object",
             "additionalProperties": {
@@ -59803,8 +59803,8 @@
         },
         "required": [
           "ruleset_id",
-          "rules_count",
-          "rule_criteria_type_counts"
+          "rule_total_count",
+          "rule_criteria_types_counts"
         ]
       },
       "_global.rank_eval:RankEvalRequestItem": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1350,6 +1350,12 @@
         "response definition _global.put_script:Response / body / instance_of - Non-leaf type cannot be used here: '_types:AcknowledgedResponseBase'"
       ]
     },
+    "query_rule.delete": {
+      "request": [],
+      "response": [
+        "response definition query_rule.delete:Response / body / instance_of - Non-leaf type cannot be used here: '_types:AcknowledgedResponseBase'"
+      ]
+    },
     "query_ruleset.delete": {
       "request": [],
       "response": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5948,7 +5948,7 @@ export interface QueryDslQueryContainer {
   range?: Partial<Record<Field, QueryDslRangeQuery>>
   rank_feature?: QueryDslRankFeatureQuery
   regexp?: Partial<Record<Field, QueryDslRegexpQuery | string>>
-  rule_query?: QueryDslRuleQuery
+  rule?: QueryDslRuleQuery
   script?: QueryDslScriptQuery
   script_score?: QueryDslScriptScoreQuery
   semantic?: QueryDslSemanticQuery
@@ -6053,7 +6053,7 @@ export interface QueryDslRegexpQuery extends QueryDslQueryBase {
 
 export interface QueryDslRuleQuery extends QueryDslQueryBase {
   organic: QueryDslQueryContainer
-  ruleset_id: Id
+  ruleset_ids: Id[]
   match_criteria: any
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16419,8 +16419,8 @@ export type QueryRulesetGetResponse = QueryRulesetQueryRuleset
 
 export interface QueryRulesetListQueryRulesetListItem {
   ruleset_id: Id
-  rules_count: integer
-  rule_criteria_type_counts: Record<string, string>
+  rule_total_count: integer
+  rule_criteria_types_counts: Record<string, string>
 }
 
 export interface QueryRulesetListRequest extends RequestBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16350,6 +16350,34 @@ export interface NodesUsageResponseBase extends NodesNodesResponseBase {
   nodes: Record<string, NodesUsageNodeUsage>
 }
 
+export interface QueryRuleDeleteRequest extends RequestBase {
+  ruleset_id: Id
+  rule_id: Id
+}
+
+export type QueryRuleDeleteResponse = AcknowledgedResponseBase
+
+export interface QueryRuleGetRequest extends RequestBase {
+  ruleset_id: Id
+  rule_id: Id
+}
+
+export type QueryRuleGetResponse = QueryRulesetQueryRule
+
+export interface QueryRulePutRequest extends RequestBase {
+  ruleset_id: Id
+  rule_id: Id
+  body?: {
+    type: QueryRulesetQueryRuleType
+    criteria: QueryRulesetQueryRuleCriteria[]
+    actions: QueryRulesetQueryRuleActions
+  }
+}
+
+export interface QueryRulePutResponse {
+  result: Result
+}
+
 export interface QueryRulesetQueryRule {
   rule_id: Id
   type: QueryRulesetQueryRuleType

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16392,11 +16392,11 @@ export interface QueryRulesetQueryRuleActions {
 
 export interface QueryRulesetQueryRuleCriteria {
   type: QueryRulesetQueryRuleCriteriaType
-  metadata: string
+  metadata?: string
   values?: any[]
 }
 
-export type QueryRulesetQueryRuleCriteriaType = 'global' | 'exact' | 'exact_fuzzy' | 'prefix' | 'suffix' | 'contains' | 'lt' | 'lte' | 'gt' | 'gte'
+export type QueryRulesetQueryRuleCriteriaType = 'global' | 'exact' | 'exact_fuzzy' | 'prefix' | 'suffix' | 'contains' | 'lt' | 'lte' | 'gt' | 'gte' | 'always'
 
 export type QueryRulesetQueryRuleType = 'pinned'
 
@@ -16420,6 +16420,7 @@ export type QueryRulesetGetResponse = QueryRulesetQueryRuleset
 export interface QueryRulesetListQueryRulesetListItem {
   ruleset_id: Id
   rules_count: integer
+  rule_criteria_type_counts: Record<string, string>
 }
 
 export interface QueryRulesetListRequest extends RequestBase {

--- a/specification/_json_spec/query_rule.delete.json
+++ b/specification/_json_spec/query_rule.delete.json
@@ -1,0 +1,31 @@
+{
+  "query_rule.delete": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-rule.html",
+      "description": "Deletes an individual query rule within a query ruleset."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_query_rules/{ruleset_id}/_rule/{rule_id}",
+          "methods": ["DELETE"],
+          "parts": {
+            "ruleset_id": {
+              "type": "string",
+              "description": "The unique identifier of the query ruleset containing the rule to delete"
+            },
+            "rule_id": {
+              "type": "string",
+              "description": "The unique identifier of the query rule to delete"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/specification/_json_spec/query_rule.get.json
+++ b/specification/_json_spec/query_rule.get.json
@@ -1,0 +1,31 @@
+{
+  "query_rule.get": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-rule.html",
+      "description": "Returns the details about an individual query rule within a query ruleset."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_query_rules/{ruleset_id}/_rule/{rule_id}",
+          "methods": ["GET"],
+          "parts": {
+            "ruleset_id": {
+              "type": "string",
+              "description": "The unique identifier of the query ruleset"
+            },
+            "rule_id": {
+              "type": "string",
+              "description": "The unique identifier of the query rule"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/specification/_json_spec/query_rule.put.json
+++ b/specification/_json_spec/query_rule.put.json
@@ -1,0 +1,36 @@
+{
+  "query_rule.put": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-rule.html",
+      "description": "Creates or updates an individual query rule within a query ruleset."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_query_rules/{ruleset_id}/_rule/{rule_id}",
+          "methods": ["PUT"],
+          "parts": {
+            "ruleset_id": {
+              "type": "string",
+              "description": "The unique identifier of the ruleset containing the rule to be created or updated."
+            },
+            "rule_id": {
+              "type": "string",
+              "description": "The unique identifier of the query rule to be created or updated."
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "The query rule",
+      "required": true
+    }
+  }
+}

--- a/specification/_json_spec/query_ruleset.delete.json
+++ b/specification/_json_spec/query_ruleset.delete.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-ruleset.html",
       "description": "Deletes a query ruleset."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/query_ruleset.get.json
+++ b/specification/_json_spec/query_ruleset.get.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-ruleset.html",
       "description": "Returns the details about a query ruleset."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/query_ruleset.list.json
+++ b/specification/_json_spec/query_ruleset.list.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-query-rulesets.html",
       "description": "Lists query rulesets."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/query_ruleset.put.json
+++ b/specification/_json_spec/query_ruleset.put.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-ruleset.html",
       "description": "Creates or updates a query ruleset."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"],

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -290,7 +290,7 @@ export class QueryContainer {
    * @doc_id query-dsl-regexp-query
    */
   regexp?: SingleKeyDictionary<Field, RegexpQuery>
-  rule_query?: RuleQuery
+  rule?: RuleQuery
   /**
    * Filters documents based on a provided script.
    * The script query is typically used in a filter context.

--- a/specification/_types/query_dsl/specialized.ts
+++ b/specification/_types/query_dsl/specialized.ts
@@ -368,6 +368,6 @@ export class ShapeFieldQuery {
 
 export class RuleQuery extends QueryBase {
   organic: QueryContainer
-  ruleset_id: Id
+  ruleset_ids: Id[]
   match_criteria: UserDefinedValue
 }

--- a/specification/query_rule/delete/QueryRuleDeleteRequest.ts
+++ b/specification/query_rule/delete/QueryRuleDeleteRequest.ts
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+
+/**
+ * Deletes a query rule within a query ruleset.
+ * @rest_spec_name query_rule.delete
+ * @availability stack since=8.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the query ruleset containing the rule to delete
+     */
+    ruleset_id: Id,
+
+    /**
+     * The unique identifier of the query rule within the specified ruleset to delete
+     */
+    rule_id: Id
+  }
+}

--- a/specification/query_rule/delete/QueryRuleDeleteRequest.ts
+++ b/specification/query_rule/delete/QueryRuleDeleteRequest.ts
@@ -30,7 +30,7 @@ export interface Request extends RequestBase {
     /**
      * The unique identifier of the query ruleset containing the rule to delete
      */
-    ruleset_id: Id,
+    ruleset_id: Id
 
     /**
      * The unique identifier of the query rule within the specified ruleset to delete

--- a/specification/query_rule/delete/QueryRuleDeleteResponse.ts
+++ b/specification/query_rule/delete/QueryRuleDeleteResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  body: AcknowledgedResponseBase
+}

--- a/specification/query_rule/get/QueryRuleGetRequest.ts
+++ b/specification/query_rule/get/QueryRuleGetRequest.ts
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+
+/**
+ * Returns the details about a query rule within a query ruleset
+ * @rest_spec_name query_rule.get
+ * @availability stack since=8.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the query ruleset containing the rule to retrieve
+     */
+    ruleset_id: Id,
+
+    /**
+     * The unique identifier of the query rule within the specified ruleset to retrieve
+     */
+    rule_id: Id,
+  }
+}

--- a/specification/query_rule/get/QueryRuleGetRequest.ts
+++ b/specification/query_rule/get/QueryRuleGetRequest.ts
@@ -30,11 +30,11 @@ export interface Request extends RequestBase {
     /**
      * The unique identifier of the query ruleset containing the rule to retrieve
      */
-    ruleset_id: Id,
+    ruleset_id: Id
 
     /**
      * The unique identifier of the query rule within the specified ruleset to retrieve
      */
-    rule_id: Id,
+    rule_id: Id
   }
 }

--- a/specification/query_rule/get/QueryRuleGetResponse.ts
+++ b/specification/query_rule/get/QueryRuleGetResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { QueryRule } from '../../query_ruleset/_types/QueryRuleset'
+
+export class Response {
+  body: QueryRule
+}

--- a/specification/query_rule/put/QueryRulePutRequest.ts
+++ b/specification/query_rule/put/QueryRulePutRequest.ts
@@ -18,7 +18,11 @@
  */
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
-import { QueryRuleType, QueryRuleCriteria, QueryRuleActions } from '../../query_ruleset/_types/QueryRuleset'
+import {
+  QueryRuleType,
+  QueryRuleCriteria,
+  QueryRuleActions
+} from '../../query_ruleset/_types/QueryRuleset'
 
 /**
  * Creates or updates a query rule within a query ruleset.
@@ -31,7 +35,7 @@ export interface Request extends RequestBase {
     /**
      * The unique identifier of the query ruleset containing the rule to be created or updated
      */
-    ruleset_id: Id,
+    ruleset_id: Id
 
     /**
      * The unique identifier of the query rule within the specified ruleset to be created or updated

--- a/specification/query_rule/put/QueryRulePutRequest.ts
+++ b/specification/query_rule/put/QueryRulePutRequest.ts
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+import { QueryRuleType, QueryRuleCriteria, QueryRuleActions } from '../../query_ruleset/_types/QueryRuleset'
+
+/**
+ * Creates or updates a query rule within a query ruleset.
+ * @rest_spec_name query_rule.put
+ * @availability stack since=8.15.0 stability=stable
+ * @availability serverless stability=stable visibility=public
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the query ruleset containing the rule to be created or updated
+     */
+    ruleset_id: Id,
+
+    /**
+     * The unique identifier of the query rule within the specified ruleset to be created or updated
+     */
+    rule_id: Id
+  }
+  /**
+   * The query rule information
+   */
+  /** @codegen_name query_rule */
+  body: {
+    type: QueryRuleType
+    criteria: QueryRuleCriteria[]
+    actions: QueryRuleActions
+  }
+}

--- a/specification/query_rule/put/QueryRulePutResponse.ts
+++ b/specification/query_rule/put/QueryRulePutResponse.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Result } from '@_types/Result'
+
+export class Response {
+  body: {
+    result: Result
+  }
+}

--- a/specification/query_ruleset/_types/QueryRuleset.ts
+++ b/specification/query_ruleset/_types/QueryRuleset.ts
@@ -47,7 +47,7 @@ export enum QueryRuleType {
 
 export class QueryRuleCriteria {
   type: QueryRuleCriteriaType
-  metadata: string
+  metadata?: string
   values?: UserDefinedValue[]
 }
 
@@ -61,7 +61,8 @@ export enum QueryRuleCriteriaType {
   lt,
   lte,
   gt,
-  gte
+  gte,
+  always
 }
 
 export class QueryRuleActions {

--- a/specification/query_ruleset/delete/QueryRulesetDeleteRequest.ts
+++ b/specification/query_ruleset/delete/QueryRulesetDeleteRequest.ts
@@ -22,8 +22,8 @@ import { Id } from '@_types/common'
 /**
  * Deletes a query ruleset.
  * @rest_spec_name query_ruleset.delete
- * @availability stack since=8.10.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/query_ruleset/get/QueryRulesetGetRequest.ts
+++ b/specification/query_ruleset/get/QueryRulesetGetRequest.ts
@@ -22,8 +22,8 @@ import { Id } from '@_types/common'
 /**
  * Returns the details about a query ruleset
  * @rest_spec_name query_ruleset.get
- * @availability stack since=8.10.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/query_ruleset/list/QueryRulesetListRequest.ts
+++ b/specification/query_ruleset/list/QueryRulesetListRequest.ts
@@ -22,8 +22,8 @@ import { integer } from '@_types/Numeric'
 /**
  * Returns summarized information about existing query rulesets.
  * @rest_spec_name query_ruleset.list
- * @availability stack since=8.10.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/query_ruleset/list/types.ts
+++ b/specification/query_ruleset/list/types.ts
@@ -28,10 +28,10 @@ export class QueryRulesetListItem {
   /**
    * The number of rules associated with this ruleset
    */
-  rules_count: integer
+  rule_total_count: integer
 
   /**
    * A map of criteria type to the number of rules of that type
    */
-  rule_criteria_type_counts: Dictionary<string, string>
+  rule_criteria_types_counts: Dictionary<string, string>
 }

--- a/specification/query_ruleset/list/types.ts
+++ b/specification/query_ruleset/list/types.ts
@@ -18,6 +18,7 @@
  */
 import { integer } from '@_types/Numeric'
 import { Id } from '@_types/common'
+import { Dictionary } from '@spec_utils/Dictionary'
 
 export class QueryRulesetListItem {
   /**
@@ -28,4 +29,9 @@ export class QueryRulesetListItem {
    * The number of rules associated with this ruleset
    */
   rules_count: integer
+
+  /**
+   * A map of criteria type to the number of rules of that type
+   */
+  rule_criteria_type_counts: Dictionary<string, string>
 }

--- a/specification/query_ruleset/put/QueryRulesetPutRequest.ts
+++ b/specification/query_ruleset/put/QueryRulesetPutRequest.ts
@@ -23,8 +23,8 @@ import { QueryRule } from '../_types/QueryRuleset'
 /**
  * Creates or updates a query ruleset.
  * @rest_spec_name query_ruleset.put
- * @availability stack since=8.10.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.10.0 stability=stable
+ * @availability serverless stability=stable visibility=public
  */
 export interface Request extends RequestBase {
   path_parts: {


### PR DESCRIPTION
The following changes are going live in 8.15 for query rules: 

- The feature is moving from Technical Preview to GA 
- The `rule_query` has been renamed to `rule` and support for multiple rulesets was added in https://github.com/elastic/elasticsearch/pull/108831
- A CRUD API for individual rule updates was added in https://github.com/elastic/elasticsearch/pull/109042 and https://github.com/elastic/elasticsearch/pull/109554
