### PR TITLE
Populate endpoint deprecation from request definition

### DIFF
--- a/compiler/src/index.ts
+++ b/compiler/src/index.ts
@@ -27,6 +27,7 @@ import addDescription from './steps/add-description'
 import validateModel from './steps/validate-model'
 import addContentType from './steps/add-content-type'
 import readDefinitionValidation from './steps/read-definition-validation'
+import addDeprecation from './steps/add-deprecation'
 
 const nvmrc = readFileSync(join(__dirname, '..', '..', '.nvmrc'), 'utf8')
 const nodejsMajor = process.version.split('.').shift()?.slice(1) ?? ''
@@ -67,6 +68,7 @@ const compiler = new Compiler(specsFolder, outputFolder)
 compiler
   .generateModel()
   .step(addInfo)
+  .step(addDeprecation)
   .step(addContentType)
   .step(readDefinitionValidation)
   .step(validateRestSpec)

--- a/compiler/src/steps/add-deprecation.ts
+++ b/compiler/src/steps/add-deprecation.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as model from '../model/metamodel'
+import { JsonSpec } from '../model/json-spec'
+
+/**
+ * Populates the `deprecation` field for endpoints from the value of the corresponding request definition.
+ */
+export default async function addContentType (model: model.Model, jsonSpec: Map<string, JsonSpec>): Promise<model.Model> {
+  for (const endpoint of model.endpoints) {
+    if (endpoint.deprecation != null) {
+      continue
+    }
+
+    if (endpoint.request == null) {
+      continue
+    }
+
+    const request = model.types.find(x => x.kind === 'request' && x.name === endpoint.request)
+    if (request == null) {
+      continue
+    }
+
+    if (request.deprecation == null) {
+      continue
+    }
+
+    endpoint.deprecation = request.deprecation
+  }
+
+  return model
+}

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -165,6 +165,9 @@ export class QueryContainer {
    * @doc_id query-dsl-geo-distance-query
    */
   geo_distance?: GeoDistanceQuery
+  /**
+   * @deprecated 7.12.0 Use geo-shape instead.
+   */
   geo_polygon?: GeoPolygonQuery
   /**
    * Filter documents indexed using either the `geo_shape` or the `geo_point` type.


### PR DESCRIPTION
Populates the `deprecation` field for endpoints from the value of the corresponding request definition.

Currently, the `deprecation` info is only available on the request type, but not on the corresponding endpoint.