### PR TITLE
Wrap ts-morph errors to provide helpful error

### DIFF
--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -483,14 +483,19 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
         const property = modelProperty(member)
         if (type.variants?.kind === 'container' && property.containerProperty == null) {
           assert(
-              member,
-              !property.required,
-              'All @variants container properties must be optional'
+            member,
+            !property.required,
+            'All @variants container properties must be optional'
           )
         }
         type.properties.push(property)
-      } catch(e) {
-        console.log(`failed to parse ${declaration.getName()}, reason:`, e.message)
+      } catch (e) {
+        const name = declaration.getName()
+        if (name !== undefined) {
+          console.log(`failed to parse ${name}, reason:`, e.message)
+        } else {
+          console.log('failed to parse field, reason:', e.message)
+        }
         process.exit(1)
       }
     }

--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -479,15 +479,20 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
         Node.isPropertyDeclaration(member) || Node.isPropertySignature(member),
         'Class and interfaces can only have property declarations or signatures'
       )
-      const property = modelProperty(member)
-      if (type.variants?.kind === 'container' && property.containerProperty == null) {
-        assert(
-          member,
-          !property.required,
-          'All @variants container properties must be optional'
-        )
+      try {
+        const property = modelProperty(member)
+        if (type.variants?.kind === 'container' && property.containerProperty == null) {
+          assert(
+              member,
+              !property.required,
+              'All @variants container properties must be optional'
+          )
+        }
+        type.properties.push(property)
+      } catch(e) {
+        console.log(`failed to parse ${declaration.getName()}, reason:`, e.message)
+        process.exit(1)
       }
-      type.properties.push(property)
     }
 
     // The class or interface is extended, an extended class or interface could

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -532,10 +532,15 @@ export function modelProperty (declaration: PropertySignature | PropertyDeclarat
 
   // names that contains `.` or `-` will be wrapped inside single quotes
   const name = declaration.getName().replace(/'/g, '')
-  const property = {
-    name,
-    required: !declaration.hasQuestionToken(),
-    type: modelType(type)
+  let property: model.Property
+  try {
+    property = {
+      name,
+      required: !declaration.hasQuestionToken(),
+      type: modelType(type)
+    }
+  } catch (e) {
+    throw new Error(`cannot determine type of ${name}, got:${type.getFullText()}`)
   }
   hoistPropertyAnnotations(property, declaration.getJsDocs())
   return property


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch-specification/commit/5828dc9eb34856ceee270c5e6be638e7a9fc9f10 we wrap the propagated error such that the message become:

`failed to parse SparseVectorQuery, reason: cannot determine type of query, got: String`