### PR TITLE
Fix 'Non-leaf type' errors in xpack

### DIFF
--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -744,22 +744,16 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
       switch (fqName) {
         // Base type also used as property, no polymorphic usage
         case '_builtins:ErrorCause':
-        case 'x_pack.enrich:EnrichPolicy':
-        case 'x_pack.info.x_pack_usage:XPackUsage':
-        case 'x_pack.info.x_pack_usage:SecurityFeatureToggle':
-        case 'x_pack.watcher.watcher_stats:WatchRecordQueuedStats':
-        case 'x_pack.security.user.get_user:XPackUser':
         case 'cluster.nodes_stats:MemoryStats':
         case 'search.search:SearchResponse':
+        case 'xpack.usage:Base':
+        case 'xpack.usage:Counter':
+        case 'xpack.usage:FeatureToggle':
           return
 
         // Have a "type" attribute that identifies the variant
         case 'mapping.types:PropertyBase':
         case 'analysis.token_filters:TokenFilterBase':
-          return
-
-        // Single subclass with no additional properties, can probably be removed
-        case 'x_pack.watcher.input:HttpInputRequestDefinition':
           return
       }
 

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1810,36 +1810,6 @@
         "request definition xpack.info:Request / query - Property 'human' is already defined in an ancestor class"
       ],
       "response": []
-    },
-    "xpack.usage": {
-      "request": [],
-      "response": [
-        "response definition xpack.usage:Response / body / Property 'aggregate_metric' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Base'",
-        "interface definition xpack.usage:WatcherWatch / Property 'input' / dictionary_of / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Counter'",
-        "interface definition xpack.usage:WatcherWatch / Property 'condition' / dictionary_of / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Counter'",
-        "interface definition xpack.usage:WatcherWatch / Property 'action' / dictionary_of / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Counter'",
-        "interface definition xpack.usage:WatcherWatchTriggerSchedule / Property 'cron' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Counter'",
-        "interface definition xpack.usage:WatcherWatchTriggerSchedule / Property '_all' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Counter'",
-        "interface definition xpack.usage:WatcherWatchTrigger / Property '_all' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Counter'",
-        "interface definition xpack.usage:Watcher / Property 'count' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Counter'",
-        "response definition xpack.usage:Response / body / Property 'data_frame' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Base'",
-        "response definition xpack.usage:Response / body / Property 'data_science' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Base'",
-        "response definition xpack.usage:Response / body / Property 'enrich' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Base'",
-        "response definition xpack.usage:Response / body / Property 'graph' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Base'",
-        "response definition xpack.usage:Response / body / Property 'logstash' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Base'",
-        "response definition xpack.usage:Response / body / Property 'rollup' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Base'",
-        "response definition xpack.usage:Response / body / Property 'spatial' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Base'",
-        "interface definition xpack.usage:Security / Property 'api_key_service' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:FeatureToggle'",
-        "interface definition xpack.usage:Security / Property 'anonymous' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:FeatureToggle'",
-        "interface definition xpack.usage:Security / Property 'fips_140' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:FeatureToggle'",
-        "interface definition xpack.usage:Ssl / Property 'http' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:FeatureToggle'",
-        "interface definition xpack.usage:Ssl / Property 'transport' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:FeatureToggle'",
-        "interface definition xpack.usage:Security / Property 'system_key' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:FeatureToggle'",
-        "interface definition xpack.usage:Security / Property 'token_service' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:FeatureToggle'",
-        "interface definition xpack.usage:Security / Property 'operator_privileges' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Base'",
-        "response definition xpack.usage:Response / body / Property 'transform' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Base'",
-        "response definition xpack.usage:Response / body / Property 'voting_only' / instance_of - Non-leaf type cannot be used here: 'xpack.usage:Base'"
-      ]
     }
   },
   "generalErrors": []


### PR DESCRIPTION
And also remove unused x_pack special cases. The namespace is named xpack now, so they did not have any effect.

This fixes around 25 validation errors. More generally, I'm not sure how useful those "Non-leaf type cannot be used here" errors really are. It's pretty common to use a class in a property and then subclass it to add more things, and then use that too.