### PR TITLE
Remove deprecated code

### DIFF
--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -44,7 +44,6 @@ import {
   modelBehaviors,
   modelEnumDeclaration,
   modelGenerics,
-  modelImplements,
   modelInherits,
   modelProperty,
   modelType,
@@ -77,8 +76,6 @@ export function compileEndpoints (): Record<string, model.Endpoint> {
           visibility: spec.visibility
         }
       },
-      stability: spec.stability,
-      visibility: spec.visibility,
       request: null,
       requestBodyRequired: Boolean(spec.body?.required),
       response: null,
@@ -91,7 +88,7 @@ export function compileEndpoints (): Record<string, model.Endpoint> {
       })
     }
     if (typeof spec.feature_flag === 'string') {
-      map[api].featureFlag = spec.feature_flag
+      map[api].availability.stack.featureFlag = spec.feature_flag
     }
   }
   return map
@@ -534,8 +531,6 @@ function compileClassOrInterfaceDeclaration (declaration: ClassDeclaration | Int
       for (const implement of declaration.getImplements()) {
         if (isKnownBehavior(implement)) {
           type.behaviors = (type.behaviors ?? []).concat(modelBehaviors(implement, jsDocs))
-        } else {
-          type.implements = (type.implements ?? []).concat(modelImplements(implement))
         }
       }
     }

--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -235,7 +235,6 @@ export class Interface extends BaseType {
    */
   generics?: TypeName[]
   inherits?: Inherits
-  implements?: Inherits[] // Unused!
 
   /**
    * Behaviors directly implemented by this interface
@@ -266,7 +265,6 @@ export class Request extends BaseType {
   generics?: TypeName[]
   /** The parent defines additional body properties that are added to the body, that has to be a PropertyBody */
   inherits?: Inherits
-  implements?: Inherits[]
   /** URL path properties */
   path: Property[]
   /** Query string properties */

--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -126,11 +126,9 @@ export class Property {
   description?: string
   docUrl?: string
   docId?: string
-  since?: string
   serverDefault?: boolean | string | number | string[] | number[]
   deprecation?: Deprecation
   availability?: Availabilities
-  stability?: Stability
   /**
    * If specified takes precedence over `name` when generating code. `name` is always the value
    * to be sent over the wire
@@ -237,7 +235,7 @@ export class Interface extends BaseType {
    */
   generics?: TypeName[]
   inherits?: Inherits
-  implements?: Inherits[]
+  implements?: Inherits[] // Unused!
 
   /**
    * Behaviors directly implemented by this interface
@@ -344,7 +342,6 @@ export class EnumMember {
   codegenName?: string
   description?: string
   deprecation?: Deprecation
-  since?: string
   availability?: Availabilities
 }
 
@@ -429,14 +426,6 @@ export class Endpoint {
 
   urls: UrlTemplate[]
 
-  /**
-   * The version when this endpoint reached its current stability level.
-   * Missing data means "forever", i.e. before any of the target client versions produced from this spec.
-   */
-  since?: string
-  stability?: Stability
-  visibility?: Visibility
-  featureFlag?: string
   requestMediaType?: string[]
   responseMediaType?: string[]
   privileges?: {

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -695,22 +695,6 @@ export function hoistRequestAnnotations (
       // Apply the availabilities to the Endpoint.
       for (const [availabilityName, availabilityValue] of Object.entries(availabilities)) {
         endpoint.availability[availabilityName] = availabilityValue
-
-        // Backfilling deprecated fields on an endpoint.
-        if (availabilityName === 'stack') {
-          if (availabilityValue.since !== undefined) {
-            endpoint.since = availabilityValue.since
-          }
-          if (availabilityValue.stability !== undefined) {
-            endpoint.stability = availabilityValue.stability
-          }
-          if (availabilityValue.visibility !== undefined) {
-            endpoint.visibility = availabilityValue.visibility
-          }
-          if (availabilityValue.featureFlag !== undefined) {
-            endpoint.featureFlag = availabilityValue.featureFlag
-          }
-        }
       }
     } else {
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on request ${request.name.name}`)
@@ -813,16 +797,6 @@ function hoistPropertyAnnotations (property: model.Property, jsDocs: JSDoc[]): v
       property.availability = {}
       for (const [availabilityName, availabilityValue] of Object.entries(availabilities)) {
         property.availability[availabilityName] = availabilityValue
-
-        // Backfilling deprecated fields on a property.
-        if (availabilityName === 'stack') {
-          if (availabilityValue.since !== undefined) {
-            property.since = availabilityValue.since
-          }
-          if (availabilityValue.stability !== undefined) {
-            property.stability = availabilityValue.stability
-          }
-        }
       }
     } else if (tag === 'doc_id') {
       assert(jsDocs, value.trim() !== '', `Property ${property.name}'s @doc_id is cannot be empty`)
@@ -924,13 +898,6 @@ function hoistEnumMemberAnnotations (member: model.EnumMember, jsDocs: JSDoc[]):
       member.availability = {}
       for (const [availabilityName, availabilityValue] of Object.entries(availabilities)) {
         member.availability[availabilityName] = availabilityValue
-
-        // Backfilling deprecated fields on a property.
-        if (availabilityName === 'stack') {
-          if (availabilityValue.since !== undefined) {
-            member.since = availabilityValue.since
-          }
-        }
       }
     } else {
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on enum member ${member.name}`)

--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -135,8 +135,8 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
   const parentTypes = new Set<string>()
   for (const type of apiModel.types) {
     if (type.kind === 'request' || type.kind === 'interface') {
-      for (const parent of (type.implements ?? []).concat(type.inherits ?? [])) {
-        parentTypes.add(fqn(parent.type))
+      if (type.inherits != null) {
+        parentTypes.add(fqn(type.inherits.type))
       }
     }
   }
@@ -380,7 +380,6 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     const openGenerics = openGenericSet(typeDef)
 
     validateInherits(typeDef.inherits, openGenerics)
-    validateImplements(typeDef.implements, openGenerics)
     validateBehaviors(typeDef, openGenerics)
 
     // Note: we validate codegen_name/name uniqueness independently in the path, query and body as there are some
@@ -495,7 +494,6 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
       if (typeDef.inherits != null) {
         addInherits(typeDef.inherits)
       }
-      typeDef.implements?.forEach(addInherits)
       typeDef.behaviors?.forEach(addInherits)
     }
 
@@ -505,7 +503,6 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
   function validateInterface (typeDef: model.Interface): void {
     const openGenerics = openGenericSet(typeDef)
 
-    validateImplements(typeDef.implements, openGenerics)
     validateInherits(typeDef.inherits, openGenerics)
     validateBehaviors(typeDef, openGenerics)
     validateProperties(typeDef.properties, openGenerics, inheritedProperties(typeDef))
@@ -694,16 +691,6 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     context.pop()
   }
 
-  function validateImplements (parents: (model.Inherits[] | undefined), openGenerics: Set<string>): void {
-    if (parents == null || parents.length === 0) return
-
-    context.push('Implements')
-    for (const parent of parents) {
-      validateTypeRef(parent.type, parent.generics, openGenerics)
-    }
-    context.pop()
-  }
-
   function validateBehaviors (typeDef: model.Request | model.Response | model.Interface, openGenerics: Set<string>): void {
     if (typeDef.kind !== 'response' && typeDef.behaviors != null && typeDef.behaviors.length > 0) {
       context.push('Behaviors')
@@ -746,11 +733,10 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     }
 
     // Does a parent have this behavior?
-    const parents = (type.implements ?? []).concat(type.inherits ?? [])
-    for (const parent of parents) {
-      const parentDef = getTypeDef(parent.type)
+    if (type.inherits != null) {
+      const parentDef = getTypeDef(type.inherits.type)
       if (parentDef == null) {
-        modelError(`No type definition for parent '${fqn(parent.type)}'`)
+        modelError(`No type definition for parent '${fqn(type.inherits.type)}'`)
         return false
       }
       if (parentDef.kind === 'request' || parentDef.kind === 'interface') {

--- a/compiler/src/transform/filter-by-availability.ts
+++ b/compiler/src/transform/filter-by-availability.ts
@@ -131,9 +131,6 @@ function filterModel (inputModel: Model, stack: boolean, serverless: boolean, vi
       if (typeDef.inherits !== undefined) {
         addTypeToOutput(typeDef.inherits.type)
       }
-      typeDef.implements?.forEach((implemented) => {
-        addTypeToOutput(implemented.type)
-      })
     }
 
     // handle body value and body properties for request and response

--- a/compiler/test/request-availability/test.ts
+++ b/compiler/test/request-availability/test.ts
@@ -35,9 +35,4 @@ test('Request @availability can fulfill all the fields', t => {
     stack: { stability: 'beta', visibility: 'feature_flag', featureFlag: 'abc', since: '1.2.3' },
     serverless: { visibility: 'private', stability: 'experimental' }
   });
-  // Assert backfilled values are correct
-  t.true(endpoint?.visibility === 'feature_flag');
-  t.true(endpoint?.stability === 'beta');
-  t.true(endpoint?.featureFlag === 'abc');
-  t.true(endpoint?.since === '1.2.3');
 })

--- a/typescript-generator/src/index.ts
+++ b/typescript-generator/src/index.ts
@@ -160,16 +160,15 @@ function buildGenerics (types: M.ValueOf[] | M.TypeName[] | undefined, openGener
 
 function buildInherits (type: M.Interface | M.Request, openGenerics?: string[]): string {
   const inherits = (type.inherits != null ? [type.inherits] : []).filter(type => !skipBehaviors.includes(type.type.name))
-  const interfaces = (type.implements ?? []).filter(type => !skipBehaviors.includes(type.type.name))
   const behaviors = (type.behaviors ?? []).filter(type => !skipBehaviors.includes(type.type.name))
-  const extendAll = inherits.concat(interfaces).concat(behaviors)
+  const extendAll = inherits.concat(behaviors)
     // do not extend from empty interfaces
     .filter(inherit => {
       for (const type of model.types) {
         if (inherit.type.name === type.name.name && inherit.type.namespace === type.name.namespace) {
           switch (type.kind) {
             case 'interface':
-              return type.properties.length > 0 || type.inherits != null || type.implements != null || type.behaviors != null || type.generics != null
+              return type.properties.length > 0 || type.inherits != null || type.behaviors != null || type.generics != null
             case 'request':
             case 'response':
               return true

--- a/typescript-generator/src/metamodel.ts
+++ b/typescript-generator/src/metamodel.ts
@@ -235,7 +235,6 @@ export class Interface extends BaseType {
    */
   generics?: TypeName[]
   inherits?: Inherits
-  implements?: Inherits[] // Unused!
 
   /**
    * Behaviors directly implemented by this interface
@@ -266,7 +265,6 @@ export class Request extends BaseType {
   generics?: TypeName[]
   /** The parent defines additional body properties that are added to the body, that has to be a PropertyBody */
   inherits?: Inherits
-  implements?: Inherits[]
   /** URL path properties */
   path: Property[]
   /** Query string properties */

--- a/typescript-generator/src/metamodel.ts
+++ b/typescript-generator/src/metamodel.ts
@@ -126,11 +126,9 @@ export class Property {
   description?: string
   docUrl?: string
   docId?: string
-  since?: string
   serverDefault?: boolean | string | number | string[] | number[]
   deprecation?: Deprecation
   availability?: Availabilities
-  stability?: Stability
   /**
    * If specified takes precedence over `name` when generating code. `name` is always the value
    * to be sent over the wire
@@ -237,7 +235,7 @@ export class Interface extends BaseType {
    */
   generics?: TypeName[]
   inherits?: Inherits
-  implements?: Inherits[]
+  implements?: Inherits[] // Unused!
 
   /**
    * Behaviors directly implemented by this interface
@@ -344,7 +342,6 @@ export class EnumMember {
   codegenName?: string
   description?: string
   deprecation?: Deprecation
-  since?: string
   availability?: Availabilities
 }
 
@@ -429,14 +426,6 @@ export class Endpoint {
 
   urls: UrlTemplate[]
 
-  /**
-   * The version when this endpoint reached its current stability level.
-   * Missing data means "forever", i.e. before any of the target client versions produced from this spec.
-   */
-  since?: string
-  stability?: Stability
-  visibility?: Visibility
-  featureFlag?: string
   requestMediaType?: string[]
   responseMediaType?: string[]
   privileges?: {


### PR DESCRIPTION
Removes some deprecated fields which got replaced by `availability` a long time ago.

@elastic/devtools-team Please check, if your generator correctly uses the new `availability` field instead of the legacy ones.