### PR TITLE
Add missing type for ignore_dynamic_beyond_limit for the Indices Settings API

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -72601,6 +72601,10 @@
           "limit": {
             "description": "The maximum number of fields in an index. Field and object mappings, as well as field aliases count towards this limit.\nThe limit is in place to prevent mappings and searches from becoming too large. Higher values can lead to performance\ndegradations and memory issues, especially in clusters with a high load or few resources.",
             "type": "number"
+          },
+          "ignore_dynamic_beyond_limit": {
+            "description": "A flag to ignore fields beyond the limit set for the maximum number of fields in an index.\nIf set to true, fields exceeding the limit will be ignored instead of causing an error.\nThis can be useful in scenarios where the data is dynamic and, it's acceptable to overlook extra fields.\nHowever, use this setting with caution as ignoring additional fields might lead to loss of data or unexpected search results.",
+            "type": "boolean"
           }
         }
       },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -72603,7 +72603,7 @@
             "type": "number"
           },
           "ignore_dynamic_beyond_limit": {
-            "description": "A flag to ignore fields beyond the limit set for the maximum number of fields in an index.\nIf set to true, fields exceeding the limit will be ignored instead of causing an error.\nThis can be useful in scenarios where the data is dynamic and, it's acceptable to overlook extra fields.\nHowever, use this setting with caution as ignoring additional fields might lead to loss of data or unexpected search results.",
+            "description": "This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set\nto false (the default), the index request of the document that tries to add a dynamic field to the mapping will fail\nwith the message Limit of total fields [X] has been exceeded. When set to true, the index request will not fail.\nInstead, fields that would exceed the limit are not added to the mapping, similar to dynamic: false.\nThe fields that were not added to the mapping will be added to the _ignored field.",
             "type": "boolean"
           }
         }

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -47611,7 +47611,7 @@
             "type": "number"
           },
           "ignore_dynamic_beyond_limit": {
-            "description": "A flag to ignore fields beyond the limit set for the maximum number of fields in an index.\nIf set to true, fields exceeding the limit will be ignored instead of causing an error.\nThis can be useful in scenarios where the data is dynamic and, it's acceptable to overlook extra fields.\nHowever, use this setting with caution as ignoring additional fields might lead to loss of data or unexpected search results.",
+            "description": "This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set\nto false (the default), the index request of the document that tries to add a dynamic field to the mapping will fail\nwith the message Limit of total fields [X] has been exceeded. When set to true, the index request will not fail.\nInstead, fields that would exceed the limit are not added to the mapping, similar to dynamic: false.\nThe fields that were not added to the mapping will be added to the _ignored field.",
             "type": "boolean"
           }
         }

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -47609,6 +47609,10 @@
           "limit": {
             "description": "The maximum number of fields in an index. Field and object mappings, as well as field aliases count towards this limit.\nThe limit is in place to prevent mappings and searches from becoming too large. Higher values can lead to performance\ndegradations and memory issues, especially in clusters with a high load or few resources.",
             "type": "number"
+          },
+          "ignore_dynamic_beyond_limit": {
+            "description": "A flag to ignore fields beyond the limit set for the maximum number of fields in an index.\nIf set to true, fields exceeding the limit will be ignored instead of causing an error.\nThis can be useful in scenarios where the data is dynamic and, it's acceptable to overlook extra fields.\nHowever, use this setting with caution as ignoring additional fields might lead to loss of data or unexpected search results.",
+            "type": "boolean"
           }
         }
       },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10632,6 +10632,7 @@ export interface IndicesMappingLimitSettingsNestedObjects {
 
 export interface IndicesMappingLimitSettingsTotalFields {
   limit?: long
+  ignore_dynamic_beyond_limit?: boolean
 }
 
 export interface IndicesMerge {

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -430,10 +430,11 @@ export class MappingLimitSettingsTotalFields {
    */
   limit?: long
   /**
-   * A flag to ignore fields beyond the limit set for the maximum number of fields in an index.
-   * If set to true, fields exceeding the limit will be ignored instead of causing an error.
-   * This can be useful in scenarios where the data is dynamic and, it's acceptable to overlook extra fields.
-   * However, use this setting with caution as ignoring additional fields might lead to loss of data or unexpected search results.
+   * This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set
+   * to false (the default), the index request of the document that tries to add a dynamic field to the mapping will fail
+   * with the message Limit of total fields [X] has been exceeded. When set to true, the index request will not fail.
+   * Instead, fields that would exceed the limit are not added to the mapping, similar to dynamic: false.
+   * The fields that were not added to the mapping will be added to the _ignored field.
    * @server_default false
    */
   ignore_dynamic_beyond_limit?: boolean

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -429,6 +429,14 @@ export class MappingLimitSettingsTotalFields {
    * @server_default 1000
    */
   limit?: long
+  /**
+   * A flag to ignore fields beyond the limit set for the maximum number of fields in an index.
+   * If set to true, fields exceeding the limit will be ignored instead of causing an error.
+   * This can be useful in scenarios where the data is dynamic and, it's acceptable to overlook extra fields.
+   * However, use this setting with caution as ignoring additional fields might lead to loss of data or unexpected search results.
+   * @server_default false
+   */
+  ignore_dynamic_beyond_limit?: boolean
 }
 
 export class MappingLimitSettingsDepth {


### PR DESCRIPTION
## Summary

The Index Settings API returns an additional optional field called `ignore_dynamic_beyond_limit`.
The Type definition for the same was missing in the specifications. Hence as part of this PR added.

## Full API details from the edge-lite server

`Request`
```
GET /logs-endpoint.alerts-default/_settings
```

`Response`
```
{
  ".ds-logs-endpoint.alerts-default-2024.06.24-000001": {
    "settings": {
      "index": {
        "mapping": {
          "nested_fields": {
            "limit": "80"
          },
          "total_fields": {
            "limit": "5000",
            "ignore_dynamic_beyond_limit": "true"
          },
          "ignore_malformed": "true"
        },
        "hidden": "true",
        "provided_name": ".ds-logs-endpoint.alerts-default-2024.06.24-000001",
        "final_pipeline": ".fleet_final_pipeline-1",
        "creation_date": "1719193327497",
        "number_of_replicas": "1",
        "uuid": "GnzWPltpSHKtwnyC3QdH2Q",
        "version": {
          "created": "8508000"
        },
        "lifecycle": {
          "name": "logs"
        },
        "codec": "best_compression",
        "routing": {
          "allocation": {
            "include": {
              "_tier_preference": "data_hot"
            }
          }
        },
        "number_of_shards": "1",
        "default_pipeline": "logs-endpoint.alerts-8.14.0"
      }
    }
  }
}
```