### PR TITLE
[Backport 8.14] Add missing index setting ignore_dynamic_beyond_limit

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -47350,6 +47350,10 @@
           "limit": {
             "description": "The maximum number of fields in an index. Field and object mappings, as well as field aliases count towards this limit.\nThe limit is in place to prevent mappings and searches from becoming too large. Higher values can lead to performance\ndegradations and memory issues, especially in clusters with a high load or few resources.",
             "type": "number"
+          },
+          "ignore_dynamic_beyond_limit": {
+            "description": "This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set\nto false (the default), the index request of the document that tries to add a dynamic field to the mapping will fail\nwith the message Limit of total fields [X] has been exceeded. When set to true, the index request will not fail.\nInstead, fields that would exceed the limit are not added to the mapping, similar to dynamic: false.\nThe fields that were not added to the mapping will be added to the _ignored field.",
+            "type": "boolean"
           }
         }
       },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10602,6 +10602,7 @@ export interface IndicesMappingLimitSettingsNestedObjects {
 
 export interface IndicesMappingLimitSettingsTotalFields {
   limit?: long
+  ignore_dynamic_beyond_limit?: boolean
 }
 
 export interface IndicesMerge {

--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -429,6 +429,15 @@ export class MappingLimitSettingsTotalFields {
    * @server_default 1000
    */
   limit?: long
+  /**
+   * This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set
+   * to false (the default), the index request of the document that tries to add a dynamic field to the mapping will fail
+   * with the message Limit of total fields [X] has been exceeded. When set to true, the index request will not fail.
+   * Instead, fields that would exceed the limit are not added to the mapping, similar to dynamic: false.
+   * The fields that were not added to the mapping will be added to the _ignored field.
+   * @server_default false
+   */
+  ignore_dynamic_beyond_limit?: boolean
 }
 
 export class MappingLimitSettingsDepth {


### PR DESCRIPTION
(cherry picked from commit 084db754215a47db52b5c288629a21f1737c9081 from #2653)

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
