### PR TITLE
Update rest-api-spec

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -577,6 +577,12 @@
       ],
       "response": []
     },
+    "connector.sync_job_claim": {
+      "request": [
+        "Missing request & response"
+      ],
+      "response": []
+    },
     "connector.sync_job_error": {
       "request": [
         "Missing request & response"
@@ -584,6 +590,12 @@
       "response": []
     },
     "connector.sync_job_update_stats": {
+      "request": [
+        "Missing request & response"
+      ],
+      "response": []
+    },
+    "connector.update_features": {
       "request": [
         "Missing request & response"
       ],
@@ -648,6 +660,12 @@
       ]
     },
     "features.get_features": {
+      "request": [
+        "Request: missing json spec query parameter 'master_timeout'"
+      ],
+      "response": []
+    },
+    "features.reset_features": {
       "request": [
         "Request: missing json spec query parameter 'master_timeout'"
       ],
@@ -900,12 +918,6 @@
       ],
       "response": []
     },
-    "ml.get_categories": {
-      "request": [
-        "Url path '/_ml/anomaly_detectors/{job_id}/results/categories/' has a trailing slash"
-      ],
-      "response": []
-    },
     "ml.get_memory_stats": {
       "request": [
         "Request: query parameter 'human' does not exist in the json spec",
@@ -999,18 +1011,6 @@
       ],
       "response": []
     },
-    "rollup.get_jobs": {
-      "request": [
-        "Url path '/_rollup/job/' has a trailing slash"
-      ],
-      "response": []
-    },
-    "rollup.get_rollup_caps": {
-      "request": [
-        "Url path '/_rollup/data/' has a trailing slash"
-      ],
-      "response": []
-    },
     "search": {
       "request": [
         "Request: missing json spec query parameter 'include_named_queries_score'",
@@ -1099,12 +1099,6 @@
       ],
       "response": []
     },
-    "security.put_privileges": {
-      "request": [
-        "Url path '/_security/privilege/' has a trailing slash"
-      ],
-      "response": []
-    },
     "security.query_user": {
       "request": [
         "Missing request & response"
@@ -1176,6 +1170,12 @@
       ],
       "response": []
     },
+    "snapshot.delete": {
+      "request": [
+        "Request: missing json spec query parameter 'wait_for_completion'"
+      ],
+      "response": []
+    },
     "snapshot.repository_analyze": {
       "request": [
         "Missing request & response"
@@ -1197,6 +1197,12 @@
       "response": []
     },
     "text_structure.find_message_structure": {
+      "request": [
+        "Missing request & response"
+      ],
+      "response": []
+    },
+    "transform.get_node_stats": {
       "request": [
         "Missing request & response"
       ],

--- a/specification/_json_spec/connector.sync_job_claim.json
+++ b/specification/_json_spec/connector.sync_job_claim.json
@@ -1,0 +1,32 @@
+{
+  "connector.sync_job_claim": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/claim-connector-sync-job-api.html",
+      "description": "Claims a connector sync job."
+    },
+    "stability": "experimental",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_connector/_sync_job/{connector_sync_job_id}/_claim",
+          "methods": ["PUT"],
+          "parts": {
+            "connector_sync_job_id": {
+              "type": "string",
+              "description": "The unique identifier of the connector sync job to be claimed."
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "Data to claim a sync job.",
+      "required": true
+    }
+  }
+}

--- a/specification/_json_spec/connector.update_features.json
+++ b/specification/_json_spec/connector.update_features.json
@@ -1,0 +1,32 @@
+{
+  "connector.update_features": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-features-api.html",
+      "description": "Updates the connector features in the connector document."
+    },
+    "stability": "experimental",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_connector/{connector_id}/_features",
+          "methods": ["PUT"],
+          "parts": {
+            "connector_id": {
+              "type": "string",
+              "description": "The unique identifier of the connector to be updated."
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "An object containing the connector's features definition.",
+      "required": true
+    }
+  }
+}

--- a/specification/_json_spec/features.reset_features.json
+++ b/specification/_json_spec/features.reset_features.json
@@ -16,6 +16,12 @@
           "methods": ["POST"]
         }
       ]
+    },
+    "params": {
+      "master_timeout": {
+        "type": "time",
+        "description": "Explicit operation timeout for connection to master node"
+      }
     }
   }
 }

--- a/specification/_json_spec/inference.delete.json
+++ b/specification/_json_spec/inference.delete.json
@@ -45,7 +45,7 @@
       },
       "force": {
         "type": "boolean",
-        "description": "True if the endpoint should be forcefully stopped (regardless of whether or not it is referenced by any ingest processors or semantic text fields).",
+        "description": "If true the endpoint will be forcefully stopped (regardless of whether or not it is referenced by any ingest processors or semantic text fields).",
         "required": false
       }
     }

--- a/specification/_json_spec/ml.get_categories.json
+++ b/specification/_json_spec/ml.get_categories.json
@@ -27,7 +27,7 @@
           }
         },
         {
-          "path": "/_ml/anomaly_detectors/{job_id}/results/categories/",
+          "path": "/_ml/anomaly_detectors/{job_id}/results/categories",
           "methods": ["GET", "POST"],
           "parts": {
             "job_id": {

--- a/specification/_json_spec/query_rule.delete.json
+++ b/specification/_json_spec/query_rule.delete.json
@@ -2,7 +2,7 @@
   "query_rule.delete": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-rule.html",
-      "description": "Deletes an individual query rule within a query ruleset."
+      "description": "Deletes an individual query rule within a ruleset."
     },
     "stability": "stable",
     "visibility": "public",
@@ -17,11 +17,11 @@
           "parts": {
             "ruleset_id": {
               "type": "string",
-              "description": "The unique identifier of the query ruleset containing the rule to delete"
+              "description": "The unique identifier of the query ruleset this rule exists in"
             },
             "rule_id": {
               "type": "string",
-              "description": "The unique identifier of the query rule to delete"
+              "description": "The unique identifier of the rule to delete."
             }
           }
         }

--- a/specification/_json_spec/query_rule.get.json
+++ b/specification/_json_spec/query_rule.get.json
@@ -2,7 +2,7 @@
   "query_rule.get": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-rule.html",
-      "description": "Returns the details about an individual query rule within a query ruleset."
+      "description": "Returns the details about an individual query rule within a ruleset."
     },
     "stability": "stable",
     "visibility": "public",
@@ -17,11 +17,11 @@
           "parts": {
             "ruleset_id": {
               "type": "string",
-              "description": "The unique identifier of the query ruleset"
+              "description": "The unique identifier of the query ruleset the rule exists within"
             },
             "rule_id": {
               "type": "string",
-              "description": "The unique identifier of the query rule"
+              "description": "The unique identifier of the rule to be retrieved."
             }
           }
         }

--- a/specification/_json_spec/query_rule.put.json
+++ b/specification/_json_spec/query_rule.put.json
@@ -2,7 +2,7 @@
   "query_rule.put": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-rule.html",
-      "description": "Creates or updates an individual query rule within a query ruleset."
+      "description": "Creates or updates a query rule within a ruleset."
     },
     "stability": "stable",
     "visibility": "public",
@@ -18,18 +18,18 @@
           "parts": {
             "ruleset_id": {
               "type": "string",
-              "description": "The unique identifier of the ruleset containing the rule to be created or updated."
+              "description": "The unique identifier of the ruleset this rule should be added to. The ruleset will be created if it does not exist."
             },
             "rule_id": {
               "type": "string",
-              "description": "The unique identifier of the query rule to be created or updated."
+              "description": "The unique identifier of the rule to be created or updated."
             }
           }
         }
       ]
     },
     "body": {
-      "description": "The query rule",
+      "description": "The query rule configuration, including the type of rule, the criteria to match the rule, and the action that should be taken if the rule matches.",
       "required": true
     }
   }

--- a/specification/_json_spec/rollup.get_jobs.json
+++ b/specification/_json_spec/rollup.get_jobs.json
@@ -22,7 +22,7 @@
           }
         },
         {
-          "path": "/_rollup/job/",
+          "path": "/_rollup/job",
           "methods": ["GET"]
         }
       ]

--- a/specification/_json_spec/rollup.get_rollup_caps.json
+++ b/specification/_json_spec/rollup.get_rollup_caps.json
@@ -22,7 +22,7 @@
           }
         },
         {
-          "path": "/_rollup/data/",
+          "path": "/_rollup/data",
           "methods": ["GET"]
         }
       ]

--- a/specification/_json_spec/security.get_settings.json
+++ b/specification/_json_spec/security.get_settings.json
@@ -18,6 +18,11 @@
         }
       ]
     },
-    "params": {}
+    "params": {
+      "master_timeout": {
+        "type": "time",
+        "description": "Timeout for connection to master"
+      }
+    }
   }
 }

--- a/specification/_json_spec/security.put_privileges.json
+++ b/specification/_json_spec/security.put_privileges.json
@@ -13,7 +13,7 @@
     "url": {
       "paths": [
         {
-          "path": "/_security/privilege/",
+          "path": "/_security/privilege",
           "methods": ["PUT", "POST"]
         }
       ]

--- a/specification/_json_spec/security.update_settings.json
+++ b/specification/_json_spec/security.update_settings.json
@@ -18,7 +18,16 @@
         }
       ]
     },
-    "params": {},
+    "params": {
+      "master_timeout": {
+        "type": "time",
+        "description": "Timeout for connection to master"
+      },
+      "timeout": {
+        "type": "time",
+        "description": "Timeout for acknowledgements from all nodes"
+      }
+    },
     "body": {
       "description": "An object with the new settings for each index, if any",
       "required": true

--- a/specification/_json_spec/snapshot.delete.json
+++ b/specification/_json_spec/snapshot.delete.json
@@ -31,6 +31,11 @@
       "master_timeout": {
         "type": "time",
         "description": "Explicit operation timeout for connection to master node"
+      },
+      "wait_for_completion": {
+        "type": "boolean",
+        "description": "Should this request wait until the operation has completed before returning",
+        "default": true
       }
     }
   }

--- a/specification/_json_spec/transform.get_node_stats.json
+++ b/specification/_json_spec/transform.get_node_stats.json
@@ -1,0 +1,21 @@
+{
+  "transform.get_node_stats": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-transform-node-stats.html",
+      "description": "Retrieves transform usage information for transform nodes."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_transform/_node_stats",
+          "methods": ["GET"]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
In particular, I wanted to include three trailing slashes validation errors that I've fixed usptream:

 * https://github.com/elastic/elasticsearch/pull/110146
 * https://github.com/elastic/elasticsearch/pull/110176
 * https://github.com/elastic/elasticsearch/pull/110177

This could be done automatically, but the automation that does this is currently broken. Thankfully, https://github.com/elastic/elasticsearch-specification/pull/2650 should fix it.