### PR TITLE
Switch to actions/setup-node@v4

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Use Node.js 20.x
-      uses: actions/setup-node@v1
+    - name: Use Node.js 20
+      uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 20
 
     - name: Install
       run: |

--- a/.github/workflows/compiler.test.yml
+++ b/.github/workflows/compiler.test.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 20
 
       - name: Install deps
         run: |

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -34,10 +34,10 @@ jobs:
         token: ${{ secrets.PAT }}
         persist-credentials: true
 
-    - name: Setup Node 20.x
-      uses: actions/setup-node@v3
+    - name: Setup Node 20
+      uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 20
         cache: npm
         cache-dependency-path: '**/package-lock.json'
 

--- a/.github/workflows/gh-pages-report.yml
+++ b/.github/workflows/gh-pages-report.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Use Node.js 20.x
-      uses: actions/setup-node@v1
+    - name: Use Node.js 20
+      uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 20
 
     - name: Install
       run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Use Node.js 20.x
-      uses: actions/setup-node@v1
+    - name: Use Node.js 20
+      uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: 20
 
     - name: Install
       run: |

--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
 
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 20
 
       - name: Install deps
         run: |

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -26,10 +26,10 @@ jobs:
           token: ${{ secrets.PAT }}
           ref: main
 
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v1
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 20
 
       - name: Install deps 1/2
         working-directory: ./clients-flight-recorder


### PR DESCRIPTION
Older actions used older versions of Node.js themselves.

While `20.x` still works, 20 is the recommended way to setup the version now: https://github.com/actions/setup-node. Also, it's called Node.js 20, not Node.js 20.x.