### PR TITLE
Set fail-fast: false on update-rest-api workflow

### DIFF
--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         branch: ['main', '8.13', '8.14', '7.17']
 


### PR DESCRIPTION
Otherwise, as soon as a job like 7.17 fails, everything else is canceled. But they are independent, and 1/ any success is welcome 2/ understanding fully all failures is welcome too.
