### PR TITLE
ESQL is now stable (GA)

### DIFF
--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -2638,13 +2638,9 @@
     },
     {
       "availability": {
-        "serverless": {
-          "stability": "experimental",
-          "visibility": "public"
-        },
+        "serverless": {},
         "stack": {
-          "since": "8.11.0",
-          "stability": "experimental"
+          "since": "8.11.0"
         }
       },
       "description": "Executes an ES|QL request",
@@ -2667,7 +2663,7 @@
         "application/json"
       ],
       "since": "8.11.0",
-      "stability": "experimental",
+      "stability": "stable",
       "urls": [
         {
           "methods": [

--- a/specification/esql/query/QueryRequest.ts
+++ b/specification/esql/query/QueryRequest.ts
@@ -24,8 +24,8 @@ import { ScalarValue } from '@_types/common'
 /**
  * Executes an ES|QL request
  * @rest_spec_name esql.query
- * @availability stack since=8.11.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.11.0
+ * @availability serverless
  * @doc_id esql-query
  */
 export interface Request extends RequestBase {


### PR DESCRIPTION
Removes the experimental status on ESQL. It's GA and available on Serverless.