### PR TITLE
Collapse diffs in PRs for everything in output/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -232,13 +232,6 @@ dist/*            binary
 
 ### Linguist Overrides #############################################################################
 
-output/dangling-types/dangling.csv linguist-generated=true
-output/schema/schema.json linguist-generated=true
-output/openapi/elasticsearch-serverless-openapi.json linguist-generated=true
-output/schema/import-type-graph.json linguist-generated=true
-output/schema/import-namespace-graph-compact.json linguist-generated=true
-output/schema/import-namespace-graph-expanded.json linguist-generated=true
-output/schema/validation-errors.json linguist-generated=true
-output/typescript/types.ts linguist-generated=true
+output/** linguist-generated=true
 
 ####################################################################################################


### PR DESCRIPTION
We recently added new output files (e.g. schema-serverless.json) and their diff is displayed in PRs.

This PR updates `.gitattributes` to set the `linguist-generated` attribute [indicating generated files](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) to everything in `output/`.