### PR TITLE
Expand team in update rest-api-spec action

### DIFF
--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -51,7 +51,6 @@ jobs:
           commit-message: 'Update rest-api-spec'
           labels: specification
           delete-branch: true
-          team-reviewers: elastic/devtools-team
           branch: automated/rest-api-spec-update-${{ matrix.branch }}
 
       - name: Open an issue if the action fails

--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -51,6 +51,7 @@ jobs:
           commit-message: 'Update rest-api-spec'
           labels: specification
           delete-branch: true
+          reviewers: Anaethelion,ezimuel,flobernd,JoshMock,l-trotta,miguelgrinberg,picandocodigo,pquentin,srikanthmanvi,swallez,technige
           branch: automated/rest-api-spec-update-${{ matrix.branch }}
 
       - name: Open an issue if the action fails


### PR DESCRIPTION
Requesting a team review no longer works with the current PAT, which fails the action with:

```
  Requesting team reviewers 'devtools-team'
  Error: Unable to request reviewers. If requesting team reviewers a 'repo' scoped PAT is required.
```

Example: https://github.com/elastic/elasticsearch-specification/actions/runs/9774982444/job/26984431897