### PR TITLE
Fix Query Rules validation

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -24625,13 +24625,23 @@
                     "$ref": "#/components/schemas/query_rules._types:QueryRuleType"
                   },
                   "criteria": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
-                    }
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
+                        }
+                      }
+                    ]
                   },
                   "actions": {
                     "$ref": "#/components/schemas/query_rules._types:QueryRuleActions"
+                  },
+                  "priority": {
+                    "type": "number"
                   }
                 },
                 "required": [
@@ -24777,10 +24787,17 @@
                 "type": "object",
                 "properties": {
                   "rules": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/query_rules._types:QueryRule"
-                    }
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/query_rules._types:QueryRule"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/query_rules._types:QueryRule"
+                        }
+                      }
+                    ]
                   }
                 },
                 "required": [
@@ -93163,13 +93180,23 @@
             "$ref": "#/components/schemas/query_rules._types:QueryRuleType"
           },
           "criteria": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
-            }
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
+                }
+              }
+            ]
           },
           "actions": {
             "$ref": "#/components/schemas/query_rules._types:QueryRuleActions"
+          },
+          "priority": {
+            "type": "number"
           }
         },
         "required": [
@@ -93211,6 +93238,7 @@
           "global",
           "exact",
           "exact_fuzzy",
+          "fuzzy",
           "prefix",
           "suffix",
           "contains",
@@ -93271,7 +93299,7 @@
             "description": "A map of criteria type to the number of rules of that type",
             "type": "object",
             "additionalProperties": {
-              "type": "string"
+              "type": "number"
             }
           }
         },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -15307,13 +15307,23 @@
                     "$ref": "#/components/schemas/query_rules._types:QueryRuleType"
                   },
                   "criteria": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
-                    }
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
+                        }
+                      }
+                    ]
                   },
                   "actions": {
                     "$ref": "#/components/schemas/query_rules._types:QueryRuleActions"
+                  },
+                  "priority": {
+                    "type": "number"
                   }
                 },
                 "required": [
@@ -15459,10 +15469,17 @@
                 "type": "object",
                 "properties": {
                   "rules": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/query_rules._types:QueryRule"
-                    }
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/query_rules._types:QueryRule"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/query_rules._types:QueryRule"
+                        }
+                      }
+                    ]
                   }
                 },
                 "required": [
@@ -59938,13 +59955,23 @@
             "$ref": "#/components/schemas/query_rules._types:QueryRuleType"
           },
           "criteria": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
-            }
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
+                }
+              }
+            ]
           },
           "actions": {
             "$ref": "#/components/schemas/query_rules._types:QueryRuleActions"
+          },
+          "priority": {
+            "type": "number"
           }
         },
         "required": [
@@ -59986,6 +60013,7 @@
           "global",
           "exact",
           "exact_fuzzy",
+          "fuzzy",
           "prefix",
           "suffix",
           "contains",
@@ -60046,7 +60074,7 @@
             "description": "A map of criteria type to the number of rules of that type",
             "type": "object",
             "additionalProperties": {
-              "type": "string"
+              "type": "number"
             }
           }
         },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -35825,14 +35825,26 @@
             "name": "criteria",
             "required": true,
             "type": {
-              "kind": "array_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "QueryRuleCriteria",
-                  "namespace": "query_rules._types"
+              "items": [
+                {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "QueryRuleCriteria",
+                    "namespace": "query_rules._types"
+                  }
+                },
+                {
+                  "kind": "array_of",
+                  "value": {
+                    "kind": "instance_of",
+                    "type": {
+                      "name": "QueryRuleCriteria",
+                      "namespace": "query_rules._types"
+                    }
+                  }
                 }
-              }
+              ],
+              "kind": "union_of"
             }
           },
           {
@@ -35843,6 +35855,17 @@
               "type": {
                 "name": "QueryRuleActions",
                 "namespace": "query_rules._types"
+              }
+            }
+          },
+          {
+            "name": "priority",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
               }
             }
           }
@@ -35887,7 +35910,7 @@
         }
       ],
       "query": [],
-      "specLocation": "query_rules/put_rule/QueryRulePutRequest.ts#L27-L54"
+      "specLocation": "query_rules/put_rule/QueryRulePutRequest.ts#L28-L56"
     },
     {
       "body": {
@@ -35924,14 +35947,26 @@
             "name": "rules",
             "required": true,
             "type": {
-              "kind": "array_of",
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "QueryRule",
-                  "namespace": "query_rules._types"
+              "items": [
+                {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "QueryRule",
+                    "namespace": "query_rules._types"
+                  }
+                },
+                {
+                  "kind": "array_of",
+                  "value": {
+                    "kind": "instance_of",
+                    "type": {
+                      "name": "QueryRule",
+                      "namespace": "query_rules._types"
+                    }
+                  }
                 }
-              }
+              ],
+              "kind": "union_of"
             }
           }
         ]
@@ -99340,6 +99375,9 @@
           "name": "exact_fuzzy"
         },
         {
+          "name": "fuzzy"
+        },
+        {
           "name": "prefix"
         },
         {
@@ -99368,7 +99406,7 @@
         "name": "QueryRuleCriteriaType",
         "namespace": "query_rules._types"
       },
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L54-L66"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L56-L69"
     },
     {
       "kind": "enum",
@@ -99381,7 +99419,7 @@
         "name": "QueryRuleType",
         "namespace": "query_rules._types"
       },
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L44-L46"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L46-L48"
     },
     {
       "kind": "enum",
@@ -132762,14 +132800,26 @@
           "name": "criteria",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "QueryRuleCriteria",
-                "namespace": "query_rules._types"
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "QueryRuleCriteria",
+                  "namespace": "query_rules._types"
+                }
+              },
+              {
+                "kind": "array_of",
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "QueryRuleCriteria",
+                    "namespace": "query_rules._types"
+                  }
+                }
               }
-            }
+            ],
+            "kind": "union_of"
           }
         },
         {
@@ -132782,9 +132832,20 @@
               "namespace": "query_rules._types"
             }
           }
+        },
+        {
+          "name": "priority",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
         }
       ],
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L37-L42"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L38-L44"
     },
     {
       "kind": "interface",
@@ -132826,7 +132887,7 @@
           }
         }
       ],
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L48-L52"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L50-L54"
     },
     {
       "kind": "interface",
@@ -132864,7 +132925,7 @@
           }
         }
       ],
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L68-L71"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L71-L74"
     },
     {
       "kind": "interface",
@@ -132901,7 +132962,7 @@
           }
         }
       ],
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L26-L35"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L27-L36"
     },
     {
       "kind": "interface",
@@ -132951,8 +133012,8 @@
             "value": {
               "kind": "instance_of",
               "type": {
-                "name": "string",
-                "namespace": "_builtins"
+                "name": "integer",
+                "namespace": "_types"
               }
             }
           }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16366,8 +16366,9 @@ export interface NodesUsageResponseBase extends NodesNodesResponseBase {
 export interface QueryRulesQueryRule {
   rule_id: Id
   type: QueryRulesQueryRuleType
-  criteria: QueryRulesQueryRuleCriteria[]
+  criteria: QueryRulesQueryRuleCriteria | QueryRulesQueryRuleCriteria[]
   actions: QueryRulesQueryRuleActions
+  priority?: integer
 }
 
 export interface QueryRulesQueryRuleActions {
@@ -16381,7 +16382,7 @@ export interface QueryRulesQueryRuleCriteria {
   values?: any[]
 }
 
-export type QueryRulesQueryRuleCriteriaType = 'global' | 'exact' | 'exact_fuzzy' | 'prefix' | 'suffix' | 'contains' | 'lt' | 'lte' | 'gt' | 'gte' | 'always'
+export type QueryRulesQueryRuleCriteriaType = 'global' | 'exact' | 'exact_fuzzy' | 'fuzzy' | 'prefix' | 'suffix' | 'contains' | 'lt' | 'lte' | 'gt' | 'gte' | 'always'
 
 export type QueryRulesQueryRuleType = 'pinned'
 
@@ -16419,7 +16420,7 @@ export type QueryRulesGetRulesetResponse = QueryRulesQueryRuleset
 export interface QueryRulesListRulesetsQueryRulesetListItem {
   ruleset_id: Id
   rule_total_count: integer
-  rule_criteria_types_counts: Record<string, string>
+  rule_criteria_types_counts: Record<string, integer>
 }
 
 export interface QueryRulesListRulesetsRequest extends RequestBase {
@@ -16437,8 +16438,9 @@ export interface QueryRulesPutRuleRequest extends RequestBase {
   rule_id: Id
   body?: {
     type: QueryRulesQueryRuleType
-    criteria: QueryRulesQueryRuleCriteria[]
+    criteria: QueryRulesQueryRuleCriteria | QueryRulesQueryRuleCriteria[]
     actions: QueryRulesQueryRuleActions
+    priority?: integer
   }
 }
 
@@ -16449,7 +16451,7 @@ export interface QueryRulesPutRuleResponse {
 export interface QueryRulesPutRulesetRequest extends RequestBase {
   ruleset_id: Id
   body?: {
-    rules: QueryRulesQueryRule[]
+    rules: QueryRulesQueryRule | QueryRulesQueryRule[]
   }
 }
 

--- a/specification/query_rules/_types/QueryRuleset.ts
+++ b/specification/query_rules/_types/QueryRuleset.ts
@@ -18,6 +18,7 @@
  */
 
 import { Id, IndexName, Name } from '@_types/common'
+import { integer } from '@_types/Numeric'
 import { EpochTime, UnitMillis } from '@_types/Time'
 import { InlineScript } from '@_types/Scripting'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
@@ -39,6 +40,7 @@ export class QueryRule {
   type: QueryRuleType
   criteria: QueryRuleCriteria[]
   actions: QueryRuleActions
+  priority?: integer
 }
 
 export enum QueryRuleType {

--- a/specification/query_rules/_types/QueryRuleset.ts
+++ b/specification/query_rules/_types/QueryRuleset.ts
@@ -57,6 +57,7 @@ export enum QueryRuleCriteriaType {
   global,
   exact,
   exact_fuzzy,
+  fuzzy,
   prefix,
   suffix,
   contains,

--- a/specification/query_rules/_types/QueryRuleset.ts
+++ b/specification/query_rules/_types/QueryRuleset.ts
@@ -38,7 +38,7 @@ export class QueryRuleset {
 export class QueryRule {
   rule_id: Id
   type: QueryRuleType
-  criteria: QueryRuleCriteria[]
+  criteria: QueryRuleCriteria | QueryRuleCriteria[]
   actions: QueryRuleActions
   priority?: integer
 }

--- a/specification/query_rules/list_rulesets/types.ts
+++ b/specification/query_rules/list_rulesets/types.ts
@@ -33,5 +33,5 @@ export class QueryRulesetListItem {
   /**
    * A map of criteria type to the number of rules of that type
    */
-  rule_criteria_types_counts: Dictionary<string, string>
+  rule_criteria_types_counts: Dictionary<string, integer>
 }

--- a/specification/query_rules/put_rule/QueryRulePutRequest.ts
+++ b/specification/query_rules/put_rule/QueryRulePutRequest.ts
@@ -49,7 +49,7 @@ export interface Request extends RequestBase {
   /** @codegen_name query_rule */
   body: {
     type: QueryRuleType
-    criteria: QueryRuleCriteria[]
+    criteria: QueryRuleCriteria | QueryRuleCriteria[]
     actions: QueryRuleActions
     priority?: integer
   }

--- a/specification/query_rules/put_rule/QueryRulePutRequest.ts
+++ b/specification/query_rules/put_rule/QueryRulePutRequest.ts
@@ -18,6 +18,7 @@
  */
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { integer } from '@_types/Numeric'
 import {
   QueryRuleType,
   QueryRuleCriteria,
@@ -50,5 +51,6 @@ export interface Request extends RequestBase {
     type: QueryRuleType
     criteria: QueryRuleCriteria[]
     actions: QueryRuleActions
+    priority?: integer
   }
 }

--- a/specification/query_rules/put_ruleset/QueryRulesetPutRequest.ts
+++ b/specification/query_rules/put_ruleset/QueryRulesetPutRequest.ts
@@ -38,6 +38,6 @@ export interface Request extends RequestBase {
    */
   /** @codegen_name query_ruleset */
   body: {
-    rules: QueryRule[]
+    rules: QueryRule | QueryRule[]
   }
 }


### PR DESCRIPTION
For reference, now that [we can use Query Rules YAML tests](https://github.com/elastic/elasticsearch/pull/110411), here is the current validation status:

| API | Status | Request | Response | Stability | Visibility |
| --- | --- | --- | --- | --- | --- |
| `delete_rule` | :green_circle: | 6/6 | 6/6 | stable | public |
| `delete_ruleset` | :green_circle: | 7/7 | 7/7 | stable | public |
| `get_rule` | :red_circle: | 5/5 | 3/5 | stable | public |
| `get_ruleset` | :red_circle: | 8/8 | 5/8 | stable | public |
| `list_rulesets` | :red_circle: | 7/7 | 1/7 | stable | public |
| `put_rule` | :red_circle: | 0/7 | 7/7 | stable | public |
| `put_ruleset` | :red_circle: | 4/10 | 10/10 | stable | public |
| **Summary** | :red_circle: | 74% | 78% | | |

With only looking at docs and validation errors (not the code), I've fixed validation of all APIs in four commits:

 * [`0ce3f1c` (#2677)](https://github.com/elastic/elasticsearch-specification/pull/2677/commits/0ce3f1c85549d5b18c7a59e5b1324548e2d755c1) Add missing priority field
 * [`0053366` (#2677)](https://github.com/elastic/elasticsearch-specification/pull/2677/commits/0053366a872781f70d88c529bdf75f2819211df4) Add fuzzy criteria type
 * [`c7d91cb` (#2677)](https://github.com/elastic/elasticsearch-specification/pull/2677/commits/c7d91cbb1539040a189f13ef9f39b21e0b73afc6) Allow criteria and rules to be single objects. I'm not sure we actually want to allow that, but the YAML tests make use of it.
 * [`8a54468` (#2677)](https://github.com/elastic/elasticsearch-specification/pull/2677/commits/8a544682cfb3343a1cc33726d81640901b8e6739) Fix type of rule_criteria_type_counts
