### PR TITLE
Mark data stream stats API as private on Serverless

### DIFF
--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -24,7 +24,7 @@ import { ExpandWildcards, IndexName } from '@_types/common'
  * Retrieves statistics for one or more data streams.
  * @rest_spec_name indices.data_streams_stats
  * @availability stack since=7.9.0 stability=stable
- * @availability serverless stability=stable visibility=public
+ * @availability serverless stability=stable visibility=private
  * @index_privileges monitor
  */
 export interface Request extends RequestBase {


### PR DESCRIPTION
As done by @dakrone in https://github.com/elastic/elasticsearch/pull/108745. This will remove this method from the Serverless clients.