### PR TITLE
Add spec for bulk put roles

### DIFF
--- a/specification/security/bulk_put_role/SecurityBulkPutRoleRequest.ts
+++ b/specification/security/bulk_put_role/SecurityBulkPutRoleRequest.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Dictionary } from '@spec_utils/Dictionary'
+import { RequestBase } from '@_types/Base'
+import { Refresh } from '@_types/common'
+import {RoleDescriptor} from "@security/_types/RoleDescriptor";
+
+/**
+ * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
+ * The bulk create or update roles API cannot update roles that are defined in roles files.
+ * @rest_spec_name security.bulk_put_role
+ * @availability stack since=8.15.0 stability=stable
+ * @availability serverless stability=stable visibility=private
+ * @cluster_privileges manage_security
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+  }
+  query_parameters: {
+    refresh?: Refresh
+  }
+  body: {
+    /**
+     * A dictionary of role name to RoleDescriptor objects to add or update
+     */
+    roles: Dictionary<string, RoleDescriptor>
+  }
+}

--- a/specification/security/bulk_put_role/SecurityBulkPutRoleResponse.ts
+++ b/specification/security/bulk_put_role/SecurityBulkPutRoleResponse.ts
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {integer} from "@_types/Numeric";
+import {ErrorCause} from "@_types/Errors";
+import {Dictionary} from "@spec_utils/Dictionary";
+
+export class Response {
+  body: {
+    /**
+     * Array of created roles
+     */
+    created?: string[]
+    /**
+     * Array of updated roles
+     */
+    updated?: string[]
+    /**
+     * Array of role names without any changes
+     */
+    noop?: string[]
+    /**
+     * Present if any updates resulted in errors
+     */
+    errors?: {
+      /**
+       * The number of errors
+       */
+      count: integer
+      /**
+       * Details about the errors, keyed by role name
+       */
+      details: Dictionary<string, ErrorCause>
+    }
+  }
+}


### PR DESCRIPTION
This adds a new spec for the bulk put roles API added in 8.15 in https://github.com/elastic/elasticsearch/pull/109339. 

