### PR TITLE
Add specification for delete roles

### DIFF
--- a/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
+++ b/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Dictionary } from '@spec_utils/Dictionary'
+import { RequestBase } from '@_types/Base'
+import { Refresh } from '@_types/common'
+import {RoleDescriptor} from "@security/_types/RoleDescriptor";
+
+/**
+ * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
+ * The bulk delete roles API cannot delete roles that are defined in roles files.
+ * @rest_spec_name security.bulk_delete_role
+ * @availability stack since=8.15.0 stability=stable
+ * @availability serverless stability=stable visibility=private
+ * @cluster_privileges manage_security
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+  }
+  query_parameters: {
+    refresh?: Refresh
+  }
+  body: {
+    /**
+     * An array of role names to delete
+     */
+    names: string[]
+  }
+}

--- a/specification/security/bulk_delete_role/SecurityBulkDeleteRoleResponse.ts
+++ b/specification/security/bulk_delete_role/SecurityBulkDeleteRoleResponse.ts
@@ -1,0 +1,47 @@
+/**
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {Dictionary} from "@spec_utils/Dictionary";
+import {ErrorCause} from "@_types/Errors";
+import {integer} from "@_types/Numeric";
+
+export class Response {
+  body: {
+    /**
+     * Array of deleted roles
+     */
+    deleted?: string[]
+    /**
+     * Array of roles that could not be found
+     */
+    not_found?: string[]
+    /**
+     * Present if any deletes resulted in errors
+     */
+    errors?: {
+      /**
+       * The number of errors
+       */
+      count: integer
+      /**
+       * Details about the errors, keyed by role name
+       */
+      details: Dictionary<string, ErrorCause>
+    }
+  }
+}


### PR DESCRIPTION
This adds a new spec for the bulk delete roles API added in 8.15 in https://github.com/elastic/elasticsearch/pull/110383. 