### PR TITLE
Add specification for delete roles

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27887,6 +27887,82 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "security.bulk_delete_role"
+        ],
+        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
+        "description": "The bulk delete roles API cannot delete roles that are defined in roles files.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-bulk-delete-role.html"
+        },
+        "operationId": "security-bulk-delete-role",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "refresh",
+            "description": "If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Refresh"
+            },
+            "style": "form"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "names": {
+                    "description": "An array of role names to delete",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "names"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "deleted": {
+                      "description": "Array of deleted roles",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "not_found": {
+                      "description": "Array of roles that could not be found",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "errors": {
+                      "$ref": "#/components/schemas/security._types:BulkError"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/_security/user/{username}/_password": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1049,12 +1049,6 @@
       ],
       "response": []
     },
-    "security.bulk_delete_role": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "security.bulk_update_api_keys": {
       "request": [
         "Missing request & response"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17031,6 +17031,19 @@ export interface SecurityAuthenticateToken {
   type?: string
 }
 
+export interface SecurityBulkDeleteRoleRequest extends RequestBase {
+  refresh?: Refresh
+  body?: {
+    names: string[]
+  }
+}
+
+export interface SecurityBulkDeleteRoleResponse {
+  deleted?: string[]
+  not_found?: string[]
+  errors?: SecurityBulkError
+}
+
 export interface SecurityBulkPutRoleRequest extends RequestBase {
   refresh?: Refresh
   body?: {

--- a/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
+++ b/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Refresh } from '@_types/common'
+
+/**
+ * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
+ * The bulk delete roles API cannot delete roles that are defined in roles files.
+ * @rest_spec_name security.bulk_delete_role
+ * @availability stack since=8.15.0 stability=stable
+ * @availability serverless stability=stable visibility=private
+ * @cluster_privileges manage_security
+ */
+export interface Request extends RequestBase {
+  path_parts: {}
+  query_parameters: {
+    refresh?: Refresh
+  }
+  body: {
+    /**
+     * An array of role names to delete
+     */
+    names: string[]
+  }
+}

--- a/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
+++ b/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
@@ -29,7 +29,6 @@ import { Refresh } from '@_types/common'
  * @cluster_privileges manage_security
  */
 export interface Request extends RequestBase {
-  path_parts: {}
   query_parameters: {
     refresh?: Refresh
   }

--- a/specification/security/bulk_delete_role/SecurityBulkDeleteRoleResponse.ts
+++ b/specification/security/bulk_delete_role/SecurityBulkDeleteRoleResponse.ts
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Dictionary } from '@spec_utils/Dictionary'
+import { ErrorCause } from '@_types/Errors'
+import { integer } from '@_types/Numeric'
+import { BulkError } from '@security/_types/Bulk'
+
+export class Response {
+  body: {
+    /**
+     * Array of deleted roles
+     */
+    deleted?: string[]
+    /**
+     * Array of roles that could not be found
+     */
+    not_found?: string[]
+    /**
+     * Present if any deletes resulted in errors
+     */
+    errors?: BulkError
+  }
+}


### PR DESCRIPTION
This adds a new spec for the bulk delete roles API added in 8.15 in https://github.com/elastic/elasticsearch/pull/110383. 