### PR TITLE
[Connector API] Update endpoint stability

### DIFF
--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -1079,12 +1079,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Deletes a connector.",
@@ -1104,7 +1104,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1118,12 +1118,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Retrieves a connector.",
@@ -1143,7 +1143,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1199,12 +1199,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Returns existing connectors.",
@@ -1224,7 +1224,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1238,12 +1238,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Creates a connector.",
@@ -1266,7 +1266,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1280,12 +1280,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Creates or updates a connector.",
@@ -1308,7 +1308,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1328,12 +1328,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Cancels a connector sync job.",
@@ -1353,7 +1353,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1367,12 +1367,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Deletes a connector sync job.",
@@ -1392,7 +1392,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1406,12 +1406,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Retrieves a connector sync job.",
@@ -1431,7 +1431,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1445,12 +1445,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Lists connector sync jobs.",
@@ -1470,7 +1470,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1484,12 +1484,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Creates a connector sync job.",
@@ -1512,7 +1512,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1610,12 +1610,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Updates the configuration field in the connector document",
@@ -1638,7 +1638,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1694,12 +1694,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Updates the filtering field in the connector document",
@@ -1722,7 +1722,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1778,12 +1778,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Updates the index_name in the connector document",
@@ -1806,7 +1806,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1820,12 +1820,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Updates the name and description fields in the connector document",
@@ -1848,7 +1848,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1862,12 +1862,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Updates the is_native flag in the connector document",
@@ -1890,7 +1890,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1904,12 +1904,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Updates the pipeline field in the connector document",
@@ -1932,7 +1932,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1946,12 +1946,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Updates the scheduling field in the connector document",
@@ -1974,7 +1974,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [
@@ -1988,12 +1988,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Updates the service type of the connector",
@@ -2016,7 +2016,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -1568,12 +1568,12 @@
     {
       "availability": {
         "serverless": {
-          "stability": "experimental",
+          "stability": "beta",
           "visibility": "public"
         },
         "stack": {
           "since": "8.12.0",
-          "stability": "experimental"
+          "stability": "beta"
         }
       },
       "description": "Updates the API key id in the connector document",
@@ -1596,7 +1596,7 @@
         "application/json"
       ],
       "since": "8.12.0",
-      "stability": "experimental",
+      "stability": "beta",
       "urls": [
         {
           "methods": [

--- a/specification/connector/delete/ConnectorDeleteRequest.ts
+++ b/specification/connector/delete/ConnectorDeleteRequest.ts
@@ -22,8 +22,8 @@ import { Id } from '@_types/common'
 /**
  * Deletes a connector.
  * @rest_spec_name connector.delete
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-delete
  */
 export interface Request extends RequestBase {

--- a/specification/connector/get/ConnectorGetRequest.ts
+++ b/specification/connector/get/ConnectorGetRequest.ts
@@ -22,8 +22,8 @@ import { Id } from '@_types/common'
 /**
  * Retrieves a connector.
  * @rest_spec_name connector.get
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-get
  */
 export interface Request extends RequestBase {

--- a/specification/connector/list/ConnectorListRequest.ts
+++ b/specification/connector/list/ConnectorListRequest.ts
@@ -23,8 +23,8 @@ import { integer } from '@_types/Numeric'
 /**
  * Returns existing connectors.
  * @rest_spec_name connector.list
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-list
  */
 export interface Request extends RequestBase {

--- a/specification/connector/post/ConnectorPostRequest.ts
+++ b/specification/connector/post/ConnectorPostRequest.ts
@@ -23,8 +23,8 @@ import { WithNullValue } from '@spec_utils/utils'
 /**
  * Creates a connector.
  * @rest_spec_name connector.post
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-post
  */
 export interface Request extends RequestBase {

--- a/specification/connector/put/ConnectorPutRequest.ts
+++ b/specification/connector/put/ConnectorPutRequest.ts
@@ -23,8 +23,8 @@ import { WithNullValue } from '@spec_utils/utils'
 /**
  * Creates or updates a connector.
  * @rest_spec_name connector.put
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-put
  */
 export interface Request extends RequestBase {

--- a/specification/connector/sync_job_cancel/SyncJobCancelRequest.ts
+++ b/specification/connector/sync_job_cancel/SyncJobCancelRequest.ts
@@ -22,8 +22,8 @@ import { Id } from '@_types/common'
 /**
  * Cancels a connector sync job.
  * @rest_spec_name connector.sync_job_cancel
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-sync-job-cancel
  */
 export interface Request extends RequestBase {

--- a/specification/connector/sync_job_delete/SyncJobDeleteRequest.ts
+++ b/specification/connector/sync_job_delete/SyncJobDeleteRequest.ts
@@ -22,8 +22,8 @@ import { Id } from '@_types/common'
 /**
  * Deletes a connector sync job.
  * @rest_spec_name connector.sync_job_delete
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-sync-job-delete
  */
 export interface Request extends RequestBase {

--- a/specification/connector/sync_job_get/SyncJobGetRequest.ts
+++ b/specification/connector/sync_job_get/SyncJobGetRequest.ts
@@ -22,8 +22,8 @@ import { Id } from '@_types/common'
 /**
  * Retrieves a connector sync job.
  * @rest_spec_name connector.sync_job_get
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-sync-job-get
  */
 export interface Request extends RequestBase {

--- a/specification/connector/sync_job_list/SyncJobListRequest.ts
+++ b/specification/connector/sync_job_list/SyncJobListRequest.ts
@@ -25,8 +25,8 @@ import { SyncStatus } from '../_types/Connector'
 /**
  * Lists connector sync jobs.
  * @rest_spec_name connector.sync_job_list
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-sync-job-list
  */
 export interface Request extends RequestBase {

--- a/specification/connector/sync_job_post/SyncJobPostRequest.ts
+++ b/specification/connector/sync_job_post/SyncJobPostRequest.ts
@@ -23,8 +23,8 @@ import { SyncJobType, SyncJobTriggerMethod } from '../_types/SyncJob'
 /**
  * Creates a connector sync job.
  * @rest_spec_name connector.sync_job_post
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-sync-job-post
  */
 export interface Request extends RequestBase {

--- a/specification/connector/update_api_key_id/ConnectorUpdateAPIKeyIDRequest.ts
+++ b/specification/connector/update_api_key_id/ConnectorUpdateAPIKeyIDRequest.ts
@@ -23,8 +23,8 @@ import { WithNullValue } from '@spec_utils/utils'
 /**
  * Updates the API key id in the connector document
  * @rest_spec_name connector.update_api_key_id
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-update-api-key-id
  */
 export interface Request extends RequestBase {

--- a/specification/connector/update_configuration/ConnectorUpdateConfigurationRequest.ts
+++ b/specification/connector/update_configuration/ConnectorUpdateConfigurationRequest.ts
@@ -25,8 +25,8 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 /**
  * Updates the configuration field in the connector document
  * @rest_spec_name connector.update_configuration
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-configuration
  */
 export interface Request extends RequestBase {

--- a/specification/connector/update_filtering/ConnectorUpdateFilteringRequest.ts
+++ b/specification/connector/update_filtering/ConnectorUpdateFilteringRequest.ts
@@ -27,8 +27,8 @@ import {
 /**
  * Updates the filtering field in the connector document
  * @rest_spec_name connector.update_filtering
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-update-filtering
  */
 export interface Request extends RequestBase {

--- a/specification/connector/update_index_name/ConnectorUpdateIndexNameRequest.ts
+++ b/specification/connector/update_index_name/ConnectorUpdateIndexNameRequest.ts
@@ -23,8 +23,8 @@ import { WithNullValue } from '@spec_utils/utils'
 /**
  * Updates the index_name in the connector document
  * @rest_spec_name connector.update_index_name
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-update-index-name
  */
 export interface Request extends RequestBase {

--- a/specification/connector/update_name/ConnectorUpdateNameRequest.ts
+++ b/specification/connector/update_name/ConnectorUpdateNameRequest.ts
@@ -22,8 +22,8 @@ import { Id } from '@_types/common'
 /**
  * Updates the name and description fields in the connector document
  * @rest_spec_name connector.update_name
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-update-name
  */
 export interface Request extends RequestBase {

--- a/specification/connector/update_native/ConnectorUpdateNativeRequest.ts
+++ b/specification/connector/update_native/ConnectorUpdateNativeRequest.ts
@@ -22,8 +22,8 @@ import { Id } from '@_types/common'
 /**
  * Updates the is_native flag in the connector document
  * @rest_spec_name connector.update_native
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-update-native
  */
 export interface Request extends RequestBase {

--- a/specification/connector/update_pipeline/ConnectorUpdatePipelineRequest.ts
+++ b/specification/connector/update_pipeline/ConnectorUpdatePipelineRequest.ts
@@ -23,8 +23,8 @@ import { IngestPipelineParams } from '../_types/Connector'
 /**
  * Updates the pipeline field in the connector document
  * @rest_spec_name connector.update_pipeline
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-update-pipeline
  */
 export interface Request extends RequestBase {

--- a/specification/connector/update_scheduling/ConnectorUpdateSchedulingRequest.ts
+++ b/specification/connector/update_scheduling/ConnectorUpdateSchedulingRequest.ts
@@ -23,8 +23,8 @@ import { SchedulingConfiguration } from '../_types/Connector'
 /**
  * Updates the scheduling field in the connector document
  * @rest_spec_name connector.update_scheduling
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-update-scheduling
  */
 export interface Request extends RequestBase {

--- a/specification/connector/update_service_type/ConnectorUpdateServiceTypeRequest.ts
+++ b/specification/connector/update_service_type/ConnectorUpdateServiceTypeRequest.ts
@@ -22,8 +22,8 @@ import { Id } from '@_types/common'
 /**
  * Updates the service type of the connector
  * @rest_spec_name connector.update_service_type
- * @availability stack since=8.12.0 stability=experimental
- * @availability serverless stability=experimental visibility=public
+ * @availability stack since=8.12.0 stability=beta
+ * @availability serverless stability=beta visibility=public
  * @doc_id connector-update-service-type
  */
 export interface Request extends RequestBase {


### PR DESCRIPTION
### Changes

Connector management endpoints are marked as beta: https://www.elastic.co/guide/en/elasticsearch/reference/master/connector-apis.html

This PR updates `experimental` -> `beta` stability for connector management endpoints.