### PR TITLE
[Backport 7.17] Change `QueryCacheStats` field types from `int` -> `long` (#2513)

### DIFF
--- a/specification/_types/Stats.ts
+++ b/specification/_types/Stats.ts
@@ -147,14 +147,14 @@ export class PluginStats {
 }
 
 export class QueryCacheStats {
-  cache_count: integer
-  cache_size: integer
-  evictions: integer
-  hit_count: integer
+  cache_count: long
+  cache_size: long
+  evictions: long
+  hit_count: long
   memory_size?: ByteSize
   memory_size_in_bytes: long
-  miss_count: integer
-  total_count: integer
+  miss_count: long
+  total_count: long
 }
 
 export class RecoveryStats {


### PR DESCRIPTION
It's a backport of following PR to 7.17

https://github.com/elastic/elasticsearch-specification/pull/2513

Which addresses following issues:

https://github.com/elastic/elasticsearch-net/issues/8015
https://github.com/elastic/elasticsearch-java/issues/685