### PR TITLE
make validate: Download recordings using branch, not version

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -57,7 +57,7 @@ jobs:
           else
             branch=$GITHUB_REF_NAME
           fi
-          node scripts/upload-recording/download.js --branch latest
+          node scripts/upload-recording/download.js --branch $branch
           node scripts/clone-elasticsearch/index.js --branch $branch
         env:
           GCS_CREDENTIALS: ${{ secrets.GCS_CREDENTIALS }}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 SHELL := /bin/bash
 
 validate: ## Validate a given endpoint request or response
-	@node compiler/run-validations.js --api $(api) --type $(type) --stack-version $(stack-version)
+	@node compiler/run-validations.js --api $(api) --type $(type) --branch $(branch)
 
 validate-no-cache: ## Validate a given endpoint request or response without local cache
-	@node compiler/run-validations.js --api $(api) --type $(type) --stack-version $(stack-version) --no-cache
+	@node compiler/run-validations.js --api $(api) --type $(type) --branch $(branch) --no-cache
 
 generate:	  ## Generate the output spec
 	@echo ">> generating the spec .."

--- a/README.md
+++ b/README.md
@@ -204,16 +204,16 @@ git clone https://github.com/elastic/elasticsearch-specification.git
 git clone https://github.com/elastic/clients-flight-recorder.git
 
 cd elasticsearch-specification
-# this will validate the xpack.info request type against the 8.1.0 stack version
-make validate api=xpack.info type=request stack-version=8.1.0-SNAPSHOT
+# this will validate the xpack.info request type against the main branch of Elasticsearch
+make validate api=xpack.info type=request branch=main
 
-# this will validate the xpack.info request and response types against the 8.1.0 stack version
-make validate api=xpack.info stack-version=8.1.0-SNAPSHOT
+# this will validate the xpack.info request and response types against the 8.15 branch
+make validate api=xpack.info branch=8.15
 ```
 
 The last command above will install all the dependencies and run, download
 the test recordings and finally validate the specification.
-If you need to download the recordings again, run `make validate-no-cache api=xpack.info type=request stack-version=8.1.0-SNAPSHOT`.
+If you need to download the recordings again, run `make validate-no-cache api=xpack.info type=request branch=main`.
 
 Once you see the errors, you can fix the original definition in `/specification`
 and then run the command again until the types validator does not trigger any new error.

--- a/compiler/run-validations.js
+++ b/compiler/run-validations.js
@@ -166,7 +166,7 @@ async function run () {
 
   spinner.text = 'Running validations'
 
-  const branchArg = argv.branchArg.toString()
+  const branchArg = argv.branch.toString()
   const branchName = branchArg.startsWith('7.') ? '7.x' : branchArg
 
   if (noCache || isStale || metadata.branchName !== branchName) {

--- a/compiler/run-validations.js
+++ b/compiler/run-validations.js
@@ -64,7 +64,7 @@ async function run () {
   const isStale = lastRun.getTime() + DAY < Date.now()
 
   if (typeof argv.api !== 'string') {
-    spinner.fail('You must specify the api, for example: \'make validate api=index type=request stack-version=8.1.0-SNAPSHOT\'')
+    spinner.fail('You must specify the api, for example: \'make validate api=index type=request branch=main\'')
     process.exit(1)
   }
 
@@ -75,14 +75,15 @@ async function run () {
 
   // if true it's because the make target wasn't configured with a type argument
   if (argv.type !== true && argv.type !== 'request' && argv.type !== 'response') {
-    spinner.fail('You must specify the type (request or response), for example: \'make validate api=index type=request stack-version=8.1.0-SNAPSHOT\'')
+    spinner.fail('You must specify the type (request or response), for example: \'make validate api=index type=request branch=main\'')
     process.exit(1)
   }
 
-  if (typeof argv['stack-version'] !== 'string') {
-    spinner.fail('You must specify the stack version, for example: \'make validate api=index type=request stack-version=8.1.0-SNAPSHOT\'')
+  if (typeof argv.branch !== 'string' && typeof argv.branch !== 'number') {
+    spinner.fail('You must specify the branch, for example: \'make validate api=index type=request branch=main\'')
     process.exit(1)
   }
+
 
   const isFlightRecorderCloned = await $`[[ -d ${path.join(__dirname, '..', '..', 'clients-flight-recorder')} ]]`.exitCode === 0
   if (!isFlightRecorderCloned) {
@@ -165,7 +166,8 @@ async function run () {
 
   spinner.text = 'Running validations'
 
-  const branchName = argv['branch'].startsWith('7.') ? '7.x' : argv['branch']
+  const branchArg = argv.branchArg.toString()
+  const branchName = branchArg.startsWith('7.') ? '7.x' : branchArg
 
   if (noCache || isStale || metadata.branchName !== branchName) {
     metadata.lastRun = new Date()
@@ -188,7 +190,7 @@ async function run () {
   } else {
     flags.push(`--${argv.type}`)
   }
-  const output = await $`STACK_VERSION=${argv['stack-version']} node ${path.join(tsValidationPath, 'index.js')} --api ${argv.api} ${flags}`
+  const output = await $`node ${path.join(tsValidationPath, 'index.js')} --api ${argv.api} --branch ${branchName} ${flags}`
 
   cd(path.join(compilerPath, '..'))
   if (output.exitCode === 0) {

--- a/compiler/run-validations.js
+++ b/compiler/run-validations.js
@@ -165,7 +165,7 @@ async function run () {
 
   spinner.text = 'Running validations'
 
-  const branchName = argv['stack-version'].startsWith('7.') ? '7.x' : argv['stack-version'].slice(0, 3)
+  const branchName = argv['branch'].startsWith('7.') ? '7.x' : argv['branch']
 
   if (noCache || isStale || metadata.branchName !== branchName) {
     metadata.lastRun = new Date()
@@ -175,7 +175,7 @@ async function run () {
     await $`node ${path.join(uploadRecordingsPath, 'download.js')} --branch ${branchName}`
 
     spinner.text = 'Fetching artifacts'
-    await $`node ${path.join(cloneEsPath, 'index.js')} --version ${argv['stack-version']}`
+    await $`node ${path.join(cloneEsPath, 'index.js')} --branch ${argv['branch']}`
   }
 
   cd(tsValidationPath)

--- a/docs/validation-example.md
+++ b/docs/validation-example.md
@@ -16,7 +16,7 @@ The example assumes that you have already performed the necessary steps to run a
 if not, take a look at the [README](./README.md).
 
 ```sh
-make validate api=index type=request stack-version=8.1.0-SNAPSHOT
+make validate api=index type=request branch=main
 ```
 
 You will see an output like the following:
@@ -82,7 +82,7 @@ open it with your favourite editor and perform the fix
 Finally run the validation again:
 
 ```sh
-make validate api=index type=request stack-version=8.1.0-SNAPSHOT
+make validate api=index type=request branch=main
 ```
 
-If there are no more errors, open a pr with the fix.
+If there are no more errors, open a pull request with the fix.


### PR DESCRIPTION
Since #2536, validation in pull requests works based on branches, not versions. However, I had not updated `make validate` yet. It was even still suffering from the `slice(0, 3)` bug which was converting `8.15-SNAPSHOT` into `8.1`.

This should not be merged until we have `main` recordings, which should happen later today.