### PR TITLE
Fix `RoleDescriptor` field annotations for Serverless

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -95105,7 +95105,7 @@
             "externalDocs": {
               "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/run-as-privilege.html"
             },
-            "description": "A list of users that the API keys can impersonate.",
+            "description": "A list of users that the API keys can impersonate. *Note*: in Serverless, the run-as feature is disabled. For API compatibility, you can still specify an empty `run_as` field, but a non-empty list will be rejected.",
             "type": "array",
             "items": {
               "type": "string"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -51477,6 +51477,10 @@
                     "type": "string"
                   }
                 },
+                "description": {
+                  "description": "Optional description of the role descriptor",
+                  "type": "string"
+                },
                 "transient_metadata": {
                   "description": "Indicates roles that might be incompatible with the current cluster license, specifically roles with document and field level security. When the cluster license doesn’t allow certain features for a given role, this parameter is updated dynamically to list the incompatible features. If `enabled` is `false`, the role is ignored, but is still listed in the response from the authenticate API.",
                   "type": "object",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -60861,20 +60861,6 @@
               "$ref": "#/components/schemas/security._types:IndicesPrivileges"
             }
           },
-          "global": {
-            "description": "An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges.",
-            "oneOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/security._types:GlobalPrivilege"
-                }
-              },
-              {
-                "$ref": "#/components/schemas/security._types:GlobalPrivilege"
-              }
-            ]
-          },
           "applications": {
             "description": "A list of application privilege entries",
             "type": "array",
@@ -60889,7 +60875,7 @@
             "externalDocs": {
               "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/run-as-privilege.html"
             },
-            "description": "A list of users that the API keys can impersonate.",
+            "description": "A list of users that the API keys can impersonate. *Note*: in Serverless, the run-as feature is disabled. For API compatibility, you can still specify an empty `run_as` field, but a non-empty list will be rejected.",
             "type": "array",
             "items": {
               "type": "string"
@@ -61077,42 +61063,6 @@
           {
             "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
           }
-        ]
-      },
-      "security._types:GlobalPrivilege": {
-        "type": "object",
-        "properties": {
-          "application": {
-            "$ref": "#/components/schemas/security._types:ApplicationGlobalUserPrivileges"
-          }
-        },
-        "required": [
-          "application"
-        ]
-      },
-      "security._types:ApplicationGlobalUserPrivileges": {
-        "type": "object",
-        "properties": {
-          "manage": {
-            "$ref": "#/components/schemas/security._types:ManageUserPrivileges"
-          }
-        },
-        "required": [
-          "manage"
-        ]
-      },
-      "security._types:ManageUserPrivileges": {
-        "type": "object",
-        "properties": {
-          "applications": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "applications"
         ]
       },
       "security._types:ApplicationPrivileges": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -134837,33 +134837,6 @@
           }
         },
         {
-          "description": "An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges.",
-          "name": "global",
-          "required": false,
-          "type": {
-            "items": [
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "GlobalPrivilege",
-                    "namespace": "security._types"
-                  }
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "GlobalPrivilege",
-                  "namespace": "security._types"
-                }
-              }
-            ],
-            "kind": "union_of"
-          }
-        },
-        {
           "description": "A list of application privilege entries",
           "name": "applications",
           "required": false,
@@ -134891,7 +134864,7 @@
           }
         },
         {
-          "description": "A list of users that the API keys can impersonate.",
+          "description": "A list of users that the API keys can impersonate. *Note*: in Serverless, the run-as feature is disabled. For API compatibility, you can still specify an empty `run_as` field, but a non-empty list will be rejected.",
           "docId": "run-as-privilege",
           "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/run-as-privilege.html",
           "name": "run_as",
@@ -134938,7 +134911,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/RoleDescriptor.ts#L28-L60"
+      "specLocation": "security/_types/RoleDescriptor.ts#L28-L61"
     },
     {
       "kind": "interface",
@@ -135034,72 +135007,6 @@
         }
       ],
       "specLocation": "security/_types/FieldSecurity.ts#L22-L25"
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "GlobalPrivilege",
-        "namespace": "security._types"
-      },
-      "properties": [
-        {
-          "name": "application",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "ApplicationGlobalUserPrivileges",
-              "namespace": "security._types"
-            }
-          }
-        }
-      ],
-      "specLocation": "security/_types/Privileges.ts#L325-L327"
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "ApplicationGlobalUserPrivileges",
-        "namespace": "security._types"
-      },
-      "properties": [
-        {
-          "name": "manage",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "ManageUserPrivileges",
-              "namespace": "security._types"
-            }
-          }
-        }
-      ],
-      "specLocation": "security/_types/Privileges.ts#L329-L331"
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "ManageUserPrivileges",
-        "namespace": "security._types"
-      },
-      "properties": [
-        {
-          "name": "applications",
-          "required": true,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "_builtins"
-              }
-            }
-          }
-        }
-      ],
-      "specLocation": "security/_types/Privileges.ts#L333-L335"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17555,6 +17555,7 @@ export interface SecurityPutRoleRequest extends RequestBase {
     indices?: SecurityIndicesPrivileges[]
     metadata?: Metadata
     run_as?: string[]
+    description?: string
     transient_metadata?: Record<string, any>
   }
 }

--- a/specification/security/_types/RoleDescriptor.ts
+++ b/specification/security/_types/RoleDescriptor.ts
@@ -37,6 +37,7 @@ export class RoleDescriptor {
   indices?: IndicesPrivileges[]
   /**
    * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges.
+   * @availability stack
    */
   global?: GlobalPrivilege[] | GlobalPrivilege
   /**
@@ -48,7 +49,7 @@ export class RoleDescriptor {
    */
   metadata?: Metadata
   /**
-   * A list of users that the API keys can impersonate.
+   * A list of users that the API keys can impersonate. *Note*: in Serverless, the run-as feature is disabled. For API compatibility, you can still specify an empty `run_as` field, but a non-empty list will be rejected.
    * @doc_id run-as-privilege
    */
   run_as?: string[]

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -73,6 +73,10 @@ export interface Request extends RequestBase {
      */
     run_as?: string[]
     /**
+     * Optional description of the role descriptor
+     */
+    description?: string
+    /**
      * Indicates roles that might be incompatible with the current cluster license, specifically roles with document and field level security. When the cluster license doesn’t allow certain features for a given role, this parameter is updated dynamically to list the incompatible features. If `enabled` is `false`, the role is ignored, but is still listed in the response from the authenticate API.
      */
     transient_metadata?: Dictionary<string, UserDefinedValue>


### PR DESCRIPTION
I included these changes for `SecurityPutRoleRequest` but they also need to be part of the role descriptor model since that is referenced by e.g. the API key APIs. 