### PR TITLE
Java issues batch 7

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -71538,8 +71538,7 @@
               }
             },
             "required": [
-              "type",
-              "language"
+              "type"
             ]
           }
         ]

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -80571,8 +80571,7 @@
         },
         "required": [
           "slm_status",
-          "policies",
-          "unhealthy_policies"
+          "policies"
         ]
       },
       "_global.health_report:SlmIndicatorUnhealthyPolicies": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -65607,6 +65607,42 @@
             "description": "Number of primary and replica shards assigned to the node.",
             "type": "string"
           },
+          "shards.undesired": {
+            "description": "Amount of shards that are scheduled to be moved elsewhere in the cluster or -1 other than desired balance allocator is used",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
+          },
+          "write_load.forecast": {
+            "description": "Sum of index write load forecasts",
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
+          },
+          "disk.indices.forecast": {
+            "description": "Sum of shard size forecasts",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/_types:ByteSize"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
+          },
           "disk.indices": {
             "description": "Disk space used by the node’s shards. Does not include disk space for the translog or unassigned shards.\nIMPORTANT: This metric double-counts disk space for hard-linked files, such as those created when shrinking, splitting, or cloning an index.",
             "oneOf": [
@@ -65694,6 +65730,18 @@
           "node": {
             "description": "Name for the node. Set using the `node.name` setting.",
             "type": "string"
+          },
+          "node.role": {
+            "description": "Node roles",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
           }
         }
       },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -59571,6 +59571,9 @@
           },
           "unit": {
             "$ref": "#/components/schemas/_types:DistanceUnit"
+          },
+          "nested": {
+            "$ref": "#/components/schemas/_types:NestedSortValue"
           }
         }
       },
@@ -59596,6 +59599,26 @@
           "m",
           "cm",
           "mm"
+        ]
+      },
+      "_types:NestedSortValue": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
+          },
+          "max_children": {
+            "type": "number"
+          },
+          "nested": {
+            "$ref": "#/components/schemas/_types:NestedSortValue"
+          },
+          "path": {
+            "$ref": "#/components/schemas/_types:Field"
+          }
+        },
+        "required": [
+          "path"
         ]
       },
       "_types:ScriptSort": {
@@ -59627,26 +59650,6 @@
           "string",
           "number",
           "version"
-        ]
-      },
-      "_types:NestedSortValue": {
-        "type": "object",
-        "properties": {
-          "filter": {
-            "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
-          },
-          "max_children": {
-            "type": "number"
-          },
-          "nested": {
-            "$ref": "#/components/schemas/_types:NestedSortValue"
-          },
-          "path": {
-            "$ref": "#/components/schemas/_types:Field"
-          }
-        },
-        "required": [
-          "path"
         ]
       },
       "_global.search._types:SourceConfig": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -98561,10 +98561,7 @@
         },
         "required": [
           "docs_indexed",
-          "docs_processed",
-          "docs_remaining",
-          "percent_complete",
-          "total_docs"
+          "docs_processed"
         ]
       },
       "transform.get_transform_stats:TransformStatsHealth": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -61884,10 +61884,7 @@
         },
         "required": [
           "docs_indexed",
-          "docs_processed",
-          "docs_remaining",
-          "percent_complete",
-          "total_docs"
+          "docs_processed"
         ]
       },
       "transform.get_transform_stats:TransformStatsHealth": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -46160,8 +46160,7 @@
               }
             },
             "required": [
-              "type",
-              "language"
+              "type"
             ]
           }
         ]

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -36509,6 +36509,9 @@
           },
           "unit": {
             "$ref": "#/components/schemas/_types:DistanceUnit"
+          },
+          "nested": {
+            "$ref": "#/components/schemas/_types:NestedSortValue"
           }
         }
       },
@@ -36534,6 +36537,26 @@
           "m",
           "cm",
           "mm"
+        ]
+      },
+      "_types:NestedSortValue": {
+        "type": "object",
+        "properties": {
+          "filter": {
+            "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
+          },
+          "max_children": {
+            "type": "number"
+          },
+          "nested": {
+            "$ref": "#/components/schemas/_types:NestedSortValue"
+          },
+          "path": {
+            "$ref": "#/components/schemas/_types:Field"
+          }
+        },
+        "required": [
+          "path"
         ]
       },
       "_types:ScriptSort": {
@@ -36565,26 +36588,6 @@
           "string",
           "number",
           "version"
-        ]
-      },
-      "_types:NestedSortValue": {
-        "type": "object",
-        "properties": {
-          "filter": {
-            "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
-          },
-          "max_children": {
-            "type": "number"
-          },
-          "nested": {
-            "$ref": "#/components/schemas/_types:NestedSortValue"
-          },
-          "path": {
-            "$ref": "#/components/schemas/_types:Field"
-          }
-        },
-        "required": [
-          "path"
         ]
       },
       "_global.search._types:SourceConfig": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -53237,7 +53237,7 @@
         "name": "Sort",
         "namespace": "_types"
       },
-      "specLocation": "_types/sort.ts#L104-L104",
+      "specLocation": "_types/sort.ts#L105-L105",
       "type": {
         "items": [
           {
@@ -53271,7 +53271,7 @@
         "name": "SortCombinations",
         "namespace": "_types"
       },
-      "specLocation": "_types/sort.ts#L98-L102",
+      "specLocation": "_types/sort.ts#L99-L103",
       "type": {
         "items": [
           {
@@ -53377,7 +53377,7 @@
           }
         }
       ],
-      "specLocation": "_types/sort.ts#L86-L96",
+      "specLocation": "_types/sort.ts#L87-L97",
       "variants": {
         "kind": "container"
       }
@@ -53534,7 +53534,7 @@
         "name": "SortMode",
         "namespace": "_types"
       },
-      "specLocation": "_types/sort.ts#L108-L117"
+      "specLocation": "_types/sort.ts#L109-L118"
     },
     {
       "kind": "interface",
@@ -53606,7 +53606,7 @@
         "name": "SortOrder",
         "namespace": "_types"
       },
-      "specLocation": "_types/sort.ts#L119-L128"
+      "specLocation": "_types/sort.ts#L120-L129"
     },
     {
       "kind": "enum",
@@ -53906,9 +53906,20 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "name": "nested",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "NestedSortValue",
+              "namespace": "_types"
+            }
+          }
         }
       ],
-      "specLocation": "_types/sort.ts#L59-L70"
+      "specLocation": "_types/sort.ts#L59-L71"
     },
     {
       "kind": "enum",
@@ -54019,7 +54030,7 @@
           }
         }
       ],
-      "specLocation": "_types/sort.ts#L72-L78"
+      "specLocation": "_types/sort.ts#L73-L79"
     },
     {
       "kind": "enum",
@@ -54038,7 +54049,7 @@
         "name": "ScriptSortType",
         "namespace": "_types"
       },
-      "specLocation": "_types/sort.ts#L80-L84"
+      "specLocation": "_types/sort.ts#L81-L85"
     },
     {
       "codegenNames": [
@@ -66989,7 +67000,7 @@
         "name": "SortResults",
         "namespace": "_types"
       },
-      "specLocation": "_types/sort.ts#L106-L106",
+      "specLocation": "_types/sort.ts#L107-L107",
       "type": {
         "kind": "array_of",
         "value": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -80069,7 +80069,7 @@
         },
         {
           "name": "language",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -136110,7 +136110,7 @@
         },
         {
           "name": "docs_remaining",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -136121,7 +136121,7 @@
         },
         {
           "name": "percent_complete",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -136132,7 +136132,7 @@
         },
         {
           "name": "total_docs",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -608,7 +608,7 @@ export interface HealthReportSlmIndicator extends HealthReportBaseIndicator {
 export interface HealthReportSlmIndicatorDetails {
   slm_status: LifecycleOperationMode
   policies: long
-  unhealthy_policies: HealthReportSlmIndicatorUnhealthyPolicies
+  unhealthy_policies?: HealthReportSlmIndicatorUnhealthyPolicies
 }
 
 export interface HealthReportSlmIndicatorUnhealthyPolicies {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4754,7 +4754,7 @@ export type AnalysisSnowballLanguage = 'Armenian' | 'Basque' | 'Catalan' | 'Dani
 
 export interface AnalysisSnowballTokenFilter extends AnalysisTokenFilterBase {
   type: 'snowball'
-  language: AnalysisSnowballLanguage
+  language?: AnalysisSnowballLanguage
 }
 
 export interface AnalysisStandardAnalyzer {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -18958,9 +18958,9 @@ export interface TransformGetTransformStatsTransformIndexerStats {
 export interface TransformGetTransformStatsTransformProgress {
   docs_indexed: long
   docs_processed: long
-  docs_remaining: long
-  percent_complete: double
-  total_docs: long
+  docs_remaining?: long
+  percent_complete?: double
+  total_docs?: long
 }
 
 export interface TransformGetTransformStatsTransformStats {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6509,6 +6509,13 @@ export type CatAliasesResponse = CatAliasesAliasesRecord[]
 export interface CatAllocationAllocationRecord {
   shards?: string
   s?: string
+  'shards.undesired'?: string | null
+  'write_load.forecast'?: double | null
+  wlf?: double | null
+  writeLoadForecast?: double | null
+  'disk.indices.forecast'?: ByteSize | null
+  dif?: ByteSize | null
+  diskIndicesForecast?: ByteSize | null
   'disk.indices'?: ByteSize | null
   di?: ByteSize | null
   diskIndices?: ByteSize | null
@@ -6529,6 +6536,10 @@ export interface CatAllocationAllocationRecord {
   ip?: Ip | null
   node?: string
   n?: string
+  'node.role'?: string | null
+  r?: string | null
+  role?: string | null
+  nodeRole?: string | null
 }
 
 export interface CatAllocationRequest extends CatCatRequestBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2242,9 +2242,10 @@ export interface GeoDistanceSortKeys {
   ignore_unmapped?: boolean
   order?: SortOrder
   unit?: DistanceUnit
+  nested?: NestedSortValue
 }
 export type GeoDistanceSort = GeoDistanceSortKeys
-  & { [property: string]: GeoLocation | GeoLocation[] | SortMode | GeoDistanceType | boolean | SortOrder | DistanceUnit }
+  & { [property: string]: GeoLocation | GeoLocation[] | SortMode | GeoDistanceType | boolean | SortOrder | DistanceUnit | NestedSortValue }
 
 export type GeoDistanceType = 'arc' | 'plane'
 

--- a/specification/_global/health_report/types.ts
+++ b/specification/_global/health_report/types.ts
@@ -160,7 +160,7 @@ export class SlmIndicator extends BaseIndicator {
 export class SlmIndicatorDetails {
   slm_status: LifecycleOperationMode
   policies: long
-  unhealthy_policies: SlmIndicatorUnhealthyPolicies
+  unhealthy_policies?: SlmIndicatorUnhealthyPolicies
 }
 
 export class SlmIndicatorUnhealthyPolicies {

--- a/specification/_types/analysis/token_filters.ts
+++ b/specification/_types/analysis/token_filters.ts
@@ -310,7 +310,7 @@ export class ReverseTokenFilter extends TokenFilterBase {
 
 export class SnowballTokenFilter extends TokenFilterBase {
   type: 'snowball'
-  language: SnowballLanguage
+  language?: SnowballLanguage
 }
 
 export class StemmerOverrideTokenFilter extends TokenFilterBase {

--- a/specification/_types/sort.ts
+++ b/specification/_types/sort.ts
@@ -67,6 +67,7 @@ export class GeoDistanceSort
   ignore_unmapped?: boolean
   order?: SortOrder
   unit?: DistanceUnit
+  nested?: NestedSortValue
 }
 
 export class ScriptSort {

--- a/specification/cat/allocation/types.ts
+++ b/specification/cat/allocation/types.ts
@@ -19,7 +19,7 @@
 
 import { ByteSize } from '@_types/common'
 import { Host, Ip } from '@_types/Networking'
-import { Percentage } from '@_types/Numeric'
+import { double, Percentage } from '@_types/Numeric'
 
 export class AllocationRecord {
   /**
@@ -27,6 +27,23 @@ export class AllocationRecord {
    * @aliases s
    */
   shards?: string
+
+  /**
+   * Amount of shards that are scheduled to be moved elsewhere in the cluster or -1 other than desired balance allocator is used
+   */
+  'shards.undesired'?: string | null
+
+  /**
+   * Sum of index write load forecasts
+   * @aliases wlf,writeLoadForecast
+   */
+  'write_load.forecast'?: double | null
+
+  /**
+   * Sum of shard size forecasts
+   * @aliases dif,diskIndicesForecast
+   */
+  'disk.indices.forecast'?: ByteSize | null
   /**
    * Disk space used by the node’s shards. Does not include disk space for the translog or unassigned shards.
    * IMPORTANT: This metric double-counts disk space for hard-linked files, such as those created when shrinking, splitting, or cloning an index.
@@ -72,4 +89,10 @@ export class AllocationRecord {
    * @aliases n
    */
   node?: string
+
+  /**
+   * Node roles
+   * @aliases r,role,nodeRole
+   */
+  'node.role'?: string | null
 }

--- a/specification/transform/get_transform_stats/types.ts
+++ b/specification/transform/get_transform_stats/types.ts
@@ -48,9 +48,9 @@ export class TransformStatsHealth {
 export class TransformProgress {
   docs_indexed: long
   docs_processed: long
-  docs_remaining: long
-  percent_complete: double
-  total_docs: long
+  docs_remaining?: long
+  percent_complete?: double
+  total_docs?: long
 }
 
 export class TransformIndexerStats {


### PR DESCRIPTION
- [826](https://github.com/elastic/elasticsearch-java/issues/826): `language` in snowball token filter should be optional, server defaults to English. [server code](https://github.com/elastic/elasticsearch/blob/89113e9b3c2fc73b5d94213285197ecc39ae94b5/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SnowballTokenFilterFactory.java#L28)
- [831](https://github.com/elastic/elasticsearch-java/issues/831): `nested` missing from geo distance sort. [server code](https://github.com/elastic/elasticsearch/blob/2a193b53d84b65395003e5be9cb5502c764be8e4/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java#L90)
- [834](https://github.com/elastic/elasticsearch-java/issues/834): `unhealthy_policies` is optional in SlmIndicator, no hard proof found in the [server code](https://github.com/elastic/elasticsearch/blob/97650b02b9a90608f539fb19d8846e6dea5243ae/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java#L203) except that it can be an empty collection, but it's easily verifiable by calling `GET _health_report` in a new cloud instance. 
- [835](https://github.com/elastic/elasticsearch-java/issues/835): AllocationRecord was missing some fields. [server code](https://github.com/elastic/elasticsearch/blob/97650b02b9a90608f539fb19d8846e6dea5243ae/server/src/main/java/org/elasticsearch/rest/action/cat/RestAllocationAction.java#L93), [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-allocation.html#cat-allocation-api-response-body). 
- [842](https://github.com/elastic/elasticsearch-java/issues/842): in TransformProgress, `total_docs` can be null, and if it is, `docs_remaining` and `percent_complete` are null too. [server code](https://github.com/elastic/elasticsearch/blob/4a77e062334b06b88ab437014a48b7e402ff4b2c/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformProgress.java#L152)
