### PR TITLE
[Proposal] Transform script into a container

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -58375,43 +58375,32 @@
         ]
       },
       "_types:Script": {
-        "allOf": [
-          {
+        "type": "object",
+        "properties": {
+          "source": {
+            "description": "The script source.",
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "params": {
+            "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
             "type": "object",
-            "properties": {
-              "params": {
-                "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
-                "type": "object",
-                "additionalProperties": {
-                  "type": "object"
-                }
-              },
-              "lang": {
-                "$ref": "#/components/schemas/_types:ScriptLanguage"
-              },
-              "options": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              }
+            "additionalProperties": {
+              "type": "object"
             }
           },
-          {
+          "lang": {
+            "$ref": "#/components/schemas/_types:ScriptLanguage"
+          },
+          "options": {
             "type": "object",
-            "properties": {
-              "source": {
-                "description": "The script source.",
-                "type": "string"
-              },
-              "id": {
-                "$ref": "#/components/schemas/_types:Id"
-              }
-            },
-            "minProperties": 1,
-            "maxProperties": 1
+            "additionalProperties": {
+              "type": "string"
+            }
           }
-        ]
+        }
       },
       "_types:ScriptLanguage": {
         "anyOf": [

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -95463,46 +95463,14 @@
         }
       },
       "security._types:RoleTemplateScript": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/security._types:RoleTemplateInlineScript"
-          },
-          {
-            "$ref": "#/components/schemas/_types:Script"
-          }
-        ]
-      },
-      "security._types:RoleTemplateInlineScript": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/_types:ScriptBase"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "source": {
-                "$ref": "#/components/schemas/security._types:RoleTemplateInlineQuery"
-              }
-            },
-            "required": [
-              "source"
-            ]
-          }
-        ]
-      },
-      "security._types:RoleTemplateInlineQuery": {
-        "oneOf": [
-          {
-            "type": "string"
-          },
-          {
-            "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
-          }
-        ]
-      },
-      "_types:ScriptBase": {
         "type": "object",
         "properties": {
+          "source": {
+            "$ref": "#/components/schemas/security._types:RoleTemplateInlineQuery"
+          },
+          "id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
           "params": {
             "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
             "type": "object",
@@ -95519,7 +95487,20 @@
               "type": "string"
             }
           }
-        }
+        },
+        "required": [
+          "source"
+        ]
+      },
+      "security._types:RoleTemplateInlineQuery": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
+          }
+        ]
       },
       "security._types:GlobalPrivilege": {
         "type": "object",

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -95487,10 +95487,7 @@
               "type": "string"
             }
           }
-        },
-        "required": [
-          "source"
-        ]
+        }
       },
       "security._types:RoleTemplateInlineQuery": {
         "oneOf": [

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -95480,15 +95480,6 @@
           {
             "type": "object",
             "properties": {
-              "lang": {
-                "$ref": "#/components/schemas/_types:ScriptLanguage"
-              },
-              "options": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              },
               "source": {
                 "$ref": "#/components/schemas/security._types:RoleTemplateInlineQuery"
               }

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -51170,7 +51170,7 @@
                   "$ref": "#/components/schemas/_global.scripts_painless_execute:PainlessContextSetup"
                 },
                 "script": {
-                  "$ref": "#/components/schemas/_types:InlineScript"
+                  "$ref": "#/components/schemas/_types:Script"
                 }
               }
             }
@@ -58375,23 +58375,17 @@
         ]
       },
       "_types:Script": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/_types:InlineScript"
-          },
-          {
-            "$ref": "#/components/schemas/_types:StoredScriptId"
-          }
-        ]
-      },
-      "_types:InlineScript": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/_types:ScriptBase"
-          },
           {
             "type": "object",
             "properties": {
+              "params": {
+                "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
               "lang": {
                 "$ref": "#/components/schemas/_types:ScriptLanguage"
               },
@@ -58400,15 +58394,22 @@
                 "additionalProperties": {
                   "type": "string"
                 }
-              },
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
               "source": {
                 "description": "The script source.",
                 "type": "string"
+              },
+              "id": {
+                "$ref": "#/components/schemas/_types:Id"
               }
             },
-            "required": [
-              "source"
-            ]
+            "minProperties": 1,
+            "maxProperties": 1
           }
         ]
       },
@@ -58425,36 +58426,6 @@
           },
           {
             "type": "string"
-          }
-        ]
-      },
-      "_types:ScriptBase": {
-        "type": "object",
-        "properties": {
-          "params": {
-            "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
-            "type": "object",
-            "additionalProperties": {
-              "type": "object"
-            }
-          }
-        }
-      },
-      "_types:StoredScriptId": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/_types:ScriptBase"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "id": {
-                "$ref": "#/components/schemas/_types:Id"
-              }
-            },
-            "required": [
-              "id"
-            ]
           }
         ]
       },
@@ -94828,7 +94799,7 @@
         "type": "object",
         "properties": {
           "script": {
-            "$ref": "#/components/schemas/_types:InlineScript"
+            "$ref": "#/components/schemas/_types:Script"
           }
         },
         "required": [
@@ -95508,7 +95479,7 @@
             "$ref": "#/components/schemas/security._types:RoleTemplateInlineScript"
           },
           {
-            "$ref": "#/components/schemas/_types:StoredScriptId"
+            "$ref": "#/components/schemas/_types:Script"
           }
         ]
       },
@@ -95548,6 +95519,27 @@
             "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
           }
         ]
+      },
+      "_types:ScriptBase": {
+        "type": "object",
+        "properties": {
+          "params": {
+            "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "lang": {
+            "$ref": "#/components/schemas/_types:ScriptLanguage"
+          },
+          "options": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
       },
       "security._types:GlobalPrivilege": {
         "type": "object",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -61049,8 +61049,6 @@
           }
         ]
       },
-<<<<<<< HEAD
-=======
       "_types:ScriptBase": {
         "type": "object",
         "properties": {
@@ -61072,43 +61070,6 @@
           }
         }
       },
-      "security._types:GlobalPrivilege": {
-        "type": "object",
-        "properties": {
-          "application": {
-            "$ref": "#/components/schemas/security._types:ApplicationGlobalUserPrivileges"
-          }
-        },
-        "required": [
-          "application"
-        ]
-      },
-      "security._types:ApplicationGlobalUserPrivileges": {
-        "type": "object",
-        "properties": {
-          "manage": {
-            "$ref": "#/components/schemas/security._types:ManageUserPrivileges"
-          }
-        },
-        "required": [
-          "manage"
-        ]
-      },
-      "security._types:ManageUserPrivileges": {
-        "type": "object",
-        "properties": {
-          "applications": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "applications"
-        ]
-      },
->>>>>>> 5459757b6 (transform script union to a container variant)
       "security._types:ApplicationPrivileges": {
         "type": "object",
         "properties": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -35313,43 +35313,32 @@
         ]
       },
       "_types:Script": {
-        "allOf": [
-          {
+        "type": "object",
+        "properties": {
+          "source": {
+            "description": "The script source.",
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "params": {
+            "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
             "type": "object",
-            "properties": {
-              "params": {
-                "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
-                "type": "object",
-                "additionalProperties": {
-                  "type": "object"
-                }
-              },
-              "lang": {
-                "$ref": "#/components/schemas/_types:ScriptLanguage"
-              },
-              "options": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              }
+            "additionalProperties": {
+              "type": "object"
             }
           },
-          {
+          "lang": {
+            "$ref": "#/components/schemas/_types:ScriptLanguage"
+          },
+          "options": {
             "type": "object",
-            "properties": {
-              "source": {
-                "description": "The script source.",
-                "type": "string"
-              },
-              "id": {
-                "$ref": "#/components/schemas/_types:Id"
-              }
-            },
-            "minProperties": 1,
-            "maxProperties": 1
+            "additionalProperties": {
+              "type": "string"
+            }
           }
-        ]
+        }
       },
       "_types:ScriptLanguage": {
         "anyOf": [

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -61009,15 +61009,6 @@
           {
             "type": "object",
             "properties": {
-              "lang": {
-                "$ref": "#/components/schemas/_types:ScriptLanguage"
-              },
-              "options": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                }
-              },
               "source": {
                 "$ref": "#/components/schemas/security._types:RoleTemplateInlineQuery"
               }

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -60992,46 +60992,14 @@
         }
       },
       "security._types:RoleTemplateScript": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/security._types:RoleTemplateInlineScript"
-          },
-          {
-            "$ref": "#/components/schemas/_types:Script"
-          }
-        ]
-      },
-      "security._types:RoleTemplateInlineScript": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/_types:ScriptBase"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "source": {
-                "$ref": "#/components/schemas/security._types:RoleTemplateInlineQuery"
-              }
-            },
-            "required": [
-              "source"
-            ]
-          }
-        ]
-      },
-      "security._types:RoleTemplateInlineQuery": {
-        "oneOf": [
-          {
-            "type": "string"
-          },
-          {
-            "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
-          }
-        ]
-      },
-      "_types:ScriptBase": {
         "type": "object",
         "properties": {
+          "source": {
+            "$ref": "#/components/schemas/security._types:RoleTemplateInlineQuery"
+          },
+          "id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
           "params": {
             "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
             "type": "object",
@@ -61048,7 +61016,20 @@
               "type": "string"
             }
           }
-        }
+        },
+        "required": [
+          "source"
+        ]
+      },
+      "security._types:RoleTemplateInlineQuery": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
+          }
+        ]
       },
       "security._types:ApplicationPrivileges": {
         "type": "object",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -28623,7 +28623,7 @@
                   "$ref": "#/components/schemas/_global.scripts_painless_execute:PainlessContextSetup"
                 },
                 "script": {
-                  "$ref": "#/components/schemas/_types:InlineScript"
+                  "$ref": "#/components/schemas/_types:Script"
                 }
               }
             }
@@ -35313,23 +35313,17 @@
         ]
       },
       "_types:Script": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/_types:InlineScript"
-          },
-          {
-            "$ref": "#/components/schemas/_types:StoredScriptId"
-          }
-        ]
-      },
-      "_types:InlineScript": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/_types:ScriptBase"
-          },
           {
             "type": "object",
             "properties": {
+              "params": {
+                "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "object"
+                }
+              },
               "lang": {
                 "$ref": "#/components/schemas/_types:ScriptLanguage"
               },
@@ -35338,15 +35332,22 @@
                 "additionalProperties": {
                   "type": "string"
                 }
-              },
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
               "source": {
                 "description": "The script source.",
                 "type": "string"
+              },
+              "id": {
+                "$ref": "#/components/schemas/_types:Id"
               }
             },
-            "required": [
-              "source"
-            ]
+            "minProperties": 1,
+            "maxProperties": 1
           }
         ]
       },
@@ -35363,36 +35364,6 @@
           },
           {
             "type": "string"
-          }
-        ]
-      },
-      "_types:ScriptBase": {
-        "type": "object",
-        "properties": {
-          "params": {
-            "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
-            "type": "object",
-            "additionalProperties": {
-              "type": "object"
-            }
-          }
-        }
-      },
-      "_types:StoredScriptId": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/_types:ScriptBase"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "id": {
-                "$ref": "#/components/schemas/_types:Id"
-              }
-            },
-            "required": [
-              "id"
-            ]
           }
         ]
       },
@@ -60695,7 +60666,7 @@
         "type": "object",
         "properties": {
           "script": {
-            "$ref": "#/components/schemas/_types:InlineScript"
+            "$ref": "#/components/schemas/_types:Script"
           }
         },
         "required": [
@@ -61037,7 +61008,7 @@
             "$ref": "#/components/schemas/security._types:RoleTemplateInlineScript"
           },
           {
-            "$ref": "#/components/schemas/_types:StoredScriptId"
+            "$ref": "#/components/schemas/_types:Script"
           }
         ]
       },
@@ -61078,6 +61049,66 @@
           }
         ]
       },
+<<<<<<< HEAD
+=======
+      "_types:ScriptBase": {
+        "type": "object",
+        "properties": {
+          "params": {
+            "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "lang": {
+            "$ref": "#/components/schemas/_types:ScriptLanguage"
+          },
+          "options": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "security._types:GlobalPrivilege": {
+        "type": "object",
+        "properties": {
+          "application": {
+            "$ref": "#/components/schemas/security._types:ApplicationGlobalUserPrivileges"
+          }
+        },
+        "required": [
+          "application"
+        ]
+      },
+      "security._types:ApplicationGlobalUserPrivileges": {
+        "type": "object",
+        "properties": {
+          "manage": {
+            "$ref": "#/components/schemas/security._types:ManageUserPrivileges"
+          }
+        },
+        "required": [
+          "manage"
+        ]
+      },
+      "security._types:ManageUserPrivileges": {
+        "type": "object",
+        "properties": {
+          "applications": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "applications"
+        ]
+      },
+>>>>>>> 5459757b6 (transform script union to a container variant)
       "security._types:ApplicationPrivileges": {
         "type": "object",
         "properties": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -61016,10 +61016,7 @@
               "type": "string"
             }
           }
-        },
-        "required": [
-          "source"
-        ]
+        }
       },
       "security._types:RoleTemplateInlineQuery": {
         "oneOf": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -98757,7 +98757,7 @@
         "name": "ClusterPrivilege",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L41-L194"
+      "specLocation": "security/_types/Privileges.ts#L42-L195"
     },
     {
       "kind": "enum",
@@ -98834,7 +98834,7 @@
         "name": "IndexPrivilege",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L279-L321"
+      "specLocation": "security/_types/Privileges.ts#L292-L334"
     },
     {
       "codegenNames": [
@@ -98848,7 +98848,7 @@
         "name": "IndicesPrivilegesQuery",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L246-L254",
+      "specLocation": "security/_types/Privileges.ts#L247-L255",
       "type": {
         "items": [
           {
@@ -98898,49 +98898,12 @@
           }
         }
       ],
-      "specLocation": "security/_types/Privileges.ts#L256-L266"
+      "specLocation": "security/_types/Privileges.ts#L257-L267"
     },
     {
-      "codegenNames": [
-        "inline",
-        "stored"
-      ],
-      "kind": "type_alias",
-      "name": {
-        "name": "RoleTemplateScript",
-        "namespace": "security._types"
-      },
-      "specLocation": "security/_types/Privileges.ts#L276-L277",
-      "type": {
-        "items": [
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "RoleTemplateInlineScript",
-              "namespace": "security._types"
-            }
-          },
-          {
-            "kind": "instance_of",
-            "type": {
-              "name": "Script",
-              "namespace": "_types"
-            }
-          }
-        ],
-        "kind": "union_of"
-      }
-    },
-    {
-      "inherits": {
-        "type": {
-          "name": "ScriptBase",
-          "namespace": "_types"
-        }
-      },
       "kind": "interface",
       "name": {
-        "name": "RoleTemplateInlineScript",
+        "name": "RoleTemplateScript",
         "namespace": "security._types"
       },
       "properties": [
@@ -98954,18 +98917,19 @@
               "namespace": "security._types"
             }
           }
-        }
-      ],
-      "shortcutProperty": "source",
-      "specLocation": "security/_types/Privileges.ts#L268-L271"
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "ScriptBase",
-        "namespace": "_types"
-      },
-      "properties": [
+        },
+        {
+          "description": "The `id` for a stored script.",
+          "name": "id",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
         {
           "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
           "name": "params",
@@ -99021,7 +98985,8 @@
           }
         }
       ],
-      "specLocation": "_types/Scripting.ts#L59-L71"
+      "shortcutProperty": "source",
+      "specLocation": "security/_types/Privileges.ts#L269-L287"
     },
     {
       "codegenNames": [
@@ -99033,7 +98998,7 @@
         "name": "RoleTemplateInlineQuery",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L273-L274",
+      "specLocation": "security/_types/Privileges.ts#L289-L290",
       "type": {
         "items": [
           {
@@ -134140,7 +134105,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/Privileges.ts#L196-L220"
+      "specLocation": "security/_types/Privileges.ts#L197-L221"
     },
     {
       "kind": "interface",
@@ -134224,7 +134189,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/Privileges.ts#L26-L39"
+      "specLocation": "security/_types/Privileges.ts#L27-L40"
     },
     {
       "kind": "interface",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -36059,7 +36059,7 @@
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "InlineScript",
+                "name": "Script",
                 "namespace": "_types"
               }
             }
@@ -49859,50 +49859,58 @@
       "specLocation": "_types/query_dsl/compound.ts#L121-L126"
     },
     {
-      "codegenNames": [
-        "inline",
-        "stored"
-      ],
-      "kind": "type_alias",
+      "kind": "interface",
       "name": {
         "name": "Script",
         "namespace": "_types"
       },
-      "specLocation": "_types/Scripting.ts#L88-L89",
-      "type": {
-        "items": [
-          {
+      "properties": [
+        {
+          "description": "The script source.",
+          "name": "source",
+          "required": false,
+          "type": {
             "kind": "instance_of",
             "type": {
-              "name": "InlineScript",
-              "namespace": "_types"
+              "name": "string",
+              "namespace": "_builtins"
             }
-          },
-          {
+          }
+        },
+        {
+          "description": "The `id` for a stored script.",
+          "name": "id",
+          "required": false,
+          "type": {
             "kind": "instance_of",
             "type": {
-              "name": "StoredScriptId",
+              "name": "Id",
               "namespace": "_types"
             }
           }
-        ],
-        "kind": "union_of"
-      }
-    },
-    {
-      "inherits": {
-        "type": {
-          "name": "ScriptBase",
-          "namespace": "_types"
-        }
-      },
-      "kind": "interface",
-      "name": {
-        "name": "InlineScript",
-        "namespace": "_types"
-      },
-      "properties": [
+        },
         {
+          "containerProperty": true,
+          "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
+          "name": "params",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "_builtins"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "user_defined_value"
+            }
+          }
+        },
+        {
+          "containerProperty": true,
           "description": "Specifies the language the script is written in.",
           "name": "lang",
           "required": false,
@@ -49916,6 +49924,7 @@
           }
         },
         {
+          "containerProperty": true,
           "name": "options",
           "required": false,
           "type": {
@@ -49936,51 +49945,13 @@
               }
             }
           }
-        },
-        {
-          "description": "The script source.",
-          "name": "source",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
         }
       ],
       "shortcutProperty": "source",
-      "specLocation": "_types/Scripting.ts#L67-L79"
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "ScriptBase",
-        "namespace": "_types"
-      },
-      "properties": [
-        {
-          "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
-          "name": "params",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "_builtins"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "user_defined_value"
-            }
-          }
-        }
-      ],
-      "specLocation": "_types/Scripting.ts#L59-L65"
+      "specLocation": "_types/Scripting.ts#L73-L103",
+      "variants": {
+        "kind": "container"
+      }
     },
     {
       "isOpen": true,
@@ -50008,34 +49979,6 @@
         "namespace": "_types"
       },
       "specLocation": "_types/Scripting.ts#L24-L45"
-    },
-    {
-      "inherits": {
-        "type": {
-          "name": "ScriptBase",
-          "namespace": "_types"
-        }
-      },
-      "kind": "interface",
-      "name": {
-        "name": "StoredScriptId",
-        "namespace": "_types"
-      },
-      "properties": [
-        {
-          "description": "The `id` for a stored script.",
-          "name": "id",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Id",
-              "namespace": "_types"
-            }
-          }
-        }
-      ],
-      "specLocation": "_types/Scripting.ts#L81-L86"
     },
     {
       "kind": "enum",
@@ -53229,7 +53172,7 @@
           }
         }
       ],
-      "specLocation": "_types/Scripting.ts#L91-L94"
+      "specLocation": "_types/Scripting.ts#L105-L108"
     },
     {
       "kind": "type_alias",
@@ -98646,7 +98589,7 @@
         "name": "QueryRuleCriteriaType",
         "namespace": "query_rules._types"
       },
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L56-L69"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L54-L67"
     },
     {
       "kind": "enum",
@@ -98659,7 +98602,7 @@
         "name": "QueryRuleType",
         "namespace": "query_rules._types"
       },
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L46-L48"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L44-L46"
     },
     {
       "kind": "enum",
@@ -98986,7 +98929,7 @@
           {
             "kind": "instance_of",
             "type": {
-              "name": "StoredScriptId",
+              "name": "Script",
               "namespace": "_types"
             }
           }
@@ -99054,6 +98997,70 @@
       ],
       "shortcutProperty": "source",
       "specLocation": "security/_types/Privileges.ts#L268-L273"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "ScriptBase",
+        "namespace": "_types"
+      },
+      "properties": [
+        {
+          "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
+          "name": "params",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "_builtins"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "user_defined_value"
+            }
+          }
+        },
+        {
+          "description": "Specifies the language the script is written in.",
+          "name": "lang",
+          "required": false,
+          "serverDefault": "painless",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ScriptLanguage",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "options",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "_builtins"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "_builtins"
+              }
+            }
+          }
+        }
+      ],
+      "specLocation": "_types/Scripting.ts#L59-L71"
     },
     {
       "codegenNames": [
@@ -132047,7 +132054,7 @@
           }
         }
       ],
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L38-L44"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L36-L42"
     },
     {
       "kind": "interface",
@@ -132089,7 +132096,7 @@
           }
         }
       ],
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L50-L54"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L48-L52"
     },
     {
       "kind": "interface",
@@ -132127,7 +132134,7 @@
           }
         }
       ],
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L71-L74"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L69-L72"
     },
     {
       "kind": "interface",
@@ -132164,7 +132171,7 @@
           }
         }
       ],
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L27-L36"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L25-L34"
     },
     {
       "kind": "interface",
@@ -133631,7 +133638,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "InlineScript",
+              "name": "Script",
               "namespace": "_types"
             }
           }

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -98909,7 +98909,7 @@
       "properties": [
         {
           "name": "source",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -98834,7 +98834,7 @@
         "name": "IndexPrivilege",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L281-L323"
+      "specLocation": "security/_types/Privileges.ts#L279-L321"
     },
     {
       "codegenNames": [
@@ -98910,7 +98910,7 @@
         "name": "RoleTemplateScript",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L278-L279",
+      "specLocation": "security/_types/Privileges.ts#L276-L277",
       "type": {
         "items": [
           {
@@ -98945,39 +98945,6 @@
       },
       "properties": [
         {
-          "name": "lang",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "ScriptLanguage",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "options",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "_builtins"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "_builtins"
-              }
-            }
-          }
-        },
-        {
           "name": "source",
           "required": true,
           "type": {
@@ -98990,7 +98957,7 @@
         }
       ],
       "shortcutProperty": "source",
-      "specLocation": "security/_types/Privileges.ts#L268-L273"
+      "specLocation": "security/_types/Privileges.ts#L268-L271"
     },
     {
       "kind": "interface",
@@ -99066,7 +99033,7 @@
         "name": "RoleTemplateInlineQuery",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L275-L276",
+      "specLocation": "security/_types/Privileges.ts#L273-L274",
       "type": {
         "items": [
           {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -49890,7 +49890,6 @@
           }
         },
         {
-          "containerProperty": true,
           "description": "Specifies any named parameters that are passed into the script as variables.\nUse parameters instead of hard-coded values to decrease compile time.",
           "name": "params",
           "required": false,
@@ -49910,7 +49909,6 @@
           }
         },
         {
-          "containerProperty": true,
           "description": "Specifies the language the script is written in.",
           "name": "lang",
           "required": false,
@@ -49924,7 +49922,6 @@
           }
         },
         {
-          "containerProperty": true,
           "name": "options",
           "required": false,
           "type": {
@@ -49948,10 +49945,7 @@
         }
       ],
       "shortcutProperty": "source",
-      "specLocation": "_types/Scripting.ts#L73-L103",
-      "variants": {
-        "kind": "container"
-      }
+      "specLocation": "_types/Scripting.ts#L73-L97"
     },
     {
       "isOpen": true,
@@ -53172,7 +53166,7 @@
           }
         }
       ],
-      "specLocation": "_types/Scripting.ts#L105-L108"
+      "specLocation": "_types/Scripting.ts#L99-L102"
     },
     {
       "kind": "type_alias",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1047,6 +1047,13 @@
       ],
       "response": []
     },
+    "security.authenticate": {
+      "request": [],
+      "response": [
+        "interface definition security._types:RoleTemplateInlineScript - Property 'lang' is already defined in an ancestor class",
+        "interface definition security._types:RoleTemplateInlineScript - Property 'options' is already defined in an ancestor class"
+      ]
+    },
     "security.bulk_update_api_keys": {
       "request": [
         "Missing request & response"

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1047,13 +1047,6 @@
       ],
       "response": []
     },
-    "security.authenticate": {
-      "request": [],
-      "response": [
-        "interface definition security._types:RoleTemplateInlineScript - Property 'lang' is already defined in an ancestor class",
-        "interface definition security._types:RoleTemplateInlineScript - Property 'options' is already defined in an ancestor class"
-      ]
-    },
     "security.bulk_update_api_keys": {
       "request": [
         "Missing request & response"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16938,8 +16938,6 @@ export interface SecurityRoleTemplate {
 export type SecurityRoleTemplateInlineQuery = string | QueryDslQueryContainer
 
 export interface SecurityRoleTemplateInlineScript extends ScriptBase {
-  lang?: ScriptLanguage
-  options?: Record<string, string>
   source: SecurityRoleTemplateInlineQuery
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -84,7 +84,7 @@ export interface BulkUpdateAction<TDocument = unknown, TPartialDocument = unknow
   detect_noop?: boolean
   doc?: TPartialDocument
   doc_as_upsert?: boolean
-  script?: Script
+  script?: Script | string
   scripted_upsert?: boolean
   _source?: SearchSourceConfig
   upsert?: TDocument
@@ -1021,7 +1021,7 @@ export interface ReindexRequest extends RequestBase {
     conflicts?: Conflicts
     dest: ReindexDestination
     max_docs?: long
-    script?: Script
+    script?: Script | string
     size?: long
     source: ReindexSource
   }
@@ -1122,7 +1122,7 @@ export interface ScriptsPainlessExecuteRequest extends RequestBase {
   body?: {
     context?: string
     context_setup?: ScriptsPainlessExecutePainlessContextSetup
-    script?: InlineScript | string
+    script?: Script | string
   }
 }
 
@@ -1933,7 +1933,7 @@ export interface UpdateRequest<TDocument = unknown, TPartialDocument = unknown> 
     detect_noop?: boolean
     doc?: TPartialDocument
     doc_as_upsert?: boolean
-    script?: Script
+    script?: Script | string
     scripted_upsert?: boolean
     _source?: SearchSourceConfig
     upsert?: TDocument
@@ -1981,7 +1981,7 @@ export interface UpdateByQueryRequest extends RequestBase {
   body?: {
     max_docs?: long
     query?: QueryDslQueryContainer
-    script?: Script
+    script?: Script | string
     slice?: SlicedScroll
     conflicts?: Conflicts
   }
@@ -2350,12 +2350,6 @@ export interface InlineGetKeys<TDocument = unknown> {
 export type InlineGet<TDocument = unknown> = InlineGetKeys<TDocument>
   & { [property: string]: any }
 
-export interface InlineScript extends ScriptBase {
-  lang?: ScriptLanguage
-  options?: Record<string, string>
-  source: string
-}
-
 export type Ip = string
 
 export interface KnnQuery extends QueryDslQueryBase {
@@ -2598,14 +2592,22 @@ export interface ScoreSort {
   order?: SortOrder
 }
 
-export type Script = InlineScript | string | StoredScriptId
+export interface Script {
+  source?: string
+  id?: Id
+  params?: Record<string, any>
+  lang?: ScriptLanguage
+  options?: Record<string, string>
+}
 
 export interface ScriptBase {
   params?: Record<string, any>
+  lang?: ScriptLanguage
+  options?: Record<string, string>
 }
 
 export interface ScriptField {
-  script: Script
+  script: Script | string
   ignore_failure?: boolean
 }
 
@@ -2613,7 +2615,7 @@ export type ScriptLanguage = 'painless' | 'expression' | 'mustache' | 'java'| st
 
 export interface ScriptSort {
   order?: SortOrder
-  script: Script
+  script: Script | string
   type?: ScriptSortType
   mode?: SortMode
   nested?: NestedSortValue
@@ -2762,10 +2764,6 @@ export interface StoredScript {
   lang: ScriptLanguage
   options?: Record<string, string>
   source: string
-}
-
-export interface StoredScriptId extends ScriptBase {
-  id: Id
 }
 
 export type SuggestMode = 'missing' | 'popular' | 'always'
@@ -3016,7 +3014,7 @@ export interface AggregationsAutoDateHistogramAggregation extends AggregationsBu
   missing?: DateTime
   offset?: string
   params?: Record<string, any>
-  script?: Script
+  script?: Script | string
   time_zone?: TimeZone
 }
 
@@ -3086,11 +3084,11 @@ export interface AggregationsBucketPathAggregation {
 }
 
 export interface AggregationsBucketScriptAggregation extends AggregationsPipelineAggregationBase {
-  script?: Script
+  script?: Script | string
 }
 
 export interface AggregationsBucketSelectorAggregation extends AggregationsPipelineAggregationBase {
-  script?: Script
+  script?: Script | string
 }
 
 export interface AggregationsBucketSortAggregation {
@@ -3163,7 +3161,7 @@ export interface AggregationsCompositeAggregationBase {
   field?: Field
   missing_bucket?: boolean
   missing_order?: AggregationsMissingOrder
-  script?: Script
+  script?: Script | string
   value_type?: AggregationsValueType
   order?: SortOrder
 }
@@ -3234,7 +3232,7 @@ export interface AggregationsDateHistogramAggregation extends AggregationsBucket
   offset?: Duration
   order?: AggregationsAggregateOrder
   params?: Record<string, any>
-  script?: Script
+  script?: Script | string
   time_zone?: TimeZone
   keyed?: boolean
 }
@@ -3275,7 +3273,7 @@ export interface AggregationsDerivativeAggregation extends AggregationsPipelineA
 export interface AggregationsDiversifiedSamplerAggregation extends AggregationsBucketAggregationBase {
   execution_hint?: AggregationsSamplerAggregationExecutionHint
   max_docs_per_value?: integer
-  script?: Script
+  script?: Script | string
   shard_size?: integer
   field?: Field
 }
@@ -3524,7 +3522,7 @@ export interface AggregationsHistogramAggregation extends AggregationsBucketAggr
   missing?: double
   offset?: double
   order?: AggregationsAggregateOrder
-  script?: Script
+  script?: Script | string
   format?: string
   keyed?: boolean
 }
@@ -3712,7 +3710,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregation extends Aggregat
 export interface AggregationsMetricAggregationBase {
   field?: Field
   missing?: AggregationsMissing
-  script?: Script
+  script?: Script | string
 }
 
 export interface AggregationsMinAggregate extends AggregationsSingleMetricAggregateBase {
@@ -3867,7 +3865,7 @@ export interface AggregationsRangeAggregation extends AggregationsBucketAggregat
   field?: Field
   missing?: integer
   ranges?: AggregationsAggregationRange[]
-  script?: Script
+  script?: Script | string
   keyed?: boolean
   format?: string
 }
@@ -3925,7 +3923,7 @@ export interface AggregationsSamplerAggregation extends AggregationsBucketAggreg
 export type AggregationsSamplerAggregationExecutionHint = 'map' | 'global_ordinals' | 'bytes_hash'
 
 export interface AggregationsScriptedHeuristic {
-  script: Script
+  script: Script | string
 }
 
 export interface AggregationsScriptedMetricAggregate extends AggregationsAggregateBase {
@@ -3933,11 +3931,11 @@ export interface AggregationsScriptedMetricAggregate extends AggregationsAggrega
 }
 
 export interface AggregationsScriptedMetricAggregation extends AggregationsMetricAggregationBase {
-  combine_script?: Script
-  init_script?: Script
-  map_script?: Script
+  combine_script?: Script | string
+  init_script?: Script | string
+  map_script?: Script | string
   params?: Record<string, any>
-  reduce_script?: Script
+  reduce_script?: Script | string
 }
 
 export interface AggregationsSerialDifferencingAggregation extends AggregationsPipelineAggregationBase {
@@ -4150,7 +4148,7 @@ export interface AggregationsTermsAggregation extends AggregationsBucketAggregat
   missing_bucket?: boolean
   value_type?: string
   order?: AggregationsAggregateOrder
-  script?: Script
+  script?: Script | string
   shard_min_doc_count?: long
   shard_size?: integer
   show_term_doc_count_error?: boolean
@@ -4177,7 +4175,7 @@ export interface AggregationsTermsPartition {
 
 export interface AggregationsTestPopulation {
   field: Field
-  script?: Script
+  script?: Script | string
   filter?: QueryDslQueryContainer
 }
 
@@ -4250,7 +4248,7 @@ export interface AggregationsVariableWidthHistogramAggregation {
   buckets?: integer
   shard_size?: integer
   initial_buffer?: integer
-  script?: Script
+  script?: Script | string
 }
 
 export interface AggregationsVariableWidthHistogramBucketKeys extends AggregationsMultiBucketBase {
@@ -4274,7 +4272,7 @@ export interface AggregationsWeightedAverageAggregation {
 export interface AggregationsWeightedAverageValue {
   field?: Field
   missing?: double
-  script?: Script
+  script?: Script | string
 }
 
 export interface AggregationsWeightedAvgAggregate extends AggregationsSingleMetricAggregateBase {
@@ -4322,7 +4320,7 @@ export interface AnalysisCompoundWordTokenFilterBase extends AnalysisTokenFilter
 export interface AnalysisConditionTokenFilter extends AnalysisTokenFilterBase {
   type: 'condition'
   filter: string[]
-  script: Script
+  script: Script | string
 }
 
 export interface AnalysisCustomAnalyzer {
@@ -4717,7 +4715,7 @@ export interface AnalysisPorterStemTokenFilter extends AnalysisTokenFilterBase {
 
 export interface AnalysisPredicateTokenFilter extends AnalysisTokenFilterBase {
   type: 'predicate_token_filter'
-  script: Script
+  script: Script | string
 }
 
 export interface AnalysisRemoveDuplicatesTokenFilter extends AnalysisTokenFilterBase {
@@ -5035,7 +5033,7 @@ export interface MappingDynamicProperty extends MappingDocValuesPropertyBase {
   null_value?: FieldValue
   boost?: double
   coerce?: boolean
-  script?: Script
+  script?: Script | string
   on_script_error?: MappingOnScriptError
   ignore_malformed?: boolean
   time_series_metric?: MappingTimeSeriesMetricType
@@ -5113,7 +5111,7 @@ export interface MappingGeoPointProperty extends MappingDocValuesPropertyBase {
   null_value?: GeoLocation
   index?: boolean
   on_script_error?: MappingOnScriptError
-  script?: Script
+  script?: Script | string
   type: 'geo_point'
 }
 
@@ -5179,7 +5177,7 @@ export interface MappingIpProperty extends MappingDocValuesPropertyBase {
   ignore_malformed?: boolean
   null_value?: string
   on_script_error?: MappingOnScriptError
-  script?: Script
+  script?: Script | string
   time_series_dimension?: boolean
   type: 'ip'
 }
@@ -5199,7 +5197,7 @@ export interface MappingKeywordProperty extends MappingDocValuesPropertyBase {
   eager_global_ordinals?: boolean
   index?: boolean
   index_options?: MappingIndexOptions
-  script?: Script
+  script?: Script | string
   on_script_error?: MappingOnScriptError
   normalizer?: string
   norms?: boolean
@@ -5244,7 +5242,7 @@ export interface MappingNumberPropertyBase extends MappingDocValuesPropertyBase 
   ignore_malformed?: boolean
   index?: boolean
   on_script_error?: MappingOnScriptError
-  script?: Script
+  script?: Script | string
   time_series_metric?: MappingTimeSeriesMetricType
   time_series_dimension?: boolean
 }
@@ -5304,7 +5302,7 @@ export interface MappingRuntimeField {
   input_field?: Field
   target_field?: Field
   target_index?: IndexName
-  script?: Script
+  script?: Script | string
   type: MappingRuntimeFieldType
 }
 
@@ -5694,7 +5692,7 @@ export interface QueryDslIntervalsFilter {
   not_containing?: QueryDslIntervalsContainer
   not_overlapping?: QueryDslIntervalsContainer
   overlapping?: QueryDslIntervalsContainer
-  script?: Script
+  script?: Script | string
 }
 
 export interface QueryDslIntervalsFuzzy {
@@ -6053,17 +6051,17 @@ export interface QueryDslRuleQuery extends QueryDslQueryBase {
 }
 
 export interface QueryDslScriptQuery extends QueryDslQueryBase {
-  script: Script
+  script: Script | string
 }
 
 export interface QueryDslScriptScoreFunction {
-  script: Script
+  script: Script | string
 }
 
 export interface QueryDslScriptScoreQuery extends QueryDslQueryBase {
   min_score?: float
   query: QueryDslQueryContainer
-  script: Script
+  script: Script | string
 }
 
 export interface QueryDslSemanticQuery extends QueryDslQueryBase {
@@ -6197,7 +6195,7 @@ export type QueryDslTermsQueryField = FieldValue[] | QueryDslTermsLookup
 
 export interface QueryDslTermsSetQuery extends QueryDslQueryBase {
   minimum_should_match_field?: Field
-  minimum_should_match_script?: Script
+  minimum_should_match_script?: Script | string
   terms: string[]
 }
 
@@ -10733,8 +10731,8 @@ export interface IndicesSettingsSimilarityLmj {
 
 export interface IndicesSettingsSimilarityScripted {
   type: 'scripted'
-  script: Script
-  weight_script?: Script
+  script: Script | string
+  weight_script?: Script | string
 }
 
 export interface IndicesSlowlogSettings {
@@ -16668,7 +16666,7 @@ export interface SearchApplicationSearchApplication {
 }
 
 export interface SearchApplicationSearchApplicationTemplate {
-  script: InlineScript | string
+  script: Script | string
 }
 
 export interface SearchApplicationDeleteRequest extends RequestBase {
@@ -16934,7 +16932,7 @@ export interface SecurityRoleMappingRule {
 
 export interface SecurityRoleTemplate {
   format?: SecurityTemplateFormat
-  template: Script
+  template: Script | string
 }
 
 export type SecurityRoleTemplateInlineQuery = string | QueryDslQueryContainer
@@ -16949,7 +16947,7 @@ export interface SecurityRoleTemplateQuery {
   template?: SecurityRoleTemplateScript
 }
 
-export type SecurityRoleTemplateScript = SecurityRoleTemplateInlineScript | SecurityRoleTemplateInlineQuery | StoredScriptId
+export type SecurityRoleTemplateScript = SecurityRoleTemplateInlineScript | SecurityRoleTemplateInlineQuery | Script | string
 
 export type SecurityTemplateFormat = 'string' | 'json'
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2600,12 +2600,6 @@ export interface Script {
   options?: Record<string, string>
 }
 
-export interface ScriptBase {
-  params?: Record<string, any>
-  lang?: ScriptLanguage
-  options?: Record<string, string>
-}
-
 export interface ScriptField {
   script: Script | string
   ignore_failure?: boolean
@@ -16937,15 +16931,17 @@ export interface SecurityRoleTemplate {
 
 export type SecurityRoleTemplateInlineQuery = string | QueryDslQueryContainer
 
-export interface SecurityRoleTemplateInlineScript extends ScriptBase {
-  source: SecurityRoleTemplateInlineQuery
-}
-
 export interface SecurityRoleTemplateQuery {
-  template?: SecurityRoleTemplateScript
+  template?: SecurityRoleTemplateScript | SecurityRoleTemplateInlineQuery
 }
 
-export type SecurityRoleTemplateScript = SecurityRoleTemplateInlineScript | SecurityRoleTemplateInlineQuery | Script | string
+export interface SecurityRoleTemplateScript {
+  source: SecurityRoleTemplateInlineQuery
+  id?: Id
+  params?: Record<string, any>
+  lang?: ScriptLanguage
+  options?: Record<string, string>
+}
 
 export type SecurityTemplateFormat = 'string' | 'json'
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16936,7 +16936,7 @@ export interface SecurityRoleTemplateQuery {
 }
 
 export interface SecurityRoleTemplateScript {
-  source: SecurityRoleTemplateInlineQuery
+  source?: SecurityRoleTemplateInlineQuery
   id?: Id
   params?: Record<string, any>
   lang?: ScriptLanguage

--- a/specification/_global/scripts_painless_execute/ExecutePainlessScriptRequest.ts
+++ b/specification/_global/scripts_painless_execute/ExecutePainlessScriptRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { InlineScript } from '@_types/Scripting'
+import { Script } from '@_types/Scripting'
 import { PainlessContextSetup } from './types'
 
 /**
@@ -41,6 +41,6 @@ export interface Request extends RequestBase {
     /**
      * The Painless script to execute.
      */
-    script?: InlineScript
+    script?: Script
   }
 }

--- a/specification/_types/Scripting.ts
+++ b/specification/_types/Scripting.ts
@@ -71,7 +71,6 @@ export class ScriptBase {
 }
 
 /**
- * @variants container
  * @shortcut_property source
  * */
 export class Script {
@@ -87,18 +86,13 @@ export class Script {
   /**
    * Specifies any named parameters that are passed into the script as variables.
    * Use parameters instead of hard-coded values to decrease compile time.
-   * @variant container_property
    */
   params?: Dictionary<string, UserDefinedValue>
   /**
    * Specifies the language the script is written in.
    * @server_default painless
-   * @variant container_property
    */
   lang?: ScriptLanguage
-  /**
-   * @variant container_property
-   */
   options?: Dictionary<string, string>
 }
 

--- a/specification/_types/Scripting.ts
+++ b/specification/_types/Scripting.ts
@@ -62,31 +62,45 @@ export class ScriptBase {
    * Use parameters instead of hard-coded values to decrease compile time.
    */
   params?: Dictionary<string, UserDefinedValue>
-}
-
-/** @shortcut_property source */
-export class InlineScript extends ScriptBase {
   /**
    * Specifies the language the script is written in.
    * @server_default painless
    */
   lang?: ScriptLanguage
   options?: Dictionary<string, string>
+}
+
+/**
+ * @variants container
+ * @shortcut_property source
+ * */
+export class Script {
   /**
    * The script source.
    */
-  source: string
-}
-
-export class StoredScriptId extends ScriptBase {
+  source?: string
   /**
    * The `id` for a stored script.
    */
-  id: Id
-}
+  id?: Id
 
-/** @codegen_names inline, stored */
-export type Script = InlineScript | StoredScriptId
+  /**
+   * Specifies any named parameters that are passed into the script as variables.
+   * Use parameters instead of hard-coded values to decrease compile time.
+   * @variant container_property
+   */
+  params?: Dictionary<string, UserDefinedValue>
+  /**
+   * Specifies the language the script is written in.
+   * @server_default painless
+   * @variant container_property
+   */
+  lang?: ScriptLanguage
+  /**
+   * @variant container_property
+   */
+  options?: Dictionary<string, string>
+}
 
 export class ScriptField {
   script: Script

--- a/specification/query_rules/_types/QueryRuleset.ts
+++ b/specification/query_rules/_types/QueryRuleset.ts
@@ -17,10 +17,8 @@
  * under the License.
  */
 
-import { Id, IndexName, Name } from '@_types/common'
+import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
-import { EpochTime, UnitMillis } from '@_types/Time'
-import { InlineScript } from '@_types/Scripting'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { PinnedDoc } from '../../_types/query_dsl/specialized'
 

--- a/specification/search_application/_types/SearchApplication.ts
+++ b/specification/search_application/_types/SearchApplication.ts
@@ -19,7 +19,7 @@
 
 import { IndexName, Name } from '@_types/common'
 import { EpochTime, UnitMillis } from '@_types/Time'
-import { InlineScript } from '@_types/Scripting'
+import { Script } from '@_types/Scripting'
 
 export class SearchApplication {
   /**
@@ -48,5 +48,5 @@ export class SearchApplicationTemplate {
   /**
    * The associated mustache template.
    */
-  script: InlineScript
+  script: Script
 }

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -267,8 +267,6 @@ export class RoleTemplateQuery {
 
 /** @shortcut_property source */
 export class RoleTemplateInlineScript extends ScriptBase {
-  lang?: ScriptLanguage
-  options?: Dictionary<string, string>
   source: RoleTemplateInlineQuery
 }
 

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -268,7 +268,7 @@ export class RoleTemplateQuery {
 
 /** @shortcut_property source */
 export class RoleTemplateScript {
-  source: RoleTemplateInlineQuery
+  source?: RoleTemplateInlineQuery
   /**
    * The `id` for a stored script.
    */

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -18,10 +18,11 @@
  */
 
 import { Dictionary } from '@spec_utils/Dictionary'
-import { Indices } from '@_types/common'
+import { Id, Indices } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { FieldSecurity } from './FieldSecurity'
 import { ScriptLanguage, ScriptBase, Script } from '@_types/Scripting'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 export class ApplicationPrivileges {
   /**
@@ -266,15 +267,27 @@ export class RoleTemplateQuery {
 }
 
 /** @shortcut_property source */
-export class RoleTemplateInlineScript extends ScriptBase {
+export class RoleTemplateScript {
   source: RoleTemplateInlineQuery
+  /**
+   * The `id` for a stored script.
+   */
+  id?: Id
+  /**
+   * Specifies any named parameters that are passed into the script as variables.
+   * Use parameters instead of hard-coded values to decrease compile time.
+   */
+  params?: Dictionary<string, UserDefinedValue>
+  /**
+   * Specifies the language the script is written in.
+   * @server_default painless
+   */
+  lang?: ScriptLanguage
+  options?: Dictionary<string, string>
 }
 
 /** @codegen_names query_string, query_object */
 export type RoleTemplateInlineQuery = string | QueryContainer
-
-/** @codegen_names inline, stored */
-export type RoleTemplateScript = RoleTemplateInlineScript | Script
 
 /** @non_exhaustive */
 export enum IndexPrivilege {

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -21,7 +21,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { Indices } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { FieldSecurity } from './FieldSecurity'
-import { ScriptLanguage, ScriptBase, StoredScriptId } from '@_types/Scripting'
+import { ScriptLanguage, ScriptBase, Script } from '@_types/Scripting'
 
 export class ApplicationPrivileges {
   /**
@@ -276,7 +276,7 @@ export class RoleTemplateInlineScript extends ScriptBase {
 export type RoleTemplateInlineQuery = string | QueryContainer
 
 /** @codegen_names inline, stored */
-export type RoleTemplateScript = RoleTemplateInlineScript | StoredScriptId
+export type RoleTemplateScript = RoleTemplateInlineScript | Script
 
 /** @non_exhaustive */
 export enum IndexPrivilege {


### PR DESCRIPTION
`@shortcut_property` on `InlineScript` is unreachable from the union.
From the server code, `Script` could benefit from being a container instead.