### PR TITLE
[DOCS] Add operation summaries for data stream APIs

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -11304,7 +11304,8 @@
         "tags": [
           "indices.get_data_stream"
         ],
-        "summary": "Retrieves information about one or more data streams",
+        "summary": "Get data streams",
+        "description": "Retrieves information about one or more data streams.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -11331,8 +11332,8 @@
         "tags": [
           "indices.create_data_stream"
         ],
-        "summary": "Creates a data stream",
-        "description": "You must have a matching index template with data stream enabled.",
+        "summary": "Create a data stream",
+        "description": "Creates a data stream. You must have a matching index template with data stream enabled.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -11368,7 +11369,8 @@
         "tags": [
           "indices.delete_data_stream"
         ],
-        "summary": "Deletes one or more data streams and their backing indices",
+        "summary": "Delete data streams",
+        "description": "Deletes one or more data streams and their backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -11416,7 +11418,8 @@
         "tags": [
           "indices.data_streams_stats"
         ],
-        "summary": "Retrieves statistics for one or more data streams",
+        "summary": "Get data stream stats",
+        "description": "Retrieves statistics for one or more data streams.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -11439,7 +11442,8 @@
         "tags": [
           "indices.data_streams_stats"
         ],
-        "summary": "Retrieves statistics for one or more data streams",
+        "summary": "Get data stream stats",
+        "description": "Retrieves statistics for one or more data streams.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -11725,7 +11729,8 @@
         "tags": [
           "indices.get_data_lifecycle"
         ],
-        "summary": "Retrieves the data stream lifecycle configuration of one or more data streams",
+        "summary": "Get data stream lifecycles",
+        "description": "Retrieves the data stream lifecycle configuration of one or more data streams.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle.html"
         },
@@ -11792,7 +11797,8 @@
         "tags": [
           "indices.put_data_lifecycle"
         ],
-        "summary": "Update the data lifecycle of the specified data streams",
+        "summary": "Update data stream lifecycles",
+        "description": "Update the data stream lifecycle of the specified data streams.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-put-lifecycle.html"
         },
@@ -11875,7 +11881,8 @@
         "tags": [
           "indices.delete_data_lifecycle"
         ],
-        "summary": "Removes the data lifecycle from a data stream rendering it not managed by the data stream lifecycle",
+        "summary": "Delete data stream lifecycles",
+        "description": "Removes the data stream lifecycle from a data stream, rendering it not managed by the data stream lifecycle.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html"
         },
@@ -13044,7 +13051,8 @@
         "tags": [
           "indices.get_data_stream"
         ],
-        "summary": "Retrieves information about one or more data streams",
+        "summary": "Get data streams",
+        "description": "Retrieves information about one or more data streams.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -13631,8 +13639,8 @@
         "tags": [
           "indices.migrate_to_data_stream"
         ],
-        "summary": "Converts an index alias to a data stream",
-        "description": "You must have a matching index template that is data stream enabled. The alias must meet the following criteria: The alias must have a write index; All indices for the alias must have a `@timestamp` field mapping of a `date` or `date_nanos` field type; The alias must not have any filters; The alias must not use custom routing. If successful, the request removes the alias and creates a data stream with the same name. The indices for the alias become hidden backing indices for the stream. The write index for the alias becomes the write index for the stream.",
+        "summary": "Convert an index alias to a data stream",
+        "description": "Converts an index alias to a data stream. You must have a matching index template that is data stream enabled. The alias must meet the following criteria: The alias must have a write index; All indices for the alias must have a `@timestamp` field mapping of a `date` or `date_nanos` field type; The alias must not have any filters; The alias must not use custom routing. If successful, the request removes the alias and creates a data stream with the same name. The indices for the alias become hidden backing indices for the stream. The write index for the alias becomes the write index for the stream.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -13670,7 +13678,8 @@
         "tags": [
           "indices.modify_data_stream"
         ],
-        "summary": "Performs one or more data stream modification actions in a single atomic operation",
+        "summary": "Update data streams",
+        "description": "Performs one or more data stream modification actions in a single atomic operation.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -6805,7 +6805,8 @@
         "tags": [
           "indices.get_data_stream"
         ],
-        "summary": "Retrieves information about one or more data streams",
+        "summary": "Get data streams",
+        "description": "Retrieves information about one or more data streams.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -6832,8 +6833,8 @@
         "tags": [
           "indices.create_data_stream"
         ],
-        "summary": "Creates a data stream",
-        "description": "You must have a matching index template with data stream enabled.",
+        "summary": "Create a data stream",
+        "description": "Creates a data stream. You must have a matching index template with data stream enabled.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -6869,7 +6870,8 @@
         "tags": [
           "indices.delete_data_stream"
         ],
-        "summary": "Deletes one or more data streams and their backing indices",
+        "summary": "Delete data streams",
+        "description": "Deletes one or more data streams and their backing indices.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -6917,7 +6919,8 @@
         "tags": [
           "indices.data_streams_stats"
         ],
-        "summary": "Retrieves statistics for one or more data streams",
+        "summary": "Get data stream stats",
+        "description": "Retrieves statistics for one or more data streams.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -6940,7 +6943,8 @@
         "tags": [
           "indices.data_streams_stats"
         ],
-        "summary": "Retrieves statistics for one or more data streams",
+        "summary": "Get data stream stats",
+        "description": "Retrieves statistics for one or more data streams.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -7226,7 +7230,8 @@
         "tags": [
           "indices.get_data_lifecycle"
         ],
-        "summary": "Retrieves the data stream lifecycle configuration of one or more data streams",
+        "summary": "Get data stream lifecycles",
+        "description": "Retrieves the data stream lifecycle configuration of one or more data streams.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle.html"
         },
@@ -7293,7 +7298,8 @@
         "tags": [
           "indices.put_data_lifecycle"
         ],
-        "summary": "Update the data lifecycle of the specified data streams",
+        "summary": "Update data stream lifecycles",
+        "description": "Update the data stream lifecycle of the specified data streams.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-put-lifecycle.html"
         },
@@ -7376,7 +7382,8 @@
         "tags": [
           "indices.delete_data_lifecycle"
         ],
-        "summary": "Removes the data lifecycle from a data stream rendering it not managed by the data stream lifecycle",
+        "summary": "Delete data stream lifecycles",
+        "description": "Removes the data stream lifecycle from a data stream, rendering it not managed by the data stream lifecycle.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html"
         },
@@ -7846,7 +7853,8 @@
         "tags": [
           "indices.get_data_stream"
         ],
-        "summary": "Retrieves information about one or more data streams",
+        "summary": "Get data streams",
+        "description": "Retrieves information about one or more data streams.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -8325,8 +8333,8 @@
         "tags": [
           "indices.migrate_to_data_stream"
         ],
-        "summary": "Converts an index alias to a data stream",
-        "description": "You must have a matching index template that is data stream enabled. The alias must meet the following criteria: The alias must have a write index; All indices for the alias must have a `@timestamp` field mapping of a `date` or `date_nanos` field type; The alias must not have any filters; The alias must not use custom routing. If successful, the request removes the alias and creates a data stream with the same name. The indices for the alias become hidden backing indices for the stream. The write index for the alias becomes the write index for the stream.",
+        "summary": "Convert an index alias to a data stream",
+        "description": "Converts an index alias to a data stream. You must have a matching index template that is data stream enabled. The alias must meet the following criteria: The alias must have a write index; All indices for the alias must have a `@timestamp` field mapping of a `date` or `date_nanos` field type; The alias must not have any filters; The alias must not use custom routing. If successful, the request removes the alias and creates a data stream with the same name. The indices for the alias become hidden backing indices for the stream. The write index for the alias becomes the write index for the stream.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },
@@ -8364,7 +8372,8 @@
         "tags": [
           "indices.modify_data_stream"
         ],
-        "summary": "Performs one or more data stream modification actions in a single atomic operation",
+        "summary": "Update data streams",
+        "description": "Performs one or more data stream modification actions in a single atomic operation.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html"
         },

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -76,7 +76,7 @@ export class DataStream {
    */
   indices: DataStreamIndex[]
   /**
-   * Contains the configuration for the data lifecycle management of this data stream.
+   * Contains the configuration for the data stream lifecycle of this data stream.
    * @availability stack since=8.11.0 stability=stable
    * @availability serverless stability=stable
    */

--- a/specification/indices/_types/DataStreamLifecycle.ts
+++ b/specification/indices/_types/DataStreamLifecycle.ts
@@ -23,7 +23,7 @@ import { ByteSize } from '@_types/common'
 import { DataStreamLifecycleDownsampling } from '@indices/_types/DataStreamLifecycleDownsampling'
 
 /**
- * Data lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration.
+ * Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration.
  */
 export class DataStreamLifecycle {
   data_retention?: Duration
@@ -31,7 +31,7 @@ export class DataStreamLifecycle {
 }
 
 /**
- * Data lifecycle with rollover can be used to display the configuration including the default rollover conditions,
+ * Data stream lifecycle with rollover can be used to display the configuration including the default rollover conditions,
  * if asked.
  */
 export class DataStreamLifecycleWithRollover {

--- a/specification/indices/_types/IndexState.ts
+++ b/specification/indices/_types/IndexState.ts
@@ -32,7 +32,7 @@ export class IndexState {
   defaults?: IndexSettings
   data_stream?: DataStreamName
   /**
-   * Data lifecycle applicable if this is a data stream.
+   * Data stream lifecycle applicable if this is a data stream.
    * @availability stack since=8.11.0 stability=stable
    * @availability serverless stability=stable
    */

--- a/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
+++ b/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { DataStreamName } from '@_types/common'
 
 /**
+ * Create a data stream.
  * Creates a data stream.
  * You must have a matching index template with data stream enabled.
  * @rest_spec_name indices.create_data_stream

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, IndexName } from '@_types/common'
 
 /**
+ * Get data stream stats.
  * Retrieves statistics for one or more data streams.
  * @rest_spec_name indices.data_streams_stats
  * @availability stack since=7.9.0 stability=stable

--- a/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
+++ b/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
@@ -22,7 +22,8 @@ import { ExpandWildcards, DataStreamNames } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Removes the data lifecycle from a data stream rendering it not managed by the data stream lifecycle
+ * Delete data stream lifecycles.
+ * Removes the data stream lifecycle from a data stream, rendering it not managed by the data stream lifecycle.
  * @rest_spec_name indices.delete_data_lifecycle
  * @availability stack since=8.11.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
+++ b/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, DataStreamNames } from '@_types/common'
 
 /**
+ * Delete data streams.
  * Deletes one or more data streams and their backing indices.
  * @rest_spec_name indices.delete_data_stream
  * @availability stack since=7.9.0 stability=stable

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, DataStreamNames } from '@_types/common'
 
 /**
+ * Get data stream lifecycles.
  * Retrieves the data stream lifecycle configuration of one or more data streams.
  * @rest_spec_name indices.get_data_lifecycle
  * @availability stack since=8.11.0 stability=stable

--- a/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
+++ b/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, DataStreamNames } from '@_types/common'
 
 /**
+ * Get data streams.
  * Retrieves information about one or more data streams.
  * @rest_spec_name indices.get_data_stream
  * @availability stack since=7.9.0 stability=stable

--- a/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
+++ b/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
@@ -25,12 +25,10 @@ import { IndexName } from '@_types/common'
  * Converts an index alias to a data stream.
  * You must have a matching index template that is data stream enabled.
  * The alias must meet the following criteria:
- * 
- * * The alias must have a write index.
- * * All indices for the alias must have a `@timestamp` field mapping of a `date` or `date_nanos` field type.
- * * The alias must not have any filters.
- * * The alias must not use custom routing.
- * 
+ * The alias must have a write index;
+ * All indices for the alias must have a `@timestamp` field mapping of a `date` or `date_nanos` field type;
+ * The alias must not have any filters;
+ * The alias must not use custom routing.
  * If successful, the request removes the alias and creates a data stream with the same name.
  * The indices for the alias become hidden backing indices for the stream.
  * The write index for the alias becomes the write index for the stream.

--- a/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
+++ b/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
@@ -21,13 +21,16 @@ import { RequestBase } from '@_types/Base'
 import { IndexName } from '@_types/common'
 
 /**
+ * Convert an index alias to a data stream.
  * Converts an index alias to a data stream.
  * You must have a matching index template that is data stream enabled.
  * The alias must meet the following criteria:
- * The alias must have a write index;
- * All indices for the alias must have a `@timestamp` field mapping of a `date` or `date_nanos` field type;
- * The alias must not have any filters;
- * The alias must not use custom routing.
+ * 
+ * * The alias must have a write index.
+ * * All indices for the alias must have a `@timestamp` field mapping of a `date` or `date_nanos` field type.
+ * * The alias must not have any filters.
+ * * The alias must not use custom routing.
+ * 
  * If successful, the request removes the alias and creates a data stream with the same name.
  * The indices for the alias become hidden backing indices for the stream.
  * The write index for the alias becomes the write index for the stream.

--- a/specification/indices/modify_data_stream/IndicesModifyDataStreamRequest.ts
+++ b/specification/indices/modify_data_stream/IndicesModifyDataStreamRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Action } from './types'
 
 /**
+ * Update data streams.
  * Performs one or more data stream modification actions in a single atomic operation.
  * @rest_spec_name indices.modify_data_stream
  * @availability stack since=7.16.0 stability=stable

--- a/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
+++ b/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
@@ -23,7 +23,8 @@ import { Duration } from '@_types/Time'
 import { DataStreamLifecycleDownsampling } from '@indices/_types/DataStreamLifecycleDownsampling'
 
 /**
- * Update the data lifecycle of the specified data streams.
+ * Update data stream lifecycles.
+ * Update the data stream lifecycle of the specified data streams.
  * @rest_spec_name indices.put_data_lifecycle
  * @availability stack since=8.11.0 stability=stable
  * @availability serverless stability=stable visibility=public


### PR DESCRIPTION
This PR adds operation summaries for the data stream and data stream lifecycle APIs, using text from the appropriate pages from the [elasticsearch API reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/data-stream-apis.html).

A couple of terminology fixes for data streams in the types area while I'm here as well

part of https://github.com/elastic/elasticsearch-specification/issues/2635