### PR TITLE
Fixing properties in dense vector index options

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -75217,12 +75217,13 @@
           },
           "ef_construction": {
             "type": "number"
+          },
+          "confidence_interval": {
+            "type": "number"
           }
         },
         "required": [
-          "type",
-          "m",
-          "ef_construction"
+          "type"
         ]
       },
       "_types.mapping:FlattenedProperty": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -49474,12 +49474,13 @@
           },
           "ef_construction": {
             "type": "number"
+          },
+          "confidence_interval": {
+            "type": "number"
           }
         },
         "required": [
-          "type",
-          "m",
-          "ef_construction"
+          "type"
         ]
       },
       "_types.mapping:FlattenedProperty": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -84605,7 +84605,7 @@
         },
         {
           "name": "m",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -84616,7 +84616,7 @@
         },
         {
           "name": "ef_construction",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -84624,9 +84624,20 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "name": "confidence_interval",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "float",
+              "namespace": "_types"
+            }
+          }
         }
       ],
-      "specLocation": "_types/mapping/DenseVectorIndexOptions.ts#L22-L26"
+      "specLocation": "_types/mapping/DenseVectorIndexOptions.ts#L22-L27"
     },
     {
       "inherits": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4996,8 +4996,9 @@ export interface MappingDateRangeProperty extends MappingRangePropertyBase {
 
 export interface MappingDenseVectorIndexOptions {
   type: string
-  m: integer
-  ef_construction: integer
+  m?: integer
+  ef_construction?: integer
+  confidence_interval?: float
 }
 
 export interface MappingDenseVectorProperty extends MappingPropertyBase {

--- a/specification/_types/mapping/DenseVectorIndexOptions.ts
+++ b/specification/_types/mapping/DenseVectorIndexOptions.ts
@@ -17,10 +17,11 @@
  * under the License.
  */
 
-import { integer } from '@_types/Numeric'
+import { float, integer } from '@_types/Numeric'
 
 export class DenseVectorIndexOptions {
   type: string
-  m: integer
-  ef_construction: integer
+  m?: integer
+  ef_construction?: integer
+  confidence_interval?: float
 }


### PR DESCRIPTION
From https://github.com/elastic/elasticsearch-java/issues/846
DenseVectorIndexOptions was missing a property + other fields except `type` are all optional because different types of algorithms support different options. 
[server code](https://github.com/elastic/elasticsearch/blob/199910c10b3bf63cfc1791f1e439cea85cee7fbc/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java#L1169)