### PR TITLE
adding _rank to hit, fix property name

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -56111,6 +56111,9 @@
           "_source": {
             "type": "object"
           },
+          "_rank": {
+            "type": "number"
+          },
           "_seq_no": {
             "$ref": "#/components/schemas/_types:SequenceNumber"
           },
@@ -95356,7 +95359,7 @@
                 "description": "How much influence documents in individual result sets per query have over the final ranked result set",
                 "type": "number"
               },
-              "window_size": {
+              "rank_window_size": {
                 "description": "Size of the individual result sets per query",
                 "type": "number"
               }

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -32747,6 +32747,9 @@
           "_source": {
             "type": "object"
           },
+          "_rank": {
+            "type": "number"
+          },
           "_seq_no": {
             "$ref": "#/components/schemas/_types:SequenceNumber"
           },
@@ -60846,7 +60849,7 @@
                 "description": "How much influence documents in individual result sets per query have over the final ranked result set",
                 "type": "number"
               },
-              "window_size": {
+              "rank_window_size": {
                 "description": "Size of the individual result sets per query",
                 "type": "number"
               }

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -51302,7 +51302,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/_types/hits.ts#L106-L140"
+      "specLocation": "_global/search/_types/hits.ts#L107-L141"
     },
     {
       "kind": "type_alias",
@@ -66917,7 +66917,7 @@
         "name": "TrackHits",
         "namespace": "_global.search._types"
       },
-      "specLocation": "_global/search/_types/hits.ts#L142-L150",
+      "specLocation": "_global/search/_types/hits.ts#L143-L151",
       "type": {
         "items": [
           {
@@ -69041,7 +69041,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/_types/hits.ts#L66-L72"
+      "specLocation": "_global/search/_types/hits.ts#L67-L73"
     },
     {
       "kind": "interface",
@@ -69073,7 +69073,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/_types/hits.ts#L94-L97"
+      "specLocation": "_global/search/_types/hits.ts#L95-L98"
     },
     {
       "kind": "enum",
@@ -69091,7 +69091,7 @@
         "name": "TotalHitsRelation",
         "namespace": "_global.search._types"
       },
-      "specLocation": "_global/search/_types/hits.ts#L99-L104"
+      "specLocation": "_global/search/_types/hits.ts#L100-L105"
     },
     {
       "generics": [
@@ -69337,6 +69337,17 @@
           }
         },
         {
+          "name": "_rank",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "name": "_seq_no",
           "required": false,
           "type": {
@@ -69381,7 +69392,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/_types/hits.ts#L40-L64"
+      "specLocation": "_global/search/_types/hits.ts#L40-L65"
     },
     {
       "kind": "interface",
@@ -69499,7 +69510,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/_types/hits.ts#L84-L86"
+      "specLocation": "_global/search/_types/hits.ts#L85-L87"
     },
     {
       "kind": "interface",
@@ -69542,7 +69553,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/_types/hits.ts#L88-L92"
+      "specLocation": "_global/search/_types/hits.ts#L89-L93"
     },
     {
       "description": "The aggregation name as returned from the server. Depending whether typed_keys is specified this could come back\nin the form of `name#type` instead of simply `name`",
@@ -133097,7 +133108,7 @@
         },
         {
           "description": "Size of the individual result sets per query",
-          "name": "window_size",
+          "name": "rank_window_size",
           "required": false,
           "type": {
             "kind": "instance_of",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1469,6 +1469,7 @@ export interface SearchHit<TDocument = unknown> {
   _node?: string
   _routing?: string
   _source?: TDocument
+  _rank?: integer
   _seq_no?: SequenceNumber
   _primary_term?: long
   _version?: VersionNumber
@@ -2586,7 +2587,7 @@ export type Routing = string
 
 export interface RrfRank {
   rank_constant?: long
-  window_size?: long
+  rank_window_size?: long
 }
 
 export type ScalarValue = long | double | string | boolean | null

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -57,6 +57,7 @@ export class Hit<TDocument> {
   _node?: string
   _routing?: string
   _source?: TDocument
+  _rank?: integer
   _seq_no?: SequenceNumber
   _primary_term?: long
   _version?: VersionNumber

--- a/specification/_types/Rank.ts
+++ b/specification/_types/Rank.ts
@@ -33,5 +33,5 @@ export class RrfRank extends RankBase {
   /** How much influence documents in individual result sets per query have over the final ranked result set  */
   rank_constant?: long
   /** Size of the individual result sets per query */
-  window_size?: long
+  rank_window_size?: long
 }


### PR DESCRIPTION
Originally reported on [discuss](https://discuss.elastic.co/t/hybrid-search-java-api-not-returning-rank/360700).
Hit is missing the optional `_rank` field -> [server code ](https://github.com/elastic/elasticsearch/blob/512bca8669faa69e0cf3be12416b000eafaf7f7c/server/src/main/java/org/elasticsearch/search/SearchHit.java#L842)
Also `window_size` in Rank was recently changed to `rank_window_size`  -> [commit](https://github.com/elastic/elasticsearch/commit/fdefe090418aed09243fb150548909e3e0c4ff0e)