### PR TITLE
Optional fields in term vector res

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -40670,7 +40670,6 @@
               },
               "required": [
                 "found",
-                "_id",
                 "_index",
                 "took",
                 "_version"
@@ -91659,7 +91658,6 @@
           }
         },
         "required": [
-          "_id",
           "_index"
         ]
       },
@@ -91677,7 +91675,6 @@
           }
         },
         "required": [
-          "field_statistics",
           "terms"
         ]
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -22592,7 +22592,6 @@
               },
               "required": [
                 "found",
-                "_id",
                 "_index",
                 "took",
                 "_version"
@@ -60206,7 +60205,6 @@
           }
         },
         "required": [
-          "_id",
           "_index"
         ]
       },
@@ -60224,7 +60222,6 @@
           }
         },
         "required": [
-          "field_statistics",
           "terms"
         ]
       },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -42105,7 +42105,7 @@
           },
           {
             "name": "_id",
-            "required": true,
+            "required": false,
             "type": {
               "kind": "instance_of",
               "type": {
@@ -131595,7 +131595,7 @@
       "properties": [
         {
           "name": "_id",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -131693,7 +131693,7 @@
       "properties": [
         {
           "name": "field_statistics",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -860,7 +860,7 @@ export interface MtermvectorsResponse {
 }
 
 export interface MtermvectorsTermVectorsResult {
-  _id: Id
+  _id?: Id
   _index: IndexName
   _version?: VersionNumber
   took?: long
@@ -1890,7 +1890,7 @@ export interface TermvectorsRequest<TDocument = unknown> extends RequestBase {
 
 export interface TermvectorsResponse {
   found: boolean
-  _id: Id
+  _id?: Id
   _index: IndexName
   term_vectors?: Record<Field, TermvectorsTermVector>
   took: long
@@ -1906,7 +1906,7 @@ export interface TermvectorsTerm {
 }
 
 export interface TermvectorsTermVector {
-  field_statistics: TermvectorsFieldStatistics
+  field_statistics?: TermvectorsFieldStatistics
   terms: Record<string, TermvectorsTerm>
 }
 

--- a/specification/_global/mtermvectors/types.ts
+++ b/specification/_global/mtermvectors/types.ts
@@ -94,7 +94,7 @@ export class Operation {
 }
 
 export class TermVectorsResult {
-  _id: Id
+  _id?: Id
   _index: IndexName
   _version?: VersionNumber
   took?: long

--- a/specification/_global/termvectors/TermVectorsResponse.ts
+++ b/specification/_global/termvectors/TermVectorsResponse.ts
@@ -25,7 +25,7 @@ import { TermVector } from './types'
 export class Response {
   body: {
     found: boolean
-    _id: Id
+    _id?: Id
     _index: IndexName
     term_vectors?: Dictionary<Field, TermVector>
     took: long

--- a/specification/_global/termvectors/types.ts
+++ b/specification/_global/termvectors/types.ts
@@ -21,7 +21,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { double, integer, long } from '@_types/Numeric'
 
 export class TermVector {
-  field_statistics: FieldStatistics
+  field_statistics?: FieldStatistics
   terms: Dictionary<string, Term>
 }
 


### PR DESCRIPTION
(MtermVector and TermVector have the same response class in the server code, in the spec we have them separate because of json formatting I think)

reported in java client issue [838](https://github.com/elastic/elasticsearch-java/issues/838):
`field_statistics` is not present in response if specified so in request (setting `field_statistics` as `false`).[ server code](https://github.com/elastic/elasticsearch/blob/4a77e062334b06b88ab437014a48b7e402ff4b2c/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java#L311) logic seems to be that if `field_statistics` wasn't requested, then `doc_count` will be set as `-1`, which will omit building the field in the response.

reported in java client issue [839](https://github.com/elastic/elasticsearch-java/issues/839)
`id` is not present in the response if the request was made with an artificial document. [server code](https://github.com/elastic/elasticsearch/blob/4a77e062334b06b88ab437014a48b7e402ff4b2c/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java#L163)