### PR TITLE
[OAS] Add OpenAPI overlays

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -14,9 +14,9 @@ rules:
   oas3-valid-schema-example: false
   oas2-valid-media-example: false
   # Operations 
-  operation-operationId: false
-  operation-operationId-unique: false
-  operation-operationId-valid-in-url: false
+  operation-operationId: warn
+  operation-operationId-unique: warn
+  operation-operationId-valid-in-url: warn
   operation-tag-defined: warn
   operation-tags: warn
   # Responses

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ dump-routes: ## Create a new schema with all generics expanded
 
 contrib: | generate license-check spec-format-fix transform-to-openapi filter-for-serverless ## Pre contribution target
 
+overlay-docs: ## Apply overlays to OpenAPI documents
+	@npx bump overlay "output/openapi/elasticsearch-serverless-openapi.json" "docs/overlays/elasticsearch-serverless-openapi-overlays.yaml" > "output/openapi/elasticsearch-serverless-openapi.new.json"
+
 lint-docs: ## Lint the OpenAPI documents
 	@npx @stoplight/spectral-cli lint output/openapi/*.json --ruleset .spectral.yaml
 

--- a/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
@@ -1,0 +1,15 @@
+# overlays.yaml
+overlay: 1.0.0
+info:
+  title: Overlays for the Elasticsearch Serverless OpenAPI document
+  version: 0.0.1
+actions:
+  - target: '$.info'
+    description: Add a document description
+    update:
+      description: >
+        **Technical preview**  
+        This functionality is in technical preview and may be changed or removed in a future release.
+        Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+
+


### PR DESCRIPTION
This PR:

- Adds an overlay file to add the missing OpenAPI `info.description`.
- Updates the linting rules to check for operation identifiers, since poor or inconsistent URLs might be created in their absence
- Adds an overlay command to the makefile for testing purposes

Per https://docs.bump.sh/guides/openapi/augmenting-generated-openapi/#deploy-overlay-changes-to-bumpsh overlays could ultimately be applied during a GitHub action so we don't need to store the modified version of the file.

