### PR TITLE
Added include_named_queries_score to search

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -23418,6 +23418,9 @@
             "$ref": "#/components/parameters/msearch#ignore_unavailable"
           },
           {
+            "$ref": "#/components/parameters/msearch#include_named_queries_score"
+          },
+          {
             "$ref": "#/components/parameters/msearch#max_concurrent_searches"
           },
           {
@@ -23473,6 +23476,9 @@
           },
           {
             "$ref": "#/components/parameters/msearch#ignore_unavailable"
+          },
+          {
+            "$ref": "#/components/parameters/msearch#include_named_queries_score"
           },
           {
             "$ref": "#/components/parameters/msearch#max_concurrent_searches"
@@ -23537,6 +23543,9 @@
             "$ref": "#/components/parameters/msearch#ignore_unavailable"
           },
           {
+            "$ref": "#/components/parameters/msearch#include_named_queries_score"
+          },
+          {
             "$ref": "#/components/parameters/msearch#max_concurrent_searches"
           },
           {
@@ -23595,6 +23604,9 @@
           },
           {
             "$ref": "#/components/parameters/msearch#ignore_unavailable"
+          },
+          {
+            "$ref": "#/components/parameters/msearch#include_named_queries_score"
           },
           {
             "$ref": "#/components/parameters/msearch#max_concurrent_searches"
@@ -47233,6 +47245,16 @@
         "in": "query",
         "name": "ignore_unavailable",
         "description": "If true, missing or closed indices are not included in the response.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
+      "msearch#include_named_queries_score": {
+        "in": "query",
+        "name": "include_named_queries_score",
+        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)",
         "deprecated": false,
         "schema": {
           "type": "boolean"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -26389,6 +26389,9 @@
             "$ref": "#/components/parameters/search#ignore_unavailable"
           },
           {
+            "$ref": "#/components/parameters/search#include_named_queries_score"
+          },
+          {
             "$ref": "#/components/parameters/search#lenient"
           },
           {
@@ -26540,6 +26543,9 @@
           },
           {
             "$ref": "#/components/parameters/search#ignore_unavailable"
+          },
+          {
+            "$ref": "#/components/parameters/search#include_named_queries_score"
           },
           {
             "$ref": "#/components/parameters/search#lenient"
@@ -26700,6 +26706,9 @@
             "$ref": "#/components/parameters/search#ignore_unavailable"
           },
           {
+            "$ref": "#/components/parameters/search#include_named_queries_score"
+          },
+          {
             "$ref": "#/components/parameters/search#lenient"
           },
           {
@@ -26854,6 +26863,9 @@
           },
           {
             "$ref": "#/components/parameters/search#ignore_unavailable"
+          },
+          {
+            "$ref": "#/components/parameters/search#include_named_queries_score"
           },
           {
             "$ref": "#/components/parameters/search#lenient"
@@ -48157,6 +48169,16 @@
         "in": "query",
         "name": "ignore_unavailable",
         "description": "If `false`, the request returns an error if it targets a missing or closed index.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
+      "search#include_named_queries_score": {
+        "in": "query",
+        "name": "include_named_queries_score",
+        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)",
         "deprecated": false,
         "schema": {
           "type": "boolean"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -47254,7 +47254,7 @@
       "msearch#include_named_queries_score": {
         "in": "query",
         "name": "include_named_queries_score",
-        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)",
+        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)\nThis functionality reruns each named query on every hit in a search response.\nTypically, this adds a small overhead to a request.\nHowever, using computationally expensive named queries on a large number of hits may add significant overhead.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -48200,7 +48200,7 @@
       "search#include_named_queries_score": {
         "in": "query",
         "name": "include_named_queries_score",
-        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)",
+        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)\nThis functionality reruns each named query on every hit in a search response.\nTypically, this adds a small overhead to a request.\nHowever, using computationally expensive named queries on a large number of hits may add significant overhead.",
         "deprecated": false,
         "schema": {
           "type": "boolean"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -56097,10 +56097,23 @@
             }
           },
           "matched_queries": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            ]
           },
           "_nested": {
             "$ref": "#/components/schemas/_global.search._types:NestedIdentity"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -14721,6 +14721,9 @@
             "$ref": "#/components/parameters/msearch#ignore_unavailable"
           },
           {
+            "$ref": "#/components/parameters/msearch#include_named_queries_score"
+          },
+          {
             "$ref": "#/components/parameters/msearch#max_concurrent_searches"
           },
           {
@@ -14776,6 +14779,9 @@
           },
           {
             "$ref": "#/components/parameters/msearch#ignore_unavailable"
+          },
+          {
+            "$ref": "#/components/parameters/msearch#include_named_queries_score"
           },
           {
             "$ref": "#/components/parameters/msearch#max_concurrent_searches"
@@ -14840,6 +14846,9 @@
             "$ref": "#/components/parameters/msearch#ignore_unavailable"
           },
           {
+            "$ref": "#/components/parameters/msearch#include_named_queries_score"
+          },
+          {
             "$ref": "#/components/parameters/msearch#max_concurrent_searches"
           },
           {
@@ -14898,6 +14907,9 @@
           },
           {
             "$ref": "#/components/parameters/msearch#ignore_unavailable"
+          },
+          {
+            "$ref": "#/components/parameters/msearch#include_named_queries_score"
           },
           {
             "$ref": "#/components/parameters/msearch#max_concurrent_searches"
@@ -26372,6 +26384,16 @@
         "in": "query",
         "name": "ignore_unavailable",
         "description": "If true, missing or closed indices are not included in the response.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
+      "msearch#include_named_queries_score": {
+        "in": "query",
+        "name": "include_named_queries_score",
+        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)",
         "deprecated": false,
         "schema": {
           "type": "boolean"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -32733,10 +32733,23 @@
             }
           },
           "matched_queries": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            ]
           },
           "_nested": {
             "$ref": "#/components/schemas/_global.search._types:NestedIdentity"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -26393,7 +26393,7 @@
       "msearch#include_named_queries_score": {
         "in": "query",
         "name": "include_named_queries_score",
-        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)",
+        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)\nThis functionality reruns each named query on every hit in a search response.\nTypically, this adds a small overhead to a request.\nHowever, using computationally expensive named queries on a large number of hits may add significant overhead.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -26954,7 +26954,7 @@
       "search#include_named_queries_score": {
         "in": "query",
         "name": "include_named_queries_score",
-        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)",
+        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)\nThis functionality reruns each named query on every hit in a search response.\nTypically, this adds a small overhead to a request.\nHowever, using computationally expensive named queries on a large number of hits may add significant overhead.",
         "deprecated": false,
         "schema": {
           "type": "boolean"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -16400,6 +16400,9 @@
             "$ref": "#/components/parameters/search#ignore_unavailable"
           },
           {
+            "$ref": "#/components/parameters/search#include_named_queries_score"
+          },
+          {
             "$ref": "#/components/parameters/search#lenient"
           },
           {
@@ -16548,6 +16551,9 @@
           },
           {
             "$ref": "#/components/parameters/search#ignore_unavailable"
+          },
+          {
+            "$ref": "#/components/parameters/search#include_named_queries_score"
           },
           {
             "$ref": "#/components/parameters/search#lenient"
@@ -16705,6 +16711,9 @@
             "$ref": "#/components/parameters/search#ignore_unavailable"
           },
           {
+            "$ref": "#/components/parameters/search#include_named_queries_score"
+          },
+          {
             "$ref": "#/components/parameters/search#lenient"
           },
           {
@@ -16856,6 +16865,9 @@
           },
           {
             "$ref": "#/components/parameters/search#ignore_unavailable"
+          },
+          {
+            "$ref": "#/components/parameters/search#include_named_queries_score"
           },
           {
             "$ref": "#/components/parameters/search#lenient"
@@ -26911,6 +26923,16 @@
         "in": "query",
         "name": "ignore_unavailable",
         "description": "If `false`, the request returns an error if it targets a missing or closed index.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
+      "search#include_named_queries_score": {
+        "in": "query",
+        "name": "include_named_queries_score",
+        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)",
         "deprecated": false,
         "schema": {
           "type": "boolean"

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -33937,6 +33937,18 @@
           }
         },
         {
+          "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)",
+          "name": "include_named_queries_score",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
           "description": "Maximum number of concurrent searches the multi search API can execute.",
           "name": "max_concurrent_searches",
           "required": false,
@@ -34023,7 +34035,7 @@
           }
         }
       ],
-      "specLocation": "_global/msearch/MultiSearchRequest.ts#L25-L96"
+      "specLocation": "_global/msearch/MultiSearchRequest.ts#L25-L102"
     },
     {
       "body": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -33937,9 +33937,10 @@
           }
         },
         {
-          "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)",
+          "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)\nThis functionality reruns each named query on every hit in a search response.\nTypically, this adds a small overhead to a request.\nHowever, using computationally expensive named queries on a large number of hits may add significant overhead.",
           "name": "include_named_queries_score",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -34035,7 +34036,7 @@
           }
         }
       ],
-      "specLocation": "_global/msearch/MultiSearchRequest.ts#L25-L102"
+      "specLocation": "_global/msearch/MultiSearchRequest.ts#L25-L106"
     },
     {
       "body": {
@@ -36953,9 +36954,10 @@
           }
         },
         {
-          "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)",
+          "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)\nThis functionality reruns each named query on every hit in a search response.\nTypically, this adds a small overhead to a request.\nHowever, using computationally expensive named queries on a large number of hits may add significant overhead.",
           "name": "include_named_queries_score",
           "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -37359,7 +37361,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/SearchRequest.ts#L54-L526"
+      "specLocation": "_global/search/SearchRequest.ts#L54-L530"
     },
     {
       "body": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -36941,6 +36941,18 @@
           }
         },
         {
+          "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)",
+          "name": "include_named_queries_score",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
           "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.\nThis parameter can only be used when the `q` query string parameter is specified.",
           "name": "lenient",
           "required": false,
@@ -37335,7 +37347,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/SearchRequest.ts#L54-L520"
+      "specLocation": "_global/search/SearchRequest.ts#L54-L526"
     },
     {
       "body": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -69244,14 +69244,40 @@
           "name": "matched_queries",
           "required": false,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "_builtins"
+            "items": [
+              {
+                "kind": "array_of",
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "string",
+                    "namespace": "_builtins"
+                  }
+                }
+              },
+              {
+                "key": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "string",
+                    "namespace": "_builtins"
+                  }
+                },
+                "kind": "dictionary_of",
+                "singleKey": false,
+                "value": {
+                  "kind": "array_of",
+                  "value": {
+                    "kind": "instance_of",
+                    "type": {
+                      "name": "double",
+                      "namespace": "_types"
+                    }
+                  }
+                }
               }
-            }
+            ],
+            "kind": "union_of"
           }
         },
         {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -950,6 +950,7 @@
         "Request: query parameter 'expand_wildcards' does not exist in the json spec",
         "Request: query parameter 'ignore_throttled' does not exist in the json spec",
         "Request: query parameter 'ignore_unavailable' does not exist in the json spec",
+        "Request: query parameter 'include_named_queries_score' does not exist in the json spec",
         "Request: query parameter 'routing' does not exist in the json spec"
       ],
       "response": []

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1011,7 +1011,6 @@
     },
     "search": {
       "request": [
-        "Request: missing json spec query parameter 'include_named_queries_score'",
         "interface definition _types:RankContainer - Property rrf is a single-variant and must be required"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1462,7 +1462,7 @@ export interface SearchHit<TDocument = unknown> {
   fields?: Record<string, any>
   highlight?: Record<string, string[]>
   inner_hits?: Record<string, SearchInnerHitsResult>
-  matched_queries?: string[]
+  matched_queries?: string[] | Record<string, double[]>
   _nested?: SearchNestedIdentity
   _ignored?: string[]
   ignored_field_values?: Record<string, string[]>

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -781,6 +781,7 @@ export interface MsearchRequest extends RequestBase {
   expand_wildcards?: ExpandWildcards
   ignore_throttled?: boolean
   ignore_unavailable?: boolean
+  include_named_queries_score?: boolean
   max_concurrent_searches?: long
   max_concurrent_shard_requests?: long
   pre_filter_shard_size?: long

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1159,6 +1159,7 @@ export interface SearchRequest extends RequestBase {
   explain?: boolean
   ignore_throttled?: boolean
   ignore_unavailable?: boolean
+  include_named_queries_score?: boolean
   lenient?: boolean
   max_concurrent_shard_requests?: long
   min_compatible_shard_node?: VersionString

--- a/specification/_global/msearch/MultiSearchRequest.ts
+++ b/specification/_global/msearch/MultiSearchRequest.ts
@@ -64,6 +64,10 @@ export interface Request extends RequestBase {
      * Indicates whether hit.matched_queries should be rendered as a map that includes
      * the name of the matched query associated with its score (true)
      * or as an array containing the name of the matched queries (false)
+     * This functionality reruns each named query on every hit in a search response.
+     * Typically, this adds a small overhead to a request.
+     * However, using computationally expensive named queries on a large number of hits may add significant overhead.
+     * @server_default false
      */
     include_named_queries_score?: boolean
     /**

--- a/specification/_global/msearch/MultiSearchRequest.ts
+++ b/specification/_global/msearch/MultiSearchRequest.ts
@@ -61,6 +61,12 @@ export interface Request extends RequestBase {
      */
     ignore_unavailable?: boolean
     /**
+     * Indicates whether hit.matched_queries should be rendered as a map that includes
+     * the name of the matched query associated with its score (true)
+     * or as an array containing the name of the matched queries (false)
+     */
+    include_named_queries_score?: boolean
+    /**
      * Maximum number of concurrent searches the multi search API can execute.
      */
     max_concurrent_searches?: long

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -145,6 +145,10 @@ export interface Request extends RequestBase {
      * Indicates whether hit.matched_queries should be rendered as a map that includes
      * the name of the matched query associated with its score (true)
      * or as an array containing the name of the matched queries (false)
+     * This functionality reruns each named query on every hit in a search response.
+     * Typically, this adds a small overhead to a request.
+     * However, using computationally expensive named queries on a large number of hits may add significant overhead.
+     * @server_default false
      */
     include_named_queries_score?: boolean
     /**

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -142,6 +142,12 @@ export interface Request extends RequestBase {
      */
     ignore_unavailable?: boolean
     /**
+     * Indicates whether hit.matched_queries should be rendered as a map that includes
+     * the name of the matched query associated with its score (true)
+     * or as an array containing the name of the matched queries (false)
+     */
+    include_named_queries_score?: boolean
+    /**
      *  If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
      * This parameter can only be used when the `q` query string parameter is specified.
      * @server_default false

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -49,7 +49,7 @@ export class Hit<TDocument> {
   fields?: Dictionary<string, UserDefinedValue>
   highlight?: Dictionary<string, string[]>
   inner_hits?: Dictionary<string, InnerHitsResult>
-  matched_queries?: string[]
+  matched_queries?: string[] | Dictionary<string, double[]>
   _nested?: NestedIdentity
   _ignored?: string[]
   ignored_field_values?: Dictionary<string, string[]>


### PR DESCRIPTION
Added in [8.8](https://github.com/elastic/elasticsearch/pull/94564), `include_named_queries_score` adds the score to the result of named query. 
In practice, it changes the type of [matched_queries](https://github.com/elastic/elasticsearch-specification/blob/5615a46a870f15fa51edf6a3c4e8c2ed8cc3ebf7/specification/_global/search/_types/hits.ts#L52) in Hit from `string[]` to `string[] | Dictionary<string,double>`, because the server will return a different data structure depending on the value of `include_named_queries_score` in the request. 

After discussing this, we decided that for now strongly typed clients (java, go, .net) won't support it, but we're still adding this to the spec for completeness and for other clients that might be able to support it. 

@Anaethelion, @flobernd before merging this we need to exclude `include_named_queries_score` from the available query parameters and ignore the secondary type of `matched_queries`.

@JoshMock does this cause any problem for javascript?


fixes #2405