### PR TITLE
Make sure that the type discriminator is the first property

### DIFF
--- a/compiler/package-lock.json
+++ b/compiler/package-lock.json
@@ -13,7 +13,7 @@
         "compiler-wasm-lib": "file:../compiler-rs/compiler-wasm-lib/pkg",
         "fastest-levenshtein": "^1.0.12",
         "ora": "^5.4.1",
-        "safe-stable-stringify": "^2.3.1",
+        "safe-stable-stringify": "github:BridgeAR/safe-stable-stringify",
         "semver": "^7.5.2",
         "ts-morph": "^13.0.3",
         "zx": "^4.3.0"
@@ -31,10 +31,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "../compiler-rs/compiler-wasm-lib/pkg": {
-      "name": "compiler-wasm-lib",
-      "version": "0.1.0"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
@@ -1543,8 +1539,8 @@
       "dev": true
     },
     "node_modules/compiler-wasm-lib": {
-      "resolved": "../compiler-rs/compiler-wasm-lib/pkg",
-      "link": true
+      "version": "0.1.0",
+      "resolved": "file:../compiler-rs/compiler-wasm-lib/pkg"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4493,9 +4489,9 @@
       ]
     },
     "node_modules/safe-stable-stringify": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
-      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
+      "version": "2.5.0",
+      "resolved": "git+ssh://git@github.com/BridgeAR/safe-stable-stringify.git#0c192c2c1e26676ba5af1f7dbe066b98d76f353f",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -6462,7 +6458,7 @@
       "dev": true
     },
     "compiler-wasm-lib": {
-      "version": "file:../compiler-rs/compiler-wasm-lib/pkg"
+      "version": "0.1.0"
     },
     "concat-map": {
       "version": "0.0.1",
@@ -8552,9 +8548,8 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "safe-stable-stringify": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
-      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
+      "version": "git+ssh://git@github.com/BridgeAR/safe-stable-stringify.git#0c192c2c1e26676ba5af1f7dbe066b98d76f353f",
+      "from": "safe-stable-stringify@https://github.com/BridgeAR/safe-stable-stringify"
     },
     "semver": {
       "version": "7.5.2",

--- a/compiler/package.json
+++ b/compiler/package.json
@@ -34,10 +34,10 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
+    "compiler-wasm-lib": "file:../compiler-rs/compiler-wasm-lib/pkg",
     "fastest-levenshtein": "^1.0.12",
     "ora": "^5.4.1",
-    "safe-stable-stringify": "^2.3.1",
-    "compiler-wasm-lib": "file:../compiler-rs/compiler-wasm-lib/pkg",
+    "safe-stable-stringify": "^2.5.0",
     "semver": "^7.5.2",
     "ts-morph": "^13.0.3",
     "zx": "^4.3.0"

--- a/compiler/src/compiler.ts
+++ b/compiler/src/compiler.ts
@@ -62,10 +62,24 @@ export default class Compiler {
       this.model = await step(this.model, this.jsonSpec, this.errors)
     }
 
+    const customStringify = stringify.configure(
+      {
+        deterministic: (a, b) => {
+          // Make sure the discriminator property is always emitted first
+          if (a === 'kind') {
+            return -1
+          }
+          if (b === 'kind') {
+            return 1
+          }
+          return a.localeCompare(b)
+        }
+      })
+
     await mkdir(join(this.outputFolder, 'schema'), { recursive: true })
     await writeFile(
       join(this.outputFolder, 'schema', 'schema.json'),
-      stringify(this.model, null, 2),
+      customStringify(this.model, null, 2),
       'utf8'
     )
 


### PR DESCRIPTION
This changes allows to speed up deserialization a lot (for statically typed languages) as the polymorhic variants can be determined by peeking a single JSON key-value pair instead of deserializing a complete object into an intermediate representation.

This as well allows to use built-in polymorphic JSON deserialization with several JSON frameworks (like e.g. `System.Text.Json` in .NET).

Note:
For other polymorhic objects like `Body`, `Value`, `Variant`, the discriminator is already emitted as the first key already.

Edit:
Needs further work to ensure rest of the properties stay sorted. In the best case, [safe-stable-stringify](https://github.com/BridgeAR/safe-stable-stringify/issues/48) would provide an option to customize the sort order.