### PR TITLE
put_user: Drop username from body

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17625,7 +17625,6 @@ export interface SecurityPutUserRequest extends RequestBase {
   username: Username
   refresh?: Refresh
   body?: {
-    username?: Username
     email?: string | null
     full_name?: string | null
     metadata?: Metadata

--- a/specification/security/put_user/SecurityPutUserRequest.ts
+++ b/specification/security/put_user/SecurityPutUserRequest.ts
@@ -32,7 +32,6 @@ export interface Request extends RequestBase {
     refresh?: Refresh
   }
   body: {
-    username?: Username
     email?: string | null
     full_name?: string | null
     metadata?: Metadata


### PR DESCRIPTION
Username is present in the path, and then again redundantly in the body. [The docs](https://www.elastic.co/guide/en/elasticsearch/reference/8.14/security-api-put-user.html) indicate that it should only be in the path.
