### PR TITLE
Change required_native_memory_bytes type to ByteSize

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14073,7 +14073,7 @@ export interface MlTrainedModelPrefixStrings {
 
 export interface MlTrainedModelSizeStats {
   model_size_bytes: ByteSize
-  required_native_memory_bytes: integer
+  required_native_memory_bytes: ByteSize
 }
 
 export interface MlTrainedModelStats {

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -127,7 +127,7 @@ export class TrainedModelSizeStats {
   /** The size of the model in bytes. */
   model_size_bytes: ByteSize
   /** The amount of memory required to load the model in bytes. */
-  required_native_memory_bytes: integer
+  required_native_memory_bytes: ByteSize
 }
 
 export class TrainedModelDeploymentNodesStats {


### PR DESCRIPTION
Fixes #2739. The required_native_memory_bytes represents a value in bytes, an integer is too small to fit the range, and other bytes parameters in the spec are already using the ByteSyze type.
<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
