### PR TITLE
Change required_native_memory_bytes type to ByteSize (#2740)

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14078,7 +14078,7 @@ export interface MlTrainedModelPrefixStrings {
 
 export interface MlTrainedModelSizeStats {
   model_size_bytes: ByteSize
-  required_native_memory_bytes: integer
+  required_native_memory_bytes: ByteSize
 }
 
 export interface MlTrainedModelStats {

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -127,7 +127,7 @@ export class TrainedModelSizeStats {
   /** The size of the model in bytes. */
   model_size_bytes: ByteSize
   /** The amount of memory required to load the model in bytes. */
-  required_native_memory_bytes: integer
+  required_native_memory_bytes: ByteSize
 }
 
 export class TrainedModelDeploymentNodesStats {


### PR DESCRIPTION
I opened this PR on behalf of @svalbuena so that CI can run on this change

Original change: https://github.com/elastic/elasticsearch-specification/pull/2740
Backport PR: https://github.com/elastic/elasticsearch-specification/pull/2742