### PR TITLE
Non required field in connector config

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -78915,9 +78915,6 @@
           "options",
           "required",
           "sensitive",
-          "type",
-          "ui_restrictions",
-          "validations",
           "value"
         ]
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -51208,9 +51208,6 @@
           "options",
           "required",
           "sensitive",
-          "type",
-          "ui_restrictions",
-          "validations",
           "value"
         ]
       },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -88180,7 +88180,7 @@
         },
         {
           "name": "type",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -88191,7 +88191,7 @@
         },
         {
           "name": "ui_restrictions",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {
@@ -88205,7 +88205,7 @@
         },
         {
           "name": "validations",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "array_of",
             "value": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9227,9 +9227,9 @@ export interface ConnectorConnectorConfigProperties {
   required: boolean
   sensitive: boolean
   tooltip?: string | null
-  type: ConnectorConnectorFieldType
-  ui_restrictions: string[]
-  validations: ConnectorValidation[]
+  type?: ConnectorConnectorFieldType
+  ui_restrictions?: string[]
+  validations?: ConnectorValidation[]
   value: any
 }
 

--- a/specification/connector/_types/Connector.ts
+++ b/specification/connector/_types/Connector.ts
@@ -92,9 +92,9 @@ export interface ConnectorConfigProperties {
   required: boolean
   sensitive: boolean
   tooltip?: string | null
-  type: ConnectorFieldType
-  ui_restrictions: string[]
-  validations: Validation[]
+  type?: ConnectorFieldType
+  ui_restrictions?: string[]
+  validations?: Validation[]
   value: UserDefinedValue
 }
 


### PR DESCRIPTION
As explained in the [latest connector PR](https://github.com/elastic/elasticsearch-specification/pull/2675#issuecomment-2245299918), some of the ConnectorConfig properties are only nullable to support an edge case which will be removed from the server. In the meantime though, this breaks the java client, so for now let's make them nullable. 