### PR TITLE
Reviews summaries of ML APIs (A-E)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -19152,7 +19152,7 @@
         "tags": [
           "ml.evaluate_data_frame"
         ],
-        "summary": "Evaluates the data frame analytics for an annotated index",
+        "summary": "Evaluate data frame analytics",
         "description": "The API packages together commonly used evaluation metrics for various types\nof machine learning features. This has been designed for use on indexes\ncreated by data frame analytics. Evaluation requires both a ground truth\nfield and an analytics result field to be present.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/evaluate-dfanalytics.html"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -16975,8 +16975,8 @@
         "tags": [
           "ml.clear_trained_model_deployment_cache"
         ],
-        "summary": "Clears a trained model deployment cache on all nodes where the trained model is assigned",
-        "description": "A trained model deployment may have an inference cache enabled.\nAs requests are handled by each allocated node, their responses may be cached on that individual node.\nCalling this API clears the caches without restarting the deployment.",
+        "summary": "Clear trained model deployment cache",
+        "description": "Cache will be cleared on all nodes where the trained model is assigned.\nA trained model deployment may have an inference cache enabled.\nAs requests are handled by each allocated node, their responses may be cached on that individual node.\nCalling this API clears the caches without restarting the deployment.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/clear-trained-model-deployment-cache.html"
         },
@@ -17255,7 +17255,8 @@
         "tags": [
           "ml.delete_calendar"
         ],
-        "summary": "Removes all scheduled events from a calendar, then deletes it",
+        "summary": "Delete a calendar",
+        "description": "Removes all scheduled events from a calendar, then deletes it.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar.html"
         },
@@ -17293,7 +17294,7 @@
         "tags": [
           "ml.delete_calendar_event"
         ],
-        "summary": "Deletes scheduled events from a calendar",
+        "summary": "Delete events from a calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar-event.html"
         },
@@ -17405,7 +17406,7 @@
         "tags": [
           "ml.delete_calendar_job"
         ],
-        "summary": "Deletes anomaly detection jobs from a calendar",
+        "summary": "Delete anomaly jobs from a calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar-job.html"
         },
@@ -17644,7 +17645,7 @@
         "tags": [
           "ml.delete_data_frame_analytics"
         ],
-        "summary": "Deletes a data frame analytics job",
+        "summary": "Delete a data frame analytics job",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html"
         },
@@ -17936,7 +17937,7 @@
         "tags": [
           "ml.delete_datafeed"
         ],
-        "summary": "Deletes an existing datafeed",
+        "summary": "Delete a datafeed",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html"
         },
@@ -17984,7 +17985,7 @@
         "tags": [
           "ml.delete_expired_data"
         ],
-        "summary": "Deletes expired and unused machine learning data",
+        "summary": "Delete expired ML data",
         "description": "Deletes all job results, model snapshots and forecast data that have exceeded\ntheir retention days period. Machine learning state documents that are not\nassociated with any job are also deleted.\nYou can limit the request to a single or set of anomaly detection jobs by\nusing a job identifier, a group name, a comma-separated list of jobs, or a\nwildcard expression. You can delete expired data for all anomaly detection\njobs by using _all, by specifying * as the <job_id>, or by omitting the\n<job_id>.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-expired-data.html"
@@ -18017,7 +18018,7 @@
         "tags": [
           "ml.delete_expired_data"
         ],
-        "summary": "Deletes expired and unused machine learning data",
+        "summary": "Delete expired ML data",
         "description": "Deletes all job results, model snapshots and forecast data that have exceeded\ntheir retention days period. Machine learning state documents that are not\nassociated with any job are also deleted.\nYou can limit the request to a single or set of anomaly detection jobs by\nusing a job identifier, a group name, a comma-separated list of jobs, or a\nwildcard expression. You can delete expired data for all anomaly detection\njobs by using _all, by specifying * as the <job_id>, or by omitting the\n<job_id>.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-expired-data.html"
@@ -18154,7 +18155,7 @@
         "tags": [
           "ml.delete_filter"
         ],
-        "summary": "Deletes a filter",
+        "summary": "Delete a filter",
         "description": "If an anomaly detection job references the filter, you cannot delete the\nfilter. You must update or delete the job before you can delete the filter.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-filter.html"
@@ -18293,7 +18294,7 @@
         "tags": [
           "ml.delete_forecast"
         ],
-        "summary": "Deletes forecasts from a machine learning job",
+        "summary": "Delete forecasts from a job",
         "description": "By default, forecasts are retained for 14 days. You can specify a\ndifferent retention period with the `expires_in` parameter in the forecast\njobs API. The delete forecast API enables you to delete one or more\nforecasts before they expire.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html"
@@ -18323,7 +18324,7 @@
         "tags": [
           "ml.delete_forecast"
         ],
-        "summary": "Deletes forecasts from a machine learning job",
+        "summary": "Delete forecasts from a job",
         "description": "By default, forecasts are retained for 14 days. You can specify a\ndifferent retention period with the `expires_in` parameter in the forecast\njobs API. The delete forecast API enables you to delete one or more\nforecasts before they expire.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-forecast.html"
@@ -18729,7 +18730,7 @@
         "tags": [
           "ml.delete_model_snapshot"
         ],
-        "summary": "Deletes an existing model snapshot",
+        "summary": "Delete a model snapshot",
         "description": "You cannot delete the active model snapshot. To delete that snapshot, first\nrevert to a different one. To identify the active model snapshot, refer to\nthe `model_snapshot_id` in the results from the get jobs API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-snapshot.html"
@@ -18931,8 +18932,8 @@
         "tags": [
           "ml.delete_trained_model"
         ],
-        "summary": "Deletes an existing trained inference model that is currently not referenced\n",
-        "description": "by an ingest pipeline.",
+        "summary": "Delete an unreferenced trained model",
+        "description": "The request deletes a trained inference model that is not referenced by an ingest pipeline.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-trained-models.html"
         },
@@ -19038,7 +19039,7 @@
         "tags": [
           "ml.delete_trained_model_alias"
         ],
-        "summary": "Deletes a trained model alias",
+        "summary": "Delete a trained model alias",
         "description": "This API deletes an existing model alias that refers to a trained model. If\nthe model alias is missing or refers to a model other than the one identified\nby the `model_id`, this API returns an error.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-trained-models-aliases.html"
@@ -19088,8 +19089,8 @@
         "tags": [
           "ml.estimate_model_memory"
         ],
-        "summary": "Makes an estimation of the memory usage for an anomaly detection job model",
-        "description": "It is based on analysis configuration details for the job and cardinality\nestimates for the fields it references.",
+        "summary": "Estimate job model memory usage",
+        "description": "Makes an estimation of the memory usage for an anomaly detection job model.\nIt is based on analysis configuration details for the job and cardinality\nestimates for the fields it references.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-apis.html"
         },
@@ -19213,7 +19214,7 @@
         "tags": [
           "ml.explain_data_frame_analytics"
         ],
-        "summary": "Explains a data frame analytics config",
+        "summary": "Explain data frame analytics config",
         "description": "This API provides explanations for a data frame analytics config that either\nexists already or one that has not been created yet. The following\nexplanations are provided:\n* which fields are included or not in the analysis and why,\n* how much memory is estimated to be required. The estimate can be used when deciding the appropriate value for model_memory_limit setting later on.\nIf you have object fields or fields that are excluded via source filtering, they are not included in the explanation.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html"
@@ -19233,7 +19234,7 @@
         "tags": [
           "ml.explain_data_frame_analytics"
         ],
-        "summary": "Explains a data frame analytics config",
+        "summary": "Explain data frame analytics config",
         "description": "This API provides explanations for a data frame analytics config that either\nexists already or one that has not been created yet. The following\nexplanations are provided:\n* which fields are included or not in the analysis and why,\n* how much memory is estimated to be required. The estimate can be used when deciding the appropriate value for model_memory_limit setting later on.\nIf you have object fields or fields that are excluded via source filtering, they are not included in the explanation.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html"
@@ -19255,7 +19256,7 @@
         "tags": [
           "ml.explain_data_frame_analytics"
         ],
-        "summary": "Explains a data frame analytics config",
+        "summary": "Explain data frame analytics config",
         "description": "This API provides explanations for a data frame analytics config that either\nexists already or one that has not been created yet. The following\nexplanations are provided:\n* which fields are included or not in the analysis and why,\n* how much memory is estimated to be required. The estimate can be used when deciding the appropriate value for model_memory_limit setting later on.\nIf you have object fields or fields that are excluded via source filtering, they are not included in the explanation.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html"
@@ -19280,7 +19281,7 @@
         "tags": [
           "ml.explain_data_frame_analytics"
         ],
-        "summary": "Explains a data frame analytics config",
+        "summary": "Explain data frame analytics config",
         "description": "This API provides explanations for a data frame analytics config that either\nexists already or one that has not been created yet. The following\nexplanations are provided:\n* which fields are included or not in the analysis and why,\n* how much memory is estimated to be required. The estimate can be used when deciding the appropriate value for model_memory_limit setting later on.\nIf you have object fields or fields that are excluded via source filtering, they are not included in the explanation.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/explain-dfanalytics.html"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -10423,7 +10423,8 @@
         "tags": [
           "ml.delete_calendar"
         ],
-        "summary": "Removes all scheduled events from a calendar, then deletes it",
+        "summary": "Delete a calendar",
+        "description": "Removes all scheduled events from a calendar, then deletes it.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar.html"
         },
@@ -10461,7 +10462,7 @@
         "tags": [
           "ml.delete_calendar_event"
         ],
-        "summary": "Deletes scheduled events from a calendar",
+        "summary": "Delete events from a calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar-event.html"
         },
@@ -10573,7 +10574,7 @@
         "tags": [
           "ml.delete_calendar_job"
         ],
-        "summary": "Deletes anomaly detection jobs from a calendar",
+        "summary": "Delete anomaly jobs from a calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-calendar-job.html"
         },
@@ -10812,7 +10813,7 @@
         "tags": [
           "ml.delete_data_frame_analytics"
         ],
-        "summary": "Deletes a data frame analytics job",
+        "summary": "Delete a data frame analytics job",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-dfanalytics.html"
         },
@@ -11104,7 +11105,7 @@
         "tags": [
           "ml.delete_datafeed"
         ],
-        "summary": "Deletes an existing datafeed",
+        "summary": "Delete a datafeed",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-datafeed.html"
         },
@@ -11259,7 +11260,7 @@
         "tags": [
           "ml.delete_filter"
         ],
-        "summary": "Deletes a filter",
+        "summary": "Delete a filter",
         "description": "If an anomaly detection job references the filter, you cannot delete the\nfilter. You must update or delete the job before you can delete the filter.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-filter.html"
@@ -11733,8 +11734,8 @@
         "tags": [
           "ml.delete_trained_model"
         ],
-        "summary": "Deletes an existing trained inference model that is currently not referenced\n",
-        "description": "by an ingest pipeline.",
+        "summary": "Delete an unreferenced trained model",
+        "description": "The request deletes a trained inference model that is not referenced by an ingest pipeline.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-trained-models.html"
         },
@@ -11840,7 +11841,7 @@
         "tags": [
           "ml.delete_trained_model_alias"
         ],
-        "summary": "Deletes a trained model alias",
+        "summary": "Delete a trained model alias",
         "description": "This API deletes an existing model alias that refers to a trained model. If\nthe model alias is missing or refers to a model other than the one identified\nby the `model_id`, this API returns an error.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-trained-models-aliases.html"
@@ -11890,8 +11891,8 @@
         "tags": [
           "ml.estimate_model_memory"
         ],
-        "summary": "Makes an estimation of the memory usage for an anomaly detection job model",
-        "description": "It is based on analysis configuration details for the job and cardinality\nestimates for the fields it references.",
+        "summary": "Estimate job model memory usage",
+        "description": "Makes an estimation of the memory usage for an anomaly detection job model.\nIt is based on analysis configuration details for the job and cardinality\nestimates for the fields it references.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-apis.html"
         },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -11954,7 +11954,7 @@
         "tags": [
           "ml.evaluate_data_frame"
         ],
-        "summary": "Evaluates the data frame analytics for an annotated index",
+        "summary": "Evaluate data frame analytics",
         "description": "The API packages together commonly used evaluation metrics for various types\nof machine learning features. This has been designed for use on indexes\ncreated by data frame analytics. Evaluation requires both a ground truth\nfield and an analytics result field to be present.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/evaluate-dfanalytics.html"

--- a/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheRequest.ts
+++ b/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheRequest.ts
@@ -23,7 +23,8 @@ import { integer } from '@_types/Numeric'
 import { Include } from '@ml/_types/Include'
 
 /**
- * Clears a trained model deployment cache on all nodes where the trained model is assigned.
+ * Clear trained model deployment cache.
+ * Cache will be cleared on all nodes where the trained model is assigned.
  * A trained model deployment may have an inference cache enabled.
  * As requests are handled by each allocated node, their responses may be cached on that individual node.
  * Calling this API clears the caches without restarting the deployment.

--- a/specification/ml/delete_calendar/MlDeleteCalendarRequest.ts
+++ b/specification/ml/delete_calendar/MlDeleteCalendarRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
+ * Delete a calendar.
  * Removes all scheduled events from a calendar, then deletes it.
  * @rest_spec_name ml.delete_calendar
  * @availability stack since=6.2.0 stability=stable

--- a/specification/ml/delete_calendar_event/MlDeleteCalendarEventRequest.ts
+++ b/specification/ml/delete_calendar_event/MlDeleteCalendarEventRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes scheduled events from a calendar.
+ * Delete events from a calendar.
  * @rest_spec_name ml.delete_calendar_event
  * @availability stack since=6.2.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/delete_calendar_job/MlDeleteCalendarJobRequest.ts
+++ b/specification/ml/delete_calendar_job/MlDeleteCalendarJobRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id, Ids } from '@_types/common'
 
 /**
- * Deletes anomaly detection jobs from a calendar.
+ * Delete anomaly jobs from a calendar.
  * @rest_spec_name ml.delete_calendar_job
  * @availability stack since=6.2.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/delete_data_frame_analytics/MlDeleteDataFrameAnalyticsRequest.ts
+++ b/specification/ml/delete_data_frame_analytics/MlDeleteDataFrameAnalyticsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Deletes a data frame analytics job.
+ * Delete a data frame analytics job.
  * @rest_spec_name ml.delete_data_frame_analytics
  * @availability stack since=7.3.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/delete_datafeed/MlDeleteDatafeedRequest.ts
+++ b/specification/ml/delete_datafeed/MlDeleteDatafeedRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes an existing datafeed.
+ * Delete a datafeed.
  * @rest_spec_name ml.delete_datafeed
  * @availability stack since=5.4.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/delete_expired_data/MlDeleteExpiredDataRequest.ts
+++ b/specification/ml/delete_expired_data/MlDeleteExpiredDataRequest.ts
@@ -23,7 +23,7 @@ import { float } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 /**
- * Deletes expired and unused machine learning data.
+ * Delete expired ML data.
  * Deletes all job results, model snapshots and forecast data that have exceeded
  * their retention days period. Machine learning state documents that are not
  * associated with any job are also deleted.

--- a/specification/ml/delete_filter/MlDeleteFilterRequest.ts
+++ b/specification/ml/delete_filter/MlDeleteFilterRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes a filter.
+ * Delete a filter.
  * If an anomaly detection job references the filter, you cannot delete the
  * filter. You must update or delete the job before you can delete the filter.
  * @rest_spec_name ml.delete_filter

--- a/specification/ml/delete_forecast/MlDeleteForecastRequest.ts
+++ b/specification/ml/delete_forecast/MlDeleteForecastRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Deletes forecasts from a machine learning job.
+ * Delete forecasts from a job.
  * By default, forecasts are retained for 14 days. You can specify a
  * different retention period with the `expires_in` parameter in the forecast
  * jobs API. The delete forecast API enables you to delete one or more

--- a/specification/ml/delete_model_snapshot/MlDeleteModelSnapshotRequest.ts
+++ b/specification/ml/delete_model_snapshot/MlDeleteModelSnapshotRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes an existing model snapshot.
+ * Delete a model snapshot.
  * You cannot delete the active model snapshot. To delete that snapshot, first
  * revert to a different one. To identify the active model snapshot, refer to
  * the `model_snapshot_id` in the results from the get jobs API.

--- a/specification/ml/delete_trained_model/MlDeleteTrainedModelRequest.ts
+++ b/specification/ml/delete_trained_model/MlDeleteTrainedModelRequest.ts
@@ -21,8 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes an existing trained inference model that is currently not referenced
- * by an ingest pipeline.
+ * Delete an unreferenced trained model.
+ * The request deletes a trained inference model that is not referenced by an ingest pipeline.
  * @rest_spec_name ml.delete_trained_model
  * @availability stack since=7.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/delete_trained_model_alias/MlDeleteTrainedModelAliasRequest.ts
+++ b/specification/ml/delete_trained_model_alias/MlDeleteTrainedModelAliasRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id, Name } from '@_types/common'
 
 /**
- * Deletes a trained model alias.
+ * Delete a trained model alias.
  * This API deletes an existing model alias that refers to a trained model. If
  * the model alias is missing or refers to a model other than the one identified
  * by the `model_id`, this API returns an error.

--- a/specification/ml/estimate_model_memory/MlEstimateModelMemoryRequest.ts
+++ b/specification/ml/estimate_model_memory/MlEstimateModelMemoryRequest.ts
@@ -24,6 +24,7 @@ import { Field } from '@_types/common'
 import { long } from '@_types/Numeric'
 
 /**
+ * Estimate job model memory usage.
  * Makes an estimation of the memory usage for an anomaly detection job model.
  * It is based on analysis configuration details for the job and cardinality
  * estimates for the fields it references.

--- a/specification/ml/evaluate_data_frame/MlEvaluateDataFrameRequest.ts
+++ b/specification/ml/evaluate_data_frame/MlEvaluateDataFrameRequest.ts
@@ -23,7 +23,7 @@ import { IndexName } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 
 /**
- * Evaluates the data frame analytics for an annotated index.
+ * Evaluate data frame analytics.
  * The API packages together commonly used evaluation metrics for various types
  * of machine learning features. This has been designed for use on indexes
  * created by data frame analytics. Evaluation requires both a ground truth

--- a/specification/ml/explain_data_frame_analytics/MlExplainDataFrameAnalyticsRequest.ts
+++ b/specification/ml/explain_data_frame_analytics/MlExplainDataFrameAnalyticsRequest.ts
@@ -28,7 +28,7 @@ import { ByteSize, Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Explains a data frame analytics config.
+ * Explain data frame analytics config.
  * This API provides explanations for a data frame analytics config that either
  * exists already or one that has not been created yet. The following
  * explanations are provided:


### PR DESCRIPTION
## Overview

Relates to https://github.com/elastic/elasticsearch-specification/issues/2635 and https://github.com/elastic/search-docs-team/issues/136

This PR fixes the operation summaries for ML APIs (A-E) (ending period is necessary per https://github.com/elastic/elasticsearch-specification/blob/main/docs/doc-comments-guide.md), then runs the `make generate` and `make transform-to-openapi` commands to refresh the output.