### PR TITLE
Mark connector.last_sync as private for now

### DIFF
--- a/specification/connector/last_sync/ConnectorUpdateLastSyncRequest.ts
+++ b/specification/connector/last_sync/ConnectorUpdateLastSyncRequest.ts
@@ -26,7 +26,7 @@ import { SyncStatus } from '../_types/Connector'
 /**
  * Updates last sync stats in the connector document
  * @rest_spec_name connector.last_sync
- * @availability stack since=8.12.0 stability=experimental
+ * @availability stack since=8.12.0 stability=experimental visibility=private
  * @availability serverless stability=experimental visibility=private
  * @doc_id connector-last-sync
  */


### PR DESCRIPTION
There is currently a bug when updating errors. When fixed (most likely for 8.16), this endpoint will be added back to the specification.