### PR TITLE
Update rest-api-spec only once a day

### DIFF
--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -3,7 +3,7 @@ name: Update rest-api-spec
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 */3 * * *'  # At minute 0 past every 3rd hour.
+    - cron: '0 4 * * *'  # At 04:00.
 
 jobs:
   update-rest-api:


### PR DESCRIPTION
It currently runs 8 times per day, which is just too much. But maybe it should be once a week instead?