### PR TITLE
Generalize references to APIs

### DIFF
--- a/specification/cat/aliases/CatAliasesRequest.ts
+++ b/specification/cat/aliases/CatAliasesRequest.ts
@@ -25,7 +25,7 @@ import { ExpandWildcards, Names } from '@_types/common'
  * Retrieves the cluster’s index aliases, including filter and routing information.
  * The API does not return data stream aliases.
  *
- * CAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the /_alias endpoints.
+ * CAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.
  * @rest_spec_name cat.aliases
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/cat/component_templates/CatComponentTemplatesRequest.ts
+++ b/specification/cat/component_templates/CatComponentTemplatesRequest.ts
@@ -25,7 +25,7 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.
  *
  * CAT APIs are only intended for human consumption using the command line or Kibana console.
- * They are not intended for use by applications. For application consumption, use the /_component_template endpoints.
+ * They are not intended for use by applications. For application consumption, use the get component template API.
  * @rest_spec_name cat.component_templates
  * @availability stack since=5.1.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/cat/count/CatCountRequest.ts
+++ b/specification/cat/count/CatCountRequest.ts
@@ -26,7 +26,7 @@ import { Indices } from '@_types/common'
  * The document count only includes live documents, not deleted documents which have not yet been removed by the merge process.
  *
  * CAT APIs are only intended for human consumption using the command line or Kibana console.
- * They are not intended for use by applications. For application consumption, use /_count endpoints.
+ * They are not intended for use by applications. For application consumption, use the count API.
  * @rest_spec_name cat.count
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/cat/indices/CatIndicesRequest.ts
+++ b/specification/cat/indices/CatIndicesRequest.ts
@@ -33,7 +33,7 @@ import { TimeUnit } from '@_types/Time'
  * - total store size of all shards, including shard replicas
  *
  * These metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.
- * To get an accurate count of Elasticsearch documents, use the /_cat/count or _count endpoints.
+ * To get an accurate count of Elasticsearch documents, use the cat count or count APIs.
  *
  * CAT APIs are only intended for human consumption using the command line or Kibana console.
  * They are not intended for use by applications. For application consumption, use an index endpoint.

--- a/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
+++ b/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
@@ -27,7 +27,7 @@ import { Duration } from '@_types/Time'
  *
  * CAT APIs are only intended for human consumption using the Kibana
  * console or command line. They are not intended for use by applications. For
- * application consumption, use the /_ml/data_frame/analytics endpoints.
+ * application consumption, use the get data frame analytics jobs statistics API.
  *
  * @rest_spec_name cat.ml_data_frame_analytics
  * @availability stack since=7.7.0 stability=stable

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -30,7 +30,7 @@ import { TimeUnit } from '@_types/Time'
  *
  * CAT APIs are only intended for human consumption using the Kibana
  * console or command line. They are not intended for use by applications. For
- * application consumption, use the /_ml/datafeeds endpoints.
+ * application consumption, use the get datafeed statistics API.
  *
  * @rest_spec_name cat.ml_datafeeds
  * @availability stack since=7.7.0 stability=stable

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -30,7 +30,7 @@ import { TimeUnit } from '@_types/Time'
  *
  * CAT APIs are only intended for human consumption using the Kibana
  * console or command line. They are not intended for use by applications. For
- * application consumption, use the /_ml/anomaly_detectors endpoints.
+ * application consumption, use the get anomaly detection job statistics API.
  *
  * @rest_spec_name cat.ml_jobs
  * @availability stack since=7.7.0 stability=stable

--- a/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
+++ b/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
@@ -27,7 +27,7 @@ import { integer } from '@_types/Numeric'
  *
  * CAT APIs are only intended for human consumption using the Kibana
  * console or command line. They are not intended for use by applications. For
- * application consumption, use the /_ml/trained_models endpoints.
+ * application consumption, use the get trained models statistics API.
  *
  * @rest_spec_name cat.ml_trained_models
  * @availability stack since=7.7.0 stability=stable

--- a/specification/cat/transforms/CatTransformsRequest.ts
+++ b/specification/cat/transforms/CatTransformsRequest.ts
@@ -28,7 +28,7 @@ import { Duration, TimeUnit } from '@_types/Time'
  *
  * CAT APIs are only intended for human consumption using the Kibana
  * console or command line. They are not intended for use by applications. For
- * application consumption, use the /_transform endpoints.
+ * application consumption, use the get transform statistics API.
  *
  * @rest_spec_name cat.transforms
  * @availability stack since=7.7.0 stability=stable


### PR DESCRIPTION
To avoid confusing people reading these docs in the client references, I'm removing explicit references to endpoints and endpoint names, and going back to general API names. We might revisit this [as we improve our link tech](https://github.com/elastic/elasticsearch-specification/issues/2758).
