### PR TITLE
Reviews summaries of ML APIs (F-Z)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -849,7 +849,7 @@
           "cat.aliases"
         ],
         "summary": "Get aliases",
-        "description": "Retrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the /_alias endpoints.",
+        "description": "Retrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-alias.html"
         },
@@ -872,7 +872,7 @@
           "cat.aliases"
         ],
         "summary": "Get aliases",
-        "description": "Retrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the /_alias endpoints.",
+        "description": "Retrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-alias.html"
         },
@@ -947,7 +947,7 @@
           "cat.component_templates"
         ],
         "summary": "Get component templates",
-        "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the /_component_template endpoints.",
+        "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html"
         },
@@ -966,7 +966,7 @@
           "cat.component_templates"
         ],
         "summary": "Get component templates",
-        "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the /_component_template endpoints.",
+        "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html"
         },
@@ -990,7 +990,7 @@
           "cat.count"
         ],
         "summary": "Get a document count",
-        "description": "Provides quick access to a document count for a data stream, an index, or an entire cluster.n/\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use /_count endpoints.",
+        "description": "Provides quick access to a document count for a data stream, an index, or an entire cluster.n/\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-count.html"
         },
@@ -1008,7 +1008,7 @@
           "cat.count"
         ],
         "summary": "Get a document count",
-        "description": "Provides quick access to a document count for a data stream, an index, or an entire cluster.n/\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use /_count endpoints.",
+        "description": "Provides quick access to a document count for a data stream, an index, or an entire cluster.n/\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-count.html"
         },
@@ -1164,7 +1164,7 @@
           "cat.indices"
         ],
         "summary": "Get index information",
-        "description": "Returns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the /_cat/count or _count endpoints.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
+        "description": "Returns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html"
         },
@@ -1202,7 +1202,7 @@
           "cat.indices"
         ],
         "summary": "Get index information",
-        "description": "Returns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the /_cat/count or _count endpoints.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
+        "description": "Returns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html"
         },
@@ -1271,7 +1271,7 @@
           "cat.ml_data_frame_analytics"
         ],
         "summary": "Get data frame analytics jobs",
-        "description": "Returns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/data_frame/analytics endpoints.",
+        "description": "Returns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-dfanalytics.html"
         },
@@ -1307,7 +1307,7 @@
           "cat.ml_data_frame_analytics"
         ],
         "summary": "Get data frame analytics jobs",
-        "description": "Returns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/data_frame/analytics endpoints.",
+        "description": "Returns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-dfanalytics.html"
         },
@@ -1346,7 +1346,7 @@
           "cat.ml_datafeeds"
         ],
         "summary": "Get datafeeds",
-        "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/datafeeds endpoints.",
+        "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-datafeeds.html"
         },
@@ -1379,7 +1379,7 @@
           "cat.ml_datafeeds"
         ],
         "summary": "Get datafeeds",
-        "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/datafeeds endpoints.",
+        "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-datafeeds.html"
         },
@@ -1415,7 +1415,7 @@
           "cat.ml_jobs"
         ],
         "summary": "Get anomaly detection jobs",
-        "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/anomaly_detectors endpoints.",
+        "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-anomaly-detectors.html"
         },
@@ -1451,7 +1451,7 @@
           "cat.ml_jobs"
         ],
         "summary": "Get anomaly detection jobs",
-        "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/anomaly_detectors endpoints.",
+        "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-anomaly-detectors.html"
         },
@@ -1490,7 +1490,7 @@
           "cat.ml_trained_models"
         ],
         "summary": "Get trained models",
-        "description": "Returns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/trained_models endpoints.",
+        "description": "Returns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-trained-model.html"
         },
@@ -1529,7 +1529,7 @@
           "cat.ml_trained_models"
         ],
         "summary": "Get trained models",
-        "description": "Returns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/trained_models endpoints.",
+        "description": "Returns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-trained-model.html"
         },
@@ -2131,7 +2131,7 @@
           "cat.transforms"
         ],
         "summary": "Get transforms",
-        "description": "Returns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_transform endpoints.",
+        "description": "Returns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-transforms.html"
         },
@@ -2170,7 +2170,7 @@
           "cat.transforms"
         ],
         "summary": "Get transforms",
-        "description": "Returns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_transform endpoints.",
+        "description": "Returns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-transforms.html"
         },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -17121,7 +17121,7 @@
         "tags": [
           "ml.get_calendars"
         ],
-        "summary": "Retrieves configuration information for calendars",
+        "summary": "Get calendar configuration info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar.html"
         },
@@ -17151,7 +17151,7 @@
         "tags": [
           "ml.put_calendar"
         ],
-        "summary": "Creates a calendar",
+        "summary": "Create a calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-calendar.html"
         },
@@ -17225,7 +17225,7 @@
         "tags": [
           "ml.get_calendars"
         ],
-        "summary": "Retrieves configuration information for calendars",
+        "summary": "Get calendar configuration info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar.html"
         },
@@ -17343,7 +17343,7 @@
         "tags": [
           "ml.put_calendar_job"
         ],
-        "summary": "Adds an anomaly detection job to a calendar",
+        "summary": "Add anomaly detection job to calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-calendar-job.html"
         },
@@ -17471,7 +17471,7 @@
         "tags": [
           "ml.get_data_frame_analytics"
         ],
-        "summary": "Retrieves configuration information for data frame analytics jobs",
+        "summary": "Get data frame analytics job configuration info",
         "description": "You can get information for multiple data frame analytics jobs in a single\nAPI request by using a comma-separated list of data frame analytics jobs or a\nwildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html"
@@ -17505,7 +17505,7 @@
         "tags": [
           "ml.put_data_frame_analytics"
         ],
-        "summary": "Instantiates a data frame analytics job",
+        "summary": "Create a data frame analytics job",
         "description": "This API creates a data frame analytics job that performs an analysis on the\nsource indices and stores the outcome in a destination index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html"
@@ -17703,7 +17703,7 @@
         "tags": [
           "ml.get_datafeeds"
         ],
-        "summary": "Retrieves configuration information for datafeeds",
+        "summary": "Get datafeeds configuration info",
         "description": "You can get information for multiple datafeeds in a single API request by\nusing a comma-separated list of datafeeds or a wildcard expression. You can\nget information for all datafeeds by using `_all`, by specifying `*` as the\n`<feed_id>`, or by omitting the `<feed_id>`.\nThis API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html"
@@ -17731,7 +17731,7 @@
         "tags": [
           "ml.put_datafeed"
         ],
-        "summary": "Instantiates a datafeed",
+        "summary": "Create a datafeed",
         "description": "Datafeeds retrieve data from Elasticsearch for analysis by an anomaly detection job.\nYou can associate only one datafeed with each anomaly detection job.\nThe datafeed contains a query that runs at a defined interval (`frequency`).\nIf you are concerned about delayed data, you can add a delay (`query_delay') at each interval.\nWhen Elasticsearch security features are enabled, your datafeed remembers which roles the user who created it had\nat the time of creation and runs the query using those same roles. If you provide secondary authorization headers,\nthose credentials are used instead.\nYou must use Kibana, this API, or the create anomaly detection jobs API to create a datafeed. Do not add a datafeed\ndirectly to the `.ml-config` index. Do not give users `write` privileges on the `.ml-config` index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html"
@@ -18048,7 +18048,7 @@
         "tags": [
           "ml.get_filters"
         ],
-        "summary": "Retrieves filters",
+        "summary": "Get filters",
         "description": "You can get a single filter or all filters.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-filter.html"
@@ -18076,7 +18076,7 @@
         "tags": [
           "ml.put_filter"
         ],
-        "summary": "Instantiates a filter",
+        "summary": "Create a filter",
         "description": "A filter contains a list of strings. It can be used by one or more anomaly detection jobs.\nSpecifically, filters are referenced in the `custom_rules` property of detector configuration objects.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-filter.html"
@@ -18194,8 +18194,8 @@
         "tags": [
           "ml.forecast"
         ],
-        "summary": "Predicts the future behavior of a time series by using its historical\n",
-        "description": "behavior.\n\nForecasts are not supported for jobs that perform population analysis; an\nerror occurs if you try to create a forecast for a job that has an\n`over_field_name` in its configuration.",
+        "summary": "Predict future behavior of a time series",
+        "description": "Forecasts are not supported for jobs that perform population analysis; an\nerror occurs if you try to create a forecast for a job that has an\n`over_field_name` in its configuration. Forcasts predict future behavior\nbased on historical data.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-forecast.html"
         },
@@ -18357,7 +18357,7 @@
         "tags": [
           "ml.get_jobs"
         ],
-        "summary": "Retrieves configuration information for anomaly detection jobs",
+        "summary": "Get anomaly detection jobs configuration info",
         "description": "You can get information for multiple anomaly detection jobs in a single API\nrequest by using a group name, a comma-separated list of jobs, or a wildcard\nexpression. You can get information for all anomaly detection jobs by using\n`_all`, by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html"
@@ -18640,7 +18640,7 @@
         "tags": [
           "ml.get_model_snapshots"
         ],
-        "summary": "Retrieves information about model snapshots",
+        "summary": "Get model snapshots info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html"
         },
@@ -18685,7 +18685,7 @@
         "tags": [
           "ml.get_model_snapshots"
         ],
-        "summary": "Retrieves information about model snapshots",
+        "summary": "Get model snapshots info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html"
         },
@@ -18780,7 +18780,7 @@
         "tags": [
           "ml.get_trained_models"
         ],
-        "summary": "Retrieves configuration information for a trained model",
+        "summary": "Get trained model configuration info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models.html"
         },
@@ -18822,7 +18822,8 @@
         "tags": [
           "ml.put_trained_model"
         ],
-        "summary": "Enables you to supply a trained model that is not created by data frame analytics",
+        "summary": "Supply external trained model",
+        "description": "Enable you to supply a trained model that is not created by data frame analytics.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-models.html"
         },
@@ -18981,8 +18982,8 @@
         "tags": [
           "ml.put_trained_model_alias"
         ],
-        "summary": "Creates or updates a trained model alias",
-        "description": "A trained model alias is a logical\nname used to reference a single trained model.\nYou can use aliases instead of trained model identifiers to make it easier to\nreference your models. For example, you can use aliases in inference\naggregations and processors.\nAn alias must be unique and refer to only a single trained model. However,\nyou can have multiple aliases for each trained model.\nIf you use this API to update an alias such that it references a different\ntrained model ID and the model uses a different type of data frame analytics,\nan error occurs. For example, this situation occurs if you have a trained\nmodel for regression analysis and a trained model for classification\nanalysis; you cannot reassign an alias from one type of trained model to\nanother.\nIf you use this API to update an alias and there are very few input fields in\ncommon between the old and new trained models for the model alias, the API\nreturns a warning.",
+        "summary": "Create or update a trained model alias",
+        "description": "A trained model alias is a logical name used to reference a single trained\nmodel.\nYou can use aliases instead of trained model identifiers to make it easier to\nreference your models. For example, you can use aliases in inference\naggregations and processors.\nAn alias must be unique and refer to only a single trained model. However,\nyou can have multiple aliases for each trained model.\nIf you use this API to update an alias such that it references a different\ntrained model ID and the model uses a different type of data frame analytics,\nan error occurs. For example, this situation occurs if you have a trained\nmodel for regression analysis and a trained model for classification\nanalysis; you cannot reassign an alias from one type of trained model to\nanother.\nIf you use this API to update an alias and there are very few input fields in\ncommon between the old and new trained models for the model alias, the API\nreturns a warning.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-models-aliases.html"
         },
@@ -19308,7 +19309,7 @@
         "tags": [
           "ml.flush_job"
         ],
-        "summary": "Forces any buffered data to be processed by the job",
+        "summary": "Force buffered data to be processed",
         "description": "The flush jobs API is only applicable when sending data for analysis using\nthe post data API. Depending on the content of the buffer, then it might\nadditionally calculate new results. Both flush and close operations are\nsimilar, however the flush is more efficient if you are expecting to send\nmore data for analysis. When flushing, the job remains open and is available\nto continue analyzing data. A close operation additionally prunes and\npersists the model state to disk and the job must be opened again before\nanalyzing further data.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html"
@@ -19436,7 +19437,7 @@
         "tags": [
           "ml.get_buckets"
         ],
-        "summary": "Retrieves anomaly detection job results for one or more buckets",
+        "summary": "Get anomaly detection job results",
         "description": "The API presents a chronological view of the records, grouped by bucket.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html"
@@ -19491,7 +19492,7 @@
         "tags": [
           "ml.get_buckets"
         ],
-        "summary": "Retrieves anomaly detection job results for one or more buckets",
+        "summary": "Get anomaly detection job results",
         "description": "The API presents a chronological view of the records, grouped by bucket.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html"
@@ -19548,7 +19549,7 @@
         "tags": [
           "ml.get_buckets"
         ],
-        "summary": "Retrieves anomaly detection job results for one or more buckets",
+        "summary": "Get anomaly detection job results",
         "description": "The API presents a chronological view of the records, grouped by bucket.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html"
@@ -19600,7 +19601,7 @@
         "tags": [
           "ml.get_buckets"
         ],
-        "summary": "Retrieves anomaly detection job results for one or more buckets",
+        "summary": "Get anomaly detection job results",
         "description": "The API presents a chronological view of the records, grouped by bucket.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-bucket.html"
@@ -19654,7 +19655,7 @@
         "tags": [
           "ml.get_calendar_events"
         ],
-        "summary": "Retrieves information about the scheduled events in calendars",
+        "summary": "Get info about events in calendars",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar-event.html"
         },
@@ -19755,7 +19756,7 @@
         "tags": [
           "ml.post_calendar_events"
         ],
-        "summary": "Adds scheduled events to a calendar",
+        "summary": "Add scheduled events to calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-calendar-event.html"
         },
@@ -19826,7 +19827,7 @@
         "tags": [
           "ml.get_calendars"
         ],
-        "summary": "Retrieves configuration information for calendars",
+        "summary": "Get calendar configuration info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar.html"
         },
@@ -19853,7 +19854,7 @@
         "tags": [
           "ml.get_calendars"
         ],
-        "summary": "Retrieves configuration information for calendars",
+        "summary": "Get calendar configuration info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar.html"
         },
@@ -19882,7 +19883,7 @@
         "tags": [
           "ml.get_categories"
         ],
-        "summary": "Retrieves anomaly detection job results for one or more categories",
+        "summary": "Get anomaly detection job results for categories",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html"
         },
@@ -19918,7 +19919,7 @@
         "tags": [
           "ml.get_categories"
         ],
-        "summary": "Retrieves anomaly detection job results for one or more categories",
+        "summary": "Get anomaly detection job results for categories",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html"
         },
@@ -19956,7 +19957,7 @@
         "tags": [
           "ml.get_categories"
         ],
-        "summary": "Retrieves anomaly detection job results for one or more categories",
+        "summary": "Get anomaly detection job results for categories",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html"
         },
@@ -19989,7 +19990,7 @@
         "tags": [
           "ml.get_categories"
         ],
-        "summary": "Retrieves anomaly detection job results for one or more categories",
+        "summary": "Get anomaly detection job results for categories",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html"
         },
@@ -20024,7 +20025,7 @@
         "tags": [
           "ml.get_data_frame_analytics"
         ],
-        "summary": "Retrieves configuration information for data frame analytics jobs",
+        "summary": "Get data frame analytics job configuration info",
         "description": "You can get information for multiple data frame analytics jobs in a single\nAPI request by using a comma-separated list of data frame analytics jobs or a\nwildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html"
@@ -20057,7 +20058,7 @@
         "tags": [
           "ml.get_data_frame_analytics_stats"
         ],
-        "summary": "Retrieves usage information for data frame analytics jobs",
+        "summary": "Get data frame analytics jobs usage info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics-stats.html"
         },
@@ -20089,7 +20090,7 @@
         "tags": [
           "ml.get_data_frame_analytics_stats"
         ],
-        "summary": "Retrieves usage information for data frame analytics jobs",
+        "summary": "Get data frame analytics jobs usage info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics-stats.html"
         },
@@ -20124,7 +20125,7 @@
         "tags": [
           "ml.get_datafeed_stats"
         ],
-        "summary": "Retrieves usage information for datafeeds",
+        "summary": "Get datafeeds usage info",
         "description": "You can get statistics for multiple datafeeds in a single API request by\nusing a comma-separated list of datafeeds or a wildcard expression. You can\nget statistics for all datafeeds by using `_all`, by specifying `*` as the\n`<feed_id>`, or by omitting the `<feed_id>`. If the datafeed is stopped, the\nonly information you receive is the `datafeed_id` and the `state`.\nThis API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html"
@@ -20151,7 +20152,7 @@
         "tags": [
           "ml.get_datafeed_stats"
         ],
-        "summary": "Retrieves usage information for datafeeds",
+        "summary": "Get datafeeds usage info",
         "description": "You can get statistics for multiple datafeeds in a single API request by\nusing a comma-separated list of datafeeds or a wildcard expression. You can\nget statistics for all datafeeds by using `_all`, by specifying `*` as the\n`<feed_id>`, or by omitting the `<feed_id>`. If the datafeed is stopped, the\nonly information you receive is the `datafeed_id` and the `state`.\nThis API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html"
@@ -20175,7 +20176,7 @@
         "tags": [
           "ml.get_datafeeds"
         ],
-        "summary": "Retrieves configuration information for datafeeds",
+        "summary": "Get datafeeds configuration info",
         "description": "You can get information for multiple datafeeds in a single API request by\nusing a comma-separated list of datafeeds or a wildcard expression. You can\nget information for all datafeeds by using `_all`, by specifying `*` as the\n`<feed_id>`, or by omitting the `<feed_id>`.\nThis API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html"
@@ -20202,7 +20203,7 @@
         "tags": [
           "ml.get_filters"
         ],
-        "summary": "Retrieves filters",
+        "summary": "Get filters",
         "description": "You can get a single filter or all filters.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-filter.html"
@@ -20229,7 +20230,7 @@
         "tags": [
           "ml.get_influencers"
         ],
-        "summary": "Retrieves anomaly detection job results for one or more influencers",
+        "summary": "Get anomaly detection job results for influencers",
         "description": "Influencers are the entities that have contributed to, or are to blame for,\nthe anomalies. Influencer results are available only if an\n`influencer_field_name` is specified in the job configuration.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html"
@@ -20278,7 +20279,7 @@
         "tags": [
           "ml.get_influencers"
         ],
-        "summary": "Retrieves anomaly detection job results for one or more influencers",
+        "summary": "Get anomaly detection job results for influencers",
         "description": "Influencers are the entities that have contributed to, or are to blame for,\nthe anomalies. Influencer results are available only if an\n`influencer_field_name` is specified in the job configuration.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-influencer.html"
@@ -20329,7 +20330,7 @@
         "tags": [
           "ml.get_job_stats"
         ],
-        "summary": "Retrieves usage information for anomaly detection jobs",
+        "summary": "Get anomaly detection jobs usage info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html"
         },
@@ -20352,7 +20353,7 @@
         "tags": [
           "ml.get_job_stats"
         ],
-        "summary": "Retrieves usage information for anomaly detection jobs",
+        "summary": "Get anomaly detection jobs usage info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html"
         },
@@ -20378,7 +20379,7 @@
         "tags": [
           "ml.get_jobs"
         ],
-        "summary": "Retrieves configuration information for anomaly detection jobs",
+        "summary": "Get anomaly detection jobs configuration info",
         "description": "You can get information for multiple anomaly detection jobs in a single API\nrequest by using a group name, a comma-separated list of jobs, or a wildcard\nexpression. You can get information for all anomaly detection jobs by using\n`_all`, by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html"
@@ -20405,8 +20406,8 @@
         "tags": [
           "ml.get_memory_stats"
         ],
-        "summary": "Get information about how machine learning jobs and trained models are using memory,\n",
-        "description": "on each node, both within the JVM heap, and natively, outside of the JVM.",
+        "summary": "Get machine learning memory usage info",
+        "description": "Get information about how machine learning jobs and trained models are using memory,\non each node, both within the JVM heap, and natively, outside of the JVM.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-ml-memory.html"
         },
@@ -20435,8 +20436,8 @@
         "tags": [
           "ml.get_memory_stats"
         ],
-        "summary": "Get information about how machine learning jobs and trained models are using memory,\n",
-        "description": "on each node, both within the JVM heap, and natively, outside of the JVM.",
+        "summary": "Get machine learning memory usage info",
+        "description": "Get information about how machine learning jobs and trained models are using memory,\non each node, both within the JVM heap, and natively, outside of the JVM.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-ml-memory.html"
         },
@@ -20468,7 +20469,7 @@
         "tags": [
           "ml.get_model_snapshot_upgrade_stats"
         ],
-        "summary": "Retrieves usage information for anomaly detection job model snapshot upgrades",
+        "summary": "Get anomaly detection job model snapshot upgrade usage info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-model-snapshot-upgrade-stats.html"
         },
@@ -20542,7 +20543,7 @@
         "tags": [
           "ml.get_model_snapshots"
         ],
-        "summary": "Retrieves information about model snapshots",
+        "summary": "Get model snapshots info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html"
         },
@@ -20584,7 +20585,7 @@
         "tags": [
           "ml.get_model_snapshots"
         ],
-        "summary": "Retrieves information about model snapshots",
+        "summary": "Get model snapshots info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-snapshot.html"
         },
@@ -20628,8 +20629,8 @@
         "tags": [
           "ml.get_overall_buckets"
         ],
-        "summary": "Retrieves overall bucket results that summarize the bucket results of\n",
-        "description": "multiple anomaly detection jobs.\n\nThe `overall_score` is calculated by combining the scores of all the\nbuckets within the overall bucket span. First, the maximum\n`anomaly_score` per anomaly detection job in the overall bucket is\ncalculated. Then the `top_n` of those scores are averaged to result in\nthe `overall_score`. This means that you can fine-tune the\n`overall_score` so that it is more or less sensitive to the number of\njobs that detect an anomaly at the same time. For example, if you set\n`top_n` to `1`, the `overall_score` is the maximum bucket score in the\noverall bucket. Alternatively, if you set `top_n` to the number of jobs,\nthe `overall_score` is high only when all jobs detect anomalies in that\noverall bucket. If you set the `bucket_span` parameter (to a value\ngreater than its default), the `overall_score` is the maximum\n`overall_score` of the overall buckets that have a span equal to the\njobs' largest bucket span.",
+        "summary": "Get overall bucket results",
+        "description": "Retrievs overall bucket results that summarize the bucket results of\nmultiple anomaly detection jobs.\n\nThe `overall_score` is calculated by combining the scores of all the\nbuckets within the overall bucket span. First, the maximum\n`anomaly_score` per anomaly detection job in the overall bucket is\ncalculated. Then the `top_n` of those scores are averaged to result in\nthe `overall_score`. This means that you can fine-tune the\n`overall_score` so that it is more or less sensitive to the number of\njobs that detect an anomaly at the same time. For example, if you set\n`top_n` to `1`, the `overall_score` is the maximum bucket score in the\noverall bucket. Alternatively, if you set `top_n` to the number of jobs,\nthe `overall_score` is high only when all jobs detect anomalies in that\noverall bucket. If you set the `bucket_span` parameter (to a value\ngreater than its default), the `overall_score` is the maximum\n`overall_score` of the overall buckets that have a span equal to the\njobs' largest bucket span.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html"
         },
@@ -20674,8 +20675,8 @@
         "tags": [
           "ml.get_overall_buckets"
         ],
-        "summary": "Retrieves overall bucket results that summarize the bucket results of\n",
-        "description": "multiple anomaly detection jobs.\n\nThe `overall_score` is calculated by combining the scores of all the\nbuckets within the overall bucket span. First, the maximum\n`anomaly_score` per anomaly detection job in the overall bucket is\ncalculated. Then the `top_n` of those scores are averaged to result in\nthe `overall_score`. This means that you can fine-tune the\n`overall_score` so that it is more or less sensitive to the number of\njobs that detect an anomaly at the same time. For example, if you set\n`top_n` to `1`, the `overall_score` is the maximum bucket score in the\noverall bucket. Alternatively, if you set `top_n` to the number of jobs,\nthe `overall_score` is high only when all jobs detect anomalies in that\noverall bucket. If you set the `bucket_span` parameter (to a value\ngreater than its default), the `overall_score` is the maximum\n`overall_score` of the overall buckets that have a span equal to the\njobs' largest bucket span.",
+        "summary": "Get overall bucket results",
+        "description": "Retrievs overall bucket results that summarize the bucket results of\nmultiple anomaly detection jobs.\n\nThe `overall_score` is calculated by combining the scores of all the\nbuckets within the overall bucket span. First, the maximum\n`anomaly_score` per anomaly detection job in the overall bucket is\ncalculated. Then the `top_n` of those scores are averaged to result in\nthe `overall_score`. This means that you can fine-tune the\n`overall_score` so that it is more or less sensitive to the number of\njobs that detect an anomaly at the same time. For example, if you set\n`top_n` to `1`, the `overall_score` is the maximum bucket score in the\noverall bucket. Alternatively, if you set `top_n` to the number of jobs,\nthe `overall_score` is high only when all jobs detect anomalies in that\noverall bucket. If you set the `bucket_span` parameter (to a value\ngreater than its default), the `overall_score` is the maximum\n`overall_score` of the overall buckets that have a span equal to the\njobs' largest bucket span.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html"
         },
@@ -20722,7 +20723,7 @@
         "tags": [
           "ml.get_records"
         ],
-        "summary": "Retrieves anomaly records for an anomaly detection job",
+        "summary": "Get anomaly records for an anomaly detection job",
         "description": "Records contain the detailed analytical results. They describe the anomalous\nactivity that has been identified in the input data based on the detector\nconfiguration.\nThere can be many anomaly records depending on the characteristics and size\nof the input data. In practice, there are often too many to be able to\nmanually process them. The machine learning features therefore perform a\nsophisticated aggregation of the anomaly records into buckets.\nThe number of record results depends on the number of anomalies found in each\nbucket, which relates to the number of time series being modeled and the\nnumber of detectors.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html"
@@ -20771,7 +20772,7 @@
         "tags": [
           "ml.get_records"
         ],
-        "summary": "Retrieves anomaly records for an anomaly detection job",
+        "summary": "Get anomaly records for an anomaly detection job",
         "description": "Records contain the detailed analytical results. They describe the anomalous\nactivity that has been identified in the input data based on the detector\nconfiguration.\nThere can be many anomaly records depending on the characteristics and size\nof the input data. In practice, there are often too many to be able to\nmanually process them. The machine learning features therefore perform a\nsophisticated aggregation of the anomaly records into buckets.\nThe number of record results depends on the number of anomalies found in each\nbucket, which relates to the number of time series being modeled and the\nnumber of detectors.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-record.html"
@@ -20822,7 +20823,7 @@
         "tags": [
           "ml.get_trained_models"
         ],
-        "summary": "Retrieves configuration information for a trained model",
+        "summary": "Get trained model configuration info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models.html"
         },
@@ -20863,7 +20864,7 @@
         "tags": [
           "ml.get_trained_models_stats"
         ],
-        "summary": "Retrieves usage information for trained models",
+        "summary": "Get trained models usage info",
         "description": "You can get usage information for multiple trained\nmodels in a single API request by using a comma-separated list of model IDs or a wildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models-stats.html"
@@ -20896,7 +20897,7 @@
         "tags": [
           "ml.get_trained_models_stats"
         ],
-        "summary": "Retrieves usage information for trained models",
+        "summary": "Get trained models usage info",
         "description": "You can get usage information for multiple trained\nmodels in a single API request by using a comma-separated list of model IDs or a wildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models-stats.html"
@@ -20926,7 +20927,7 @@
         "tags": [
           "ml.infer_trained_model"
         ],
-        "summary": "Evaluates a trained model",
+        "summary": "Evaluate a trained model",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html"
         },
@@ -20955,7 +20956,7 @@
         "tags": [
           "ml.infer_trained_model"
         ],
-        "summary": "Evaluates a trained model",
+        "summary": "Evaluate a trained model",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html"
         },
@@ -20984,8 +20985,8 @@
         "tags": [
           "ml.info"
         ],
-        "summary": "Returns defaults and limits used by machine learning",
-        "description": "This endpoint is designed to be used by a user interface that needs to fully\nunderstand machine learning configurations where some options are not\nspecified, meaning that the defaults should be used. This endpoint may be\nused to find out what those defaults are. It also provides information about\nthe maximum size of machine learning jobs that could run in the current\ncluster configuration.",
+        "summary": "Return ML defaults and limits",
+        "description": "Returns defaults and limits used by machine learning.\nThis endpoint is designed to be used by a user interface that needs to fully\nunderstand machine learning configurations where some options are not\nspecified, meaning that the defaults should be used. This endpoint may be\nused to find out what those defaults are. It also provides information about\nthe maximum size of machine learning jobs that could run in the current\ncluster configuration.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-ml-info.html"
         },
@@ -21031,7 +21032,7 @@
           "ml.open_job"
         ],
         "summary": "Open anomaly detection jobs",
-        "description": "An anomaly detection job must be opened in order for it to be ready to\nreceive and analyze data. It can be opened and closed multiple times\nthroughout its lifecycle.\nWhen you open a new job, it starts with an empty model.\nWhen you open an existing job, the most recent model state is automatically\nloaded. The job is ready to resume its analysis from where it left off, once\nnew data is received.",
+        "description": "An anomaly detection job must be opened to be ready to receive and analyze\ndata. It can be opened and closed multiple times throughout its lifecycle.\nWhen you open a new job, it starts with an empty model.\nWhen you open an existing job, the most recent model state is automatically\nloaded. The job is ready to resume its analysis from where it left off, once\nnew data is received.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html"
         },
@@ -21105,7 +21106,7 @@
         "tags": [
           "ml.post_data"
         ],
-        "summary": "Sends data to an anomaly detection job for analysis",
+        "summary": "Send data to an anomaly detection job for analysis",
         "description": "IMPORTANT: For each job, data can be accepted from only a single connection at a time.\nIt is not currently possible to post data to multiple jobs using wildcards or a comma-separated list.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-data.html"
@@ -21242,7 +21243,8 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews the extracted features used by a data frame analytics config",
+        "summary": "Preview features used by data frame analytics",
+        "description": "Previews the extracted features used by a data frame analytics config.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -21261,7 +21263,8 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews the extracted features used by a data frame analytics config",
+        "summary": "Preview features used by data frame analytics",
+        "description": "Previews the extracted features used by a data frame analytics config.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -21282,7 +21285,8 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews the extracted features used by a data frame analytics config",
+        "summary": "Preview features used by data frame analytics",
+        "description": "Previews the extracted features used by a data frame analytics config.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -21306,7 +21310,8 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews the extracted features used by a data frame analytics config",
+        "summary": "Preview features used by data frame analytics",
+        "description": "Previews the extracted features used by a data frame analytics config.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -21332,7 +21337,7 @@
         "tags": [
           "ml.preview_datafeed"
         ],
-        "summary": "Previews a datafeed",
+        "summary": "Preview a datafeed",
         "description": "This API returns the first \"page\" of search results from a datafeed.\nYou can preview an existing datafeed or provide configuration details for a datafeed\nand anomaly detection job in the API. The preview shows the structure of the data\nthat will be passed to the anomaly detection engine.\nIMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that\ncalled the API. However, when the datafeed starts it uses the roles of the last user that created or updated the\ndatafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials.\nYou can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
@@ -21363,7 +21368,7 @@
         "tags": [
           "ml.preview_datafeed"
         ],
-        "summary": "Previews a datafeed",
+        "summary": "Preview a datafeed",
         "description": "This API returns the first \"page\" of search results from a datafeed.\nYou can preview an existing datafeed or provide configuration details for a datafeed\nand anomaly detection job in the API. The preview shows the structure of the data\nthat will be passed to the anomaly detection engine.\nIMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that\ncalled the API. However, when the datafeed starts it uses the roles of the last user that created or updated the\ndatafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials.\nYou can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
@@ -21396,7 +21401,7 @@
         "tags": [
           "ml.preview_datafeed"
         ],
-        "summary": "Previews a datafeed",
+        "summary": "Preview a datafeed",
         "description": "This API returns the first \"page\" of search results from a datafeed.\nYou can preview an existing datafeed or provide configuration details for a datafeed\nand anomaly detection job in the API. The preview shows the structure of the data\nthat will be passed to the anomaly detection engine.\nIMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that\ncalled the API. However, when the datafeed starts it uses the roles of the last user that created or updated the\ndatafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials.\nYou can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
@@ -21424,7 +21429,7 @@
         "tags": [
           "ml.preview_datafeed"
         ],
-        "summary": "Previews a datafeed",
+        "summary": "Preview a datafeed",
         "description": "This API returns the first \"page\" of search results from a datafeed.\nYou can preview an existing datafeed or provide configuration details for a datafeed\nand anomaly detection job in the API. The preview shows the structure of the data\nthat will be passed to the anomaly detection engine.\nIMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that\ncalled the API. However, when the datafeed starts it uses the roles of the last user that created or updated the\ndatafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials.\nYou can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
@@ -21454,7 +21459,7 @@
         "tags": [
           "ml.put_trained_model_definition_part"
         ],
-        "summary": "Creates part of a trained model definition",
+        "summary": "Create part of a trained model definition",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-model-definition-part.html"
         },
@@ -21532,7 +21537,7 @@
         "tags": [
           "ml.put_trained_model_vocabulary"
         ],
-        "summary": "Creates a trained model vocabulary",
+        "summary": "Create a trained model vocabulary",
         "description": "This API is supported only for natural language processing (NLP) models.\nThe vocabulary is stored in the index as described in `inference_config.*.vocabulary` of the trained model definition.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-model-vocabulary.html"
@@ -21609,7 +21614,7 @@
         "tags": [
           "ml.reset_job"
         ],
-        "summary": "Resets an anomaly detection job",
+        "summary": "Reset an anomaly detection job",
         "description": "All model state and results are deleted. The job is ready to start over as if\nit had just been created.\nIt is not currently possible to reset multiple jobs using wildcards or a\ncomma separated list.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-reset-job.html"
@@ -21668,7 +21673,7 @@
         "tags": [
           "ml.revert_model_snapshot"
         ],
-        "summary": "Reverts to a specific snapshot",
+        "summary": "Revert to a snapshot",
         "description": "The machine learning features react quickly to anomalous input, learning new\nbehaviors in data. Highly anomalous input increases the variance in the\nmodels whilst the system learns whether this is a new step-change in behavior\nor a one-off event. In the case where this anomalous input is known to be a\none-off, then it might be appropriate to reset the model state to a time\nbefore this event. For example, you might consider reverting to a saved\nsnapshot after Black Friday or a critical system failure.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-revert-snapshot.html"
@@ -21751,8 +21756,8 @@
         "tags": [
           "ml.set_upgrade_mode"
         ],
-        "summary": "Sets a cluster wide upgrade_mode setting that prepares machine learning\n",
-        "description": "indices for an upgrade.\nWhen upgrading your cluster, in some circumstances you must restart your\nnodes and reindex your machine learning indices. In those circumstances,\nthere must be no machine learning jobs running. You can close the machine\nlearning jobs, do the upgrade, then open all the jobs again. Alternatively,\nyou can use this API to temporarily halt tasks associated with the jobs and\ndatafeeds and prevent new jobs from opening. You can also use this API\nduring upgrades that do not require you to reindex your machine learning\nindices, though stopping jobs is not a requirement in that case.\nYou can see the current value for the upgrade_mode setting by using the get\nmachine learning info API.",
+        "summary": "Set upgrade_mode for ML indices",
+        "description": "Sets a cluster wide upgrade_mode setting that prepares machine learning\nindices for an upgrade.\nWhen upgrading your cluster, in some circumstances you must restart your\nnodes and reindex your machine learning indices. In those circumstances,\nthere must be no machine learning jobs running. You can close the machine\nlearning jobs, do the upgrade, then open all the jobs again. Alternatively,\nyou can use this API to temporarily halt tasks associated with the jobs and\ndatafeeds and prevent new jobs from opening. You can also use this API\nduring upgrades that do not require you to reindex your machine learning\nindices, though stopping jobs is not a requirement in that case.\nYou can see the current value for the upgrade_mode setting by using the get\nmachine learning info API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-set-upgrade-mode.html"
         },
@@ -21799,7 +21804,7 @@
         "tags": [
           "ml.start_data_frame_analytics"
         ],
-        "summary": "Starts a data frame analytics job",
+        "summary": "Start a data frame analytics job",
         "description": "A data frame analytics job can be started and stopped multiple times\nthroughout its lifecycle.\nIf the destination index does not exist, it is created automatically the\nfirst time you start the data frame analytics job. The\n`index.number_of_shards` and `index.number_of_replicas` settings for the\ndestination index are copied from the source index. If there are multiple\nsource indices, the destination index copies the highest setting values. The\nmappings for the destination index are also copied from the source indices.\nIf there are any mapping conflicts, the job fails to start.\nIf the destination index exists, it is used as is. You can therefore set up\nthe destination index in advance with custom settings and mappings.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/start-dfanalytics.html"
@@ -21860,7 +21865,7 @@
         "tags": [
           "ml.start_datafeed"
         ],
-        "summary": "Starts one or more datafeeds",
+        "summary": "Start one or more datafeeds",
         "description": "A datafeed must be started in order to retrieve data from Elasticsearch. A datafeed can be started and stopped\nmultiple times throughout its lifecycle.\n\nBefore you can start a datafeed, the anomaly detection job must be open. Otherwise, an error occurs.\n\nIf you restart a stopped datafeed, it continues processing input data from the next millisecond after it was stopped.\nIf new data was indexed for that exact millisecond between stopping and starting, it will be ignored.\n\nWhen Elasticsearch security features are enabled, your datafeed remembers which roles the last user to create or\nupdate it had at the time of creation or update and runs the query using those same roles. If you provided secondary\nauthorization headers when you created or updated the datafeed, those credentials are used instead.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html"
@@ -21962,7 +21967,8 @@
         "tags": [
           "ml.start_trained_model_deployment"
         ],
-        "summary": "Starts a trained model deployment, which allocates the model to every machine learning node",
+        "summary": "Start a trained model deployment",
+        "description": "It allocates the model to every machine learning node.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trained-model-deployment.html"
         },
@@ -22088,7 +22094,7 @@
         "tags": [
           "ml.stop_data_frame_analytics"
         ],
-        "summary": "Stops one or more data frame analytics jobs",
+        "summary": "Stop one or more data frame analytics jobs",
         "description": "A data frame analytics job can be started and stopped multiple times\nthroughout its lifecycle.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-dfanalytics.html"
@@ -22165,7 +22171,7 @@
         "tags": [
           "ml.stop_datafeed"
         ],
-        "summary": "Stops one or more datafeeds",
+        "summary": "Stop one or more datafeeds",
         "description": "A datafeed that is stopped ceases to retrieve data from Elasticsearch. A datafeed can be started and stopped\nmultiple times throughout its lifecycle.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html"
@@ -22264,7 +22270,7 @@
         "tags": [
           "ml.stop_trained_model_deployment"
         ],
-        "summary": "Stops a trained model deployment",
+        "summary": "Stop a trained model deployment",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-trained-model-deployment.html"
         },
@@ -22330,7 +22336,7 @@
         "tags": [
           "ml.update_data_frame_analytics"
         ],
-        "summary": "Updates an existing data frame analytics job",
+        "summary": "Update a data frame analytics job",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-dfanalytics.html"
         },
@@ -22451,7 +22457,7 @@
         "tags": [
           "ml.update_datafeed"
         ],
-        "summary": "Updates the properties of a datafeed",
+        "summary": "Update a datafeed",
         "description": "You must stop and start the datafeed for the changes to be applied.\nWhen Elasticsearch security features are enabled, your datafeed remembers which roles the user who updated it had at\nthe time of the update and runs the query using those same roles. If you provide secondary authorization headers,\nthose credentials are used instead.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html"
@@ -22660,7 +22666,8 @@
         "tags": [
           "ml.update_filter"
         ],
-        "summary": "Updates the description of a filter, adds items, or removes items from the list",
+        "summary": "Update a filter",
+        "description": "Updates the description of a filter, adds items, or removes items from the list.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-filter.html"
         },
@@ -22747,7 +22754,8 @@
         "tags": [
           "ml.update_job"
         ],
-        "summary": "Updates certain properties of an anomaly detection job",
+        "summary": "Update an anomaly detection job",
+        "description": "Updates certain properties of an anomaly detection job.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html"
         },
@@ -22956,7 +22964,8 @@
         "tags": [
           "ml.update_model_snapshot"
         ],
-        "summary": "Updates certain properties of a snapshot",
+        "summary": "Update a snapshot",
+        "description": "Updates certain properties of a snapshot.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-snapshot.html"
         },
@@ -23037,7 +23046,7 @@
         "tags": [
           "ml.update_trained_model_deployment"
         ],
-        "summary": "Starts a trained model deployment, which allocates the model to every machine learning node",
+        "summary": "Update a trained model deployment",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-trained-model-deployment.html"
         },
@@ -23109,8 +23118,8 @@
         "tags": [
           "ml.upgrade_job_snapshot"
         ],
-        "summary": "Upgrades an anomaly detection model snapshot to the latest major version",
-        "description": "Over time, older snapshot formats are deprecated and removed. Anomaly\ndetection jobs support only snapshots that are from the current or previous\nmajor version.\nThis API provides a means to upgrade a snapshot to the current major version.\nThis aids in preparing the cluster for an upgrade to the next major version.\nOnly one snapshot per anomaly detection job can be upgraded at a time and the\nupgraded snapshot cannot be the current snapshot of the anomaly detection\njob.",
+        "summary": "Upgrade a snapshot",
+        "description": "Upgrades an anomaly detection model snapshot to the latest major version.\nOver time, older snapshot formats are deprecated and removed. Anomaly\ndetection jobs support only snapshots that are from the current or previous\nmajor version.\nThis API provides a means to upgrade a snapshot to the current major version.\nThis aids in preparing the cluster for an upgrade to the next major version.\nOnly one snapshot per anomaly detection job can be upgraded at a time and the\nupgraded snapshot cannot be the current snapshot of the anomaly detection\njob.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-upgrade-job-model-snapshot.html"
         },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -689,7 +689,7 @@
           "cat.aliases"
         ],
         "summary": "Get aliases",
-        "description": "Retrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the /_alias endpoints.",
+        "description": "Retrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-alias.html"
         },
@@ -712,7 +712,7 @@
           "cat.aliases"
         ],
         "summary": "Get aliases",
-        "description": "Retrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the /_alias endpoints.",
+        "description": "Retrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-alias.html"
         },
@@ -738,7 +738,7 @@
           "cat.component_templates"
         ],
         "summary": "Get component templates",
-        "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the /_component_template endpoints.",
+        "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html"
         },
@@ -757,7 +757,7 @@
           "cat.component_templates"
         ],
         "summary": "Get component templates",
-        "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the /_component_template endpoints.",
+        "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html"
         },
@@ -781,7 +781,7 @@
           "cat.count"
         ],
         "summary": "Get a document count",
-        "description": "Provides quick access to a document count for a data stream, an index, or an entire cluster.n/\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use /_count endpoints.",
+        "description": "Provides quick access to a document count for a data stream, an index, or an entire cluster.n/\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-count.html"
         },
@@ -799,7 +799,7 @@
           "cat.count"
         ],
         "summary": "Get a document count",
-        "description": "Provides quick access to a document count for a data stream, an index, or an entire cluster.n/\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use /_count endpoints.",
+        "description": "Provides quick access to a document count for a data stream, an index, or an entire cluster.n/\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-count.html"
         },
@@ -850,7 +850,7 @@
           "cat.indices"
         ],
         "summary": "Get index information",
-        "description": "Returns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the /_cat/count or _count endpoints.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
+        "description": "Returns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html"
         },
@@ -888,7 +888,7 @@
           "cat.indices"
         ],
         "summary": "Get index information",
-        "description": "Returns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the /_cat/count or _count endpoints.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
+        "description": "Returns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html"
         },
@@ -929,7 +929,7 @@
           "cat.ml_data_frame_analytics"
         ],
         "summary": "Get data frame analytics jobs",
-        "description": "Returns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/data_frame/analytics endpoints.",
+        "description": "Returns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-dfanalytics.html"
         },
@@ -965,7 +965,7 @@
           "cat.ml_data_frame_analytics"
         ],
         "summary": "Get data frame analytics jobs",
-        "description": "Returns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/data_frame/analytics endpoints.",
+        "description": "Returns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-dfanalytics.html"
         },
@@ -1004,7 +1004,7 @@
           "cat.ml_datafeeds"
         ],
         "summary": "Get datafeeds",
-        "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/datafeeds endpoints.",
+        "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-datafeeds.html"
         },
@@ -1037,7 +1037,7 @@
           "cat.ml_datafeeds"
         ],
         "summary": "Get datafeeds",
-        "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/datafeeds endpoints.",
+        "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-datafeeds.html"
         },
@@ -1073,7 +1073,7 @@
           "cat.ml_jobs"
         ],
         "summary": "Get anomaly detection jobs",
-        "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/anomaly_detectors endpoints.",
+        "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-anomaly-detectors.html"
         },
@@ -1109,7 +1109,7 @@
           "cat.ml_jobs"
         ],
         "summary": "Get anomaly detection jobs",
-        "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/anomaly_detectors endpoints.",
+        "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-anomaly-detectors.html"
         },
@@ -1148,7 +1148,7 @@
           "cat.ml_trained_models"
         ],
         "summary": "Get trained models",
-        "description": "Returns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/trained_models endpoints.",
+        "description": "Returns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-trained-model.html"
         },
@@ -1187,7 +1187,7 @@
           "cat.ml_trained_models"
         ],
         "summary": "Get trained models",
-        "description": "Returns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/trained_models endpoints.",
+        "description": "Returns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-trained-model.html"
         },
@@ -1229,7 +1229,7 @@
           "cat.transforms"
         ],
         "summary": "Get transforms",
-        "description": "Returns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_transform endpoints.",
+        "description": "Returns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-transforms.html"
         },
@@ -1268,7 +1268,7 @@
           "cat.transforms"
         ],
         "summary": "Get transforms",
-        "description": "Returns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_transform endpoints.",
+        "description": "Returns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-transforms.html"
         },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -10289,7 +10289,7 @@
         "tags": [
           "ml.get_calendars"
         ],
-        "summary": "Retrieves configuration information for calendars",
+        "summary": "Get calendar configuration info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar.html"
         },
@@ -10319,7 +10319,7 @@
         "tags": [
           "ml.put_calendar"
         ],
-        "summary": "Creates a calendar",
+        "summary": "Create a calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-calendar.html"
         },
@@ -10393,7 +10393,7 @@
         "tags": [
           "ml.get_calendars"
         ],
-        "summary": "Retrieves configuration information for calendars",
+        "summary": "Get calendar configuration info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar.html"
         },
@@ -10511,7 +10511,7 @@
         "tags": [
           "ml.put_calendar_job"
         ],
-        "summary": "Adds an anomaly detection job to a calendar",
+        "summary": "Add anomaly detection job to calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-calendar-job.html"
         },
@@ -10639,7 +10639,7 @@
         "tags": [
           "ml.get_data_frame_analytics"
         ],
-        "summary": "Retrieves configuration information for data frame analytics jobs",
+        "summary": "Get data frame analytics job configuration info",
         "description": "You can get information for multiple data frame analytics jobs in a single\nAPI request by using a comma-separated list of data frame analytics jobs or a\nwildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html"
@@ -10673,7 +10673,7 @@
         "tags": [
           "ml.put_data_frame_analytics"
         ],
-        "summary": "Instantiates a data frame analytics job",
+        "summary": "Create a data frame analytics job",
         "description": "This API creates a data frame analytics job that performs an analysis on the\nsource indices and stores the outcome in a destination index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-dfanalytics.html"
@@ -10871,7 +10871,7 @@
         "tags": [
           "ml.get_datafeeds"
         ],
-        "summary": "Retrieves configuration information for datafeeds",
+        "summary": "Get datafeeds configuration info",
         "description": "You can get information for multiple datafeeds in a single API request by\nusing a comma-separated list of datafeeds or a wildcard expression. You can\nget information for all datafeeds by using `_all`, by specifying `*` as the\n`<feed_id>`, or by omitting the `<feed_id>`.\nThis API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html"
@@ -10899,7 +10899,7 @@
         "tags": [
           "ml.put_datafeed"
         ],
-        "summary": "Instantiates a datafeed",
+        "summary": "Create a datafeed",
         "description": "Datafeeds retrieve data from Elasticsearch for analysis by an anomaly detection job.\nYou can associate only one datafeed with each anomaly detection job.\nThe datafeed contains a query that runs at a defined interval (`frequency`).\nIf you are concerned about delayed data, you can add a delay (`query_delay') at each interval.\nWhen Elasticsearch security features are enabled, your datafeed remembers which roles the user who created it had\nat the time of creation and runs the query using those same roles. If you provide secondary authorization headers,\nthose credentials are used instead.\nYou must use Kibana, this API, or the create anomaly detection jobs API to create a datafeed. Do not add a datafeed\ndirectly to the `.ml-config` index. Do not give users `write` privileges on the `.ml-config` index.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-datafeed.html"
@@ -11153,7 +11153,7 @@
         "tags": [
           "ml.get_filters"
         ],
-        "summary": "Retrieves filters",
+        "summary": "Get filters",
         "description": "You can get a single filter or all filters.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-filter.html"
@@ -11181,7 +11181,7 @@
         "tags": [
           "ml.put_filter"
         ],
-        "summary": "Instantiates a filter",
+        "summary": "Create a filter",
         "description": "A filter contains a list of strings. It can be used by one or more anomaly detection jobs.\nSpecifically, filters are referenced in the `custom_rules` property of detector configuration objects.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-filter.html"
@@ -11299,7 +11299,7 @@
         "tags": [
           "ml.get_jobs"
         ],
-        "summary": "Retrieves configuration information for anomaly detection jobs",
+        "summary": "Get anomaly detection jobs configuration info",
         "description": "You can get information for multiple anomaly detection jobs in a single API\nrequest by using a group name, a comma-separated list of jobs, or a wildcard\nexpression. You can get information for all anomaly detection jobs by using\n`_all`, by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html"
@@ -11582,7 +11582,7 @@
         "tags": [
           "ml.get_trained_models"
         ],
-        "summary": "Retrieves configuration information for a trained model",
+        "summary": "Get trained model configuration info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models.html"
         },
@@ -11624,7 +11624,8 @@
         "tags": [
           "ml.put_trained_model"
         ],
-        "summary": "Enables you to supply a trained model that is not created by data frame analytics",
+        "summary": "Supply external trained model",
+        "description": "Enable you to supply a trained model that is not created by data frame analytics.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-models.html"
         },
@@ -11783,8 +11784,8 @@
         "tags": [
           "ml.put_trained_model_alias"
         ],
-        "summary": "Creates or updates a trained model alias",
-        "description": "A trained model alias is a logical\nname used to reference a single trained model.\nYou can use aliases instead of trained model identifiers to make it easier to\nreference your models. For example, you can use aliases in inference\naggregations and processors.\nAn alias must be unique and refer to only a single trained model. However,\nyou can have multiple aliases for each trained model.\nIf you use this API to update an alias such that it references a different\ntrained model ID and the model uses a different type of data frame analytics,\nan error occurs. For example, this situation occurs if you have a trained\nmodel for regression analysis and a trained model for classification\nanalysis; you cannot reassign an alias from one type of trained model to\nanother.\nIf you use this API to update an alias and there are very few input fields in\ncommon between the old and new trained models for the model alias, the API\nreturns a warning.",
+        "summary": "Create or update a trained model alias",
+        "description": "A trained model alias is a logical name used to reference a single trained\nmodel.\nYou can use aliases instead of trained model identifiers to make it easier to\nreference your models. For example, you can use aliases in inference\naggregations and processors.\nAn alias must be unique and refer to only a single trained model. However,\nyou can have multiple aliases for each trained model.\nIf you use this API to update an alias such that it references a different\ntrained model ID and the model uses a different type of data frame analytics,\nan error occurs. For example, this situation occurs if you have a trained\nmodel for regression analysis and a trained model for classification\nanalysis; you cannot reassign an alias from one type of trained model to\nanother.\nIf you use this API to update an alias and there are very few input fields in\ncommon between the old and new trained models for the model alias, the API\nreturns a warning.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-models-aliases.html"
         },
@@ -12016,7 +12017,7 @@
         "tags": [
           "ml.flush_job"
         ],
-        "summary": "Forces any buffered data to be processed by the job",
+        "summary": "Force buffered data to be processed",
         "description": "The flush jobs API is only applicable when sending data for analysis using\nthe post data API. Depending on the content of the buffer, then it might\nadditionally calculate new results. Both flush and close operations are\nsimilar, however the flush is more efficient if you are expecting to send\nmore data for analysis. When flushing, the job remains open and is available\nto continue analyzing data. A close operation additionally prunes and\npersists the model state to disk and the job must be opened again before\nanalyzing further data.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-flush-job.html"
@@ -12144,7 +12145,7 @@
         "tags": [
           "ml.get_calendar_events"
         ],
-        "summary": "Retrieves information about the scheduled events in calendars",
+        "summary": "Get info about events in calendars",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar-event.html"
         },
@@ -12245,7 +12246,7 @@
         "tags": [
           "ml.post_calendar_events"
         ],
-        "summary": "Adds scheduled events to a calendar",
+        "summary": "Add scheduled events to calendar",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-post-calendar-event.html"
         },
@@ -12316,7 +12317,7 @@
         "tags": [
           "ml.get_calendars"
         ],
-        "summary": "Retrieves configuration information for calendars",
+        "summary": "Get calendar configuration info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar.html"
         },
@@ -12343,7 +12344,7 @@
         "tags": [
           "ml.get_calendars"
         ],
-        "summary": "Retrieves configuration information for calendars",
+        "summary": "Get calendar configuration info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-calendar.html"
         },
@@ -12372,7 +12373,7 @@
         "tags": [
           "ml.get_data_frame_analytics"
         ],
-        "summary": "Retrieves configuration information for data frame analytics jobs",
+        "summary": "Get data frame analytics job configuration info",
         "description": "You can get information for multiple data frame analytics jobs in a single\nAPI request by using a comma-separated list of data frame analytics jobs or a\nwildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics.html"
@@ -12405,7 +12406,7 @@
         "tags": [
           "ml.get_data_frame_analytics_stats"
         ],
-        "summary": "Retrieves usage information for data frame analytics jobs",
+        "summary": "Get data frame analytics jobs usage info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics-stats.html"
         },
@@ -12437,7 +12438,7 @@
         "tags": [
           "ml.get_data_frame_analytics_stats"
         ],
-        "summary": "Retrieves usage information for data frame analytics jobs",
+        "summary": "Get data frame analytics jobs usage info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-dfanalytics-stats.html"
         },
@@ -12472,7 +12473,7 @@
         "tags": [
           "ml.get_datafeed_stats"
         ],
-        "summary": "Retrieves usage information for datafeeds",
+        "summary": "Get datafeeds usage info",
         "description": "You can get statistics for multiple datafeeds in a single API request by\nusing a comma-separated list of datafeeds or a wildcard expression. You can\nget statistics for all datafeeds by using `_all`, by specifying `*` as the\n`<feed_id>`, or by omitting the `<feed_id>`. If the datafeed is stopped, the\nonly information you receive is the `datafeed_id` and the `state`.\nThis API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html"
@@ -12499,7 +12500,7 @@
         "tags": [
           "ml.get_datafeed_stats"
         ],
-        "summary": "Retrieves usage information for datafeeds",
+        "summary": "Get datafeeds usage info",
         "description": "You can get statistics for multiple datafeeds in a single API request by\nusing a comma-separated list of datafeeds or a wildcard expression. You can\nget statistics for all datafeeds by using `_all`, by specifying `*` as the\n`<feed_id>`, or by omitting the `<feed_id>`. If the datafeed is stopped, the\nonly information you receive is the `datafeed_id` and the `state`.\nThis API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed-stats.html"
@@ -12523,7 +12524,7 @@
         "tags": [
           "ml.get_datafeeds"
         ],
-        "summary": "Retrieves configuration information for datafeeds",
+        "summary": "Get datafeeds configuration info",
         "description": "You can get information for multiple datafeeds in a single API request by\nusing a comma-separated list of datafeeds or a wildcard expression. You can\nget information for all datafeeds by using `_all`, by specifying `*` as the\n`<feed_id>`, or by omitting the `<feed_id>`.\nThis API returns a maximum of 10,000 datafeeds.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-datafeed.html"
@@ -12550,7 +12551,7 @@
         "tags": [
           "ml.get_filters"
         ],
-        "summary": "Retrieves filters",
+        "summary": "Get filters",
         "description": "You can get a single filter or all filters.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-filter.html"
@@ -12577,7 +12578,7 @@
         "tags": [
           "ml.get_job_stats"
         ],
-        "summary": "Retrieves usage information for anomaly detection jobs",
+        "summary": "Get anomaly detection jobs usage info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html"
         },
@@ -12600,7 +12601,7 @@
         "tags": [
           "ml.get_job_stats"
         ],
-        "summary": "Retrieves usage information for anomaly detection jobs",
+        "summary": "Get anomaly detection jobs usage info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job-stats.html"
         },
@@ -12626,7 +12627,7 @@
         "tags": [
           "ml.get_jobs"
         ],
-        "summary": "Retrieves configuration information for anomaly detection jobs",
+        "summary": "Get anomaly detection jobs configuration info",
         "description": "You can get information for multiple anomaly detection jobs in a single API\nrequest by using a group name, a comma-separated list of jobs, or a wildcard\nexpression. You can get information for all anomaly detection jobs by using\n`_all`, by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-job.html"
@@ -12653,8 +12654,8 @@
         "tags": [
           "ml.get_overall_buckets"
         ],
-        "summary": "Retrieves overall bucket results that summarize the bucket results of\n",
-        "description": "multiple anomaly detection jobs.\n\nThe `overall_score` is calculated by combining the scores of all the\nbuckets within the overall bucket span. First, the maximum\n`anomaly_score` per anomaly detection job in the overall bucket is\ncalculated. Then the `top_n` of those scores are averaged to result in\nthe `overall_score`. This means that you can fine-tune the\n`overall_score` so that it is more or less sensitive to the number of\njobs that detect an anomaly at the same time. For example, if you set\n`top_n` to `1`, the `overall_score` is the maximum bucket score in the\noverall bucket. Alternatively, if you set `top_n` to the number of jobs,\nthe `overall_score` is high only when all jobs detect anomalies in that\noverall bucket. If you set the `bucket_span` parameter (to a value\ngreater than its default), the `overall_score` is the maximum\n`overall_score` of the overall buckets that have a span equal to the\njobs' largest bucket span.",
+        "summary": "Get overall bucket results",
+        "description": "Retrievs overall bucket results that summarize the bucket results of\nmultiple anomaly detection jobs.\n\nThe `overall_score` is calculated by combining the scores of all the\nbuckets within the overall bucket span. First, the maximum\n`anomaly_score` per anomaly detection job in the overall bucket is\ncalculated. Then the `top_n` of those scores are averaged to result in\nthe `overall_score`. This means that you can fine-tune the\n`overall_score` so that it is more or less sensitive to the number of\njobs that detect an anomaly at the same time. For example, if you set\n`top_n` to `1`, the `overall_score` is the maximum bucket score in the\noverall bucket. Alternatively, if you set `top_n` to the number of jobs,\nthe `overall_score` is high only when all jobs detect anomalies in that\noverall bucket. If you set the `bucket_span` parameter (to a value\ngreater than its default), the `overall_score` is the maximum\n`overall_score` of the overall buckets that have a span equal to the\njobs' largest bucket span.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html"
         },
@@ -12699,8 +12700,8 @@
         "tags": [
           "ml.get_overall_buckets"
         ],
-        "summary": "Retrieves overall bucket results that summarize the bucket results of\n",
-        "description": "multiple anomaly detection jobs.\n\nThe `overall_score` is calculated by combining the scores of all the\nbuckets within the overall bucket span. First, the maximum\n`anomaly_score` per anomaly detection job in the overall bucket is\ncalculated. Then the `top_n` of those scores are averaged to result in\nthe `overall_score`. This means that you can fine-tune the\n`overall_score` so that it is more or less sensitive to the number of\njobs that detect an anomaly at the same time. For example, if you set\n`top_n` to `1`, the `overall_score` is the maximum bucket score in the\noverall bucket. Alternatively, if you set `top_n` to the number of jobs,\nthe `overall_score` is high only when all jobs detect anomalies in that\noverall bucket. If you set the `bucket_span` parameter (to a value\ngreater than its default), the `overall_score` is the maximum\n`overall_score` of the overall buckets that have a span equal to the\njobs' largest bucket span.",
+        "summary": "Get overall bucket results",
+        "description": "Retrievs overall bucket results that summarize the bucket results of\nmultiple anomaly detection jobs.\n\nThe `overall_score` is calculated by combining the scores of all the\nbuckets within the overall bucket span. First, the maximum\n`anomaly_score` per anomaly detection job in the overall bucket is\ncalculated. Then the `top_n` of those scores are averaged to result in\nthe `overall_score`. This means that you can fine-tune the\n`overall_score` so that it is more or less sensitive to the number of\njobs that detect an anomaly at the same time. For example, if you set\n`top_n` to `1`, the `overall_score` is the maximum bucket score in the\noverall bucket. Alternatively, if you set `top_n` to the number of jobs,\nthe `overall_score` is high only when all jobs detect anomalies in that\noverall bucket. If you set the `bucket_span` parameter (to a value\ngreater than its default), the `overall_score` is the maximum\n`overall_score` of the overall buckets that have a span equal to the\njobs' largest bucket span.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-overall-buckets.html"
         },
@@ -12747,7 +12748,7 @@
         "tags": [
           "ml.get_trained_models"
         ],
-        "summary": "Retrieves configuration information for a trained model",
+        "summary": "Get trained model configuration info",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models.html"
         },
@@ -12788,7 +12789,7 @@
         "tags": [
           "ml.get_trained_models_stats"
         ],
-        "summary": "Retrieves usage information for trained models",
+        "summary": "Get trained models usage info",
         "description": "You can get usage information for multiple trained\nmodels in a single API request by using a comma-separated list of model IDs or a wildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models-stats.html"
@@ -12821,7 +12822,7 @@
         "tags": [
           "ml.get_trained_models_stats"
         ],
-        "summary": "Retrieves usage information for trained models",
+        "summary": "Get trained models usage info",
         "description": "You can get usage information for multiple trained\nmodels in a single API request by using a comma-separated list of model IDs or a wildcard expression.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models-stats.html"
@@ -12851,7 +12852,7 @@
         "tags": [
           "ml.infer_trained_model"
         ],
-        "summary": "Evaluates a trained model",
+        "summary": "Evaluate a trained model",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html"
         },
@@ -12880,7 +12881,7 @@
         "tags": [
           "ml.infer_trained_model"
         ],
-        "summary": "Evaluates a trained model",
+        "summary": "Evaluate a trained model",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/infer-trained-model.html"
         },
@@ -12910,7 +12911,7 @@
           "ml.open_job"
         ],
         "summary": "Open anomaly detection jobs",
-        "description": "An anomaly detection job must be opened in order for it to be ready to\nreceive and analyze data. It can be opened and closed multiple times\nthroughout its lifecycle.\nWhen you open a new job, it starts with an empty model.\nWhen you open an existing job, the most recent model state is automatically\nloaded. The job is ready to resume its analysis from where it left off, once\nnew data is received.",
+        "description": "An anomaly detection job must be opened to be ready to receive and analyze\ndata. It can be opened and closed multiple times throughout its lifecycle.\nWhen you open a new job, it starts with an empty model.\nWhen you open an existing job, the most recent model state is automatically\nloaded. The job is ready to resume its analysis from where it left off, once\nnew data is received.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-open-job.html"
         },
@@ -12984,7 +12985,8 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews the extracted features used by a data frame analytics config",
+        "summary": "Preview features used by data frame analytics",
+        "description": "Previews the extracted features used by a data frame analytics config.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -13003,7 +13005,8 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews the extracted features used by a data frame analytics config",
+        "summary": "Preview features used by data frame analytics",
+        "description": "Previews the extracted features used by a data frame analytics config.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -13024,7 +13027,8 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews the extracted features used by a data frame analytics config",
+        "summary": "Preview features used by data frame analytics",
+        "description": "Previews the extracted features used by a data frame analytics config.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -13048,7 +13052,8 @@
         "tags": [
           "ml.preview_data_frame_analytics"
         ],
-        "summary": "Previews the extracted features used by a data frame analytics config",
+        "summary": "Preview features used by data frame analytics",
+        "description": "Previews the extracted features used by a data frame analytics config.",
         "externalDocs": {
           "url": "http://www.elastic.co/guide/en/elasticsearch/reference/current/preview-dfanalytics.html"
         },
@@ -13074,7 +13079,7 @@
         "tags": [
           "ml.preview_datafeed"
         ],
-        "summary": "Previews a datafeed",
+        "summary": "Preview a datafeed",
         "description": "This API returns the first \"page\" of search results from a datafeed.\nYou can preview an existing datafeed or provide configuration details for a datafeed\nand anomaly detection job in the API. The preview shows the structure of the data\nthat will be passed to the anomaly detection engine.\nIMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that\ncalled the API. However, when the datafeed starts it uses the roles of the last user that created or updated the\ndatafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials.\nYou can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
@@ -13105,7 +13110,7 @@
         "tags": [
           "ml.preview_datafeed"
         ],
-        "summary": "Previews a datafeed",
+        "summary": "Preview a datafeed",
         "description": "This API returns the first \"page\" of search results from a datafeed.\nYou can preview an existing datafeed or provide configuration details for a datafeed\nand anomaly detection job in the API. The preview shows the structure of the data\nthat will be passed to the anomaly detection engine.\nIMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that\ncalled the API. However, when the datafeed starts it uses the roles of the last user that created or updated the\ndatafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials.\nYou can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
@@ -13138,7 +13143,7 @@
         "tags": [
           "ml.preview_datafeed"
         ],
-        "summary": "Previews a datafeed",
+        "summary": "Preview a datafeed",
         "description": "This API returns the first \"page\" of search results from a datafeed.\nYou can preview an existing datafeed or provide configuration details for a datafeed\nand anomaly detection job in the API. The preview shows the structure of the data\nthat will be passed to the anomaly detection engine.\nIMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that\ncalled the API. However, when the datafeed starts it uses the roles of the last user that created or updated the\ndatafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials.\nYou can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
@@ -13166,7 +13171,7 @@
         "tags": [
           "ml.preview_datafeed"
         ],
-        "summary": "Previews a datafeed",
+        "summary": "Preview a datafeed",
         "description": "This API returns the first \"page\" of search results from a datafeed.\nYou can preview an existing datafeed or provide configuration details for a datafeed\nand anomaly detection job in the API. The preview shows the structure of the data\nthat will be passed to the anomaly detection engine.\nIMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that\ncalled the API. However, when the datafeed starts it uses the roles of the last user that created or updated the\ndatafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials.\nYou can also use secondary authorization headers to supply the credentials.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html"
@@ -13196,7 +13201,7 @@
         "tags": [
           "ml.put_trained_model_definition_part"
         ],
-        "summary": "Creates part of a trained model definition",
+        "summary": "Create part of a trained model definition",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-model-definition-part.html"
         },
@@ -13274,7 +13279,7 @@
         "tags": [
           "ml.put_trained_model_vocabulary"
         ],
-        "summary": "Creates a trained model vocabulary",
+        "summary": "Create a trained model vocabulary",
         "description": "This API is supported only for natural language processing (NLP) models.\nThe vocabulary is stored in the index as described in `inference_config.*.vocabulary` of the trained model definition.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/put-trained-model-vocabulary.html"
@@ -13351,7 +13356,7 @@
         "tags": [
           "ml.reset_job"
         ],
-        "summary": "Resets an anomaly detection job",
+        "summary": "Reset an anomaly detection job",
         "description": "All model state and results are deleted. The job is ready to start over as if\nit had just been created.\nIt is not currently possible to reset multiple jobs using wildcards or a\ncomma separated list.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-reset-job.html"
@@ -13410,7 +13415,7 @@
         "tags": [
           "ml.start_data_frame_analytics"
         ],
-        "summary": "Starts a data frame analytics job",
+        "summary": "Start a data frame analytics job",
         "description": "A data frame analytics job can be started and stopped multiple times\nthroughout its lifecycle.\nIf the destination index does not exist, it is created automatically the\nfirst time you start the data frame analytics job. The\n`index.number_of_shards` and `index.number_of_replicas` settings for the\ndestination index are copied from the source index. If there are multiple\nsource indices, the destination index copies the highest setting values. The\nmappings for the destination index are also copied from the source indices.\nIf there are any mapping conflicts, the job fails to start.\nIf the destination index exists, it is used as is. You can therefore set up\nthe destination index in advance with custom settings and mappings.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/start-dfanalytics.html"
@@ -13471,7 +13476,7 @@
         "tags": [
           "ml.start_datafeed"
         ],
-        "summary": "Starts one or more datafeeds",
+        "summary": "Start one or more datafeeds",
         "description": "A datafeed must be started in order to retrieve data from Elasticsearch. A datafeed can be started and stopped\nmultiple times throughout its lifecycle.\n\nBefore you can start a datafeed, the anomaly detection job must be open. Otherwise, an error occurs.\n\nIf you restart a stopped datafeed, it continues processing input data from the next millisecond after it was stopped.\nIf new data was indexed for that exact millisecond between stopping and starting, it will be ignored.\n\nWhen Elasticsearch security features are enabled, your datafeed remembers which roles the last user to create or\nupdate it had at the time of creation or update and runs the query using those same roles. If you provided secondary\nauthorization headers when you created or updated the datafeed, those credentials are used instead.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-start-datafeed.html"
@@ -13573,7 +13578,8 @@
         "tags": [
           "ml.start_trained_model_deployment"
         ],
-        "summary": "Starts a trained model deployment, which allocates the model to every machine learning node",
+        "summary": "Start a trained model deployment",
+        "description": "It allocates the model to every machine learning node.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/start-trained-model-deployment.html"
         },
@@ -13689,7 +13695,7 @@
         "tags": [
           "ml.stop_data_frame_analytics"
         ],
-        "summary": "Stops one or more data frame analytics jobs",
+        "summary": "Stop one or more data frame analytics jobs",
         "description": "A data frame analytics job can be started and stopped multiple times\nthroughout its lifecycle.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/stop-dfanalytics.html"
@@ -13766,7 +13772,7 @@
         "tags": [
           "ml.stop_datafeed"
         ],
-        "summary": "Stops one or more datafeeds",
+        "summary": "Stop one or more datafeeds",
         "description": "A datafeed that is stopped ceases to retrieve data from Elasticsearch. A datafeed can be started and stopped\nmultiple times throughout its lifecycle.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-stop-datafeed.html"
@@ -13865,7 +13871,7 @@
         "tags": [
           "ml.stop_trained_model_deployment"
         ],
-        "summary": "Stops a trained model deployment",
+        "summary": "Stop a trained model deployment",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-trained-model-deployment.html"
         },
@@ -13931,7 +13937,7 @@
         "tags": [
           "ml.update_data_frame_analytics"
         ],
-        "summary": "Updates an existing data frame analytics job",
+        "summary": "Update a data frame analytics job",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-dfanalytics.html"
         },
@@ -14052,7 +14058,7 @@
         "tags": [
           "ml.update_datafeed"
         ],
-        "summary": "Updates the properties of a datafeed",
+        "summary": "Update a datafeed",
         "description": "You must stop and start the datafeed for the changes to be applied.\nWhen Elasticsearch security features are enabled, your datafeed remembers which roles the user who updated it had at\nthe time of the update and runs the query using those same roles. If you provide secondary authorization headers,\nthose credentials are used instead.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-datafeed.html"
@@ -14261,7 +14267,8 @@
         "tags": [
           "ml.update_filter"
         ],
-        "summary": "Updates the description of a filter, adds items, or removes items from the list",
+        "summary": "Update a filter",
+        "description": "Updates the description of a filter, adds items, or removes items from the list.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-filter.html"
         },
@@ -14348,7 +14355,8 @@
         "tags": [
           "ml.update_job"
         ],
-        "summary": "Updates certain properties of an anomaly detection job",
+        "summary": "Update an anomaly detection job",
+        "description": "Updates certain properties of an anomaly detection job.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-job.html"
         },
@@ -14557,7 +14565,7 @@
         "tags": [
           "ml.update_trained_model_deployment"
         ],
-        "summary": "Starts a trained model deployment, which allocates the model to every machine learning node",
+        "summary": "Update a trained model deployment",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/update-trained-model-deployment.html"
         },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -216,7 +216,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get aliases.\nRetrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the /_alias endpoints.",
+      "description": "Get aliases.\nRetrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
       "docId": "cat-alias",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-alias.html",
       "name": "cat.aliases",
@@ -264,7 +264,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get component templates.\nReturns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the /_component_template endpoints.",
+      "description": "Get component templates.\nReturns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html",
       "name": "cat.component_templates",
       "privileges": {
@@ -310,7 +310,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get a document count.\nProvides quick access to a document count for a data stream, an index, or an entire cluster.n/\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use /_count endpoints.",
+      "description": "Get a document count.\nProvides quick access to a document count for a data stream, an index, or an entire cluster.n/\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
       "docId": "cat-count",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-count.html",
       "name": "cat.count",
@@ -392,7 +392,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get index information.\nReturns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the /_cat/count or _count endpoints.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
+      "description": "Get index information.\nReturns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
       "docId": "cat-indices",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-indices.html",
       "name": "cat.indices",
@@ -443,7 +443,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get data frame analytics jobs.\nReturns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/data_frame/analytics endpoints.",
+      "description": "Get data frame analytics jobs.\nReturns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
       "docId": "cat-dfanalytics",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-dfanalytics.html",
       "name": "cat.ml_data_frame_analytics",
@@ -491,7 +491,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get datafeeds.\nReturns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/datafeeds endpoints.",
+      "description": "Get datafeeds.\nReturns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
       "docId": "cat-datafeeds",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-datafeeds.html",
       "name": "cat.ml_datafeeds",
@@ -539,7 +539,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get anomaly detection jobs.\nReturns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/anomaly_detectors endpoints.",
+      "description": "Get anomaly detection jobs.\nReturns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
       "docId": "cat-anomaly-detectors",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-anomaly-detectors.html",
       "name": "cat.ml_jobs",
@@ -587,7 +587,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get trained models.\nReturns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/trained_models endpoints.",
+      "description": "Get trained models.\nReturns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
       "docId": "cat-trained-model",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-trained-model.html",
       "name": "cat.ml_trained_models",
@@ -635,7 +635,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get transforms.\nReturns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_transform endpoints.",
+      "description": "Get transforms.\nReturns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
       "docId": "cat-transforms",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-transforms.html",
       "name": "cat.transforms",
@@ -11389,7 +11389,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get aliases.\nRetrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the /_alias endpoints.",
+      "description": "Get aliases.\nRetrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -11460,7 +11460,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get component templates.\nReturns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the /_component_template endpoints.",
+      "description": "Get component templates.\nReturns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -11518,7 +11518,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get a document count.\nProvides quick access to a document count for a data stream, an index, or an entire cluster.n/\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use /_count endpoints.",
+      "description": "Get a document count.\nProvides quick access to a document count for a data stream, an index, or an entire cluster.n/\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -11621,7 +11621,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get index information.\nReturns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the /_cat/count or _count endpoints.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
+      "description": "Get index information.\nReturns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -11754,7 +11754,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get data frame analytics jobs.\nReturns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/data_frame/analytics endpoints.",
+      "description": "Get data frame analytics jobs.\nReturns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -11874,7 +11874,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get datafeeds.\nReturns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/datafeeds endpoints.",
+      "description": "Get datafeeds.\nReturns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -11983,7 +11983,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get anomaly detection jobs.\nReturns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/anomaly_detectors endpoints.",
+      "description": "Get anomaly detection jobs.\nReturns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -12104,7 +12104,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get trained models.\nReturns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_ml/trained_models endpoints.",
+      "description": "Get trained models.\nReturns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",
@@ -12236,7 +12236,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get transforms.\nReturns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the /_transform endpoints.",
+      "description": "Get transforms.\nReturns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
       "inherits": {
         "type": {
           "name": "CatRequestBase",

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,6 +199,7 @@
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.11.1.tgz",
       "integrity": "sha512-1zqsQ0TOuVSnxxZ9mHBfC0IygV6ex7nAY6Mp59mLmw5fW103U9yPVK5ZcX9ZngCmr3PdteAnMDUIIaoDGso6nA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/json": "~3.21.0",
         "@stoplight/path": "1.3.2",

--- a/specification/ml/flush_job/MlFlushJobRequest.ts
+++ b/specification/ml/flush_job/MlFlushJobRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { DateTime } from '@_types/Time'
 
 /**
- * Forces any buffered data to be processed by the job.
+ * Force buffered data to be processed.
  * The flush jobs API is only applicable when sending data for analysis using
  * the post data API. Depending on the content of the buffer, then it might
  * additionally calculate new results. Both flush and close operations are

--- a/specification/ml/forecast/MlForecastJobRequest.ts
+++ b/specification/ml/forecast/MlForecastJobRequest.ts
@@ -22,12 +22,12 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Predicts the future behavior of a time series by using its historical
- * behavior.
+ * Predict future behavior of a time series.
  *
  * Forecasts are not supported for jobs that perform population analysis; an
  * error occurs if you try to create a forecast for a job that has an
- * `over_field_name` in its configuration.
+ * `over_field_name` in its configuration. Forcasts predict future behavior
+ * based on historical data.
  *
  * @rest_spec_name ml.forecast
  * @availability stack since=6.1.0 stability=stable

--- a/specification/ml/get_buckets/MlGetBucketsRequest.ts
+++ b/specification/ml/get_buckets/MlGetBucketsRequest.ts
@@ -24,7 +24,7 @@ import { double, integer } from '@_types/Numeric'
 import { DateTime } from '@_types/Time'
 
 /**
- * Retrieves anomaly detection job results for one or more buckets.
+ * Get anomaly detection job results.
  * The API presents a chronological view of the records, grouped by bucket.
  * @rest_spec_name ml.get_buckets
  * @availability stack since=5.4.0 stability=stable

--- a/specification/ml/get_buckets/MlGetBucketsRequest.ts
+++ b/specification/ml/get_buckets/MlGetBucketsRequest.ts
@@ -24,7 +24,7 @@ import { double, integer } from '@_types/Numeric'
 import { DateTime } from '@_types/Time'
 
 /**
- * Get anomaly detection job results.
+ * Get anomaly detection job results for buckets.
  * The API presents a chronological view of the records, grouped by bucket.
  * @rest_spec_name ml.get_buckets
  * @availability stack since=5.4.0 stability=stable

--- a/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
+++ b/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
@@ -23,7 +23,7 @@ import { integer } from '@_types/Numeric'
 import { DateTime } from '@_types/Time'
 
 /**
- * Retrieves information about the scheduled events in calendars.
+ * Get info about events in calendars.
  * @rest_spec_name ml.get_calendar_events
  * @availability stack since=6.2.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/get_calendars/MlGetCalendarsRequest.ts
+++ b/specification/ml/get_calendars/MlGetCalendarsRequest.ts
@@ -23,7 +23,7 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Get config info for calendars.
+ * Get calendar configuration info.
  * @rest_spec_name ml.get_calendars
  * @availability stack since=6.2.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/get_calendars/MlGetCalendarsRequest.ts
+++ b/specification/ml/get_calendars/MlGetCalendarsRequest.ts
@@ -23,7 +23,7 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Retrieves configuration information for calendars.
+ * Get config info for calendars.
  * @rest_spec_name ml.get_calendars
  * @availability stack since=6.2.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/get_categories/MlGetCategoriesRequest.ts
+++ b/specification/ml/get_categories/MlGetCategoriesRequest.ts
@@ -23,7 +23,7 @@ import { CategoryId, Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Retrieves anomaly detection job results for one or more categories.
+ * Get anomaly detection job results for categories.
  * @rest_spec_name ml.get_categories
  * @availability stack since=5.4.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/ml/get_data_frame_analytics/MlGetDataFrameAnalyticsRequest.ts
+++ b/specification/ml/get_data_frame_analytics/MlGetDataFrameAnalyticsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Retrieves configuration information for data frame analytics jobs.
+ * Get config info for data frame analytics jobs.
  * You can get information for multiple data frame analytics jobs in a single
  * API request by using a comma-separated list of data frame analytics jobs or a
  * wildcard expression.

--- a/specification/ml/get_data_frame_analytics/MlGetDataFrameAnalyticsRequest.ts
+++ b/specification/ml/get_data_frame_analytics/MlGetDataFrameAnalyticsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Get config info for data frame analytics jobs.
+ * Get data frame analytics job configuration info.
  * You can get information for multiple data frame analytics jobs in a single
  * API request by using a comma-separated list of data frame analytics jobs or a
  * wildcard expression.

--- a/specification/ml/get_data_frame_analytics_stats/MlGetDataFrameAnalyticsStatsRequest.ts
+++ b/specification/ml/get_data_frame_analytics_stats/MlGetDataFrameAnalyticsStatsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Get usage info for data frame analytics jobs.
+ * Get data frame analytics jobs usage info.
  * @rest_spec_name ml.get_data_frame_analytics_stats
  * @availability stack since=7.3.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/get_data_frame_analytics_stats/MlGetDataFrameAnalyticsStatsRequest.ts
+++ b/specification/ml/get_data_frame_analytics_stats/MlGetDataFrameAnalyticsStatsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Retrieves usage information for data frame analytics jobs.
+ * Get usage info for data frame analytics jobs.
  * @rest_spec_name ml.get_data_frame_analytics_stats
  * @availability stack since=7.3.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/get_datafeed_stats/MlGetDatafeedStatsRequest.ts
+++ b/specification/ml/get_datafeed_stats/MlGetDatafeedStatsRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Ids } from '@_types/common'
 
 /**
- * Get usage info for datafeeds.
+ * Get datafeeds usage info.
  * You can get statistics for multiple datafeeds in a single API request by
  * using a comma-separated list of datafeeds or a wildcard expression. You can
  * get statistics for all datafeeds by using `_all`, by specifying `*` as the

--- a/specification/ml/get_datafeed_stats/MlGetDatafeedStatsRequest.ts
+++ b/specification/ml/get_datafeed_stats/MlGetDatafeedStatsRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Ids } from '@_types/common'
 
 /**
- * Retrieves usage information for datafeeds.
+ * Get usage info for datafeeds.
  * You can get statistics for multiple datafeeds in a single API request by
  * using a comma-separated list of datafeeds or a wildcard expression. You can
  * get statistics for all datafeeds by using `_all`, by specifying `*` as the

--- a/specification/ml/get_datafeeds/MlGetDatafeedsRequest.ts
+++ b/specification/ml/get_datafeeds/MlGetDatafeedsRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Ids } from '@_types/common'
 
 /**
- * Get config info for datafeeds.
+ * Get datafeeds configuration info.
  * You can get information for multiple datafeeds in a single API request by
  * using a comma-separated list of datafeeds or a wildcard expression. You can
  * get information for all datafeeds by using `_all`, by specifying `*` as the

--- a/specification/ml/get_datafeeds/MlGetDatafeedsRequest.ts
+++ b/specification/ml/get_datafeeds/MlGetDatafeedsRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Ids } from '@_types/common'
 
 /**
- * Retrieves configuration information for datafeeds.
+ * Get config info for datafeeds.
  * You can get information for multiple datafeeds in a single API request by
  * using a comma-separated list of datafeeds or a wildcard expression. You can
  * get information for all datafeeds by using `_all`, by specifying `*` as the

--- a/specification/ml/get_filters/MlGetFiltersRequest.ts
+++ b/specification/ml/get_filters/MlGetFiltersRequest.ts
@@ -22,7 +22,7 @@ import { Ids } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Retrieves filters.
+ * Get filters.
  * You can get a single filter or all filters.
  * @rest_spec_name ml.get_filters
  * @availability stack since=5.5.0 stability=stable

--- a/specification/ml/get_influencers/MlGetInfluencersRequest.ts
+++ b/specification/ml/get_influencers/MlGetInfluencersRequest.ts
@@ -24,7 +24,7 @@ import { double, integer } from '@_types/Numeric'
 import { DateTime } from '@_types/Time'
 
 /**
- * Retrieves anomaly detection job results for one or more influencers.
+ * Get anomaly detection job results for influencers.
  * Influencers are the entities that have contributed to, or are to blame for,
  * the anomalies. Influencer results are available only if an
  * `influencer_field_name` is specified in the job configuration.

--- a/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
+++ b/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Get usage info for anomaly detection jobs.
+ * Get anomaly detection jobs usage info.
  * @rest_spec_name ml.get_job_stats
  * @availability stack since=5.5.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
+++ b/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Retrieves usage information for anomaly detection jobs.
+ * Get usage info for anomaly detection jobs.
  * @rest_spec_name ml.get_job_stats
  * @availability stack since=5.5.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/get_jobs/MlGetJobsRequest.ts
+++ b/specification/ml/get_jobs/MlGetJobsRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Ids } from '@_types/common'
 
 /**
- * Get config info for anomaly detection jobs.
+ * Get anomaly detection jobs configuration info.
  * You can get information for multiple anomaly detection jobs in a single API
  * request by using a group name, a comma-separated list of jobs, or a wildcard
  * expression. You can get information for all anomaly detection jobs by using

--- a/specification/ml/get_jobs/MlGetJobsRequest.ts
+++ b/specification/ml/get_jobs/MlGetJobsRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Ids } from '@_types/common'
 
 /**
- * Retrieves configuration information for anomaly detection jobs.
+ * Get config info for anomaly detection jobs.
  * You can get information for multiple anomaly detection jobs in a single API
  * request by using a group name, a comma-separated list of jobs, or a wildcard
  * expression. You can get information for all anomaly detection jobs by using

--- a/specification/ml/get_memory_stats/MlGetMemoryStatsRequest.ts
+++ b/specification/ml/get_memory_stats/MlGetMemoryStatsRequest.ts
@@ -22,6 +22,7 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Get info on machine learning memory usage.
  * Get information about how machine learning jobs and trained models are using memory,
  * on each node, both within the JVM heap, and natively, outside of the JVM.
  * @rest_spec_name ml.get_memory_stats

--- a/specification/ml/get_memory_stats/MlGetMemoryStatsRequest.ts
+++ b/specification/ml/get_memory_stats/MlGetMemoryStatsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Get info on machine learning memory usage.
+ * Get machine learning memory usage info.
  * Get information about how machine learning jobs and trained models are using memory,
  * on each node, both within the JVM heap, and natively, outside of the JVM.
  * @rest_spec_name ml.get_memory_stats

--- a/specification/ml/get_model_snapshot_upgrade_stats/MlGetModelSnapshotUpgradeStatsRequest.ts
+++ b/specification/ml/get_model_snapshot_upgrade_stats/MlGetModelSnapshotUpgradeStatsRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Retrieves usage information for anomaly detection job model snapshot upgrades.
+ * Get usage info for anomaly detection job model snapshot upgrades.
  * @rest_spec_name ml.get_model_snapshot_upgrade_stats
  * @availability stack since=7.16.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/ml/get_model_snapshot_upgrade_stats/MlGetModelSnapshotUpgradeStatsRequest.ts
+++ b/specification/ml/get_model_snapshot_upgrade_stats/MlGetModelSnapshotUpgradeStatsRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Get usage info for anomaly detection job model snapshot upgrades.
+ * Get anomaly detection job model snapshot upgrade usage info.
  * @rest_spec_name ml.get_model_snapshot_upgrade_stats
  * @availability stack since=7.16.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/ml/get_model_snapshots/MlGetModelSnapshotsRequest.ts
+++ b/specification/ml/get_model_snapshots/MlGetModelSnapshotsRequest.ts
@@ -24,7 +24,7 @@ import { integer } from '@_types/Numeric'
 import { Duration, DateTime } from '@_types/Time'
 
 /**
- * Retrieves information about model snapshots.
+ * Get info about model snapshots.
  * @rest_spec_name ml.get_model_snapshots
  * @availability stack since=5.4.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/ml/get_model_snapshots/MlGetModelSnapshotsRequest.ts
+++ b/specification/ml/get_model_snapshots/MlGetModelSnapshotsRequest.ts
@@ -24,7 +24,7 @@ import { integer } from '@_types/Numeric'
 import { Duration, DateTime } from '@_types/Time'
 
 /**
- * Get info about model snapshots.
+ * Get model snapshots info.
  * @rest_spec_name ml.get_model_snapshots
  * @availability stack since=5.4.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
+++ b/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
@@ -24,7 +24,7 @@ import { Duration, DateTime } from '@_types/Time'
 
 /**
  * Get overall bucket results.
- * 
+ *
  * Retrievs overall bucket results that summarize the bucket results of
  * multiple anomaly detection jobs.
  *

--- a/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
+++ b/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
@@ -23,7 +23,9 @@ import { double, integer } from '@_types/Numeric'
 import { Duration, DateTime } from '@_types/Time'
 
 /**
- * Retrieves overall bucket results that summarize the bucket results of
+ * Get overall bucket results.
+ * 
+ * Retrievs overall bucket results that summarize the bucket results of
  * multiple anomaly detection jobs.
  *
  * The `overall_score` is calculated by combining the scores of all the

--- a/specification/ml/get_records/MlGetAnomalyRecordsRequest.ts
+++ b/specification/ml/get_records/MlGetAnomalyRecordsRequest.ts
@@ -24,7 +24,7 @@ import { double, integer } from '@_types/Numeric'
 import { DateTime } from '@_types/Time'
 
 /**
- * Retrieves anomaly records for an anomaly detection job.
+ * Get anomaly records for an anomaly detection job.
  * Records contain the detailed analytical results. They describe the anomalous
  * activity that has been identified in the input data based on the detector
  * configuration.

--- a/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
+++ b/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
@@ -23,7 +23,7 @@ import { integer } from '@_types/Numeric'
 import { Include } from '@ml/_types/Include'
 
 /**
- * Retrieves configuration information for a trained model.
+ * Get config info for a trained model.
  * @rest_spec_name ml.get_trained_models
  * @availability stack since=7.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
+++ b/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
@@ -23,7 +23,7 @@ import { integer } from '@_types/Numeric'
 import { Include } from '@ml/_types/Include'
 
 /**
- * Get config info for a trained model.
+ * Get trained model configuration info.
  * @rest_spec_name ml.get_trained_models
  * @availability stack since=7.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsRequest.ts
+++ b/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsRequest.ts
@@ -22,7 +22,8 @@ import { Ids } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Retrieves usage information for trained models. You can get usage information for multiple trained
+ * get usage info for trained models.
+ * You can get usage information for multiple trained
  * models in a single API request by using a comma-separated list of model IDs or a wildcard expression.
  * @rest_spec_name ml.get_trained_models_stats
  * @availability stack since=7.10.0 stability=stable

--- a/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsRequest.ts
+++ b/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsRequest.ts
@@ -22,7 +22,7 @@ import { Ids } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * get usage info for trained models.
+ * Get trained models usage info.
  * You can get usage information for multiple trained
  * models in a single API request by using a comma-separated list of model IDs or a wildcard expression.
  * @rest_spec_name ml.get_trained_models_stats

--- a/specification/ml/infer_trained_model/MlInferTrainedModelRequest.ts
+++ b/specification/ml/infer_trained_model/MlInferTrainedModelRequest.ts
@@ -25,7 +25,7 @@ import { InferenceConfigUpdateContainer } from '@ml/_types/inference'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
- * Evaluates a trained model.
+ * Evaluate a trained model.
  * @rest_spec_name ml.infer_trained_model
  * @availability stack since=8.3.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/info/MlInfoRequest.ts
+++ b/specification/ml/info/MlInfoRequest.ts
@@ -20,6 +20,7 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Return ML defaults and limits.
  * Returns defaults and limits used by machine learning.
  * This endpoint is designed to be used by a user interface that needs to fully
  * understand machine learning configurations where some options are not

--- a/specification/ml/open_job/MlOpenJobRequest.ts
+++ b/specification/ml/open_job/MlOpenJobRequest.ts
@@ -23,9 +23,8 @@ import { Duration } from '@_types/Time'
 
 /**
  * Open anomaly detection jobs.
- * An anomaly detection job must be opened in order for it to be ready to
- * receive and analyze data. It can be opened and closed multiple times
- * throughout its lifecycle.
+ * An anomaly detection job must be opened to be ready to receive and analyze
+ * data. It can be opened and closed multiple times throughout its lifecycle.
  * When you open a new job, it starts with an empty model.
  * When you open an existing job, the most recent model state is automatically
  * loaded. The job is ready to resume its analysis from where it left off, once

--- a/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
+++ b/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { CalendarEvent } from '../_types/CalendarEvent'
 
 /**
- * Adds scheduled events to a calendar.
+ * Add scheduled events to calendar.
  * @rest_spec_name ml.post_calendar_events
  * @availability stack since=6.2.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
+++ b/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { CalendarEvent } from '../_types/CalendarEvent'
 
 /**
- * Add scheduled events to calendar.
+ * Add scheduled events to the calendar.
  * @rest_spec_name ml.post_calendar_events
  * @availability stack since=6.2.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/post_data/MlPostJobDataRequest.ts
+++ b/specification/ml/post_data/MlPostJobDataRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { DateTime } from '@_types/Time'
 
 /**
- * Sends data to an anomaly detection job for analysis.
+ * Send data to an anomaly detection job for analysis.
  *
  * IMPORTANT: For each job, data can be accepted from only a single connection at a time.
  * It is not currently possible to post data to multiple jobs using wildcards or a comma-separated list.

--- a/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsRequest.ts
+++ b/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { DataframePreviewConfig } from './types'
 
 /**
- * Previews the extracted features used by a data frame analytics config.
+ * Preview the extracted features used by a data frame analytics config.
  * @rest_spec_name ml.preview_data_frame_analytics
  * @availability stack since=7.13.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsRequest.ts
+++ b/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsRequest.ts
@@ -22,7 +22,8 @@ import { Id } from '@_types/common'
 import { DataframePreviewConfig } from './types'
 
 /**
- * Preview the extracted features used by a data frame analytics config.
+ * Preview features used by data frame analytics.
+ * Previews the extracted features used by a data frame analytics config.
  * @rest_spec_name ml.preview_data_frame_analytics
  * @availability stack since=7.13.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
@@ -24,7 +24,7 @@ import { JobConfig } from '@ml/_types/Job'
 import { DateTime } from '@_types/Time'
 
 /**
- * Previews a datafeed.
+ * Preview a datafeed.
  * This API returns the first "page" of search results from a datafeed.
  * You can preview an existing datafeed or provide configuration details for a datafeed
  * and anomaly detection job in the API. The preview shows the structure of the data

--- a/specification/ml/put_calendar/MlPutCalendarRequest.ts
+++ b/specification/ml/put_calendar/MlPutCalendarRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Creates a calendar.
+ * Create a calendar.
  * @rest_spec_name ml.put_calendar
  * @availability stack since=6.2.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/put_calendar_job/MlPutCalendarJobRequest.ts
+++ b/specification/ml/put_calendar_job/MlPutCalendarJobRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id, Ids } from '@_types/common'
 
 /**
- * Adds an anomaly detection job to a calendar.
+ * Add anomaly detection job to calendar.
  * @rest_spec_name ml.put_calendar_job
  * @availability stack since=6.2.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
+++ b/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
@@ -28,7 +28,7 @@ import { HttpHeaders, Id, VersionString } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Instantiates a data frame analytics job.
+ * Create a data frame analytics job.
  * This API creates a data frame analytics job that performs an analysis on the
  * source indices and stores the outcome in a destination index.
  * @rest_spec_name ml.put_data_frame_analytics

--- a/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
@@ -35,7 +35,7 @@ import { ScriptField } from '@_types/Scripting'
 import { Duration } from '@_types/Time'
 
 /**
- * Instantiates a datafeed.
+ * Create a datafeed.
  * Datafeeds retrieve data from Elasticsearch for analysis by an anomaly detection job.
  * You can associate only one datafeed with each anomaly detection job.
  * The datafeed contains a query that runs at a defined interval (`frequency`).

--- a/specification/ml/put_filter/MlPutFilterRequest.ts
+++ b/specification/ml/put_filter/MlPutFilterRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Instantiates a filter.
+ * Create a filter.
  * A filter contains a list of strings. It can be used by one or more anomaly detection jobs.
  * Specifically, filters are referenced in the `custom_rules` property of detector configuration objects.
  * @rest_spec_name ml.put_filter

--- a/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
@@ -27,6 +27,7 @@ import { TrainedModelType } from '../_types/TrainedModel'
 import { InferenceConfigCreateContainer } from '@ml/_types/inference'
 
 /**
+ * Supply external trained model.
  * Enable you to supply a trained model that is not created by data frame analytics.
  * @rest_spec_name ml.put_trained_model
  * @availability stack since=7.10.0 stability=stable

--- a/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
@@ -27,7 +27,7 @@ import { TrainedModelType } from '../_types/TrainedModel'
 import { InferenceConfigCreateContainer } from '@ml/_types/inference'
 
 /**
- * Supply external trained model.
+ * Create a trained model.
  * Enable you to supply a trained model that is not created by data frame analytics.
  * @rest_spec_name ml.put_trained_model
  * @availability stack since=7.10.0 stability=stable

--- a/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
@@ -27,7 +27,7 @@ import { TrainedModelType } from '../_types/TrainedModel'
 import { InferenceConfigCreateContainer } from '@ml/_types/inference'
 
 /**
- * Enables you to supply a trained model that is not created by data frame analytics.
+ * Enable you to supply a trained model that is not created by data frame analytics.
  * @rest_spec_name ml.put_trained_model
  * @availability stack since=7.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/put_trained_model_alias/MlPutTrainedModelAliasRequest.ts
+++ b/specification/ml/put_trained_model_alias/MlPutTrainedModelAliasRequest.ts
@@ -21,8 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { Id, Name } from '@_types/common'
 
 /**
- * Creates or updates a trained model alias. A trained model alias is a logical
- * name used to reference a single trained model.
+ * Create or update a trained model alias.
+ * A trained model alias is a logical name used to reference a single trained
+ * model.
  * You can use aliases instead of trained model identifiers to make it easier to
  * reference your models. For example, you can use aliases in inference
  * aggregations and processors.

--- a/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartRequest.ts
+++ b/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartRequest.ts
@@ -22,7 +22,7 @@ import { integer, long } from '@_types/Numeric'
 import { Id } from '@_types/common'
 
 /**
- * Creates part of a trained model definition.
+ * Create part of a trained model definition.
  * @rest_spec_name ml.put_trained_model_definition_part
  * @availability stack since=8.0.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
+++ b/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { double } from '@_types/Numeric'
 
 /**
- * Creates a trained model vocabulary.
+ * Create a trained model vocabulary.
  * This API is supported only for natural language processing (NLP) models.
  * The vocabulary is stored in the index as described in `inference_config.*.vocabulary` of the trained model definition.
  * @rest_spec_name ml.put_trained_model_vocabulary

--- a/specification/ml/reset_job/MlResetJobRequest.ts
+++ b/specification/ml/reset_job/MlResetJobRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Resets an anomaly detection job.
+ * Reset an anomaly detection job.
  * All model state and results are deleted. The job is ready to start over as if
  * it had just been created.
  * It is not currently possible to reset multiple jobs using wildcards or a

--- a/specification/ml/revert_model_snapshot/MlRevertModelSnapshotRequest.ts
+++ b/specification/ml/revert_model_snapshot/MlRevertModelSnapshotRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Reverts to a specific snapshot.
+ * Revert to a snapshot.
  * The machine learning features react quickly to anomalous input, learning new
  * behaviors in data. Highly anomalous input increases the variance in the
  * models whilst the system learns whether this is a new step-change in behavior

--- a/specification/ml/set_upgrade_mode/MlSetUpgradeModeRequest.ts
+++ b/specification/ml/set_upgrade_mode/MlSetUpgradeModeRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Duration } from '@_types/Time'
 
 /**
- * Set upgrade_mode that prepares ML indices for upgrade.
+ * Set upgrade_mode for ML indices.
  * Sets a cluster wide upgrade_mode setting that prepares machine learning
  * indices for an upgrade.
  * When upgrading your cluster, in some circumstances you must restart your

--- a/specification/ml/set_upgrade_mode/MlSetUpgradeModeRequest.ts
+++ b/specification/ml/set_upgrade_mode/MlSetUpgradeModeRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Duration } from '@_types/Time'
 
 /**
+ * Set upgrade_mode that prepares ML indices for upgrade.
  * Sets a cluster wide upgrade_mode setting that prepares machine learning
  * indices for an upgrade.
  * When upgrading your cluster, in some circumstances you must restart your

--- a/specification/ml/start_data_frame_analytics/MlStartDataFrameAnalyticsRequest.ts
+++ b/specification/ml/start_data_frame_analytics/MlStartDataFrameAnalyticsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Starts a data frame analytics job.
+ * Start a data frame analytics job.
  * A data frame analytics job can be started and stopped multiple times
  * throughout its lifecycle.
  * If the destination index does not exist, it is created automatically the

--- a/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
+++ b/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Duration, DateTime } from '@_types/Time'
 
 /**
- * Starts one or more datafeeds.
+ * Start one or more datafeeds.
  *
  * A datafeed must be started in order to retrieve data from Elasticsearch. A datafeed can be started and stopped
  * multiple times throughout its lifecycle.

--- a/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
+++ b/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Duration, DateTime } from '@_types/Time'
 
 /**
- * Start one or more datafeeds.
+ * Start datafeeds.
  *
  * A datafeed must be started in order to retrieve data from Elasticsearch. A datafeed can be started and stopped
  * multiple times throughout its lifecycle.

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
@@ -27,7 +27,7 @@ import {
 } from '../_types/TrainedModel'
 
 /**
- * Start a trained model deployment. 
+ * Start a trained model deployment.
  * It allocates the model to every machine learning node.
  * @rest_spec_name ml.start_trained_model_deployment
  * @availability stack since=8.0.0 stability=stable

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
@@ -27,7 +27,8 @@ import {
 } from '../_types/TrainedModel'
 
 /**
- * Starts a trained model deployment, which allocates the model to every machine learning node.
+ * Start a trained model deployment. 
+ * It allocates the model to every machine learning node.
  * @rest_spec_name ml.start_trained_model_deployment
  * @availability stack since=8.0.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/stop_data_frame_analytics/MlStopDataFrameAnalyticsRequest.ts
+++ b/specification/ml/stop_data_frame_analytics/MlStopDataFrameAnalyticsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Stop one or more data frame analytics jobs.
+ * Stop data frame analytics jobs.
  * A data frame analytics job can be started and stopped multiple times
  * throughout its lifecycle.
  * @rest_spec_name ml.stop_data_frame_analytics

--- a/specification/ml/stop_data_frame_analytics/MlStopDataFrameAnalyticsRequest.ts
+++ b/specification/ml/stop_data_frame_analytics/MlStopDataFrameAnalyticsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Stops one or more data frame analytics jobs.
+ * Stop one or more data frame analytics jobs.
  * A data frame analytics job can be started and stopped multiple times
  * throughout its lifecycle.
  * @rest_spec_name ml.stop_data_frame_analytics

--- a/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
+++ b/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Stops one or more datafeeds.
+ * Stop one or more datafeeds.
  * A datafeed that is stopped ceases to retrieve data from Elasticsearch. A datafeed can be started and stopped
  * multiple times throughout its lifecycle.
  * @rest_spec_name ml.stop_datafeed

--- a/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
+++ b/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Stop one or more datafeeds.
+ * Stop datafeeds.
  * A datafeed that is stopped ceases to retrieve data from Elasticsearch. A datafeed can be started and stopped
  * multiple times throughout its lifecycle.
  * @rest_spec_name ml.stop_datafeed

--- a/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentRequest.ts
+++ b/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Stops a trained model deployment.
+ * Stop a trained model deployment.
  * @rest_spec_name ml.stop_trained_model_deployment
  * @availability stack since=8.0.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/update_data_frame_analytics/MlUpdateDataFrameAnalyticsRequest.ts
+++ b/specification/ml/update_data_frame_analytics/MlUpdateDataFrameAnalyticsRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Updates an existing data frame analytics job.
+ * Update a data frame analytics job.
  * @rest_spec_name ml.update_data_frame_analytics
  * @availability stack since=7.3.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
@@ -29,7 +29,7 @@ import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { ScriptField } from '@_types/Scripting'
 
 /**
- * Updates the properties of a datafeed.
+ * Update a datafeed.
  * You must stop and start the datafeed for the changes to be applied.
  * When Elasticsearch security features are enabled, your datafeed remembers which roles the user who updated it had at
  * the time of the update and runs the query using those same roles. If you provide secondary authorization headers,

--- a/specification/ml/update_filter/MlUpdateFilterRequest.ts
+++ b/specification/ml/update_filter/MlUpdateFilterRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
+ * Update a filter.
  * Updates the description of a filter, adds items, or removes items from the list.
  * @rest_spec_name ml.update_filter
  * @availability stack since=6.4.0 stability=stable

--- a/specification/ml/update_job/MlUpdateJobRequest.ts
+++ b/specification/ml/update_job/MlUpdateJobRequest.ts
@@ -31,6 +31,7 @@ import { long } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 /**
+ * Update an anomaly detection job.
  * Updates certain properties of an anomaly detection job.
  * @rest_spec_name ml.update_job
  * @availability stack since=5.5.0 stability=stable

--- a/specification/ml/update_model_snapshot/MlUpdateModelSnapshotRequest.ts
+++ b/specification/ml/update_model_snapshot/MlUpdateModelSnapshotRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
+ * Update a snapshot.
  * Updates certain properties of a snapshot.
  * @rest_spec_name ml.update_model_snapshot
  * @availability stack since=5.4.0 stability=stable

--- a/specification/ml/update_trained_model_deployment/MlUpdateTrainedModelDeploymentRequest.ts
+++ b/specification/ml/update_trained_model_deployment/MlUpdateTrainedModelDeploymentRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Starts a trained model deployment, which allocates the model to every machine learning node.
+ * Update a trained model deployment.
  * @rest_spec_name ml.update_trained_model_deployment
  * @availability stack since=8.6.0 stability=stable
  * @availability serverless stability=beta visibility=public

--- a/specification/ml/upgrade_job_snapshot/MlUpgradeJobSnapshotRequest.ts
+++ b/specification/ml/upgrade_job_snapshot/MlUpgradeJobSnapshotRequest.ts
@@ -22,6 +22,7 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Upgrade a snapshot.
  * Upgrades an anomaly detection model snapshot to the latest major version.
  * Over time, older snapshot formats are deprecated and removed. Anomaly
  * detection jobs support only snapshots that are from the current or previous


### PR DESCRIPTION
## Overview

Relates to https://github.com/elastic/elasticsearch-specification/issues/2635 and https://github.com/elastic/search-docs-team/issues/136

This PR fixes the operation summaries for ML APIs (F-z) (ending period is necessary per https://github.com/elastic/elasticsearch-specification/blob/main/docs/doc-comments-guide.md), then runs the `make generate` and `make transform-to-openapi` commands to refresh the output.
