### PR TITLE
Fix Get trained models statistics API types

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14081,7 +14081,7 @@ export interface MlTrainedModelDeploymentStats {
   error_count: integer
   inference_count: integer
   model_id: Id
-  nodes: MlTrainedModelDeploymentNodesStats
+  nodes: MlTrainedModelDeploymentNodesStats[]
   number_of_allocations: integer
   queue_capacity: integer
   rejected_execution_count: integer
@@ -14116,7 +14116,7 @@ export interface MlTrainedModelInferenceStats {
   failure_count: integer
   inference_count: integer
   missing_all_fields_count: integer
-  timestamp: DateTime
+  timestamp: long
 }
 
 export interface MlTrainedModelLocation {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14116,7 +14116,7 @@ export interface MlTrainedModelInferenceStats {
   failure_count: integer
   inference_count: integer
   missing_all_fields_count: integer
-  timestamp: long
+  timestamp: EpochTime<UnitMillis>
 }
 
 export interface MlTrainedModelLocation {

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -120,7 +120,7 @@ export class TrainedModelInferenceStats {
   /** The number of inference calls where all the training features for the model were missing. */
   missing_all_fields_count: integer
   /** The time when the statistics were last updated. */
-  timestamp: long
+  timestamp: EpochTime<UnitMillis>
 }
 
 export class TrainedModelSizeStats {

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -75,7 +75,7 @@ export class TrainedModelDeploymentStats {
    * The deployment stats for each node that currently has the model allocated.
    * In serverless, stats are reported for a single unnamed virtual node.
    */
-  nodes: TrainedModelDeploymentNodesStats
+  nodes: TrainedModelDeploymentNodesStats[]
   /** The number of allocations requested. */
   number_of_allocations: integer
   /** The number of inference requests that can be queued before new requests are rejected. */
@@ -120,7 +120,7 @@ export class TrainedModelInferenceStats {
   /** The number of inference calls where all the training features for the model were missing. */
   missing_all_fields_count: integer
   /** The time when the statistics were last updated. */
-  timestamp: DateTime
+  timestamp: long
 }
 
 export class TrainedModelSizeStats {


### PR DESCRIPTION
To run validation in https://github.com/elastic/elasticsearch-specification/pull/2763, I need to open a new pull request with the same changes, but from a branch.