### PR TITLE
Update CatCountRequest.ts documentation

### DIFF
--- a/specification/cat/count/CatCountRequest.ts
+++ b/specification/cat/count/CatCountRequest.ts
@@ -22,7 +22,7 @@ import { Indices } from '@_types/common'
 
 /**
  * Get a document count.
- * Provides quick access to a document count for a data stream, an index, or an entire cluster.n/
+ * Provides quick access to a document count for a data stream, an index, or an entire cluster.
  * The document count only includes live documents, not deleted documents which have not yet been removed by the merge process.
  *
  * CAT APIs are only intended for human consumption using the command line or Kibana console.


### PR DESCRIPTION
Small fix on the documentation. I found this while adding markdown support to the Ruby client code generator.
