### PR TITLE
Fix `CustomAnalyzer`

### DIFF
--- a/specification/_types/analysis/analyzers.ts
+++ b/specification/_types/analysis/analyzers.ts
@@ -27,8 +27,8 @@ import { KuromojiAnalyzer } from './kuromoji-plugin'
 
 export class CustomAnalyzer {
   type: 'custom'
-  char_filter?: string[]
-  filter?: string[]
+  char_filter?: string | string[]
+  filter?: string | string[]
   position_increment_gap?: integer
   position_offset_gap?: integer
   tokenizer: string


### PR DESCRIPTION
`CustomAnalyzer` is used in the `IndexSettings` structure for which the server flattens single-element-arrays to the element itself.

This PR fixes deserialization of `CustomAnalyzer` when e.g. requested by the `GetIndexSettings` API.

Note: There are more analyzer types with array fields that probably must be adjusted.

Closes: https://github.com/elastic/elasticsearch-net/issues/8291