### PR TITLE
Fix indices.get_data_stream response type

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -82500,6 +82500,9 @@
             "description": "If `true`, the data stream allows custom routing on write request.",
             "type": "boolean"
           },
+          "failure_store": {
+            "$ref": "#/components/schemas/indices._types:FailureStore"
+          },
           "generation": {
             "description": "Current generation for the data stream. This number acts as a cumulative count of the stream’s rollovers, starting at 1.",
             "type": "number"
@@ -82535,6 +82538,10 @@
             "description": "If `true`, the data stream is created and managed by cross-cluster replication and the local cluster can not write into this data stream or change its mappings.",
             "type": "boolean"
           },
+          "rollover_on_write": {
+            "description": "If `true`, the next write to this data stream will trigger a rollover first and the document will be indexed in the new backing index. If the rollover fails the indexing request will fail too.",
+            "type": "boolean"
+          },
           "status": {
             "$ref": "#/components/schemas/_types:HealthStatus"
           },
@@ -82557,17 +82564,32 @@
           "prefer_ilm",
           "indices",
           "name",
+          "rollover_on_write",
           "status",
           "template",
           "timestamp_field"
         ]
       },
-      "indices._types:ManagedBy": {
-        "type": "string",
-        "enum": [
-          "Index Lifecycle Management",
-          "Data stream lifecycle",
-          "Unmanaged"
+      "indices._types:FailureStore": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "indices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/indices._types:DataStreamIndex"
+            }
+          },
+          "rollover_on_write": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enabled",
+          "indices",
+          "rollover_on_write"
         ]
       },
       "indices._types:DataStreamIndex": {
@@ -82592,9 +82614,15 @@
         },
         "required": [
           "index_name",
-          "index_uuid",
-          "managed_by",
-          "prefer_ilm"
+          "index_uuid"
+        ]
+      },
+      "indices._types:ManagedBy": {
+        "type": "string",
+        "enum": [
+          "Index Lifecycle Management",
+          "Data stream lifecycle",
+          "Unmanaged"
         ]
       },
       "indices._types:DataStreamTimestampField": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -53204,6 +53204,9 @@
             "description": "If `true`, the data stream allows custom routing on write request.",
             "type": "boolean"
           },
+          "failure_store": {
+            "$ref": "#/components/schemas/indices._types:FailureStore"
+          },
           "generation": {
             "description": "Current generation for the data stream. This number acts as a cumulative count of the stream’s rollovers, starting at 1.",
             "type": "number"
@@ -53239,6 +53242,10 @@
             "description": "If `true`, the data stream is created and managed by cross-cluster replication and the local cluster can not write into this data stream or change its mappings.",
             "type": "boolean"
           },
+          "rollover_on_write": {
+            "description": "If `true`, the next write to this data stream will trigger a rollover first and the document will be indexed in the new backing index. If the rollover fails the indexing request will fail too.",
+            "type": "boolean"
+          },
           "status": {
             "$ref": "#/components/schemas/_types:HealthStatus"
           },
@@ -53261,17 +53268,32 @@
           "prefer_ilm",
           "indices",
           "name",
+          "rollover_on_write",
           "status",
           "template",
           "timestamp_field"
         ]
       },
-      "indices._types:ManagedBy": {
-        "type": "string",
-        "enum": [
-          "Index Lifecycle Management",
-          "Data stream lifecycle",
-          "Unmanaged"
+      "indices._types:FailureStore": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "indices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/indices._types:DataStreamIndex"
+            }
+          },
+          "rollover_on_write": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enabled",
+          "indices",
+          "rollover_on_write"
         ]
       },
       "indices._types:DataStreamIndex": {
@@ -53296,9 +53318,15 @@
         },
         "required": [
           "index_name",
-          "index_uuid",
-          "managed_by",
-          "prefer_ilm"
+          "index_uuid"
+        ]
+      },
+      "indices._types:ManagedBy": {
+        "type": "string",
+        "enum": [
+          "Index Lifecycle Management",
+          "Data stream lifecycle",
+          "Unmanaged"
         ]
       },
       "indices._types:DataStreamTimestampField": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -114784,6 +114784,18 @@
           }
         },
         {
+          "description": "Information about failure store backing indices",
+          "name": "failure_store",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "FailureStore",
+              "namespace": "indices._types"
+            }
+          }
+        },
+        {
           "description": "Current generation for the data stream. This number acts as a cumulative count of the stream’s rollovers, starting at 1.",
           "name": "generation",
           "required": true,
@@ -114904,6 +114916,18 @@
           }
         },
         {
+          "description": "If `true`, the next write to this data stream will trigger a rollover first and the document will be indexed in the new backing index. If the rollover fails the indexing request will fail too.",
+          "name": "rollover_on_write",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
           "description": "Health status of the data stream.\nThis health status is based on the state of the primary and replica shards of the stream’s backing indices.",
           "name": "status",
           "required": true,
@@ -114958,7 +114982,53 @@
           }
         }
       ],
-      "specLocation": "indices/_types/DataStream.ts#L39-L112"
+      "specLocation": "indices/_types/DataStream.ts#L45-L127"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "FailureStore",
+        "namespace": "indices._types"
+      },
+      "properties": [
+        {
+          "name": "enabled",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "name": "indices",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "DataStreamIndex",
+                "namespace": "indices._types"
+              }
+            }
+          }
+        },
+        {
+          "name": "rollover_on_write",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        }
+      ],
+      "specLocation": "indices/_types/DataStream.ts#L39-L43"
     },
     {
       "kind": "interface",
@@ -115006,7 +115076,7 @@
         {
           "description": "Name of the lifecycle system that's currently managing this backing index.",
           "name": "managed_by",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -115018,7 +115088,7 @@
         {
           "description": "Indicates if ILM should take precedence over DSL in case both are configured to manage this index.",
           "name": "prefer_ilm",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -115028,7 +115098,7 @@
           }
         }
       ],
-      "specLocation": "indices/_types/DataStream.ts#L121-L142"
+      "specLocation": "indices/_types/DataStream.ts#L136-L157"
     },
     {
       "kind": "interface",
@@ -115050,7 +115120,7 @@
           }
         }
       ],
-      "specLocation": "indices/_types/DataStream.ts#L114-L119"
+      "specLocation": "indices/_types/DataStream.ts#L129-L134"
     },
     {
       "kind": "interface",
@@ -115506,7 +115576,7 @@
           }
         }
       ],
-      "specLocation": "indices/_types/DataStream.ts#L144-L146"
+      "specLocation": "indices/_types/DataStream.ts#L159-L161"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10427,13 +10427,13 @@ export interface IndicesDataStream {
   generation: integer
   hidden: boolean
   ilm_policy?: Name
-  next_generation_managed_by?: IndicesManagedBy
-  prefer_ilm?: boolean
+  next_generation_managed_by: IndicesManagedBy
+  prefer_ilm: boolean
   indices: IndicesDataStreamIndex[]
   lifecycle?: IndicesDataStreamLifecycleWithRollover
   name: DataStreamName
   replicated?: boolean
-  rollover_on_write?: boolean
+  rollover_on_write: boolean
   status: HealthStatus
   system?: boolean
   template: Name

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10423,15 +10423,17 @@ export interface IndicesCacheQueries {
 export interface IndicesDataStream {
   _meta?: Metadata
   allow_custom_routing?: boolean
+  failure_store?: IndicesFailureStore
   generation: integer
   hidden: boolean
   ilm_policy?: Name
-  next_generation_managed_by: IndicesManagedBy
-  prefer_ilm: boolean
+  next_generation_managed_by?: IndicesManagedBy
+  prefer_ilm?: boolean
   indices: IndicesDataStreamIndex[]
   lifecycle?: IndicesDataStreamLifecycleWithRollover
   name: DataStreamName
   replicated?: boolean
+  rollover_on_write?: boolean
   status: HealthStatus
   system?: boolean
   template: Name
@@ -10442,8 +10444,8 @@ export interface IndicesDataStreamIndex {
   index_name: IndexName
   index_uuid: Uuid
   ilm_policy?: Name
-  managed_by: IndicesManagedBy
-  prefer_ilm: boolean
+  managed_by?: IndicesManagedBy
+  prefer_ilm?: boolean
 }
 
 export interface IndicesDataStreamLifecycle {
@@ -10489,6 +10491,12 @@ export interface IndicesDownsampleConfig {
 export interface IndicesDownsamplingRound {
   after: Duration
   config: IndicesDownsampleConfig
+}
+
+export interface IndicesFailureStore {
+  enabled: boolean
+  indices: IndicesDataStreamIndex[]
+  rollover_on_write: boolean
 }
 
 export interface IndicesFielddataFrequencyFilter {

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -76,11 +76,11 @@ export class DataStream {
   /**
    * Name of the lifecycle system that'll manage the next generation of the data stream.
    */
-  next_generation_managed_by?: ManagedBy
+  next_generation_managed_by: ManagedBy
   /**
    * Indicates if ILM should take precedence over DSL in case both are configured to managed this data stream.
    */
-  prefer_ilm?: boolean
+  prefer_ilm: boolean
   /**
    * Array of objects containing information about the data stream’s backing indices.
    * The last item in this array contains information about the stream’s current write index.
@@ -103,7 +103,7 @@ export class DataStream {
   /**
    * If `true`, the next write to this data stream will trigger a rollover first and the document will be indexed in the new backing index. If the rollover fails the indexing request will fail too.
    */
-  rollover_on_write?: boolean
+  rollover_on_write: boolean
   /**
    * Health status of the data stream.
    * This health status is based on the state of the primary and replica shards of the stream’s backing indices.

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -36,6 +36,12 @@ enum ManagedBy {
   unmanaged = 'Unmanaged'
 }
 
+export class FailureStore {
+  enabled: boolean
+  indices: DataStreamIndex[]
+  rollover_on_write: boolean
+}
+
 export class DataStream {
   /**
    * Custom metadata for the stream, copied from the `_meta` object of the stream’s matching index template.
@@ -47,6 +53,11 @@ export class DataStream {
    *  If `true`, the data stream allows custom routing on write request.
    */
   allow_custom_routing?: boolean
+  /**
+   * Information about failure store backing indices
+   *
+   */
+  failure_store?: FailureStore
   /**
    * Current generation for the data stream. This number acts as a cumulative count of the stream’s rollovers, starting at 1.
    */
@@ -65,11 +76,11 @@ export class DataStream {
   /**
    * Name of the lifecycle system that'll manage the next generation of the data stream.
    */
-  next_generation_managed_by: ManagedBy
+  next_generation_managed_by?: ManagedBy
   /**
    * Indicates if ILM should take precedence over DSL in case both are configured to managed this data stream.
    */
-  prefer_ilm: boolean
+  prefer_ilm?: boolean
   /**
    * Array of objects containing information about the data stream’s backing indices.
    * The last item in this array contains information about the stream’s current write index.
@@ -89,6 +100,10 @@ export class DataStream {
    *  If `true`, the data stream is created and managed by cross-cluster replication and the local cluster can not write into this data stream or change its mappings.
    */
   replicated?: boolean
+  /**
+   * If `true`, the next write to this data stream will trigger a rollover first and the document will be indexed in the new backing index. If the rollover fails the indexing request will fail too.
+   */
+  rollover_on_write?: boolean
   /**
    * Health status of the data stream.
    * This health status is based on the state of the primary and replica shards of the stream’s backing indices.
@@ -134,11 +149,11 @@ export class DataStreamIndex {
   /**
    * Name of the lifecycle system that's currently managing this backing index.
    */
-  managed_by: ManagedBy
+  managed_by?: ManagedBy
   /**
    * Indicates if ILM should take precedence over DSL in case both are configured to manage this index.
    */
-  prefer_ilm: boolean
+  prefer_ilm?: boolean
 }
 
 export class DataStreamVisibility {


### PR DESCRIPTION
We used to score 3/11 on responses, it's now 11/11.

| API | Status | Request | Response |
| --- | --- | --- | --- |
| `indices.get_data_stream` | :green_circle: | 11/11 | 11/11 |