### PR TITLE
Fix infer_trained_model API

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -91193,10 +91193,22 @@
             "type": "number"
           },
           {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          {
             "type": "boolean"
           },
           {
             "type": "number"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
           }
         ]
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -59238,10 +59238,22 @@
             "type": "number"
           },
           {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          {
             "type": "boolean"
           },
           {
             "type": "number"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
           }
         ]
       },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -91163,7 +91163,7 @@
         "name": "PredictedValue",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/inference.ts#L457-L457",
+      "specLocation": "ml/_types/inference.ts#L457-L463",
       "type": {
         "items": [
           {
@@ -91181,6 +91181,16 @@
             }
           },
           {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "double",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
             "kind": "instance_of",
             "type": {
               "name": "boolean",
@@ -91192,6 +91202,16 @@
             "type": {
               "name": "integer",
               "namespace": "_types"
+            }
+          },
+          {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
             }
           }
         ],
@@ -129600,7 +129620,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L459-L506"
+      "specLocation": "ml/_types/inference.ts#L465-L512"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13894,7 +13894,7 @@ export interface MlPerPartitionCategorization {
   stop_on_warn?: boolean
 }
 
-export type MlPredictedValue = string | double | boolean | integer
+export type MlPredictedValue = string | double | double[] | boolean | integer | integer[]
 
 export interface MlQuestionAnsweringInferenceOptions {
   num_top_classes?: integer

--- a/specification/ml/_types/inference.ts
+++ b/specification/ml/_types/inference.ts
@@ -454,7 +454,13 @@ export class TrainedModelInferenceFeatureImportance {
   classes?: TrainedModelInferenceClassImportance[]
 }
 
-export type PredictedValue = string | double | boolean | integer
+export type PredictedValue =
+  | string
+  | double
+  | double[]
+  | boolean
+  | integer
+  | integer[]
 
 export class InferenceResponseResult {
   /**


### PR DESCRIPTION
It can return list of lists of integers and floats.

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
