### PR TITLE
Updating put_synonyms api specification

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -18714,7 +18714,7 @@ export interface SynonymsGetSynonymsSetsSynonymsSetItem {
 export interface SynonymsPutSynonymRequest extends RequestBase {
   id: Id
   body?: {
-    synonyms_set: SynonymsSynonymRule[]
+    synonyms_set: SynonymsSynonymRule | SynonymsSynonymRule[]
   }
 }
 

--- a/specification/synonyms/put_synonym/SynonymsPutRequest.ts
+++ b/specification/synonyms/put_synonym/SynonymsPutRequest.ts
@@ -37,6 +37,6 @@ export interface Request extends RequestBase {
     /**
      * The synonym set information to update
      */
-    synonyms_set: SynonymRule[]
+    synonyms_set: SynonymRule | SynonymRule[]
   }
 }


### PR DESCRIPTION
With the recent changes, `put_synonmys` can now support both `list` and `object`. Updating he specification to reflect the change.


