### PR TITLE
[Backport 8.15] Add q parameter to Update By Query API (#2792)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -35435,6 +35435,16 @@
           },
           {
             "in": "query",
+            "name": "q",
+            "description": "Query in the Lucene query string syntax.",
+            "deprecated": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "refresh",
             "description": "If `true`, Elasticsearch refreshes affected shards to make the operation visible to search.",
             "deprecated": false,

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -20268,6 +20268,16 @@
           },
           {
             "in": "query",
+            "name": "q",
+            "description": "Query in the Lucene query string syntax.",
+            "deprecated": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "refresh",
             "description": "If `true`, Elasticsearch refreshes affected shards to make the operation visible to search.",
             "deprecated": false,

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -44977,6 +44977,18 @@
           }
         },
         {
+          "description": "Query in the Lucene query string syntax.",
+          "name": "q",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
           "description": "If `true`, Elasticsearch refreshes affected shards to make the operation visible to search.",
           "name": "refresh",
           "required": false,
@@ -45194,7 +45206,7 @@
           }
         }
       ],
-      "specLocation": "_global/update_by_query/UpdateByQueryRequest.ts#L37-L221"
+      "specLocation": "_global/update_by_query/UpdateByQueryRequest.ts#L37-L225"
     },
     {
       "body": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1221,12 +1221,6 @@
       ],
       "response": []
     },
-    "update_by_query": {
-      "request": [
-        "Request: missing json spec query parameter 'q'"
-      ],
-      "response": []
-    },
     "watcher.execute_watch": {
       "request": [
         "interface definition watcher._types:TriggerContainer - Property schedule is a single-variant and must be required"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1961,6 +1961,7 @@ export interface UpdateByQueryRequest extends RequestBase {
   max_docs?: long
   pipeline?: string
   preference?: string
+  q?: string
   refresh?: boolean
   request_cache?: boolean
   requests_per_second?: float

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -116,6 +116,10 @@ export interface Request extends RequestBase {
      */
     preference?: string
     /**
+     * Query in the Lucene query string syntax.
+     */
+    q?: string
+    /**
      * If `true`, Elasticsearch refreshes affected shards to make the operation visible to search.
      * @server_default false
      */


### PR DESCRIPTION
(cherry picked from commit afc109553aeb809f05919836dc9da9f471e6e8eb)

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
