### PR TITLE
Add _ignored to Get API response type

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -365,6 +365,7 @@ export interface FieldCapsResponse {
 export interface GetGetResult<TDocument = unknown> {
   _index: IndexName
   fields?: Record<string, any>
+  _ignored?: string[]
   found: boolean
   _id: Id
   _primary_term?: long

--- a/specification/_global/get/types.ts
+++ b/specification/_global/get/types.ts
@@ -25,6 +25,7 @@ import { long } from '@_types/Numeric'
 export class GetResult<TDocument> {
   _index: IndexName
   fields?: Dictionary<string, UserDefinedValue>
+  _ignored?: string[]
   found: boolean
   _id: Id
   _primary_term?: long


### PR DESCRIPTION
As documented in https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-ignored-field.html. It also applies to get, as you can see in eg. https://github.com/elastic/elasticsearch/blob/84ddd6c7af4143861b2765bd5ff1f2a66bd41fae/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/120_stored_fields_ignored.yml#L138-L142.

This fix the response validation for the Get API, while https://github.com/elastic/elasticsearch/pull/112059 will fix the request validation.