### PR TITLE
Add data_stream_lifecycle to Health API response

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -81576,7 +81576,7 @@
         "type": "object",
         "properties": {
           "index_name": {
-            "type": "string"
+            "$ref": "#/components/schemas/_types:IndexName"
           },
           "first_occurrence_timestamp": {
             "type": "number"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -81150,6 +81150,9 @@
           "repository_integrity": {
             "$ref": "#/components/schemas/_global.health_report:RepositoryIntegrityIndicator"
           },
+          "data_stream_lifecycle": {
+            "$ref": "#/components/schemas/_global.health_report:DataStreamLifecycleIndicator"
+          },
           "ilm": {
             "$ref": "#/components/schemas/_global.health_report:IlmIndicator"
           },
@@ -81532,6 +81535,61 @@
             }
           }
         }
+      },
+      "_global.health_report:DataStreamLifecycleIndicator": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/_global.health_report:BaseIndicator"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "details": {
+                "$ref": "#/components/schemas/_global.health_report:DataStreamLifecycleDetails"
+              }
+            }
+          }
+        ]
+      },
+      "_global.health_report:DataStreamLifecycleDetails": {
+        "type": "object",
+        "properties": {
+          "stagnating_backing_indices_count": {
+            "type": "number"
+          },
+          "total_backing_indices_in_error": {
+            "type": "number"
+          },
+          "stagnating_backing_indices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_global.health_report:StagnatingBackingIndices"
+            }
+          }
+        },
+        "required": [
+          "stagnating_backing_indices_count",
+          "total_backing_indices_in_error"
+        ]
+      },
+      "_global.health_report:StagnatingBackingIndices": {
+        "type": "object",
+        "properties": {
+          "index_name": {
+            "type": "string"
+          },
+          "first_occurrence_timestamp": {
+            "type": "number"
+          },
+          "retry_count": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "index_name",
+          "first_occurrence_timestamp",
+          "retry_count"
+        ]
       },
       "_global.health_report:IlmIndicator": {
         "allOf": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -44610,7 +44610,7 @@
         "name": "ImpactArea",
         "namespace": "_global.health_report"
       },
-      "specLocation": "_global/health_report/types.ts#L72-L77"
+      "specLocation": "_global/health_report/types.ts#L73-L78"
     },
     {
       "kind": "enum",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -464,6 +464,16 @@ export interface HealthReportBaseIndicator {
   diagnosis?: HealthReportDiagnosis[]
 }
 
+export interface HealthReportDataStreamLifecycleDetails {
+  stagnating_backing_indices_count: integer
+  total_backing_indices_in_error: integer
+  stagnating_backing_indices?: HealthReportStagnatingBackingIndices[]
+}
+
+export interface HealthReportDataStreamLifecycleIndicator extends HealthReportBaseIndicator {
+  details?: HealthReportDataStreamLifecycleDetails
+}
+
 export interface HealthReportDiagnosis {
   id: string
   action: string
@@ -523,6 +533,7 @@ export interface HealthReportIndicators {
   shards_availability?: HealthReportShardsAvailabilityIndicator
   disk?: HealthReportDiskIndicator
   repository_integrity?: HealthReportRepositoryIntegrityIndicator
+  data_stream_lifecycle?: HealthReportDataStreamLifecycleIndicator
   ilm?: HealthReportIlmIndicator
   slm?: HealthReportSlmIndicator
   shards_capacity?: HealthReportShardsCapacityIndicator
@@ -617,6 +628,12 @@ export interface HealthReportSlmIndicatorDetails {
 export interface HealthReportSlmIndicatorUnhealthyPolicies {
   count: long
   invocations_since_last_success?: Record<string, long>
+}
+
+export interface HealthReportStagnatingBackingIndices {
+  index_name: string
+  first_occurrence_timestamp: integer
+  retry_count: integer
 }
 
 export interface IndexRequest<TDocument = unknown> extends RequestBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -631,8 +631,8 @@ export interface HealthReportSlmIndicatorUnhealthyPolicies {
 }
 
 export interface HealthReportStagnatingBackingIndices {
-  index_name: string
-  first_occurrence_timestamp: integer
+  index_name: IndexName
+  first_occurrence_timestamp: long
   retry_count: integer
 }
 

--- a/specification/_global/health_report/types.ts
+++ b/specification/_global/health_report/types.ts
@@ -34,6 +34,7 @@ export class Indicators {
   shards_availability?: ShardsAvailabilityIndicator
   disk?: DiskIndicator
   repository_integrity?: RepositoryIntegrityIndicator
+  data_stream_lifecycle?: DataStreamLifecycleIndicator
   ilm?: IlmIndicator
   slm?: SlmIndicator
   shards_capacity?: ShardsCapacityIndicator
@@ -141,6 +142,22 @@ export class RepositoryIntegrityIndicatorDetails {
   total_repositories?: long
   corrupted_repositories?: long
   corrupted?: string[]
+}
+
+/** DATA_STREAM_LIFECYCLE */
+
+export class DataStreamLifecycleIndicator extends BaseIndicator {
+  details?: DataStreamLifecycleDetails
+}
+export class DataStreamLifecycleDetails {
+  stagnating_backing_indices_count: integer
+  total_backing_indices_in_error: integer
+  stagnating_backing_indices?: StagnatingBackingIndices[]
+}
+export class StagnatingBackingIndices {
+  index_name: string
+  first_occurrence_timestamp: integer
+  retry_count: integer
 }
 
 /** ILM */

--- a/specification/_global/health_report/types.ts
+++ b/specification/_global/health_report/types.ts
@@ -156,7 +156,7 @@ export class DataStreamLifecycleDetails {
 }
 export class StagnatingBackingIndices {
   index_name: string
-  first_occurrence_timestamp: integer
+  first_occurrence_timestamp: long
   retry_count: integer
 }
 

--- a/specification/_global/health_report/types.ts
+++ b/specification/_global/health_report/types.ts
@@ -19,7 +19,7 @@
 
 import { LifecycleOperationMode } from '@_types/Lifecycle'
 import { integer, long } from '@_types/Numeric'
-import { Indices } from '@_types/common'
+import { IndexName, Indices } from '@_types/common'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export enum IndicatorHealthStatus {

--- a/specification/_global/health_report/types.ts
+++ b/specification/_global/health_report/types.ts
@@ -155,7 +155,7 @@ export class DataStreamLifecycleDetails {
   stagnating_backing_indices?: StagnatingBackingIndices[]
 }
 export class StagnatingBackingIndices {
-  index_name: string
+  index_name: IndexName
   first_occurrence_timestamp: long
   retry_count: integer
 }


### PR DESCRIPTION
I noticed this error with `make validate`. I used the server source for [stagnating_backing_indices](https://github.com/elastic/elasticsearch/blob/158901577d27b426543cf1a30a7b9bd6cf93a0ba/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/health/DataStreamLifecycleHealthIndicatorService.java#L108-L127) which was missing from the example. Note that this indicator is not documented.