### PR TITLE
Add exclude query rule type to specification

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -95873,7 +95873,8 @@
       "query_rules._types:QueryRuleType": {
         "type": "string",
         "enum": [
-          "pinned"
+          "pinned",
+          "exclude"
         ]
       },
       "query_rules._types:QueryRuleCriteria": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -61607,7 +61607,8 @@
       "query_rules._types:QueryRuleType": {
         "type": "string",
         "enum": [
-          "pinned"
+          "pinned",
+          "exclude"
         ]
       },
       "query_rules._types:QueryRuleCriteria": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -100812,20 +100812,23 @@
         "name": "QueryRuleCriteriaType",
         "namespace": "query_rules._types"
       },
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L54-L67"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L55-L68"
     },
     {
       "kind": "enum",
       "members": [
         {
           "name": "pinned"
+        },
+        {
+          "name": "exclude"
         }
       ],
       "name": {
         "name": "QueryRuleType",
         "namespace": "query_rules._types"
       },
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L44-L46"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L44-L47"
     },
     {
       "kind": "enum",
@@ -134440,7 +134443,7 @@
           }
         }
       ],
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L48-L52"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L49-L53"
     },
     {
       "kind": "interface",
@@ -134478,7 +134481,7 @@
           }
         }
       ],
-      "specLocation": "query_rules/_types/QueryRuleset.ts#L69-L72"
+      "specLocation": "query_rules/_types/QueryRuleset.ts#L70-L73"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16747,7 +16747,7 @@ export interface QueryRulesQueryRuleCriteria {
 
 export type QueryRulesQueryRuleCriteriaType = 'global' | 'exact' | 'exact_fuzzy' | 'fuzzy' | 'prefix' | 'suffix' | 'contains' | 'lt' | 'lte' | 'gt' | 'gte' | 'always'
 
-export type QueryRulesQueryRuleType = 'pinned'
+export type QueryRulesQueryRuleType = 'pinned' | 'exclude'
 
 export interface QueryRulesQueryRuleset {
   ruleset_id: Id

--- a/specification/query_rules/_types/QueryRuleset.ts
+++ b/specification/query_rules/_types/QueryRuleset.ts
@@ -42,7 +42,8 @@ export class QueryRule {
 }
 
 export enum QueryRuleType {
-  pinned
+  pinned,
+  exclude
 }
 
 export class QueryRuleCriteria {


### PR DESCRIPTION
The `exclude` query rule type will go live with 8.16.0, this PR updates the specification accordingly. 