### PR TITLE
[DOCS] Add more transform example overlays

### DIFF
--- a/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
@@ -38,13 +38,13 @@ actions:
           application/json: 
             examples: 
               createTransformRequestExample1: 
-                $ref: "../../specification/transform/put_transform/examples/request/PutTransformRequestExample1.json"
+                $ref: "../../specification/transform/put_transform/PutTransformRequestExample1.json"
               createTransformRequestExample2:
-                $ref: "../../specification/transform/put_transform/examples/request/PutTransformRequestExample2.json"
+                $ref: "../../specification/transform/put_transform/PutTransformRequestExample2.json"
       responses:
         200:
           content:
             application/json:
               examples:
                 createTransformResponseExample1:
-                  $ref: "../../specification/transform/put_transform/examples/200_response/PutTransformResponseExample1.json"
+                  $ref: "../../specification/transform/put_transform/PutTransformResponseExample1.json"

--- a/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
@@ -48,3 +48,35 @@ actions:
               examples:
                 createTransformResponseExample1:
                   $ref: "../../specification/transform/put_transform/PutTransformResponseExample1.json"
+  - target: "$.components['requestBodies']['transform.preview_transform']"
+    description: "Add examples for preview transform operation"
+    update: 
+      content: 
+        application/json: 
+          examples: 
+            previewTransformRequestExample1: 
+              $ref: "../../specification/transform/preview_transform/PreviewTransformRequestExample1.json"
+  - target: "$.components['reponses']['transform.preview_transform#200']"
+    description: "Add examples for preview transform operation"
+    update: 
+      content:
+        application/json:
+          examples:
+            previewTransformResponseExample1:
+              $ref: "../../specification/transform/preview_transform/PreviewTransformResponseExample1.json"
+  - target: "$.paths['/_transform/{transform_id}/_update']['post']"
+    description: "Add examples for update transform operation"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              updateTransformRequestExample1: 
+                $ref: "../../specification/transform/update_transform/UpdateTransformRequestExample1.json"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                updateTransformResponseExample1:
+                  $ref: "../../specification/transform/update_transform/UpdateTransformResponseExample1.json"


### PR DESCRIPTION
This PR fixes the existing "create transform" example overlay, since the file path had changed. It also adds the "update transform" and "preview transform" examples.

NOTE: You need to run "make overlay-docs" to see the updated output, so I'm no longer checking in that file.