### PR TITLE
Fix Painless execute API

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -96876,8 +96876,7 @@
         },
         "required": [
           "document",
-          "index",
-          "query"
+          "index"
         ]
       },
       "_types:RankContainer": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -62085,8 +62085,7 @@
         },
         "required": [
           "document",
-          "index",
-          "query"
+          "index"
         ]
       },
       "_types:RankContainer": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -135456,7 +135456,7 @@
         {
           "description": "Use this parameter to specify a query for computing a score.",
           "name": "query",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1136,7 +1136,7 @@ export interface RenderSearchTemplateResponse {
 export interface ScriptsPainlessExecutePainlessContextSetup {
   document: any
   index: IndexName
-  query: QueryDslQueryContainer
+  query?: QueryDslQueryContainer
 }
 
 export interface ScriptsPainlessExecuteRequest extends RequestBase {

--- a/specification/_global/scripts_painless_execute/types.ts
+++ b/specification/_global/scripts_painless_execute/types.ts
@@ -35,7 +35,7 @@ export class PainlessContextSetup {
   /**
    * Use this parameter to specify a query for computing a score.
    */
-  query: QueryContainer
+  query?: QueryContainer
 }
 
 /**


### PR DESCRIPTION
According to https://github.com/elastic/elasticsearch/blob/44758b3823a4982e9c62598f184cf90b67ab5d2a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java#L167-L223 all `context_setup` fields are optional, but [docs](https://www.elastic.co/guide/en/elasticsearch/painless/8.15/painless-execute-api.html) say that `index` and `document` are required, [all YAML tests](https://github.com/search?q=repo%3Aelastic%2Felasticsearch+scripts_painless_execute+language%3AYAML&type=code&l=YAML) include them and `context_setup` itself is already optional. As a result, I left them required.