### PR TITLE
Making beider_morse only parameters optional

### DIFF
--- a/compiler/package-lock.json
+++ b/compiler/package-lock.json
@@ -33,6 +33,7 @@
       }
     },
     "../compiler-rs/compiler-wasm-lib/pkg": {
+      "name": "compiler-wasm-lib",
       "version": "0.1.0"
     },
     "node_modules/@babel/code-frame": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -74158,10 +74158,7 @@
             },
             "required": [
               "type",
-              "encoder",
-              "languageset",
-              "name_type",
-              "rule_type"
+              "encoder"
             ]
           }
         ]

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -48320,10 +48320,7 @@
             },
             "required": [
               "type",
-              "encoder",
-              "languageset",
-              "name_type",
-              "rule_type"
+              "encoder"
             ]
           }
         ]

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -83402,7 +83402,7 @@
         },
         {
           "name": "languageset",
-          "required": true,
+          "required": false,
           "type": {
             "items": [
               {
@@ -83439,7 +83439,7 @@
         },
         {
           "name": "name_type",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -83461,7 +83461,7 @@
         },
         {
           "name": "rule_type",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4905,11 +4905,11 @@ export type AnalysisPhoneticRuleType = 'approx' | 'exact'
 export interface AnalysisPhoneticTokenFilter extends AnalysisTokenFilterBase {
   type: 'phonetic'
   encoder: AnalysisPhoneticEncoder
-  languageset: AnalysisPhoneticLanguage | AnalysisPhoneticLanguage[]
+  languageset?: AnalysisPhoneticLanguage | AnalysisPhoneticLanguage[]
   max_code_len?: integer
-  name_type: AnalysisPhoneticNameType
+  name_type?: AnalysisPhoneticNameType
   replace?: boolean
-  rule_type: AnalysisPhoneticRuleType
+  rule_type?: AnalysisPhoneticRuleType
 }
 
 export interface AnalysisPorterStemTokenFilter extends AnalysisTokenFilterBase {

--- a/specification/_types/analysis/phonetic-plugin.ts
+++ b/specification/_types/analysis/phonetic-plugin.ts
@@ -64,9 +64,9 @@ export enum PhoneticRuleType {
 export class PhoneticTokenFilter extends TokenFilterBase {
   type: 'phonetic'
   encoder: PhoneticEncoder
-  languageset: PhoneticLanguage | PhoneticLanguage[]
+  languageset?: PhoneticLanguage | PhoneticLanguage[]
   max_code_len?: integer
-  name_type: PhoneticNameType
+  name_type?: PhoneticNameType
   replace?: boolean
-  rule_type: PhoneticRuleType
+  rule_type?: PhoneticRuleType
 }


### PR DESCRIPTION
As the [documentation](https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-phonetic-token-filter.html#_beider_morse_settings) states, the parameters `rule_type`, `name_type` and `languageset` are only available for `beider_morse` encoder, so they should be optional. 