### PR TITLE
Mark delete_geoip_database id as mandatory

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -870,7 +870,6 @@
     },
     "ingest.delete_geoip_database": {
       "request": [
-        "Request: path parameter 'id' is required in the json spec",
         "Request: query parameter 'master_timeout' does not exist in the json spec",
         "Request: query parameter 'timeout' does not exist in the json spec"
       ],

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12957,7 +12957,7 @@ export interface IngestUserAgentProcessor extends IngestProcessorBase {
 export type IngestUserAgentProperty = 'NAME' | 'MAJOR' | 'MINOR' | 'PATCH' | 'OS' | 'OS_NAME' | 'OS_MAJOR' | 'OS_MINOR' | 'DEVICE' | 'BUILD'
 
 export interface IngestDeleteGeoipDatabaseRequest extends RequestBase {
-  id?: Ids
+  id: Ids
   master_timeout?: Duration
   timeout?: Duration
 }

--- a/specification/ingest/delete_geoip_database/DeleteGeoipDatabaseRequest.ts
+++ b/specification/ingest/delete_geoip_database/DeleteGeoipDatabaseRequest.ts
@@ -32,7 +32,7 @@ export interface Request extends RequestBase {
     /**
      * A comma-separated list of geoip database configurations to delete
      */
-    id?: Ids
+    id: Ids
   }
   query_parameters: {
     /**


### PR DESCRIPTION
It was also a validation error here, but lost among the 400 other errors.
