### PR TITLE
Add 'dataset' size to cat indices and cat shards

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -66625,6 +66625,19 @@
               }
             ]
           },
+          "dataset.size": {
+            "description": "total size of dataset (includes the cache for partially mounted indices)",
+            "x-available-since": "8.11.0",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
+          },
           "completion.size": {
             "description": "size of completion",
             "type": "string"
@@ -68646,6 +68659,19 @@
           },
           "store": {
             "description": "The disk space used by the shard.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
+          },
+          "dataset": {
+            "description": "total size of dataset (includes the cache for partially mounted indices)",
+            "x-available-since": "8.11.0",
             "oneOf": [
               {
                 "type": "string"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -42533,6 +42533,19 @@
               }
             ]
           },
+          "dataset.size": {
+            "description": "total size of dataset (includes the cache for partially mounted indices)",
+            "x-available-since": "8.11.0",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
+          },
           "completion.size": {
             "description": "size of completion",
             "type": "string"

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -105427,6 +105427,40 @@
           }
         },
         {
+          "availability": {
+            "serverless": {
+              "stability": "stable",
+              "visibility": "public"
+            },
+            "stack": {
+              "since": "8.11.0",
+              "stability": "stable"
+            }
+          },
+          "description": "total size of dataset (includes the cache for partially mounted indices)",
+          "name": "dataset.size",
+          "required": false,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "_builtins"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "null",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
+          }
+        },
+        {
           "aliases": [
             "cs",
             "completionSize"
@@ -107232,7 +107266,7 @@
           }
         }
       ],
-      "specLocation": "cat/indices/types.ts#L20-L801"
+      "specLocation": "cat/indices/types.ts#L20-L808"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6964,6 +6964,7 @@ export interface CatIndicesIndicesRecord {
   ss?: string | null
   storeSize?: string | null
   'pri.store.size'?: string | null
+  'dataset.size'?: string | null
   'completion.size'?: string
   cs?: string
   completionSize?: string
@@ -8081,6 +8082,7 @@ export interface CatShardsShardsRecord {
   dc?: string | null
   store?: string | null
   sto?: string | null
+  dataset?: string | null
   ip?: string | null
   id?: string
   node?: string | null

--- a/specification/cat/indices/types.ts
+++ b/specification/cat/indices/types.ts
@@ -90,6 +90,13 @@ export class IndicesRecord {
   'pri.store.size'?: string | null
 
   /**
+   * total size of dataset (including the cache for partially mounted indices)
+   * @availability stack since=8.11.0 stability=stable
+   * @availability serverless stability=stable visibility=public
+   */
+  'dataset.size'?: string | null
+
+  /**
    * size of completion
    * @aliases cs,completionSize
    */

--- a/specification/cat/shards/types.ts
+++ b/specification/cat/shards/types.ts
@@ -54,6 +54,12 @@ export class ShardsRecord {
    */
   'store'?: string | null
   /**
+   * total size of dataset (including the cache for partially mounted indices)
+   * @availability stack since=8.11.0 stability=stable
+   * @availability serverless stability=stable visibility=public
+   */
+  'dataset'?: string | null
+  /**
    * The IP address of the node.
    */
   'ip'?: string | null


### PR DESCRIPTION
As was done in this Elasticsearch pull request: https://github.com/elastic/elasticsearch/pull/98622