### PR TITLE
[Backport 8.15] Fix search_shards API (#2834)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -39278,7 +39278,7 @@
                 "nodes": {
                   "type": "object",
                   "additionalProperties": {
-                    "$ref": "#/components/schemas/_types:NodeAttributes"
+                    "$ref": "#/components/schemas/_global.search_shards:SearchShardsNodeAttributes"
                   }
                 },
                 "shards": {
@@ -87818,12 +87818,6 @@
           },
           "transport_address": {
             "$ref": "#/components/schemas/_types:TransportAddress"
-          },
-          "roles": {
-            "$ref": "#/components/schemas/_types:NodeRoles"
-          },
-          "external_id": {
-            "type": "string"
           }
         },
         "required": [
@@ -87831,32 +87825,6 @@
           "ephemeral_id",
           "name",
           "transport_address"
-        ]
-      },
-      "_types:NodeRoles": {
-        "description": "* @doc_id node-roles",
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/_types:NodeRole"
-        }
-      },
-      "_types:NodeRole": {
-        "type": "string",
-        "enum": [
-          "master",
-          "data",
-          "data_cold",
-          "data_content",
-          "data_frozen",
-          "data_hot",
-          "data_warm",
-          "client",
-          "ingest",
-          "ml",
-          "voting_only",
-          "transform",
-          "remote_cluster_client",
-          "coordinating_only"
         ]
       },
       "ml._types:DataframeAnalyticsStatsProgress": {
@@ -92059,6 +92027,32 @@
           "refresh_interval_in_millis"
         ]
       },
+      "_types:NodeRoles": {
+        "description": "* @doc_id node-roles",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/_types:NodeRole"
+        }
+      },
+      "_types:NodeRole": {
+        "type": "string",
+        "enum": [
+          "master",
+          "data",
+          "data_cold",
+          "data_content",
+          "data_frozen",
+          "data_hot",
+          "data_warm",
+          "client",
+          "ingest",
+          "ml",
+          "voting_only",
+          "transform",
+          "remote_cluster_client",
+          "coordinating_only"
+        ]
+      },
       "nodes.info:NodeInfoSettings": {
         "type": "object",
         "properties": {
@@ -95321,6 +95315,53 @@
       },
       "_types:MapboxVectorTiles": {
         "type": "object"
+      },
+      "_global.search_shards:SearchShardsNodeAttributes": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:NodeName"
+          },
+          "ephemeral_id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "transport_address": {
+            "$ref": "#/components/schemas/_types:TransportAddress"
+          },
+          "external_id": {
+            "type": "string"
+          },
+          "attributes": {
+            "description": "Lists node attributes.",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "roles": {
+            "$ref": "#/components/schemas/_types:NodeRoles"
+          },
+          "version": {
+            "$ref": "#/components/schemas/_types:VersionString"
+          },
+          "min_index_version": {
+            "type": "number"
+          },
+          "max_index_version": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "ephemeral_id",
+          "transport_address",
+          "external_id",
+          "attributes",
+          "roles",
+          "version",
+          "min_index_version",
+          "max_index_version"
+        ]
       },
       "_types:NodeShard": {
         "type": "object",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -77338,7 +77338,7 @@
         "name": "NodeRole",
         "namespace": "_types"
       },
-      "specLocation": "_types/Node.ts#L77-L95"
+      "specLocation": "_types/Node.ts#L71-L89"
     },
     {
       "description": "* @doc_id node-roles",
@@ -77347,7 +77347,7 @@
         "name": "NodeRoles",
         "namespace": "_types"
       },
-      "specLocation": "_types/Node.ts#L97-L100",
+      "specLocation": "_types/Node.ts#L91-L94",
       "type": {
         "kind": "array_of",
         "value": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1783,9 +1783,21 @@ export interface SearchShardsRequest extends RequestBase {
 }
 
 export interface SearchShardsResponse {
-  nodes: Record<string, NodeAttributes>
+  nodes: Record<NodeId, SearchShardsSearchShardsNodeAttributes>
   shards: NodeShard[][]
   indices: Record<IndexName, SearchShardsShardStoreIndex>
+}
+
+export interface SearchShardsSearchShardsNodeAttributes {
+  name: NodeName
+  ephemeral_id: Id
+  transport_address: TransportAddress
+  external_id: string
+  attributes: Record<string, string>
+  roles: NodeRoles
+  version: VersionString
+  min_index_version: integer
+  max_index_version: integer
 }
 
 export interface SearchShardsShardStoreIndex {
@@ -2447,8 +2459,6 @@ export interface NodeAttributes {
   id?: NodeId
   name: NodeName
   transport_address: TransportAddress
-  roles?: NodeRoles
-  external_id?: string
 }
 
 export type NodeId = string

--- a/specification/_global/search_shards/SearchShardsResponse.ts
+++ b/specification/_global/search_shards/SearchShardsResponse.ts
@@ -18,16 +18,45 @@
  */
 
 import { Dictionary } from '@spec_utils/Dictionary'
-import { IndexName, Name } from '@_types/common'
-import { NodeAttributes, NodeShard } from '@_types/Node'
+import {
+  Id,
+  IndexName,
+  Name,
+  NodeId,
+  NodeName,
+  VersionString
+} from '@_types/common'
+import { NodeRoles, NodeShard } from '@_types/Node'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
+import { TransportAddress } from '@_types/Networking'
+import { integer } from '@_types/Numeric'
 
 export class Response {
   body: {
-    nodes: Dictionary<string, NodeAttributes>
+    nodes: Dictionary<NodeId, SearchShardsNodeAttributes>
     shards: NodeShard[][]
     indices: Dictionary<IndexName, ShardStoreIndex>
   }
+}
+
+class SearchShardsNodeAttributes {
+  /** The human-readable identifier of the node. */
+  name: NodeName
+  /** The ephemeral ID of the node. */
+  ephemeral_id: Id
+  /** The host and port where transport HTTP connections are accepted. */
+  transport_address: TransportAddress
+  /**
+   * @availability stack since=8.3.0
+   * @availability serverless
+   */
+  external_id: string
+  /** Lists node attributes. */
+  attributes: Dictionary<string, string>
+  roles: NodeRoles
+  version: VersionString
+  min_index_version: integer
+  max_index_version: integer
 }
 
 export class ShardStoreIndex {

--- a/specification/_types/Node.ts
+++ b/specification/_types/Node.ts
@@ -22,7 +22,7 @@ import { ShardRoutingState } from '@indices/stats/types'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { ErrorCause } from '@_types/Errors'
 import { integer } from '@_types/Numeric'
-import { Id, IndexName, NodeId, NodeName } from './common'
+import { Id, IndexName, NodeId, NodeName, VersionString } from './common'
 import { TransportAddress } from './Networking'
 
 /**
@@ -49,12 +49,6 @@ export class NodeAttributes {
   name: NodeName
   /** The host and port where transport HTTP connections are accepted. */
   transport_address: TransportAddress
-  roles?: NodeRoles
-  /**
-   * @availability stack since=8.3.0
-   * @availability serverless
-   */
-  external_id?: string
 }
 
 export class NodeShard {


### PR DESCRIPTION
* Fix search_shards API

* Use a specialized version of NodeAttributes for search_shards

(cherry picked from commit 72b6781a56ff0ffc93c5949c6327e550180ce721)
