### PR TITLE
Add hits_time_in_millis and misses_time_in_millis to enrich stats

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -81452,13 +81452,13 @@
             "type": "number"
           },
           "hits_time_in_millis": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
           },
           "misses": {
             "type": "number"
           },
           "misses_time_in_millis": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
           },
           "evictions": {
             "type": "number"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -81451,7 +81451,13 @@
           "hits": {
             "type": "number"
           },
+          "hits_time_in_millis": {
+            "type": "number"
+          },
           "misses": {
+            "type": "number"
+          },
+          "misses_time_in_millis": {
             "type": "number"
           },
           "evictions": {
@@ -81462,7 +81468,9 @@
           "node_id",
           "count",
           "hits",
+          "hits_time_in_millis",
           "misses",
+          "misses_time_in_millis",
           "evictions"
         ]
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -53361,7 +53361,13 @@
           "hits": {
             "type": "number"
           },
+          "hits_time_in_millis": {
+            "type": "number"
+          },
           "misses": {
+            "type": "number"
+          },
+          "misses_time_in_millis": {
             "type": "number"
           },
           "evictions": {
@@ -53372,7 +53378,9 @@
           "node_id",
           "count",
           "hits",
+          "hits_time_in_millis",
           "misses",
+          "misses_time_in_millis",
           "evictions"
         ]
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -53362,13 +53362,13 @@
             "type": "number"
           },
           "hits_time_in_millis": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
           },
           "misses": {
             "type": "number"
           },
           "misses_time_in_millis": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
           },
           "evictions": {
             "type": "number"

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -115090,7 +115090,7 @@
           }
         }
       ],
-      "specLocation": "enrich/stats/types.ts#L29-L35"
+      "specLocation": "enrich/stats/types.ts#L30-L36"
     },
     {
       "kind": "interface",
@@ -115122,7 +115122,7 @@
           }
         }
       ],
-      "specLocation": "enrich/stats/types.ts#L24-L27"
+      "specLocation": "enrich/stats/types.ts#L25-L28"
     },
     {
       "kind": "interface",
@@ -115168,9 +115168,18 @@
           "name": "hits_time_in_millis",
           "required": true,
           "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "DurationValue",
               "namespace": "_types"
             }
           }
@@ -115190,9 +115199,18 @@
           "name": "misses_time_in_millis",
           "required": true,
           "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "DurationValue",
               "namespace": "_types"
             }
           }
@@ -115220,7 +115238,7 @@
           }
         }
       ],
-      "specLocation": "enrich/stats/types.ts#L37-L49"
+      "specLocation": "enrich/stats/types.ts#L38-L50"
     },
     {
       "generics": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -115165,12 +115165,34 @@
           }
         },
         {
+          "name": "hits_time_in_millis",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "name": "misses",
           "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
               "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "misses_time_in_millis",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
               "namespace": "_types"
             }
           }
@@ -115187,7 +115209,7 @@
           }
         }
       ],
-      "specLocation": "enrich/stats/types.ts#L37-L43"
+      "specLocation": "enrich/stats/types.ts#L37-L47"
     },
     {
       "generics": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10064,9 +10064,9 @@ export interface EnrichStatsCacheStats {
   node_id: Id
   count: integer
   hits: integer
-  hits_time_in_millis: long
+  hits_time_in_millis: DurationValue<UnitMillis>
   misses: integer
-  misses_time_in_millis: long
+  misses_time_in_millis: DurationValue<UnitMillis>
   evictions: integer
   size_in_bytes: long
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10064,7 +10064,9 @@ export interface EnrichStatsCacheStats {
   node_id: Id
   count: integer
   hits: integer
+  hits_time_in_millis: long
   misses: integer
+  misses_time_in_millis: long
   evictions: integer
 }
 

--- a/specification/enrich/stats/types.ts
+++ b/specification/enrich/stats/types.ts
@@ -20,6 +20,7 @@
 import { TaskInfo } from '@tasks/_types/TaskInfo'
 import { Id, Name } from '@_types/common'
 import { integer, long } from '@_types/Numeric'
+import { DurationValue, UnitMillis } from '@_types/Time'
 
 export class ExecutingPolicy {
   name: Name
@@ -39,10 +40,10 @@ export class CacheStats {
   count: integer
   hits: integer
   /* The amount of time in milliseconds spent fetching data from the cache on successful cache hits only. */
-  hits_time_in_millis: long
+  hits_time_in_millis: DurationValue<UnitMillis>
   misses: integer
   /* The amount of time in milliseconds spent fetching data from the enrich index and updating the cache, on cache misses only. */
-  misses_time_in_millis: long
+  misses_time_in_millis: DurationValue<UnitMillis>
   evictions: integer
   /* An _approximation_ of the size in bytes that the enrich cache takes up on the heap. */
   size_in_bytes: long

--- a/specification/enrich/stats/types.ts
+++ b/specification/enrich/stats/types.ts
@@ -38,6 +38,10 @@ export class CacheStats {
   node_id: Id
   count: integer
   hits: integer
+  /* The amount of time in milliseconds spent fetching data from the cache on successful cache hits only. */
+  hits_time_in_millis: long
   misses: integer
+  /* The amount of time in milliseconds spent fetching data from the enrich index and updating the cache, on cache misses only. */
+  misses_time_in_millis: long
   evictions: integer
 }


### PR DESCRIPTION
This was done in https://github.com/elastic/elasticsearch/pull/107579.

Unlike https://github.com/elastic/elasticsearch-specification/pull/2846, this went into 8.15, so I'll backport it. The two changes together will fix the enrich stats API response validation.
