### PR TITLE
Add size_in_bytes to enrich stats API

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -81456,6 +81456,9 @@
           },
           "evictions": {
             "type": "number"
+          },
+          "size_in_bytes": {
+            "type": "number"
           }
         },
         "required": [
@@ -81463,7 +81466,8 @@
           "count",
           "hits",
           "misses",
-          "evictions"
+          "evictions",
+          "size_in_bytes"
         ]
       },
       "eql._types:EqlSearchResponseBase": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -53366,6 +53366,9 @@
           },
           "evictions": {
             "type": "number"
+          },
+          "size_in_bytes": {
+            "type": "number"
           }
         },
         "required": [
@@ -53373,7 +53376,8 @@
           "count",
           "hits",
           "misses",
-          "evictions"
+          "evictions",
+          "size_in_bytes"
         ]
       },
       "eql._types:EqlSearchResponseBase": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -115185,9 +115185,20 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "name": "size_in_bytes",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
         }
       ],
-      "specLocation": "enrich/stats/types.ts#L37-L43"
+      "specLocation": "enrich/stats/types.ts#L37-L45"
     },
     {
       "generics": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10066,6 +10066,7 @@ export interface EnrichStatsCacheStats {
   hits: integer
   misses: integer
   evictions: integer
+  size_in_bytes: long
 }
 
 export interface EnrichStatsCoordinatorStats {

--- a/specification/enrich/stats/types.ts
+++ b/specification/enrich/stats/types.ts
@@ -40,4 +40,6 @@ export class CacheStats {
   hits: integer
   misses: integer
   evictions: integer
+  /* An _approximation_ of the size in bytes that the enrich cache takes up on the heap. */
+  size_in_bytes: long
 }


### PR DESCRIPTION
This was done in https://github.com/elastic/elasticsearch/pull/110578.

Unlike https://github.com/elastic/elasticsearch-specification/pull/2845, it will only appear in 8.16, so I won't backport it. But the two changes together will fix the enrich stats API response validation.