### PR TITLE
Add unassigned primary shards to health reports

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -66514,6 +66514,10 @@
             "description": "number of initializing nodes",
             "type": "string"
           },
+          "unassign.pri": {
+            "description": "number of unassigned primary shards",
+            "type": "string"
+          },
           "unassign": {
             "description": "number of unassigned shards",
             "type": "string"
@@ -78043,6 +78047,10 @@
             "description": "If false the response returned within the period of time that is specified by the timeout parameter (30s by default)",
             "type": "boolean"
           },
+          "unassigned_primary_shards": {
+            "description": "The number of primary shards that are not allocated.",
+            "type": "number"
+          },
           "unassigned_shards": {
             "description": "The number of shards that are not allocated.",
             "type": "number"
@@ -78063,6 +78071,7 @@
           "status",
           "task_max_waiting_in_queue_millis",
           "timed_out",
+          "unassigned_primary_shards",
           "unassigned_shards"
         ]
       },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -78107,6 +78107,9 @@
           },
           "unassigned_shards": {
             "type": "number"
+          },
+          "unassigned_primary_shards": {
+            "type": "number"
           }
         },
         "required": [
@@ -78117,7 +78120,8 @@
           "number_of_shards",
           "relocating_shards",
           "status",
-          "unassigned_shards"
+          "unassigned_shards",
+          "unassigned_primary_shards"
         ]
       },
       "cluster.health:ShardHealthStats": {
@@ -78140,6 +78144,9 @@
           },
           "unassigned_shards": {
             "type": "number"
+          },
+          "unassigned_primary_shards": {
+            "type": "number"
           }
         },
         "required": [
@@ -78148,7 +78155,8 @@
           "primary_active",
           "relocating_shards",
           "status",
-          "unassigned_shards"
+          "unassigned_shards",
+          "unassigned_primary_shards"
         ]
       },
       "_types:ClusterInfoTargets": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6911,6 +6911,10 @@ export interface CatHealthHealthRecord {
   i?: string
   'shards.initializing'?: string
   shardsInitializing?: string
+  'unassign.pri'?: string
+  up?: string
+  'shards.unassigned.primary'?: string
+  shardsUnassignedPrimary?: string
   unassign?: string
   u?: string
   'shards.unassigned'?: string
@@ -8978,6 +8982,7 @@ export interface ClusterHealthHealthResponseBody {
   task_max_waiting_in_queue?: Duration
   task_max_waiting_in_queue_millis: DurationValue<UnitMillis>
   timed_out: boolean
+  unassigned_primary_shards: integer
   unassigned_shards: integer
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8996,6 +8996,7 @@ export interface ClusterHealthIndexHealthStats {
   shards?: Record<string, ClusterHealthShardHealthStats>
   status: HealthStatus
   unassigned_shards: integer
+  unassigned_primary_shards: integer
 }
 
 export interface ClusterHealthRequest extends RequestBase {
@@ -9022,6 +9023,7 @@ export interface ClusterHealthShardHealthStats {
   relocating_shards: integer
   status: HealthStatus
   unassigned_shards: integer
+  unassigned_primary_shards: integer
 }
 
 export interface ClusterInfoRequest extends RequestBase {

--- a/specification/cat/health/types.ts
+++ b/specification/cat/health/types.ts
@@ -72,6 +72,11 @@ export class HealthRecord {
    */
   'init'?: string
   /**
+   * number of unassigned primary shards
+   * @aliases up,shards.unassigned.primary,shardsUnassignedPrimary
+   */
+  'unassign.pri'?: string
+  /**
    * number of unassigned shards
    * @aliases u,shards.unassigned,shardsUnassigned
    */

--- a/specification/cluster/health/ClusterHealthResponse.ts
+++ b/specification/cluster/health/ClusterHealthResponse.ts
@@ -67,6 +67,8 @@ export class HealthResponseBody {
   task_max_waiting_in_queue_millis: DurationValue<UnitMillis>
   /** If false the response returned within the period of time that is specified by the timeout parameter (30s by default) */
   timed_out: boolean
+  /** The number of primary shards that are not allocated. */
+  unassigned_primary_shards: integer
   /** The number of shards that are not allocated. */
   unassigned_shards: integer
 }

--- a/specification/cluster/health/types.ts
+++ b/specification/cluster/health/types.ts
@@ -31,6 +31,7 @@ export class IndexHealthStats {
   shards?: Dictionary<string, ShardHealthStats>
   status: HealthStatus
   unassigned_shards: integer
+  unassigned_primary_shards: integer
 }
 
 export class ShardHealthStats {
@@ -40,4 +41,5 @@ export class ShardHealthStats {
   relocating_shards: integer
   status: HealthStatus
   unassigned_shards: integer
+  unassigned_primary_shards: integer
 }


### PR DESCRIPTION
This was added in https://github.com/elastic/elasticsearch/pull/112024

Validation will fail because we're still using some old NEST client tests that don't have this field. I'll merge tomorrow when they will be gone.