### PR TITLE
Update resolve index missing type definition

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -14368,7 +14368,7 @@
           {
             "in": "query",
             "name": "allow_no_indices",
-            "description": "If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing\nor closed indices. This behavior applies even if the request targets other open indices. For example, a request\ntargeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.",
+            "description": "If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.\nThis behavior applies even if the request targets other open indices.\nFor example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.",
             "deprecated": false,
             "schema": {
               "type": "boolean"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -14354,6 +14354,16 @@
               "$ref": "#/components/schemas/_types:ExpandWildcards"
             },
             "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "ignore_unavailable",
+            "description": "If `false`, the request returns an error if it targets a missing or closed index.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
           }
         ],
         "responses": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -14364,6 +14364,16 @@
               "type": "boolean"
             },
             "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "allow_no_indices",
+            "description": "If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing\nor closed indices. This behavior applies even if the request targets other open indices. For example, a request\ntargeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
           }
         ],
         "responses": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -8667,6 +8667,16 @@
               "type": "boolean"
             },
             "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "allow_no_indices",
+            "description": "If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing\nor closed indices. This behavior applies even if the request targets other open indices. For example, a request\ntargeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
           }
         ],
         "responses": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -8657,6 +8657,16 @@
               "$ref": "#/components/schemas/_types:ExpandWildcards"
             },
             "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "ignore_unavailable",
+            "description": "If `false`, the request returns an error if it targets a missing or closed index.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
           }
         ],
         "responses": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -8671,7 +8671,7 @@
           {
             "in": "query",
             "name": "allow_no_indices",
-            "description": "If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing\nor closed indices. This behavior applies even if the request targets other open indices. For example, a request\ntargeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.",
+            "description": "If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.\nThis behavior applies even if the request targets other open indices.\nFor example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.",
             "deprecated": false,
             "schema": {
               "type": "boolean"

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -23610,9 +23610,35 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "description": "If `false`, the request returns an error if it targets a missing or closed index.",
+          "name": "ignore_unavailable",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "description": "If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.\nThis behavior applies even if the request targets other open indices.\nFor example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.",
+          "name": "allow_no_indices",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
         }
       ],
-      "specLocation": "indices/resolve_index/ResolveIndexRequest.ts#L23-L48"
+      "specLocation": "indices/resolve_index/ResolveIndexRequest.ts#L23-L60"
     },
     {
       "body": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -848,6 +848,13 @@
       ],
       "response": []
     },
+    "indices.resolve_index": {
+      "request": [
+        "Request: query parameter 'ignore_unavailable' does not exist in the json spec",
+        "Request: query parameter 'allow_no_indices' does not exist in the json spec"
+      ],
+      "response": []
+    },
     "indices.rollover": {
       "request": [
         "Request: missing json spec query parameter 'lazy'",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12038,6 +12038,7 @@ export type IndicesResolveClusterResponse = Record<ClusterAlias, IndicesResolveC
 export interface IndicesResolveIndexRequest extends RequestBase {
   name: Names
   expand_wildcards?: ExpandWildcards
+  ignore_unavailable?: boolean
 }
 
 export interface IndicesResolveIndexResolveIndexAliasItem {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12039,6 +12039,7 @@ export interface IndicesResolveIndexRequest extends RequestBase {
   name: Names
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
+  allow_no_indices?: boolean
 }
 
 export interface IndicesResolveIndexResolveIndexAliasItem {

--- a/specification/_json_spec/indices.resolve_index.json
+++ b/specification/_json_spec/indices.resolve_index.json
@@ -29,10 +29,6 @@
         "options": ["open", "closed", "hidden", "none", "all"],
         "default": "open",
         "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)"
-      },
-      "ignore_unavailable": {
-        "type": "boolean",
-        "description": "Ignore unavailable indexes (default: false)"
       }
     }
   }

--- a/specification/_json_spec/indices.resolve_index.json
+++ b/specification/_json_spec/indices.resolve_index.json
@@ -29,6 +29,10 @@
         "options": ["open", "closed", "hidden", "none", "all"],
         "default": "open",
         "description": "Whether wildcard expressions should get expanded to open or closed indices (default: open)"
+      },
+      "ignore_unavailable": {
+        "type": "boolean",
+        "description": "Ignore unavailable indexes (default: false)"
       }
     }
   }

--- a/specification/indices/resolve_index/ResolveIndexRequest.ts
+++ b/specification/indices/resolve_index/ResolveIndexRequest.ts
@@ -44,5 +44,10 @@ export interface Request extends RequestBase {
      * @server_default open
      */
     expand_wildcards?: ExpandWildcards
+    /**
+     * If `false`, the request returns an error if it targets a missing or closed index.
+     * @server_default false
+     */
+    ignore_unavailable?: boolean
   }
 }

--- a/specification/indices/resolve_index/ResolveIndexRequest.ts
+++ b/specification/indices/resolve_index/ResolveIndexRequest.ts
@@ -49,5 +49,12 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     ignore_unavailable?: boolean
+    /**
+     * If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing
+     * or closed indices. This behavior applies even if the request targets other open indices. For example, a request
+     * targeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.
+     * @server_default true
+     */
+    allow_no_indices?: boolean
   }
 }

--- a/specification/indices/resolve_index/ResolveIndexRequest.ts
+++ b/specification/indices/resolve_index/ResolveIndexRequest.ts
@@ -50,9 +50,9 @@ export interface Request extends RequestBase {
      */
     ignore_unavailable?: boolean
     /**
-     * If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing
-     * or closed indices. This behavior applies even if the request targets other open indices. For example, a request
-     * targeting foo*,bar* returns an error if an index starts with foo but no index starts with bar.
+     * If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
+     * This behavior applies even if the request targets other open indices.
+     * For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
      * @server_default true
      */
     allow_no_indices?: boolean


### PR DESCRIPTION
This PR adds the missing type definition for `ignore_unavailable` and `allow_no_indices` query param` which are [accepted by ES](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-resolve-index-api.html#resolve-index-api-query-params) but the definition is missing.