### PR TITLE
[OAS][DOCS] Clarify license, version, and source URL 

### DIFF
--- a/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
@@ -11,7 +11,12 @@ actions:
         **Technical preview**  
         This functionality is in technical preview and may be changed or removed in a future release.
         Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-      license:
+
+        ## Documentation source and versions
+        
+        This documentation derived from the `main` branch of the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification) repository.
+        It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
+      x-doc-license:
         name: Attribution-NonCommercial-NoDerivatives 4.0 International
         url: 'https://creativecommons.org/licenses/by-nc-nd/4.0/'
       x-feedbackLink:

--- a/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
@@ -14,7 +14,7 @@ actions:
 
         ## Documentation source and versions
         
-        This documentation derived from the `main` branch of the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification) repository.
+        This documentation is derived from the `main` branch of the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification) repository.
         It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
       x-doc-license:
         name: Attribution-NonCommercial-NoDerivatives 4.0 International


### PR DESCRIPTION
This PR removes the `info.license` overlay implemented in https://github.com/elastic/elasticsearch-specification/pull/2817, since per https://spec.openapis.org/oas/v3.0.3#info-object the info.license pertains to the API license, not the documentation license.

I've moved the documentation license information to a custom extension and to the info.description until that extension is supported. I've also added a comment about which branch and repo the documentation is derived from.

### Preview

![image](https://github.com/user-attachments/assets/e99af720-7c90-4def-be98-e609e1a0af57)

