### PR TITLE
Disable _search rank on serverless

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -29212,9 +29212,6 @@
                     }
                   ]
                 },
-                "rank": {
-                  "$ref": "#/components/schemas/_types:RankContainer"
-                },
                 "min_score": {
                   "description": "Minimum `_score` for matching documents.\nDocuments with a lower `_score` are not included in the search results.",
                   "type": "number"
@@ -62356,39 +62353,6 @@
           "document",
           "index"
         ]
-      },
-      "_types:RankContainer": {
-        "type": "object",
-        "properties": {
-          "rrf": {
-            "$ref": "#/components/schemas/_types:RrfRank"
-          }
-        },
-        "minProperties": 1,
-        "maxProperties": 1
-      },
-      "_types:RrfRank": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/_types:RankBase"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "rank_constant": {
-                "description": "How much influence documents in individual result sets per query have over the final ranked result set",
-                "type": "number"
-              },
-              "rank_window_size": {
-                "description": "Size of the individual result sets per query",
-                "type": "number"
-              }
-            }
-          }
-        ]
-      },
-      "_types:RankBase": {
-        "type": "object"
       },
       "_types:RetrieverContainer": {
         "type": "object",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -37298,7 +37298,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/SearchRequest.ts#L54-L530"
+      "specLocation": "_global/search/SearchRequest.ts#L54-L529"
     },
     {
       "body": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -36374,24 +36374,6 @@
             }
           },
           {
-            "availability": {
-              "serverless": {},
-              "stack": {
-                "since": "8.8.0"
-              }
-            },
-            "description": "Defines the Reciprocal Rank Fusion (RRF) to use.",
-            "name": "rank",
-            "required": false,
-            "type": {
-              "kind": "instance_of",
-              "type": {
-                "name": "RankContainer",
-                "namespace": "_types"
-              }
-            }
-          },
-          {
             "description": "Minimum `_score` for matching documents.\nDocuments with a lower `_score` are not included in the search results.",
             "name": "min_score",
             "required": false,
@@ -136139,80 +136121,6 @@
         }
       ],
       "specLocation": "_global/scripts_painless_execute/types.ts#L25-L39"
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "RankContainer",
-        "namespace": "_types"
-      },
-      "properties": [
-        {
-          "description": "The reciprocal rank fusion parameters",
-          "name": "rrf",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "RrfRank",
-              "namespace": "_types"
-            }
-          }
-        }
-      ],
-      "specLocation": "_types/Rank.ts#L22-L28",
-      "variants": {
-        "kind": "container"
-      }
-    },
-    {
-      "inherits": {
-        "type": {
-          "name": "RankBase",
-          "namespace": "_types"
-        }
-      },
-      "kind": "interface",
-      "name": {
-        "name": "RrfRank",
-        "namespace": "_types"
-      },
-      "properties": [
-        {
-          "description": "How much influence documents in individual result sets per query have over the final ranked result set",
-          "name": "rank_constant",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Size of the individual result sets per query",
-          "name": "rank_window_size",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
-          }
-        }
-      ],
-      "specLocation": "_types/Rank.ts#L32-L37"
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "RankBase",
-        "namespace": "_types"
-      },
-      "properties": [],
-      "specLocation": "_types/Rank.ts#L30-L30"
     },
     {
       "kind": "interface",

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -399,7 +399,6 @@ export interface Request extends RequestBase {
     /**
      * Defines the Reciprocal Rank Fusion (RRF) to use.
      * @availability stack since=8.8.0
-     * @availability serverless visibility=private
      */
     rank?: RankContainer
     /**

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -399,7 +399,7 @@ export interface Request extends RequestBase {
     /**
      * Defines the Reciprocal Rank Fusion (RRF) to use.
      * @availability stack since=8.8.0
-     * @availability serverless
+     * @availability serverless visibility=private
      */
     rank?: RankContainer
     /**


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-specification/pull/2861 addresses the failing build.