### PR TITLE
Allow null from/to in range aggregation

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -63776,7 +63776,15 @@
         "properties": {
           "from": {
             "description": "Start of the range (inclusive).",
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
           },
           "key": {
             "description": "Custom key to return the range with.",
@@ -63784,7 +63792,15 @@
           },
           "to": {
             "description": "End of the range (exclusive).",
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
           }
         }
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -40089,7 +40089,15 @@
         "properties": {
           "from": {
             "description": "Start of the range (inclusive).",
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
           },
           "key": {
             "description": "Custom key to return the range with.",
@@ -40097,7 +40105,15 @@
           },
           "to": {
             "description": "End of the range (exclusive).",
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
           }
         }
       },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -61297,11 +61297,23 @@
           "name": "from",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "double",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "null",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
@@ -61321,11 +61333,23 @@
           "name": "to",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "double",
-              "namespace": "_types"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "double",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "null",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         }
       ],

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -3024,9 +3024,9 @@ export interface AggregationsAggregationContainer {
 }
 
 export interface AggregationsAggregationRange {
-  from?: double
+  from?: double | null
   key?: string
-  to?: double
+  to?: double | null
 }
 
 export interface AggregationsArrayPercentilesItem {

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -680,7 +680,7 @@ export class AggregationRange {
   /**
    * Start of the range (inclusive).
    */
-  from?: double
+  from?: double | null
   /**
    * Custom key to return the range with.
    */
@@ -688,7 +688,7 @@ export class AggregationRange {
   /**
    * End of the range (exclusive).
    */
-  to?: double
+  to?: double | null
 }
 
 export class RareTermsAggregation extends BucketAggregationBase {


### PR DESCRIPTION
This fixes the following YAML test in the Search API:

```json
{
  "api": "search",
  "file": "/test/free/aggregations/range.yml",
  "name": "Null to and from",
  "origin": "yaml",
  "request": {
    "args": {
      "body": {
        "aggs": {
          "double_range": {
            "range": {
              "field": "double",
              "ranges": [
                {
                  "from": null,
                  "to": 50
                },
                {
                  "from": 50,
                  "to": 150
                },
                {
                  "from": 150,
                  "to": null
                }
              ]
            }
          }
        },
        "size": 0
      },
      "index": "test",
      "typed_keys": true
    }
  },
  "response": {
    "headers": {
      "content-encoding": "gzip",
      "content-type": "application/json",
      "transfer-encoding": "chunked",
      "x-elastic-product": "Elasticsearch"
    },
    "payload": {
      "_shards": {
        "failed": 0,
        "skipped": 0,
        "successful": 1,
        "total": 1
      },
      "aggregations": {
        "range#double_range": {
          "buckets": [
            {
              "doc_count": 1,
              "key": "*-50.0",
              "to": 50
            },
            {
              "doc_count": 2,
              "from": 50,
              "key": "50.0-150.0",
              "to": 150
            },
            {
              "doc_count": 0,
              "from": 150,
              "key": "150.0-*"
            }
          ]
        }
      },
      "hits": {
        "hits": [
        ],
        "max_score": null,
        "total": {
          "relation": "eq",
          "value": 4
        }
      },
      "timed_out": false,
      "took": 2
    },
    "statusCode": 200
  }
}
```