### PR TITLE
Fix content-type of put_geoip_database.json

### DIFF
--- a/specification/_json_spec/ingest.put_geoip_database.json
+++ b/specification/_json_spec/ingest.put_geoip_database.json
@@ -7,7 +7,8 @@
     "stability": "stable",
     "visibility": "public",
     "headers": {
-      "accept": ["application/json"]
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
     },
     "url": {
       "paths": [


### PR DESCRIPTION
I've opened https://github.com/elastic/elasticsearch/pull/112581 too with the same contents. This is breaking the Python code generator, so I would appreciate merging this ahaed of the Elasticsearch pull request.