### PR TITLE
Add examples to both OpenAPI documents via overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,7 @@ output/schema/schema
 compiler/test/**/output/
 
 # Temporary openAPI files
-output/openapi/elasticsearch-serverless-openapi.tmp.json
+output/openapi/elasticsearch-serverless-openapi.tmp*.json
 output/openapi/elasticsearch-serverless-openapi.examples.json
+output/openapi/elasticsearch-openapi.tmp*.json
+output/openapi/elasticsearch-openapi.examples.json

--- a/Makefile
+++ b/Makefile
@@ -60,12 +60,20 @@ dump-routes: ## Create a new schema with all generics expanded
 contrib: | generate license-check spec-format-fix transform-to-openapi filter-for-serverless ## Pre contribution target
 
 overlay-docs: ## Apply overlays to OpenAPI documents
-	@npx bump overlay "output/openapi/elasticsearch-serverless-openapi.json" "docs/overlays/elasticsearch-serverless-openapi-overlays.yaml" > "output/openapi/elasticsearch-serverless-openapi.tmp.json"
-	@npx @redocly/cli bundle output/openapi/elasticsearch-serverless-openapi.tmp.json --ext json -o output/openapi/elasticsearch-serverless-openapi.examples.json
-	rm output/openapi/elasticsearch-serverless-openapi.tmp.json
+	@npx bump overlay "output/openapi/elasticsearch-serverless-openapi.json" "docs/overlays/elasticsearch-serverless-openapi-overlays.yaml" > "output/openapi/elasticsearch-serverless-openapi.tmp1.json"
+	@npx bump overlay "output/openapi/elasticsearch-serverless-openapi.tmp1.json" "docs/overlays/elasticsearch-shared-example-overlays.yaml" > "output/openapi/elasticsearch-serverless-openapi.tmp2.json"
+	@npx @redocly/cli bundle output/openapi/elasticsearch-serverless-openapi.tmp2.json --ext json -o output/openapi/elasticsearch-serverless-openapi.examples.json
+	@npx bump overlay "output/openapi/elasticsearch-openapi.json" "docs/overlays/elasticsearch-openapi-overlays.yaml" > "output/openapi/elasticsearch-openapi.tmp1.json"
+	@npx bump overlay "output/openapi/elasticsearch-openapi.tmp1.json" "docs/overlays/elasticsearch-shared-example-overlays.yaml" > "output/openapi/elasticsearch-openapi.tmp2.json"
+	@npx @redocly/cli bundle output/openapi/elasticsearch-openapi.tmp2.json --ext json -o output/openapi/elasticsearch-openapi.examples.json
+	rm output/openapi/elasticsearch-serverless-openapi.tmp*.json
+	rm output/openapi/elasticsearch-openapi.tmp*.json
 
 lint-docs: ## Lint the OpenAPI documents
 	@npx @stoplight/spectral-cli lint output/openapi/*.json --ruleset .spectral.yaml
+
+lint-docs-errs: ## Lint the OpenAPI documents and return only errors
+	@npx @stoplight/spectral-cli lint output/openapi/*.json --ruleset .spectral.yaml -D
 
 lint-docs-serverless: ## Lint only the serverless OpenAPI document
 	@npx @stoplight/spectral-cli lint output/openapi/elasticsearch-serverless-openapi.json --ruleset .spectral.yaml

--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -1,18 +1,14 @@
 # overlays.yaml
 overlay: 1.0.0
 info:
-  title: Overlays for the Elasticsearch Serverless OpenAPI document
+  title: Overlays for the Elasticsearch OpenAPI document
   version: 0.0.1
 actions:
   - target: '$.info'
     description: Add a document description and feedback link
     update:
-      title: Elasticsearch Serverless API
+      title: Elasticsearch API
       description: >
-        **Technical preview**  
-        This functionality is in technical preview and may be changed or removed in a future release.
-        Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-
         ## Documentation source and versions
         
         This documentation is derived from the `main` branch of the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification) repository.
@@ -23,8 +19,3 @@ actions:
       x-feedbackLink:
         label: Feedback
         url: https://github.com/elastic/docs-content/issues/new?assignees=&labels=feedback%2Ccommunity&projects=&template=api-feedback.yaml&title=%5BFeedback%5D%3A+
-  # Temporarily mark all operations as beta
-  - target: "$.paths[*]['get','put','post','delete','options','head','patch','trace']"
-    description: Add x-beta
-    update:
-      x-beta: true

--- a/docs/overlays/elasticsearch-shared-example-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-example-overlays.yaml
@@ -1,0 +1,72 @@
+# overlays.yaml
+overlay: 1.0.0
+info:
+  title: Overlays for examples that apply to both Elasticsearcb and Elasticsearch Serverless OpenAPI documents
+  version: 0.0.1
+actions:
+  - target: "$.components['requestBodies']['async_search.submit']"
+    description: "Add example for asynch search submit request"
+    update: 
+      content:
+        application/json:
+          examples:
+            asyncSearchSubmitResponseExample1:
+              $ref: "../../specification/async_search/submit/AsyncSearchSubmitRequestExample1.json"
+  - target: "$.components['responses']['async_search.submit#200']"
+    description: "Add example for asynch search submit response"
+    update: 
+      content:
+        application/json:
+          examples:
+            asyncSearchSubmitResponseExample1:
+              $ref: "../../specification/async_search/submit/AsyncSearchSubmitResponseExample1.json"
+  - target: "$.paths['/_transform/{transform_id}']['put']"
+    description: "Add examples for create transform operation"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              createTransformRequestExample1: 
+                $ref: "../../specification/transform/put_transform/PutTransformRequestExample1.json"
+              createTransformRequestExample2:
+                $ref: "../../specification/transform/put_transform/PutTransformRequestExample2.json"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                createTransformResponseExample1:
+                  $ref: "../../specification/transform/put_transform/PutTransformResponseExample1.json"
+  - target: "$.components['requestBodies']['transform.preview_transform']"
+    description: "Add examples for preview transform operation"
+    update: 
+      content: 
+        application/json: 
+          examples: 
+            previewTransformRequestExample1: 
+              $ref: "../../specification/transform/preview_transform/PreviewTransformRequestExample1.json"
+  - target: "$.components['reponses']['transform.preview_transform#200']"
+    description: "Add examples for preview transform operation"
+    update: 
+      content:
+        application/json:
+          examples:
+            previewTransformResponseExample1:
+              $ref: "../../specification/transform/preview_transform/PreviewTransformResponseExample1.json"
+  - target: "$.paths['/_transform/{transform_id}/_update']['post']"
+    description: "Add examples for update transform operation"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              updateTransformRequestExample1: 
+                $ref: "../../specification/transform/update_transform/UpdateTransformRequestExample1.json"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                updateTransformResponseExample1:
+                  $ref: "../../specification/transform/update_transform/UpdateTransformResponseExample1.json"


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2144, https://github.com/elastic/elasticsearch-specification/issues/2482

Until we can automatically include examples in the OpenAPI documents, they are being applied by using https://github.com/elastic/elasticsearch-specification/tree/main/docs/overlays

In preparation for publishing https://github.com/elastic/elasticsearch-specification/blob/main/output/openapi/elasticsearch-openapi.json, this PR splits the existing overlay into (1) an overlay that is specific to the serverless openAPI document, (2) an overlay that is specific to the non-serverless openAPI document, and (3) an overlay that contains any common updates such as examples that are applicable to both.

The make overlay-docs command is updated to apply all those overlays. I've also created a make lint-docs-errs command to only return linting errors rather than all the warnings and information messages.