### PR TITLE
Fix ingest statistics in cluster.info

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -62870,7 +62870,7 @@
             "description": "Contains statistics about ingest pipelines for the node.",
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/components/schemas/nodes._types:IngestTotal"
+              "$ref": "#/components/schemas/nodes._types:IngestStats"
             }
           },
           "total": {
@@ -62878,7 +62878,7 @@
           }
         }
       },
-      "nodes._types:IngestTotal": {
+      "nodes._types:IngestStats": {
         "type": "object",
         "properties": {
           "count": {
@@ -62905,8 +62905,27 @@
           },
           "time_in_millis": {
             "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
+          },
+          "ingested_as_first_pipeline_in_bytes": {
+            "description": "Total number of bytes of all documents ingested by the pipeline.\nThis field is only present on pipelines which are the first to process a document.\nThus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.",
+            "x-available-since": "8.15.0",
+            "type": "number"
+          },
+          "produced_as_first_pipeline_in_bytes": {
+            "description": "Total number of bytes of all documents produced by the pipeline.\nThis field is only present on pipelines which are the first to process a document.\nThus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.\nIn situations where there are subsequent pipelines, the value represents the size of the document after all pipelines have run.",
+            "x-available-since": "8.15.0",
+            "type": "number"
           }
-        }
+        },
+        "required": [
+          "count",
+          "current",
+          "failed",
+          "processors",
+          "time_in_millis",
+          "ingested_as_first_pipeline_in_bytes",
+          "produced_as_first_pipeline_in_bytes"
+        ]
       },
       "nodes._types:KeyedProcessor": {
         "type": "object",
@@ -62938,6 +62957,32 @@
             "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
           }
         }
+      },
+      "nodes._types:IngestTotal": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "Total number of documents ingested during the lifetime of this node.",
+            "type": "number"
+          },
+          "current": {
+            "description": "Total number of documents currently being ingested.",
+            "type": "number"
+          },
+          "failed": {
+            "description": "Total number of failed ingest operations during the lifetime of this node.",
+            "type": "number"
+          },
+          "time_in_millis": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
+          }
+        },
+        "required": [
+          "count",
+          "current",
+          "failed",
+          "time_in_millis"
+        ]
       },
       "nodes._types:ThreadCount": {
         "type": "object",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -43529,7 +43529,7 @@
             "description": "Contains statistics about ingest pipelines for the node.",
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/components/schemas/nodes._types:IngestTotal"
+              "$ref": "#/components/schemas/nodes._types:IngestStats"
             }
           },
           "total": {
@@ -43537,7 +43537,7 @@
           }
         }
       },
-      "nodes._types:IngestTotal": {
+      "nodes._types:IngestStats": {
         "type": "object",
         "properties": {
           "count": {
@@ -43564,8 +43564,27 @@
           },
           "time_in_millis": {
             "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
+          },
+          "ingested_as_first_pipeline_in_bytes": {
+            "description": "Total number of bytes of all documents ingested by the pipeline.\nThis field is only present on pipelines which are the first to process a document.\nThus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.",
+            "x-available-since": "8.15.0",
+            "type": "number"
+          },
+          "produced_as_first_pipeline_in_bytes": {
+            "description": "Total number of bytes of all documents produced by the pipeline.\nThis field is only present on pipelines which are the first to process a document.\nThus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.\nIn situations where there are subsequent pipelines, the value represents the size of the document after all pipelines have run.",
+            "x-available-since": "8.15.0",
+            "type": "number"
           }
-        }
+        },
+        "required": [
+          "count",
+          "current",
+          "failed",
+          "processors",
+          "time_in_millis",
+          "ingested_as_first_pipeline_in_bytes",
+          "produced_as_first_pipeline_in_bytes"
+        ]
       },
       "nodes._types:KeyedProcessor": {
         "type": "object",
@@ -43597,6 +43616,32 @@
             "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
           }
         }
+      },
+      "nodes._types:IngestTotal": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "Total number of documents ingested during the lifetime of this node.",
+            "type": "number"
+          },
+          "current": {
+            "description": "Total number of documents currently being ingested.",
+            "type": "number"
+          },
+          "failed": {
+            "description": "Total number of failed ingest operations during the lifetime of this node.",
+            "type": "number"
+          },
+          "time_in_millis": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
+          }
+        },
+        "required": [
+          "count",
+          "current",
+          "failed",
+          "time_in_millis"
+        ]
       },
       "nodes._types:ThreadCount": {
         "type": "object",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -94381,7 +94381,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L403-L432"
+      "specLocation": "nodes/_types/Stats.ts#L439-L468"
     },
     {
       "kind": "interface",
@@ -94463,7 +94463,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L434-L459"
+      "specLocation": "nodes/_types/Stats.ts#L470-L495"
     },
     {
       "kind": "interface",
@@ -94524,7 +94524,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L698-L716"
+      "specLocation": "nodes/_types/Stats.ts#L734-L752"
     },
     {
       "kind": "interface",
@@ -94719,7 +94719,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L550-L594"
+      "specLocation": "nodes/_types/Stats.ts#L586-L630"
     },
     {
       "kind": "interface",
@@ -94801,7 +94801,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L757-L786"
+      "specLocation": "nodes/_types/Stats.ts#L793-L822"
     },
     {
       "kind": "interface",
@@ -94838,7 +94838,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L718-L728"
+      "specLocation": "nodes/_types/Stats.ts#L754-L764"
     },
     {
       "kind": "interface",
@@ -94920,7 +94920,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L730-L755"
+      "specLocation": "nodes/_types/Stats.ts#L766-L791"
     },
     {
       "kind": "interface",
@@ -94969,7 +94969,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L633-L647"
+      "specLocation": "nodes/_types/Stats.ts#L669-L683"
     },
     {
       "kind": "interface",
@@ -95111,7 +95111,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L649-L696"
+      "specLocation": "nodes/_types/Stats.ts#L685-L732"
     },
     {
       "kind": "interface",
@@ -95137,7 +95137,7 @@
             "value": {
               "kind": "instance_of",
               "type": {
-                "name": "IngestTotal",
+                "name": "IngestStats",
                 "namespace": "nodes._types"
               }
             }
@@ -95161,14 +95161,14 @@
     {
       "kind": "interface",
       "name": {
-        "name": "IngestTotal",
+        "name": "IngestStats",
         "namespace": "nodes._types"
       },
       "properties": [
         {
           "description": "Total number of documents ingested during the lifetime of this node.",
           "name": "count",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -95180,7 +95180,7 @@
         {
           "description": "Total number of documents currently being ingested.",
           "name": "current",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -95192,7 +95192,7 @@
         {
           "description": "Total number of failed ingest operations during the lifetime of this node.",
           "name": "failed",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -95204,7 +95204,7 @@
         {
           "description": "Total number of ingest processors.",
           "name": "processors",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "array_of",
             "value": {
@@ -95230,7 +95230,7 @@
         {
           "description": "Total time, in milliseconds, spent preprocessing ingest documents during the lifetime of this node.",
           "name": "time_in_millis",
-          "required": false,
+          "required": true,
           "type": {
             "generics": [
               {
@@ -95247,9 +95247,47 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.15.0",
+              "stability": "stable"
+            }
+          },
+          "description": "Total number of bytes of all documents ingested by the pipeline.\nThis field is only present on pipelines which are the first to process a document.\nThus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.",
+          "name": "ingested_as_first_pipeline_in_bytes",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.15.0",
+              "stability": "stable"
+            }
+          },
+          "description": "Total number of bytes of all documents produced by the pipeline.\nThis field is only present on pipelines which are the first to process a document.\nThus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.\nIn situations where there are subsequent pipelines, the value represents the size of the document after all pipelines have run.",
+          "name": "produced_as_first_pipeline_in_bytes",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L356-L377"
+      "specLocation": "nodes/_types/Stats.ts#L356-L394"
     },
     {
       "kind": "interface",
@@ -95281,7 +95319,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L379-L382"
+      "specLocation": "nodes/_types/Stats.ts#L415-L418"
     },
     {
       "kind": "interface",
@@ -95348,7 +95386,74 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L384-L401"
+      "specLocation": "nodes/_types/Stats.ts#L420-L437"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "IngestTotal",
+        "namespace": "nodes._types"
+      },
+      "properties": [
+        {
+          "description": "Total number of documents ingested during the lifetime of this node.",
+          "name": "count",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Total number of documents currently being ingested.",
+          "name": "current",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Total number of failed ingest operations during the lifetime of this node.",
+          "name": "failed",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Total time, in milliseconds, spent preprocessing ingest documents during the lifetime of this node.",
+          "name": "time_in_millis",
+          "required": true,
+          "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "instance_of",
+            "type": {
+              "name": "DurationValue",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "specLocation": "nodes/_types/Stats.ts#L396-L413"
     },
     {
       "kind": "interface",
@@ -95465,7 +95570,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L811-L845"
+      "specLocation": "nodes/_types/Stats.ts#L847-L881"
     },
     {
       "kind": "interface",
@@ -95535,7 +95640,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L788-L809"
+      "specLocation": "nodes/_types/Stats.ts#L824-L845"
     },
     {
       "kind": "interface",
@@ -95581,7 +95686,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L908-L921"
+      "specLocation": "nodes/_types/Stats.ts#L944-L957"
     },
     {
       "kind": "interface",
@@ -95614,7 +95719,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L923-L928"
+      "specLocation": "nodes/_types/Stats.ts#L959-L964"
     },
     {
       "kind": "interface",
@@ -95660,7 +95765,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L930-L943"
+      "specLocation": "nodes/_types/Stats.ts#L966-L979"
     },
     {
       "kind": "interface",
@@ -95765,7 +95870,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L847-L876"
+      "specLocation": "nodes/_types/Stats.ts#L883-L912"
     },
     {
       "kind": "interface",
@@ -95823,7 +95928,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L878-L895"
+      "specLocation": "nodes/_types/Stats.ts#L914-L931"
     },
     {
       "kind": "interface",
@@ -95857,7 +95962,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L897-L906"
+      "specLocation": "nodes/_types/Stats.ts#L933-L942"
     },
     {
       "kind": "interface",
@@ -95922,7 +96027,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L945-L951"
+      "specLocation": "nodes/_types/Stats.ts#L981-L987"
     },
     {
       "kind": "interface",
@@ -96058,7 +96163,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L539-L548"
+      "specLocation": "nodes/_types/Stats.ts#L575-L584"
     },
     {
       "inherits": {
@@ -96098,7 +96203,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L622-L631"
+      "specLocation": "nodes/_types/Stats.ts#L658-L667"
     },
     {
       "kind": "interface",
@@ -96222,7 +96327,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L596-L620"
+      "specLocation": "nodes/_types/Stats.ts#L632-L656"
     },
     {
       "kind": "interface",
@@ -96268,7 +96373,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L461-L474"
+      "specLocation": "nodes/_types/Stats.ts#L497-L510"
     },
     {
       "kind": "interface",
@@ -96311,7 +96416,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L476-L485"
+      "specLocation": "nodes/_types/Stats.ts#L512-L521"
     },
     {
       "kind": "interface",
@@ -96369,7 +96474,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L487-L504"
+      "specLocation": "nodes/_types/Stats.ts#L523-L540"
     },
     {
       "kind": "interface",
@@ -96424,7 +96529,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L506-L519"
+      "specLocation": "nodes/_types/Stats.ts#L542-L555"
     },
     {
       "kind": "interface",
@@ -96470,7 +96575,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L521-L537"
+      "specLocation": "nodes/_types/Stats.ts#L557-L573"
     },
     {
       "kind": "interface",
@@ -96540,7 +96645,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L953-L975"
+      "specLocation": "nodes/_types/Stats.ts#L989-L1011"
     },
     {
       "kind": "interface",
@@ -96623,7 +96728,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L977-L995"
+      "specLocation": "nodes/_types/Stats.ts#L1013-L1031"
     },
     {
       "kind": "interface",
@@ -96677,7 +96782,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L997-L1002"
+      "specLocation": "nodes/_types/Stats.ts#L1033-L1038"
     },
     {
       "kind": "interface",
@@ -96734,7 +96839,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L1031-L1045"
+      "specLocation": "nodes/_types/Stats.ts#L1067-L1081"
     },
     {
       "kind": "interface",
@@ -96816,7 +96921,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L1004-L1029"
+      "specLocation": "nodes/_types/Stats.ts#L1040-L1065"
     },
     {
       "kind": "interface",
@@ -96952,7 +97057,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L1047-L1090"
+      "specLocation": "nodes/_types/Stats.ts#L1083-L1126"
     },
     {
       "kind": "interface",
@@ -96998,7 +97103,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L1092-L1106"
+      "specLocation": "nodes/_types/Stats.ts#L1128-L1142"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16182,16 +16182,25 @@ export interface NodesIndexingPressureMemory {
 }
 
 export interface NodesIngest {
-  pipelines?: Record<string, NodesIngestTotal>
+  pipelines?: Record<string, NodesIngestStats>
   total?: NodesIngestTotal
 }
 
+export interface NodesIngestStats {
+  count: long
+  current: long
+  failed: long
+  processors: Record<string, NodesKeyedProcessor>[]
+  time_in_millis: DurationValue<UnitMillis>
+  ingested_as_first_pipeline_in_bytes: long
+  produced_as_first_pipeline_in_bytes: long
+}
+
 export interface NodesIngestTotal {
-  count?: long
-  current?: long
-  failed?: long
-  processors?: Record<string, NodesKeyedProcessor>[]
-  time_in_millis?: DurationValue<UnitMillis>
+  count: long
+  current: long
+  failed: long
+  time_in_millis: DurationValue<UnitMillis>
 }
 
 export interface NodesIoStatDevice {

--- a/specification/nodes/_types/Stats.ts
+++ b/specification/nodes/_types/Stats.ts
@@ -346,34 +346,70 @@ export class Ingest {
   /**
    * Contains statistics about ingest pipelines for the node.
    */
-  pipelines?: Dictionary<string, IngestTotal>
+  pipelines?: Dictionary<string, IngestStats>
   /**
    * Contains statistics about ingest operations for the node.
    */
   total?: IngestTotal
 }
 
+export class IngestStats {
+  /**
+   * Total number of documents ingested during the lifetime of this node.
+   */
+  count: long
+  /**
+   * Total number of documents currently being ingested.
+   */
+  current: long
+  /**
+   * Total number of failed ingest operations during the lifetime of this node.
+   */
+  failed: long
+  /**
+   * Total number of ingest processors.
+   */
+  processors: Dictionary<string, KeyedProcessor>[]
+  /**
+   * Total time, in milliseconds, spent preprocessing ingest documents during the lifetime of this node.
+   */
+  time_in_millis: DurationValue<UnitMillis>
+  /**
+   * Total number of bytes of all documents ingested by the pipeline.
+   * This field is only present on pipelines which are the first to process a document.
+   * Thus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.
+   * @availability stack since=8.15.0 stability=stable
+   * @availability serverless
+   */
+  ingested_as_first_pipeline_in_bytes: long
+  /**
+   * Total number of bytes of all documents produced by the pipeline.
+   * This field is only present on pipelines which are the first to process a document.
+   * Thus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after a reroute processor, or pipelines in pipeline processors.
+   * In situations where there are subsequent pipelines, the value represents the size of the document after all pipelines have run.
+   * @availability stack since=8.15.0 stability=stable
+   * @availability serverless
+   */
+  produced_as_first_pipeline_in_bytes: long
+}
+
 export class IngestTotal {
   /**
    * Total number of documents ingested during the lifetime of this node.
    */
-  count?: long
+  count: long
   /**
    * Total number of documents currently being ingested.
    */
-  current?: long
+  current: long
   /**
    * Total number of failed ingest operations during the lifetime of this node.
    */
-  failed?: long
-  /**
-   * Total number of ingest processors.
-   */
-  processors?: Dictionary<string, KeyedProcessor>[]
+  failed: long
   /**
    * Total time, in milliseconds, spent preprocessing ingest documents during the lifetime of this node.
    */
-  time_in_millis?: DurationValue<UnitMillis>
+  time_in_millis: DurationValue<UnitMillis>
 }
 
 export class KeyedProcessor {


### PR DESCRIPTION
Splitting IngestTotal in two allowed me to remove all optional fields. I have no idea if this can break typed clients or not.