### PR TITLE
Add HTTP routes to cluster/nodes stats

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -62811,8 +62811,19 @@
             "items": {
               "$ref": "#/components/schemas/nodes._types:Client"
             }
+          },
+          "routes": {
+            "description": "Detailed HTTP stats broken down by route",
+            "x-available-since": "8.12.0",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/nodes._types:HttpRoute"
+            }
           }
-        }
+        },
+        "required": [
+          "routes"
+        ]
       },
       "nodes._types:Client": {
         "type": "object",
@@ -62862,6 +62873,106 @@
             "type": "string"
           }
         }
+      },
+      "nodes._types:HttpRoute": {
+        "type": "object",
+        "properties": {
+          "requests": {
+            "$ref": "#/components/schemas/nodes._types:HttpRouteRequests"
+          },
+          "responses": {
+            "$ref": "#/components/schemas/nodes._types:HttpRouteResponses"
+          }
+        },
+        "required": [
+          "requests",
+          "responses"
+        ]
+      },
+      "nodes._types:HttpRouteRequests": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "number"
+          },
+          "total_size_in_bytes": {
+            "type": "number"
+          },
+          "size_histogram": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/nodes._types:SizeHttpHistogram"
+            }
+          }
+        },
+        "required": [
+          "count",
+          "total_size_in_bytes",
+          "size_histogram"
+        ]
+      },
+      "nodes._types:SizeHttpHistogram": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "number"
+          },
+          "ge_bytes": {
+            "type": "number"
+          },
+          "lt_bytes": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "count"
+        ]
+      },
+      "nodes._types:HttpRouteResponses": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "number"
+          },
+          "total_size_in_bytes": {
+            "type": "number"
+          },
+          "handling_time_histogram": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/nodes._types:TimeHttpHistogram"
+            }
+          },
+          "size_histogram": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/nodes._types:SizeHttpHistogram"
+            }
+          }
+        },
+        "required": [
+          "count",
+          "total_size_in_bytes",
+          "handling_time_histogram",
+          "size_histogram"
+        ]
+      },
+      "nodes._types:TimeHttpHistogram": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "number"
+          },
+          "ge_millis": {
+            "type": "number"
+          },
+          "lt_millis": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "count"
+        ]
       },
       "nodes._types:Ingest": {
         "type": "object",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -94524,7 +94524,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L734-L752"
+      "specLocation": "nodes/_types/Stats.ts#L770-L788"
     },
     {
       "kind": "interface",
@@ -94801,7 +94801,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L793-L822"
+      "specLocation": "nodes/_types/Stats.ts#L829-L858"
     },
     {
       "kind": "interface",
@@ -94838,7 +94838,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L754-L764"
+      "specLocation": "nodes/_types/Stats.ts#L790-L800"
     },
     {
       "kind": "interface",
@@ -94920,7 +94920,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L766-L791"
+      "specLocation": "nodes/_types/Stats.ts#L802-L827"
     },
     {
       "kind": "interface",
@@ -94969,7 +94969,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L669-L683"
+      "specLocation": "nodes/_types/Stats.ts#L669-L688"
     },
     {
       "kind": "interface",
@@ -95111,7 +95111,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L685-L732"
+      "specLocation": "nodes/_types/Stats.ts#L721-L768"
     },
     {
       "kind": "interface",
@@ -95570,7 +95570,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L847-L881"
+      "specLocation": "nodes/_types/Stats.ts#L883-L917"
     },
     {
       "kind": "interface",
@@ -95640,7 +95640,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L824-L845"
+      "specLocation": "nodes/_types/Stats.ts#L860-L881"
     },
     {
       "kind": "interface",
@@ -95686,7 +95686,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L944-L957"
+      "specLocation": "nodes/_types/Stats.ts#L980-L993"
     },
     {
       "kind": "interface",
@@ -95719,7 +95719,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L959-L964"
+      "specLocation": "nodes/_types/Stats.ts#L995-L1000"
     },
     {
       "kind": "interface",
@@ -95765,7 +95765,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L966-L979"
+      "specLocation": "nodes/_types/Stats.ts#L1002-L1015"
     },
     {
       "kind": "interface",
@@ -95870,7 +95870,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L883-L912"
+      "specLocation": "nodes/_types/Stats.ts#L919-L948"
     },
     {
       "kind": "interface",
@@ -95928,7 +95928,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L914-L931"
+      "specLocation": "nodes/_types/Stats.ts#L950-L967"
     },
     {
       "kind": "interface",
@@ -95962,7 +95962,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L933-L942"
+      "specLocation": "nodes/_types/Stats.ts#L969-L978"
     },
     {
       "kind": "interface",
@@ -96027,7 +96027,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L981-L987"
+      "specLocation": "nodes/_types/Stats.ts#L1017-L1023"
     },
     {
       "kind": "interface",
@@ -96645,7 +96645,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L989-L1011"
+      "specLocation": "nodes/_types/Stats.ts#L1025-L1047"
     },
     {
       "kind": "interface",
@@ -96728,7 +96728,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L1013-L1031"
+      "specLocation": "nodes/_types/Stats.ts#L1049-L1067"
     },
     {
       "kind": "interface",
@@ -96782,7 +96782,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L1033-L1038"
+      "specLocation": "nodes/_types/Stats.ts#L1069-L1074"
     },
     {
       "kind": "interface",
@@ -96839,7 +96839,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L1067-L1081"
+      "specLocation": "nodes/_types/Stats.ts#L1103-L1117"
     },
     {
       "kind": "interface",
@@ -96921,7 +96921,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L1040-L1065"
+      "specLocation": "nodes/_types/Stats.ts#L1076-L1101"
     },
     {
       "kind": "interface",
@@ -97057,7 +97057,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L1083-L1126"
+      "specLocation": "nodes/_types/Stats.ts#L1119-L1162"
     },
     {
       "kind": "interface",
@@ -97103,7 +97103,7 @@
           }
         }
       ],
-      "specLocation": "nodes/_types/Stats.ts#L1128-L1142"
+      "specLocation": "nodes/_types/Stats.ts#L1164-L1178"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16168,6 +16168,25 @@ export interface NodesHttp {
   current_open?: integer
   total_opened?: long
   clients?: NodesClient[]
+  routes: Record<string, NodesHttpRoute>
+}
+
+export interface NodesHttpRoute {
+  requests: NodesHttpRouteRequests
+  responses: NodesHttpRouteResponses
+}
+
+export interface NodesHttpRouteRequests {
+  count: long
+  total_size_in_bytes: long
+  size_histogram: NodesSizeHttpHistogram[]
+}
+
+export interface NodesHttpRouteResponses {
+  count: long
+  total_size_in_bytes: long
+  handling_time_histogram: NodesTimeHttpHistogram[]
+  size_histogram: NodesSizeHttpHistogram[]
 }
 
 export interface NodesIndexingPressure {
@@ -16405,6 +16424,12 @@ export interface NodesSerializedClusterStateDetail {
   compressed_size_in_bytes?: long
 }
 
+export interface NodesSizeHttpHistogram {
+  count: long
+  ge_bytes?: long
+  lt_bytes?: long
+}
+
 export interface NodesStats {
   adaptive_selection?: Record<string, NodesAdaptiveSelection>
   breakers?: Record<string, NodesBreaker>
@@ -16437,6 +16462,12 @@ export interface NodesThreadCount {
   queue?: long
   rejected?: long
   threads?: long
+}
+
+export interface NodesTimeHttpHistogram {
+  count: long
+  ge_millis?: long
+  lt_millis?: long
 }
 
 export interface NodesTransport {

--- a/specification/nodes/_types/Stats.ts
+++ b/specification/nodes/_types/Stats.ts
@@ -680,6 +680,41 @@ export class Http {
    * Clients that have been closed longer than the `http.client_stats.closed_channels.max_age` setting will not be represented here.
    */
   clients?: Client[]
+  /**
+   * Detailed HTTP stats broken down by route
+   * @availability stack since=8.12.0 stability=stable
+   */
+  routes: Dictionary<string, HttpRoute>
+}
+
+export class HttpRoute {
+  requests: HttpRouteRequests
+  responses: HttpRouteResponses
+}
+
+export class HttpRouteRequests {
+  count: long
+  total_size_in_bytes: long
+  size_histogram: SizeHttpHistogram[]
+}
+
+export class HttpRouteResponses {
+  count: long
+  total_size_in_bytes: long
+  handling_time_histogram: TimeHttpHistogram[]
+  size_histogram: SizeHttpHistogram[]
+}
+
+export class TimeHttpHistogram {
+  count: long
+  ge_millis?: long
+  lt_millis?: long
+}
+
+export class SizeHttpHistogram {
+  count: long
+  ge_bytes?: long
+  lt_bytes?: long
 }
 
 export class Client {


### PR DESCRIPTION
This was added in https://github.com/elastic/elasticsearch/pull/99852. The `toXContent` code is fairly easy to follow in [HttpRouteStats.java](https://github.com/elastic/elasticsearch/blob/v8.15.1/server/src/main/java/org/elasticsearch/http/HttpRouteStats.java).

This also happens to fix the cluster.info API.