### PR TITLE
Fix get field mapping API response

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -60539,9 +60539,6 @@
               "copy_to": {
                 "$ref": "#/components/schemas/_types:Fields"
               },
-              "similarity": {
-                "type": "string"
-              },
               "store": {
                 "type": "boolean"
               }
@@ -60687,7 +60684,15 @@
                 "type": "boolean"
               },
               "index_prefixes": {
-                "$ref": "#/components/schemas/_types.mapping:TextIndexPrefixes"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/_types.mapping:TextIndexPrefixes"
+                  },
+                  {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                ]
               },
               "norms": {
                 "type": "boolean"
@@ -60848,6 +60853,17 @@
               "null_value": {
                 "type": "string"
               },
+              "similarity": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                ]
+              },
               "split_queries_on_whitespace": {
                 "type": "boolean"
               },
@@ -61004,6 +61020,17 @@
               "search_quote_analyzer": {
                 "type": "string"
               },
+              "similarity": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                ]
+              },
               "term_vector": {
                 "$ref": "#/components/schemas/_types.mapping:TermVectorOption"
               },
@@ -61053,7 +61080,15 @@
                 "type": "boolean"
               },
               "index_prefixes": {
-                "$ref": "#/components/schemas/_types.mapping:TextIndexPrefixes"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/_types.mapping:TextIndexPrefixes"
+                  },
+                  {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                ]
               },
               "norms": {
                 "type": "boolean"
@@ -61066,6 +61101,17 @@
               },
               "search_quote_analyzer": {
                 "type": "string"
+              },
+              "similarity": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                ]
               },
               "term_vector": {
                 "$ref": "#/components/schemas/_types.mapping:TermVectorOption"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -41393,9 +41393,6 @@
               "copy_to": {
                 "$ref": "#/components/schemas/_types:Fields"
               },
-              "similarity": {
-                "type": "string"
-              },
               "store": {
                 "type": "boolean"
               }
@@ -41541,7 +41538,15 @@
                 "type": "boolean"
               },
               "index_prefixes": {
-                "$ref": "#/components/schemas/_types.mapping:TextIndexPrefixes"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/_types.mapping:TextIndexPrefixes"
+                  },
+                  {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                ]
               },
               "norms": {
                 "type": "boolean"
@@ -41702,6 +41707,17 @@
               "null_value": {
                 "type": "string"
               },
+              "similarity": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                ]
+              },
               "split_queries_on_whitespace": {
                 "type": "boolean"
               },
@@ -41858,6 +41874,17 @@
               "search_quote_analyzer": {
                 "type": "string"
               },
+              "similarity": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                ]
+              },
               "term_vector": {
                 "$ref": "#/components/schemas/_types.mapping:TermVectorOption"
               },
@@ -41907,7 +41934,15 @@
                 "type": "boolean"
               },
               "index_prefixes": {
-                "$ref": "#/components/schemas/_types.mapping:TextIndexPrefixes"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/_types.mapping:TextIndexPrefixes"
+                  },
+                  {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                ]
               },
               "norms": {
                 "type": "boolean"
@@ -41920,6 +41955,17 @@
               },
               "search_quote_analyzer": {
                 "type": "string"
+              },
+              "similarity": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "nullable": true,
+                    "type": "string"
+                  }
+                ]
               },
               "term_vector": {
                 "$ref": "#/components/schemas/_types.mapping:TermVectorOption"

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -84899,7 +84899,7 @@
         "name": "IndexOptions",
         "namespace": "_types.mapping"
       },
-      "specLocation": "_types/mapping/core.ts#L257-L262"
+      "specLocation": "_types/mapping/core.ts#L258-L263"
     },
     {
       "kind": "enum",
@@ -85317,7 +85317,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L55-L57"
+      "specLocation": "_types/mapping/core.ts#L54-L56"
     },
     {
       "inherits": {
@@ -85344,7 +85344,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L51-L53"
+      "specLocation": "_types/mapping/core.ts#L50-L52"
     },
     {
       "inherits": {
@@ -85371,17 +85371,6 @@
           }
         },
         {
-          "name": "similarity",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
           "name": "store",
           "required": false,
           "type": {
@@ -85393,7 +85382,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L45-L49"
+      "specLocation": "_types/mapping/core.ts#L45-L48"
     },
     {
       "kind": "interface",
@@ -85562,7 +85551,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L59-L65"
+      "specLocation": "_types/mapping/core.ts#L58-L64"
     },
     {
       "kind": "interface",
@@ -85769,11 +85758,23 @@
           "name": "index_prefixes",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "TextIndexPrefixes",
-              "namespace": "_types.mapping"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "TextIndexPrefixes",
+                  "namespace": "_types.mapping"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "null",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
@@ -85865,7 +85866,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L300-L331"
+      "specLocation": "_types/mapping/core.ts#L302-L333"
     },
     {
       "kind": "enum",
@@ -85922,7 +85923,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L264-L267"
+      "specLocation": "_types/mapping/core.ts#L265-L268"
     },
     {
       "kind": "enum",
@@ -86025,7 +86026,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L89-L93"
+      "specLocation": "_types/mapping/core.ts#L88-L92"
     },
     {
       "inherits": {
@@ -86140,6 +86141,29 @@
           }
         },
         {
+          "name": "similarity",
+          "required": false,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "_builtins"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "null",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
+          }
+        },
+        {
           "name": "split_queries_on_whitespace",
           "required": false,
           "type": {
@@ -86179,7 +86203,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L95-L113"
+      "specLocation": "_types/mapping/core.ts#L94-L113"
     },
     {
       "description": "A variant of text that trades scoring and efficiency of positional queries for space efficiency. This field\neffectively stores data the same way as a text field that only indexes documents (index_options: docs) and\ndisables norms (norms: false). Term queries perform as fast if not faster as on text fields, however queries\nthat need positions such as the match_phrase query perform slower as they need to look at the _source document\nto verify whether a phrase matches. All queries return constant scores that are equal to 1.0.",
@@ -86260,7 +86284,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L230-L255"
+      "specLocation": "_types/mapping/core.ts#L231-L256"
     },
     {
       "inherits": {
@@ -86447,6 +86471,29 @@
           }
         },
         {
+          "name": "similarity",
+          "required": false,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "_builtins"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "null",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
+          }
+        },
+        {
           "name": "term_vector",
           "required": false,
           "type": {
@@ -86466,7 +86513,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L212-L222"
+      "specLocation": "_types/mapping/core.ts#L212-L223"
     },
     {
       "inherits": {
@@ -86573,11 +86620,23 @@
           "name": "index_prefixes",
           "required": false,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "TextIndexPrefixes",
-              "namespace": "_types.mapping"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "TextIndexPrefixes",
+                  "namespace": "_types.mapping"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "null",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
@@ -86625,6 +86684,29 @@
           }
         },
         {
+          "name": "similarity",
+          "required": false,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "_builtins"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "null",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
+          }
+        },
+        {
           "name": "term_vector",
           "required": false,
           "type": {
@@ -86644,7 +86726,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L269-L285"
+      "specLocation": "_types/mapping/core.ts#L270-L287"
     },
     {
       "kind": "interface",
@@ -86711,7 +86793,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L287-L289"
+      "specLocation": "_types/mapping/core.ts#L289-L291"
     },
     {
       "inherits": {
@@ -86752,7 +86834,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L291-L298"
+      "specLocation": "_types/mapping/core.ts#L293-L300"
     },
     {
       "inherits": {
@@ -86842,7 +86924,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L79-L87"
+      "specLocation": "_types/mapping/core.ts#L78-L86"
     },
     {
       "inherits": {
@@ -86954,7 +87036,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/core.ts#L67-L77"
+      "specLocation": "_types/mapping/core.ts#L66-L76"
     },
     {
       "inherits": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5281,7 +5281,6 @@ export interface MappingConstantKeywordProperty extends MappingPropertyBase {
 
 export interface MappingCorePropertyBase extends MappingPropertyBase {
   copy_to?: Fields
-  similarity?: string
   store?: boolean
 }
 
@@ -5362,7 +5361,7 @@ export interface MappingDynamicProperty extends MappingDocValuesPropertyBase {
   index?: boolean
   index_options?: MappingIndexOptions
   index_phrases?: boolean
-  index_prefixes?: MappingTextIndexPrefixes
+  index_prefixes?: MappingTextIndexPrefixes | null
   norms?: boolean
   position_increment_gap?: integer
   search_analyzer?: string
@@ -5522,6 +5521,7 @@ export interface MappingKeywordProperty extends MappingDocValuesPropertyBase {
   normalizer?: string
   norms?: boolean
   null_value?: string
+  similarity?: string | null
   split_queries_on_whitespace?: boolean
   time_series_dimension?: boolean
   type: 'keyword'
@@ -5650,6 +5650,7 @@ export interface MappingSearchAsYouTypeProperty extends MappingCorePropertyBase 
   norms?: boolean
   search_analyzer?: string
   search_quote_analyzer?: string
+  similarity?: string | null
   term_vector?: MappingTermVectorOption
   type: 'search_as_you_type'
 }
@@ -5715,11 +5716,12 @@ export interface MappingTextProperty extends MappingCorePropertyBase {
   index?: boolean
   index_options?: MappingIndexOptions
   index_phrases?: boolean
-  index_prefixes?: MappingTextIndexPrefixes
+  index_prefixes?: MappingTextIndexPrefixes | null
   norms?: boolean
   position_increment_gap?: integer
   search_analyzer?: string
   search_quote_analyzer?: string
+  similarity?: string | null
   term_vector?: MappingTermVectorOption
   type: 'text'
 }

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -44,7 +44,6 @@ import { TimeSeriesMetricType } from './TimeSeriesMetricType'
 
 export class CorePropertyBase extends PropertyBase {
   copy_to?: Fields
-  similarity?: string
   store?: boolean
 }
 
@@ -102,6 +101,7 @@ export class KeywordProperty extends DocValuesPropertyBase {
   normalizer?: string
   norms?: boolean
   null_value?: string
+  similarity?: string | null
   split_queries_on_whitespace?: boolean
   /**
    * For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.
@@ -217,6 +217,7 @@ export class SearchAsYouTypeProperty extends CorePropertyBase {
   norms?: boolean
   search_analyzer?: string
   search_quote_analyzer?: string
+  similarity?: string | null
   term_vector?: TermVectorOption
   type: 'search_as_you_type'
 }
@@ -275,11 +276,12 @@ export class TextProperty extends CorePropertyBase {
   index?: boolean
   index_options?: IndexOptions
   index_phrases?: boolean
-  index_prefixes?: TextIndexPrefixes
+  index_prefixes?: TextIndexPrefixes | null
   norms?: boolean
   position_increment_gap?: integer
   search_analyzer?: string
   search_quote_analyzer?: string
+  similarity?: string | null
   term_vector?: TermVectorOption
   type: 'text'
 }
@@ -317,7 +319,7 @@ export class DynamicProperty extends DocValuesPropertyBase {
   index?: boolean
   index_options?: IndexOptions
   index_phrases?: boolean
-  index_prefixes?: TextIndexPrefixes
+  index_prefixes?: TextIndexPrefixes | null
   norms?: boolean
   position_increment_gap?: integer
   search_analyzer?: string


### PR DESCRIPTION
The [default value](https://github.com/elastic/elasticsearch/blob/8e289f2b10f86959393b43bbf6c77abeb3a12622/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java#L274-L277) of the indexPrefixes [Parameter](https://github.com/elastic/elasticsearch/blob/8e289f2b10f86959393b43bbf6c77abeb3a12622/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java#L764-L785) is null, which is what gets returned with the `include_defaults` parameter.

I'm not sure why `similarity` can be null (other than seeing it in a YAML test), but I did notice that https://github.com/elastic/elasticsearch/pull/58439 (shipped to 8.0) moved it so that it only applies to text, keyword and search as you type.