### PR TITLE
Fix make validate generation

### DIFF
--- a/compiler/run-validations.js
+++ b/compiler/run-validations.js
@@ -49,7 +49,7 @@ const uploadRecordingsPath = path.join(__dirname, '..', '..', 'clients-flight-re
 const tsValidationPath = path.join(__dirname, '..', '..', 'clients-flight-recorder', 'scripts', 'types-validator')
 const DAY = 1000 * 60 * 60 * 24
 const specPath = path.join(__dirname, '..', 'specification')
-const outputPath = path.join(__dirname, '..', 'output/schema')
+const outputPath = path.join(__dirname, '..', 'output')
 
 const apis = require('../output/schema/schema.json')
   .endpoints


### PR DESCRIPTION
Without this fix, `make validate` does not take into account specification changes as it was generating them in the wrong directory. (You can check that this is the correct directory in the Makefile.) This is also why we had to add output/schema/schema to the .gitignore file.