### PR TITLE
Add minimum_should_match to terms_set

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -46869,6 +46869,9 @@
           {
             "type": "object",
             "properties": {
+              "minimum_should_match": {
+                "$ref": "#/components/schemas/_types:MinimumShouldMatch"
+              },
               "minimum_should_match_field": {
                 "$ref": "#/components/schemas/_types:Field"
               },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -30149,6 +30149,9 @@
           {
             "type": "object",
             "properties": {
+              "minimum_should_match": {
+                "$ref": "#/components/schemas/_types:MinimumShouldMatch"
+              },
               "minimum_should_match_field": {
                 "$ref": "#/components/schemas/_types:Field"
               },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -49046,7 +49046,7 @@
           }
         }
       ],
-      "specLocation": "_types/query_dsl/term.ts#L37-L42"
+      "specLocation": "_types/query_dsl/term.ts#L38-L43"
     },
     {
       "inherits": {
@@ -50103,7 +50103,7 @@
         }
       ],
       "shortcutProperty": "value",
-      "specLocation": "_types/query_dsl/term.ts#L44-L79"
+      "specLocation": "_types/query_dsl/term.ts#L45-L80"
     },
     {
       "docId": "query-dsl-multi-term-rewrite",
@@ -53036,7 +53036,7 @@
           }
         }
       ],
-      "specLocation": "_types/query_dsl/term.ts#L81-L86"
+      "specLocation": "_types/query_dsl/term.ts#L82-L87"
     },
     {
       "kind": "type_alias",
@@ -55630,7 +55630,7 @@
         }
       ],
       "shortcutProperty": "value",
-      "specLocation": "_types/query_dsl/term.ts#L88-L107"
+      "specLocation": "_types/query_dsl/term.ts#L89-L108"
     },
     {
       "inherits": {
@@ -56000,7 +56000,7 @@
         "name": "RangeQuery",
         "namespace": "_types.query_dsl"
       },
-      "specLocation": "_types/query_dsl/term.ts#L161-L170",
+      "specLocation": "_types/query_dsl/term.ts#L162-L171",
       "type": {
         "items": [
           {
@@ -56085,7 +56085,7 @@
           }
         }
       ],
-      "specLocation": "_types/query_dsl/term.ts#L135-L144"
+      "specLocation": "_types/query_dsl/term.ts#L136-L145"
     },
     {
       "generics": [
@@ -56214,7 +56214,7 @@
           }
         }
       ],
-      "specLocation": "_types/query_dsl/term.ts#L109-L133"
+      "specLocation": "_types/query_dsl/term.ts#L110-L134"
     },
     {
       "kind": "enum",
@@ -56236,7 +56236,7 @@
         "name": "RangeRelation",
         "namespace": "_types.query_dsl"
       },
-      "specLocation": "_types/query_dsl/term.ts#L172-L185"
+      "specLocation": "_types/query_dsl/term.ts#L173-L186"
     },
     {
       "docId": "mapping-date-format",
@@ -56302,7 +56302,7 @@
           }
         }
       ],
-      "specLocation": "_types/query_dsl/term.ts#L146-L155"
+      "specLocation": "_types/query_dsl/term.ts#L147-L156"
     },
     {
       "inherits": {
@@ -56326,7 +56326,7 @@
         "namespace": "_types.query_dsl"
       },
       "properties": [],
-      "specLocation": "_types/query_dsl/term.ts#L157-L157"
+      "specLocation": "_types/query_dsl/term.ts#L158-L158"
     },
     {
       "inherits": {
@@ -56350,7 +56350,7 @@
         "namespace": "_types.query_dsl"
       },
       "properties": [],
-      "specLocation": "_types/query_dsl/term.ts#L159-L159"
+      "specLocation": "_types/query_dsl/term.ts#L160-L160"
     },
     {
       "inherits": {
@@ -56637,7 +56637,7 @@
         }
       ],
       "shortcutProperty": "value",
-      "specLocation": "_types/query_dsl/term.ts#L187-L217"
+      "specLocation": "_types/query_dsl/term.ts#L188-L218"
     },
     {
       "inherits": {
@@ -57927,7 +57927,7 @@
         }
       ],
       "shortcutProperty": "value",
-      "specLocation": "_types/query_dsl/term.ts#L219-L233"
+      "specLocation": "_types/query_dsl/term.ts#L220-L234"
     },
     {
       "codegenNames": [
@@ -58033,7 +58033,7 @@
         "namespace": "_types.query_dsl"
       },
       "properties": [],
-      "specLocation": "_types/query_dsl/term.ts#L235-L240"
+      "specLocation": "_types/query_dsl/term.ts#L236-L241"
     },
     {
       "codegenNames": [
@@ -58045,7 +58045,7 @@
         "name": "TermsQueryField",
         "namespace": "_types.query_dsl"
       },
-      "specLocation": "_types/query_dsl/term.ts#L242-L245",
+      "specLocation": "_types/query_dsl/term.ts#L243-L246",
       "type": {
         "items": [
           {
@@ -58121,7 +58121,7 @@
           }
         }
       ],
-      "specLocation": "_types/query_dsl/term.ts#L247-L252"
+      "specLocation": "_types/query_dsl/term.ts#L248-L253"
     },
     {
       "inherits": {
@@ -58136,6 +58136,24 @@
         "namespace": "_types.query_dsl"
       },
       "properties": [
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.10.0"
+            }
+          },
+          "description": "Specification describing number of matching terms required to return a document.",
+          "name": "minimum_should_match",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "MinimumShouldMatch",
+              "namespace": "_types"
+            }
+          }
+        },
         {
           "description": "Numeric field containing the number of matching terms required to return a document.",
           "name": "minimum_should_match_field",
@@ -58176,7 +58194,7 @@
           }
         }
       ],
-      "specLocation": "_types/query_dsl/term.ts#L254-L267"
+      "specLocation": "_types/query_dsl/term.ts#L255-L274"
     },
     {
       "inherits": {
@@ -58361,7 +58379,7 @@
         }
       ],
       "shortcutProperty": "value",
-      "specLocation": "_types/query_dsl/term.ts#L273-L290"
+      "specLocation": "_types/query_dsl/term.ts#L280-L297"
     },
     {
       "inherits": {
@@ -58416,7 +58434,7 @@
           }
         }
       ],
-      "specLocation": "_types/query_dsl/term.ts#L269-L271"
+      "specLocation": "_types/query_dsl/term.ts#L276-L278"
     },
     {
       "inherits": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6515,6 +6515,7 @@ export type QueryDslTermsQuery = QueryDslTermsQueryKeys
 export type QueryDslTermsQueryField = FieldValue[] | QueryDslTermsLookup
 
 export interface QueryDslTermsSetQuery extends QueryDslQueryBase {
+  minimum_should_match?: MinimumShouldMatch
   minimum_should_match_field?: Field
   minimum_should_match_script?: Script | string
   terms: string[]

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -255,6 +255,8 @@ export class TermsLookup {
 export class TermsSetQuery extends QueryBase {
   /**
    * Specification describing number of matching terms required to return a document.
+   * @availability stack since=8.10.0
+   * @availability serverless
    */
   minimum_should_match?: MinimumShouldMatch
   /**

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -26,6 +26,7 @@ import {
   Id,
   Ids,
   IndexName,
+  MinimumShouldMatch,
   MultiTermQueryRewrite,
   Routing
 } from '@_types/common'
@@ -252,6 +253,10 @@ export class TermsLookup {
 }
 
 export class TermsSetQuery extends QueryBase {
+  /**
+   * Specification describing number of matching terms required to return a document.
+   */
+  minimum_should_match?: MinimumShouldMatch
   /**
    * Numeric field containing the number of matching terms required to return a document.
    */


### PR DESCRIPTION
Elasticsearch has supported the `minimum_should_match` parameter to `terms_set` since 8.10.0 (see https://github.com/elastic/elasticsearch/pull/96082), but it is not reflected here, so the parameter is not exposed in the autogenerated clients.

Closes https://github.com/elastic/elasticsearch-specification/pull/2908