### PR TITLE
Add overlay for query object in ML datafeed_config

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -40,4 +40,20 @@ actions:
               examples:
                 resetFeaturesResponseExample1:
                   $ref: "../../specification/features/reset_features/ResetFeaturesResponseExample1.json"
-    
+ # Remove and annotate items that are not shown in Bump.sh due to depth limits  
+  - target: "$.components['schemas']['ml._types:Datafeed'].properties.query"
+    remove: true
+  - target: "$.components['schemas']['ml._types:Datafeed'].properties"
+    description: Re-add a simplified query object
+    update:
+      query:
+        x-abbreviated: true
+        type: object
+        description: >
+          The Elasticsearch query domain-specific language (DSL).
+          This value corresponds to the query object in an Elasticsearch search POST body.
+          All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch.
+          By default, this property has the following value: {"match_all": {"boost": 1}}.
+        externalDocs:
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+          description: Query DSL

--- a/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
@@ -28,3 +28,21 @@ actions:
     description: Add x-beta
     update:
       x-beta: true
+  # Remove and annotate items that are not shown in Bump.sh due to depth limits
+  - target: "$.components['schemas']['ml._types:Datafeed'].properties.query"
+    remove: true
+  - target: "$.components['schemas']['ml._types:Datafeed'].properties"
+    description: Re-add a simplified query object
+    update:
+      query:
+        x-abbreviated: true
+        type: object
+        description: >
+          The Elasticsearch query domain-specific language (DSL).
+          This value corresponds to the query object in an Elasticsearch search POST body.
+          All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch.
+          By default, this property has the following value: {"match_all": {"boost": 1}}.
+        externalDocs:
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+          description: Query DSL
+        


### PR DESCRIPTION
This PR adds overlays that address the following errors that appear when deploying documents in Bump.sh:

```
“09:13:35 PM Rendering of the API documentation will be limited to a max depth of 11.”
...
09:13:35 PM Ml > Create an anomaly detection job > Request Body (application/json); datafeed_config.query.span_containing...; has 28 hidden branches, e.g.; datafeed_config.query.span_containing.span_field_masking
09:13:35 PM Ml > Create an anomaly detection job > Request Body (application/json); datafeed_config.query.pinned...; has 1 hidden branches, e.g.; datafeed_config.query.pinned.docs[]
09:13:35 PM Ml > Create an anomaly detection job > Request Body (application/json); datafeed_config.query.function_score...; has 2 hidden branches, e.g.; datafeed_config.query.function_score.functions[]
...
```
For now I've overlaid the entire query object within the `ml._types:Datafeed` schema object and replaced it with a description so that it matches what we had in https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-job.html. However, we could potentially overlay only the identified objects within `_types.query_dsl:QueryContainer`, depending on further analysis of where they're re-used.

I've also added an `x-abbreviated: true` property so that we can have an indicator of where the abbreviation occurs.