### PR TITLE
Add minimum_should_match to terms_set

### DIFF
--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -255,6 +255,8 @@ export class TermsLookup {
 export class TermsSetQuery extends QueryBase {
   /**
    * Specification describing number of matching terms required to return a document.
+   * @availability stack since=8.10.0
+   * @availability serverless
    */
   minimum_should_match?: MinimumShouldMatch
   /**

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -26,6 +26,7 @@ import {
   Id,
   Ids,
   IndexName,
+  MinimumShouldMatch,
   MultiTermQueryRewrite,
   Routing
 } from '@_types/common'
@@ -252,6 +253,10 @@ export class TermsLookup {
 }
 
 export class TermsSetQuery extends QueryBase {
+  /**
+   * Specification describing number of matching terms required to return a document.
+   */
+  minimum_should_match?: MinimumShouldMatch
   /**
    * Numeric field containing the number of matching terms required to return a document.
    */


### PR DESCRIPTION
This is simply a trick to get validation to run in https://github.com/elastic/elasticsearch-specification/pull/2901.