### PR TITLE
Add overlay for deep object in security APIs

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -4,14 +4,6 @@ info:
   title: Overlays for changes that apply to both Elasticsearch and Elasticsearch Serverless OpenAPI documents
   version: 0.0.1
 actions:
-# Add x-model to hide children of schema objects that are defined elsewhere
-  - target: "$.components['schemas']['_types.query_dsl:QueryContainer']"
-    description: Add x-model and updated externalDocs for the QueryContainer object
-    update:
-      x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl.html
-        description: Query domain specific language (DSL) reference
 # Add an alphabetically sorted list of tags
   - target: '$'
     description: Add document-level tags sorted by display name
@@ -244,6 +236,13 @@ actions:
         - name: watcher
           x-displayName: Watcher
 # Add x-model and/or abbreviate schemas that should point to other references
+  - target: "$.components['schemas']['_types.query_dsl:QueryContainer']"
+    description: Add x-model and updated externalDocs for the QueryContainer object
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl.html
+        description: Query domain specific language (DSL) reference
   - target: "$.components['schemas']['_types.analysis:CharFilter'].oneOf"
     description: Remove existing oneOf definition for CharFilter
     remove: true
@@ -280,6 +279,13 @@ actions:
       externalDocs:
         url: https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-tokenfilters.html
         description: Token filter reference
+  - target: "$.components['schemas']['security._types:RoleTemplateScript']"
+    description: Add x-model where recommended by Bump.sh
+    update:
+      x-model: true
+      externalDocs:
+        description: Templating a role query
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/field-and-document-access-control.html#templating-role-query
 # Abbreviate and annotate items that are not shown in Bump.sh due to depth limits
   - target: "$.components['schemas']['ml._types:Datafeed'].properties.query"
     description: Remove query object from anomaly detection datafeed
@@ -350,13 +356,6 @@ actions:
         externalDocs:
           url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
           description: Query DSL
-  - target: "$.components['schemas']['security._types:RoleTemplateScript']"
-    description: Add x-model where recommended by Bump.sh
-    update:
-      x-model: true
-      externalDocs:
-        description: Templating a role query
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/field-and-document-access-control.html#templating-role-query
 # Examples
   - target: "$.components['requestBodies']['async_search.submit']"
     description: "Add example for asynch search submit request"

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -281,7 +281,6 @@ actions:
         url: https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-tokenfilters.html
         description: Token filter reference
 # Abbreviate and annotate items that are not shown in Bump.sh due to depth limits
-<<<<<<< HEAD:docs/overlays/elasticsearch-shared-overlays.yaml
   - target: "$.components['schemas']['ml._types:Datafeed'].properties.query"
     description: Remove query object from anomaly detection datafeed
     remove: true
@@ -351,7 +350,6 @@ actions:
         externalDocs:
           url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
           description: Query DSL
-=======
   - target: "$.components['schemas']['security._types:IndicesPrivilegesQuery'].oneOf"
     description: Remove types from security role descriptors indices query
     remove: true
@@ -362,7 +360,45 @@ actions:
       oneOf:
         - type: string
         - type: object
->>>>>>> 295ccb76c (Add overlay for deep objects in security APIs):docs/overlays/elasticsearch-shared-example-overlays.yaml
+  - target: "$.components['schemas']['indices.update_aliases:AddAction'].properties.filter"
+    description: Remove filter from update aliases add action
+    remove: true
+  - target: "$.components['schemas']['indices.update_aliases:AddAction'].properties"
+    description: Re-add simplified filter for update aliases add action
+    update:
+      filter:
+        x-abbreviated: true
+        type: object
+        description: A query used to limit the documents the alias can access. 
+        externalDocs:
+          description: Query DSL
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+  - target: "$.components['requestBodies']['indices.put_alias'].content['application/json'].schema.properties.filter"
+    description: Remove filter from create or update alias
+    remove: true
+  - target: "$.components['requestBodies']['indices.put_alias'].content['application/json'].schema.properties"
+    description: Re-add simplified filter for create or update alias 
+    update:
+      filter:
+        x-abbreviated: true
+        type: object
+        description: A query used to limit the documents the alias can access. 
+        externalDocs:
+          description: Query DSL
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+  - target: "$.components['schemas']['indices._types:AliasDefinition'].properties.filter"
+    description: Remove filter from alias definition
+    remove: true
+  - target: "$.components['schemas']['indices._types:AliasDefinition'].properties"
+    description: Re-add simplified filter for alias definition
+    update:
+      filter:
+        x-abbreviated: true
+        type: object
+        description: A query used to limit the documents the alias can access. 
+        externalDocs:
+          description: Query DSL
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
 # Examples
   - target: "$.components['requestBodies']['async_search.submit']"
     description: "Add example for asynch search submit request"

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -350,55 +350,13 @@ actions:
         externalDocs:
           url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
           description: Query DSL
-  - target: "$.components['schemas']['security._types:IndicesPrivilegesQuery'].oneOf"
-    description: Remove types from security role descriptors indices query
-    remove: true
-  - target: "$.components['schemas']['security._types:IndicesPrivilegesQuery']"
-    description: Re-add simplified types for security role descriptors indices query
+  - target: "$.components['schemas']['security._types:RoleTemplateScript']"
+    description: Add x-model where recommended by Bump.sh
     update:
-      x-abbreviated: true
-      oneOf:
-        - type: string
-        - type: object
-  - target: "$.components['schemas']['indices.update_aliases:AddAction'].properties.filter"
-    description: Remove filter from update aliases add action
-    remove: true
-  - target: "$.components['schemas']['indices.update_aliases:AddAction'].properties"
-    description: Re-add simplified filter for update aliases add action
-    update:
-      filter:
-        x-abbreviated: true
-        type: object
-        description: A query used to limit the documents the alias can access. 
-        externalDocs:
-          description: Query DSL
-          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
-  - target: "$.components['requestBodies']['indices.put_alias'].content['application/json'].schema.properties.filter"
-    description: Remove filter from create or update alias
-    remove: true
-  - target: "$.components['requestBodies']['indices.put_alias'].content['application/json'].schema.properties"
-    description: Re-add simplified filter for create or update alias 
-    update:
-      filter:
-        x-abbreviated: true
-        type: object
-        description: A query used to limit the documents the alias can access. 
-        externalDocs:
-          description: Query DSL
-          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
-  - target: "$.components['schemas']['indices._types:AliasDefinition'].properties.filter"
-    description: Remove filter from alias definition
-    remove: true
-  - target: "$.components['schemas']['indices._types:AliasDefinition'].properties"
-    description: Re-add simplified filter for alias definition
-    update:
-      filter:
-        x-abbreviated: true
-        type: object
-        description: A query used to limit the documents the alias can access. 
-        externalDocs:
-          description: Query DSL
-          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+      x-model: true
+      externalDocs:
+        description: Templating a role query
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/field-and-document-access-control.html#templating-role-query
 # Examples
   - target: "$.components['requestBodies']['async_search.submit']"
     description: "Add example for asynch search submit request"

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -281,6 +281,7 @@ actions:
         url: https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-tokenfilters.html
         description: Token filter reference
 # Abbreviate and annotate items that are not shown in Bump.sh due to depth limits
+<<<<<<< HEAD:docs/overlays/elasticsearch-shared-overlays.yaml
   - target: "$.components['schemas']['ml._types:Datafeed'].properties.query"
     description: Remove query object from anomaly detection datafeed
     remove: true
@@ -350,6 +351,18 @@ actions:
         externalDocs:
           url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
           description: Query DSL
+=======
+  - target: "$.components['schemas']['security._types:IndicesPrivilegesQuery'].oneOf"
+    description: Remove types from security role descriptors indices query
+    remove: true
+  - target: "$.components['schemas']['security._types:IndicesPrivilegesQuery']"
+    description: Re-add simplified types for security role descriptors indices query
+    update:
+      x-abbreviated: true
+      oneOf:
+        - type: string
+        - type: object
+>>>>>>> 295ccb76c (Add overlay for deep objects in security APIs):docs/overlays/elasticsearch-shared-example-overlays.yaml
 # Examples
   - target: "$.components['requestBodies']['async_search.submit']"
     description: "Add example for asynch search submit request"


### PR DESCRIPTION
This PR adds the `x-model` extension for the role template query schema in the role APIs, since it is too deep to display well at this time. It also adds a link to https://www.elastic.co/guide/en/elasticsearch/reference/master/field-and-document-access-control.html#templating-role-query 