### PR TITLE
Add remote_indices to Create or update roles API

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -83971,6 +83971,39 @@
           "created"
         ]
       },
+      "security._types:RemoteIndicesPrivileges": {
+        "type": "object",
+        "properties": {
+          "clusters": {
+            "$ref": "#/components/schemas/_types:Names"
+          },
+          "field_security": {
+            "$ref": "#/components/schemas/security._types:FieldSecurity"
+          },
+          "names": {
+            "$ref": "#/components/schemas/_types:Indices"
+          },
+          "privileges": {
+            "description": "The index level privileges that owners of the role have on the specified indices.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:IndexPrivilege"
+            }
+          },
+          "query": {
+            "$ref": "#/components/schemas/security._types:IndicesPrivilegesQuery"
+          },
+          "allow_restricted_indices": {
+            "description": "Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "clusters",
+          "names",
+          "privileges"
+        ]
+      },
       "security.query_api_keys:ApiKeyAggregationContainer": {
         "allOf": [
           {
@@ -104769,6 +104802,13 @@
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/security._types:IndicesPrivileges"
+                  }
+                },
+                "remote_indices": {
+                  "description": "A list of remote indices permissions entries.",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/security._types:RemoteIndicesPrivileges"
                   }
                 },
                 "metadata": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -101609,7 +101609,7 @@
         "name": "IndexPrivilege",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L292-L334"
+      "specLocation": "security/_types/Privileges.ts#L325-L367"
     },
     {
       "codegenNames": [
@@ -101623,7 +101623,7 @@
         "name": "IndicesPrivilegesQuery",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L247-L255",
+      "specLocation": "security/_types/Privileges.ts#L280-L288",
       "type": {
         "items": [
           {
@@ -101673,7 +101673,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/Privileges.ts#L257-L267"
+      "specLocation": "security/_types/Privileges.ts#L290-L300"
     },
     {
       "kind": "interface",
@@ -101761,7 +101761,7 @@
         }
       ],
       "shortcutProperty": "source",
-      "specLocation": "security/_types/Privileges.ts#L269-L287"
+      "specLocation": "security/_types/Privileges.ts#L302-L320"
     },
     {
       "codegenNames": [
@@ -101773,7 +101773,7 @@
         "name": "RoleTemplateInlineQuery",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L289-L290",
+      "specLocation": "security/_types/Privileges.ts#L322-L323",
       "type": {
         "items": [
           {
@@ -137657,7 +137657,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/Privileges.ts#L197-L221"
+      "specLocation": "security/_types/Privileges.ts#L198-L222"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17472,6 +17472,15 @@ export interface SecurityRealmInfo {
   type: string
 }
 
+export interface SecurityRemoteIndicesPrivileges {
+  clusters: Names
+  field_security?: SecurityFieldSecurity
+  names: Indices
+  privileges: SecurityIndexPrivilege[]
+  query?: SecurityIndicesPrivilegesQuery
+  allow_restricted_indices?: boolean
+}
+
 export interface SecurityRoleDescriptor {
   cluster?: SecurityClusterPrivilege[]
   indices?: SecurityIndicesPrivileges[]
@@ -18147,6 +18156,7 @@ export interface SecurityPutRoleRequest extends RequestBase {
     cluster?: SecurityClusterPrivilege[]
     global?: Record<string, any>
     indices?: SecurityIndicesPrivileges[]
+    remote_indices?: SecurityRemoteIndicesPrivileges[]
     metadata?: Metadata
     run_as?: string[]
     description?: string

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -19,7 +19,7 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { Id, Indices } from '@_types/common'
+import { Id, Indices, Names } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { ScriptLanguage } from '@_types/Scripting'
 import { FieldSecurity } from './FieldSecurity'
@@ -194,7 +194,39 @@ export enum ClusterPrivilege {
   write_fleet_secrets
 }
 
+// Keep in sync with RemoteIndicesPrivileges
 export class IndicesPrivileges {
+  /**
+   * The document fields that the owners of the role have read access to.
+   * @doc_id field-and-document-access-control
+   */
+  field_security?: FieldSecurity
+  /**
+   * A list of indices (or index name patterns) to which the permissions in this entry apply.
+   */
+  names: Indices
+  /**
+   * The index level privileges that owners of the role have on the specified indices.
+   */
+  privileges: IndexPrivilege[]
+  /**
+   * A search query that defines the documents the owners of the role have access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.
+   */
+  query?: IndicesPrivilegesQuery
+  /**
+   * Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.
+   * @server_default false
+   * @availability stack
+   */
+  allow_restricted_indices?: boolean
+}
+
+// Keep in sync with IndicesPrivileges
+export class RemoteIndicesPrivileges {
+  /**
+   *  A list of cluster aliases to which the permissions in this entry apply.
+   */
+  clusters: Names
   /**
    * The document fields that the owners of the role have read access to.
    * @doc_id field-and-document-access-control

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -20,7 +20,8 @@
 import {
   ApplicationPrivileges,
   ClusterPrivilege,
-  IndicesPrivileges
+  IndicesPrivileges,
+  RemoteIndicesPrivileges
 } from '@security/_types/Privileges'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
@@ -63,6 +64,12 @@ export interface Request extends RequestBase {
      * A list of indices permissions entries.
      */
     indices?: IndicesPrivileges[]
+    /**
+     * A list of remote indices permissions entries.
+     * @availability stack since=8.14.0
+     *
+     */
+    remote_indices?: RemoteIndicesPrivileges[]
     /**
      * Optional metadata. Within the metadata object, keys that begin with an underscore (`_`) are reserved for system use.
      */


### PR DESCRIPTION
As documented in https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html. Note that `remote_cluster` is still missing, so that won't fully fix the validation.