### PR TITLE
[OpenAPI] Improve analyze and async search summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -78,7 +78,7 @@
         "tags": [
           "search"
         ],
-        "summary": "Deletes an async search",
+        "summary": "Delete an async search",
         "description": "If the asynchronous search is still running, it is cancelled.\nOtherwise, the saved search results are deleted.\nIf the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.",
         "operationId": "async-search-delete",
         "parameters": [

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -9977,7 +9977,8 @@
         "tags": [
           "indices"
         ],
-        "summary": "Performs analysis on a text string and returns the resulting tokens",
+        "summary": "Get tokens from text analysis",
+        "description": "The analyze API performs [analysis](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html) on a text string and returns the resulting tokens.",
         "operationId": "indices-analyze",
         "requestBody": {
           "$ref": "#/components/requestBodies/indices.analyze"
@@ -9992,7 +9993,8 @@
         "tags": [
           "indices"
         ],
-        "summary": "Performs analysis on a text string and returns the resulting tokens",
+        "summary": "Get tokens from text analysis",
+        "description": "The analyze API performs [analysis](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html) on a text string and returns the resulting tokens.",
         "operationId": "indices-analyze-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/indices.analyze"
@@ -10009,7 +10011,8 @@
         "tags": [
           "indices"
         ],
-        "summary": "Performs analysis on a text string and returns the resulting tokens",
+        "summary": "Get tokens from text analysis",
+        "description": "The analyze API performs [analysis](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html) on a text string and returns the resulting tokens.",
         "operationId": "indices-analyze-2",
         "parameters": [
           {
@@ -10029,7 +10032,8 @@
         "tags": [
           "indices"
         ],
-        "summary": "Performs analysis on a text string and returns the resulting tokens",
+        "summary": "Get tokens from text analysis",
+        "description": "The analyze API performs [analysis](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html) on a text string and returns the resulting tokens.",
         "operationId": "indices-analyze-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -14,8 +14,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Retrieves the results of a previously submitted async search request given its identifier",
-        "description": "If the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.",
+        "summary": "Get async search results",
+        "description": "Retrieve the results of a previously submitted asynchronous search request.\nIf the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.",
         "operationId": "async-search-get",
         "parameters": [
           {
@@ -78,8 +78,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Deletes an async search by identifier",
-        "description": "If the search is still running, the search request will be cancelled.\nOtherwise, the saved search results are deleted.\nIf the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.",
+        "summary": "Deletes an async search",
+        "description": "If the asynchronous search is still running, it is cancelled.\nOtherwise, the saved search results are deleted.\nIf the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.",
         "operationId": "async-search-delete",
         "parameters": [
           {
@@ -114,8 +114,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Get async search status\n",
-        "description": "Retrieves the status of a previously submitted async search request given its identifier, without retrieving search results.\nIf the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.",
+        "summary": "Get async search status",
+        "description": "Retrieve the status of a previously submitted async search request given its identifier, without retrieving search results.\nIf the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.",
         "operationId": "async-search-status",
         "parameters": [
           {
@@ -150,8 +150,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs a search request asynchronously",
-        "description": "When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field, hence partial results become available following the sort criteria that was requested.\nWarning: Async search does not support scroll nor search requests that only include the suggest section.\nBy default, Elasticsearch doesn’t allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.\nThe maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.",
+        "summary": "Run an async search",
+        "description": "When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field. Partial results become available following the sort criteria that was requested.\n\nWarning: Asynchronous search does not support scroll or search requests that include only the suggest section.\n\nBy default, Elasticsearch does not allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.\nThe maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.",
         "operationId": "async-search-submit",
         "parameters": [
           {
@@ -309,8 +309,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs a search request asynchronously",
-        "description": "When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field, hence partial results become available following the sort criteria that was requested.\nWarning: Async search does not support scroll nor search requests that only include the suggest section.\nBy default, Elasticsearch doesn’t allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.\nThe maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.",
+        "summary": "Run an async search",
+        "description": "When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field. Partial results become available following the sort criteria that was requested.\n\nWarning: Asynchronous search does not support scroll or search requests that include only the suggest section.\n\nBy default, Elasticsearch does not allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.\nThe maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.",
         "operationId": "async-search-submit-1",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -78,7 +78,7 @@
         "tags": [
           "search"
         ],
-        "summary": "Deletes an async search",
+        "summary": "Delete an async search",
         "description": "If the asynchronous search is still running, it is cancelled.\nOtherwise, the saved search results are deleted.\nIf the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.",
         "operationId": "async-search-delete",
         "parameters": [

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -14,8 +14,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Retrieves the results of a previously submitted async search request given its identifier",
-        "description": "If the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.",
+        "summary": "Get async search results",
+        "description": "Retrieve the results of a previously submitted asynchronous search request.\nIf the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.",
         "operationId": "async-search-get",
         "parameters": [
           {
@@ -78,8 +78,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Deletes an async search by identifier",
-        "description": "If the search is still running, the search request will be cancelled.\nOtherwise, the saved search results are deleted.\nIf the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.",
+        "summary": "Deletes an async search",
+        "description": "If the asynchronous search is still running, it is cancelled.\nOtherwise, the saved search results are deleted.\nIf the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.",
         "operationId": "async-search-delete",
         "parameters": [
           {
@@ -114,8 +114,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Get async search status\n",
-        "description": "Retrieves the status of a previously submitted async search request given its identifier, without retrieving search results.\nIf the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.",
+        "summary": "Get async search status",
+        "description": "Retrieve the status of a previously submitted async search request given its identifier, without retrieving search results.\nIf the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.",
         "operationId": "async-search-status",
         "parameters": [
           {
@@ -150,8 +150,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs a search request asynchronously",
-        "description": "When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field, hence partial results become available following the sort criteria that was requested.\nWarning: Async search does not support scroll nor search requests that only include the suggest section.\nBy default, Elasticsearch doesn’t allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.\nThe maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.",
+        "summary": "Run an async search",
+        "description": "When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field. Partial results become available following the sort criteria that was requested.\n\nWarning: Asynchronous search does not support scroll or search requests that include only the suggest section.\n\nBy default, Elasticsearch does not allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.\nThe maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.",
         "operationId": "async-search-submit",
         "parameters": [
           {
@@ -309,8 +309,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs a search request asynchronously",
-        "description": "When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field, hence partial results become available following the sort criteria that was requested.\nWarning: Async search does not support scroll nor search requests that only include the suggest section.\nBy default, Elasticsearch doesn’t allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.\nThe maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.",
+        "summary": "Run an async search",
+        "description": "When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field. Partial results become available following the sort criteria that was requested.\n\nWarning: Asynchronous search does not support scroll or search requests that include only the suggest section.\n\nBy default, Elasticsearch does not allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.\nThe maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.",
         "operationId": "async-search-submit-1",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -5849,7 +5849,8 @@
         "tags": [
           "indices"
         ],
-        "summary": "Performs analysis on a text string and returns the resulting tokens",
+        "summary": "Get tokens from text analysis",
+        "description": "The analyze API performs [analysis](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html) on a text string and returns the resulting tokens.",
         "operationId": "indices-analyze",
         "requestBody": {
           "$ref": "#/components/requestBodies/indices.analyze"
@@ -5864,7 +5865,8 @@
         "tags": [
           "indices"
         ],
-        "summary": "Performs analysis on a text string and returns the resulting tokens",
+        "summary": "Get tokens from text analysis",
+        "description": "The analyze API performs [analysis](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html) on a text string and returns the resulting tokens.",
         "operationId": "indices-analyze-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/indices.analyze"
@@ -5881,7 +5883,8 @@
         "tags": [
           "indices"
         ],
-        "summary": "Performs analysis on a text string and returns the resulting tokens",
+        "summary": "Get tokens from text analysis",
+        "description": "The analyze API performs [analysis](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html) on a text string and returns the resulting tokens.",
         "operationId": "indices-analyze-2",
         "parameters": [
           {
@@ -5901,7 +5904,8 @@
         "tags": [
           "indices"
         ],
-        "summary": "Performs analysis on a text string and returns the resulting tokens",
+        "summary": "Get tokens from text analysis",
+        "description": "The analyze API performs [analysis](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html) on a text string and returns the resulting tokens.",
         "operationId": "indices-analyze-3",
         "parameters": [
           {

--- a/specification/async_search/delete/AsyncSearchDeleteRequest.ts
+++ b/specification/async_search/delete/AsyncSearchDeleteRequest.ts
@@ -21,8 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes an async search by identifier.
- * If the search is still running, the search request will be cancelled.
+ * Deletes an async search.
+ * If the asynchronous search is still running, it is cancelled.
  * Otherwise, the saved search results are deleted.
  * If the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.
  * @rest_spec_name async_search.delete

--- a/specification/async_search/delete/AsyncSearchDeleteRequest.ts
+++ b/specification/async_search/delete/AsyncSearchDeleteRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes an async search.
+ * Delete an async search.
  * If the asynchronous search is still running, it is cancelled.
  * Otherwise, the saved search results are deleted.
  * If the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.

--- a/specification/async_search/get/AsyncSearchGetRequest.ts
+++ b/specification/async_search/get/AsyncSearchGetRequest.ts
@@ -22,7 +22,8 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Retrieves the results of a previously submitted async search request given its identifier.
+ * Get async search results.
+ * Retrieve the results of a previously submitted asynchronous search request.
  * If the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.
  * @rest_spec_name async_search.get
  * @availability stack since=7.7.0 stability=stable

--- a/specification/async_search/status/AsyncSearchStatusRequest.ts
+++ b/specification/async_search/status/AsyncSearchStatusRequest.ts
@@ -21,8 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Get async search status
- * Retrieves the status of a previously submitted async search request given its identifier, without retrieving search results.
+ * Get async search status.
+ * Retrieve the status of a previously submitted async search request given its identifier, without retrieving search results.
  * If the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.
  * @rest_spec_name async_search.status
  * @availability stack since=7.11.0 stability=stable

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -53,10 +53,12 @@ import { Sort, SortResults } from '@_types/sort'
 import { Duration } from '@_types/Time'
 
 /**
- * Runs a search request asynchronously.
- * When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field, hence partial results become available following the sort criteria that was requested.
- * Warning: Async search does not support scroll nor search requests that only include the suggest section.
- * By default, Elasticsearch doesn’t allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.
+ * Run an async search.
+ * When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field. Partial results become available following the sort criteria that was requested.
+ * 
+ * Warning: Asynchronous search does not support scroll or search requests that include only the suggest section.
+ * 
+ * By default, Elasticsearch does not allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.
  * The maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.
  * @rest_spec_name async_search.submit
  * @availability stack since=7.7.0 stability=stable

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -55,9 +55,9 @@ import { Duration } from '@_types/Time'
 /**
  * Run an async search.
  * When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field. Partial results become available following the sort criteria that was requested.
- * 
+ *
  * Warning: Asynchronous search does not support scroll or search requests that include only the suggest section.
- * 
+ *
  * By default, Elasticsearch does not allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.
  * The maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.
  * @rest_spec_name async_search.submit

--- a/specification/indices/analyze/IndicesAnalyzeRequest.ts
+++ b/specification/indices/analyze/IndicesAnalyzeRequest.ts
@@ -25,7 +25,8 @@ import { Field, IndexName } from '@_types/common'
 import { TextToAnalyze } from './types'
 
 /**
- * Performs analysis on a text string and returns the resulting tokens.
+ * Get tokens from text analysis.
+ * The analyze API performs [analysis](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html) on a text string and returns the resulting tokens.
  * @doc_id indices-analyze
  * @rest_spec_name indices.analyze
  * @availability stack stability=stable


### PR DESCRIPTION
This PR improves the operation summary for the [analyze API](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html) and [async search](https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html)

Note that it adds a link from the API docs to the Elasticsearch Guide, which relates to https://github.com/elastic/elasticsearch-specification/issues/2748. If this is problematic per discussions in https://github.com/elastic/elasticsearch-specification/issues/2758, I can omit it for now.
