### PR TITLE
[OpenAPI] Edit search application summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27333,7 +27333,7 @@
         "tags": [
           "search_application.get"
         ],
-        "summary": "Returns the details about a search application",
+        "summary": "Get search application details",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-search-application.html"
         },
@@ -27370,7 +27370,7 @@
         "tags": [
           "search_application.put"
         ],
-        "summary": "Creates or updates a search application",
+        "summary": "Create or update a search application",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html"
         },
@@ -27435,7 +27435,8 @@
         "tags": [
           "search_application.delete"
         ],
-        "summary": "Deletes a search application",
+        "summary": "Delete a search application",
+        "description": "Remove a search application and its associated alias. Indices attached to the search application are not removed.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-search-application.html"
         },
@@ -27474,7 +27475,7 @@
         "tags": [
           "search_application.get_behavioral_analytics"
         ],
-        "summary": "Returns the existing behavioral analytics collections",
+        "summary": "Get behavioral analytics collections",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html"
         },
@@ -27496,7 +27497,7 @@
         "tags": [
           "search_application.put_behavioral_analytics"
         ],
-        "summary": "Creates a behavioral analytics collection",
+        "summary": "Create a behavioral analytics collection",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html"
         },
@@ -27534,6 +27535,7 @@
           "search_application.delete_behavioral_analytics"
         ],
         "summary": "Delete a behavioral analytics collection",
+        "description": "The associated data stream is also deleted.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html"
         },
@@ -27572,7 +27574,7 @@
         "tags": [
           "search_application.get_behavioral_analytics"
         ],
-        "summary": "Returns the existing behavioral analytics collections",
+        "summary": "Get behavioral analytics collections",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html"
         },
@@ -27664,7 +27666,8 @@
         "tags": [
           "search_application.search"
         ],
-        "summary": "Perform a search against a search application",
+        "summary": "Run a search application search",
+        "description": "Generate and run an Elasticsearch query that uses the specified query parameteter and the search template associated with the search application or default template.\nUnspecified template parameters are assigned their default values if applicable.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-search.html"
         },
@@ -27692,7 +27695,8 @@
         "tags": [
           "search_application.search"
         ],
-        "summary": "Perform a search against a search application",
+        "summary": "Run a search application search",
+        "description": "Generate and run an Elasticsearch query that uses the specified query parameteter and the search template associated with the search application or default template.\nUnspecified template parameters are assigned their default values if applicable.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-search.html"
         },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -17043,7 +17043,7 @@
         "tags": [
           "search_application.get"
         ],
-        "summary": "Returns the details about a search application",
+        "summary": "Get search application details",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-search-application.html"
         },
@@ -17080,7 +17080,7 @@
         "tags": [
           "search_application.put"
         ],
-        "summary": "Creates or updates a search application",
+        "summary": "Create or update a search application",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html"
         },
@@ -17145,7 +17145,8 @@
         "tags": [
           "search_application.delete"
         ],
-        "summary": "Deletes a search application",
+        "summary": "Delete a search application",
+        "description": "Remove a search application and its associated alias. Indices attached to the search application are not removed.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-search-application.html"
         },
@@ -17184,7 +17185,7 @@
         "tags": [
           "search_application.get_behavioral_analytics"
         ],
-        "summary": "Returns the existing behavioral analytics collections",
+        "summary": "Get behavioral analytics collections",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html"
         },
@@ -17206,7 +17207,7 @@
         "tags": [
           "search_application.put_behavioral_analytics"
         ],
-        "summary": "Creates a behavioral analytics collection",
+        "summary": "Create a behavioral analytics collection",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html"
         },
@@ -17244,6 +17245,7 @@
           "search_application.delete_behavioral_analytics"
         ],
         "summary": "Delete a behavioral analytics collection",
+        "description": "The associated data stream is also deleted.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html"
         },
@@ -17282,7 +17284,7 @@
         "tags": [
           "search_application.get_behavioral_analytics"
         ],
-        "summary": "Returns the existing behavioral analytics collections",
+        "summary": "Get behavioral analytics collections",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html"
         },
@@ -17374,7 +17376,8 @@
         "tags": [
           "search_application.search"
         ],
-        "summary": "Perform a search against a search application",
+        "summary": "Run a search application search",
+        "description": "Generate and run an Elasticsearch query that uses the specified query parameteter and the search template associated with the search application or default template.\nUnspecified template parameters are assigned their default values if applicable.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-search.html"
         },
@@ -17402,7 +17405,8 @@
         "tags": [
           "search_application.search"
         ],
-        "summary": "Perform a search against a search application",
+        "summary": "Run a search application search",
+        "description": "Generate and run an Elasticsearch query that uses the specified query parameteter and the search template associated with the search application or default template.\nUnspecified template parameters are assigned their default values if applicable.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-search.html"
         },

--- a/specification/search_application/delete/SearchApplicationsDeleteRequest.ts
+++ b/specification/search_application/delete/SearchApplicationsDeleteRequest.ts
@@ -20,7 +20,8 @@ import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 
 /**
- * Deletes a search application.
+ * Delete a search application.
+ * Remove a search application and its associated alias. Indices attached to the search application are not removed.
  * @rest_spec_name search_application.delete
  * @availability stack since=8.8.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteRequest.ts
+++ b/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteRequest.ts
@@ -21,6 +21,7 @@ import { Name } from '@_types/common'
 
 /**
  * Delete a behavioral analytics collection.
+ * The associated data stream is also deleted.
  * @rest_spec_name search_application.delete_behavioral_analytics
  * @availability stack since=8.8.0 stability=experimental
  * @availability serverless stability=experimental visibility=public

--- a/specification/search_application/get/SearchApplicationsGetRequest.ts
+++ b/specification/search_application/get/SearchApplicationsGetRequest.ts
@@ -20,7 +20,7 @@ import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 
 /**
- * Returns the details about a search application
+ * Get search application details.
  * @rest_spec_name search_application.get
  * @availability stack since=8.8.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
+++ b/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
@@ -20,7 +20,7 @@ import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 
 /**
- * Returns the existing behavioral analytics collections.
+ * Get behavioral analytics collections.
  * @rest_spec_name search_application.get_behavioral_analytics
  * @availability stack since=8.8.0 stability=experimental
  * @availability serverless stability=experimental visibility=public

--- a/specification/search_application/put/SearchApplicationsPutRequest.ts
+++ b/specification/search_application/put/SearchApplicationsPutRequest.ts
@@ -21,7 +21,7 @@ import { Name } from '@_types/common'
 import { SearchApplication } from '../_types/SearchApplication'
 
 /**
- * Creates or updates a search application.
+ * Create or update a search application.
  * @rest_spec_name search_application.put
  * @availability stack since=8.8.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutRequest.ts
+++ b/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutRequest.ts
@@ -20,7 +20,7 @@ import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 
 /**
- * Creates a behavioral analytics collection.
+ * Create a behavioral analytics collection.
  * @rest_spec_name search_application.put_behavioral_analytics
  * @availability stack since=8.8.0 stability=experimental
  * @availability serverless stability=experimental visibility=public

--- a/specification/search_application/search/SearchApplicationsSearchRequest.ts
+++ b/specification/search_application/search/SearchApplicationsSearchRequest.ts
@@ -22,7 +22,9 @@ import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 
 /**
- * Perform a search against a search application.
+ * Run a search application search.
+ * Generate and run an Elasticsearch query that uses the specified query parameteter and the search template associated with the search application or default template.
+ * Unspecified template parameters are assigned their default values if applicable.
  * @rest_spec_name search_application.search
  * @availability stack since=8.8.0 stability=beta
  * @availability serverless stability=beta visibility=public


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR edits the operation summaries for the [search application](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-application-apis.html) and [behavioral analytics](https://www.elastic.co/guide/en/elasticsearch/reference/current/behavioral-analytics-apis.html) APIs.