### PR TITLE
Approximate snapshot verify integrity mapping

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -33298,6 +33298,125 @@
         "x-available-since": "0.0.0"
       }
     },
+    "/_snapshot/{repository}/_verify_integrity": {
+      "post": {
+        "tags": [
+          "snapshot.repository_verify_integrity"
+        ],
+        "summary": "Verifies the integrity of the contents of a snapshot repository",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html"
+        },
+        "operationId": "snapshot-repository-verify-integrity",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "repository",
+            "description": "A repository name",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "meta_thread_pool_concurrency",
+            "description": "Number of threads to use for reading metadata",
+            "deprecated": false,
+            "schema": {
+              "type": "number"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "blob_thread_pool_concurrency",
+            "description": "Number of threads to use for reading blob contents",
+            "deprecated": false,
+            "schema": {
+              "type": "number"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "snapshot_verification_concurrency",
+            "description": "Number of snapshots to verify concurrently",
+            "deprecated": false,
+            "schema": {
+              "type": "number"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "index_verification_concurrency",
+            "description": "Number of indices to verify concurrently",
+            "deprecated": false,
+            "schema": {
+              "type": "number"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "index_snapshot_verification_concurrency",
+            "description": "Number of snapshots to verify concurrently within each index",
+            "deprecated": false,
+            "schema": {
+              "type": "number"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "max_failed_shard_snapshots",
+            "description": "Maximum permitted number of failed shard snapshots",
+            "deprecated": false,
+            "schema": {
+              "type": "number"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "verify_blob_contents",
+            "description": "Whether to verify the contents of individual blobs",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "max_bytes_per_sec",
+            "description": "Rate limit for individual blob verification",
+            "deprecated": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "x-available-since": "8.16.0",
+        "x-technical-preview": true
+      }
+    },
     "/_snapshot/{repository}/{snapshot}/_restore": {
       "post": {
         "tags": [

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1194,6 +1194,12 @@
       ],
       "response": []
     },
+    "snapshot.repository_verify_integrity": {
+      "request": [
+        "Request: path parameter 'repository' is required in the json spec"
+      ],
+      "response": []
+    },
     "tasks.list": {
       "request": [
         "Request: query parameter 'node_id' does not exist in the json spec",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -19058,6 +19058,20 @@ export interface SnapshotGetRepositoryRequest extends RequestBase {
 
 export type SnapshotGetRepositoryResponse = Record<string, SnapshotRepository>
 
+export interface SnapshotRepositoryVerifyIntegrityRequest extends RequestBase {
+  name?: Names
+  meta_thread_pool_concurrency?: integer
+  blob_thread_pool_concurrency?: integer
+  snapshot_verification_concurrency?: integer
+  index_verification_concurrency?: integer
+  index_snapshot_verification_concurrency?: integer
+  max_failed_shard_snapshots?: integer
+  verify_blob_contents?: boolean
+  max_bytes_per_sec?: string
+}
+
+export type SnapshotRepositoryVerifyIntegrityResponse = any
+
 export interface SnapshotRestoreRequest extends RequestBase {
   repository: Name
   snapshot: Name

--- a/specification/_json_spec/snapshot.repository_verify_integrity.json
+++ b/specification/_json_spec/snapshot.repository_verify_integrity.json
@@ -1,0 +1,61 @@
+{
+  "snapshot.repository_verify_integrity": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-snapshots.html",
+      "description": "Verifies the integrity of the contents of a snapshot repository"
+    },
+    "stability": "experimental",
+    "visibility": "private",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_snapshot/{repository}/_verify_integrity",
+          "methods": ["POST"],
+          "parts": {
+            "repository": {
+              "type": "string",
+              "description": "A repository name"
+            }
+          }
+        }
+      ]
+    },
+    "params": {
+      "meta_thread_pool_concurrency": {
+        "type": "number",
+        "description": "Number of threads to use for reading metadata"
+      },
+      "blob_thread_pool_concurrency": {
+        "type": "number",
+        "description": "Number of threads to use for reading blob contents"
+      },
+      "snapshot_verification_concurrency": {
+        "type": "number",
+        "description": "Number of snapshots to verify concurrently"
+      },
+      "index_verification_concurrency": {
+        "type": "number",
+        "description": "Number of indices to verify concurrently"
+      },
+      "index_snapshot_verification_concurrency": {
+        "type": "number",
+        "description": "Number of snapshots to verify concurrently within each index"
+      },
+      "max_failed_shard_snapshots": {
+        "type": "number",
+        "description": "Maximum permitted number of failed shard snapshots"
+      },
+      "verify_blob_contents": {
+        "type": "boolean",
+        "description": "Whether to verify the contents of individual blobs"
+      },
+      "max_bytes_per_sec": {
+        "type": "string",
+        "description": "Rate limit for individual blob verification"
+      }
+    }
+  }
+}

--- a/specification/snapshot/repository_verify_integrity/SnapshotRepositoryVerifyIntegrityRequest.ts
+++ b/specification/snapshot/repository_verify_integrity/SnapshotRepositoryVerifyIntegrityRequest.ts
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Names } from '@_types/common'
+import { integer } from '@_types/Numeric'
+
+/**
+ * @rest_spec_name snapshot.repository_verify_integrity
+ * @availability stack since=8.16.0 stability=experimental visibility=private
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /** @codegen_name name */
+    repository?: Names
+  }
+  query_parameters: {
+    meta_thread_pool_concurrency?: integer
+    blob_thread_pool_concurrency?: integer
+    snapshot_verification_concurrency?: integer
+    index_verification_concurrency?: integer
+    index_snapshot_verification_concurrency?: integer
+    max_failed_shard_snapshots?: integer
+    verify_blob_contents?: boolean
+    max_bytes_per_sec?: string
+  }
+}

--- a/specification/snapshot/repository_verify_integrity/SnapshotRepositoryVerifyIntegrityResponse.ts
+++ b/specification/snapshot/repository_verify_integrity/SnapshotRepositoryVerifyIntegrityResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+
+export class Response {
+  body: UserDefinedValue
+}


### PR DESCRIPTION
Mapping the new [repository integrity verification API](https://github.com/elastic/elasticsearch/pull/112348), allowing to merge the [latest spec update](https://github.com/elastic/elasticsearch-specification/pull/2890) without introducing new validation errors.

The query parameter `max_bytes_per_sec` is a string, but it has a specific format: `<<size-units, size units>>`. Considering it's the same in the DevTools I think we can keep it as a string for now. 
