### PR TITLE
Fix snapshot.create response

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -85260,6 +85260,9 @@
           "shard_id": {
             "$ref": "#/components/schemas/_types:Id"
           },
+          "index_uuid": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
           "status": {
             "type": "string"
           }
@@ -85268,6 +85271,7 @@
           "index",
           "reason",
           "shard_id",
+          "index_uuid",
           "status"
         ]
       },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -18904,6 +18904,7 @@ export interface SnapshotSnapshotShardFailure {
   node_id?: Id
   reason: string
   shard_id: Id
+  index_uuid: Id
   status: string
 }
 

--- a/specification/snapshot/_types/SnapshotShardFailure.ts
+++ b/specification/snapshot/_types/SnapshotShardFailure.ts
@@ -24,5 +24,6 @@ export class SnapshotShardFailure {
   node_id?: Id
   reason: string
   shard_id: Id
+  index_uuid: Id
   status: string
 }


### PR DESCRIPTION
I'm not sure when this was added, but we only notice it now because of the new YAML test added in https://github.com/elastic/elasticsearch/pull/113233.

This field is also used in `snapshot.get`.