### PR TITLE
Fix ignored_field_values type

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -40949,7 +40949,7 @@
             "additionalProperties": {
               "type": "array",
               "items": {
-                "type": "string"
+                "$ref": "#/components/schemas/_types:FieldValue"
               }
             }
           },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -24229,7 +24229,7 @@
             "additionalProperties": {
               "type": "array",
               "items": {
-                "type": "string"
+                "$ref": "#/components/schemas/_types:FieldValue"
               }
             }
           },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -51326,7 +51326,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/_types/hits.ts#L107-L141"
+      "specLocation": "_global/search/_types/hits.ts#L108-L142"
     },
     {
       "kind": "type_alias",
@@ -65917,7 +65917,7 @@
         "name": "TrackHits",
         "namespace": "_global.search._types"
       },
-      "specLocation": "_global/search/_types/hits.ts#L143-L151",
+      "specLocation": "_global/search/_types/hits.ts#L144-L152",
       "type": {
         "items": [
           {
@@ -68085,7 +68085,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/_types/hits.ts#L67-L73"
+      "specLocation": "_global/search/_types/hits.ts#L68-L74"
     },
     {
       "kind": "interface",
@@ -68117,7 +68117,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/_types/hits.ts#L95-L98"
+      "specLocation": "_global/search/_types/hits.ts#L96-L99"
     },
     {
       "kind": "enum",
@@ -68135,7 +68135,7 @@
         "name": "TotalHitsRelation",
         "namespace": "_global.search._types"
       },
-      "specLocation": "_global/search/_types/hits.ts#L100-L105"
+      "specLocation": "_global/search/_types/hits.ts#L101-L106"
     },
     {
       "generics": [
@@ -68352,8 +68352,8 @@
               "value": {
                 "kind": "instance_of",
                 "type": {
-                  "name": "string",
-                  "namespace": "_builtins"
+                  "name": "FieldValue",
+                  "namespace": "_types"
                 }
               }
             }
@@ -68459,7 +68459,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/_types/hits.ts#L40-L65"
+      "specLocation": "_global/search/_types/hits.ts#L41-L66"
     },
     {
       "kind": "interface",
@@ -68577,7 +68577,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/_types/hits.ts#L85-L87"
+      "specLocation": "_global/search/_types/hits.ts#L86-L88"
     },
     {
       "kind": "interface",
@@ -68620,7 +68620,7 @@
           }
         }
       ],
-      "specLocation": "_global/search/_types/hits.ts#L89-L93"
+      "specLocation": "_global/search/_types/hits.ts#L90-L94"
     },
     {
       "description": "The aggregation name as returned from the server. Depending whether typed_keys is specified this could come back\nin the form of `name#type` instead of simply `name`",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1524,7 +1524,7 @@ export interface SearchHit<TDocument = unknown> {
   matched_queries?: string[] | Record<string, double>
   _nested?: SearchNestedIdentity
   _ignored?: string[]
-  ignored_field_values?: Record<string, string[]>
+  ignored_field_values?: Record<string, FieldValue[]>
   _shard?: string
   _node?: string
   _routing?: string

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -23,6 +23,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import {
   Field,
   Fields,
+  FieldValue,
   Id,
   IndexName,
   Name,
@@ -52,7 +53,7 @@ export class Hit<TDocument> {
   matched_queries?: string[] | Dictionary<string, double>
   _nested?: NestedIdentity
   _ignored?: string[]
-  ignored_field_values?: Dictionary<string, string[]>
+  ignored_field_values?: Dictionary<string, FieldValue[]>
   _shard?: string
   _node?: string
   _routing?: string


### PR DESCRIPTION
There are still three failing test on the search response side, this fixes one of them. In [this YAML test](https://github.com/elastic/elasticsearch/blob/8dbc9f34d622711405a04793df6af7282a02169e/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/600_flattened_ignore_above.yml#L28-L45), the ignored field value is:

```json
{
  "key": "foo bar key",
  "value": "foo bar"
}
```