### PR TITLE
Fix overlay syntax error

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -40,7 +40,7 @@ actions:
               examples:
                 resetFeaturesResponseExample1:
                   $ref: "../../specification/features/reset_features/ResetFeaturesResponseExample1.json"
-    - target: "$.components['requestBodies']['cluster.allocation_explain']"
+  - target: "$.components['requestBodies']['cluster.allocation_explain']"
     description: "Add examples for cluster allocation explain operation"
     update: 
       content: 


### PR DESCRIPTION
This PR addresses an error that occurs when you run the "make overlay-docs" command due to invalid spacing in the overlay file.