### PR TITLE
Replace DeploymentState with DeploymentAssignmentState

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14054,9 +14054,7 @@ export interface MlDelayedDataCheckConfig {
 
 export type MlDeploymentAllocationState = 'started' | 'starting' | 'fully_allocated'
 
-export type MlDeploymentAssignmentState = 'starting' | 'started' | 'stopping' | 'failed'
-
-export type MlDeploymentState = 'started' | 'starting' | 'stopping'
+export type MlDeploymentAssignmentState = 'started' | 'starting' | 'stopping' | 'failed'
 
 export interface MlDetectionRule {
   actions?: MlRuleAction[]
@@ -14646,7 +14644,7 @@ export interface MlTrainedModelDeploymentStats {
   rejected_execution_count: integer
   reason: string
   start_time: EpochTime<UnitMillis>
-  state: MlDeploymentState
+  state: MlDeploymentAssignmentState
   threads_per_allocation: integer
   timeout_count: integer
 }

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -93,7 +93,7 @@ export class TrainedModelDeploymentStats {
   /** The epoch timestamp when the deployment started. */
   start_time: EpochTime<UnitMillis>
   /** The overall state of the deployment. */
-  state: DeploymentState
+  state: DeploymentAssignmentState
   /** The number of threads used be each allocation during inference. */
   threads_per_allocation: integer
   /** The sum of `timeout_count` for all nodes in the deployment. */
@@ -270,21 +270,6 @@ export enum TrainedModelType {
   pytorch
 }
 
-export enum DeploymentState {
-  /**
-   * The deployment is usable; at least one node has the model allocated.
-   */
-  started,
-  /**
-   * The deployment has recently started but is not yet usable; the model is not allocated on any nodes.
-   */
-  starting,
-  /**
-   * The deployment is preparing to stop and deallocate the model from the relevant nodes.
-   */
-  stopping
-}
-
 export enum DeploymentAllocationState {
   /**
    * The trained model is started on at least one node.
@@ -301,9 +286,21 @@ export enum DeploymentAllocationState {
 }
 
 export enum DeploymentAssignmentState {
-  starting,
+  /**
+   * The deployment is usable; at least one node has the model allocated.
+   */
   started,
+  /**
+   * The deployment has recently started but is not yet usable; the model is not allocated on any nodes.
+   */
+  starting,
+  /**
+   * The deployment is preparing to stop and deallocate the model from the relevant nodes.
+   */
   stopping,
+  /**
+   * The deployment is on a failed state and must be re-deployed.
+   */
   failed
 }
 


### PR DESCRIPTION
Fixes #2941.

While the server uses the [AssignmentState](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentState.java#L13) enum for both the [state](https://github.com/elastic/elasticsearch/blob/99015aa948d3244deb924865b91317ac53ff75bd/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java#L418) and [assignment_state](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java#L104) fields, the spec defines two different enums ([DeploymentState](https://github.com/elastic/elasticsearch-specification/blob/44322a45a33639817b972864bbe2164b86d42e02/specification/ml/_types/TrainedModel.ts#L273) and [DeploymentAssignmentState](https://github.com/elastic/elasticsearch-specification/blob/44322a45a33639817b972864bbe2164b86d42e02/specification/ml/_types/TrainedModel.ts#L303)) for it and one of them has not been updated with all the possible values:
* The `assignment_state` field is serialized [here](https://github.com/elastic/elasticsearch/blob/99015aa948d3244deb924865b91317ac53ff75bd/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java#L367) and it is of type AssignmentState.
* The `state` field is serialized [here](https://github.com/elastic/elasticsearch/blob/99015aa948d3244deb924865b91317ac53ff75bd/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java#L599C8-L599C43) and it is of type AssignmentState too (this is the one I'm raising the issue for).

In this PR I've replaced `TrainedModel.DeploymentState` with `TrainedModel.DeploymentAssignmentState` so that the spec is aligned with the server model and added comments to the cases of `TrainedModel.DeploymentAssignmentState`.