### PR TITLE
Fix indices.get_alias error response

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -65172,7 +65172,14 @@
         "type": "object",
         "properties": {
           "error": {
-            "$ref": "#/components/schemas/_types:ErrorCause"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/_types:ErrorCause"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "status": {
             "type": "number"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -52351,7 +52351,14 @@
         "type": "object",
         "properties": {
           "error": {
-            "$ref": "#/components/schemas/_types:ErrorCause"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/_types:ErrorCause"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "status": {
             "type": "number"

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -21281,41 +21281,12 @@
           }
         }
       },
-      "exceptions": [
-        {
-          "body": {
-            "kind": "value",
-            "value": {
-              "items": [
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "NotFoundAliases",
-                    "namespace": "indices.get_alias"
-                  }
-                },
-                {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "ErrorResponseBase",
-                    "namespace": "_types"
-                  }
-                }
-              ],
-              "kind": "union_of"
-            }
-          },
-          "statusCodes": [
-            404
-          ]
-        }
-      ],
       "kind": "response",
       "name": {
         "name": "Response",
         "namespace": "indices.get_alias"
       },
-      "specLocation": "indices/get_alias/IndicesGetAliasResponse.ts#L26-L35"
+      "specLocation": "indices/get_alias/IndicesGetAliasResponse.ts#L24-L27"
     },
     {
       "attachedBehaviors": [
@@ -75411,11 +75382,23 @@
           "name": "error",
           "required": true,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "ErrorCause",
-              "namespace": "_types"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "ErrorCause",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
@@ -118210,7 +118193,7 @@
           }
         }
       ],
-      "specLocation": "indices/get_alias/IndicesGetAliasResponse.ts#L37-L39"
+      "specLocation": "indices/get_alias/IndicesGetAliasResponse.ts#L29-L31"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2304,7 +2304,7 @@ export type ErrorCause = ErrorCauseKeys
   & { [property: string]: any }
 
 export interface ErrorResponseBase {
-  error: ErrorCause
+  error: ErrorCause | string
   status: integer
 }
 

--- a/specification/_types/Base.ts
+++ b/specification/_types/Base.ts
@@ -80,7 +80,7 @@ export class ErrorResponseBase {
   // In some edge cases `error` can be a string that is a shortcut to `error.reason`, for example if you call `GET _cat/foo`.
   // If the error is a string, it means that it was not caused by an exception on ES side, but on the HTTP routing layer.
   // This should never happen in clients, because we assume we will never send malformed request.
-  error: ErrorCause
+  error: ErrorCause | string
   status: integer
 }
 

--- a/specification/indices/get_alias/IndicesGetAliasResponse.ts
+++ b/specification/indices/get_alias/IndicesGetAliasResponse.ts
@@ -18,27 +18,14 @@
  */
 
 import { AliasDefinition } from '@indices/_types/AliasDefinition'
-import { AdditionalProperties } from '@spec_utils/behaviors'
 import { Dictionary } from '@spec_utils/Dictionary'
-import { ErrorResponseBase } from '@_types/Base'
 import { IndexName } from '@_types/common'
 
 export class Response {
   /** @codegen_name aliases */
   body: Dictionary<IndexName, IndexAliases>
-  exceptions: [
-    {
-      statusCodes: [404]
-      body: NotFoundAliases | ErrorResponseBase
-    }
-  ]
 }
 
 export class IndexAliases {
   aliases: Dictionary<string, AliasDefinition>
-}
-
-class NotFoundAliases implements AdditionalProperties<string, IndexAliases> {
-  error: string
-  status: number
 }


### PR DESCRIPTION
Our recordings show two different errors paths. The first one is supported:

```json
{
  "api": "indices.get_alias",
  "file": "/test/free/indices.get_alias/10_basic.yml",
  "name": "Getting alias on an non-existent index should return 404",
  "origin": "yaml",
  "request": {
    "args": {
      "index": "non-existent",
      "name": "foo"
    }
  },
  "response": {
    "headers": {
      "content-encoding": "gzip",
      "content-length": "164",
      "content-type": "application/json",
      "x-elastic-product": "Elasticsearch"
    },
    "payload": {
      "error": {
        "index": "non-existent",
        "index_uuid": "_na_",
        "reason": "no such index [non-existent]",
        "resource.id": "non-existent",
        "resource.type": "index_or_alias",
        "root_cause": [
          {
            "index": "non-existent",
            "index_uuid": "_na_",
            "reason": "no such index [non-existent]",
            "resource.id": "non-existent",
            "resource.type": "index_or_alias",
            "type": "index_not_found_exception"
          }
        ],
        "type": "index_not_found_exception"
      },
      "status": 404
    },
    "statusCode": 404
  }
}
```

But the second one was not supported:

```json
{
  "api": "indices.get_alias",
  "file": "/test/free/indices.delete_alias/all_path_options.yml",
  "name": "check delete with * index",
  "origin": "yaml",
  "request": {
    "args": {
      "name": "alias1"
    }
  },
  "response": {
    "headers": {
      "content-encoding": "gzip",
      "content-length": "70",
      "content-type": "application/json",
      "x-elastic-product": "Elasticsearch"
    },
    "payload": {
      "error": "alias [alias1] missing",
      "status": 404
    },
    "statusCode": 404
  }
}
```

Not sure if changing `ErrorResponseBase` this way is OK or not.