### PR TITLE
7.17 - Fix nodes security response

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14096,7 +14096,7 @@ export interface NodesInfoNodeInfoXpackLicenseType {
 }
 
 export interface NodesInfoNodeInfoXpackSecurity {
-  http: NodesInfoNodeInfoXpackSecuritySsl
+  http?: NodesInfoNodeInfoXpackSecuritySsl
   enabled: string
   transport?: NodesInfoNodeInfoXpackSecuritySsl
   authc?: NodesInfoNodeInfoXpackSecurityAuthc

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -236,7 +236,7 @@ export class NodeInfoXpack {
 }
 
 export class NodeInfoXpackSecurity {
-  http: NodeInfoXpackSecuritySsl
+  http?: NodeInfoXpackSecuritySsl
   enabled: string
   transport?: NodeInfoXpackSecuritySsl
   authc?: NodeInfoXpackSecurityAuthc


### PR DESCRIPTION
If security is disabled all other values are null, so `http` has to be optional as well