### PR TITLE
Java issues batch 8

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -9643,7 +9643,11 @@
                   "next_step": {
                     "$ref": "#/components/schemas/ilm.move_to_step:StepKey"
                   }
-                }
+                },
+                "required": [
+                  "current_step",
+                  "next_step"
+                ]
               }
             }
           }

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -67313,6 +67313,9 @@
         "properties": {
           "hidden": {
             "type": "boolean"
+          },
+          "allow_custom_routing": {
+            "type": "boolean"
           }
         }
       },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -66738,10 +66738,7 @@
           "_shards": {
             "$ref": "#/components/schemas/_types:ShardStatistics"
           }
-        },
-        "required": [
-          "_shards"
-        ]
+        }
       },
       "indices.close:CloseIndexResult": {
         "type": "object",

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -66528,8 +66528,6 @@
           }
         },
         "required": [
-          "action",
-          "name",
           "phase"
         ]
       },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -57499,9 +57499,7 @@
               }
             },
             "required": [
-              "type",
-              "max_gram",
-              "min_gram"
+              "type"
             ]
           }
         ]
@@ -57614,9 +57612,7 @@
               }
             },
             "required": [
-              "type",
-              "max_gram",
-              "min_gram"
+              "type"
             ]
           }
         ]

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -39244,9 +39244,7 @@
               }
             },
             "required": [
-              "type",
-              "max_gram",
-              "min_gram"
+              "type"
             ]
           }
         ]
@@ -39359,9 +39357,7 @@
               }
             },
             "required": [
-              "type",
-              "max_gram",
-              "min_gram"
+              "type"
             ]
           }
         ]

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -45340,10 +45340,7 @@
           "_shards": {
             "$ref": "#/components/schemas/_types:ShardStatistics"
           }
-        },
-        "required": [
-          "_shards"
-        ]
+        }
       },
       "indices.resolve_index:ResolveIndexItem": {
         "type": "object",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -45331,6 +45331,9 @@
         "properties": {
           "hidden": {
             "type": "boolean"
+          },
+          "allow_custom_routing": {
+            "type": "boolean"
           }
         }
       },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -119116,7 +119116,7 @@
       "properties": [
         {
           "name": "_shards",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -119126,7 +119126,7 @@
           }
         }
       ],
-      "specLocation": "_types/Base.ts#L91-L93"
+      "specLocation": "_types/Base.ts#L91-L94"
     },
     {
       "kind": "interface",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -84773,7 +84773,7 @@
         },
         {
           "name": "max_gram",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -84784,7 +84784,7 @@
         },
         {
           "name": "min_gram",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -84929,7 +84929,7 @@
         },
         {
           "name": "max_gram",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -84940,7 +84940,7 @@
         },
         {
           "name": "min_gram",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -119103,9 +119103,20 @@
               "namespace": "_builtins"
             }
           }
+        },
+        {
+          "name": "allow_custom_routing",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
         }
       ],
-      "specLocation": "indices/_types/DataStream.ts#L159-L161"
+      "specLocation": "indices/_types/DataStream.ts#L159-L162"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10783,8 +10783,8 @@ export interface IlmMoveToStepRequest extends RequestBase {
 export type IlmMoveToStepResponse = AcknowledgedResponseBase
 
 export interface IlmMoveToStepStepKey {
-  action: string
-  name: string
+  action?: string
+  name?: string
   phase: string
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -4590,8 +4590,8 @@ export interface AnalysisEdgeNGramTokenFilter extends AnalysisTokenFilterBase {
 export interface AnalysisEdgeNGramTokenizer extends AnalysisTokenizerBase {
   type: 'edge_ngram'
   custom_token_chars?: string
-  max_gram: integer
-  min_gram: integer
+  max_gram?: integer
+  min_gram?: integer
   token_chars?: AnalysisTokenChar[]
 }
 
@@ -4933,8 +4933,8 @@ export interface AnalysisNGramTokenFilter extends AnalysisTokenFilterBase {
 export interface AnalysisNGramTokenizer extends AnalysisTokenizerBase {
   type: 'ngram'
   custom_token_chars?: string
-  max_gram: integer
-  min_gram: integer
+  max_gram?: integer
+  min_gram?: integer
   token_chars?: AnalysisTokenChar[]
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10775,8 +10775,8 @@ export interface IlmMigrateToDataTiersResponse {
 export interface IlmMoveToStepRequest extends RequestBase {
   index: IndexName
   body?: {
-    current_step?: IlmMoveToStepStepKey
-    next_step?: IlmMoveToStepStepKey
+    current_step: IlmMoveToStepStepKey
+    next_step: IlmMoveToStepStepKey
   }
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2830,7 +2830,7 @@ export interface ShardStatistics {
 }
 
 export interface ShardsOperationResponseBase {
-  _shards: ShardStatistics
+  _shards?: ShardStatistics
 }
 
 export interface SlicedScroll {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10912,6 +10912,7 @@ export interface IndicesDataStreamTimestampField {
 
 export interface IndicesDataStreamVisibility {
   hidden?: boolean
+  allow_custom_routing?: boolean
 }
 
 export interface IndicesDownsampleConfig {

--- a/specification/_types/Base.ts
+++ b/specification/_types/Base.ts
@@ -89,7 +89,8 @@ export class IndicesResponseBase extends AcknowledgedResponseBase {
 }
 
 export class ShardsOperationResponseBase {
-  _shards: ShardStatistics
+  // _shards is always returned, but not when wait_for_completion is false in the request
+  _shards?: ShardStatistics
 }
 
 export class CustomResponseBuilderBase {}

--- a/specification/_types/analysis/tokenizers.ts
+++ b/specification/_types/analysis/tokenizers.ts
@@ -48,8 +48,8 @@ export class ClassicTokenizer extends TokenizerBase {
 export class EdgeNGramTokenizer extends TokenizerBase {
   type: 'edge_ngram'
   custom_token_chars?: string
-  max_gram: integer
-  min_gram: integer
+  max_gram?: integer
+  min_gram?: integer
   /**
    * @server_default []
    */
@@ -84,8 +84,8 @@ export class LowercaseTokenizer extends TokenizerBase {
 export class NGramTokenizer extends TokenizerBase {
   type: 'ngram'
   custom_token_chars?: string
-  max_gram: integer
-  min_gram: integer
+  max_gram?: integer
+  min_gram?: integer
   /**
    * @server_default []
    */

--- a/specification/ilm/move_to_step/MoveToStepRequest.ts
+++ b/specification/ilm/move_to_step/MoveToStepRequest.ts
@@ -30,7 +30,7 @@ export interface Request extends RequestBase {
     index: IndexName
   }
   body: {
-    current_step?: StepKey
-    next_step?: StepKey
+    current_step: StepKey
+    next_step: StepKey
   }
 }

--- a/specification/ilm/move_to_step/types.ts
+++ b/specification/ilm/move_to_step/types.ts
@@ -18,7 +18,8 @@
  */
 
 export class StepKey {
-  action: string
-  name: string
+  // action and name are optional in case they are used in next_step
+  action?: string
+  name?: string
   phase: string
 }

--- a/specification/indices/_types/DataStream.ts
+++ b/specification/indices/_types/DataStream.ts
@@ -158,4 +158,5 @@ export class DataStreamIndex {
 
 export class DataStreamVisibility {
   hidden?: boolean
+  allow_custom_routing?: boolean
 }


### PR DESCRIPTION
- [877](https://github.com/elastic/elasticsearch-java/issues/877): some optional values in ngram and edge tokenizer (details and server code references in the issue).
- [880](https://github.com/elastic/elasticsearch-java/issues/880): ForceMergeRequest accepts `wait_for_competion`, so the response should be optional to handle both `wait_for_competion` cases.
- [881](https://github.com/elastic/elasticsearch-java/issues/881): added missing `allow_custom_routing` to PutIndexTemplate. [server code](https://github.com/elastic/elasticsearch/blob/7b523568fac465f989910d7f58ad6abae68c05ff/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java#L366) - `failure_store` is internal.
- [883](https://github.com/elastic/elasticsearch-java/issues/883): we use StepKey as both current_step and next_step since they have the same fields, but in next_step `action` and `name` are optional. not super clear from the [server code](https://github.com/elastic/elasticsearch/blob/db632ee3cd355c8f50ec716ef9911f76b76016b7/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/Step.java#L97) (it's all String), but the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-move-to-step.html#ilm-move-to-step-request-body) confirms it (and DevTools test as well). 


Everything should be safe to backport to 8.x and 8.15
