### PR TITLE
Fix download-artifacts on main branch

### DIFF
--- a/.github/download-artifacts/index.js
+++ b/.github/download-artifacts/index.js
@@ -95,6 +95,9 @@ async function downloadArtifacts (opts) {
 }
 
 async function resolve (branch) {
+  if (branch == 'main') {
+    branch = 'master'
+  }
   const url = `https://artifacts-snapshot.elastic.co/elasticsearch/latest/${branch}.json`
   const response = await fetch(url)
   if (!response.ok) {


### PR DESCRIPTION
The Artifacts Snapshot API still uses 'master'. I forgot to test https://github.com/elastic/elasticsearch-specification/pull/2949 on main. Here's how to do it:

```bash
make setup
npm install .github/download-artifacts
node .github/download-artifacts/index.js --branch main
make contrib
git status 
```