### PR TITLE
Make Inference API task_settings optional

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -69014,8 +69014,7 @@
         },
         "required": [
           "service",
-          "service_settings",
-          "task_settings"
+          "service_settings"
         ]
       },
       "inference._types:ServiceSettings": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -45639,8 +45639,7 @@
         },
         "required": [
           "service",
-          "service_settings",
-          "task_settings"
+          "service_settings"
         ]
       },
       "inference._types:ServiceSettings": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -120146,7 +120146,7 @@
         {
           "description": "Task settings specific to the service and task type",
           "name": "task_settings",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12683,7 +12683,7 @@ export type InferenceDenseVector = float[]
 export interface InferenceInferenceEndpoint {
   service: string
   service_settings: InferenceServiceSettings
-  task_settings: InferenceTaskSettings
+  task_settings?: InferenceTaskSettings
 }
 
 export interface InferenceInferenceEndpointInfo extends InferenceInferenceEndpoint {

--- a/specification/inference/_types/Services.ts
+++ b/specification/inference/_types/Services.ts
@@ -35,7 +35,7 @@ export class InferenceEndpoint {
   /**
    * Task settings specific to the service and task type
    */
-  task_settings: TaskSettings
+  task_settings?: TaskSettings
 }
 
 /**


### PR DESCRIPTION
`task_settings` are optional when creating an endpoint in the Inference API and may not be returned in the GET response. The spec incorrectly has `task_settings` as required for both creation (PUT) and retrieval (GET), this PR changes that

The Elasticsearch documentation contains an example where an endpoint is created without task_settings ,see [creating the ELSER service](https://www.elastic.co/guide/en/elasticsearch/reference/current/infer-service-elser.html#inference-example-elser).
