### PR TITLE
Fixing node info sec resp

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -77834,7 +77834,6 @@
           }
         },
         "required": [
-          "http",
           "enabled"
         ]
       },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16899,7 +16899,7 @@ export interface NodesInfoNodeInfoXpackLicenseType {
 }
 
 export interface NodesInfoNodeInfoXpackSecurity {
-  http: NodesInfoNodeInfoXpackSecuritySsl
+  http?: NodesInfoNodeInfoXpackSecuritySsl
   enabled: string
   transport?: NodesInfoNodeInfoXpackSecuritySsl
   authc?: NodesInfoNodeInfoXpackSecurityAuthc

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -243,7 +243,7 @@ export class NodeInfoXpack {
 }
 
 export class NodeInfoXpackSecurity {
-  http: NodeInfoXpackSecuritySsl
+  http?: NodeInfoXpackSecuritySsl
   enabled: string
   transport?: NodeInfoXpackSecuritySsl
   authc?: NodeInfoXpackSecurityAuthc


### PR DESCRIPTION
I had already [fixed this for 7.17](https://github.com/elastic/elasticsearch-specification/pull/2956/), somehow I was wrongly convinced that it only needed to be backported - the reasoning is the same