### PR TITLE
Xpack settings fixes

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -77789,6 +77789,9 @@
             "additionalProperties": {
               "type": "object"
             }
+          },
+          "ml": {
+            "$ref": "#/components/schemas/nodes.info:NodeInfoXpackMl"
           }
         },
         "required": [
@@ -77831,9 +77834,6 @@
           },
           "authc": {
             "$ref": "#/components/schemas/nodes.info:NodeInfoXpackSecurityAuthc"
-          },
-          "ml": {
-            "$ref": "#/components/schemas/nodes.info:NodeInfoXpackSecurityMl"
           }
         },
         "required": [
@@ -77914,7 +77914,7 @@
           "enabled"
         ]
       },
-      "nodes.info:NodeInfoXpackSecurityMl": {
+      "nodes.info:NodeInfoXpackMl": {
         "type": "object",
         "properties": {
           "use_auto_machine_memory_percent": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -77831,6 +77831,9 @@
           },
           "authc": {
             "$ref": "#/components/schemas/nodes.info:NodeInfoXpackSecurityAuthc"
+          },
+          "ml": {
+            "$ref": "#/components/schemas/nodes.info:NodeInfoXpackSecurityMl"
           }
         },
         "required": [
@@ -77861,11 +77864,7 @@
           "token": {
             "$ref": "#/components/schemas/nodes.info:NodeInfoXpackSecurityAuthcToken"
           }
-        },
-        "required": [
-          "realms",
-          "token"
-        ]
+        }
       },
       "nodes.info:NodeInfoXpackSecurityAuthcRealms": {
         "type": "object",
@@ -77914,6 +77913,14 @@
         "required": [
           "enabled"
         ]
+      },
+      "nodes.info:NodeInfoXpackSecurityMl": {
+        "type": "object",
+        "properties": {
+          "use_auto_machine_memory_percent": {
+            "type": "boolean"
+          }
+        }
       },
       "nodes.info:NodeInfoScript": {
         "type": "object",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16903,11 +16903,12 @@ export interface NodesInfoNodeInfoXpackSecurity {
   enabled: string
   transport?: NodesInfoNodeInfoXpackSecuritySsl
   authc?: NodesInfoNodeInfoXpackSecurityAuthc
+  ml?: NodesInfoNodeInfoXpackSecurityMl
 }
 
 export interface NodesInfoNodeInfoXpackSecurityAuthc {
-  realms: NodesInfoNodeInfoXpackSecurityAuthcRealms
-  token: NodesInfoNodeInfoXpackSecurityAuthcToken
+  realms?: NodesInfoNodeInfoXpackSecurityAuthcRealms
+  token?: NodesInfoNodeInfoXpackSecurityAuthcToken
 }
 
 export interface NodesInfoNodeInfoXpackSecurityAuthcRealms {
@@ -16923,6 +16924,10 @@ export interface NodesInfoNodeInfoXpackSecurityAuthcRealmsStatus {
 
 export interface NodesInfoNodeInfoXpackSecurityAuthcToken {
   enabled: string
+}
+
+export interface NodesInfoNodeInfoXpackSecurityMl {
+  use_auto_machine_memory_percent?: boolean
 }
 
 export interface NodesInfoNodeInfoXpackSecuritySsl {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16888,6 +16888,7 @@ export interface NodesInfoNodeInfoXpack {
   license?: NodesInfoNodeInfoXpackLicense
   security: NodesInfoNodeInfoXpackSecurity
   notification?: Record<string, any>
+  ml?: NodesInfoNodeInfoXpackMl
 }
 
 export interface NodesInfoNodeInfoXpackLicense {
@@ -16898,12 +16899,15 @@ export interface NodesInfoNodeInfoXpackLicenseType {
   type: string
 }
 
+export interface NodesInfoNodeInfoXpackMl {
+  use_auto_machine_memory_percent?: boolean
+}
+
 export interface NodesInfoNodeInfoXpackSecurity {
   http: NodesInfoNodeInfoXpackSecuritySsl
   enabled: string
   transport?: NodesInfoNodeInfoXpackSecuritySsl
   authc?: NodesInfoNodeInfoXpackSecurityAuthc
-  ml?: NodesInfoNodeInfoXpackSecurityMl
 }
 
 export interface NodesInfoNodeInfoXpackSecurityAuthc {
@@ -16924,10 +16928,6 @@ export interface NodesInfoNodeInfoXpackSecurityAuthcRealmsStatus {
 
 export interface NodesInfoNodeInfoXpackSecurityAuthcToken {
   enabled: string
-}
-
-export interface NodesInfoNodeInfoXpackSecurityMl {
-  use_auto_machine_memory_percent?: boolean
 }
 
 export interface NodesInfoNodeInfoXpackSecuritySsl {

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -240,6 +240,7 @@ export class NodeInfoXpack {
   license?: NodeInfoXpackLicense
   security: NodeInfoXpackSecurity
   notification?: Dictionary<string, UserDefinedValue>
+  ml?: NodeInfoXpackMl
 }
 
 export class NodeInfoXpackSecurity {
@@ -247,10 +248,9 @@ export class NodeInfoXpackSecurity {
   enabled: string
   transport?: NodeInfoXpackSecuritySsl
   authc?: NodeInfoXpackSecurityAuthc
-  ml?: NodeInfoXpackSecurityMl
 }
 
-export class NodeInfoXpackSecurityMl {
+export class NodeInfoXpackMl {
   use_auto_machine_memory_percent?: boolean
 }
 

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -247,6 +247,11 @@ export class NodeInfoXpackSecurity {
   enabled: string
   transport?: NodeInfoXpackSecuritySsl
   authc?: NodeInfoXpackSecurityAuthc
+  ml?: NodeInfoXpackSecurityMl
+}
+
+export class NodeInfoXpackSecurityMl {
+  use_auto_machine_memory_percent?: boolean
 }
 
 export class NodeInfoXpackSecuritySsl {
@@ -254,8 +259,8 @@ export class NodeInfoXpackSecuritySsl {
 }
 
 export class NodeInfoXpackSecurityAuthc {
-  realms: NodeInfoXpackSecurityAuthcRealms
-  token: NodeInfoXpackSecurityAuthcToken
+  realms?: NodeInfoXpackSecurityAuthcRealms
+  token?: NodeInfoXpackSecurityAuthcToken
 }
 
 export class NodeInfoXpackSecurityAuthcRealms {


### PR DESCRIPTION
The ml field in NodeInfoXpackSecurity is used in start-local.
A java user [reported](https://github.com/elastic/elasticsearch-java/issues/892) that having an anonymous realm means the realm field is null (and according to the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/anonymous-access.html), probably also the token field).

Unfortunately I couldn't find any server side proof, let's see what the validation says. 