### PR TITLE
Fixing snapshot restore response

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -31461,13 +31461,13 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "accepted": {
+                      "type": "boolean"
+                    },
                     "snapshot": {
                       "$ref": "#/components/schemas/snapshot.restore:SnapshotRestore"
                     }
-                  },
-                  "required": [
-                    "snapshot"
-                  ]
+                  }
                 }
               }
             }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -19105,7 +19105,8 @@ export interface SnapshotRestoreRequest extends RequestBase {
 }
 
 export interface SnapshotRestoreResponse {
-  snapshot: SnapshotRestoreSnapshotRestore
+  accepted?: boolean
+  snapshot?: SnapshotRestoreSnapshotRestore
 }
 
 export interface SnapshotRestoreSnapshotRestore {

--- a/specification/snapshot/restore/SnapshotRestoreResponse.ts
+++ b/specification/snapshot/restore/SnapshotRestoreResponse.ts
@@ -21,7 +21,10 @@ import { IndexName } from '@_types/common'
 import { ShardStatistics } from '@_types/Stats'
 
 export class Response {
-  body: { snapshot: SnapshotRestore }
+  body: {
+    accepted?: boolean
+    snapshot?: SnapshotRestore
+  }
 }
 
 export class SnapshotRestore {


### PR DESCRIPTION
This is one of the many endpoints which changes its response depending if `wait_for_completion` was set as true or false in the request. [server code](https://github.com/elastic/elasticsearch/blob/21e3a17e5b70a26c6703590d10bd4305ca81425b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotResponse.java#L64)