### PR TITLE
Add community_id, fingerprint, and network_direction processors

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -78,6 +78,7 @@ cluster-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/c
 cluster-update-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-update-settings.html
 cluster,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster.html
 common-options,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/common-options.html
+community-id-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/community-id-processor.html
 connector-sync-job-cancel,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cancel-connector-sync-job-api.html
 connector-sync-job-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-connector-sync-job-api.html
 connector-sync-job-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-connector-sync-job-api.html
@@ -157,6 +158,7 @@ fail-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/
 field-and-document-access-control,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/field-and-document-access-control.html
 field-usage-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/field-usage-stats.html
 find-structure,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/find-structure.html
+fingerprint-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/fingerprint-processor.html
 foreach-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/foreach-processor.html
 fuzziness,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/common-options.html#fuzziness
 gap-policy,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-pipeline.html#gap-policy
@@ -329,6 +331,7 @@ modules-scripting,https://www.elastic.co/guide/en/elasticsearch/reference/{branc
 modules-snapshots,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-snapshots.html
 monitor-elasticsearch-cluster,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/monitor-elasticsearch-cluster.html
 multi-fields,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/multi-fields.html
+network-direction-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/network-direction-processor.html
 node-roles,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html#node-roles
 paginate-search-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html
 painless-contexts,https://www.elastic.co/guide/en/elasticsearch/painless/{branch}/painless-contexts.html

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -531,10 +531,11 @@ export class CircleProcessor extends ProcessorBase {
 export enum ConvertType {
   integer,
   long,
-  float,
   double,
-  string,
+  float,
   boolean,
+  ip,
+  string,
   auto
 }
 

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -56,6 +56,13 @@ export class ProcessorContainer {
    */
   circle?: CircleProcessor
   /**
+   * Computes the Community ID for network flow data as defined in the
+   * Community ID Specification. You can use a community ID to correlate network
+   * events related to a single flow.
+   * @doc_id community-id-processor
+   */
+  community_id?: CommunityIDProcessor
+  /**
    * Converts a field in the currently ingested document to a different type, such as converting a string to an integer.
    * If the field value is an array, all members will be converted.
    * @doc_id convert-processor
@@ -526,6 +533,58 @@ export class CircleProcessor extends ProcessorBase {
    * By default, the field is updated in-place.
    */
   target_field?: Field
+}
+
+export class CommunityIDProcessor extends ProcessorBase {
+  /**
+   * Field containing the source IP address.
+   */
+  source_ip?: string
+  /**
+   * Field containing the source port.
+   */
+  source_port?: string
+  /**
+   * Field containing the destination IP address.
+   */
+  destination_ip?: string
+  /**
+   * Field containing the destination port.
+   */
+  destination_port?: string
+  /**
+   * Field containing the IANA number.
+   */
+  iana_number?: string
+  /**
+   * Field containing the ICMP type.
+   */
+  icmp_type?: string
+  /**
+   * Field containing the ICMP code.
+   */
+  icmp_code?: string
+  /**
+   * Field containing the transport protocol name or number. Used only when the
+   * iana_number field is not present. The following protocol names are currently
+   * supported: ICMP, IGMP, TCP, UDP, GRE, ICMP IPv6, EIGRP, OSPF, PIM, and SCTP.
+   */
+  transport?: string
+  /**
+   * Output field for the community ID.
+   */
+  target_field?: Field
+  /**
+   * Seed for the community ID hash. Must be between 0 and 65535 (inclusive). The
+   * seed can prevent hash collisions between network domains, such as a staging
+   * and production network that use the same addressing scheme.
+   */
+  seed?: integer
+  /**
+   * If true and any required fields are missing, the processor quietly exits
+   * without modifying the document.
+   */
+  ignore_missing?: boolean
 }
 
 export enum ConvertType {

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -183,6 +183,12 @@ export class ProcessorContainer {
    */
   lowercase?: LowercaseProcessor
   /**
+   * Calculates the network direction given a source IP address, destination IP
+   * address, and a list of internal networks.
+   * @doc_id network-direction-processor
+   */
+  network_direction?: NetworkDirectionProcessor
+  /**
    * Executes another pipeline.
    * @doc_id pipeline-processor
    */
@@ -1137,6 +1143,38 @@ export class LowercaseProcessor extends ProcessorBase {
    * @server_default field
    */
   target_field?: Field
+}
+
+export class NetworkDirectionProcessor extends ProcessorBase {
+  /**
+   * Field containing the source IP address.
+   */
+  source_ip?: string
+  /**
+   * Field containing the destination IP address.
+   */
+  destination_ip?: string
+  /**
+   * Output field for the network direction.
+   */
+  target_field?: Field
+  /**
+   * List of internal networks. Supports IPv4 and IPv6 addresses and ranges in
+   * CIDR notation. Also supports the named ranges listed below. These may be
+   * constructed with template snippets. Must specify only one of
+   * internal_networks or internal_networks_field.
+   */
+  internal_networks: string[]
+  /**
+   * A field on the given document to read the internal_networks configuration
+   * from.
+   */
+  internal_networks_field?: string
+  /**
+   * If true and any required fields are missing, the processor quietly exits
+   * without modifying the document.
+   */
+  ignore_missing?: boolean
 }
 
 export class PipelineProcessor extends ProcessorBase {

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -114,6 +114,12 @@ export class ProcessorContainer {
    */
   fail?: FailProcessor
   /**
+   * Computes a hash of the document’s content. You can use this hash for
+   * content fingerprinting.
+   * @doc_id fingerprint-processor
+   */
+  fingerprint?: FingerprintProcessor
+  /**
    * Runs an ingest processor on each element of an array or object.
    * @doc_id foreach-processor
    */
@@ -814,6 +820,33 @@ export class FailProcessor extends ProcessorBase {
    * Supports template snippets.
    */
   message: string
+}
+
+export class FingerprintProcessor extends ProcessorBase {
+  /**
+   * Array of fields to include in the fingerprint. For objects, the processor
+   * hashes both the field key and value. For other fields, the processor hashes
+   * only the field value.
+   */
+  fields: string[]
+  /**
+   * Output field for the fingerprint.
+   */
+  target_field?: Field
+  /**
+   * Salt value for the hash function.
+   */
+  salt?: string
+  /**
+   * The hash method used to compute the fingerprint. Must be one of MD5, SHA-1,
+   * SHA-256, SHA-512, or MurmurHash3.
+   */
+  method?: string
+  /**
+   * If true, the processor ignores any missing fields. If all fields are
+   * missing, the processor silently exits without modifying the document.
+   */
+  ignore_missing?: boolean
 }
 
 export class ForeachProcessor extends ProcessorBase {


### PR DESCRIPTION
Add ingest processor definitions for community_id, fingerprint, and network_direction processors. All parameter descriptions were scraped from the 8.16 docs.

Add ip to the list of types supported by the convert processor.

Related issues

- Fixes #2309
- Fixes #2553
- Fixes #2593
- Fixes #2617