### PR TITLE
Add community_id, fingerprint, and network_direction processors

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -78,6 +78,7 @@ cluster-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/c
 cluster-update-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-update-settings.html
 cluster,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster.html
 common-options,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/common-options.html
+community-id-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/community-id-processor.html
 connector-sync-job-cancel,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cancel-connector-sync-job-api.html
 connector-sync-job-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-connector-sync-job-api.html
 connector-sync-job-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-connector-sync-job-api.html
@@ -157,6 +158,7 @@ fail-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/
 field-and-document-access-control,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/field-and-document-access-control.html
 field-usage-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/field-usage-stats.html
 find-structure,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/find-structure.html
+fingerprint-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/fingerprint-processor.html
 foreach-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/foreach-processor.html
 fuzziness,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/common-options.html#fuzziness
 gap-policy,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-pipeline.html#gap-policy
@@ -329,6 +331,7 @@ modules-scripting,https://www.elastic.co/guide/en/elasticsearch/reference/{branc
 modules-snapshots,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-snapshots.html
 monitor-elasticsearch-cluster,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/monitor-elasticsearch-cluster.html
 multi-fields,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/multi-fields.html
+network-direction-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/network-direction-processor.html
 node-roles,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-node.html#node-roles
 paginate-search-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html
 painless-contexts,https://www.elastic.co/guide/en/elasticsearch/painless/{branch}/painless-contexts.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -410,6 +410,7 @@ query-dsl,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query
 realtime,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-get.html#realtime
 redact-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/redact-processor.html
 regexp-syntax,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/regexp-syntax.html
+registered-domain-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/registered-domain-processor.html
 remove-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/remove-processor.html
 rename-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/rename-processor.html
 reroute-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/reroute-processor.html

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -558,62 +558,62 @@ export class CircleProcessor extends ProcessorBase {
 export class CommunityIDProcessor extends ProcessorBase {
   /**
    * Field containing the source IP address.
-   * @server-default source.ip
+   * @server_default source.ip
    */
   source_ip?: Field
   /**
    * Field containing the source port.
-   * @server-default source.port
+   * @server_default source.port
    */
   source_port?: Field
   /**
    * Field containing the destination IP address.
-   * @server-default destination.ip
+   * @server_default destination.ip
    */
   destination_ip?: Field
   /**
    * Field containing the destination port.
-   * @server-default destination.port
+   * @server_default destination.port
    */
   destination_port?: Field
   /**
    * Field containing the IANA number.
-   * @server-default network.iana_number
+   * @server_default network.iana_number
    */
   iana_number?: Field
   /**
    * Field containing the ICMP type.
-   * @server-default icmp.type
+   * @server_default icmp.type
    */
   icmp_type?: Field
   /**
    * Field containing the ICMP code.
-   * @server-default icmp.code
+   * @server_default icmp.code
    */
   icmp_code?: Field
   /**
    * Field containing the transport protocol name or number. Used only when the
    * iana_number field is not present. The following protocol names are currently
    * supported: eigrp, gre, icmp, icmpv6, igmp, ipv6-icmp, ospf, pim, sctp, tcp, udp
-   * @server-default network.transport
+   * @server_default network.transport
    */
   transport?: Field
   /**
    * Output field for the community ID.
-   * @server-default network.community_id
+   * @server_default network.community_id
    */
   target_field?: Field
   /**
    * Seed for the community ID hash. Must be between 0 and 65535 (inclusive). The
    * seed can prevent hash collisions between network domains, such as a staging
    * and production network that use the same addressing scheme.
-   * @server-default 0
+   * @server_default 0
    */
   seed?: integer
   /**
    * If true and any required fields are missing, the processor quietly exits
    * without modifying the document.
-   * @server-default true
+   * @server_default true
    */
   ignore_missing?: boolean
 }
@@ -756,7 +756,7 @@ export class DateProcessor extends ProcessorBase {
   /**
    * The format to use when writing the date to target_field. Must be a valid
    * java time pattern.
-   * @server-default yyyy-MM-dd'T'HH:mm:ss.SSSXXX
+   * @server_default yyyy-MM-dd'T'HH:mm:ss.SSSXXX
    */
   output_format?: string
 }
@@ -870,7 +870,7 @@ export class FingerprintProcessor extends ProcessorBase {
   fields: Fields
   /**
    * Output field for the fingerprint.
-   * @server-default fingerprint
+   * @server_default fingerprint
    */
   target_field?: Field
   /**
@@ -880,13 +880,13 @@ export class FingerprintProcessor extends ProcessorBase {
   /**
    * The hash method used to compute the fingerprint. Must be one of MD5, SHA-1,
    * SHA-256, SHA-512, or MurmurHash3.
-   * @server-default SHA-1
+   * @server_default SHA-1
    */
   method?: FingerprintDigest
   /**
    * If true, the processor ignores any missing fields. If all fields are
    * missing, the processor silently exits without modifying the document.
-   * @server-default false
+   * @server_default false
    */
   ignore_missing?: boolean
 }
@@ -911,7 +911,7 @@ export class GrokProcessor extends ProcessorBase {
   /**
    * Must be disabled or v1. If v1, the processor uses patterns with Elastic
    * Common Schema (ECS) field names.
-   * @server-default disabled
+   * @server_default disabled
    */
   ecs_compatibility?: string
   /**
@@ -1190,17 +1190,17 @@ export class LowercaseProcessor extends ProcessorBase {
 export class NetworkDirectionProcessor extends ProcessorBase {
   /**
    * Field containing the source IP address.
-   * @server-default source.ip
+   * @server_default source.ip
    */
   source_ip?: Field
   /**
    * Field containing the destination IP address.
-   * @server-default destination.ip
+   * @server_default destination.ip
    */
   destination_ip?: Field
   /**
    * Output field for the network direction.
-   * @server-default network.direction
+   * @server_default network.direction
    */
   target_field?: Field
   /**
@@ -1218,7 +1218,7 @@ export class NetworkDirectionProcessor extends ProcessorBase {
   /**
    * If true and any required fields are missing, the processor quietly exits
    * without modifying the document.
-   * @server-default true
+   * @server_default true
    */
   ignore_missing?: boolean
 }
@@ -1287,13 +1287,13 @@ export class RegisteredDomainProcessor extends ProcessorBase {
   /**
    * Object field containing extracted domain components. If an empty string,
    * the processor adds components to the document’s root.
-   * @server-default <empty string>
+   * @server_default <empty string>
    */
   target_field?: Field
   /**
    * If true and any required fields are missing, the processor quietly exits
    * without modifying the document.
-   * @server-default true
+   * @server_default true
    */
   ignore_missing?: boolean
 }

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -531,10 +531,11 @@ export class CircleProcessor extends ProcessorBase {
 export enum ConvertType {
   integer,
   long,
-  float,
   double,
-  string,
+  float,
   boolean,
+  ip,
+  string,
   auto
 }
 

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -550,51 +550,62 @@ export class CircleProcessor extends ProcessorBase {
 export class CommunityIDProcessor extends ProcessorBase {
   /**
    * Field containing the source IP address.
+   * @server-default source.ip
    */
-  source_ip?: string
+  source_ip?: Field
   /**
    * Field containing the source port.
+   * @server-default source.port
    */
-  source_port?: string
+  source_port?: Field
   /**
    * Field containing the destination IP address.
+   * @server-default destination.ip
    */
-  destination_ip?: string
+  destination_ip?: Field
   /**
    * Field containing the destination port.
+   * @server-default destination.port
    */
-  destination_port?: string
+  destination_port?: Field
   /**
    * Field containing the IANA number.
+   * @server-default network.iana_number
    */
-  iana_number?: string
+  iana_number?: Field
   /**
    * Field containing the ICMP type.
+   * @server-default icmp.type
    */
-  icmp_type?: string
+  icmp_type?: Field
   /**
    * Field containing the ICMP code.
+   * @server-default icmp.code
    */
-  icmp_code?: string
+  icmp_code?: Field
   /**
    * Field containing the transport protocol name or number. Used only when the
    * iana_number field is not present. The following protocol names are currently
    * supported: ICMP, IGMP, TCP, UDP, GRE, ICMP IPv6, EIGRP, OSPF, PIM, and SCTP.
+   * @server-default network.transport
    */
-  transport?: string
+  transport?: Field
   /**
    * Output field for the community ID.
+   * @server-default network.community_id
    */
   target_field?: Field
   /**
    * Seed for the community ID hash. Must be between 0 and 65535 (inclusive). The
    * seed can prevent hash collisions between network domains, such as a staging
    * and production network that use the same addressing scheme.
+   * @server-default 0
    */
   seed?: integer
   /**
    * If true and any required fields are missing, the processor quietly exits
    * without modifying the document.
+   * @server-default true
    */
   ignore_missing?: boolean
 }
@@ -834,9 +845,10 @@ export class FingerprintProcessor extends ProcessorBase {
    * hashes both the field key and value. For other fields, the processor hashes
    * only the field value.
    */
-  fields: string[]
+  fields: Fields
   /**
    * Output field for the fingerprint.
+   * @server-default fingerprint
    */
   target_field?: Field
   /**
@@ -846,11 +858,13 @@ export class FingerprintProcessor extends ProcessorBase {
   /**
    * The hash method used to compute the fingerprint. Must be one of MD5, SHA-1,
    * SHA-256, SHA-512, or MurmurHash3.
+   * @server-default SHA-1
    */
   method?: string
   /**
    * If true, the processor ignores any missing fields. If all fields are
    * missing, the processor silently exits without modifying the document.
+   * @server-default false
    */
   ignore_missing?: boolean
 }
@@ -1148,14 +1162,17 @@ export class LowercaseProcessor extends ProcessorBase {
 export class NetworkDirectionProcessor extends ProcessorBase {
   /**
    * Field containing the source IP address.
+   * @server-default source.ip
    */
-  source_ip?: string
+  source_ip?: Field
   /**
    * Field containing the destination IP address.
+   * @server-default destination.ip
    */
-  destination_ip?: string
+  destination_ip?: Field
   /**
    * Output field for the network direction.
+   * @server-default network.direction
    */
   target_field?: Field
   /**
@@ -1169,10 +1186,11 @@ export class NetworkDirectionProcessor extends ProcessorBase {
    * A field on the given document to read the internal_networks configuration
    * from.
    */
-  internal_networks_field?: string
+  internal_networks_field?: Field
   /**
    * If true and any required fields are missing, the processor quietly exits
    * without modifying the document.
+   * @server-default true
    */
   ignore_missing?: boolean
 }

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -909,6 +909,12 @@ export class ForeachProcessor extends ProcessorBase {
 
 export class GrokProcessor extends ProcessorBase {
   /**
+   * Must be disabled or v1. If v1, the processor uses patterns with Elastic
+   * Common Schema (ECS) field names.
+   * @server-default disabled
+   */
+  ecs_compatibility?: string
+  /**
    * The field to use for grok expression parsing.
    */
   field: Field

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -594,7 +594,7 @@ export class CommunityIDProcessor extends ProcessorBase {
   /**
    * Field containing the transport protocol name or number. Used only when the
    * iana_number field is not present. The following protocol names are currently
-   * supported: ICMP, IGMP, TCP, UDP, GRE, ICMP IPv6, EIGRP, OSPF, PIM, and SCTP.
+   * supported: eigrp, gre, icmp, icmpv6, igmp, ipv6-icmp, ospf, pim, sctp, tcp, udp
    * @server-default network.transport
    */
   transport?: Field

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -56,6 +56,13 @@ export class ProcessorContainer {
    */
   circle?: CircleProcessor
   /**
+   * Computes the Community ID for network flow data as defined in the
+   * Community ID Specification. You can use a community ID to correlate network
+   * events related to a single flow.
+   * @doc_id community-id-processor
+   */
+  community_id?: CommunityIDProcessor
+  /**
    * Converts a field in the currently ingested document to a different type, such as converting a string to an integer.
    * If the field value is an array, all members will be converted.
    * @doc_id convert-processor
@@ -526,6 +533,58 @@ export class CircleProcessor extends ProcessorBase {
    * By default, the field is updated in-place.
    */
   target_field?: Field
+}
+
+export class CommunityIDProcessor extends ProcessorBase {
+  /**
+   * Field containing the source IP address.
+   */
+  source_ip?: string
+  /**
+   * Field containing the source port.
+   */
+  source_port?: string
+  /**
+   * Field containing the destination IP address.
+   */
+  destination_ip?: string
+  /**
+   * Field containing the destination port.
+   */
+  destination_port?: string
+  /**
+   * Field containing the IANA number.
+   */
+  iana_number?: string
+  /**
+   * Field containing the ICMP type.
+   */
+  icmp_type?: string
+  /**
+   * Field containing the ICMP code.
+   */
+  icmp_code?: string
+  /**
+   * Field containing the transport protocol name or number. Used only when the
+   * iana_number field is not present. The following protocol names are currently
+   * supported: ICMP, IGMP, TCP, UDP, GRE, ICMP IPv6, EIGRP, OSPF, PIM, and SCTP.
+   */
+  transport?: string
+  /**
+   * Output field for the community ID.
+   */
+  target_field?: Field
+  /**
+   * Seed for the community ID hash. Must be between 0 and 65535 (inclusive). The
+   * seed can prevent hash collisions between network domains, such as a staging
+   * and production network that use the same addressing scheme.
+   */
+  seed?: integer
+  /**
+   * If true and any required fields are missing, the processor quietly exits
+   * without modifying the document.
+   */
+  ignore_missing?: boolean
 }
 
 export enum ConvertType {

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -839,6 +839,14 @@ export class FailProcessor extends ProcessorBase {
   message: string
 }
 
+export enum FingerprintDigest {
+  md5 = 'MD5',
+  sha1 = 'SHA-1',
+  sha256 = 'SHA-256',
+  sha512 = 'SHA-512',
+  murmurHash3 = 'MurmurHash3'
+}
+
 export class FingerprintProcessor extends ProcessorBase {
   /**
    * Array of fields to include in the fingerprint. For objects, the processor
@@ -860,7 +868,7 @@ export class FingerprintProcessor extends ProcessorBase {
    * SHA-256, SHA-512, or MurmurHash3.
    * @server-default SHA-1
    */
-  method?: string
+  method?: FingerprintDigest
   /**
    * If true, the processor ignores any missing fields. If all fields are
    * missing, the processor silently exits without modifying the document.

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -753,6 +753,12 @@ export class DateProcessor extends ProcessorBase {
    * @server_default UTC
    */
   timezone?: string
+  /**
+   * The format to use when writing the date to target_field. Must be a valid
+   * java time pattern.
+   * @server-default yyyy-MM-dd'T'HH:mm:ss.SSSXXX
+   */
+  output_format?: string
 }
 
 export class DissectProcessor extends ProcessorBase {

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -183,6 +183,12 @@ export class ProcessorContainer {
    */
   lowercase?: LowercaseProcessor
   /**
+   * Calculates the network direction given a source IP address, destination IP
+   * address, and a list of internal networks.
+   * @doc_id network-direction-processor
+   */
+  network_direction?: NetworkDirectionProcessor
+  /**
    * Executes another pipeline.
    * @doc_id pipeline-processor
    */
@@ -1137,6 +1143,38 @@ export class LowercaseProcessor extends ProcessorBase {
    * @server_default field
    */
   target_field?: Field
+}
+
+export class NetworkDirectionProcessor extends ProcessorBase {
+  /**
+   * Field containing the source IP address.
+   */
+  source_ip?: string
+  /**
+   * Field containing the destination IP address.
+   */
+  destination_ip?: string
+  /**
+   * Output field for the network direction.
+   */
+  target_field?: Field
+  /**
+   * List of internal networks. Supports IPv4 and IPv6 addresses and ranges in
+   * CIDR notation. Also supports the named ranges listed below. These may be
+   * constructed with template snippets. Must specify only one of
+   * internal_networks or internal_networks_field.
+   */
+  internal_networks: string[]
+  /**
+   * A field on the given document to read the internal_networks configuration
+   * from.
+   */
+  internal_networks_field?: string
+  /**
+   * If true and any required fields are missing, the processor quietly exits
+   * without modifying the document.
+   */
+  ignore_missing?: boolean
 }
 
 export class PipelineProcessor extends ProcessorBase {

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -1209,7 +1209,7 @@ export class NetworkDirectionProcessor extends ProcessorBase {
    * constructed with template snippets. Must specify only one of
    * internal_networks or internal_networks_field.
    */
-  internal_networks: string[]
+  internal_networks?: string[]
   /**
    * A field on the given document to read the internal_networks configuration
    * from.

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -201,6 +201,14 @@ export class ProcessorContainer {
    */
   redact?: RedactProcessor
   /**
+   * Extracts the registered domain (also known as the effective top-level
+   * domain or eTLD), sub-domain, and top-level domain from a fully qualified
+   * domain name (FQDN). Uses the registered domains defined in the Mozilla
+   * Public Suffix List.
+   * @doc_id registered-domain-processor
+   */
+  registered_domain?: RegisteredDomainProcessor
+  /**
    * Removes existing fields.
    * If one field doesn’t exist, an exception will be thrown.
    * @doc_id remove-processor
@@ -1257,6 +1265,25 @@ export class RedactProcessor extends ProcessorBase {
    * @server_default false
    */
   trace_redact?: boolean
+}
+
+export class RegisteredDomainProcessor extends ProcessorBase {
+  /**
+   * Field containing the source FQDN.
+   */
+  field: Field
+  /**
+   * Object field containing extracted domain components. If an empty string,
+   * the processor adds components to the document’s root.
+   * @server-default <empty string>
+   */
+  target_field?: Field
+  /**
+   * If true and any required fields are missing, the processor quietly exits
+   * without modifying the document.
+   * @server-default true
+   */
+  ignore_missing?: boolean
 }
 
 export class RemoveProcessor extends ProcessorBase {

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -1287,7 +1287,6 @@ export class RegisteredDomainProcessor extends ProcessorBase {
   /**
    * Object field containing extracted domain components. If an empty string,
    * the processor adds components to the document’s root.
-   * @server_default <empty string>
    */
   target_field?: Field
   /**

--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -114,6 +114,12 @@ export class ProcessorContainer {
    */
   fail?: FailProcessor
   /**
+   * Computes a hash of the document’s content. You can use this hash for
+   * content fingerprinting.
+   * @doc_id fingerprint-processor
+   */
+  fingerprint?: FingerprintProcessor
+  /**
    * Runs an ingest processor on each element of an array or object.
    * @doc_id foreach-processor
    */
@@ -814,6 +820,33 @@ export class FailProcessor extends ProcessorBase {
    * Supports template snippets.
    */
   message: string
+}
+
+export class FingerprintProcessor extends ProcessorBase {
+  /**
+   * Array of fields to include in the fingerprint. For objects, the processor
+   * hashes both the field key and value. For other fields, the processor hashes
+   * only the field value.
+   */
+  fields: string[]
+  /**
+   * Output field for the fingerprint.
+   */
+  target_field?: Field
+  /**
+   * Salt value for the hash function.
+   */
+  salt?: string
+  /**
+   * The hash method used to compute the fingerprint. Must be one of MD5, SHA-1,
+   * SHA-256, SHA-512, or MurmurHash3.
+   */
+  method?: string
+  /**
+   * If true, the processor ignores any missing fields. If all fields are
+   * missing, the processor silently exits without modifying the document.
+   */
+  ignore_missing?: boolean
 }
 
 export class ForeachProcessor extends ProcessorBase {


### PR DESCRIPTION
Add ingest processor definitions for `community_id`, `fingerprint`, `network_direction`, and `registered_domain` processors. All parameters and descriptions were scraped from the 8.16 docs.

Add `ip` to the list of types supported by the `convert` processor.

Add `ecs_compatibility` to grok processor.

Add `output_format` to date processor.

Related issues

- Fixes #2309
- Fixes #2553
- Fixes #2593
- Fixes #2617