### PR TITLE
Host can be array in info settings network

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -77816,7 +77816,17 @@
         "type": "object",
         "properties": {
           "host": {
-            "$ref": "#/components/schemas/_types:Host"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/_types:Host"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/_types:Host"
+                }
+              }
+            ]
           }
         }
       },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16865,7 +16865,7 @@ export interface NodesInfoNodeInfoSettingsIngest {
 }
 
 export interface NodesInfoNodeInfoSettingsNetwork {
-  host?: Host
+  host?: Host | Host[]
 }
 
 export interface NodesInfoNodeInfoSettingsNode {

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -221,7 +221,7 @@ export class NodeInfoSettingsTransportFeatures {
 }
 
 export class NodeInfoSettingsNetwork {
-  host?: Host
+  host?: Host | Host[]
 }
 
 export class NodeInfoIngest {


### PR DESCRIPTION
As reported [here](https://github.com/elastic/elasticsearch-java/issues/892#issuecomment-2410696170)