### PR TITLE
Security APIs: Change `Indices` -> `IndexName[]`

### DIFF
--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -19,7 +19,7 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { Id, Indices, Names } from '@_types/common'
+import { Id, IndexName, Names } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { ScriptLanguage } from '@_types/Scripting'
 import { FieldSecurity } from './FieldSecurity'
@@ -204,7 +204,7 @@ export class IndicesPrivileges {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: Indices
+  names: IndexName[]
   /**
    * The index level privileges that owners of the role have on the specified indices.
    */
@@ -235,7 +235,7 @@ export class RemoteIndicesPrivileges {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: Indices
+  names: IndexName[]
   /**
    * The index level privileges that owners of the role have on the specified indices.
    */
@@ -261,7 +261,7 @@ export class UserIndicesPrivileges {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: Indices
+  names: IndexName[]
   /**
    * The index level privileges that owners of the role have on the specified indices.
    */

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { Indices } from '@_types/common'
+import { IndexName } from '@_types/common'
 
 export class Response {
-  body: { cluster: string[]; index: Indices }
+  body: { cluster: string[]; index: IndexName[] }
 }


### PR DESCRIPTION
From the documentation, it seems that the security APIs always uses `IndexName[]` instead of `Indices`. The latter type has some special semantics, like e.g. `"_all"` string representation - which is not valid in the context of the security APIs.

Related to:
https://github.com/elastic/elasticsearch-net/issues/8377