### PR TITLE
[OpenAPI] Add x-model to specialized queries

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -276,20 +276,14 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-geo-shape-query.html
   - target: "$.components['schemas']['_types.query_dsl:GeoPolygonQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-geo-polygon-query.html
   - target: "$.components['schemas']['_types.query_dsl:GeoDistanceQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-geo-distance-query.html
   - target: "$.components['schemas']['_types.query_dsl:DistanceFeatureQueryBase']"
     description: Add x-model to distance feature query base
     update:
@@ -314,30 +308,18 @@ actions:
     description: Add x-model for more like this query
     update:
       x-model: true
-      externalDocs:
-        description: More like this query
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-mlt-query.html
   - target: "$.components['schemas']['_types.query_dsl:PercolateQuery']"
     description: Add x-model for percolate query
     update:
       x-model: true
-      externalDocs:
-        description: Percolate query
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-percolate-query.html
   - target: "$.components['schemas']['_types.query_dsl:RankFeatureQuery']"
     description: Add x-model for rank feature query
     update:
       x-model: true
-      externalDocs:
-        description: Rank feature query
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-rank-feature-query.html
   - target: "$.components['schemas']['_types.query_dsl:ScriptQuery']"
     description: Add x-model for script query
     update:
       x-model: true
-      externalDocs:
-        description: Script query
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-script-query.html
   - target: "$.components['schemas']['_types.query_dsl:ScriptScoreFunction']"
     description: Add x-model for script score query
     update:
@@ -346,36 +328,22 @@ actions:
     description: Add x-model for script score query
     update:
       x-model: true
-      externalDocs:
-        description: Script score query
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-script-score-query.html
   - target: "$.components['schemas']['_types.query_dsl:WrapperQuery']"
     description: Add x-model for wrapper query
     update:
       x-model: true
-      externalDocs:
-        description: Wrapper query
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-wrapper-query.html
   - target: "$.components['schemas']['_types.query_dsl:PinnedQuery']"
     description: Add x-model for pinned query
     update:
       x-model: true
-      externalDocs:
-        description: Pinned query
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-pinned-query.html
   - target: "$.components['schemas']['_types.query_dsl:RuleQuery']"
     description: Add x-model for rule query
     update:
       x-model: true
-      externalDocs:
-        description: Rule query
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-rule-query.html
   - target: "$.components['schemas']['_types.query_dsl:BoolQuery']"
     description: Add x-model for boolean query
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
   - target: "$.components['schemas']['_types.query_dsl:QueryBase']"
     description: Add x-model for query base
     update:
@@ -384,8 +352,6 @@ actions:
     description: Add x-model for query base
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-boosting-query.html
   - target: "$.components['schemas']['_types.query_dsl:CommonTermsQuery']"
     description: Add x-model for common terms query
     update:
@@ -398,14 +364,10 @@ actions:
     description: Add x-model for constant score query
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-constant-score-query.html
   - target: "$.components['schemas']['_types.query_dsl:DisMaxQuery']"
     description: Add x-model to Disjunction max query
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-dis-max-query.html
   - target: "$.components['schemas']['_types.query_dsl:UntypedDistanceFeatureQuery']"
     description: Add x-model to untyped distance feature query
     update:
@@ -414,14 +376,10 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-exists-query.html
   - target: "$.components['schemas']['_types.query_dsl:FunctionScoreQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html
   - target: "$.components['schemas']['_types.query_dsl:FunctionScoreContainer']"
     description: Add x-model
     update:
@@ -478,38 +436,26 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-fuzzy-query.html
   - target: "$.components['schemas']['_types.query_dsl:GeoBoundingBoxQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-query.html
   - target: "$.components['schemas']['_types.query_dsl:HasChildQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html
   - target: "$.components['schemas']['_types.query_dsl:HasParentQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-query.html
   - target: "$.components['schemas']['_types.query_dsl:ParentIdQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-parent-id-query.html
   - target: "$.components['schemas']['_types.query_dsl:IntervalsQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-intervals-query.html
   - target: "$.components['schemas']['_types.query_dsl:IntervalsAllOf']"
     description: Add x-model
     update:
@@ -546,134 +492,90 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-query.html
   - target: "$.components['schemas']['_types.query_dsl:MatchBoolPrefixQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-bool-prefix-query.html
   - target: "$.components['schemas']['_types.query_dsl:MatchPhraseQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-query-phrase.html
   - target: "$.components['schemas']['_types.query_dsl:MatchPhrasePrefixQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-query-phrase-prefix.html
   - target: "$.components['schemas']['_types.query_dsl:MultiMatchQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-multi-match-query.html
   - target: "$.components['schemas']['_types.query_dsl:QueryStringQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-query-string-query.html
   - target: "$.components['schemas']['_types.query_dsl:SimpleQueryStringQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-simple-query-string-query.html
   - target: "$.components['schemas']['_types.query_dsl:ShapeQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-shape-query.html
   - target: "$.components['schemas']['_types.query_dsl:NestedQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-nested-query.html
   - target: "$.components['schemas']['_types.query_dsl:MatchAllQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-all-query.html
   - target: "$.components['schemas']['_types.query_dsl:MatchNoneQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-all-query.html
   - target: "$.components['schemas']['_types.query_dsl:SpanContainingQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-containing-query.html
   - target: "$.components['schemas']['_types.query_dsl:SpanFieldMaskingQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-field-masking-query.html
   - target: "$.components['schemas']['_types.query_dsl:SpanFirstQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-first-query.html
   - target: "$.components['schemas']['_types.query_dsl:SpanMultiTermQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-multi-term-query.html
   - target: "$.components['schemas']['_types.query_dsl:SpanNearQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-near-query.html
   - target: "$.components['schemas']['_types.query_dsl:SpanNotQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-not-query.html
   - target: "$.components['schemas']['_types.query_dsl:SpanOrQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-or-query.html
   - target: "$.components['schemas']['_types.query_dsl:SpanTermQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-term-query.html
   - target: "$.components['schemas']['_types.query_dsl:SpanWithinQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-within-query.html
   - target: "$.components['schemas']['_types:KnnQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-knn-query.html
   - target: "$.components['schemas']['_types.query_dsl:SparseVectorQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-sparse-vector-query.html
   - target: "$.components['schemas']['_types.query_dsl:SemanticQuery']"
     description: Add x-model
     update:
@@ -745,8 +647,6 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations.html
   - target: "$.components['schemas']['_types.aggregations:CardinalityAggregate']"
     description: Add x-model
     update:
@@ -757,20 +657,26 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url:
+      # externalDocs:
+      #   url:
   - target: "$.components['schemas']['_types.aggregations:HdrPercentileRanksAggregate']"
     description: Add x-model
     update:
       x-model: true
       # externalDocs:
-      #   url:
+      #   url: 
+  - target: "$.components['schemas']['_types.aggregations:PercentileRanksAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-percentile-rank-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:TDigestPercentilesAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-percentile-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:TDigestPercentileRanksAggregate']"
     description: Add x-model
     update:
@@ -781,50 +687,50 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-percentiles-bucket-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MedianAbsoluteDeviationAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-median-absolute-deviation-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MinAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-min-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MaxAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-max-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:SumAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-sum-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:AvgAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-avg-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:WeightedAvgAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-weight-avg-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:ValueCountAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-valuecount-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:SimpleValueAggregate']"
     description: Add x-model
     update:
@@ -835,8 +741,8 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-derivative-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:BucketMetricValueAggregate']"
     description: Add x-model
     update:
@@ -847,20 +753,20 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-stats-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:StatsBucketAggregate']"
     description: Add x-model
     update:
       x-model: true
       externalDocs:
-        url:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-stats-bucket-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:ExtendedStatsAggregate']"
     description: Add x-model
     update:
       x-model: true
       externalDocs:
-        url:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-extendedstats-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:ExtendedStatsBucketAggregate']"
     description: Add x-model
     update:
@@ -871,38 +777,38 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-geobounds-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:GeoCentroidAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-geocentroid-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:HistogramAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-histogram-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:DateHistogramAggregate']"
     description: Add x-model
     update:
       x-model: true
       externalDocs:
-        url:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-datehistogram-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:AutoDateHistogramAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-autodatehistogram-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:VariableWidthHistogramAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-variablewidthhistogram-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:StringTermsAggregate']"
     description: Add x-model
     update:
@@ -949,38 +855,38 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-multi-terms-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MissingAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-missing-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:NestedAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-nested-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:ReverseNestedAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-reverse-nested-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:GlobalAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-global-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:FilterAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-filter-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:ChildrenAggregate']"
     description: Add x-model
     update:
@@ -1009,14 +915,14 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-geohashgrid-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:GeoTileGridAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-geotilegrid-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:GeoHexGridAggregate']"
     description: Add x-model
     update:
@@ -1027,38 +933,38 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-geohexgrid-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:DateRangeAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-daterange-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:GeoDistanceAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-geodistance-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:IpRangeAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-iprange-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:IpPrefixAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-ipprefix-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:FiltersAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-filters-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:AdjacencyMatrixAggregate']"
     description: Add x-model
     update:
@@ -1081,8 +987,14 @@ actions:
     description: Add x-model
     update:
       x-model: true
+      # externalDocs:
+      #   url: 
+  - target: "$.components['schemas']['_types.aggregations:SignificantTermsAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
       externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-significantterms-aggregation.html
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significanttext-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:CompositeAggregate']"
     description: Add x-model
     update:
@@ -1105,68 +1017,194 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-scripted-metric-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:TopHitsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-top-hits-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:InferenceAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-inference-bucket-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:StringStatsAggregate']"
     description: Add x-model
     update:
       x-model: true
       # externalDocs:
-      #   url:
+      #   url: 
   - target: "$.components['schemas']['_types.aggregations:BoxPlotAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-boxplot-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:TopMetricsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-top-metrics.html
   - target: "$.components['schemas']['_types.aggregations:TTestAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-ttest-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:RateAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-rate-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:CumulativeCardinalityAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-cardinality-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MatrixStatsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-matrix-stats-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:GeoLineAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-geo-line.html
+  - target: "$.components['schemas']['_types.aggregations:AutoDateHistogramAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-autodatehistogram-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:CategorizeTextAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-categorize-text-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:DiversifiedSamplerAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-diversified-sampler-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:RandomSamplerAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-random-sampler-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:RareTermsAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-rare-terms-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:SignificantTextAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-significanttext-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:TermsAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-terms-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:AverageBucketAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-avg-bucket-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:BucketScriptAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-bucket-script-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:BucketKsAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-count-ks-test-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:BucketCorrelationAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-correlation-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:BucketSelectorAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-bucket-selector-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:BucketSortAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-bucket-sort-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:CumulativeSumAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-cumulative-sum-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:MaxBucketAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-max-bucket-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:MinBucketAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-min-bucket-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:MovingFunctionAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-movfn-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:MovingPercentilesAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-moving-percentiles-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:NormalizeAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-normalize-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:SerialDifferencingAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-serialdiff-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:SumBucketAggregation']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-sum-bucket-aggregation.html  
   - target: "$.components['schemas']['_types.query_dsl:LikeDocument']"
     description: Add x-model to LikeDocument schema
     update:

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -272,6 +272,44 @@ actions:
     description: Add x-model for distance feature query
     update:
       x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:GeoShapeQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-geo-shape-query.html
+  - target: "$.components['schemas']['_types.query_dsl:GeoPolygonQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-geo-polygon-query.html
+  - target: "$.components['schemas']['_types.query_dsl:GeoDistanceQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-geo-distance-query.html
+  - target: "$.components['schemas']['_types.query_dsl:DistanceFeatureQueryBase']"
+    description: Add x-model to distance feature query base
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:GeoDistanceFeatureQuery']"
+    description: Add x-model to geo distance feature query 
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:DistanceFeatureQueryBaseGeoLocationDistance']"
+    description: Add x-model to distance feature query base geolocation distance
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:DateDistanceFeatureQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:DistanceFeatureQueryBaseDateMathDuration']"
+    description: Add x-model
+    update:
+      x-model: true
   - target: "$.components['schemas']['_types.query_dsl:MoreLikeThisQuery']"
     description: Add x-model for more like this query
     update:
@@ -300,6 +338,10 @@ actions:
       externalDocs:
         description: Script query
         url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-script-query.html
+  - target: "$.components['schemas']['_types.query_dsl:ScriptScoreFunction']"
+    description: Add x-model for script score query
+    update:
+      x-model: true
   - target: "$.components['schemas']['_types.query_dsl:ScriptScoreQuery']"
     description: Add x-model for script score query
     update:
@@ -328,6 +370,196 @@ actions:
       externalDocs:
         description: Rule query
         url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-rule-query.html
+  - target: "$.components['schemas']['_types.query_dsl:BoolQuery']"
+    description: Add x-model for boolean query
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
+  - target: "$.components['schemas']['_types.query_dsl:QueryBase']"
+    description: Add x-model for query base
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:BoostingQuery']"
+    description: Add x-model for query base
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-boosting-query.html
+  - target: "$.components['schemas']['_types.query_dsl:CommonTermsQuery']"
+    description: Add x-model for common terms query
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:CombinedFieldsQuery']"
+    description: Add x-model for combined fields query
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:ConstantScoreQuery']"
+    description: Add x-model for constant score query
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-constant-score-query.html
+  - target: "$.components['schemas']['_types.query_dsl:DisMaxQuery']"
+    description: Add x-model to Disjunction max query
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-dis-max-query.html
+  - target: "$.components['schemas']['_types.query_dsl:UntypedDistanceFeatureQuery']"
+    description: Add x-model to untyped distance feature query
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:ExistsQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-exists-query.html
+  - target: "$.components['schemas']['_types.query_dsl:FunctionScoreQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html
+  - target: "$.components['schemas']['_types.query_dsl:FunctionScoreContainer']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:DecayFunction']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:UntypedDecayFunction']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:DecayFunctionBase']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:MultiValueMode']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:DateDecayFunction']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:DecayFunctionBaseDateMathDuration']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:NumericDecayFunction']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:DecayFunctionBasedoubledouble']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:GeoDecayFunction']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:DecayFunctionBaseGeoLocationDistance']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:FieldValueFactorScoreFunction']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:RandomScoreFunction']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:FuzzyQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-fuzzy-query.html
+  - target: "$.components['schemas']['_types.query_dsl:GeoBoundingBoxQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-query.html
+  - target: "$.components['schemas']['_types.query_dsl:HasChildQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html
+  - target: "$.components['schemas']['_types.query_dsl:HasParentQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-query.html
+  - target: "$.components['schemas']['_types.query_dsl:IntervalsQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-intervals-query.html
+  - target: "$.components['schemas']['_types.query_dsl:IntervalsAllOf']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:IntervalsContainer']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:IntervalsAnyOf']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:IntervalsFilter']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:IntervalsFuzzy']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:IntervalsMatch']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:IntervalsPrefix']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:IntervalsWildcard']"
+    description: Add x-model
+    update:
+      x-model: true
+  - target: "$.components['schemas']['_types.query_dsl:MatchQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-query.html
+  - target: "$.components['schemas']['_types.query_dsl:MatchBoolPrefixQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-bool-prefix-query.html
+  - target: "$.components['schemas']['_types.query_dsl:MatchPhraseQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-query-phrase.html
+  - target: "$.components['schemas']['_types.query_dsl:MatchPhrasePrefixQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-query-phrase-prefix.html
 # Abbreviate and annotate items that are not shown in Bump.sh due to depth limits
   - target: "$.components['schemas']['_types.query_dsl:LikeDocument']"
     description: Add x-model to LikeDocument schema

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -237,7 +237,7 @@ actions:
           x-displayName: Watcher
 # Add x-model and/or abbreviate schemas that should point to other references
   - target: "$.components['schemas']['_types.query_dsl:QueryContainer']"
-    description: Add x-model and updated externalDocs for the QueryContainer object
+    description: Add x-model for the QueryContainer object
     update:
       x-model: true
   - target: "$.components['schemas']['_types.analysis:CharFilter'].oneOf"
@@ -580,68 +580,46 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-semantic-query.html
   - target: "$.components['schemas']['_types.query_dsl:TextExpansionQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-text-expansion-query.html
   - target: "$.components['schemas']['_types.query_dsl:WeightedTokensQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-weighted-tokens-query.html
   - target: "$.components['schemas']['_types.query_dsl:IdsQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-ids-query.html
   - target: "$.components['schemas']['_types.query_dsl:PrefixQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-prefix-query.html
   - target: "$.components['schemas']['_types.query_dsl:RangeQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-range-query.html
   - target: "$.components['schemas']['_types.query_dsl:RegexpQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-regexp-query.html
   - target: "$.components['schemas']['_types.query_dsl:TermQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-term-query.html
   - target: "$.components['schemas']['_types.query_dsl:TermsQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-terms-query.html
   - target: "$.components['schemas']['_types.query_dsl:TermsSetQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-terms-set-query.html
   - target: "$.components['schemas']['_types.query_dsl:WildcardQuery']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-wildcard-query.html
 # Abbreviate and annotate items that are not shown in Bump.sh due to depth limits
   - target: "$.components['schemas']['_types.aggregations:Aggregate']"
     description: Add x-model
@@ -651,560 +629,374 @@ actions:
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:HdrPercentilesAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:HdrPercentileRanksAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url: 
   - target: "$.components['schemas']['_types.aggregations:PercentileRanksAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-percentile-rank-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:TDigestPercentilesAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-percentile-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:TDigestPercentileRanksAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:PercentilesBucketAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-percentiles-bucket-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MedianAbsoluteDeviationAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-median-absolute-deviation-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MinAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-min-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MaxAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-max-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:SumAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-sum-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:AvgAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-avg-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:WeightedAvgAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-weight-avg-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:ValueCountAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-valuecount-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:SimpleValueAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:DerivativeAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-derivative-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:BucketMetricValueAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:StatsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-stats-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:StatsBucketAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-stats-bucket-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:ExtendedStatsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-extendedstats-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:ExtendedStatsBucketAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:GeoBoundsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-geobounds-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:GeoCentroidAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-geocentroid-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:HistogramAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-histogram-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:DateHistogramAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-datehistogram-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:AutoDateHistogramAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-autodatehistogram-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:VariableWidthHistogramAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-variablewidthhistogram-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:StringTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:LongTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:DoubleTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:UnmappedTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:LongRareTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:StringRareTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:UnmappedRareTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:MultiTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-multi-terms-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MissingAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-missing-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:NestedAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-nested-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:ReverseNestedAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-reverse-nested-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:GlobalAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-global-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:FilterAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-filter-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:ChildrenAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-children-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:ParentAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-parent-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:SamplerAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-sampler-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:UnmappedSamplerAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:GeoHashGridAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-geohashgrid-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:GeoTileGridAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-geotilegrid-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:GeoHexGridAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:RangeAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-geohexgrid-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:DateRangeAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-daterange-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:GeoDistanceAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-geodistance-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:IpRangeAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-iprange-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:IpPrefixAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-ipprefix-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:FiltersAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-filters-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:AdjacencyMatrixAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-adjacency-matrix-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:SignificantLongTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:SignificantStringTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url:
   - target: "$.components['schemas']['_types.aggregations:UnmappedSignificantTermsAggregate']"
     description: Add x-model
     update:
-      x-model: true
-      # externalDocs:
-      #   url: 
+      x-model: true 
   - target: "$.components['schemas']['_types.aggregations:SignificantTermsAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significanttext-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:CompositeAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-composite-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:FrequentItemSetsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-frequent-item-sets-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:TimeSeriesAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-time-series-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:ScriptedMetricAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-scripted-metric-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:TopHitsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-top-hits-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:InferenceAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-inference-bucket-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:StringStatsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      # externalDocs:
-      #   url: 
   - target: "$.components['schemas']['_types.aggregations:BoxPlotAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-boxplot-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:TopMetricsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-top-metrics.html
   - target: "$.components['schemas']['_types.aggregations:TTestAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-ttest-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:RateAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-rate-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:CumulativeCardinalityAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-cardinality-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MatrixStatsAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-matrix-stats-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:GeoLineAggregate']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-geo-line.html
   - target: "$.components['schemas']['_types.aggregations:AutoDateHistogramAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-autodatehistogram-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:CategorizeTextAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-categorize-text-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:DiversifiedSamplerAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-diversified-sampler-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:RandomSamplerAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-random-sampler-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:RareTermsAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-rare-terms-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:SignificantTextAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-significanttext-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:TermsAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-terms-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:AverageBucketAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-avg-bucket-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:BucketScriptAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-bucket-script-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:BucketKsAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-count-ks-test-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:BucketCorrelationAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-correlation-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:BucketSelectorAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-bucket-selector-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:BucketSortAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-bucket-sort-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:CumulativeSumAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-cumulative-sum-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MaxBucketAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-max-bucket-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MinBucketAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-min-bucket-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MovingFunctionAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-movfn-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:MovingPercentilesAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-moving-percentiles-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:NormalizeAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-normalize-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:SerialDifferencingAggregation']"
     description: Add x-model
     update:
       x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-serialdiff-aggregation.html
   - target: "$.components['schemas']['_types.aggregations:SumBucketAggregation']"
     description: Add x-model
     update:
-      x-model: true
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-pipeline-sum-bucket-aggregation.html  
+      x-model: true 
   - target: "$.components['schemas']['_types.query_dsl:LikeDocument']"
     description: Add x-model to LikeDocument schema
     update:

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -498,6 +498,12 @@ actions:
       x-model: true
       externalDocs:
         url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-query.html
+  - target: "$.components['schemas']['_types.query_dsl:ParentIdQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-parent-id-query.html
   - target: "$.components['schemas']['_types.query_dsl:IntervalsQuery']"
     description: Add x-model
     update:
@@ -560,7 +566,607 @@ actions:
       x-model: true
       externalDocs:
         url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-query-phrase-prefix.html
+  - target: "$.components['schemas']['_types.query_dsl:MultiMatchQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-multi-match-query.html
+  - target: "$.components['schemas']['_types.query_dsl:QueryStringQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-query-string-query.html
+  - target: "$.components['schemas']['_types.query_dsl:SimpleQueryStringQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-simple-query-string-query.html
+  - target: "$.components['schemas']['_types.query_dsl:ShapeQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-shape-query.html
+  - target: "$.components['schemas']['_types.query_dsl:NestedQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-nested-query.html
+  - target: "$.components['schemas']['_types.query_dsl:MatchAllQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-all-query.html
+  - target: "$.components['schemas']['_types.query_dsl:MatchNoneQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-all-query.html
+  - target: "$.components['schemas']['_types.query_dsl:SpanContainingQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-containing-query.html
+  - target: "$.components['schemas']['_types.query_dsl:SpanFieldMaskingQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-field-masking-query.html
+  - target: "$.components['schemas']['_types.query_dsl:SpanFirstQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-first-query.html
+  - target: "$.components['schemas']['_types.query_dsl:SpanMultiTermQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-multi-term-query.html
+  - target: "$.components['schemas']['_types.query_dsl:SpanNearQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-near-query.html
+  - target: "$.components['schemas']['_types.query_dsl:SpanNotQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-not-query.html
+  - target: "$.components['schemas']['_types.query_dsl:SpanOrQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-or-query.html
+  - target: "$.components['schemas']['_types.query_dsl:SpanTermQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-term-query.html
+  - target: "$.components['schemas']['_types.query_dsl:SpanWithinQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-span-within-query.html
+  - target: "$.components['schemas']['_types:KnnQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-knn-query.html
+  - target: "$.components['schemas']['_types.query_dsl:SparseVectorQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-sparse-vector-query.html
+  - target: "$.components['schemas']['_types.query_dsl:SemanticQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-semantic-query.html
+  - target: "$.components['schemas']['_types.query_dsl:TextExpansionQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-text-expansion-query.html
+  - target: "$.components['schemas']['_types.query_dsl:WeightedTokensQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-weighted-tokens-query.html
+  - target: "$.components['schemas']['_types.query_dsl:IdsQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-ids-query.html
+  - target: "$.components['schemas']['_types.query_dsl:PrefixQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-prefix-query.html
+  - target: "$.components['schemas']['_types.query_dsl:RangeQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-range-query.html
+  - target: "$.components['schemas']['_types.query_dsl:RegexpQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-regexp-query.html
+  - target: "$.components['schemas']['_types.query_dsl:TermQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-term-query.html
+  - target: "$.components['schemas']['_types.query_dsl:TermsQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-terms-query.html
+  - target: "$.components['schemas']['_types.query_dsl:TermsSetQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-terms-set-query.html
+  - target: "$.components['schemas']['_types.query_dsl:WildcardQuery']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-wildcard-query.html
 # Abbreviate and annotate items that are not shown in Bump.sh due to depth limits
+  - target: "$.components['schemas']['_types.aggregations:Aggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations.html
+  - target: "$.components['schemas']['_types.aggregations:CardinalityAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:HdrPercentilesAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url:
+  - target: "$.components['schemas']['_types.aggregations:HdrPercentileRanksAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:TDigestPercentilesAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:TDigestPercentileRanksAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:PercentilesBucketAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:MedianAbsoluteDeviationAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:MinAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:MaxAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:SumAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:AvgAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:WeightedAvgAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:ValueCountAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:SimpleValueAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:DerivativeAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:BucketMetricValueAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:StatsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:StatsBucketAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url:
+  - target: "$.components['schemas']['_types.aggregations:ExtendedStatsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url:
+  - target: "$.components['schemas']['_types.aggregations:ExtendedStatsBucketAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:GeoBoundsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:GeoCentroidAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:HistogramAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:DateHistogramAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url:
+  - target: "$.components['schemas']['_types.aggregations:AutoDateHistogramAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:VariableWidthHistogramAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:StringTermsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:LongTermsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:DoubleTermsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:UnmappedTermsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:LongRareTermsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:StringRareTermsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:UnmappedRareTermsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:MultiTermsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:MissingAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:NestedAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:ReverseNestedAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:GlobalAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:FilterAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:ChildrenAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-children-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:ParentAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-parent-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:SamplerAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-sampler-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:UnmappedSamplerAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:GeoHashGridAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:GeoTileGridAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:GeoHexGridAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:RangeAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:DateRangeAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:GeoDistanceAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:IpRangeAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:IpPrefixAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:FiltersAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:AdjacencyMatrixAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-adjacency-matrix-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:SignificantLongTermsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:SignificantStringTermsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:UnmappedSignificantTermsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-significantterms-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:CompositeAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-composite-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:FrequentItemSetsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-frequent-item-sets-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:TimeSeriesAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-time-series-aggregation.html
+  - target: "$.components['schemas']['_types.aggregations:ScriptedMetricAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:TopHitsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:InferenceAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:StringStatsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:BoxPlotAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:TopMetricsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:TTestAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:RateAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:CumulativeCardinalityAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:MatrixStatsAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
+  - target: "$.components['schemas']['_types.aggregations:GeoLineAggregate']"
+    description: Add x-model
+    update:
+      x-model: true
+      # externalDocs:
+      #   url:
   - target: "$.components['schemas']['_types.query_dsl:LikeDocument']"
     description: Add x-model to LikeDocument schema
     update:

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -283,7 +283,74 @@ actions:
       externalDocs:
         description: Templating a role query
         url: https://www.elastic.co/guide/en/elasticsearch/reference/master/field-and-document-access-control.html#templating-role-query
+  - target: "$.components['schemas']['_types.query_dsl:DistanceFeatureQuery']"
+    description: Add x-model for distance feature query
+    update:
+      x-model: true
+      externalDocs:
+        description: Distance feature query
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-distance-feature-query.html
+  - target: "$.components['schemas']['_types.query_dsl:MoreLikeThisQuery']"
+    description: Add x-model for more like this query
+    update:
+      x-model: true
+      externalDocs:
+        description: More like this query
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-mlt-query.html
+  - target: "$.components['schemas']['_types.query_dsl:PercolateQuery']"
+    description: Add x-model for percolate query
+    update:
+      x-model: true
+      externalDocs:
+        description: Percolate query
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-percolate-query.html
+  - target: "$.components['schemas']['_types.query_dsl:RankFeatureQuery']"
+    description: Add x-model for rank feature query
+    update:
+      x-model: true
+      externalDocs:
+        description: Rank feature query
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-rank-feature-query.html
+  - target: "$.components['schemas']['_types.query_dsl:ScriptQuery']"
+    description: Add x-model for script query
+    update:
+      x-model: true
+      externalDocs:
+        description: Script query
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-script-query.html
+  - target: "$.components['schemas']['_types.query_dsl:ScriptScoreQuery']"
+    description: Add x-model for script score query
+    update:
+      x-model: true
+      externalDocs:
+        description: Script score query
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-script-score-query.html
+  - target: "$.components['schemas']['_types.query_dsl:WrapperQuery']"
+    description: Add x-model for wrapper query
+    update:
+      x-model: true
+      externalDocs:
+        description: Wrapper query
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-wrapper-query.html
+  - target: "$.components['schemas']['_types.query_dsl:PinnedQuery']"
+    description: Add x-model for pinned query
+    update:
+      x-model: true
+      externalDocs:
+        description: Pinned query
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-pinned-query.html
+  - target: "$.components['schemas']['_types.query_dsl:RuleQuery']"
+    description: Add x-model for rule query
+    update:
+      x-model: true
+      externalDocs:
+        description: Rule query
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-rule-query.html
 # Abbreviate and annotate items that are not shown in Bump.sh due to depth limits
+  - target: "$.components['schemas']['_types.query_dsl:LikeDocument']"
+    description: Add x-model to LikeDocument schema
+    update:
+      x-model: true
   - target: "$.components['schemas']['ml._types:Datafeed'].properties.query"
     description: Remove query object from anomaly detection datafeed
     remove: true

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -247,11 +247,6 @@ actions:
     description: Simplify CharFilter definition
     update:
       x-model: true
-      description: >
-        Character filters that are used to preprocess characters before they are passed to the tokenizer.
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-charfilters.html
-        description: Character filters reference
   - target: "$.components['schemas']['_types.analysis:Tokenizer'].oneOf"
     description: Remove existing oneOf definition for tokenizer
     remove: true
@@ -259,11 +254,6 @@ actions:
     description: Simplify tokenizer definition
     update:
       x-model: true
-      description: >
-        A tokenizer to use to convert text into tokens.
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-tokenizers.html
-        description: Tokenizer reference
   - target: "$.components['schemas']['_types.analysis:TokenFilter'].oneOf"
     description: Remove existing oneOf definition for tokenfilter
     remove: true
@@ -271,11 +261,6 @@ actions:
     description: Simplify tokenfilter definition
     update:
       x-model: true
-      description: >
-        Token filters that are applied after the tokenizer.
-      externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-tokenfilters.html
-        description: Token filter reference
   - target: "$.components['schemas']['security._types:RoleTemplateScript']"
     description: Add x-model where recommended by Bump.sh
     update:

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -272,9 +272,6 @@ actions:
     description: Add x-model for distance feature query
     update:
       x-model: true
-      externalDocs:
-        description: Distance feature query
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-distance-feature-query.html
   - target: "$.components['schemas']['_types.query_dsl:MoreLikeThisQuery']"
     description: Add x-model for more like this query
     update:

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -41056,6 +41056,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:FunctionScoreQuery"
           },
           "fuzzy": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html"
+            },
             "description": "Returns documents that contain terms similar to the search term, as measured by a Levenshtein edit distance.",
             "type": "object",
             "additionalProperties": {
@@ -41086,6 +41089,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:IdsQuery"
           },
           "intervals": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-intervals-query.html"
+            },
             "description": "Returns documents based on the order and proximity of matching terms.",
             "type": "object",
             "additionalProperties": {
@@ -41098,6 +41104,9 @@
             "$ref": "#/components/schemas/_types:KnnQuery"
           },
           "match": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html"
+            },
             "description": "Returns documents that match a provided text, number, date or boolean value.\nThe provided text is analyzed before matching.",
             "type": "object",
             "additionalProperties": {
@@ -41110,6 +41119,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:MatchAllQuery"
           },
           "match_bool_prefix": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-bool-prefix-query.html"
+            },
             "description": "Analyzes its input and constructs a `bool` query from the terms.\nEach term except the last is used in a `term` query.\nThe last term is used in a prefix query.",
             "type": "object",
             "additionalProperties": {
@@ -41122,6 +41134,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:MatchNoneQuery"
           },
           "match_phrase": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html"
+            },
             "description": "Analyzes the text and creates a phrase query out of the analyzed text.",
             "type": "object",
             "additionalProperties": {
@@ -41131,6 +41146,9 @@
             "maxProperties": 1
           },
           "match_phrase_prefix": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase-prefix.html"
+            },
             "description": "Returns documents that contain the words of a provided text, in the same order as provided.\nThe last term of the provided text is treated as a prefix, matching any words that begin with that term.",
             "type": "object",
             "additionalProperties": {
@@ -41158,6 +41176,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:PinnedQuery"
           },
           "prefix": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html"
+            },
             "description": "Returns documents that contain a specific prefix in a provided field.",
             "type": "object",
             "additionalProperties": {
@@ -41170,6 +41191,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:QueryStringQuery"
           },
           "range": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html"
+            },
             "description": "Returns documents that contain terms within a provided range.",
             "type": "object",
             "additionalProperties": {
@@ -41182,6 +41206,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:RankFeatureQuery"
           },
           "regexp": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html"
+            },
             "description": "Returns documents that contain terms matching a regular expression.",
             "type": "object",
             "additionalProperties": {
@@ -41230,6 +41257,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:SpanOrQuery"
           },
           "span_term": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html"
+            },
             "description": "Matches spans containing a term.",
             "type": "object",
             "additionalProperties": {
@@ -41245,6 +41275,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:SparseVectorQuery"
           },
           "term": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html"
+            },
             "description": "Returns documents that contain an exact term in a provided field.\nTo return a document, the query term must exactly match the queried field's value, including whitespace and capitalization.",
             "type": "object",
             "additionalProperties": {
@@ -41257,6 +41290,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:TermsQuery"
           },
           "terms_set": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-set-query.html"
+            },
             "description": "Returns documents that contain a minimum number of exact terms in a provided field.\nTo return a document, a required number of terms must exactly match the field values, including whitespace and capitalization.",
             "type": "object",
             "additionalProperties": {
@@ -41267,6 +41303,9 @@
           },
           "text_expansion": {
             "deprecated": true,
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-text-expansion-query.html"
+            },
             "description": "Uses a natural language processing model to convert the query text into a list of token-weight pairs which are then used in a query against a sparse vector or rank features field.",
             "type": "object",
             "additionalProperties": {
@@ -41286,6 +41325,9 @@
             "maxProperties": 1
           },
           "wildcard": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html"
+            },
             "description": "Returns documents that contain terms matching a wildcard pattern.",
             "type": "object",
             "additionalProperties": {
@@ -41557,6 +41599,9 @@
         ]
       },
       "_types.query_dsl:DistanceFeatureQuery": {
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-distance-feature-query.html"
+        },
         "oneOf": [
           {
             "$ref": "#/components/schemas/_types.query_dsl:UntypedDistanceFeatureQuery"
@@ -43306,6 +43351,9 @@
             "type": "object",
             "properties": {
               "analyzer": {
+                "externalDocs": {
+                  "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html"
+                },
                 "description": "The analyzer that is used to analyze the free form text.\nDefaults to the analyzer associated with the first field in fields.",
                 "type": "string"
               },
@@ -43669,6 +43717,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:QueryBase"
           },
           {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-pinned-query.html"
+            },
             "allOf": [
               {
                 "type": "object",
@@ -55056,6 +55107,9 @@
         ]
       },
       "_types.analysis:CharFilter": {
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-charfilters.html"
+        },
         "oneOf": [
           {
             "type": "string"
@@ -55240,6 +55294,9 @@
         ]
       },
       "_types.analysis:TokenFilter": {
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-tokenfilters.html"
+        },
         "oneOf": [
           {
             "type": "string"
@@ -57096,6 +57153,9 @@
         ]
       },
       "_types.analysis:Tokenizer": {
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-tokenizers.html"
+        },
         "oneOf": [
           {
             "type": "string"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -41321,6 +41321,9 @@
           },
           "weighted_tokens": {
             "deprecated": true,
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-weighted-tokens-query.html"
+            },
             "description": "Supports returning text_expansion query results by sending in precomputed tokens with the query.",
             "type": "object",
             "additionalProperties": {
@@ -43919,6 +43922,9 @@
         "type": "string"
       },
       "_types.query_dsl:RangeQuery": {
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html"
+        },
         "oneOf": [
           {
             "$ref": "#/components/schemas/_types.query_dsl:UntypedRangeQuery"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -35656,6 +35656,9 @@
         ]
       },
       "_types.aggregations:Aggregate": {
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html"
+        },
         "oneOf": [
           {
             "$ref": "#/components/schemas/_types.aggregations:CardinalityAggregate"
@@ -42826,6 +42829,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:QueryBase"
           },
           {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-intervals-query.html"
+            },
             "type": "object",
             "properties": {
               "all_of": {
@@ -44833,6 +44839,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:QueryBase"
           },
           {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-sparse-vector-query.html"
+            },
             "allOf": [
               {
                 "type": "object",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -25544,6 +25544,9 @@
           },
           "weighted_tokens": {
             "deprecated": true,
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-weighted-tokens-query.html"
+            },
             "description": "Supports returning text_expansion query results by sending in precomputed tokens with the query.",
             "type": "object",
             "additionalProperties": {
@@ -28142,6 +28145,9 @@
         "type": "string"
       },
       "_types.query_dsl:RangeQuery": {
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html"
+        },
         "oneOf": [
           {
             "$ref": "#/components/schemas/_types.query_dsl:UntypedRangeQuery"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -25279,6 +25279,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:FunctionScoreQuery"
           },
           "fuzzy": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html"
+            },
             "description": "Returns documents that contain terms similar to the search term, as measured by a Levenshtein edit distance.",
             "type": "object",
             "additionalProperties": {
@@ -25309,6 +25312,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:IdsQuery"
           },
           "intervals": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-intervals-query.html"
+            },
             "description": "Returns documents based on the order and proximity of matching terms.",
             "type": "object",
             "additionalProperties": {
@@ -25321,6 +25327,9 @@
             "$ref": "#/components/schemas/_types:KnnQuery"
           },
           "match": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html"
+            },
             "description": "Returns documents that match a provided text, number, date or boolean value.\nThe provided text is analyzed before matching.",
             "type": "object",
             "additionalProperties": {
@@ -25333,6 +25342,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:MatchAllQuery"
           },
           "match_bool_prefix": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-bool-prefix-query.html"
+            },
             "description": "Analyzes its input and constructs a `bool` query from the terms.\nEach term except the last is used in a `term` query.\nThe last term is used in a prefix query.",
             "type": "object",
             "additionalProperties": {
@@ -25345,6 +25357,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:MatchNoneQuery"
           },
           "match_phrase": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html"
+            },
             "description": "Analyzes the text and creates a phrase query out of the analyzed text.",
             "type": "object",
             "additionalProperties": {
@@ -25354,6 +25369,9 @@
             "maxProperties": 1
           },
           "match_phrase_prefix": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase-prefix.html"
+            },
             "description": "Returns documents that contain the words of a provided text, in the same order as provided.\nThe last term of the provided text is treated as a prefix, matching any words that begin with that term.",
             "type": "object",
             "additionalProperties": {
@@ -25381,6 +25399,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:PinnedQuery"
           },
           "prefix": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html"
+            },
             "description": "Returns documents that contain a specific prefix in a provided field.",
             "type": "object",
             "additionalProperties": {
@@ -25393,6 +25414,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:QueryStringQuery"
           },
           "range": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html"
+            },
             "description": "Returns documents that contain terms within a provided range.",
             "type": "object",
             "additionalProperties": {
@@ -25405,6 +25429,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:RankFeatureQuery"
           },
           "regexp": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html"
+            },
             "description": "Returns documents that contain terms matching a regular expression.",
             "type": "object",
             "additionalProperties": {
@@ -25453,6 +25480,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:SpanOrQuery"
           },
           "span_term": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-term-query.html"
+            },
             "description": "Matches spans containing a term.",
             "type": "object",
             "additionalProperties": {
@@ -25468,6 +25498,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:SparseVectorQuery"
           },
           "term": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html"
+            },
             "description": "Returns documents that contain an exact term in a provided field.\nTo return a document, the query term must exactly match the queried field's value, including whitespace and capitalization.",
             "type": "object",
             "additionalProperties": {
@@ -25480,6 +25513,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:TermsQuery"
           },
           "terms_set": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-set-query.html"
+            },
             "description": "Returns documents that contain a minimum number of exact terms in a provided field.\nTo return a document, a required number of terms must exactly match the field values, including whitespace and capitalization.",
             "type": "object",
             "additionalProperties": {
@@ -25490,6 +25526,9 @@
           },
           "text_expansion": {
             "deprecated": true,
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-text-expansion-query.html"
+            },
             "description": "Uses a natural language processing model to convert the query text into a list of token-weight pairs which are then used in a query against a sparse vector or rank features field.",
             "type": "object",
             "additionalProperties": {
@@ -25509,6 +25548,9 @@
             "maxProperties": 1
           },
           "wildcard": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html"
+            },
             "description": "Returns documents that contain terms matching a wildcard pattern.",
             "type": "object",
             "additionalProperties": {
@@ -25780,6 +25822,9 @@
         ]
       },
       "_types.query_dsl:DistanceFeatureQuery": {
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-distance-feature-query.html"
+        },
         "oneOf": [
           {
             "$ref": "#/components/schemas/_types.query_dsl:UntypedDistanceFeatureQuery"
@@ -27529,6 +27574,9 @@
             "type": "object",
             "properties": {
               "analyzer": {
+                "externalDocs": {
+                  "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html"
+                },
                 "description": "The analyzer that is used to analyze the free form text.\nDefaults to the analyzer associated with the first field in fields.",
                 "type": "string"
               },
@@ -27892,6 +27940,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:QueryBase"
           },
           {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-pinned-query.html"
+            },
             "allOf": [
               {
                 "type": "object",
@@ -36829,6 +36880,9 @@
         ]
       },
       "_types.analysis:CharFilter": {
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-charfilters.html"
+        },
         "oneOf": [
           {
             "type": "string"
@@ -37013,6 +37067,9 @@
         ]
       },
       "_types.analysis:TokenFilter": {
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-tokenfilters.html"
+        },
         "oneOf": [
           {
             "type": "string"
@@ -38869,6 +38926,9 @@
         ]
       },
       "_types.analysis:Tokenizer": {
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-tokenizers.html"
+        },
         "oneOf": [
           {
             "type": "string"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -19882,6 +19882,9 @@
         ]
       },
       "_types.aggregations:Aggregate": {
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html"
+        },
         "oneOf": [
           {
             "$ref": "#/components/schemas/_types.aggregations:CardinalityAggregate"
@@ -27049,6 +27052,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:QueryBase"
           },
           {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-intervals-query.html"
+            },
             "type": "object",
             "properties": {
               "all_of": {
@@ -29056,6 +29062,9 @@
             "$ref": "#/components/schemas/_types.query_dsl:QueryBase"
           },
           {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-sparse-vector-query.html"
+            },
             "allOf": [
               {
                 "type": "object",

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -389,6 +389,7 @@ query-dsl-regexp-query,https://www.elastic.co/guide/en/elasticsearch/reference/{
 query-dsl-rule-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-rule-query.html
 query-dsl-script-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-script-query.html
 query-dsl-script-score-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-script-score-query.html
+query-dsl-semantic-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-semantic-query.html
 query-dsl-shape-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-shape-query.html
 query-dsl-simple-query-string-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-simple-query-string-query.html
 query-dsl-span-containing-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-span-containing-query.html
@@ -404,6 +405,7 @@ query-dsl-term-query,https://www.elastic.co/guide/en/elasticsearch/reference/{br
 query-dsl-terms-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-terms-query.html
 query-dsl-terms-set-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-terms-set-query.html
 query-dsl-text-expansion-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-text-expansion-query.html
+query-dsl-weighted-tokens-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-weighted-tokens-query.html
 query-dsl-wildcard-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-wildcard-query.html
 query-dsl-wrapper-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-wrapper-query.html
 query-dsl,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
@@ -451,6 +453,7 @@ search-aggregations-pipeline-bucket-path,https://www.elastic.co/guide/en/elastic
 search-aggregations-pipeline-bucket-script-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-pipeline-bucket-script-aggregation.html
 search-aggregations-pipeline-bucket-selector-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-pipeline-bucket-selector-aggregation.html
 search-aggregations-pipeline-bucket-sort-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-pipeline-bucket-sort-aggregation.html
+search-aggregations-bucket-composite-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-bucket-composite-aggregation.html
 search-aggregations-pipeline-cumulative-cardinality-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-pipeline-cumulative-cardinality-aggregation.html
 search-aggregations-pipeline-cumulative-sum-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-pipeline-cumulative-sum-aggregation.html
 search-aggregations-pipeline-derivative-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-pipeline-derivative-aggregation.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -359,6 +359,7 @@ query-dsl-function-score-query,https://www.elastic.co/guide/en/elasticsearch/ref
 query-dsl-fuzzy-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-fuzzy-query.html
 query-dsl-geo-bounding-box-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-geo-bounding-box-query.html
 query-dsl-geo-distance-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-geo-distance-query.html
+query-dsl-geo-polygon-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-geo-polygon-query.html
 query-dsl-geo-shape-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-geo-shape-query.html
 query-dsl-has-child-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-has-child-query.html
 query-dsl-has-parent-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-has-parent-query.html
@@ -385,6 +386,7 @@ query-dsl-query-string-query,https://www.elastic.co/guide/en/elasticsearch/refer
 query-dsl-range-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-range-query.html
 query-dsl-rank-feature-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-rank-feature-query.html
 query-dsl-regexp-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-regexp-query.html
+query-dsl-rule-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-rule-query.html
 query-dsl-script-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-script-query.html
 query-dsl-script-score-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-script-score-query.html
 query-dsl-shape-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-shape-query.html
@@ -427,6 +429,7 @@ run-as-privilege,https://www.elastic.co/guide/en/elasticsearch/reference/{branch
 runtime-search-request,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/runtime-search-request.html
 script-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/script-processor.html
 scroll-search-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html#scroll-search-results
+search-aggregations,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations.html
 search-aggregations-bucket-adjacency-matrix-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-bucket-adjacency-matrix-aggregation.html
 search-aggregations-bucket-autodatehistogram-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-bucket-autodatehistogram-aggregation.html
 search-aggregations-bucket-categorize-text-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-bucket-categorize-text-aggregation.html
@@ -582,6 +585,7 @@ slm-api-stop,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/sl
 sort-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/sort-processor.html
 sort-search-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/sort-search-results.html
 sort-tiebreaker,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/eql.html#eql-search-specify-a-sort-tiebreaker
+query-dsl-sparse-vector-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-sparse-vector-query.html
 split-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/split-processor.html
 sql-rest-filtering,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/sql-rest-filtering.html
 sql-rest-format,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/sql-rest-format.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -374,7 +374,6 @@ query-dsl-match-query,https://www.elastic.co/guide/en/elasticsearch/reference/{b
 query-dsl-minimum-should-match,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-minimum-should-match.html
 query-dsl-minimum-should-match,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-minimum-should-match.html
 query-dsl-mlt-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-mlt-query.html
-query-dsl-mlt-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-mlt-query.html
 query-dsl-multi-match-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-multi-match-query.html
 query-dsl-multi-term-rewrite,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-multi-term-rewrite.html
 query-dsl-nested-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-nested-query.html
@@ -389,7 +388,6 @@ query-dsl-regexp-query,https://www.elastic.co/guide/en/elasticsearch/reference/{
 query-dsl-script-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-script-query.html
 query-dsl-script-score-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-script-score-query.html
 query-dsl-shape-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-shape-query.html
-query-dsl-simple-query-string-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-simple-query-string-query.html
 query-dsl-simple-query-string-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-simple-query-string-query.html
 query-dsl-span-containing-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-span-containing-query.html
 query-dsl-span-field-masking-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-span-field-masking-query.html

--- a/specification/_global/knn_search/KnnSearchRequest.ts
+++ b/specification/_global/knn_search/KnnSearchRequest.ts
@@ -74,7 +74,10 @@ export interface Request extends RequestBase {
      * @availability serverless
      */
     filter?: QueryContainer | QueryContainer[]
-    /** kNN query to execute */
+    /**
+     * kNN query to execute
+     * @ext_doc_id query-dsl-knn-query
+     */
     knn: Query
   }
 }

--- a/specification/_types/Knn.ts
+++ b/specification/_types/Knn.ts
@@ -51,6 +51,9 @@ export interface KnnSearch {
   inner_hits?: InnerHits
 }
 
+/**
+ * @ext_doc_id query-dsl-knn-query
+ */
 export interface KnnQuery extends QueryBase {
   /** The name of the vector field to search against */
   field: Field

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -196,37 +196,52 @@ export class SingleMetricAggregateBase extends AggregateBase {
 /** @variant name=median_absolute_deviation */
 export class MedianAbsoluteDeviationAggregate extends SingleMetricAggregateBase {}
 
-/** @variant name=min */
+/**
+ * @variant name=min
+ * @ext_doc_id search-aggregations-metrics-min-aggregation
+ */
 export class MinAggregate extends SingleMetricAggregateBase {}
 
-/** @variant name=max */
+/**
+ * @variant name=max
+ * @ext_doc_id search-aggregations-metrics-max-aggregation
+ */
 export class MaxAggregate extends SingleMetricAggregateBase {}
 
 /**
  * Sum aggregation result. `value` is always present and is zero if there were no values to process.
  * @variant name=sum
+ * @ext_doc_id search-aggregations-metrics-sum-aggregation
  */
 export class SumAggregate extends SingleMetricAggregateBase {}
 
-/** @variant name=avg */
+/**
+ * @variant name=avg
+ * @ext_doc_id search-aggregations-metrics-avg-aggregation
+ */
 export class AvgAggregate extends SingleMetricAggregateBase {}
 
 /**
  * Weighted average aggregation result. `value` is missing if the weight was set to zero.
  * @variant name=weighted_avg
+ * @ext_doc_id search-aggregations-metrics-weight-avg-aggregation
  */
 export class WeightedAvgAggregate extends SingleMetricAggregateBase {}
 
 /**
  * Value count aggregation result. `value` is always present.
  * @variant name=value_count
+ * @ext_doc_id search-aggregations-metrics-valuecount-aggregation
  */
 export class ValueCountAggregate extends SingleMetricAggregateBase {}
 
 /** @variant name=simple_value */
 export class SimpleValueAggregate extends SingleMetricAggregateBase {}
 
-/** @variant name=derivative */
+/**
+ * @variant name=derivative
+ * @ext_doc_id search-aggregations-pipeline-derivative-aggregation
+ */
 export class DerivativeAggregate extends SingleMetricAggregateBase {
   normalized_value?: double
   normalized_value_as_string?: string
@@ -243,6 +258,7 @@ export class BucketMetricValueAggregate extends SingleMetricAggregateBase {
  * Statistics aggregation result. `min`, `max` and `avg` are missing if there were no values to process
  * (`count` is zero).
  * @variant name=stats
+ * @ext_doc_id search-aggregations-metrics-stats-aggregation
  */
 export class StatsAggregate extends AggregateBase {
   count: long
@@ -256,7 +272,10 @@ export class StatsAggregate extends AggregateBase {
   sum_as_string?: string
 }
 
-/** @variant name=stats_bucket */
+/**
+ * @variant name=stats_bucket
+ * @ext_doc_id search-aggregations-pipeline-stats-bucket-aggregation
+ */
 export class StatsBucketAggregate extends StatsAggregate {}
 
 export class StandardDeviationBounds {
@@ -277,7 +296,10 @@ export class StandardDeviationBoundsAsString {
   lower_sampling: string
 }
 
-/** @variant name=extended_stats */
+/**
+ * @variant name=extended_stats
+ * @ext_doc_id search-aggregations-metrics-extendedstats-aggregation
+ */
 export class ExtendedStatsAggregate extends StatsAggregate {
   sum_of_squares: double | null
   variance: double | null
@@ -302,12 +324,18 @@ export class ExtendedStatsBucketAggregate extends ExtendedStatsAggregate {}
 
 //----- Geo
 
-/** @variant name=geo_bounds */
+/**
+ * @variant name=geo_bounds
+ * @ext_doc_id search-aggregations-metrics-geobounds-aggregation
+ */
 export class GeoBoundsAggregate extends AggregateBase {
   bounds?: GeoBounds
 }
 
-/** @variant name=geo_centroid */
+/**
+ * @variant name=geo_centroid
+ * @ext_doc_id search-aggregations-metrics-geocentroid-aggregation
+ */
 export class GeoCentroidAggregate extends AggregateBase {
   count: long
   location?: GeoLocation
@@ -341,7 +369,10 @@ export class MultiBucketBase
   doc_count: long
 }
 
-/** @variant name=histogram */
+/**
+ * @variant name=histogram
+ * @ext_doc_id search-aggregations-bucket-histogram-aggregation
+ */
 export class HistogramAggregate extends MultiBucketAggregateBase<HistogramBucket> {}
 
 export class HistogramBucket extends MultiBucketBase {
@@ -349,7 +380,9 @@ export class HistogramBucket extends MultiBucketBase {
   key: double
 }
 
-/** @variant name=date_histogram */
+/** @variant name=date_histogram
+ * @ext_doc_id search-aggregations-bucket-datehistogram-aggregation
+ */
 export class DateHistogramAggregate extends MultiBucketAggregateBase<DateHistogramBucket> {}
 
 export class DateHistogramBucket extends MultiBucketBase {
@@ -357,7 +390,10 @@ export class DateHistogramBucket extends MultiBucketBase {
   key: EpochTime<UnitMillis>
 }
 
-/** @variant name=auto_date_histogram */
+/**
+ * @variant name=auto_date_histogram
+ * @ext_doc_id search-aggregations-bucket-autodatehistogram-aggregation
+ */
 // Note: no keyed variant in `InternalAutoDateHistogram`
 export class AutoDateHistogramAggregate extends MultiBucketAggregateBase<DateHistogramBucket> {
   interval: DurationLarge
@@ -462,7 +498,10 @@ export class StringRareTermsBucket extends MultiBucketBase {
 // Since the buckets array is present but always empty, we use `Void` as the bucket type.
 export class UnmappedRareTermsAggregate extends MultiBucketAggregateBase<Void> {}
 
-/** @variant name=multi_terms */
+/**
+ * @variant name=multi_terms
+ * @ext_doc_id search-aggregations-bucket-multi-terms-aggregation
+ */
 // Note: no keyed variant
 export class MultiTermsAggregate extends TermsAggregateBase<MultiTermsBucket> {}
 
@@ -486,19 +525,34 @@ export class SingleBucketAggregateBase
   doc_count: long
 }
 
-/** @variant name=missing */
+/**
+ * @variant name=missing
+ * @ext_doc_id search-aggregations-bucket-missing-aggregation
+ */
 export class MissingAggregate extends SingleBucketAggregateBase {}
 
-/** @variant name=nested */
+/**
+ * @variant name=nested
+ * @ext_doc_id search-aggregations-bucket-nested-aggregation
+ */
 export class NestedAggregate extends SingleBucketAggregateBase {}
 
-/** @variant name=reverse_nested */
+/**
+ * @variant name=reverse_nested
+ * @ext_doc_id search-aggregations-bucket-reverse-nested-aggregation
+ */
 export class ReverseNestedAggregate extends SingleBucketAggregateBase {}
 
-/** @variant name=global */
+/**
+ * @variant name=global
+ * @ext_doc_id search-aggregations-bucket-global-aggregation
+ */
 export class GlobalAggregate extends SingleBucketAggregateBase {}
 
-/** @variant name=filter */
+/**
+ * @variant name=filter
+ * @ext_doc_id search-aggregations-bucket-filter-aggregation
+ */
 export class FilterAggregate extends SingleBucketAggregateBase {}
 
 /** @variant name=sampler */
@@ -517,7 +571,10 @@ export class GeoHashGridBucket extends MultiBucketBase {
   key: GeoHash
 }
 
-/** @variant name=geotile_grid */
+/**
+ * @variant name=geotile_grid
+ * @ext_doc_id search-aggregations-bucket-geotilegrid-aggregation
+ */
 // Note: no keyed variant in the `InternalGeoGrid` parent class
 export class GeoTileGridAggregate extends MultiBucketAggregateBase<GeoTileGridBucket> {}
 
@@ -534,7 +591,10 @@ export class GeoHexGridBucket extends MultiBucketBase {
 
 //----- Ranges
 
-/** @variant name=range */
+/**
+ * @variant name=range
+ * @ext_doc_id search-aggregations-bucket-range-aggregation
+ */
 export class RangeAggregate extends MultiBucketAggregateBase<RangeBucket> {}
 
 export class RangeBucket extends MultiBucketBase {
@@ -550,16 +610,21 @@ export class RangeBucket extends MultiBucketBase {
  * Result of a `date_range` aggregation. Same format as a for a `range` aggregation: `from` and `to`
  * in `buckets` are milliseconds since the Epoch, represented as a floating point number.
  * @variant name=date_range
+ * @ext_doc_id search-aggregations-bucket-daterange-aggregation
  */
 export class DateRangeAggregate extends RangeAggregate {}
 
 /**
  * Result of a `geo_distance` aggregation. The unit for `from` and `to` is meters by default.
  * @variant name=geo_distance
+ * @ext_doc_id search-aggregations-bucket-geodistance-aggregation
  */
 export class GeoDistanceAggregate extends RangeAggregate {}
 
-/** @variant name=ip_range */
+/**
+ * @variant name=ip_range
+ * @ext_doc_id search-aggregations-bucket-iprange-aggregation 
+ */
 // ES: InternalBinaryRange
 export class IpRangeAggregate extends MultiBucketAggregateBase<IpRangeBucket> {}
 
@@ -571,12 +636,18 @@ export class IpRangeBucket extends MultiBucketBase {
 
 //----- Other multi-bucket
 
-/** @variant name=filters */
+/**
+ * @variant name=filters
+ * @ext_doc_id search-aggregations-bucket-filters-aggregation
+ */
 export class FiltersAggregate extends MultiBucketAggregateBase<FiltersBucket> {}
 
 export class FiltersBucket extends MultiBucketBase {}
 
-/** @variant name=adjacency_matrix */
+/**
+ * @variant name=adjacency_matrix
+ * @ext_doc_id search-aggregations-bucket-adjacency-matrix-aggregation
+ */
 // Note: no keyed variant in the `InternalAdjacencyMatrix`
 export class AdjacencyMatrixAggregate extends MultiBucketAggregateBase<AdjacencyMatrixBucket> {}
 
@@ -584,6 +655,9 @@ export class AdjacencyMatrixBucket extends MultiBucketBase {
   key: string
 }
 
+/**
+ * @ext_doc_id search-aggregations-bucket-significanttext-aggregation
+ */
 export class SignificantTermsAggregateBase<
   T
 > extends MultiBucketAggregateBase<T> {
@@ -632,7 +706,10 @@ export class CompositeBucket extends MultiBucketBase {
   key: CompositeAggregateKey
 }
 
-/** @variant name=ip_prefix */
+/**
+ * @variant name=ip_prefix
+ * @ext_doc_id search-aggregations-bucket-ipprefix-aggregation
+ */
 export class IpPrefixAggregate extends MultiBucketAggregateBase<IpPrefixBucket> {}
 
 export class IpPrefixBucket extends MultiBucketBase {
@@ -659,12 +736,18 @@ export class TimeSeriesBucket extends MultiBucketBase {
 
 //----- Misc
 
-/** @variant name=scripted_metric */
+/**
+ * @variant name=scripted_metric
+ * @ext_doc_id search-aggregations-metrics-scripted-metric-aggregation
+ */
 export class ScriptedMetricAggregate extends AggregateBase {
   value: UserDefinedValue
 }
 
-/** @variant name=top_hits */
+/**
+ * @variant name=top_hits
+ * @ext_doc_id search-aggregations-metrics-top-hits-aggregation
+ */
 export class TopHitsAggregate extends AggregateBase {
   hits: HitsMetadata<UserDefinedValue>
 }
@@ -672,6 +755,7 @@ export class TopHitsAggregate extends AggregateBase {
 /**
  * @variant name=inference
  * @behavior_meta AdditionalProperties fieldname=data description="Additional data"
+ * @ext_doc_id search-aggregations-pipeline-inference-bucket-aggregation
  */
 // This is a union with widely different fields, many of them being runtime-defined. We mimic below the few fields
 // present in `ParsedInference` with an additional properties spillover to not loose any data.
@@ -719,7 +803,10 @@ export class StringStatsAggregate extends AggregateBase {
   avg_length_as_string?: string
 }
 
-/** @variant name=boxplot */
+/**
+ * @variant name=boxplot
+ * @ext_doc_id search-aggregations-metrics-boxplot-aggregation
+ */
 export class BoxPlotAggregate extends AggregateBase {
   min: double
   max: double
@@ -748,13 +835,19 @@ export class TopMetrics {
   metrics: Dictionary<string, FieldValue | null>
 }
 
-/** @variant name=t_test */
+/**
+ * @variant name=t_test
+ * @ext_doc_id search-aggregations-metrics-ttest-aggregation
+ */
 export class TTestAggregate extends AggregateBase {
   value: double | null
   value_as_string?: string
 }
 
-/** @variant name=rate */
+/**
+ * @variant name=rate
+ * @ext_doc_id search-aggregations-metrics-rate-aggregation
+ */
 export class RateAggregate extends AggregateBase {
   value: double
   value_as_string?: string
@@ -770,7 +863,10 @@ export class CumulativeCardinalityAggregate extends AggregateBase {
   value_as_string?: string
 }
 
-/** @variant name=matrix_stats */
+/**
+ * @variant name=matrix_stats
+ * @ext_doc_id search-aggregations-matrix-stats-aggregation
+ */
 export class MatrixStatsAggregate extends AggregateBase {
   doc_count: long
   fields?: MatrixStatsFields[]
@@ -789,15 +885,24 @@ export class MatrixStatsFields {
 
 //----- Parent join plugin
 
-/** @variant name=children */
+/**
+ * @variant name=children
+ * @ext_doc_id search-aggregations-bucket-children-aggregation
+ */
 export class ChildrenAggregate extends SingleBucketAggregateBase {}
 
-/** @variant name=parent */
+/**
+ * @variant name=parent
+ * @ext_doc_id search-aggregations-bucket-parent-aggregation
+ */
 export class ParentAggregate extends SingleBucketAggregateBase {}
 
 //----- Spatial plugin
 
-/** @variant name=geo_line */
+/**
+ * @variant name=geo_line
+ * @ext_doc_id search-aggregations-metrics-geo-line
+ */
 export class GeoLineAggregate extends AggregateBase {
   type: string // should be "Feature"
   geometry: GeoLine

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -623,7 +623,7 @@ export class GeoDistanceAggregate extends RangeAggregate {}
 
 /**
  * @variant name=ip_range
- * @ext_doc_id search-aggregations-bucket-iprange-aggregation 
+ * @ext_doc_id search-aggregations-bucket-iprange-aggregation
  */
 // ES: InternalBinaryRange
 export class IpRangeAggregate extends MultiBucketAggregateBase<IpRangeBucket> {}

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -38,6 +38,7 @@ import { DurationLarge, EpochTime, UnitMillis } from '@_types/Time'
 /**
  * @variants external
  * @non_exhaustive
+ * @ext_doc_id search-aggregations
  */
 export type Aggregate =
   | CardinalityAggregate

--- a/specification/_types/aggregations/AggregationContainer.ts
+++ b/specification/_types/aggregations/AggregationContainer.ts
@@ -125,74 +125,74 @@ export class AggregationContainer {
    * A bucket aggregation returning a form of adjacency matrix.
    * The request provides a collection of named filter expressions, similar to the `filters` aggregation.
    * Each bucket in the response represents a non-empty cell in the matrix of intersecting filters.
-   * @doc_id search-aggregations-bucket-adjacency-matrix-aggregation
+   * @ext_doc_id search-aggregations-bucket-adjacency-matrix-aggregation
    */
   adjacency_matrix?: AdjacencyMatrixAggregation
   /**
    * A multi-bucket aggregation similar to the date histogram, except instead of providing an interval to use as the width of each bucket, a target number of buckets is provided.
-   * @doc_id search-aggregations-bucket-autodatehistogram-aggregation
+   * @ext_doc_id search-aggregations-bucket-autodatehistogram-aggregation
    */
   auto_date_histogram?: AutoDateHistogramAggregation
   /**
    * A single-value metrics aggregation that computes the average of numeric values that are extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-avg-aggregation
+   * @ext_doc_id search-aggregations-metrics-avg-aggregation
    */
   avg?: AverageAggregation
   /**
    * A sibling pipeline aggregation which calculates the mean value of a specified metric in a sibling aggregation.
    * The specified metric must be numeric and the sibling aggregation must be a multi-bucket aggregation.
-   * @doc_id search-aggregations-pipeline-avg-bucket-aggregation
+   * @ext_doc_id search-aggregations-pipeline-avg-bucket-aggregation
    */
   avg_bucket?: AverageBucketAggregation
   /**
    * A metrics aggregation that computes a box plot of numeric values extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-boxplot-aggregation
+   * @ext_doc_id search-aggregations-metrics-boxplot-aggregation
    */
   boxplot?: BoxplotAggregation
   /**
    * A parent pipeline aggregation which runs a script which can perform per bucket computations on metrics in the parent multi-bucket aggregation.
-   * @doc_id search-aggregations-pipeline-bucket-script-aggregation
+   * @ext_doc_id search-aggregations-pipeline-bucket-script-aggregation
    */
   bucket_script?: BucketScriptAggregation
   /**
    * A parent pipeline aggregation which runs a script to determine whether the current bucket will be retained in the parent multi-bucket aggregation.
-   * @doc_id search-aggregations-pipeline-bucket-selector-aggregation
+   * @ext_doc_id search-aggregations-pipeline-bucket-selector-aggregation
    */
   bucket_selector?: BucketSelectorAggregation
   /**
    * A parent pipeline aggregation which sorts the buckets of its parent multi-bucket aggregation.
-   * @doc_id search-aggregations-pipeline-bucket-sort-aggregation
+   * @ext_doc_id search-aggregations-pipeline-bucket-sort-aggregation
    */
   bucket_sort?: BucketSortAggregation
   /**
    * A sibling pipeline aggregation which runs a two sample Kolmogorov–Smirnov test ("K-S test") against a provided distribution and the distribution implied by the documents counts in the configured sibling aggregation.
-   * @doc_id search-aggregations-bucket-count-ks-test-aggregation
+   * @ext_doc_id search-aggregations-bucket-count-ks-test-aggregation
    * @availability stack stability=experimental
    * @availability serverless stability=experimental
    */
   bucket_count_ks_test?: BucketKsAggregation
   /**
    * A sibling pipeline aggregation which runs a correlation function on the configured sibling multi-bucket aggregation.
-   * @doc_id search-aggregations-bucket-correlation-aggregation
+   * @ext_doc_id search-aggregations-bucket-correlation-aggregation
    * @availability stack stability=experimental
    * @availability serverless stability=experimental
    */
   bucket_correlation?: BucketCorrelationAggregation
   /**
    * A single-value metrics aggregation that calculates an approximate count of distinct values.
-   * @doc_id search-aggregations-metrics-cardinality-aggregation
+   * @ext_doc_id search-aggregations-metrics-cardinality-aggregation
    */
   cardinality?: CardinalityAggregation
   /**
    * A multi-bucket aggregation that groups semi-structured text into buckets.
-   * @doc_id search-aggregations-bucket-categorize-text-aggregation
+   * @ext_doc_id search-aggregations-bucket-categorize-text-aggregation
    * @availability stack stability=experimental
    * @availability serverless stability=experimental
    */
   categorize_text?: CategorizeTextAggregation
   /**
    * A single bucket aggregation that selects child documents that have the specified type, as defined in a `join` field.
-   * @doc_id search-aggregations-bucket-children-aggregation
+   * @ext_doc_id search-aggregations-bucket-children-aggregation
    */
   children?: ChildrenAggregation
   /**
@@ -202,332 +202,332 @@ export class AggregationContainer {
   composite?: CompositeAggregation
   /**
    * A parent pipeline aggregation which calculates the cumulative cardinality in a parent `histogram` or `date_histogram` aggregation.
-   * @doc_id search-aggregations-pipeline-cumulative-cardinality-aggregation
+   * @ext_doc_id search-aggregations-pipeline-cumulative-cardinality-aggregation
    */
   cumulative_cardinality?: CumulativeCardinalityAggregation
   /**
    * A parent pipeline aggregation which calculates the cumulative sum of a specified metric in a parent `histogram` or `date_histogram` aggregation.
-   * @doc_id search-aggregations-pipeline-cumulative-sum-aggregation
+   * @ext_doc_id search-aggregations-pipeline-cumulative-sum-aggregation
    */
   cumulative_sum?: CumulativeSumAggregation
   /**
    * A multi-bucket values source based aggregation that can be applied on date values or date range values extracted from the documents.
    * It dynamically builds fixed size (interval) buckets over the values.
-   * @doc_id search-aggregations-bucket-datehistogram-aggregation
+   * @ext_doc_id search-aggregations-bucket-datehistogram-aggregation
    */
   date_histogram?: DateHistogramAggregation
   /**
    * A multi-bucket value source based aggregation that enables the user to define a set of date ranges - each representing a bucket.
-   * @doc_id search-aggregations-bucket-daterange-aggregation
+   * @ext_doc_id search-aggregations-bucket-daterange-aggregation
    */
   date_range?: DateRangeAggregation
   /**
    * A parent pipeline aggregation which calculates the derivative of a specified metric in a parent `histogram` or `date_histogram` aggregation.
-   * @doc_id search-aggregations-pipeline-derivative-aggregation
+   * @ext_doc_id search-aggregations-pipeline-derivative-aggregation
    */
   derivative?: DerivativeAggregation
   /**
    * A filtering aggregation used to limit any sub aggregations' processing to a sample of the top-scoring documents.
    * Similar to the `sampler` aggregation, but adds the ability to limit the number of matches that share a common value.
-   * @doc_id search-aggregations-bucket-diversified-sampler-aggregation
+   * @ext_doc_id search-aggregations-bucket-diversified-sampler-aggregation
    */
   diversified_sampler?: DiversifiedSamplerAggregation
   /**
    * A multi-value metrics aggregation that computes stats over numeric values extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-extendedstats-aggregation
+   * @ext_doc_id search-aggregations-metrics-extendedstats-aggregation
    */
   extended_stats?: ExtendedStatsAggregation
   /**
    * A sibling pipeline aggregation which calculates a variety of stats across all bucket of a specified metric in a sibling aggregation.
-   * @doc_id search-aggregations-pipeline-extended-stats-bucket-aggregation
+   * @ext_doc_id search-aggregations-pipeline-extended-stats-bucket-aggregation
    */
   extended_stats_bucket?: ExtendedStatsBucketAggregation
   /**
    * A bucket aggregation which finds frequent item sets, a form of association rules mining that identifies items that often occur together.
-   * @doc_id search-aggregations-bucket-frequent-item-sets-aggregation
+   * @ext_doc_id search-aggregations-bucket-frequent-item-sets-aggregation
    */
   frequent_item_sets?: FrequentItemSetsAggregation
   /**
    * A single bucket aggregation that narrows the set of documents to those that match a query.
-   * @doc_id search-aggregations-bucket-filter-aggregation
+   * @ext_doc_id search-aggregations-bucket-filter-aggregation
    */
   filter?: QueryContainer
   /**
    * A multi-bucket aggregation where each bucket contains the documents that match a query.
-   * @doc_id search-aggregations-bucket-filters-aggregation
+   * @ext_doc_id search-aggregations-bucket-filters-aggregation
    */
   filters?: FiltersAggregation
   /**
    * A metric aggregation that computes the geographic bounding box containing all values for a Geopoint or Geoshape field.
-   * @doc_id search-aggregations-metrics-geobounds-aggregation
+   * @ext_doc_id search-aggregations-metrics-geobounds-aggregation
    */
   geo_bounds?: GeoBoundsAggregation
   /**
    * A metric aggregation that computes the weighted centroid from all coordinate values for geo fields.
-   * @doc_id search-aggregations-metrics-geocentroid-aggregation
+   * @ext_doc_id search-aggregations-metrics-geocentroid-aggregation
    */
   geo_centroid?: GeoCentroidAggregation
   /**
    * A multi-bucket aggregation that works on `geo_point` fields.
    * Evaluates the distance of each document value from an origin point and determines the buckets it belongs to, based on ranges defined in the request.
-   * @doc_id search-aggregations-bucket-geodistance-aggregation
+   * @ext_doc_id search-aggregations-bucket-geodistance-aggregation
    */
   geo_distance?: GeoDistanceAggregation
   /**
    * A multi-bucket aggregation that groups `geo_point` and `geo_shape` values into buckets that represent a grid.
    * Each cell is labeled using a geohash which is of user-definable precision.
-   * @doc_id search-aggregations-bucket-geohashgrid-aggregation
+   * @ext_doc_id search-aggregations-bucket-geohashgrid-aggregation
    */
   geohash_grid?: GeoHashGridAggregation
   /**
    * Aggregates all `geo_point` values within a bucket into a `LineString` ordered by the chosen sort field.
-   * @doc_id search-aggregations-metrics-geo-line
+   * @ext_doc_id search-aggregations-metrics-geo-line
    */
   geo_line?: GeoLineAggregation
   /**
    * A multi-bucket aggregation that groups `geo_point` and `geo_shape` values into buckets that represent a grid.
    * Each cell corresponds to a map tile as used by many online map sites.
-   * @doc_id search-aggregations-bucket-geotilegrid-aggregation
+   * @ext_doc_id search-aggregations-bucket-geotilegrid-aggregation
    */
   geotile_grid?: GeoTileGridAggregation
   /**
    * A multi-bucket aggregation that groups `geo_point` and `geo_shape` values into buckets that represent a grid.
    * Each cell corresponds to a H3 cell index and is labeled using the H3Index representation.
-   * @doc_id search-aggregations-bucket-geohexgrid-aggregation
+   * @ext_doc_id search-aggregations-bucket-geohexgrid-aggregation
    */
   geohex_grid?: GeohexGridAggregation
   /**
    * Defines a single bucket of all the documents within the search execution context.
    * This context is defined by the indices and the document types you’re searching on, but is not influenced by the search query itself.
-   * @doc_id search-aggregations-bucket-global-aggregation
+   * @ext_doc_id search-aggregations-bucket-global-aggregation
    */
   global?: GlobalAggregation
   /**
    * A multi-bucket values source based aggregation that can be applied on numeric values or numeric range values extracted from the documents.
    * It dynamically builds fixed size (interval) buckets over the values.
-   * @doc_id search-aggregations-bucket-histogram-aggregation
+   * @ext_doc_id search-aggregations-bucket-histogram-aggregation
    */
   histogram?: HistogramAggregation
   /**
    * A multi-bucket value source based aggregation that enables the user to define a set of IP ranges - each representing a bucket.
-   * @doc_id search-aggregations-bucket-iprange-aggregation
+   * @ext_doc_id search-aggregations-bucket-iprange-aggregation
    */
   ip_range?: IpRangeAggregation
   /**
    * A bucket aggregation that groups documents based on the network or sub-network of an IP address.
-   * @doc_id search-aggregations-bucket-ipprefix-aggregation
+   * @ext_doc_id search-aggregations-bucket-ipprefix-aggregation
    */
   ip_prefix?: IpPrefixAggregation
   /**
    * A parent pipeline aggregation which loads a pre-trained model and performs inference on the collated result fields from the parent bucket aggregation.
-   * @doc_id search-aggregations-pipeline-inference-bucket-aggregation
+   * @ext_doc_id search-aggregations-pipeline-inference-bucket-aggregation
    */
   inference?: InferenceAggregation
   line?: GeoLineAggregation
   /**
    * A numeric aggregation that computes the following statistics over a set of document fields: `count`, `mean`, `variance`, `skewness`, `kurtosis`, `covariance`, and `covariance`.
-   * @doc_id search-aggregations-matrix-stats-aggregation
+   * @ext_doc_id search-aggregations-matrix-stats-aggregation
    */
   matrix_stats?: MatrixStatsAggregation
   /**
    * A single-value metrics aggregation that returns the maximum value among the numeric values extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-max-aggregation
+   * @ext_doc_id search-aggregations-metrics-max-aggregation
    */
   max?: MaxAggregation
   /**
    * A sibling pipeline aggregation which identifies the bucket(s) with the maximum value of a specified metric in a sibling aggregation and outputs both the value and the key(s) of the bucket(s).
-   * @doc_id search-aggregations-pipeline-max-bucket-aggregation
+   * @ext_doc_id search-aggregations-pipeline-max-bucket-aggregation
    */
   max_bucket?: MaxBucketAggregation
   /**
    * A single-value aggregation that approximates the median absolute deviation of its search results.
-   * @doc_id search-aggregations-metrics-median-absolute-deviation-aggregation
+   * @ext_doc_id search-aggregations-metrics-median-absolute-deviation-aggregation
    */
   median_absolute_deviation?: MedianAbsoluteDeviationAggregation
   /**
    * A single-value metrics aggregation that returns the minimum value among numeric values extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-min-aggregation
+   * @ext_doc_id search-aggregations-metrics-min-aggregation
    */
   min?: MinAggregation
   /**
    * A sibling pipeline aggregation which identifies the bucket(s) with the minimum value of a specified metric in a sibling aggregation and outputs both the value and the key(s) of the bucket(s).
-   * @doc_id search-aggregations-pipeline-min-bucket-aggregation
+   * @ext_doc_id search-aggregations-pipeline-min-bucket-aggregation
    */
   min_bucket?: MinBucketAggregation
   /**
    * A field data based single bucket aggregation, that creates a bucket of all documents in the current document set context that are missing a field value (effectively, missing a field or having the configured NULL value set).
-   * @doc_id search-aggregations-bucket-missing-aggregation
+   * @ext_doc_id search-aggregations-bucket-missing-aggregation
    */
   missing?: MissingAggregation
   moving_avg?: MovingAverageAggregation
   /**
    * Given an ordered series of percentiles, "slides" a window across those percentiles and computes cumulative percentiles.
-   * @doc_id search-aggregations-pipeline-moving-percentiles-aggregation
+   * @ext_doc_id search-aggregations-pipeline-moving-percentiles-aggregation
    */
   moving_percentiles?: MovingPercentilesAggregation
   /**
    * Given an ordered series of data, "slides" a window across the data and runs a custom script on each window of data.
    * For convenience, a number of common functions are predefined such as `min`, `max`, and moving averages.
-   * @doc_id search-aggregations-pipeline-movfn-aggregation
+   * @ext_doc_id search-aggregations-pipeline-movfn-aggregation
    */
   moving_fn?: MovingFunctionAggregation
   /**
    * A multi-bucket value source based aggregation where buckets are dynamically built - one per unique set of values.
-   * @doc_id search-aggregations-bucket-multi-terms-aggregation
+   * @ext_doc_id search-aggregations-bucket-multi-terms-aggregation
    */
   multi_terms?: MultiTermsAggregation
   /**
    * A special single bucket aggregation that enables aggregating nested documents.
-   * @doc_id search-aggregations-bucket-nested-aggregation
+   * @ext_doc_id search-aggregations-bucket-nested-aggregation
    */
   nested?: NestedAggregation
   /**
    * A parent pipeline aggregation which calculates the specific normalized/rescaled value for a specific bucket value.
-   * @doc_id search-aggregations-pipeline-normalize-aggregation
+   * @ext_doc_id search-aggregations-pipeline-normalize-aggregation
    */
   normalize?: NormalizeAggregation
   /**
    * A special single bucket aggregation that selects parent documents that have the specified type, as defined in a `join` field.
-   * @doc_id search-aggregations-bucket-parent-aggregation
+   * @ext_doc_id search-aggregations-bucket-parent-aggregation
    */
   parent?: ParentAggregation
   /**
    * A multi-value metrics aggregation that calculates one or more percentile ranks over numeric values extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-percentile-rank-aggregation
+   * @ext_doc_id search-aggregations-metrics-percentile-rank-aggregation
    */
   percentile_ranks?: PercentileRanksAggregation
   /**
    * A multi-value metrics aggregation that calculates one or more percentiles over numeric values extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-percentile-aggregation
+   * @ext_doc_id search-aggregations-metrics-percentile-aggregation
    */
   percentiles?: PercentilesAggregation
   /**
    * A sibling pipeline aggregation which calculates percentiles across all bucket of a specified metric in a sibling aggregation.
-   * @doc_id search-aggregations-pipeline-percentiles-bucket-aggregation
+   * @ext_doc_id search-aggregations-pipeline-percentiles-bucket-aggregation
    */
   percentiles_bucket?: PercentilesBucketAggregation
   /**
    * A multi-bucket value source based aggregation that enables the user to define a set of ranges - each representing a bucket.
-   * @doc_id search-aggregations-bucket-range-aggregation
+   * @ext_doc_id search-aggregations-bucket-range-aggregation
    */
   range?: RangeAggregation
   /**
    * A multi-bucket value source based aggregation which finds "rare" terms — terms that are at the long-tail of the distribution and are not frequent.
-   * @doc_id search-aggregations-bucket-rare-terms-aggregation
+   * @ext_doc_id search-aggregations-bucket-rare-terms-aggregation
    */
   rare_terms?: RareTermsAggregation
   /**
    * Calculates a rate of documents or a field in each bucket.
    * Can only be used inside a `date_histogram` or `composite` aggregation.
-   * @doc_id search-aggregations-metrics-rate-aggregation
+   * @ext_doc_id search-aggregations-metrics-rate-aggregation
    */
   rate?: RateAggregation
   /**
    * A special single bucket aggregation that enables aggregating on parent documents from nested documents.
    * Should only be defined inside a `nested` aggregation.
-   * @doc_id search-aggregations-bucket-reverse-nested-aggregation
+   * @ext_doc_id search-aggregations-bucket-reverse-nested-aggregation
    */
   reverse_nested?: ReverseNestedAggregation
   /**
    *
    * A single bucket aggregation that randomly includes documents in the aggregated results.
    * Sampling provides significant speed improvement at the cost of accuracy.
-   * @doc_id search-aggregations-random-sampler-aggregation
+   * @ext_doc_id search-aggregations-random-sampler-aggregation
    * @availability stack since=8.1.0 stability=experimental
 
    */
   random_sampler?: RandomSamplerAggregation
   /**
    * A filtering aggregation used to limit any sub aggregations' processing to a sample of the top-scoring documents.
-   * @doc_id search-aggregations-bucket-sampler-aggregation
+   * @ext_doc_id search-aggregations-bucket-sampler-aggregation
    */
   sampler?: SamplerAggregation
   /**
    * A metric aggregation that uses scripts to provide a metric output.
-   * @doc_id search-aggregations-metrics-scripted-metric-aggregation
+   * @ext_doc_id search-aggregations-metrics-scripted-metric-aggregation
    */
   scripted_metric?: ScriptedMetricAggregation
   /**
    * An aggregation that subtracts values in a time series from themselves at different time lags or periods.
-   * @doc_id search-aggregations-pipeline-serialdiff-aggregation
+   * @ext_doc_id search-aggregations-pipeline-serialdiff-aggregation
    */
   serial_diff?: SerialDifferencingAggregation
   /**
    * Returns interesting or unusual occurrences of terms in a set.
-   * @doc_id search-aggregations-bucket-significantterms-aggregation
+   * @ext_doc_id search-aggregations-bucket-significantterms-aggregation
    */
   significant_terms?: SignificantTermsAggregation
   /**
    * Returns interesting or unusual occurrences of free-text terms in a set.
-   * @doc_id search-aggregations-bucket-significanttext-aggregation
+   * @ext_doc_id search-aggregations-bucket-significanttext-aggregation
    */
   significant_text?: SignificantTextAggregation
   /**
    * A multi-value metrics aggregation that computes stats over numeric values extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-stats-aggregation
+   * @ext_doc_id search-aggregations-metrics-stats-aggregation
    */
   stats?: StatsAggregation
   /**
    * A sibling pipeline aggregation which calculates a variety of stats across all bucket of a specified metric in a sibling aggregation.
-   * @doc_id search-aggregations-pipeline-stats-bucket-aggregation
+   * @ext_doc_id search-aggregations-pipeline-stats-bucket-aggregation
    */
   stats_bucket?: StatsBucketAggregation
   /**
    * A multi-value metrics aggregation that computes statistics over string values extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-string-stats-aggregation
+   * @ext_doc_id search-aggregations-metrics-string-stats-aggregation
    */
   string_stats?: StringStatsAggregation
   /**
    * A single-value metrics aggregation that sums numeric values that are extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-sum-aggregation
+   * @ext_doc_id search-aggregations-metrics-sum-aggregation
    */
   sum?: SumAggregation
   /**
    * A sibling pipeline aggregation which calculates the sum of a specified metric across all buckets in a sibling aggregation.
-   * @doc_id search-aggregations-pipeline-sum-bucket-aggregation
+   * @ext_doc_id search-aggregations-pipeline-sum-bucket-aggregation
    */
   sum_bucket?: SumBucketAggregation
   /**
    * A multi-bucket value source based aggregation where buckets are dynamically built - one per unique value.
-   * @doc_id search-aggregations-bucket-terms-aggregation
+   * @ext_doc_id search-aggregations-bucket-terms-aggregation
    */
   terms?: TermsAggregation
   /**
    * The time series aggregation queries data created using a time series index.
    * This is typically data such as metrics or other data streams with a time component, and requires creating an index using the time series mode.
-   * @doc_id search-aggregations-bucket-time-series-aggregation
+   * @ext_doc_id search-aggregations-bucket-time-series-aggregation
    * @availability stack stability=experimental
    * @availability serverless stability=experimental
    */
   time_series?: TimeSeriesAggregation
   /**
    * A metric aggregation that returns the top matching documents per bucket.
-   * @doc_id search-aggregations-metrics-top-hits-aggregation
+   * @ext_doc_id search-aggregations-metrics-top-hits-aggregation
    */
   top_hits?: TopHitsAggregation
   /**
    * A metrics aggregation that performs a statistical hypothesis test in which the test statistic follows a Student’s t-distribution under the null hypothesis on numeric values extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-ttest-aggregation
+   * @ext_doc_id search-aggregations-metrics-ttest-aggregation
    */
   t_test?: TTestAggregation
   /**
    * A metric aggregation that selects metrics from the document with the largest or smallest sort value.
-   * @doc_id search-aggregations-metrics-top-metrics
+   * @ext_doc_id search-aggregations-metrics-top-metrics
    */
   top_metrics?: TopMetricsAggregation
   /**
    * A single-value metrics aggregation that counts the number of values that are extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-valuecount-aggregation
+   * @ext_doc_id search-aggregations-metrics-valuecount-aggregation
    */
   value_count?: ValueCountAggregation
   /**
    * A single-value metrics aggregation that computes the weighted average of numeric values that are extracted from the aggregated documents.
-   * @doc_id search-aggregations-metrics-weight-avg-aggregation
+   * @ext_doc_id search-aggregations-metrics-weight-avg-aggregation
    */
   weighted_avg?: WeightedAverageAggregation
   /**
    * A multi-bucket aggregation similar to the histogram, except instead of providing an interval to use as the width of each bucket, a target number of buckets is provided.
-   * @doc_id search-aggregations-bucket-variablewidthhistogram-aggregation
+   * @ext_doc_id search-aggregations-bucket-variablewidthhistogram-aggregation
    */
   variable_width_histogram?: VariableWidthHistogramAggregation
 }

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -69,6 +69,9 @@ export class AdjacencyMatrixAggregation extends BucketAggregationBase {
   separator?: string
 }
 
+/**
+ * @ext_doc_id search-aggregations-bucket-autodatehistogram-aggregation
+ */
 export class AutoDateHistogramAggregation extends BucketAggregationBase {
   /**
    * The target number of buckets.
@@ -124,6 +127,9 @@ export class ChildrenAggregation extends BucketAggregationBase {
 
 export type CompositeAggregateKey = Dictionary<Field, FieldValue>
 
+/**
+ * @ext_doc_id search-aggregations-bucket-composite-aggregation
+ */
 export class CompositeAggregation extends BucketAggregationBase {
   // Must be consistent with CompositeAggregate.after_key
   /**
@@ -324,6 +330,9 @@ export class DateRangeExpression {
   to?: FieldDateMath
 }
 
+/**
+ * @ext_doc_id search-aggregations-bucket-diversified-sampler-aggregation
+ */
 export class DiversifiedSamplerAggregation extends BucketAggregationBase {
   /**
    * The type of value used for de-duplication.
@@ -409,6 +418,9 @@ export class GeoDistanceAggregation extends BucketAggregationBase {
   unit?: DistanceUnit
 }
 
+/**
+ * @ext_doc_id search-aggregations-bucket-geohashgrid-aggregation
+ */
 export class GeoHashGridAggregation extends BucketAggregationBase {
   /**
    * The bounding box to filter the points in each bucket.
@@ -691,6 +703,9 @@ export class AggregationRange {
   to?: double | null
 }
 
+/**
+ * @ext_doc_id search-aggregations-bucket-rare-terms-aggregation
+ */
 export class RareTermsAggregation extends BucketAggregationBase {
   /**
    * Terms that should be excluded from the aggregation.
@@ -731,6 +746,9 @@ export class ReverseNestedAggregation extends BucketAggregationBase {
   path?: Field
 }
 
+/**
+ * @ext_doc_id search-aggregations-random-sampler-aggregation
+ */
 export class RandomSamplerAggregation extends BucketAggregationBase {
   /**
    * The probability that a document will be included in the aggregated data.
@@ -750,6 +768,9 @@ export class RandomSamplerAggregation extends BucketAggregationBase {
   shard_seed?: integer
 }
 
+/**
+ * @ext_doc_id search-aggregations-bucket-sampler-aggregation
+ */
 export class SamplerAggregation extends BucketAggregationBase {
   /**
    * Limits how many top-scoring documents are collected in the sample processed on each shard.
@@ -793,6 +814,9 @@ export class ScriptedHeuristic {
   script: Script
 }
 
+/**
+ * @ext_doc_id search-aggregations-bucket-significanttext-aggregation
+ */
 export class SignificantTermsAggregation extends BucketAggregationBase {
   /**
    * A background filter that can be used to focus in on significant terms within a narrower context, instead of the entire index.
@@ -859,6 +883,9 @@ export class SignificantTermsAggregation extends BucketAggregationBase {
   size?: integer
 }
 
+/**
+ * @ext_doc_id search-aggregations-bucket-significanttext-aggregation
+ */
 export class SignificantTextAggregation extends BucketAggregationBase {
   /**
    * A background filter that can be used to focus in on significant terms within a narrower context, instead of the entire index.
@@ -933,6 +960,9 @@ export class SignificantTextAggregation extends BucketAggregationBase {
   source_fields?: Fields
 }
 
+/**
+ * @ext_doc_id search-aggregations-bucket-terms-aggregation
+ */
 export class TermsAggregation extends BucketAggregationBase {
   /**
    * Determines how child aggregations should be calculated: breadth-first or depth-first.
@@ -1000,6 +1030,9 @@ export class TermsAggregation extends BucketAggregationBase {
   format?: string
 }
 
+/**
+ * @ext_doc_id search-aggregations-bucket-time-series-aggregation
+ */
 export class TimeSeriesAggregation extends BucketAggregationBase {
   /**
    * The maximum number of results to return.
@@ -1055,6 +1088,9 @@ export class TermsPartition {
   partition: long
 }
 
+/**
+ * @ext_doc_id search-aggregations-bucket-variablewidthhistogram-aggregation
+ */
 export class VariableWidthHistogramAggregation {
   /**
    * The name of the field.
@@ -1083,6 +1119,7 @@ export class VariableWidthHistogramAggregation {
  * field is re-analyzed using a custom analyzer. The resulting tokens are then categorized
  * creating buckets of similarly formatted text values. This aggregation works best with machine
  * generated text like system logs. Only the first 100 analyzed tokens are used to categorize the text.
+ * @ext_doc_id search-aggregations-bucket-categorize-text-aggregation
  */
 export class CategorizeTextAggregation extends Aggregation {
   /**
@@ -1200,6 +1237,9 @@ export class FrequentItemSetsField {
   include?: TermsInclude
 }
 
+/**
+ * @ext_doc_id search-aggregations-bucket-frequent-item-sets-aggregation
+ */
 export class FrequentItemSetsAggregation {
   /**
    * Fields to analyze.

--- a/specification/_types/aggregations/metric.ts
+++ b/specification/_types/aggregations/metric.ts
@@ -105,6 +105,9 @@ export class ExtendedStatsAggregation extends FormatMetricAggregationBase {
   sigma?: double
 }
 
+/**
+ * @ext_doc_id search-aggregations-metrics-geobounds-aggregation
+ */
 export class GeoBoundsAggregation extends MetricAggregationBase {
   /**
    * Specifies whether the bounding box should be allowed to overlap the international date line.
@@ -161,6 +164,9 @@ export class GeoLinePoint {
 
 export class MaxAggregation extends FormatMetricAggregationBase {}
 
+/**
+ * @ext_doc_id search-aggregations-metrics-median-absolute-deviation-aggregation
+ */
 export class MedianAbsoluteDeviationAggregation extends FormatMetricAggregationBase {
   /**
    * Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.
@@ -171,6 +177,9 @@ export class MedianAbsoluteDeviationAggregation extends FormatMetricAggregationB
 
 export class MinAggregation extends FormatMetricAggregationBase {}
 
+/**
+ * @ext_doc_id search-aggregations-metrics-percentile-rank-aggregation
+ */
 export class PercentileRanksAggregation extends FormatMetricAggregationBase {
   /**
    * By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array.
@@ -396,6 +405,9 @@ export class TopHitsAggregation extends MetricAggregationBase {
   seq_no_primary_term?: boolean
 }
 
+/**
+ * @ext_doc_id search-aggregations-metrics-top-metrics
+ */
 export class TopMetricsAggregation extends MetricAggregationBase {
   /**
    * The fields of the top document to return.

--- a/specification/_types/aggregations/pipeline.ts
+++ b/specification/_types/aggregations/pipeline.ts
@@ -75,8 +75,14 @@ export enum GapPolicy {
   keep_values
 }
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-avg-bucket-aggregation
+ */
 export class AverageBucketAggregation extends PipelineAggregationBase {}
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-bucket-script-aggregation
+ */
 export class BucketScriptAggregation extends PipelineAggregationBase {
   /**
    * The script to run for this aggregation.
@@ -84,6 +90,9 @@ export class BucketScriptAggregation extends PipelineAggregationBase {
   script?: Script
 }
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-bucket-selector-aggregation
+ */
 export class BucketSelectorAggregation extends PipelineAggregationBase {
   /**
    * The script to run for this aggregation.
@@ -101,6 +110,7 @@ export class BucketSelectorAggregation extends PipelineAggregationBase {
  * of the documents. A natural use case is if the sibling aggregation range aggregation nested in a
  * terms aggregation, in which case one compares the overall distribution of metric to its restriction
  * to each term.
+ * @ext_doc_id search-aggregations-bucket-count-ks-test-aggregation
  */
 export class BucketKsAggregation extends BucketPathAggregation {
   /**
@@ -128,6 +138,7 @@ export class BucketKsAggregation extends BucketPathAggregation {
 
 /**
  * A sibling pipeline aggregation which executes a correlation function on the configured sibling multi-bucket aggregation.
+ * @ext_doc_id search-aggregations-bucket-correlation-aggregation
  */
 export class BucketCorrelationAggregation extends BucketPathAggregation {
   /** The correlation function to execute. */
@@ -166,6 +177,9 @@ export class BucketCorrelationFunctionCountCorrelationIndicator {
   fractions?: double[]
 }
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-bucket-sort-aggregation
+ */
 export class BucketSortAggregation extends Aggregation {
   /**
    * Buckets in positions prior to `from` will be truncated.
@@ -189,8 +203,14 @@ export class BucketSortAggregation extends Aggregation {
   sort?: Sort
 }
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-cumulative-cardinality-aggregation
+ */
 export class CumulativeCardinalityAggregation extends PipelineAggregationBase {}
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-cumulative-sum-aggregation
+ */
 export class CumulativeSumAggregation extends PipelineAggregationBase {}
 
 export class DerivativeAggregation extends PipelineAggregationBase {}
@@ -221,8 +241,14 @@ class InferenceConfigContainer {
   classification?: ClassificationInferenceOptions
 }
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-max-bucket-aggregation
+ */
 export class MaxBucketAggregation extends PipelineAggregationBase {}
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-min-bucket-aggregation
+ */
 export class MinBucketAggregation extends PipelineAggregationBase {}
 
 /** @variants internal tag=model */
@@ -285,6 +311,9 @@ export enum HoltWintersType {
   Multiplicative = 'mult'
 }
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-movfn-aggregation
+ */
 export class MovingFunctionAggregation extends PipelineAggregationBase {
   /**
    * The script that should be executed on each window of data.
@@ -302,6 +331,9 @@ export class MovingFunctionAggregation extends PipelineAggregationBase {
   window?: integer
 }
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-moving-percentiles-aggregation
+ */
 export class MovingPercentilesAggregation extends PipelineAggregationBase {
   /**
    * The size of window to "slide" across the histogram.
@@ -316,6 +348,9 @@ export class MovingPercentilesAggregation extends PipelineAggregationBase {
   keyed?: boolean
 }
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-normalize-aggregation
+ */
 export class NormalizeAggregation extends PipelineAggregationBase {
   /**
    * The specific method to apply.
@@ -351,6 +386,9 @@ export enum NormalizeMethod {
   softmax
 }
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-percentiles-bucket-aggregation
+ */
 export class PercentilesBucketAggregation extends PipelineAggregationBase {
   /**
    * The list of percentiles to calculate.
@@ -358,6 +396,9 @@ export class PercentilesBucketAggregation extends PipelineAggregationBase {
   percents?: double[]
 }
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-serialdiff-aggregation
+ */
 export class SerialDifferencingAggregation extends PipelineAggregationBase {
   /**
    * The historical bucket to subtract from the current value.
@@ -368,4 +409,7 @@ export class SerialDifferencingAggregation extends PipelineAggregationBase {
 
 export class StatsBucketAggregation extends PipelineAggregationBase {}
 
+/**
+ * @ext_doc_id search-aggregations-pipeline-sum-bucket-aggregation
+ */
 export class SumBucketAggregation extends PipelineAggregationBase {}

--- a/specification/_types/analysis/char_filters.ts
+++ b/specification/_types/analysis/char_filters.ts
@@ -25,7 +25,10 @@ export class CharFilterBase {
   version?: VersionString
 }
 
-/** @codegen_names name, definition */
+/** 
+ * @codegen_names name, definition
+ * @ext_doc_id analysis-charfilters
+ */
 // ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
 export type CharFilter = string | CharFilterDefinition
 

--- a/specification/_types/analysis/char_filters.ts
+++ b/specification/_types/analysis/char_filters.ts
@@ -25,7 +25,7 @@ export class CharFilterBase {
   version?: VersionString
 }
 
-/** 
+/**
  * @codegen_names name, definition
  * @ext_doc_id analysis-charfilters
  */

--- a/specification/_types/analysis/token_filters.ts
+++ b/specification/_types/analysis/token_filters.ts
@@ -342,7 +342,10 @@ export class UppercaseTokenFilter extends TokenFilterBase {
   type: 'uppercase'
 }
 
-/** @codegen_names name, definition */
+/**
+ * @codegen_names name, definition
+ * @ext_doc_id analysis-tokenfilters
+ */
 // ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
 export type TokenFilter = string | TokenFilterDefinition
 

--- a/specification/_types/analysis/tokenizers.ts
+++ b/specification/_types/analysis/tokenizers.ts
@@ -137,7 +137,7 @@ export class WhitespaceTokenizer extends TokenizerBase {
   max_token_length?: integer
 }
 
-/** 
+/**
  * @codegen_names name, definition
  * @ext_doc_id analysis-tokenizers
  */

--- a/specification/_types/analysis/tokenizers.ts
+++ b/specification/_types/analysis/tokenizers.ts
@@ -137,7 +137,10 @@ export class WhitespaceTokenizer extends TokenizerBase {
   max_token_length?: integer
 }
 
-/** @codegen_names name, definition */
+/** 
+ * @codegen_names name, definition
+ * @ext_doc_id analysis-tokenizers
+ */
 // ES: NameOrDefinition, used everywhere charfilter, tokenfilter or tokenizer is used
 export type Tokenizer = string | TokenizerDefinition
 

--- a/specification/_types/query_dsl/MatchAllQuery.ts
+++ b/specification/_types/query_dsl/MatchAllQuery.ts
@@ -19,4 +19,7 @@
 
 import { QueryBase } from './abstractions'
 
+/**
+ * @ext_doc_id query-dsl-match-all-query
+ */
 export class MatchAllQuery extends QueryBase {}

--- a/specification/_types/query_dsl/MatchNoneQuery.ts
+++ b/specification/_types/query_dsl/MatchNoneQuery.ts
@@ -19,4 +19,7 @@
 
 import { QueryBase } from './abstractions'
 
+/**
+ * @ext_doc_id query-dsl-match-none-query
+ */
 export class MatchNoneQuery extends QueryBase {}

--- a/specification/_types/query_dsl/SemanticQuery.ts
+++ b/specification/_types/query_dsl/SemanticQuery.ts
@@ -19,6 +19,9 @@
 
 import { QueryBase } from './abstractions'
 
+/**
+ * @ext_doc_id query-dsl-semantic-query
+ */
 export class SemanticQuery extends QueryBase {
   /** The field to query, which must be a semantic_text field type */
   field: string

--- a/specification/_types/query_dsl/SparseVectorQuery.ts
+++ b/specification/_types/query_dsl/SparseVectorQuery.ts
@@ -25,6 +25,7 @@ import { TokenPruningConfig } from './TokenPruningConfig'
 
 /**
  * @variants container
+ * @ext_doc_id query-dsl-sparse-vector-query
  */
 export class SparseVectorQuery extends QueryBase {
   /**

--- a/specification/_types/query_dsl/TextExpansionQuery.ts
+++ b/specification/_types/query_dsl/TextExpansionQuery.ts
@@ -20,6 +20,9 @@
 import { QueryBase } from './abstractions'
 import { TokenPruningConfig } from './TokenPruningConfig'
 
+/**
+ * @ext_doc_id query-dsl-text-expansion-query
+ */
 export class TextExpansionQuery extends QueryBase {
   /** The text expansion NLP model to use */
   model_id: string

--- a/specification/_types/query_dsl/WeightedTokensQuery.ts
+++ b/specification/_types/query_dsl/WeightedTokensQuery.ts
@@ -22,6 +22,9 @@ import { float } from '@_types/Numeric'
 import { QueryBase } from './abstractions'
 import { TokenPruningConfig } from './TokenPruningConfig'
 
+/**
+ * @ext_doc_id query-dsl-weighted-tokens-query
+ */
 export class WeightedTokensQuery extends QueryBase {
   /** The tokens representing this query */
   tokens: Dictionary<string, float>

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -107,63 +107,63 @@ import { WeightedTokensQuery } from './WeightedTokensQuery'
 export class QueryContainer {
   /**
    * matches documents matching boolean combinations of other queries.
-   * @doc_id query-dsl-bool-query
+   * @ext_doc_id query-dsl-bool-query
    */
   bool?: BoolQuery
   /**
    * Returns documents matching a `positive` query while reducing the relevance score of documents that also match a `negative` query.
-   * @doc_id query-dsl-boosting-query
+   * @ext_doc_id query-dsl-boosting-query
    */
   boosting?: BoostingQuery
   /** @deprecated 7.3.0 */
   common?: SingleKeyDictionary<Field, CommonTermsQuery>
   /**
    * The `combined_fields` query supports searching multiple text fields as if their contents had been indexed into one combined field.
-   * @doc_id query-dsl-combined-fields-query
+   * @ext_doc_id query-dsl-combined-fields-query
    * @availability stack since=7.13.0
    * @availability serverless
    */
   combined_fields?: CombinedFieldsQuery
   /**
    * Wraps a filter query and returns every matching document with a relevance score equal to the `boost` parameter value.
-   * @doc_id query-dsl-constant-score-query
+   * @ext_doc_id query-dsl-constant-score-query
    */
   constant_score?: ConstantScoreQuery
   /**
    * Returns documents matching one or more wrapped queries, called query clauses or clauses.
    * If a returned document matches multiple query clauses, the `dis_max` query assigns the document the highest relevance score from any matching clause, plus a tie breaking increment for any additional matching subqueries.
-   * @doc_id query-dsl-dis-max-query
+   * @ext_doc_id query-dsl-dis-max-query
    */
   dis_max?: DisMaxQuery
   /**
    * Boosts the relevance score of documents closer to a provided origin date or point.
    * For example, you can use this query to give more weight to documents closer to a certain date or location.
-   * @doc_id query-dsl-distance-feature-query
+   * @ext_doc_id query-dsl-distance-feature-query
    */
   distance_feature?: DistanceFeatureQuery
   /**
    * Returns documents that contain an indexed value for a field.
-   * @doc_id query-dsl-exists-query
+   * @ext_doc_id query-dsl-exists-query
    */
   exists?: ExistsQuery
   /**
    * The `function_score` enables you to modify the score of documents that are retrieved by a query.
-   * @doc_id query-dsl-function-score-query
+   * @ext_doc_id query-dsl-function-score-query
    */
   function_score?: FunctionScoreQuery
   /**
    * Returns documents that contain terms similar to the search term, as measured by a Levenshtein edit distance.
-   * @doc_id query-dsl-fuzzy-query
+   * @ext_doc_id query-dsl-fuzzy-query
    */
   fuzzy?: SingleKeyDictionary<Field, FuzzyQuery>
   /**
    * Matches geo_point and geo_shape values that intersect a bounding box.
-   * @doc_id query-dsl-geo-bounding-box-query
+   * @ext_doc_id query-dsl-geo-bounding-box-query
    */
   geo_bounding_box?: GeoBoundingBoxQuery
   /**
    * Matches `geo_point` and `geo_shape` values within a given distance of a geopoint.
-   * @doc_id query-dsl-geo-distance-query
+   * @ext_doc_id query-dsl-geo-distance-query
    */
   geo_distance?: GeoDistanceQuery
   /**
@@ -172,138 +172,138 @@ export class QueryContainer {
   geo_polygon?: GeoPolygonQuery
   /**
    * Filter documents indexed using either the `geo_shape` or the `geo_point` type.
-   * @doc_id query-dsl-geo-shape-query
+   * @ext_doc_id query-dsl-geo-shape-query
    */
   geo_shape?: GeoShapeQuery
   /**
    * Returns parent documents whose joined child documents match a provided query.
-   * @doc_id query-dsl-has-child-query
+   * @ext_doc_id query-dsl-has-child-query
    */
   has_child?: HasChildQuery
   /**
    * Returns child documents whose joined parent document matches a provided query.
-   * @doc_id query-dsl-has-parent-query
+   * @ext_doc_id query-dsl-has-parent-query
    */
   has_parent?: HasParentQuery
   /**
    * Returns documents based on their IDs.
    * This query uses document IDs stored in the `_id` field.
-   * @doc_id query-dsl-ids-query
+   * @ext_doc_id query-dsl-ids-query
    */
   ids?: IdsQuery
   /**
    * Returns documents based on the order and proximity of matching terms.
-   * @doc_id query-dsl-intervals-query
+   * @ext_doc_id query-dsl-intervals-query
    */
   intervals?: SingleKeyDictionary<Field, IntervalsQuery>
   /**
    * Finds the k nearest vectors to a query vector, as measured by a similarity
    * metric. knn query finds nearest vectors through approximate search on indexed
    * dense_vectors.
-   * @doc_id query-dsl-knn-query
+   * @ext_doc_id query-dsl-knn-query
    */
   knn?: KnnQuery
   /**
    * Returns documents that match a provided text, number, date or boolean value.
    * The provided text is analyzed before matching.
-   * @doc_id query-dsl-match-query
+   * @ext_doc_id query-dsl-match-query
    */
   match?: SingleKeyDictionary<Field, MatchQuery>
   /**
    * Matches all documents, giving them all a `_score` of 1.0.
-   * @doc_id query-dsl-match-all-query
+   * @ext_doc_id query-dsl-match-all-query
    */
   match_all?: MatchAllQuery
   /**
    * Analyzes its input and constructs a `bool` query from the terms.
    * Each term except the last is used in a `term` query.
    * The last term is used in a prefix query.
-   * @doc_id query-dsl-match-bool-prefix-query
+   * @ext_doc_id query-dsl-match-bool-prefix-query
    */
   match_bool_prefix?: SingleKeyDictionary<Field, MatchBoolPrefixQuery>
   /**
    * Matches no documents.
-   * @doc_id query-dsl-match-none-query
+   * @ext_doc_id query-dsl-match-none-query
    */
   match_none?: MatchNoneQuery
   /**
    * Analyzes the text and creates a phrase query out of the analyzed text.
-   * @doc_id query-dsl-match-query-phrase
+   * @ext_doc_id query-dsl-match-query-phrase
    */
   match_phrase?: SingleKeyDictionary<Field, MatchPhraseQuery>
   /**
    * Returns documents that contain the words of a provided text, in the same order as provided.
    * The last term of the provided text is treated as a prefix, matching any words that begin with that term.
-   * @doc_id query-dsl-match-query-phrase-prefix
+   * @ext_doc_id query-dsl-match-query-phrase-prefix
    */
   match_phrase_prefix?: SingleKeyDictionary<Field, MatchPhrasePrefixQuery>
   /**
    * Returns documents that are "like" a given set of documents.
-   * @doc_id query-dsl-mlt-query
+   * @ext_doc_id query-dsl-mlt-query
    */
   more_like_this?: MoreLikeThisQuery
   /**
    * Enables you to search for a provided text, number, date or boolean value across multiple fields.
    * The provided text is analyzed before matching.
-   * @doc_id query-dsl-multi-match-query
+   * @ext_doc_id query-dsl-multi-match-query
    */
   multi_match?: MultiMatchQuery
   /**
    * Wraps another query to search nested fields.
    * If an object matches the search, the nested query returns the root parent document.
-   * @doc_id query-dsl-nested-query
+   * @ext_doc_id query-dsl-nested-query
    */
   nested?: NestedQuery
   /**
    * Returns child documents joined to a specific parent document.
-   * @doc_id query-dsl-parent-id-query
+   * @ext_doc_id query-dsl-parent-id-query
    */
   parent_id?: ParentIdQuery
   /**
    * Matches queries stored in an index.
-   * @doc_id query-dsl-percolate-query
+   * @ext_doc_id query-dsl-percolate-query
    */
   percolate?: PercolateQuery
   /**
    * Promotes selected documents to rank higher than those matching a given query.
-   * @doc_id query-dsl-pinned-query
+   * @ext_doc_id query-dsl-pinned-query
    */
   pinned?: PinnedQuery
   /**
    * Returns documents that contain a specific prefix in a provided field.
-   * @doc_id query-dsl-prefix-query
+   * @ext_doc_id query-dsl-prefix-query
    */
   prefix?: SingleKeyDictionary<Field, PrefixQuery>
   /**
    * Returns documents based on a provided query string, using a parser with a strict syntax.
-   * @doc_id query-dsl-query-string-query
+   * @ext_doc_id query-dsl-query-string-query
    */
   query_string?: QueryStringQuery
   /**
    * Returns documents that contain terms within a provided range.
-   * @doc_id query-dsl-range-query
+   * @ext_doc_id query-dsl-range-query
    */
   range?: SingleKeyDictionary<Field, RangeQuery>
   /**
    * Boosts the relevance score of documents based on the numeric value of a `rank_feature` or `rank_features` field.
-   * @doc_id query-dsl-rank-feature-query
+   * @ext_doc_id query-dsl-rank-feature-query
    */
   rank_feature?: RankFeatureQuery
   /**
    * Returns documents that contain terms matching a regular expression.
-   * @doc_id query-dsl-regexp-query
+   * @ext_doc_id query-dsl-regexp-query
    */
   regexp?: SingleKeyDictionary<Field, RegexpQuery>
   rule?: RuleQuery
   /**
    * Filters documents based on a provided script.
    * The script query is typically used in a filter context.
-   * @doc_id query-dsl-script-query
+   * @ext_doc_id query-dsl-script-query
    */
   script?: ScriptQuery
   /**
    * Uses a script to provide a custom score for returned documents.
-   * @doc_id query-dsl-script-score-query
+   * @ext_doc_id query-dsl-script-score-query
    */
   script_score?: ScriptScoreQuery
   /**
@@ -314,90 +314,90 @@ export class QueryContainer {
   semantic?: SemanticQuery
   /**
    * Queries documents that contain fields indexed using the `shape` type.
-   * @doc_id query-dsl-shape-query
+   * @ext_doc_id query-dsl-shape-query
    */
   shape?: ShapeQuery
   /**
    * Returns documents based on a provided query string, using a parser with a limited but fault-tolerant syntax.
-   * @doc_id query-dsl-simple-query-string-query
+   * @ext_doc_id query-dsl-simple-query-string-query
    */
   simple_query_string?: SimpleQueryStringQuery
   /**
    * Returns matches which enclose another span query.
-   * @doc_id query-dsl-span-containing-query
+   * @ext_doc_id query-dsl-span-containing-query
    */
   span_containing?: SpanContainingQuery
   /**
    * Wrapper to allow span queries to participate in composite single-field span queries by _lying_ about their search field.
-   * @doc_id query-dsl-span-field-masking-query
+   * @ext_doc_id query-dsl-span-field-masking-query
    */
   span_field_masking?: SpanFieldMaskingQuery
   /**
    * Matches spans near the beginning of a field.
-   * @doc_id query-dsl-span-first-query
+   * @ext_doc_id query-dsl-span-first-query
    */
   span_first?: SpanFirstQuery
   /**
    * Allows you to wrap a multi term query (one of `wildcard`, `fuzzy`, `prefix`, `range`, or `regexp` query) as a `span` query, so it can be nested.
-   * @doc_id query-dsl-span-multi-term-query
+   * @ext_doc_id query-dsl-span-multi-term-query
    */
   span_multi?: SpanMultiTermQuery
   /**
    * Matches spans which are near one another.
    * You can specify `slop`, the maximum number of intervening unmatched positions, as well as whether matches are required to be in-order.
-   * @doc_id query-dsl-span-near-query
+   * @ext_doc_id query-dsl-span-near-query
    */
   span_near?: SpanNearQuery
   /**
    * Removes matches which overlap with another span query or which are within x tokens before (controlled by the parameter `pre`) or y tokens after (controlled by the parameter `post`) another span query.
-   * @doc_id query-dsl-span-not-query
+   * @ext_doc_id query-dsl-span-not-query
    */
   span_not?: SpanNotQuery
   /**
    * Matches the union of its span clauses.
-   * @doc_id query-dsl-span-or-query
+   * @ext_doc_id query-dsl-span-or-query
    */
   span_or?: SpanOrQuery
   /**
    * Matches spans containing a term.
-   * @doc_id query-dsl-span-term-query
+   * @ext_doc_id query-dsl-span-term-query
    */
   span_term?: SingleKeyDictionary<Field, SpanTermQuery>
   /**
    * Returns matches which are enclosed inside another span query.
-   * @doc_id query-dsl-span-within-query
+   * @ext_doc_id query-dsl-span-within-query
    */
   span_within?: SpanWithinQuery
   /**
    * Using input query vectors or a natural language processing model to convert a query into a list of token-weight pairs, queries against a sparse vector field.
    * @availability stack since=8.15.0
    * @availability serverless
-   * @doc_id query-dsl-sparse-vector-query
+   * @ext_doc_id query-dsl-sparse-vector-query
    */
   sparse_vector?: SparseVectorQuery
   /**
    * Returns documents that contain an exact term in a provided field.
    * To return a document, the query term must exactly match the queried field's value, including whitespace and capitalization.
-   * @doc_id query-dsl-term-query
+   * @ext_doc_id query-dsl-term-query
    */
   term?: SingleKeyDictionary<Field, TermQuery>
   /**
    * Returns documents that contain one or more exact terms in a provided field.
    * To return a document, one or more terms must exactly match a field value, including whitespace and capitalization.
-   * @doc_id query-dsl-terms-query
+   * @ext_doc_id query-dsl-terms-query
    */
   terms?: TermsQuery
   /**
    * Returns documents that contain a minimum number of exact terms in a provided field.
    * To return a document, a required number of terms must exactly match the field values, including whitespace and capitalization.
-   * @doc_id query-dsl-terms-set-query
+   * @ext_doc_id query-dsl-terms-set-query
    */
   terms_set?: SingleKeyDictionary<Field, TermsSetQuery>
   /**
    * Uses a natural language processing model to convert the query text into a list of token-weight pairs which are then used in a query against a sparse vector or rank features field.
    * @availability stack since=8.8.0
    * @availability serverless
-   * @doc_id query-dsl-text-expansion-query
+   * @ext_doc_id query-dsl-text-expansion-query
    * @deprecated 8.15.0
    */
   text_expansion?: SingleKeyDictionary<Field, TextExpansionQuery>
@@ -405,18 +405,18 @@ export class QueryContainer {
    * Supports returning text_expansion query results by sending in precomputed tokens with the query.
    * @availability stack since=8.13.0
    * @availability serverless
-   * @doc_id query-dsl-weighted-tokens-query
+   * @ext_doc_id query-dsl-weighted-tokens-query
    * @deprecated 8.15.0
    */
   weighted_tokens?: SingleKeyDictionary<Field, WeightedTokensQuery>
   /**
    * Returns documents that contain terms matching a wildcard pattern.
-   * @doc_id query-dsl-wildcard-query
+   * @ext_doc_id query-dsl-wildcard-query
    */
   wildcard?: SingleKeyDictionary<Field, WildcardQuery>
   /**
    * A query that accepts any other query as base64 encoded string.
-   * @doc_id query-dsl-wrapper-query
+   * @ext_doc_id query-dsl-wrapper-query
    */
   wrapper?: WrapperQuery
 
@@ -487,7 +487,7 @@ export class CombinedFieldsQuery extends QueryBase {
 
   /**
    * Minimum number of clauses that must match for a document to be returned.
-   * @doc_id query-dsl-minimum-should-match
+   * @ext_doc_id query-dsl-minimum-should-match
    */
   minimum_should_match?: MinimumShouldMatch
 
@@ -498,6 +498,9 @@ export class CombinedFieldsQuery extends QueryBase {
   zero_terms_query?: CombinedFieldsZeroTerms
 }
 
+/**
+ * @ext_doc_id query-dsl-wrapper-query
+ */
 export class WrapperQuery extends QueryBase {
   /**
    * A base64 encoded query.

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -67,6 +67,9 @@ export class BoostingQuery extends QueryBase {
   positive: QueryContainer
 }
 
+/**
+ * @ext_doc_id query-dsl-constant-score-query
+ */
 export class ConstantScoreQuery extends QueryBase {
   /**
    * Filter query you wish to run. Any returned documents must match this query.

--- a/specification/_types/query_dsl/compound.ts
+++ b/specification/_types/query_dsl/compound.ts
@@ -26,6 +26,9 @@ import { Script } from '@_types/Scripting'
 import { DateMath, Duration } from '@_types/Time'
 import { QueryBase, QueryContainer } from './abstractions'
 
+/**
+ * @ext_doc_id query-dsl-bool-query
+ */
 export class BoolQuery extends QueryBase {
   /**
    * The clause (query) must appear in matching documents.
@@ -52,6 +55,9 @@ export class BoolQuery extends QueryBase {
   should?: QueryContainer | QueryContainer[]
 }
 
+/**
+ * @ext_doc_id query-dsl-boosting-query
+ */
 export class BoostingQuery extends QueryBase {
   /**
    * Floating point number between 0 and 1.0 used to decrease the relevance scores of documents matching the `negative` query.
@@ -79,6 +85,9 @@ export class ConstantScoreQuery extends QueryBase {
   filter: QueryContainer
 }
 
+/**
+ * @ext_doc_id query-dsl-dis-max-query
+ */
 export class DisMaxQuery extends QueryBase {
   /**
    * One or more query clauses.
@@ -95,6 +104,7 @@ export class DisMaxQuery extends QueryBase {
 
 /**
  * @shortcut_property functions
+ * @ext_doc_id query-dsl-function-score-query
  */
 export class FunctionScoreQuery extends QueryBase {
   /**

--- a/specification/_types/query_dsl/fulltext.ts
+++ b/specification/_types/query_dsl/fulltext.ts
@@ -232,7 +232,10 @@ export class IntervalsPrefix {
   use_field?: Field
 }
 
-/** @variants container */
+/**
+ * @variants container
+ * @ext_doc_id query-dsl-intervals-query
+ */
 // Note: similar to IntervalsContainer, but has to be duplicated because of the QueryBase parent class
 export class IntervalsQuery extends QueryBase {
   /**
@@ -279,7 +282,10 @@ export class IntervalsWildcard {
   use_field?: Field
 }
 
-/** @shortcut_property query */
+/**
+ * @shortcut_property query
+ * @ext_doc_id query-dsl-match-query
+ */
 export class MatchQuery extends QueryBase {
   /**
    * Analyzer used to convert the text in the query value into tokens.
@@ -346,7 +352,10 @@ export class MatchQuery extends QueryBase {
   zero_terms_query?: ZeroTermsQuery
 }
 
-/** @shortcut_property query */
+/**
+ * @shortcut_property query
+ * @ext_doc_id query-dsl-match-bool-prefix-query
+ */
 export class MatchBoolPrefixQuery extends QueryBase {
   /**
    * Analyzer used to convert the text in the query value into tokens.
@@ -402,7 +411,10 @@ export class MatchBoolPrefixQuery extends QueryBase {
   query: string
 }
 
-/** @shortcut_property query */
+/**
+ * @shortcut_property query
+ * @ext_doc_id query-dsl-match-query-phrase
+ */
 export class MatchPhraseQuery extends QueryBase {
   /**
    * Analyzer used to convert the text in the query value into tokens.
@@ -425,7 +437,10 @@ export class MatchPhraseQuery extends QueryBase {
   zero_terms_query?: ZeroTermsQuery
 }
 
-/** @shortcut_property query */
+/**
+ * @shortcut_property query
+ * @ext_doc_id query-dsl-match-query-phrase-prefix
+ */
 export class MatchPhrasePrefixQuery extends QueryBase {
   /**
    * Analyzer used to convert text in the query value into tokens.
@@ -453,6 +468,9 @@ export class MatchPhrasePrefixQuery extends QueryBase {
   zero_terms_query?: ZeroTermsQuery
 }
 
+/**
+ * @ext_doc_id query-dsl-multi-match-query
+ */
 export class MultiMatchQuery extends QueryBase {
   /**
    * Analyzer used to convert the text in the query value into tokens.
@@ -577,6 +595,9 @@ export enum ZeroTermsQuery {
   none
 }
 
+/**
+ * @ext_doc_id query-dsl-query-string-query
+ */
 export class QueryStringQuery extends QueryBase {
   /**
    * If `true`, the wildcard characters `*` and `?` are allowed as the first character of the query string.
@@ -762,6 +783,9 @@ export enum SimpleQueryStringFlag {
   ALL
 }
 
+/**
+ * @ext_doc_id query-dsl-simple-query-string-query
+ */
 export class SimpleQueryStringQuery extends QueryBase {
   /**
    * Analyzer used to convert text in the query string into tokens.

--- a/specification/_types/query_dsl/geo.ts
+++ b/specification/_types/query_dsl/geo.ts
@@ -31,6 +31,7 @@ import { FieldLookup, QueryBase } from './abstractions'
 
 /**
  * @behavior_meta AdditionalProperty key=field value=bounding_box
+ * @ext_doc_id query-dsl-geo-bounding-box-query
  */
 export class GeoBoundingBoxQuery
   extends QueryBase
@@ -59,6 +60,7 @@ export enum GeoExecution {
 
 /**
  * @behavior_meta AdditionalProperty key=field value=location
+ * @ext_doc_id query-dsl-geo-distance-query
  */
 export class GeoDistanceQuery
   extends QueryBase
@@ -97,6 +99,7 @@ export class GeoPolygonPoints {
 /**
  * @deprecated 7.12.0 Use geo-shape instead.
  * @behavior_meta AdditionalProperty key=field value=polygon
+ * @ext_doc_id query-dsl-geo-polygon-query
  */
 export class GeoPolygonQuery
   extends QueryBase
@@ -127,6 +130,7 @@ export class GeoShapeFieldQuery {
 
 /**
  * @behavior_meta AdditionalProperty key=field value=shape
+ * @ext_doc_id query-dsl-geo-shape-query
  */
 // GeoShape query doesn't follow the common pattern of having a single field-name property
 // holding also the query base fields (boost and _name)

--- a/specification/_types/query_dsl/joining.ts
+++ b/specification/_types/query_dsl/joining.ts
@@ -38,6 +38,9 @@ export enum ChildScoreMode {
   min
 }
 
+/**
+ * @ext_doc_id query-dsl-has-child-query
+ */
 export class HasChildQuery extends QueryBase {
   /**
    * Indicates whether to ignore an unmapped `type` and not return any documents instead of an error.
@@ -75,6 +78,9 @@ export class HasChildQuery extends QueryBase {
   type: RelationName
 }
 
+/**
+ * @ext_doc_id query-dsl-has-parent-query
+ */
 export class HasParentQuery extends QueryBase {
   /**
    * Indicates whether to ignore an unmapped `parent_type` and not return any documents instead of an error.
@@ -103,6 +109,9 @@ export class HasParentQuery extends QueryBase {
   score?: boolean
 }
 
+/**
+ * @ext_doc_id query-dsl-nested-query
+ */
 export class NestedQuery extends QueryBase {
   /**
    * Indicates whether to ignore an unmapped path and not return any documents instead of an error.
@@ -129,6 +138,9 @@ export class NestedQuery extends QueryBase {
   score_mode?: ChildScoreMode
 }
 
+/**
+ * @ext_doc_id query-dsl-parent-id-query
+ */
 export class ParentIdQuery extends QueryBase {
   /**
    * ID of the parent document.

--- a/specification/_types/query_dsl/span.ts
+++ b/specification/_types/query_dsl/span.ts
@@ -22,6 +22,9 @@ import { Field } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { QueryBase, QueryContainer } from './abstractions'
 
+/**
+ * @ext_doc_id query-dsl-span-containing-query
+ */
 export class SpanContainingQuery extends QueryBase {
   /**
    * Can be any span query.
@@ -35,11 +38,17 @@ export class SpanContainingQuery extends QueryBase {
   little: SpanQuery
 }
 
+/**
+ * @ext_doc_id query-dsl-span-field-masking-query
+ */
 export class SpanFieldMaskingQuery extends QueryBase {
   field: Field
   query: SpanQuery
 }
 
+/**
+ * @ext_doc_id query-dsl-span-first-query
+ */
 export class SpanFirstQuery extends QueryBase {
   /**
    * Controls the maximum end position permitted in a match.
@@ -55,6 +64,9 @@ export class SpanFirstQuery extends QueryBase {
 // The integer value is the span width
 export type SpanGapQuery = SingleKeyDictionary<Field, integer>
 
+/**
+ * @ext_doc_id query-dsl-span-multi-term-query
+ */
 export class SpanMultiTermQuery extends QueryBase {
   /**
    * Should be a multi term query (one of `wildcard`, `fuzzy`, `prefix`, `range`, or `regexp` query).
@@ -62,6 +74,9 @@ export class SpanMultiTermQuery extends QueryBase {
   match: QueryContainer
 }
 
+/**
+ * @ext_doc_id query-dsl-span-near-query
+ */
 export class SpanNearQuery extends QueryBase {
   /**
    * Array of one or more other span type queries.
@@ -77,6 +92,9 @@ export class SpanNearQuery extends QueryBase {
   slop?: integer
 }
 
+/**
+ * @ext_doc_id query-dsl-span-not-query
+ */
 export class SpanNotQuery extends QueryBase {
   /**
    * The number of tokens from within the include span that can’t have overlap with the exclude span.
@@ -103,6 +121,9 @@ export class SpanNotQuery extends QueryBase {
   pre?: integer
 }
 
+/**
+ * @ext_doc_id query-dsl-span-or-query
+ */
 export class SpanOrQuery extends QueryBase {
   /**
    * Array of one or more other span type queries.
@@ -110,11 +131,17 @@ export class SpanOrQuery extends QueryBase {
   clauses: SpanQuery[]
 }
 
-/** @shortcut_property value */
+/**
+ * @shortcut_property value
+ * @ext_doc_id query-dsl-span-term-query
+ */
 export class SpanTermQuery extends QueryBase {
   value: string
 }
 
+/**
+ * @ext_doc_id query-dsl-span-within-query
+ */
 export class SpanWithinQuery extends QueryBase {
   /**
    * Can be any span query.

--- a/specification/_types/query_dsl/specialized.ts
+++ b/specification/_types/query_dsl/specialized.ts
@@ -76,6 +76,7 @@ export class DateDistanceFeatureQuery extends DistanceFeatureQueryBase<
 /**
  * @codegen_names untyped, geo, date
  * @variants untagged untyped=_types.query_dsl.UntypedDistanceFeatureQuery
+ * @ext_doc_id query-dsl-distance-feature-query
  */
 // Note: deserialization depends on value types
 export type DistanceFeatureQuery =
@@ -83,11 +84,14 @@ export type DistanceFeatureQuery =
   | GeoDistanceFeatureQuery
   | DateDistanceFeatureQuery
 
+/**
+ * @ext_doc_id query-dsl-mlt-query
+ */
 export class MoreLikeThisQuery extends QueryBase {
   /**
    * The analyzer that is used to analyze the free form text.
    * Defaults to the analyzer associated with the first field in fields.
-   * @doc_id analysis
+   * @ext_doc_id analysis
    */
   analyzer?: string
   /**
@@ -239,6 +243,7 @@ export class PercolateQuery extends QueryBase {
 
 /**
  * @variants container
+ * @ext_doc_id query-dsl-pinned-query
  */
 export class PinnedQuery extends QueryBase {
   /**
@@ -298,6 +303,9 @@ export class RankFeatureFunctionSigmoid extends RankFeatureFunction {
   exponent: float
 }
 
+/**
+ * @ext_doc_id query-dsl-rank-feature-query
+ */
 export class RankFeatureQuery extends QueryBase {
   /**
    * `rank_feature` or `rank_features` field used to boost relevance scores.
@@ -323,6 +331,9 @@ export class RankFeatureQuery extends QueryBase {
   sigmoid?: RankFeatureFunctionSigmoid
 }
 
+/**
+ * @ext_doc_id query-dsl-script-query
+ */
 export class ScriptQuery extends QueryBase {
   /**
    * Contains a script to run as a query.
@@ -331,6 +342,9 @@ export class ScriptQuery extends QueryBase {
   script: Script
 }
 
+/**
+ * @ext_doc_id query-dsl-script-score-query
+ */
 export class ScriptScoreQuery extends QueryBase {
   /**
    * Documents with a score lower than this floating point number are excluded from the search results.
@@ -377,6 +391,9 @@ export class ShapeFieldQuery {
   shape?: GeoShape
 }
 
+/**
+ * @ext_doc_id query-dsl-regexp-query
+ */
 export class RuleQuery extends QueryBase {
   organic: QueryContainer
   ruleset_ids: Id[]

--- a/specification/_types/query_dsl/specialized.ts
+++ b/specification/_types/query_dsl/specialized.ts
@@ -202,6 +202,9 @@ export class LikeDocument {
  */
 export type Like = string | LikeDocument
 
+/**
+ * @ext_doc_id query-dsl-percolate-query
+ */
 export class PercolateQuery extends QueryBase {
   /**
    * The source of the document being percolated.
@@ -363,6 +366,7 @@ export class ScriptScoreQuery extends QueryBase {
 
 /**
  * @behavior_meta AdditionalProperty key=field value=shape
+ * @ext_doc_id query-dsl-shape-query
  */
 // Shape query doesn't follow the common pattern of having a single field-name property
 // holding also the query base fields (boost and _name)
@@ -392,7 +396,7 @@ export class ShapeFieldQuery {
 }
 
 /**
- * @ext_doc_id query-dsl-regexp-query
+ * @ext_doc_id query-dsl-rule-query
  */
 export class RuleQuery extends QueryBase {
   organic: QueryContainer

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -85,6 +85,9 @@ export class FuzzyQuery extends QueryBase {
   value: string | double | boolean
 }
 
+/**
+ * @ext_doc_id query-dsl-ids-query
+ */
 export class IdsQuery extends QueryBase {
   /**
    * An array of document IDs.
@@ -92,7 +95,10 @@ export class IdsQuery extends QueryBase {
   values?: Ids
 }
 
-/** @shortcut_property value */
+/**
+ * @shortcut_property value
+ * @ext_doc_id query-dsl-prefix-query
+ */
 export class PrefixQuery extends QueryBase {
   /**
    * Method used to rewrite the query.
@@ -170,6 +176,7 @@ export class TermRangeQuery extends RangeQueryBase<string> {}
 /**
  * @codegen_names untyped, date, number, term
  * @variants untagged untyped=_types.query_dsl.UntypedRangeQuery
+ * @ext_doc_id query-dsl-range-query
  */
 // Note: deserialization depends on value types
 export type RangeQuery =
@@ -193,7 +200,10 @@ export enum RangeRelation {
   intersects
 }
 
-/** @shortcut_property value */
+/**
+ * @shortcut_property value
+ * @ext_doc_id query-dsl-regexp-query
+ */
 export class RegexpQuery extends QueryBase {
   /**
    *  Allows case insensitive matching of the regular expression value with the indexed field values when set to `true`.
@@ -225,7 +235,10 @@ export class RegexpQuery extends QueryBase {
   value: string
 }
 
-/** @shortcut_property value */
+/**
+ * @shortcut_property value
+ * @ext_doc_id query-dsl-term-query
+ */
 export class TermQuery extends QueryBase {
   /**
    * Term you wish to find in the provided field.
@@ -243,6 +256,7 @@ export class TermQuery extends QueryBase {
 
 /**
  * @behavior_meta AdditionalProperty key=field value=term
+ * @ext_doc_id query-dsl-terms-query
  */
 export class TermsQuery
   extends QueryBase
@@ -260,6 +274,9 @@ export class TermsLookup {
   routing?: Routing
 }
 
+/**
+ * @ext_doc_id query-dsl-terms-set-query
+ */
 export class TermsSetQuery extends QueryBase {
   /**
    * Specification describing number of matching terms required to return a document.
@@ -285,7 +302,10 @@ export class TypeQuery extends QueryBase {
   value: string
 }
 
-/** @shortcut_property value */
+/**
+ * @shortcut_property value
+ * @ext_doc_id query-dsl-wildcard-query
+ */
 export class WildcardQuery extends QueryBase {
   /**
    * Allows case insensitive matching of the pattern with the indexed field values when set to true. Default is false which means the case sensitivity of matching depends on the underlying field’s mapping.

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -35,6 +35,9 @@ import { Script } from '@_types/Scripting'
 import { DateFormat, DateMath, TimeZone } from '@_types/Time'
 import { QueryBase } from './abstractions'
 
+/**
+ * @ext_doc_id query-dsl-exists-query
+ */
 export class ExistsQuery extends QueryBase {
   /**
    * Name of the field you wish to search.
@@ -42,7 +45,10 @@ export class ExistsQuery extends QueryBase {
   field: Field
 }
 
-/** @shortcut_property value */
+/**
+ * @shortcut_property value
+ * @ext_doc_id query-dsl-fuzzy-query
+ */
 export class FuzzyQuery extends QueryBase {
   /**
    * Maximum number of variations created.

--- a/specification/ml/_types/Analysis.ts
+++ b/specification/ml/_types/Analysis.ts
@@ -192,6 +192,7 @@ export class CategorizationAnalyzerDefinition {
   filter?: Array<TokenFilter>
   /**
    * The name or definition of the tokenizer to use after character filters are applied. This property is compulsory if `categorization_analyzer` is specified as an object. Machine learning provides a tokenizer called `ml_standard` that tokenizes in a way that has been determined to produce good categorization results on a variety of log file formats for logs in English. If you want to use that tokenizer but change the character or token filters, specify "tokenizer": "ml_standard" in your `categorization_analyzer`. Additionally, the `ml_classic` tokenizer is available, which tokenizes in the same way as the non-customizable tokenizer in old versions of the product (before 6.2). `ml_classic` was the default categorization tokenizer in versions 6.2 to 7.13, so if you need categorization identical to the default for jobs created in these versions, specify "tokenizer": "ml_classic" in your `categorization_analyzer`.
+   * @ext_doc_id analysis-tokenizers
    */
   tokenizer?: Tokenizer
 }

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -47,6 +47,9 @@ export class Datafeed {
   indexes?: string[]
   job_id: Id
   max_empty_searches?: integer
+  /**
+   * @ext_doc_id query-dsl
+   */
   query: QueryContainer
   query_delay?: Duration
   script_fields?: Dictionary<string, ScriptField>


### PR DESCRIPTION
This PR adds the `x-model` extension and `externalDocs` links to appropriate pages in the Query DSL reference via overlays.

In the longer term, the addition of these `x-model` extensions ideally should be implemented in the specifications rather than in overlays, per https://github.com/elastic/elasticsearch-specification/issues/3034