### PR TITLE
[Connectors API] Fix advanced snippet value type

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -63729,10 +63729,7 @@
             "$ref": "#/components/schemas/_types:DateTime"
           },
           "value": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object"
-            }
+            "type": "object"
           }
         },
         "required": [

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -43506,10 +43506,7 @@
             "$ref": "#/components/schemas/_types:DateTime"
           },
           "value": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object"
-            }
+            "type": "object"
           }
         },
         "required": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -115737,18 +115737,7 @@
           "name": "value",
           "required": true,
           "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "_builtins"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "user_defined_value"
-            }
+            "kind": "user_defined_value"
           }
         }
       ],

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9738,7 +9738,7 @@ export interface ConnectorFeatureEnabled {
 export interface ConnectorFilteringAdvancedSnippet {
   created_at?: DateTime
   updated_at?: DateTime
-  value: Record<string, any>
+  value: any
 }
 
 export interface ConnectorFilteringConfig {

--- a/specification/connector/_types/Connector.ts
+++ b/specification/connector/_types/Connector.ts
@@ -192,7 +192,7 @@ enum FilteringValidationState {
 export interface FilteringAdvancedSnippet {
   created_at?: DateTime
   updated_at?: DateTime
-  value: Dictionary<string, UserDefinedValue>
+  value: UserDefinedValue
 }
 
 export interface FilteringRulesValidation {


### PR DESCRIPTION
### Changes

Fix type mismatch between definition in ES, in ES we define the advancedSnippet value as `Object`, see [code reference](https://github.com/elastic/elasticsearch/blob/6d039c2b9dfb1dfc1eaac86ecff37b3db6521908/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringAdvancedSnippet.java#L40)

This is because this can be either object or array of objects. Changing 

`Dictionary<string, UserDefinedValue>` to `UserDefinedValue`

Shoutout to @l-trotta for spotting the issue! 🏅 

