### PR TITLE
Fix role-related API spec

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -26924,8 +26924,8 @@
         "tags": [
           "security"
         ],
-        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
-        "description": "The get roles API cannot retrieve roles that are defined in roles files.",
+        "summary": "Get roles API\n",
+        "description": "Retrieves roles in the native realm.",
         "operationId": "security-get-role-1",
         "responses": {
           "200": {
@@ -27968,8 +27968,8 @@
         "tags": [
           "security"
         ],
-        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
-        "description": "The get roles API cannot retrieve roles that are defined in roles files.",
+        "summary": "Get roles API\n",
+        "description": "Retrieves roles in the native realm.",
         "operationId": "security-get-role",
         "parameters": [
           {
@@ -27986,8 +27986,8 @@
         "tags": [
           "security"
         ],
-        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
-        "description": "The create or update roles API cannot update roles that are defined in roles files.",
+        "summary": "Create or update roles API\n",
+        "description": "Create or update roles in the native realm.",
         "operationId": "security-put-role",
         "parameters": [
           {
@@ -28010,8 +28010,8 @@
         "tags": [
           "security"
         ],
-        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
-        "description": "The create or update roles API cannot update roles that are defined in roles files.",
+        "summary": "Create or update roles API\n",
+        "description": "Create or update roles in the native realm.",
         "operationId": "security-put-role-1",
         "parameters": [
           {
@@ -28034,7 +28034,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Removes roles in the native realm",
+        "summary": "Delete roles API\n",
+        "description": "Removes roles in the native realm.",
         "operationId": "security-delete-role",
         "parameters": [
           {
@@ -28584,7 +28585,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch",
+        "summary": "Get builtin privileges API\n",
+        "description": "Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
         "operationId": "security-get-builtin-privileges",
         "responses": {
           "200": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -26924,7 +26924,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Get roles API\n",
+        "summary": "Get roles API",
         "description": "Retrieves roles in the native realm.",
         "operationId": "security-get-role-1",
         "responses": {
@@ -27968,7 +27968,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Get roles API\n",
+        "summary": "Get roles API",
         "description": "Retrieves roles in the native realm.",
         "operationId": "security-get-role",
         "parameters": [
@@ -27986,7 +27986,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Create or update roles API\n",
+        "summary": "Create or update roles API",
         "description": "Create or update roles in the native realm.",
         "operationId": "security-put-role",
         "parameters": [
@@ -28010,7 +28010,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Create or update roles API\n",
+        "summary": "Create or update roles API",
         "description": "Create or update roles in the native realm.",
         "operationId": "security-put-role-1",
         "parameters": [
@@ -28034,7 +28034,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Delete roles API\n",
+        "summary": "Delete roles API",
         "description": "Removes roles in the native realm.",
         "operationId": "security-delete-role",
         "parameters": [
@@ -28585,7 +28585,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Get builtin privileges API\n",
+        "summary": "Get builtin privileges API",
         "description": "Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
         "operationId": "security-get-builtin-privileges",
         "responses": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -16863,7 +16863,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Get roles API\n",
+        "summary": "Get roles API",
         "description": "Retrieves roles in the native realm.",
         "operationId": "security-get-role",
         "parameters": [
@@ -16881,7 +16881,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Create or update roles API\n",
+        "summary": "Create or update roles API",
         "description": "Create or update roles in the native realm.",
         "operationId": "security-put-role",
         "parameters": [
@@ -16905,7 +16905,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Create or update roles API\n",
+        "summary": "Create or update roles API",
         "description": "Create or update roles in the native realm.",
         "operationId": "security-put-role-1",
         "parameters": [
@@ -16929,7 +16929,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Delete roles API\n",
+        "summary": "Delete roles API",
         "description": "Removes roles in the native realm.",
         "operationId": "security-delete-role",
         "parameters": [
@@ -16982,7 +16982,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Get builtin privileges API\n",
+        "summary": "Get builtin privileges API",
         "description": "Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
         "operationId": "security-get-builtin-privileges",
         "responses": {
@@ -17023,7 +17023,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Get roles API\n",
+        "summary": "Get roles API",
         "description": "Retrieves roles in the native realm.",
         "operationId": "security-get-role-1",
         "responses": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -16863,8 +16863,8 @@
         "tags": [
           "security"
         ],
-        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
-        "description": "The get roles API cannot retrieve roles that are defined in roles files.",
+        "summary": "Get roles API\n",
+        "description": "Retrieves roles in the native realm.",
         "operationId": "security-get-role",
         "parameters": [
           {
@@ -16881,8 +16881,8 @@
         "tags": [
           "security"
         ],
-        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
-        "description": "The create or update roles API cannot update roles that are defined in roles files.",
+        "summary": "Create or update roles API\n",
+        "description": "Create or update roles in the native realm.",
         "operationId": "security-put-role",
         "parameters": [
           {
@@ -16905,8 +16905,8 @@
         "tags": [
           "security"
         ],
-        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
-        "description": "The create or update roles API cannot update roles that are defined in roles files.",
+        "summary": "Create or update roles API\n",
+        "description": "Create or update roles in the native realm.",
         "operationId": "security-put-role-1",
         "parameters": [
           {
@@ -16929,7 +16929,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Removes roles in the native realm",
+        "summary": "Delete roles API\n",
+        "description": "Removes roles in the native realm.",
         "operationId": "security-delete-role",
         "parameters": [
           {
@@ -16981,7 +16982,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch",
+        "summary": "Get builtin privileges API\n",
+        "description": "Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
         "operationId": "security-get-builtin-privileges",
         "responses": {
           "200": {
@@ -17021,8 +17023,8 @@
         "tags": [
           "security"
         ],
-        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
-        "description": "The get roles API cannot retrieve roles that are defined in roles files.",
+        "summary": "Get roles API\n",
+        "description": "Retrieves roles in the native realm.",
         "operationId": "security-get-role-1",
         "responses": {
           "200": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -8379,7 +8379,7 @@
           "stability": "stable"
         }
       },
-      "description": "Delete roles API\n\nRemoves roles in the native realm.",
+      "description": "Delete roles API.\nRemoves roles in the native realm.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html",
       "name": "security.delete_role",
       "request": {
@@ -8455,7 +8455,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get builtin privileges API\n\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
+      "description": "Get builtin privileges API.\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-builtin-privileges.html",
       "name": "security.get_builtin_privileges",
       "privileges": {
@@ -8494,7 +8494,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get roles API\n\nRetrieves roles in the native realm.",
+      "description": "Get roles API.\nRetrieves roles in the native realm.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html",
       "name": "security.get_role",
       "privileges": {
@@ -8629,7 +8629,7 @@
           "stability": "stable"
         }
       },
-      "description": "Create or update roles API\n\nCreate or update roles in the native realm.",
+      "description": "Create or update roles API.\nCreate or update roles in the native realm.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html",
       "name": "security.put_role",
       "privileges": {
@@ -38755,7 +38755,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Delete roles API\n\nRemoves roles in the native realm.",
+      "description": "Delete roles API.\nRemoves roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -38795,7 +38795,7 @@
           }
         }
       ],
-      "specLocation": "security/delete_role/SecurityDeleteRoleRequest.ts#L23-L38"
+      "specLocation": "security/delete_role/SecurityDeleteRoleRequest.ts#L23-L37"
     },
     {
       "body": {
@@ -38997,7 +38997,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get builtin privileges API\n\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
+      "description": "Get builtin privileges API.\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -39011,7 +39011,7 @@
       },
       "path": [],
       "query": [],
-      "specLocation": "security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts#L22-L31"
+      "specLocation": "security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts#L22-L30"
     },
     {
       "body": {
@@ -39061,7 +39061,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get roles API\n\nRetrieves roles in the native realm.",
+      "description": "Get roles API.\nRetrieves roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -39088,7 +39088,7 @@
         }
       ],
       "query": [],
-      "specLocation": "security/get_role/SecurityGetRoleRequest.ts#L23-L39"
+      "specLocation": "security/get_role/SecurityGetRoleRequest.ts#L23-L38"
     },
     {
       "body": {
@@ -39570,7 +39570,7 @@
           }
         ]
       },
-      "description": "Create or update roles API\n\nCreate or update roles in the native realm.",
+      "description": "Create or update roles API.\nCreate or update roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -39610,7 +39610,7 @@
           }
         }
       ],
-      "specLocation": "security/put_role/SecurityPutRoleRequest.ts#L31-L92"
+      "specLocation": "security/put_role/SecurityPutRoleRequest.ts#L31-L91"
     },
     {
       "body": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -8379,7 +8379,7 @@
           "stability": "stable"
         }
       },
-      "description": "Delete roles API\nRemoves roles in the native realm.",
+      "description": "Delete roles API\n\nRemoves roles in the native realm.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html",
       "name": "security.delete_role",
       "request": {
@@ -8455,7 +8455,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get builtin privileges API\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
+      "description": "Get builtin privileges API\n\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-builtin-privileges.html",
       "name": "security.get_builtin_privileges",
       "privileges": {
@@ -8494,7 +8494,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get roles API\nRetrieves roles in the native realm.",
+      "description": "Get roles API\n\nRetrieves roles in the native realm.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html",
       "name": "security.get_role",
       "privileges": {
@@ -8629,7 +8629,7 @@
           "stability": "stable"
         }
       },
-      "description": "Create or update roles API\nCreate or update roles in the native realm.",
+      "description": "Create or update roles API\n\nCreate or update roles in the native realm.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html",
       "name": "security.put_role",
       "privileges": {
@@ -38755,7 +38755,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Delete roles API\nRemoves roles in the native realm.",
+      "description": "Delete roles API\n\nRemoves roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -38795,7 +38795,7 @@
           }
         }
       ],
-      "specLocation": "security/delete_role/SecurityDeleteRoleRequest.ts#L23-L37"
+      "specLocation": "security/delete_role/SecurityDeleteRoleRequest.ts#L23-L38"
     },
     {
       "body": {
@@ -38997,7 +38997,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get builtin privileges API\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
+      "description": "Get builtin privileges API\n\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -39011,7 +39011,7 @@
       },
       "path": [],
       "query": [],
-      "specLocation": "security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts#L22-L30"
+      "specLocation": "security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts#L22-L31"
     },
     {
       "body": {
@@ -39061,7 +39061,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get roles API\nRetrieves roles in the native realm.",
+      "description": "Get roles API\n\nRetrieves roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -39088,7 +39088,7 @@
         }
       ],
       "query": [],
-      "specLocation": "security/get_role/SecurityGetRoleRequest.ts#L23-L38"
+      "specLocation": "security/get_role/SecurityGetRoleRequest.ts#L23-L39"
     },
     {
       "body": {
@@ -39570,7 +39570,7 @@
           }
         ]
       },
-      "description": "Create or update roles API\nCreate or update roles in the native realm.",
+      "description": "Create or update roles API\n\nCreate or update roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -39610,7 +39610,7 @@
           }
         }
       ],
-      "specLocation": "security/put_role/SecurityPutRoleRequest.ts#L31-L91"
+      "specLocation": "security/put_role/SecurityPutRoleRequest.ts#L31-L92"
     },
     {
       "body": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -8379,7 +8379,7 @@
           "stability": "stable"
         }
       },
-      "description": "Delete roles API.\nRemoves roles in the native realm.",
+      "description": "Delete roles API.\n\nRemoves roles in the native realm.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html",
       "name": "security.delete_role",
       "request": {
@@ -8455,7 +8455,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get builtin privileges API.\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
+      "description": "Get builtin privileges API.\n\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-builtin-privileges.html",
       "name": "security.get_builtin_privileges",
       "privileges": {
@@ -8494,7 +8494,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get roles API.\nRetrieves roles in the native realm.",
+      "description": "Get roles API.\n\nRetrieves roles in the native realm.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html",
       "name": "security.get_role",
       "privileges": {
@@ -8629,7 +8629,7 @@
           "stability": "stable"
         }
       },
-      "description": "Create or update roles API.\nCreate or update roles in the native realm.",
+      "description": "Create or update roles API.\n\nCreate or update roles in the native realm.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html",
       "name": "security.put_role",
       "privileges": {
@@ -38755,7 +38755,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Delete roles API.\nRemoves roles in the native realm.",
+      "description": "Delete roles API.\n\nRemoves roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -38795,7 +38795,7 @@
           }
         }
       ],
-      "specLocation": "security/delete_role/SecurityDeleteRoleRequest.ts#L23-L37"
+      "specLocation": "security/delete_role/SecurityDeleteRoleRequest.ts#L23-L38"
     },
     {
       "body": {
@@ -38997,7 +38997,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get builtin privileges API.\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
+      "description": "Get builtin privileges API.\n\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -39011,7 +39011,7 @@
       },
       "path": [],
       "query": [],
-      "specLocation": "security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts#L22-L30"
+      "specLocation": "security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts#L22-L31"
     },
     {
       "body": {
@@ -39061,7 +39061,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get roles API.\nRetrieves roles in the native realm.",
+      "description": "Get roles API.\n\nRetrieves roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -39088,7 +39088,7 @@
         }
       ],
       "query": [],
-      "specLocation": "security/get_role/SecurityGetRoleRequest.ts#L23-L38"
+      "specLocation": "security/get_role/SecurityGetRoleRequest.ts#L23-L39"
     },
     {
       "body": {
@@ -39570,7 +39570,7 @@
           }
         ]
       },
-      "description": "Create or update roles API.\nCreate or update roles in the native realm.",
+      "description": "Create or update roles API.\n\nCreate or update roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -39610,7 +39610,7 @@
           }
         }
       ],
-      "specLocation": "security/put_role/SecurityPutRoleRequest.ts#L31-L91"
+      "specLocation": "security/put_role/SecurityPutRoleRequest.ts#L31-L92"
     },
     {
       "body": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -8379,7 +8379,7 @@
           "stability": "stable"
         }
       },
-      "description": "Removes roles in the native realm.",
+      "description": "Delete roles API\nRemoves roles in the native realm.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-delete-role.html",
       "name": "security.delete_role",
       "request": {
@@ -8455,7 +8455,7 @@
           "stability": "stable"
         }
       },
-      "description": "Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
+      "description": "Get builtin privileges API\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-builtin-privileges.html",
       "name": "security.get_builtin_privileges",
       "privileges": {
@@ -8494,7 +8494,7 @@
           "stability": "stable"
         }
       },
-      "description": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.\nThe get roles API cannot retrieve roles that are defined in roles files.",
+      "description": "Get roles API\nRetrieves roles in the native realm.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html",
       "name": "security.get_role",
       "privileges": {
@@ -8629,7 +8629,7 @@
           "stability": "stable"
         }
       },
-      "description": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.",
+      "description": "Create or update roles API\nCreate or update roles in the native realm.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html",
       "name": "security.put_role",
       "privileges": {
@@ -38755,7 +38755,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Removes roles in the native realm.",
+      "description": "Delete roles API\nRemoves roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -38795,7 +38795,7 @@
           }
         }
       ],
-      "specLocation": "security/delete_role/SecurityDeleteRoleRequest.ts#L23-L35"
+      "specLocation": "security/delete_role/SecurityDeleteRoleRequest.ts#L23-L37"
     },
     {
       "body": {
@@ -38997,7 +38997,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
+      "description": "Get builtin privileges API\nRetrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -39011,7 +39011,7 @@
       },
       "path": [],
       "query": [],
-      "specLocation": "security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts#L22-L28"
+      "specLocation": "security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts#L22-L30"
     },
     {
       "body": {
@@ -39061,7 +39061,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.\nThe get roles API cannot retrieve roles that are defined in roles files.",
+      "description": "Get roles API\nRetrieves roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -39570,7 +39570,7 @@
           }
         ]
       },
-      "description": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.",
+      "description": "Create or update roles API\nCreate or update roles in the native realm.",
       "inherits": {
         "type": {
           "name": "RequestBase",

--- a/specification/security/delete_role/SecurityDeleteRoleRequest.ts
+++ b/specification/security/delete_role/SecurityDeleteRoleRequest.ts
@@ -22,6 +22,7 @@ import { Name, Refresh } from '@_types/common'
 
 /**
  * Delete roles API
+ *
  * Removes roles in the native realm.
  * @rest_spec_name security.delete_role
  * @availability stack stability=stable

--- a/specification/security/delete_role/SecurityDeleteRoleRequest.ts
+++ b/specification/security/delete_role/SecurityDeleteRoleRequest.ts
@@ -21,8 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Name, Refresh } from '@_types/common'
 
 /**
- * Delete roles API
- *
+ * Delete roles API.
  * Removes roles in the native realm.
  * @rest_spec_name security.delete_role
  * @availability stack stability=stable

--- a/specification/security/delete_role/SecurityDeleteRoleRequest.ts
+++ b/specification/security/delete_role/SecurityDeleteRoleRequest.ts
@@ -22,6 +22,7 @@ import { Name, Refresh } from '@_types/common'
 
 /**
  * Delete roles API.
+ *
  * Removes roles in the native realm.
  * @rest_spec_name security.delete_role
  * @availability stack stability=stable

--- a/specification/security/delete_role/SecurityDeleteRoleRequest.ts
+++ b/specification/security/delete_role/SecurityDeleteRoleRequest.ts
@@ -21,6 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Name, Refresh } from '@_types/common'
 
 /**
+ * Delete roles API
+ * Removes roles in the native realm.
  * @rest_spec_name security.delete_role
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Get builtin privileges API.
+ *
  * Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.
  * @rest_spec_name security.get_builtin_privileges
  * @availability stack since=7.3.0 stability=stable

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
@@ -20,6 +20,8 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Get builtin privileges API
+ * Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.
  * @rest_spec_name security.get_builtin_privileges
  * @availability stack since=7.3.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
@@ -20,8 +20,7 @@
 import { RequestBase } from '@_types/Base'
 
 /**
- * Get builtin privileges API
- *
+ * Get builtin privileges API.
  * Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.
  * @rest_spec_name security.get_builtin_privileges
  * @availability stack since=7.3.0 stability=stable

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Get builtin privileges API
+ *
  * Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.
  * @rest_spec_name security.get_builtin_privileges
  * @availability stack since=7.3.0 stability=stable

--- a/specification/security/get_role/SecurityGetRoleRequest.ts
+++ b/specification/security/get_role/SecurityGetRoleRequest.ts
@@ -22,6 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * Get roles API.
+ *
  * Retrieves roles in the native realm.
  * @rest_spec_name security.get_role
  * @availability stack stability=stable

--- a/specification/security/get_role/SecurityGetRoleRequest.ts
+++ b/specification/security/get_role/SecurityGetRoleRequest.ts
@@ -22,6 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * Get roles API
+ *
  * Retrieves roles in the native realm.
  * @rest_spec_name security.get_role
  * @availability stack stability=stable

--- a/specification/security/get_role/SecurityGetRoleRequest.ts
+++ b/specification/security/get_role/SecurityGetRoleRequest.ts
@@ -21,8 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Names } from '@_types/common'
 
 /**
- * Get roles API
- *
+ * Get roles API.
  * Retrieves roles in the native realm.
  * @rest_spec_name security.get_role
  * @availability stack stability=stable

--- a/specification/security/get_role/SecurityGetRoleRequest.ts
+++ b/specification/security/get_role/SecurityGetRoleRequest.ts
@@ -21,8 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Names } from '@_types/common'
 
 /**
- * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
- * The get roles API cannot retrieve roles that are defined in roles files.
+ * Get roles API
+ * Retrieves roles in the native realm.
  * @rest_spec_name security.get_role
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -30,6 +30,7 @@ import { Metadata, Name, Refresh } from '@_types/common'
 
 /**
  * Create or update roles API
+ *
  * Create or update roles in the native realm.
  * @rest_spec_name security.put_role
  * @availability stack stability=stable

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -29,8 +29,7 @@ import { RequestBase } from '@_types/Base'
 import { Metadata, Name, Refresh } from '@_types/common'
 
 /**
- * Create or update roles API
- *
+ * Create or update roles API.
  * Create or update roles in the native realm.
  * @rest_spec_name security.put_role
  * @availability stack stability=stable

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -30,6 +30,7 @@ import { Metadata, Name, Refresh } from '@_types/common'
 
 /**
  * Create or update roles API.
+ *
  * Create or update roles in the native realm.
  * @rest_spec_name security.put_role
  * @availability stack stability=stable

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -29,8 +29,8 @@ import { RequestBase } from '@_types/Base'
 import { Metadata, Name, Refresh } from '@_types/common'
 
 /**
- * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
- * The create or update roles API cannot update roles that are defined in roles files.
+ * Create or update roles API
+ * Create or update roles in the native realm.
  * @rest_spec_name security.put_role
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public


### PR DESCRIPTION
There is a display glitch in the ES serverless API: see live [spec](https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-security-get-role).

where details of several APIs are rendered as API headers. This PR fixes the rendering issue by including the relevant header info in top-level comments for each affected API. 