### PR TITLE
[OpenAPI] Edit summaries for security APIs

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -26799,7 +26799,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Creates or updates a user profile on behalf of another user",
+        "summary": "Create or update a user profile",
+        "description": "Create or update a user profile on behalf of another user.",
         "operationId": "security-activate-user-profile",
         "requestBody": {
           "content": {
@@ -26934,8 +26935,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Get roles API",
-        "description": "Retrieves roles in the native realm.",
+        "summary": "Get roles",
+        "description": "Get roles in the native realm.",
         "operationId": "security-get-role-1",
         "responses": {
           "200": {
@@ -26947,8 +26948,8 @@
         "tags": [
           "security"
         ],
-        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
-        "description": "The bulk create or update roles API cannot update roles that are defined in roles files.",
+        "summary": "Bulk create or update roles",
+        "description": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.\nThe bulk create or update roles API cannot update roles that are defined in roles files.",
         "operationId": "security-bulk-put-role",
         "parameters": [
           {
@@ -27028,8 +27029,8 @@
         "tags": [
           "security"
         ],
-        "summary": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management",
-        "description": "The bulk delete roles API cannot delete roles that are defined in roles files.",
+        "summary": "Bulk delete roles",
+        "description": "The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.\nThe bulk delete roles API cannot delete roles that are defined in roles files.",
         "operationId": "security-bulk-delete-role",
         "parameters": [
           {
@@ -27104,7 +27105,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Changes the passwords of users in the native realm and built-in users",
+        "summary": "Change passwords",
+        "description": "Change the passwords of users in the native realm and built-in users.",
         "operationId": "security-change-password",
         "parameters": [
           {
@@ -27127,7 +27129,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Changes the passwords of users in the native realm and built-in users",
+        "summary": "Change passwords",
+        "description": "Change the passwords of users in the native realm and built-in users.",
         "operationId": "security-change-password-1",
         "parameters": [
           {
@@ -27152,7 +27155,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Changes the passwords of users in the native realm and built-in users",
+        "summary": "Change passwords",
+        "description": "Change the passwords of users in the native realm and built-in users.",
         "operationId": "security-change-password-2",
         "parameters": [
           {
@@ -27172,7 +27176,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Changes the passwords of users in the native realm and built-in users",
+        "summary": "Change passwords",
+        "description": "Change the passwords of users in the native realm and built-in users.",
         "operationId": "security-change-password-3",
         "parameters": [
           {
@@ -27194,8 +27199,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Evicts a subset of all entries from the API key cache",
-        "description": "The cache is also automatically cleared on state changes of the security index.",
+        "summary": "Clear the API key cache",
+        "description": "Evict a subset of all entries from the API key cache.\nThe cache is also automatically cleared on state changes of the security index.",
         "operationId": "security-clear-api-key-cache",
         "parameters": [
           {
@@ -27249,7 +27254,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Evicts application privileges from the native application privileges cache",
+        "summary": "Clear the privileges cache",
+        "description": "Evict privileges from the native application privilege cache.\nThe cache is also automatically cleared for applications that have their privileges updated.",
         "operationId": "security-clear-cached-privileges",
         "parameters": [
           {
@@ -27303,8 +27309,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Evicts users from the user cache",
-        "description": "Can completely clear the cache or evict specific users.",
+        "summary": "Clear the user cache",
+        "description": "Evict users from the user cache. You can completely clear the cache or evict specific users.",
         "operationId": "security-clear-cached-realms",
         "parameters": [
           {
@@ -27370,7 +27376,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Evicts roles from the native role cache",
+        "summary": "Clear the roles cache",
+        "description": "Evict roles from the native role cache.",
         "operationId": "security-clear-cached-roles",
         "parameters": [
           {
@@ -27423,7 +27430,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Evicts tokens from the service account token caches",
+        "summary": "Clear service account token caches",
+        "description": "Evict a subset of all entries from the service account token caches.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/service-accounts.html"
+        },
         "operationId": "security-clear-cached-service-tokens",
         "parameters": [
           {
@@ -27613,7 +27624,7 @@
           "security"
         ],
         "summary": "Create an API key",
-        "description": "Creates an API key for access without requiring basic authentication.\nA successful request returns a JSON structure that contains the API key, its unique id, and its name.\nIf applicable, it also returns expiration information for the API key in milliseconds.\nNOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.",
+        "description": "Create an API key for access without requiring basic authentication.\nA successful request returns a JSON structure that contains the API key, its unique id, and its name.\nIf applicable, it also returns expiration information for the API key in milliseconds.\nNOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.",
         "operationId": "security-create-api-key",
         "parameters": [
           {
@@ -27635,7 +27646,7 @@
           "security"
         ],
         "summary": "Create an API key",
-        "description": "Creates an API key for access without requiring basic authentication.\nA successful request returns a JSON structure that contains the API key, its unique id, and its name.\nIf applicable, it also returns expiration information for the API key in milliseconds.\nNOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.",
+        "description": "Create an API key for access without requiring basic authentication.\nA successful request returns a JSON structure that contains the API key, its unique id, and its name.\nIf applicable, it also returns expiration information for the API key in milliseconds.\nNOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.",
         "operationId": "security-create-api-key-1",
         "parameters": [
           {
@@ -27743,7 +27754,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Creates a service accounts token for access without requiring basic authentication",
+        "summary": "Create a service account token",
+        "description": "Create a service accounts token for access without requiring basic authentication.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/service-accounts.html"
+        },
         "operationId": "security-create-service-token",
         "parameters": [
           {
@@ -27769,7 +27784,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Creates a service accounts token for access without requiring basic authentication",
+        "summary": "Create a service account token",
+        "description": "Create a service accounts token for access without requiring basic authentication.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/service-accounts.html"
+        },
         "operationId": "security-create-service-token-1",
         "parameters": [
           {
@@ -27795,7 +27814,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Deletes a service account token",
+        "summary": "Delete service account tokens",
+        "description": "Delete service account tokens for a service in a specified namespace.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/service-accounts.html"
+        },
         "operationId": "security-delete-service-token",
         "parameters": [
           {
@@ -27870,7 +27893,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Creates a service accounts token for access without requiring basic authentication",
+        "summary": "Create a service account token",
+        "description": "Create a service accounts token for access without requiring basic authentication.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/service-accounts.html"
+        },
         "operationId": "security-create-service-token-2",
         "parameters": [
           {
@@ -27895,7 +27922,10 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves application privileges",
+        "summary": "Get application privileges",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-get-privileges-2",
         "parameters": [
           {
@@ -27916,7 +27946,10 @@
         "tags": [
           "security"
         ],
-        "summary": "Removes application privileges",
+        "summary": "Delete application privileges",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-delete-privileges",
         "parameters": [
           {
@@ -27978,8 +28011,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Get roles API",
-        "description": "Retrieves roles in the native realm.",
+        "summary": "Get roles",
+        "description": "Get roles in the native realm.",
         "operationId": "security-get-role",
         "parameters": [
           {
@@ -28044,8 +28077,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Delete roles API",
-        "description": "Removes roles in the native realm.",
+        "summary": "Delete roles",
+        "description": "Remove roles in the native realm.",
         "operationId": "security-delete-role",
         "parameters": [
           {
@@ -28097,7 +28130,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves role mappings",
+        "summary": "Get role mappings",
+        "description": "Role mappings define which roles are assigned to each user.\nThe role mapping APIs are generally the preferred way to manage role mappings rather than using role mapping files.\nThe get role mappings API cannot retrieve role mappings that are defined in role mapping files.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-roles.html"
+        },
         "operationId": "security-get-role-mapping",
         "parameters": [
           {
@@ -28163,7 +28200,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Removes role mappings",
+        "summary": "Delete role mappings",
         "operationId": "security-delete-role-mapping",
         "parameters": [
           {
@@ -28216,7 +28253,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves information about users in the native realm and built-in users",
+        "summary": "Get users",
+        "description": "Get information about users in the native realm and built-in users.",
         "operationId": "security-get-user",
         "parameters": [
           {
@@ -28284,7 +28322,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Deletes users from the native realm",
+        "summary": "Delete users",
+        "description": "Delete users from the native realm.",
         "operationId": "security-delete-user",
         "parameters": [
           {
@@ -28336,7 +28375,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Disables users in the native realm",
+        "summary": "Deactivate users",
+        "description": "Deactivate users in the native realm.",
         "operationId": "security-disable-user",
         "parameters": [
           {
@@ -28356,7 +28396,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Disables users in the native realm",
+        "summary": "Deactivate users",
+        "description": "Deactivate users in the native realm.",
         "operationId": "security-disable-user-1",
         "parameters": [
           {
@@ -28378,7 +28419,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Disables a user profile so it's not visible in user profile searches",
+        "summary": "Deactivate a user profile",
+        "description": "Deactivated user profiles are not visible in user profile searches.",
         "operationId": "security-disable-user-profile",
         "parameters": [
           {
@@ -28399,7 +28441,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Disables a user profile so it's not visible in user profile searches",
+        "summary": "Deactivate a user profile",
+        "description": "Deactivated user profiles are not visible in user profile searches.",
         "operationId": "security-disable-user-profile-1",
         "parameters": [
           {
@@ -28422,7 +28465,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Enables users in the native realm",
+        "summary": "Activate users",
+        "description": "Activate users in the native realm.",
         "operationId": "security-enable-user",
         "parameters": [
           {
@@ -28442,7 +28486,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Enables users in the native realm",
+        "summary": "Activate users",
+        "description": "Activate users in the native realm.",
         "operationId": "security-enable-user-1",
         "parameters": [
           {
@@ -28464,7 +28509,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Enables a user profile so it's visible in user profile searches",
+        "summary": "Activate a user profile",
+        "description": "Activated user profiles are visible in user profile searches.",
         "operationId": "security-enable-user-profile",
         "parameters": [
           {
@@ -28485,7 +28531,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Enables a user profile so it's visible in user profile searches",
+        "summary": "Activate a user profile",
+        "description": "Activated user profiles are visible in user profile searches.",
         "operationId": "security-enable-user-profile-1",
         "parameters": [
           {
@@ -28508,7 +28555,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Enables a Kibana instance to configure itself for communication with a secured Elasticsearch cluster",
+        "summary": "Enroll Kibana",
+        "description": "Enable a Kibana instance to configure itself for communication with a secured Elasticsearch cluster.",
         "operationId": "security-enroll-kibana",
         "responses": {
           "200": {
@@ -28542,7 +28590,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Allows a new node to join an existing cluster with security features enabled",
+        "summary": "Enroll a node",
+        "description": "Enroll a new node to allow it to join an existing cluster with security features enabled.",
         "operationId": "security-enroll-node",
         "responses": {
           "200": {
@@ -28595,8 +28644,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Get builtin privileges API",
-        "description": "Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
+        "summary": "Get builtin privileges",
+        "description": "Get the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-get-builtin-privileges",
         "responses": {
           "200": {
@@ -28636,7 +28688,10 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves application privileges",
+        "summary": "Get application privileges",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-get-privileges",
         "responses": {
           "200": {
@@ -28693,7 +28748,10 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves application privileges",
+        "summary": "Get application privileges",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-get-privileges-1",
         "parameters": [
           {
@@ -28713,7 +28771,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves role mappings",
+        "summary": "Get role mappings",
+        "description": "Role mappings define which roles are assigned to each user.\nThe role mapping APIs are generally the preferred way to manage role mappings rather than using role mapping files.\nThe get role mappings API cannot retrieve role mappings that are defined in role mapping files.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-roles.html"
+        },
         "operationId": "security-get-role-mapping-1",
         "responses": {
           "200": {
@@ -28728,7 +28790,11 @@
         "tags": [
           "security"
         ],
-        "summary": "This API returns a list of service accounts that match the provided path parameter(s)",
+        "summary": "Get service accounts",
+        "description": "Get a list of service accounts that match the provided path parameters.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/service-accounts.html"
+        },
         "operationId": "security-get-service-accounts",
         "parameters": [
           {
@@ -28751,7 +28817,11 @@
         "tags": [
           "security"
         ],
-        "summary": "This API returns a list of service accounts that match the provided path parameter(s)",
+        "summary": "Get service accounts",
+        "description": "Get a list of service accounts that match the provided path parameters.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/service-accounts.html"
+        },
         "operationId": "security-get-service-accounts-1",
         "parameters": [
           {
@@ -28771,7 +28841,11 @@
         "tags": [
           "security"
         ],
-        "summary": "This API returns a list of service accounts that match the provided path parameter(s)",
+        "summary": "Get service accounts",
+        "description": "Get a list of service accounts that match the provided path parameters.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/service-accounts.html"
+        },
         "operationId": "security-get-service-accounts-2",
         "responses": {
           "200": {
@@ -28786,7 +28860,10 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves information of all service credentials for a service account",
+        "summary": "Get service account credentials",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/service-accounts.html"
+        },
         "operationId": "security-get-service-credentials",
         "parameters": [
           {
@@ -28855,7 +28932,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Creates a bearer token for access without requiring basic authentication",
+        "summary": "Get a token",
+        "description": "Create a bearer token for access without requiring basic authentication.",
         "operationId": "security-get-token",
         "requestBody": {
           "content": {
@@ -29002,7 +29080,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves information about users in the native realm and built-in users",
+        "summary": "Get users",
+        "description": "Get information about users in the native realm and built-in users.",
         "operationId": "security-get-user-1",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -26799,7 +26799,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Create or update a user profile",
+        "summary": "Activate a user profile",
         "description": "Create or update a user profile on behalf of another user.",
         "operationId": "security-activate-user-profile",
         "requestBody": {
@@ -28078,7 +28078,7 @@
           "security"
         ],
         "summary": "Delete roles",
-        "description": "Remove roles in the native realm.",
+        "description": "Delete roles in the native realm.",
         "operationId": "security-delete-role",
         "parameters": [
           {
@@ -28375,8 +28375,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Deactivate users",
-        "description": "Deactivate users in the native realm.",
+        "summary": "Disable users",
+        "description": "Disable users in the native realm.",
         "operationId": "security-disable-user",
         "parameters": [
           {
@@ -28396,8 +28396,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Deactivate users",
-        "description": "Deactivate users in the native realm.",
+        "summary": "Disable users",
+        "description": "Disable users in the native realm.",
         "operationId": "security-disable-user-1",
         "parameters": [
           {
@@ -28419,8 +28419,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Deactivate a user profile",
-        "description": "Deactivated user profiles are not visible in user profile searches.",
+        "summary": "Disable a user profile",
+        "description": "Disable user profiles so that they are not visible in user profile searches.",
         "operationId": "security-disable-user-profile",
         "parameters": [
           {
@@ -28441,8 +28441,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Deactivate a user profile",
-        "description": "Deactivated user profiles are not visible in user profile searches.",
+        "summary": "Disable a user profile",
+        "description": "Disable user profiles so that they are not visible in user profile searches.",
         "operationId": "security-disable-user-profile-1",
         "parameters": [
           {
@@ -28465,8 +28465,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Activate users",
-        "description": "Activate users in the native realm.",
+        "summary": "Enable users",
+        "description": "Enable users in the native realm.",
         "operationId": "security-enable-user",
         "parameters": [
           {
@@ -28486,8 +28486,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Activate users",
-        "description": "Activate users in the native realm.",
+        "summary": "Enable users",
+        "description": "Enable users in the native realm.",
         "operationId": "security-enable-user-1",
         "parameters": [
           {
@@ -28509,8 +28509,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Activate a user profile",
-        "description": "Activated user profiles are visible in user profile searches.",
+        "summary": "Enable a user profile",
+        "description": "Enable user profiles to make them visible in user profile searches.",
         "operationId": "security-enable-user-profile",
         "parameters": [
           {
@@ -28531,8 +28531,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Activate a user profile",
-        "description": "Activated user profiles are visible in user profile searches.",
+        "summary": "Enable a user profile",
+        "description": "Enable user profiles to make them visible in user profile searches.",
         "operationId": "security-enable-user-profile-1",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -16726,7 +16726,7 @@
           "security"
         ],
         "summary": "Create an API key",
-        "description": "Creates an API key for access without requiring basic authentication.\nA successful request returns a JSON structure that contains the API key, its unique id, and its name.\nIf applicable, it also returns expiration information for the API key in milliseconds.\nNOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.",
+        "description": "Create an API key for access without requiring basic authentication.\nA successful request returns a JSON structure that contains the API key, its unique id, and its name.\nIf applicable, it also returns expiration information for the API key in milliseconds.\nNOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.",
         "operationId": "security-create-api-key",
         "parameters": [
           {
@@ -16748,7 +16748,7 @@
           "security"
         ],
         "summary": "Create an API key",
-        "description": "Creates an API key for access without requiring basic authentication.\nA successful request returns a JSON structure that contains the API key, its unique id, and its name.\nIf applicable, it also returns expiration information for the API key in milliseconds.\nNOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.",
+        "description": "Create an API key for access without requiring basic authentication.\nA successful request returns a JSON structure that contains the API key, its unique id, and its name.\nIf applicable, it also returns expiration information for the API key in milliseconds.\nNOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.",
         "operationId": "security-create-api-key-1",
         "parameters": [
           {
@@ -16856,8 +16856,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Get roles API",
-        "description": "Retrieves roles in the native realm.",
+        "summary": "Get roles",
+        "description": "Get roles in the native realm.",
         "operationId": "security-get-role",
         "parameters": [
           {
@@ -16922,8 +16922,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Delete roles API",
-        "description": "Removes roles in the native realm.",
+        "summary": "Delete roles",
+        "description": "Remove roles in the native realm.",
         "operationId": "security-delete-role",
         "parameters": [
           {
@@ -16975,8 +16975,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Get builtin privileges API",
-        "description": "Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
+        "summary": "Get builtin privileges",
+        "description": "Get the list of cluster privileges and index privileges that are available in this version of Elasticsearch.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-get-builtin-privileges",
         "responses": {
           "200": {
@@ -17016,8 +17019,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Get roles API",
-        "description": "Retrieves roles in the native realm.",
+        "summary": "Get roles",
+        "description": "Get roles in the native realm.",
         "operationId": "security-get-role-1",
         "responses": {
           "200": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -16923,7 +16923,7 @@
           "security"
         ],
         "summary": "Delete roles",
-        "description": "Remove roles in the native realm.",
+        "description": "Delete roles in the native realm.",
         "operationId": "security-delete-role",
         "parameters": [
           {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -258,6 +258,7 @@ lowercase-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{bra
 mapping-date-format,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-date-format.html
 mapping-meta-field,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-meta-field.html
 mapping-metadata,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-fields.html
+mapping-roles,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-roles.html
 mapping-settings-limit,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-settings-limit.html
 mapping-source-field,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-source-field.html
 mapping,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping.html
@@ -573,6 +574,8 @@ security-api-saml-logout,https://www.elastic.co/guide/en/elasticsearch/reference
 security-api-saml-prepare-authentication,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-saml-prepare-authentication.html
 security-api-saml-sp-metadata,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-saml-sp-metadata.html
 security-api-ssl,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-ssl.html
+security-privileges,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-privileges.html
+service-accounts,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/service-accounts.html
 set-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/set-processor.html
 shape,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/shape.html
 simulate-pipeline-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/simulate-pipeline-api.html

--- a/specification/security/activate_user_profile/Request.ts
+++ b/specification/security/activate_user_profile/Request.ts
@@ -21,7 +21,8 @@ import { GrantType } from '@security/_types/GrantType'
 import { RequestBase } from '@_types/Base'
 
 /**
- * Creates or updates a user profile on behalf of another user.
+ * Create or update a user profile.
+ * Create or update a user profile on behalf of another user.
  * @rest_spec_name security.activate_user_profile
  * @availability stack since=8.2.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/activate_user_profile/Request.ts
+++ b/specification/security/activate_user_profile/Request.ts
@@ -22,7 +22,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Activate a user profile.
- * 
+ *
  * Create or update a user profile on behalf of another user.
  * @rest_spec_name security.activate_user_profile
  * @availability stack since=8.2.0 stability=stable

--- a/specification/security/activate_user_profile/Request.ts
+++ b/specification/security/activate_user_profile/Request.ts
@@ -21,7 +21,8 @@ import { GrantType } from '@security/_types/GrantType'
 import { RequestBase } from '@_types/Base'
 
 /**
- * Create or update a user profile.
+ * Activate a user profile.
+ * 
  * Create or update a user profile on behalf of another user.
  * @rest_spec_name security.activate_user_profile
  * @availability stack since=8.2.0 stability=stable

--- a/specification/security/authenticate/SecurityAuthenticateRequest.ts
+++ b/specification/security/authenticate/SecurityAuthenticateRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Authenticate a user.
- * 
+ *
  * Authenticates a user and returns information about the authenticated user.
  * Include the user information in a [basic auth header](https://en.wikipedia.org/wiki/Basic_access_authentication).
  * A successful call returns a JSON structure that shows user information such as their username, the roles that are assigned to the user, any assigned metadata, and information about the realms that authenticated and authorized the user.

--- a/specification/security/authenticate/SecurityAuthenticateRequest.ts
+++ b/specification/security/authenticate/SecurityAuthenticateRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Authenticate a user.
+ * 
  * Authenticates a user and returns information about the authenticated user.
  * Include the user information in a [basic auth header](https://en.wikipedia.org/wiki/Basic_access_authentication).
  * A successful call returns a JSON structure that shows user information such as their username, the roles that are assigned to the user, any assigned metadata, and information about the realms that authenticated and authorized the user.

--- a/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
+++ b/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Refresh } from '@_types/common'
 
 /**
+ * Bulk delete roles.
  * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
  * The bulk delete roles API cannot delete roles that are defined in roles files.
  * @rest_spec_name security.bulk_delete_role

--- a/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
+++ b/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
@@ -22,6 +22,7 @@ import { Refresh } from '@_types/common'
 
 /**
  * Bulk delete roles.
+ * 
  * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
  * The bulk delete roles API cannot delete roles that are defined in roles files.
  * @rest_spec_name security.bulk_delete_role

--- a/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
+++ b/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
@@ -22,7 +22,7 @@ import { Refresh } from '@_types/common'
 
 /**
  * Bulk delete roles.
- * 
+ *
  * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
  * The bulk delete roles API cannot delete roles that are defined in roles files.
  * @rest_spec_name security.bulk_delete_role

--- a/specification/security/bulk_put_role/SecurityBulkPutRoleRequest.ts
+++ b/specification/security/bulk_put_role/SecurityBulkPutRoleRequest.ts
@@ -24,6 +24,7 @@ import { Refresh } from '@_types/common'
 
 /**
  * Bulk create or update roles.
+ * 
  * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
  * The bulk create or update roles API cannot update roles that are defined in roles files.
  * @rest_spec_name security.bulk_put_role

--- a/specification/security/bulk_put_role/SecurityBulkPutRoleRequest.ts
+++ b/specification/security/bulk_put_role/SecurityBulkPutRoleRequest.ts
@@ -23,6 +23,7 @@ import { RequestBase } from '@_types/Base'
 import { Refresh } from '@_types/common'
 
 /**
+ * Bulk create or update roles.
  * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
  * The bulk create or update roles API cannot update roles that are defined in roles files.
  * @rest_spec_name security.bulk_put_role

--- a/specification/security/bulk_put_role/SecurityBulkPutRoleRequest.ts
+++ b/specification/security/bulk_put_role/SecurityBulkPutRoleRequest.ts
@@ -24,7 +24,7 @@ import { Refresh } from '@_types/common'
 
 /**
  * Bulk create or update roles.
- * 
+ *
  * The role management APIs are generally the preferred way to manage roles, rather than using file-based role management.
  * The bulk create or update roles API cannot update roles that are defined in roles files.
  * @rest_spec_name security.bulk_put_role

--- a/specification/security/change_password/SecurityChangePasswordRequest.ts
+++ b/specification/security/change_password/SecurityChangePasswordRequest.ts
@@ -21,6 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Password, Refresh, Username } from '@_types/common'
 
 /**
+ * Change passwords.
+ * Change the passwords of users in the native realm and built-in users.
  * @rest_spec_name security.change_password
  * @availability stack stability=stable
  */

--- a/specification/security/change_password/SecurityChangePasswordRequest.ts
+++ b/specification/security/change_password/SecurityChangePasswordRequest.ts
@@ -22,6 +22,7 @@ import { Password, Refresh, Username } from '@_types/common'
 
 /**
  * Change passwords.
+ * 
  * Change the passwords of users in the native realm and built-in users.
  * @rest_spec_name security.change_password
  * @availability stack stability=stable

--- a/specification/security/change_password/SecurityChangePasswordRequest.ts
+++ b/specification/security/change_password/SecurityChangePasswordRequest.ts
@@ -22,7 +22,7 @@ import { Password, Refresh, Username } from '@_types/common'
 
 /**
  * Change passwords.
- * 
+ *
  * Change the passwords of users in the native realm and built-in users.
  * @rest_spec_name security.change_password
  * @availability stack stability=stable

--- a/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
+++ b/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
@@ -21,7 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Ids } from '@_types/common'
 
 /**
- * Evicts a subset of all entries from the API key cache.
+ * Clear the API key cache.
+ * Evict a subset of all entries from the API key cache.
  * The cache is also automatically cleared on state changes of the security index.
  * @rest_spec_name security.clear_api_key_cache
  * @availability stack since=7.10.0 stability=stable

--- a/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
+++ b/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
@@ -22,7 +22,7 @@ import { Ids } from '@_types/common'
 
 /**
  * Clear the API key cache.
- * 
+ *
  * Evict a subset of all entries from the API key cache.
  * The cache is also automatically cleared on state changes of the security index.
  * @rest_spec_name security.clear_api_key_cache

--- a/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
+++ b/specification/security/clear_api_key_cache/SecurityClearApiKeyCacheRequest.ts
@@ -22,6 +22,7 @@ import { Ids } from '@_types/common'
 
 /**
  * Clear the API key cache.
+ * 
  * Evict a subset of all entries from the API key cache.
  * The cache is also automatically cleared on state changes of the security index.
  * @rest_spec_name security.clear_api_key_cache

--- a/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesRequest.ts
+++ b/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesRequest.ts
@@ -22,7 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * Clear the privileges cache.
- * 
+ *
  * Evict privileges from the native application privilege cache.
  * The cache is also automatically cleared for applications that have their privileges updated.
  * @rest_spec_name security.clear_cached_privileges

--- a/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesRequest.ts
+++ b/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesRequest.ts
@@ -21,6 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 
 /**
+ * Clear the privileges cache.
+ * Evict privileges from the native application privilege cache.
+ * The cache is also automatically cleared for applications that have their privileges updated.
  * @rest_spec_name security.clear_cached_privileges
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesRequest.ts
+++ b/specification/security/clear_cached_privileges/SecurityClearCachedPrivilegesRequest.ts
@@ -22,6 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * Clear the privileges cache.
+ * 
  * Evict privileges from the native application privilege cache.
  * The cache is also automatically cleared for applications that have their privileges updated.
  * @rest_spec_name security.clear_cached_privileges

--- a/specification/security/clear_cached_realms/SecurityClearCachedRealmsRequest.ts
+++ b/specification/security/clear_cached_realms/SecurityClearCachedRealmsRequest.ts
@@ -22,7 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * Clear the user cache.
- * 
+ *
  * Evict users from the user cache. You can completely clear the cache or evict specific users.
  * @rest_spec_name security.clear_cached_realms
  * @availability stack stability=stable

--- a/specification/security/clear_cached_realms/SecurityClearCachedRealmsRequest.ts
+++ b/specification/security/clear_cached_realms/SecurityClearCachedRealmsRequest.ts
@@ -22,6 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * Clear the user cache.
+ * 
  * Evict users from the user cache. You can completely clear the cache or evict specific users.
  * @rest_spec_name security.clear_cached_realms
  * @availability stack stability=stable

--- a/specification/security/clear_cached_realms/SecurityClearCachedRealmsRequest.ts
+++ b/specification/security/clear_cached_realms/SecurityClearCachedRealmsRequest.ts
@@ -21,6 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Names } from '@_types/common'
 
 /**
+ * Clear the user cache.
+ * Evict users from the user cache. You can completely clear the cache or evict specific users.
  * @rest_spec_name security.clear_cached_realms
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/clear_cached_roles/ClearCachedRolesRequest.ts
+++ b/specification/security/clear_cached_roles/ClearCachedRolesRequest.ts
@@ -21,6 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Names } from '@_types/common'
 
 /**
+ * Clear the roles cache.
+ * Evict roles from the native role cache.
  * @rest_spec_name security.clear_cached_roles
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/clear_cached_roles/ClearCachedRolesRequest.ts
+++ b/specification/security/clear_cached_roles/ClearCachedRolesRequest.ts
@@ -22,7 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * Clear the roles cache.
- * 
+ *
  * Evict roles from the native role cache.
  * @rest_spec_name security.clear_cached_roles
  * @availability stack stability=stable

--- a/specification/security/clear_cached_roles/ClearCachedRolesRequest.ts
+++ b/specification/security/clear_cached_roles/ClearCachedRolesRequest.ts
@@ -22,6 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * Clear the roles cache.
+ * 
  * Evict roles from the native role cache.
  * @rest_spec_name security.clear_cached_roles
  * @availability stack stability=stable

--- a/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensRequest.ts
+++ b/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensRequest.ts
@@ -21,9 +21,12 @@ import { RequestBase } from '@_types/Base'
 import { Names, Namespace, Service } from '@_types/common'
 
 /**
+ * Clear service account token caches.
+ * Evict a subset of all entries from the service account token caches.
  * @rest_spec_name security.clear_cached_service_tokens
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=private
+ * @ext_doc_id service-accounts
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensRequest.ts
+++ b/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensRequest.ts
@@ -22,7 +22,7 @@ import { Names, Namespace, Service } from '@_types/common'
 
 /**
  * Clear service account token caches.
- * 
+ *
  * Evict a subset of all entries from the service account token caches.
  * @rest_spec_name security.clear_cached_service_tokens
  * @availability stack stability=stable

--- a/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensRequest.ts
+++ b/specification/security/clear_cached_service_tokens/ClearCachedServiceTokensRequest.ts
@@ -22,6 +22,7 @@ import { Names, Namespace, Service } from '@_types/common'
 
 /**
  * Clear service account token caches.
+ * 
  * Evict a subset of all entries from the service account token caches.
  * @rest_spec_name security.clear_cached_service_tokens
  * @availability stack stability=stable

--- a/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
+++ b/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
@@ -25,7 +25,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * Create an API key.
- * Creates an API key for access without requiring basic authentication.
+ * Create an API key for access without requiring basic authentication.
  * A successful request returns a JSON structure that contains the API key, its unique id, and its name.
  * If applicable, it also returns expiration information for the API key in milliseconds.
  * NOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.

--- a/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
+++ b/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
@@ -25,7 +25,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * Create an API key.
- * 
+ *
  * Create an API key for access without requiring basic authentication.
  * A successful request returns a JSON structure that contains the API key, its unique id, and its name.
  * If applicable, it also returns expiration information for the API key in milliseconds.

--- a/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
+++ b/specification/security/create_api_key/SecurityCreateApiKeyRequest.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * Create an API key.
+ * 
  * Create an API key for access without requiring basic authentication.
  * A successful request returns a JSON structure that contains the API key, its unique id, and its name.
  * If applicable, it also returns expiration information for the API key in milliseconds.

--- a/specification/security/create_service_token/CreateServiceTokenRequest.ts
+++ b/specification/security/create_service_token/CreateServiceTokenRequest.ts
@@ -22,6 +22,7 @@ import { Name, Namespace, Refresh, Service } from '@_types/common'
 
 /**
  * Create a service account token.
+ * 
  * Create a service accounts token for access without requiring basic authentication.
  * @rest_spec_name security.create_service_token
  * @availability stack stability=stable

--- a/specification/security/create_service_token/CreateServiceTokenRequest.ts
+++ b/specification/security/create_service_token/CreateServiceTokenRequest.ts
@@ -26,7 +26,7 @@ import { Name, Namespace, Refresh, Service } from '@_types/common'
  * @rest_spec_name security.create_service_token
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=private
- * @ext_doc_id service-account
+ * @ext_doc_id service-accounts
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/create_service_token/CreateServiceTokenRequest.ts
+++ b/specification/security/create_service_token/CreateServiceTokenRequest.ts
@@ -21,10 +21,12 @@ import { RequestBase } from '@_types/Base'
 import { Name, Namespace, Refresh, Service } from '@_types/common'
 
 /**
- * Creates a service accounts token for access without requiring basic authentication.
+ * Create a service account token.
+ * Create a service accounts token for access without requiring basic authentication.
  * @rest_spec_name security.create_service_token
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=private
+ * @ext_doc_id service-account
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/create_service_token/CreateServiceTokenRequest.ts
+++ b/specification/security/create_service_token/CreateServiceTokenRequest.ts
@@ -22,7 +22,7 @@ import { Name, Namespace, Refresh, Service } from '@_types/common'
 
 /**
  * Create a service account token.
- * 
+ *
  * Create a service accounts token for access without requiring basic authentication.
  * @rest_spec_name security.create_service_token
  * @availability stack stability=stable

--- a/specification/security/delete_privileges/SecurityDeletePrivilegesRequest.ts
+++ b/specification/security/delete_privileges/SecurityDeletePrivilegesRequest.ts
@@ -21,9 +21,11 @@ import { RequestBase } from '@_types/Base'
 import { Name, Names, Refresh } from '@_types/common'
 
 /**
+ * Delete application privileges.
  * @rest_spec_name security.delete_privileges
  * @availability stack since=6.4.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @ext_doc_id security-privileges
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/delete_role/SecurityDeleteRoleRequest.ts
+++ b/specification/security/delete_role/SecurityDeleteRoleRequest.ts
@@ -22,7 +22,8 @@ import { Name, Refresh } from '@_types/common'
 
 /**
  * Delete roles.
- * Remove roles in the native realm.
+ * 
+ * Delete roles in the native realm.
  * @rest_spec_name security.delete_role
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/security/delete_role/SecurityDeleteRoleRequest.ts
+++ b/specification/security/delete_role/SecurityDeleteRoleRequest.ts
@@ -22,7 +22,7 @@ import { Name, Refresh } from '@_types/common'
 
 /**
  * Delete roles.
- * 
+ *
  * Delete roles in the native realm.
  * @rest_spec_name security.delete_role
  * @availability stack stability=stable

--- a/specification/security/delete_role/SecurityDeleteRoleRequest.ts
+++ b/specification/security/delete_role/SecurityDeleteRoleRequest.ts
@@ -21,9 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Name, Refresh } from '@_types/common'
 
 /**
- * Delete roles API.
- *
- * Removes roles in the native realm.
+ * Delete roles.
+ * Remove roles in the native realm.
  * @rest_spec_name security.delete_role
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/security/delete_role_mapping/SecurityDeleteRoleMappingRequest.ts
+++ b/specification/security/delete_role_mapping/SecurityDeleteRoleMappingRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Name, Refresh } from '@_types/common'
 
 /**
+ * Delete role mappings.
  * @rest_spec_name security.delete_role_mapping
  * @availability stack since=5.5.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/delete_service_token/DeleteServiceTokenRequest.ts
+++ b/specification/security/delete_service_token/DeleteServiceTokenRequest.ts
@@ -22,6 +22,7 @@ import { Name, Namespace, Refresh, Service } from '@_types/common'
 
 /**
  * Delete service account tokens.
+ * 
  * Delete service account tokens for a service in a specified namespace.
  * @rest_spec_name security.delete_service_token
  * @availability stack since=5.5.0 stability=stable

--- a/specification/security/delete_service_token/DeleteServiceTokenRequest.ts
+++ b/specification/security/delete_service_token/DeleteServiceTokenRequest.ts
@@ -22,7 +22,7 @@ import { Name, Namespace, Refresh, Service } from '@_types/common'
 
 /**
  * Delete service account tokens.
- * 
+ *
  * Delete service account tokens for a service in a specified namespace.
  * @rest_spec_name security.delete_service_token
  * @availability stack since=5.5.0 stability=stable

--- a/specification/security/delete_service_token/DeleteServiceTokenRequest.ts
+++ b/specification/security/delete_service_token/DeleteServiceTokenRequest.ts
@@ -21,9 +21,12 @@ import { RequestBase } from '@_types/Base'
 import { Name, Namespace, Refresh, Service } from '@_types/common'
 
 /**
+ * Delete service account tokens.
+ * Delete service account tokens for a service in a specified namespace.
  * @rest_spec_name security.delete_service_token
  * @availability stack since=5.5.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @ext_doc_id service-accounts
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/delete_user/SecurityDeleteUserRequest.ts
+++ b/specification/security/delete_user/SecurityDeleteUserRequest.ts
@@ -22,7 +22,7 @@ import { Refresh, Username } from '@_types/common'
 
 /**
  * Delete users.
- * 
+ *
  * Delete users from the native realm.
  * @rest_spec_name security.delete_user
  * @availability stack stability=stable

--- a/specification/security/delete_user/SecurityDeleteUserRequest.ts
+++ b/specification/security/delete_user/SecurityDeleteUserRequest.ts
@@ -21,6 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Refresh, Username } from '@_types/common'
 
 /**
+ * Delete users.
+ * Delete users from the native realm.
  * @rest_spec_name security.delete_user
  * @availability stack stability=stable
  */

--- a/specification/security/delete_user/SecurityDeleteUserRequest.ts
+++ b/specification/security/delete_user/SecurityDeleteUserRequest.ts
@@ -22,6 +22,7 @@ import { Refresh, Username } from '@_types/common'
 
 /**
  * Delete users.
+ * 
  * Delete users from the native realm.
  * @rest_spec_name security.delete_user
  * @availability stack stability=stable

--- a/specification/security/disable_user/SecurityDisableUserRequest.ts
+++ b/specification/security/disable_user/SecurityDisableUserRequest.ts
@@ -21,8 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { Refresh, Username } from '@_types/common'
 
 /**
- * Deactivate users.
- * Deactivate users in the native realm.
+ * Disable users.
+ * 
+ * Disable users in the native realm.
  * @rest_spec_name security.disable_user
  * @availability stack stability=stable
  */

--- a/specification/security/disable_user/SecurityDisableUserRequest.ts
+++ b/specification/security/disable_user/SecurityDisableUserRequest.ts
@@ -21,6 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Refresh, Username } from '@_types/common'
 
 /**
+ * Deactivate users.
+ * Deactivate users in the native realm.
  * @rest_spec_name security.disable_user
  * @availability stack stability=stable
  */

--- a/specification/security/disable_user/SecurityDisableUserRequest.ts
+++ b/specification/security/disable_user/SecurityDisableUserRequest.ts
@@ -22,7 +22,7 @@ import { Refresh, Username } from '@_types/common'
 
 /**
  * Disable users.
- * 
+ *
  * Disable users in the native realm.
  * @rest_spec_name security.disable_user
  * @availability stack stability=stable

--- a/specification/security/disable_user_profile/Request.ts
+++ b/specification/security/disable_user_profile/Request.ts
@@ -23,7 +23,7 @@ import { Refresh } from '@_types/common'
 
 /**
  * Disable a user profile.
- * 
+ *
  * Disable user profiles so that they are not visible in user profile searches.
  * @rest_spec_name security.disable_user_profile
  * @availability stack since=8.2.0 stability=stable

--- a/specification/security/disable_user_profile/Request.ts
+++ b/specification/security/disable_user_profile/Request.ts
@@ -22,7 +22,8 @@ import { RequestBase } from '@_types/Base'
 import { Refresh } from '@_types/common'
 
 /**
- * Disables a user profile so it's not visible in user profile searches.
+ * Deactivate a user profile.
+ * Deactivated user profiles are not visible in user profile searches.
  * @rest_spec_name security.disable_user_profile
  * @availability stack since=8.2.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/disable_user_profile/Request.ts
+++ b/specification/security/disable_user_profile/Request.ts
@@ -22,8 +22,9 @@ import { RequestBase } from '@_types/Base'
 import { Refresh } from '@_types/common'
 
 /**
- * Deactivate a user profile.
- * Deactivated user profiles are not visible in user profile searches.
+ * Disable a user profile.
+ * 
+ * Disable user profiles so that they are not visible in user profile searches.
  * @rest_spec_name security.disable_user_profile
  * @availability stack since=8.2.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/enable_user/SecurityEnableUserRequest.ts
+++ b/specification/security/enable_user/SecurityEnableUserRequest.ts
@@ -21,6 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Refresh, Username } from '@_types/common'
 
 /**
+ * Activate users.
+ * Activate users in the native realm.
  * @rest_spec_name security.enable_user
  * @availability stack stability=stable
  */

--- a/specification/security/enable_user/SecurityEnableUserRequest.ts
+++ b/specification/security/enable_user/SecurityEnableUserRequest.ts
@@ -21,8 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { Refresh, Username } from '@_types/common'
 
 /**
- * Activate users.
- * Activate users in the native realm.
+ * Enable users.
+ * 
+ * Enable users in the native realm.
  * @rest_spec_name security.enable_user
  * @availability stack stability=stable
  */

--- a/specification/security/enable_user/SecurityEnableUserRequest.ts
+++ b/specification/security/enable_user/SecurityEnableUserRequest.ts
@@ -22,7 +22,7 @@ import { Refresh, Username } from '@_types/common'
 
 /**
  * Enable users.
- * 
+ *
  * Enable users in the native realm.
  * @rest_spec_name security.enable_user
  * @availability stack stability=stable

--- a/specification/security/enable_user_profile/Request.ts
+++ b/specification/security/enable_user_profile/Request.ts
@@ -22,8 +22,9 @@ import { RequestBase } from '@_types/Base'
 import { Refresh } from '@_types/common'
 
 /**
- * Activate a user profile.
- * Activated user profiles are visible in user profile searches.
+ * Enable a user profile.
+ * 
+ * Enable user profiles to make them visible in user profile searches.
  * @rest_spec_name security.enable_user_profile
  * @availability stack since=8.2.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/enable_user_profile/Request.ts
+++ b/specification/security/enable_user_profile/Request.ts
@@ -23,7 +23,7 @@ import { Refresh } from '@_types/common'
 
 /**
  * Enable a user profile.
- * 
+ *
  * Enable user profiles to make them visible in user profile searches.
  * @rest_spec_name security.enable_user_profile
  * @availability stack since=8.2.0 stability=stable

--- a/specification/security/enable_user_profile/Request.ts
+++ b/specification/security/enable_user_profile/Request.ts
@@ -22,7 +22,8 @@ import { RequestBase } from '@_types/Base'
 import { Refresh } from '@_types/common'
 
 /**
- * Enables a user profile so it's visible in user profile searches.
+ * Activate a user profile.
+ * Activated user profiles are visible in user profile searches.
  * @rest_spec_name security.enable_user_profile
  * @availability stack since=8.2.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/enroll_kibana/Request.ts
+++ b/specification/security/enroll_kibana/Request.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Enroll Kibana.
+ * 
  * Enable a Kibana instance to configure itself for communication with a secured Elasticsearch cluster.
  * @rest_spec_name security.enroll_kibana
  * @availability stack since=8.0.0 stability=stable

--- a/specification/security/enroll_kibana/Request.ts
+++ b/specification/security/enroll_kibana/Request.ts
@@ -20,7 +20,8 @@
 import { RequestBase } from '@_types/Base'
 
 /**
- * Enables a Kibana instance to configure itself for communication with a secured Elasticsearch cluster.
+ * Enroll Kibana.
+ * Enable a Kibana instance to configure itself for communication with a secured Elasticsearch cluster.
  * @rest_spec_name security.enroll_kibana
  * @availability stack since=8.0.0 stability=stable
  */

--- a/specification/security/enroll_kibana/Request.ts
+++ b/specification/security/enroll_kibana/Request.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Enroll Kibana.
- * 
+ *
  * Enable a Kibana instance to configure itself for communication with a secured Elasticsearch cluster.
  * @rest_spec_name security.enroll_kibana
  * @availability stack since=8.0.0 stability=stable

--- a/specification/security/enroll_node/Request.ts
+++ b/specification/security/enroll_node/Request.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Enroll a node.
+ * 
  * Enroll a new node to allow it to join an existing cluster with security features enabled.
  * @rest_spec_name security.enroll_node
  * @availability stack since=8.0.0 stability=stable

--- a/specification/security/enroll_node/Request.ts
+++ b/specification/security/enroll_node/Request.ts
@@ -20,7 +20,8 @@
 import { RequestBase } from '@_types/Base'
 
 /**
- * Allows a new node to join an existing cluster with security features enabled.
+ * Enroll a node.
+ * Enroll a new node to allow it to join an existing cluster with security features enabled.
  * @rest_spec_name security.enroll_node
  * @availability stack since=8.0.0 stability=stable
  */

--- a/specification/security/enroll_node/Request.ts
+++ b/specification/security/enroll_node/Request.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Enroll a node.
- * 
+ *
  * Enroll a new node to allow it to join an existing cluster with security features enabled.
  * @rest_spec_name security.enroll_node
  * @availability stack since=8.0.0 stability=stable

--- a/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
+++ b/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
@@ -22,6 +22,7 @@ import { Id, Name, Username } from '@_types/common'
 
 /**
  * Get API key information.
+ * 
  * Retrieves information for one or more API keys.
  * NOTE: If you have only the `manage_own_api_key` privilege, this API returns only the API keys that you own.
  * If you have `read_security`, `manage_api_key` or greater privileges (including `manage_security`), this API returns all API keys regardless of ownership.

--- a/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
+++ b/specification/security/get_api_key/SecurityGetApiKeyRequest.ts
@@ -22,7 +22,7 @@ import { Id, Name, Username } from '@_types/common'
 
 /**
  * Get API key information.
- * 
+ *
  * Retrieves information for one or more API keys.
  * NOTE: If you have only the `manage_own_api_key` privilege, this API returns only the API keys that you own.
  * If you have `read_security`, `manage_api_key` or greater privileges (including `manage_security`), this API returns all API keys regardless of ownership.

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Get builtin privileges.
+ * 
  * Get the list of cluster privileges and index privileges that are available in this version of Elasticsearch.
  * @rest_spec_name security.get_builtin_privileges
  * @availability stack since=7.3.0 stability=stable

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Get builtin privileges.
- * 
+ *
  * Get the list of cluster privileges and index privileges that are available in this version of Elasticsearch.
  * @rest_spec_name security.get_builtin_privileges
  * @availability stack since=7.3.0 stability=stable

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesRequest.ts
@@ -20,12 +20,12 @@
 import { RequestBase } from '@_types/Base'
 
 /**
- * Get builtin privileges API.
- *
- * Retrieves the list of cluster privileges and index privileges that are available in this version of Elasticsearch.
+ * Get builtin privileges.
+ * Get the list of cluster privileges and index privileges that are available in this version of Elasticsearch.
  * @rest_spec_name security.get_builtin_privileges
  * @availability stack since=7.3.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_security
+ * @ext_doc_id security-privileges
  */
 export interface Request extends RequestBase {}

--- a/specification/security/get_privileges/SecurityGetPrivilegesRequest.ts
+++ b/specification/security/get_privileges/SecurityGetPrivilegesRequest.ts
@@ -21,9 +21,11 @@ import { RequestBase } from '@_types/Base'
 import { Name, Names } from '@_types/common'
 
 /**
+ * Get application privileges.
  * @rest_spec_name security.get_privileges
  * @availability stack since=6.4.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @ext_doc_id security-privileges
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/get_role/SecurityGetRoleRequest.ts
+++ b/specification/security/get_role/SecurityGetRoleRequest.ts
@@ -21,9 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Names } from '@_types/common'
 
 /**
- * Get roles API.
- *
- * Retrieves roles in the native realm.
+ * Get roles.
+ * Get roles in the native realm.
  * @rest_spec_name security.get_role
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/security/get_role/SecurityGetRoleRequest.ts
+++ b/specification/security/get_role/SecurityGetRoleRequest.ts
@@ -22,7 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * Get roles.
- * 
+ *
  * Get roles in the native realm.
  * @rest_spec_name security.get_role
  * @availability stack stability=stable

--- a/specification/security/get_role/SecurityGetRoleRequest.ts
+++ b/specification/security/get_role/SecurityGetRoleRequest.ts
@@ -22,6 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * Get roles.
+ * 
  * Get roles in the native realm.
  * @rest_spec_name security.get_role
  * @availability stack stability=stable

--- a/specification/security/get_role_mapping/SecurityGetRoleMappingRequest.ts
+++ b/specification/security/get_role_mapping/SecurityGetRoleMappingRequest.ts
@@ -22,7 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * Get role mappings.
- * 
+ *
  * Role mappings define which roles are assigned to each user.
  * The role mapping APIs are generally the preferred way to manage role mappings rather than using role mapping files.
  * The get role mappings API cannot retrieve role mappings that are defined in role mapping files.

--- a/specification/security/get_role_mapping/SecurityGetRoleMappingRequest.ts
+++ b/specification/security/get_role_mapping/SecurityGetRoleMappingRequest.ts
@@ -22,6 +22,7 @@ import { Names } from '@_types/common'
 
 /**
  * Get role mappings.
+ * 
  * Role mappings define which roles are assigned to each user.
  * The role mapping APIs are generally the preferred way to manage role mappings rather than using role mapping files.
  * The get role mappings API cannot retrieve role mappings that are defined in role mapping files.

--- a/specification/security/get_role_mapping/SecurityGetRoleMappingRequest.ts
+++ b/specification/security/get_role_mapping/SecurityGetRoleMappingRequest.ts
@@ -21,10 +21,15 @@ import { RequestBase } from '@_types/Base'
 import { Names } from '@_types/common'
 
 /**
+ * Get role mappings.
+ * Role mappings define which roles are assigned to each user.
+ * The role mapping APIs are generally the preferred way to manage role mappings rather than using role mapping files.
+ * The get role mappings API cannot retrieve role mappings that are defined in role mapping files.
  * @rest_spec_name security.get_role_mapping
  * @availability stack since=5.5.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_security
+ * @ext_doc_id mapping-roles
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/get_service_accounts/GetServiceAccountsRequest.ts
+++ b/specification/security/get_service_accounts/GetServiceAccountsRequest.ts
@@ -21,11 +21,13 @@ import { RequestBase } from '@_types/Base'
 import { Namespace, Service } from '@_types/common'
 
 /**
- * This API returns a list of service accounts that match the provided path parameter(s).
+ * Get service accounts.
+ * Get a list of service accounts that match the provided path parameters.
  * @rest_spec_name security.get_service_accounts
  * @availability stack since=7.13.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_service_account
+ * @ext_doc_id service-accounts
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/get_service_accounts/GetServiceAccountsRequest.ts
+++ b/specification/security/get_service_accounts/GetServiceAccountsRequest.ts
@@ -22,7 +22,7 @@ import { Namespace, Service } from '@_types/common'
 
 /**
  * Get service accounts.
- * 
+ *
  * Get a list of service accounts that match the provided path parameters.
  * @rest_spec_name security.get_service_accounts
  * @availability stack since=7.13.0 stability=stable

--- a/specification/security/get_service_accounts/GetServiceAccountsRequest.ts
+++ b/specification/security/get_service_accounts/GetServiceAccountsRequest.ts
@@ -22,6 +22,7 @@ import { Namespace, Service } from '@_types/common'
 
 /**
  * Get service accounts.
+ * 
  * Get a list of service accounts that match the provided path parameters.
  * @rest_spec_name security.get_service_accounts
  * @availability stack since=7.13.0 stability=stable

--- a/specification/security/get_service_credentials/GetServiceCredentialsRequest.ts
+++ b/specification/security/get_service_credentials/GetServiceCredentialsRequest.ts
@@ -21,9 +21,11 @@ import { RequestBase } from '@_types/Base'
 import { Name, Namespace } from '@_types/common'
 
 /**
+ * Get service account credentials.
  * @rest_spec_name security.get_service_credentials
  * @availability stack since=7.13.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @ext_doc_id service-accounts
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/get_token/GetUserAccessTokenRequest.ts
+++ b/specification/security/get_token/GetUserAccessTokenRequest.ts
@@ -23,6 +23,8 @@ import { Password, Username } from '@_types/common'
 import { AccessTokenGrantType } from './types'
 
 /**
+ * Get a token.
+ * Create a bearer token for access without requiring basic authentication.
  * @rest_spec_name security.get_token
  * @availability stack since=5.5.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/get_token/GetUserAccessTokenRequest.ts
+++ b/specification/security/get_token/GetUserAccessTokenRequest.ts
@@ -24,7 +24,7 @@ import { AccessTokenGrantType } from './types'
 
 /**
  * Get a token.
- * 
+ *
  * Create a bearer token for access without requiring basic authentication.
  * @rest_spec_name security.get_token
  * @availability stack since=5.5.0 stability=stable

--- a/specification/security/get_token/GetUserAccessTokenRequest.ts
+++ b/specification/security/get_token/GetUserAccessTokenRequest.ts
@@ -24,6 +24,7 @@ import { AccessTokenGrantType } from './types'
 
 /**
  * Get a token.
+ * 
  * Create a bearer token for access without requiring basic authentication.
  * @rest_spec_name security.get_token
  * @availability stack since=5.5.0 stability=stable

--- a/specification/security/get_user/SecurityGetUserRequest.ts
+++ b/specification/security/get_user/SecurityGetUserRequest.ts
@@ -22,6 +22,7 @@ import { Username } from '@_types/common'
 
 /**
  * Get users.
+ * 
  * Get information about users in the native realm and built-in users.
  * @rest_spec_name security.get_user
  * @availability stack stability=stable

--- a/specification/security/get_user/SecurityGetUserRequest.ts
+++ b/specification/security/get_user/SecurityGetUserRequest.ts
@@ -21,6 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Username } from '@_types/common'
 
 /**
+ * Get users.
+ * Get information about users in the native realm and built-in users.
  * @rest_spec_name security.get_user
  * @availability stack stability=stable
  */

--- a/specification/security/get_user/SecurityGetUserRequest.ts
+++ b/specification/security/get_user/SecurityGetUserRequest.ts
@@ -22,7 +22,7 @@ import { Username } from '@_types/common'
 
 /**
  * Get users.
- * 
+ *
  * Get information about users in the native realm and built-in users.
  * @rest_spec_name security.get_user
  * @availability stack stability=stable


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635, https://github.com/elastic/elasticsearch-specification/pull/3033

This PR adds/edits summaries for some security APIs. The first phrase is used as the "operation summary" and should basically align with what existed in the table of contents in https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api.html (omitting "API" from the end of the phrase, however). Any subsequent information gets published as the "operation description".

NOTE: I changed the "enable"/"disable" terminology to "activate"/"deactivate" for inclusivity reasons but if that's problematic lmk.

Since there's such a large set of security APIs, I'll defer the remainder to a subsequent PR.