### PR TITLE
[OpenAPI] Edit more security API summaries

### DIFF
--- a/compiler/package-lock.json
+++ b/compiler/package-lock.json
@@ -33,6 +33,10 @@
         "node": ">=14"
       }
     },
+    "../compiler-rs/compiler-wasm-lib/pkg": {
+      "name": "compiler-wasm-lib",
+      "version": "0.1.0"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -1540,8 +1544,8 @@
       "dev": true
     },
     "node_modules/compiler-wasm-lib": {
-      "version": "0.1.0",
-      "resolved": "file:../compiler-rs/compiler-wasm-lib/pkg"
+      "resolved": "../compiler-rs/compiler-wasm-lib/pkg",
+      "link": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -6484,7 +6488,7 @@
       "dev": true
     },
     "compiler-wasm-lib": {
-      "version": "0.1.0"
+      "version": "file:../compiler-rs/compiler-wasm-lib/pkg"
     },
     "concat-map": {
       "version": "0.0.1",

--- a/compiler/package-lock.json
+++ b/compiler/package-lock.json
@@ -33,10 +33,6 @@
         "node": ">=14"
       }
     },
-    "../compiler-rs/compiler-wasm-lib/pkg": {
-      "name": "compiler-wasm-lib",
-      "version": "0.1.0"
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -1544,8 +1540,8 @@
       "dev": true
     },
     "node_modules/compiler-wasm-lib": {
-      "resolved": "../compiler-rs/compiler-wasm-lib/pkg",
-      "link": true
+      "version": "0.1.0",
+      "resolved": "file:../compiler-rs/compiler-wasm-lib/pkg"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -6488,7 +6484,7 @@
       "dev": true
     },
     "compiler-wasm-lib": {
-      "version": "file:../compiler-rs/compiler-wasm-lib/pkg"
+      "version": "0.1.0"
     },
     "concat-map": {
       "version": "0.0.1",

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -28030,7 +28030,7 @@
           "security"
         ],
         "summary": "Create or update roles",
-        "description": "The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.",
+        "description": "The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.\nFile-based role management is not available in Elastic Serverless.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html"
         },
@@ -28057,7 +28057,7 @@
           "security"
         ],
         "summary": "Create or update roles",
-        "description": "The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.",
+        "description": "The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.\nFile-based role management is not available in Elastic Serverless.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html"
         },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27647,7 +27647,7 @@
           "security"
         ],
         "summary": "Invalidate API keys",
-        "description": "Invalidates one or more API keys.\nThe `manage_api_key` privilege allows deleting any API keys.\nThe `manage_own_api_key` only allows deleting API keys that are owned by the user.\nIn addition, with the `manage_own_api_key` privilege, an invalidation request must be issued in one of the three formats:\n- Set the parameter `owner=true`.\n- Or, set both `username` and `realm_name` to match the user’s identity.\n- Or, if the request is issued by an API key, i.e. an API key invalidates itself, specify its ID in the `ids` field.",
+        "description": "This API invalidates API keys created by the create API key or grant API key APIs.\nInvalidated API keys fail authentication, but they can still be viewed using the get API key information and query API key information APIs, for at least the configured retention period, until they are automatically deleted.\nThe `manage_api_key` privilege allows deleting any API keys.\nThe `manage_own_api_key` only allows deleting API keys that are owned by the user.\nIn addition, with the `manage_own_api_key` privilege, an invalidation request must be issued in one of the three formats:\n- Set the parameter `owner=true`.\n- Or, set both `username` and `realm_name` to match the user’s identity.\n- Or, if the request is issued by an API key, that is to say an API key invalidates itself, specify its ID in the `ids` field.",
         "operationId": "security-invalidate-api-key",
         "requestBody": {
           "content": {
@@ -27986,8 +27986,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Create or update roles API",
-        "description": "Create or update roles in the native realm.",
+        "summary": "Create or update roles",
+        "description": "The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html"
+        },
         "operationId": "security-put-role",
         "parameters": [
           {
@@ -28010,8 +28013,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Create or update roles API",
-        "description": "Create or update roles in the native realm.",
+        "summary": "Create or update roles",
+        "description": "The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html"
+        },
         "operationId": "security-put-role-1",
         "parameters": [
           {
@@ -28105,7 +28111,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Creates and updates role mappings",
+        "summary": "Create or update role mappings",
+        "description": "Role mappings define which roles are assigned to each user.\nEach mapping has rules that identify users and a list of roles that are granted to those users.\nThe role mapping APIs are generally the preferred way to manage role mappings rather than using role mapping files. The create or update role mappings API cannot update role mappings that are defined in role mapping files.\n\nThis API does not create roles. Rather, it maps users to existing roles.\nRoles can be created by using the create or update roles API or roles files.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-roles.html"
+        },
         "operationId": "security-put-role-mapping",
         "parameters": [
           {
@@ -28129,7 +28139,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Creates and updates role mappings",
+        "summary": "Create or update role mappings",
+        "description": "Role mappings define which roles are assigned to each user.\nEach mapping has rules that identify users and a list of roles that are granted to those users.\nThe role mapping APIs are generally the preferred way to manage role mappings rather than using role mapping files. The create or update role mappings API cannot update role mappings that are defined in role mapping files.\n\nThis API does not create roles. Rather, it maps users to existing roles.\nRoles can be created by using the create or update roles API or roles files.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-roles.html"
+        },
         "operationId": "security-put-role-mapping-1",
         "parameters": [
           {
@@ -28226,8 +28240,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Adds and updates users in the native realm",
-        "description": "These users are commonly referred to as native users.",
+        "summary": "Create or update users",
+        "description": "A password is required for adding a new user but is optional when updating an existing user.\nTo change a user’s password without updating any other fields, use the change password API.",
         "operationId": "security-put-user",
         "parameters": [
           {
@@ -28250,8 +28264,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Adds and updates users in the native realm",
-        "description": "These users are commonly referred to as native users.",
+        "summary": "Create or update users",
+        "description": "A password is required for adding a new user but is optional when updating an existing user.\nTo change a user’s password without updating any other fields, use the change password API.",
         "operationId": "security-put-user-1",
         "parameters": [
           {
@@ -28639,7 +28653,10 @@
         "tags": [
           "security"
         ],
-        "summary": "Adds or updates application privileges",
+        "summary": "Create or update application privileges",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-put-privileges",
         "parameters": [
           {
@@ -28660,7 +28677,10 @@
         "tags": [
           "security"
         ],
-        "summary": "Adds or updates application privileges",
+        "summary": "Create or update application privileges",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-put-privileges-1",
         "parameters": [
           {
@@ -28924,7 +28944,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Invalidates one or more access tokens or refresh tokens",
+        "summary": "Invalidate a token",
+        "description": "The access tokens returned by the get token API have a finite period of time for which they are valid.\nAfter that time period, they can no longer be used.\nThe time period is defined by the `xpack.security.authc.token.timeout` setting.\n\nThe refresh tokens returned by the get token API are only valid for 24 hours. They can also be used exactly once.\nIf you want to invalidate one or more access or refresh tokens immediately, use this invalidate token API.",
         "operationId": "security-invalidate-token",
         "requestBody": {
           "content": {
@@ -29011,7 +29032,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves security privileges for the logged in user",
+        "summary": "Get user privileges",
         "operationId": "security-get-user-privileges",
         "parameters": [
           {
@@ -29111,7 +29132,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves a user's profile using the unique profile ID",
+        "summary": "Get a user profile",
+        "description": "Get a user's profile using the unique profile ID.",
         "operationId": "security-get-user-profile",
         "parameters": [
           {
@@ -29190,8 +29212,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Creates an API key on behalf of another user",
-        "description": "This API is similar to Create API keys, however it creates the API key for a user that is different than the user that runs the API.\nThe caller must have authentication credentials (either an access token, or a username and password) for the user on whose behalf the API key will be created.\nIt is not possible to use this API to create an API key without that user’s credentials.\nThe user, for whom the authentication credentials is provided, can optionally \"run as\" (impersonate) another user.\nIn this case, the API key will be created on behalf of the impersonated user.\n\nThis API is intended be used by applications that need to create and manage API keys for end users, but cannot guarantee that those users have permission to create API keys on their own behalf.\n\nA successful grant API key API call returns a JSON structure that contains the API key, its unique id, and its name.\nIf applicable, it also returns expiration information for the API key in milliseconds.\n\nBy default, API keys never expire. You can specify expiration information when you create the API keys.",
+        "summary": "Grant an API key",
+        "description": "Create an API key on behalf of another user.\nThis API is similar to the create API keys API, however it creates the API key for a user that is different than the user that runs the API.\nThe caller must have authentication credentials (either an access token, or a username and password) for the user on whose behalf the API key will be created.\nIt is not possible to use this API to create an API key without that user’s credentials.\nThe user, for whom the authentication credentials is provided, can optionally \"run as\" (impersonate) another user.\nIn this case, the API key will be created on behalf of the impersonated user.\n\nThis API is intended be used by applications that need to create and manage API keys for end users, but cannot guarantee that those users have permission to create API keys on their own behalf.\n\nA successful grant API key API call returns a JSON structure that contains the API key, its unique id, and its name.\nIf applicable, it also returns expiration information for the API key in milliseconds.\n\nBy default, API keys never expire. You can specify expiration information when you create the API keys.",
         "operationId": "security-grant-api-key",
         "requestBody": {
           "content": {
@@ -29272,7 +29294,10 @@
           "security"
         ],
         "summary": "Check user privileges",
-        "description": "Determines whether the specified user has a specified list of privileges.",
+        "description": "Determine whether the specified user has a specified list of privileges.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-has-privileges",
         "requestBody": {
           "$ref": "#/components/requestBodies/security.has_privileges"
@@ -29289,7 +29314,10 @@
           "security"
         ],
         "summary": "Check user privileges",
-        "description": "Determines whether the specified user has a specified list of privileges.",
+        "description": "Determine whether the specified user has a specified list of privileges.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-has-privileges-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/security.has_privileges"
@@ -29308,7 +29336,10 @@
           "security"
         ],
         "summary": "Check user privileges",
-        "description": "Determines whether the specified user has a specified list of privileges.",
+        "description": "Determine whether the specified user has a specified list of privileges.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-has-privileges-2",
         "parameters": [
           {
@@ -29330,7 +29361,10 @@
           "security"
         ],
         "summary": "Check user privileges",
-        "description": "Determines whether the specified user has a specified list of privileges.",
+        "description": "Determine whether the specified user has a specified list of privileges.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-has-privileges-3",
         "parameters": [
           {
@@ -29353,7 +29387,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Determines whether the users associated with the specified profile IDs have all the requested privileges",
+        "summary": "Check user profile privileges",
+        "description": "Determine whether the users associated with the specified user profile IDs have all the requested privileges.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/user-profile.html"
+        },
         "operationId": "security-has-privileges-user-profile",
         "requestBody": {
           "$ref": "#/components/requestBodies/security.has_privileges_user_profile"
@@ -29369,7 +29407,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Determines whether the users associated with the specified profile IDs have all the requested privileges",
+        "summary": "Check user profile privileges",
+        "description": "Determine whether the users associated with the specified user profile IDs have all the requested privileges.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/user-profile.html"
+        },
         "operationId": "security-has-privileges-user-profile-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/security.has_privileges_user_profile"
@@ -29387,8 +29429,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Query API keys",
-        "description": "Retrieves a paginated list of API keys and their information. You can optionally filter the results with a query.",
+        "summary": "Find API keys with a query",
+        "description": "Get a paginated list of API keys and their information. You can optionally filter the results with a query.",
         "operationId": "security-query-api-keys",
         "parameters": [
           {
@@ -29415,8 +29457,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Query API keys",
-        "description": "Retrieves a paginated list of API keys and their information. You can optionally filter the results with a query.",
+        "summary": "Find API keys with a query",
+        "description": "Get a paginated list of API keys and their information. You can optionally filter the results with a query.",
         "operationId": "security-query-api-keys-1",
         "parameters": [
           {
@@ -29445,8 +29487,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves roles in a paginated manner",
-        "description": "You can optionally filter the results with a query.",
+        "summary": "Find roles with a query",
+        "description": "Get roles in a paginated manner. You can optionally filter the results with a query.",
         "operationId": "security-query-role",
         "requestBody": {
           "$ref": "#/components/requestBodies/security.query_role"
@@ -29462,8 +29504,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves roles in a paginated manner",
-        "description": "You can optionally filter the results with a query.",
+        "summary": "Find roles with a query",
+        "description": "Get roles in a paginated manner. You can optionally filter the results with a query.",
         "operationId": "security-query-role-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/security.query_role"
@@ -29481,8 +29523,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves information for Users in a paginated manner",
-        "description": "You can optionally filter the results with a query.",
+        "summary": "Find users with a query",
+        "description": "Get information for users in a paginated manner.\nYou can optionally filter the results with a query.",
         "operationId": "security-query-user",
         "parameters": [
           {
@@ -29503,8 +29545,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Retrieves information for Users in a paginated manner",
-        "description": "You can optionally filter the results with a query.",
+        "summary": "Find users with a query",
+        "description": "Get information for users in a paginated manner.\nYou can optionally filter the results with a query.",
         "operationId": "security-query-user-1",
         "parameters": [
           {
@@ -29527,7 +29569,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Submits a SAML Response message to Elasticsearch for consumption",
+        "summary": "Authenticate SAML",
+        "description": "Submits a SAML response message to Elasticsearch for consumption.",
         "operationId": "security-saml-authenticate",
         "requestBody": {
           "content": {
@@ -29600,7 +29643,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Verifies the logout response sent from the SAML IdP",
+        "summary": "Logout of SAML completely",
+        "description": "Verifies the logout response sent from the SAML IdP.",
         "operationId": "security-saml-complete-logout",
         "requestBody": {
           "content": {
@@ -29649,7 +29693,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Submits a SAML LogoutRequest message to Elasticsearch for consumption",
+        "summary": "Invalidate SAML",
+        "description": "Submits a SAML LogoutRequest message to Elasticsearch for consumption.",
         "operationId": "security-saml-invalidate",
         "requestBody": {
           "content": {
@@ -29714,7 +29759,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Submits a request to invalidate an access token and refresh token",
+        "summary": "Logout of SAML",
+        "description": "Submits a request to invalidate an access token and refresh token.",
         "operationId": "security-saml-logout",
         "requestBody": {
           "content": {
@@ -29767,7 +29813,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Creates a SAML authentication request (<AuthnRequest>) as a URL string, based on the configuration of the respective SAML realm in Elasticsearch",
+        "summary": "Prepare SAML authentication",
+        "description": "Creates a SAML authentication request (`<AuthnRequest>`) as a URL string, based on the configuration of the respective SAML realm in Elasticsearch.",
         "operationId": "security-saml-prepare-authentication",
         "requestBody": {
           "content": {
@@ -29829,7 +29876,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Generate SAML metadata for a SAML 2.0 Service Provider",
+        "summary": "Create SAML service provider metadata",
+        "description": "Generate SAML metadata for a SAML 2.0 Service Provider.",
         "operationId": "security-saml-service-provider-metadata",
         "parameters": [
           {
@@ -29872,7 +29920,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Get suggestions for user profiles that match specified search criteria",
+        "summary": "Suggest a user profile",
+        "description": "Get suggestions for user profiles that match specified search criteria.",
         "operationId": "security-suggest-user-profiles",
         "parameters": [
           {
@@ -29893,7 +29942,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Get suggestions for user profiles that match specified search criteria",
+        "summary": "Suggest a user profile",
+        "description": "Get suggestions for user profiles that match specified search criteria.",
         "operationId": "security-suggest-user-profiles-1",
         "parameters": [
           {
@@ -29985,7 +30035,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Updates specific data for the user profile that's associated with the specified unique ID",
+        "summary": "Update user profile data",
+        "description": "Update specific data for the user profile that is associated with a unique ID.",
         "operationId": "security-update-user-profile-data",
         "parameters": [
           {
@@ -30015,7 +30066,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Updates specific data for the user profile that's associated with the specified unique ID",
+        "summary": "Update user profile data",
+        "description": "Update specific data for the user profile that is associated with a unique ID.",
         "operationId": "security-update-user-profile-data-1",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -16777,7 +16777,7 @@
           "security"
         ],
         "summary": "Invalidate API keys",
-        "description": "Invalidates one or more API keys.\nThe `manage_api_key` privilege allows deleting any API keys.\nThe `manage_own_api_key` only allows deleting API keys that are owned by the user.\nIn addition, with the `manage_own_api_key` privilege, an invalidation request must be issued in one of the three formats:\n- Set the parameter `owner=true`.\n- Or, set both `username` and `realm_name` to match the user’s identity.\n- Or, if the request is issued by an API key, i.e. an API key invalidates itself, specify its ID in the `ids` field.",
+        "description": "This API invalidates API keys created by the create API key or grant API key APIs.\nInvalidated API keys fail authentication, but they can still be viewed using the get API key information and query API key information APIs, for at least the configured retention period, until they are automatically deleted.\nThe `manage_api_key` privilege allows deleting any API keys.\nThe `manage_own_api_key` only allows deleting API keys that are owned by the user.\nIn addition, with the `manage_own_api_key` privilege, an invalidation request must be issued in one of the three formats:\n- Set the parameter `owner=true`.\n- Or, set both `username` and `realm_name` to match the user’s identity.\n- Or, if the request is issued by an API key, that is to say an API key invalidates itself, specify its ID in the `ids` field.",
         "operationId": "security-invalidate-api-key",
         "requestBody": {
           "content": {
@@ -16881,8 +16881,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Create or update roles API",
-        "description": "Create or update roles in the native realm.",
+        "summary": "Create or update roles",
+        "description": "The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html"
+        },
         "operationId": "security-put-role",
         "parameters": [
           {
@@ -16905,8 +16908,11 @@
         "tags": [
           "security"
         ],
-        "summary": "Create or update roles API",
-        "description": "Create or update roles in the native realm.",
+        "summary": "Create or update roles",
+        "description": "The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html"
+        },
         "operationId": "security-put-role-1",
         "parameters": [
           {
@@ -17039,7 +17045,10 @@
           "security"
         ],
         "summary": "Check user privileges",
-        "description": "Determines whether the specified user has a specified list of privileges.",
+        "description": "Determine whether the specified user has a specified list of privileges.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-has-privileges",
         "requestBody": {
           "$ref": "#/components/requestBodies/security.has_privileges"
@@ -17056,7 +17065,10 @@
           "security"
         ],
         "summary": "Check user privileges",
-        "description": "Determines whether the specified user has a specified list of privileges.",
+        "description": "Determine whether the specified user has a specified list of privileges.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-has-privileges-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/security.has_privileges"
@@ -17075,7 +17087,10 @@
           "security"
         ],
         "summary": "Check user privileges",
-        "description": "Determines whether the specified user has a specified list of privileges.",
+        "description": "Determine whether the specified user has a specified list of privileges.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-has-privileges-2",
         "parameters": [
           {
@@ -17097,7 +17112,10 @@
           "security"
         ],
         "summary": "Check user privileges",
-        "description": "Determines whether the specified user has a specified list of privileges.",
+        "description": "Determine whether the specified user has a specified list of privileges.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html"
+        },
         "operationId": "security-has-privileges-3",
         "parameters": [
           {
@@ -17120,8 +17138,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Query API keys",
-        "description": "Retrieves a paginated list of API keys and their information. You can optionally filter the results with a query.",
+        "summary": "Find API keys with a query",
+        "description": "Get a paginated list of API keys and their information. You can optionally filter the results with a query.",
         "operationId": "security-query-api-keys",
         "parameters": [
           {
@@ -17148,8 +17166,8 @@
         "tags": [
           "security"
         ],
-        "summary": "Query API keys",
-        "description": "Retrieves a paginated list of API keys and their information. You can optionally filter the results with a query.",
+        "summary": "Find API keys with a query",
+        "description": "Get a paginated list of API keys and their information. You can optionally filter the results with a query.",
         "operationId": "security-query-api-keys-1",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -16875,7 +16875,7 @@
           "security"
         ],
         "summary": "Create or update roles",
-        "description": "The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.",
+        "description": "The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.\nFile-based role management is not available in Elastic Serverless.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html"
         },
@@ -16902,7 +16902,7 @@
           "security"
         ],
         "summary": "Create or update roles",
-        "description": "The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.",
+        "description": "The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.\nThe create or update roles API cannot update roles that are defined in roles files.\nFile-based role management is not available in Elastic Serverless.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/defining-roles.html"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@stoplight/spectral-cli": "^6.13.0"
+        "@stoplight/spectral-cli": "^6.13.1"
       }
     },
     "node_modules/@asyncapi/specs": {
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@stoplight/spectral-cli": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.13.0.tgz",
-      "integrity": "sha512-qofxmVN4czNNJdfq0OB8Qj1ihpIhyR0IgyQpJFda9FvWWn9vJqDuIsoGKWP7xIHwv3E31q3iviDIX3Ejy9tNcg==",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.13.1.tgz",
+      "integrity": "sha512-v6ipX4w6wRhtbOotwdPL7RrEkP0m1OwHTIyqzVrAPi932F/zkee24jmf1CHNrTynonmfGoU6/XpeqUHtQdKDFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/json": "~3.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@stoplight/spectral-cli": "^6.13.1"
+        "@stoplight/spectral-cli": "^6.13.0"
       }
     },
     "node_modules/@asyncapi/specs": {
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@stoplight/spectral-cli": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.13.1.tgz",
-      "integrity": "sha512-v6ipX4w6wRhtbOotwdPL7RrEkP0m1OwHTIyqzVrAPi932F/zkee24jmf1CHNrTynonmfGoU6/XpeqUHtQdKDFw==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.13.0.tgz",
+      "integrity": "sha512-qofxmVN4czNNJdfq0OB8Qj1ihpIhyR0IgyQpJFda9FvWWn9vJqDuIsoGKWP7xIHwv3E31q3iviDIX3Ejy9tNcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/json": "~3.21.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@stoplight/spectral-cli": "^6.13.0"
+    "@stoplight/spectral-cli": "^6.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@stoplight/spectral-cli": "^6.13.1"
+    "@stoplight/spectral-cli": "^6.13.0"
   }
 }

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -111,7 +111,7 @@ data-stream-path-param,https://www.elastic.co/guide/en/elasticsearch/reference/{
 data-streams,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams.html
 date-index-name-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/date-index-name-processor.html
 dcg,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#_discounted_cumulative_gain_dcg
-defining-roles,https://www.elastic.co/guide/en/elasticsearch/reference/master/defining-roles.html
+defining-roles,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/defining-roles.html
 delete-async-sql-search-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-async-sql-search-api.html
 delete-enrich-policy-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-enrich-policy-api.html
 delete-license,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-license.html
@@ -259,6 +259,7 @@ lowercase-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{bra
 mapping-date-format,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-date-format.html
 mapping-meta-field,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-meta-field.html
 mapping-metadata,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-fields.html
+mapping-roles,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-roles.html
 mapping-settings-limit,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-settings-limit.html
 mapping-source-field,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-source-field.html
 mapping,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping.html
@@ -570,6 +571,7 @@ security-api-saml-logout,https://www.elastic.co/guide/en/elasticsearch/reference
 security-api-saml-prepare-authentication,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-saml-prepare-authentication.html
 security-api-saml-sp-metadata,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-saml-sp-metadata.html
 security-api-ssl,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-ssl.html
+security-privileges,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-privileges.html
 service-accounts,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/service-accounts.html
 set-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/set-processor.html
 shape,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/shape.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -111,6 +111,7 @@ data-stream-path-param,https://www.elastic.co/guide/en/elasticsearch/reference/{
 data-streams,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams.html
 date-index-name-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/date-index-name-processor.html
 dcg,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#_discounted_cumulative_gain_dcg
+defining-roles,https://www.elastic.co/guide/en/elasticsearch/reference/master/defining-roles.html
 delete-async-sql-search-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-async-sql-search-api.html
 delete-enrich-policy-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-enrich-policy-api.html
 delete-license,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-license.html
@@ -569,6 +570,7 @@ security-api-saml-logout,https://www.elastic.co/guide/en/elasticsearch/reference
 security-api-saml-prepare-authentication,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-saml-prepare-authentication.html
 security-api-saml-sp-metadata,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-saml-sp-metadata.html
 security-api-ssl,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-ssl.html
+service-accounts,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/service-accounts.html
 set-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/set-processor.html
 shape,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/shape.html
 simulate-pipeline-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/simulate-pipeline-api.html
@@ -612,6 +614,7 @@ uppercase-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{bra
 urldecode-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/urldecode-processor.html
 usage-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/usage-api.html
 user-agent-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/user-agent-processor.html
+user-profile,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/user-profile.html
 voting-config-exclusions,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/voting-config-exclusions.html
 watcher-api-ack-watch,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-ack-watch.html
 watcher-api-activate-watch,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-activate-watch.html

--- a/specification/security/get_user_privileges/SecurityGetUserPrivilegesRequest.ts
+++ b/specification/security/get_user_privileges/SecurityGetUserPrivilegesRequest.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 
 /**
+ * Get user privileges.
  * @rest_spec_name security.get_user_privileges
  * @availability stack since=6.5.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/get_user_profile/Request.ts
+++ b/specification/security/get_user_profile/Request.ts
@@ -22,6 +22,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Get a user profile.
+ *
  * Get a user's profile using the unique profile ID.
  * @rest_spec_name security.get_user_profile
  * @availability stack since=8.2.0 stability=stable

--- a/specification/security/get_user_profile/Request.ts
+++ b/specification/security/get_user_profile/Request.ts
@@ -21,7 +21,8 @@ import { UserProfileId } from '@security/_types/UserProfile'
 import { RequestBase } from '@_types/Base'
 
 /**
- * Retrieves a user's profile using the unique profile ID.
+ * Get a user profile.
+ * Get a user's profile using the unique profile ID.
  * @rest_spec_name security.get_user_profile
  * @availability stack since=8.2.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/grant_api_key/SecurityGrantApiKeyRequest.ts
+++ b/specification/security/grant_api_key/SecurityGrantApiKeyRequest.ts
@@ -23,6 +23,7 @@ import { ApiKeyGrantType, GrantApiKey } from './types'
 
 /**
  * Grant an API key.
+ *
  * Create an API key on behalf of another user.
  * This API is similar to the create API keys API, however it creates the API key for a user that is different than the user that runs the API.
  * The caller must have authentication credentials (either an access token, or a username and password) for the user on whose behalf the API key will be created.

--- a/specification/security/grant_api_key/SecurityGrantApiKeyRequest.ts
+++ b/specification/security/grant_api_key/SecurityGrantApiKeyRequest.ts
@@ -22,8 +22,9 @@ import { Password, Username } from '@_types/common'
 import { ApiKeyGrantType, GrantApiKey } from './types'
 
 /**
- * Creates an API key on behalf of another user.
- * This API is similar to Create API keys, however it creates the API key for a user that is different than the user that runs the API.
+ * Grant an API key.
+ * Create an API key on behalf of another user.
+ * This API is similar to the create API keys API, however it creates the API key for a user that is different than the user that runs the API.
  * The caller must have authentication credentials (either an access token, or a username and password) for the user on whose behalf the API key will be created.
  * It is not possible to use this API to create an API key without that user’s credentials.
  * The user, for whom the authentication credentials is provided, can optionally "run as" (impersonate) another user.

--- a/specification/security/has_privileges/SecurityHasPrivilegesRequest.ts
+++ b/specification/security/has_privileges/SecurityHasPrivilegesRequest.ts
@@ -24,6 +24,7 @@ import { ApplicationPrivilegesCheck, IndexPrivilegesCheck } from './types'
 
 /**
  * Check user privileges.
+ *
  * Determine whether the specified user has a specified list of privileges.
  * @rest_spec_name security.has_privileges
  * @availability stack since=6.4.0 stability=stable

--- a/specification/security/has_privileges/SecurityHasPrivilegesRequest.ts
+++ b/specification/security/has_privileges/SecurityHasPrivilegesRequest.ts
@@ -24,10 +24,11 @@ import { ApplicationPrivilegesCheck, IndexPrivilegesCheck } from './types'
 
 /**
  * Check user privileges.
- * Determines whether the specified user has a specified list of privileges.
+ * Determine whether the specified user has a specified list of privileges.
  * @rest_spec_name security.has_privileges
  * @availability stack since=6.4.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @ext_doc_id security-privileges
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/has_privileges_user_profile/Request.ts
+++ b/specification/security/has_privileges_user_profile/Request.ts
@@ -23,6 +23,7 @@ import { PrivilegesCheck } from './types'
 
 /**
  * Check user profile privileges.
+ *
  * Determine whether the users associated with the specified user profile IDs have all the requested privileges.
  * @rest_spec_name security.has_privileges_user_profile
  * @availability stack since=8.3.0 stability=stable

--- a/specification/security/has_privileges_user_profile/Request.ts
+++ b/specification/security/has_privileges_user_profile/Request.ts
@@ -22,10 +22,13 @@ import { RequestBase } from '@_types/Base'
 import { PrivilegesCheck } from './types'
 
 /**
+ * Check user profile privileges.
+ * Determine whether the users associated with the specified user profile IDs have all the requested privileges.
  * @rest_spec_name security.has_privileges_user_profile
  * @availability stack since=8.3.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_user_profile
+ * @ext_doc_id user-profile
  */
 export interface Request extends RequestBase {
   body: {

--- a/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
+++ b/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
@@ -22,13 +22,14 @@ import { Id, Name, Username } from '@_types/common'
 
 /**
  * Invalidate API keys.
- * Invalidates one or more API keys.
+ * This API invalidates API keys created by the create API key or grant API key APIs.
+ * Invalidated API keys fail authentication, but they can still be viewed using the get API key information and query API key information APIs, for at least the configured retention period, until they are automatically deleted.
  * The `manage_api_key` privilege allows deleting any API keys.
  * The `manage_own_api_key` only allows deleting API keys that are owned by the user.
  * In addition, with the `manage_own_api_key` privilege, an invalidation request must be issued in one of the three formats:
  * - Set the parameter `owner=true`.
  * - Or, set both `username` and `realm_name` to match the user’s identity.
- * - Or, if the request is issued by an API key, i.e. an API key invalidates itself, specify its ID in the `ids` field.
+ * - Or, if the request is issued by an API key, that is to say an API key invalidates itself, specify its ID in the `ids` field.
  * @rest_spec_name security.invalidate_api_key
  * @availability stack since=6.7.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
+++ b/specification/security/invalidate_api_key/SecurityInvalidateApiKeyRequest.ts
@@ -22,6 +22,7 @@ import { Id, Name, Username } from '@_types/common'
 
 /**
  * Invalidate API keys.
+ *
  * This API invalidates API keys created by the create API key or grant API key APIs.
  * Invalidated API keys fail authentication, but they can still be viewed using the get API key information and query API key information APIs, for at least the configured retention period, until they are automatically deleted.
  * The `manage_api_key` privilege allows deleting any API keys.

--- a/specification/security/invalidate_token/SecurityInvalidateTokenRequest.ts
+++ b/specification/security/invalidate_token/SecurityInvalidateTokenRequest.ts
@@ -22,6 +22,7 @@ import { Name, Username } from '@_types/common'
 
 /**
  * Invalidate a token.
+ *
  * The access tokens returned by the get token API have a finite period of time for which they are valid.
  * After that time period, they can no longer be used.
  * The time period is defined by the `xpack.security.authc.token.timeout` setting.

--- a/specification/security/invalidate_token/SecurityInvalidateTokenRequest.ts
+++ b/specification/security/invalidate_token/SecurityInvalidateTokenRequest.ts
@@ -21,6 +21,13 @@ import { RequestBase } from '@_types/Base'
 import { Name, Username } from '@_types/common'
 
 /**
+ * Invalidate a token.
+ * The access tokens returned by the get token API have a finite period of time for which they are valid.
+ * After that time period, they can no longer be used.
+ * The time period is defined by the `xpack.security.authc.token.timeout` setting.
+ * 
+ * The refresh tokens returned by the get token API are only valid for 24 hours. They can also be used exactly once.
+ * If you want to invalidate one or more access or refresh tokens immediately, use this invalidate token API.
  * @rest_spec_name security.invalidate_token
  * @availability stack since=5.5.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/invalidate_token/SecurityInvalidateTokenRequest.ts
+++ b/specification/security/invalidate_token/SecurityInvalidateTokenRequest.ts
@@ -25,7 +25,7 @@ import { Name, Username } from '@_types/common'
  * The access tokens returned by the get token API have a finite period of time for which they are valid.
  * After that time period, they can no longer be used.
  * The time period is defined by the `xpack.security.authc.token.timeout` setting.
- * 
+ *
  * The refresh tokens returned by the get token API are only valid for 24 hours. They can also be used exactly once.
  * If you want to invalidate one or more access or refresh tokens immediately, use this invalidate token API.
  * @rest_spec_name security.invalidate_token

--- a/specification/security/put_privileges/SecurityPutPrivilegesRequest.ts
+++ b/specification/security/put_privileges/SecurityPutPrivilegesRequest.ts
@@ -23,10 +23,11 @@ import { Refresh } from '@_types/common'
 import { Actions } from './types'
 
 /**
+ * Create or update application privileges.
  * @rest_spec_name security.put_privileges
  * @availability stack since=6.4.0 stability=stable
  * @availability serverless stability=stable visibility=private
- *
+ * @ext_doc_id security-privileges
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -29,13 +29,14 @@ import { RequestBase } from '@_types/Base'
 import { Metadata, Name, Refresh } from '@_types/common'
 
 /**
- * Create or update roles API.
- *
- * Create or update roles in the native realm.
+ * Create or update roles.
+ * The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.
+ * The create or update roles API cannot update roles that are defined in roles files.
  * @rest_spec_name security.put_role
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_security
+ * @ext_doc_id defining-roles
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -30,8 +30,10 @@ import { Metadata, Name, Refresh } from '@_types/common'
 
 /**
  * Create or update roles.
+ *
  * The role management APIs are generally the preferred way to manage roles in the native realm, rather than using file-based role management.
  * The create or update roles API cannot update roles that are defined in roles files.
+ * File-based role management is not available in Elastic Serverless.
  * @rest_spec_name security.put_role
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
+++ b/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
@@ -27,7 +27,7 @@ import { Metadata, Name, Refresh } from '@_types/common'
  * Role mappings define which roles are assigned to each user.
  * Each mapping has rules that identify users and a list of roles that are granted to those users.
  * The role mapping APIs are generally the preferred way to manage role mappings rather than using role mapping files. The create or update role mappings API cannot update role mappings that are defined in role mapping files.
- * 
+ *
  * This API does not create roles. Rather, it maps users to existing roles.
  * Roles can be created by using the create or update roles API or roles files.
  * @rest_spec_name security.put_role_mapping

--- a/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
+++ b/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
@@ -24,6 +24,7 @@ import { Metadata, Name, Refresh } from '@_types/common'
 
 /**
  * Create or update role mappings.
+ *
  * Role mappings define which roles are assigned to each user.
  * Each mapping has rules that identify users and a list of roles that are granted to those users.
  * The role mapping APIs are generally the preferred way to manage role mappings rather than using role mapping files. The create or update role mappings API cannot update role mappings that are defined in role mapping files.

--- a/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
+++ b/specification/security/put_role_mapping/SecurityPutRoleMappingRequest.ts
@@ -23,9 +23,17 @@ import { RequestBase } from '@_types/Base'
 import { Metadata, Name, Refresh } from '@_types/common'
 
 /**
+ * Create or update role mappings.
+ * Role mappings define which roles are assigned to each user.
+ * Each mapping has rules that identify users and a list of roles that are granted to those users.
+ * The role mapping APIs are generally the preferred way to manage role mappings rather than using role mapping files. The create or update role mappings API cannot update role mappings that are defined in role mapping files.
+ * 
+ * This API does not create roles. Rather, it maps users to existing roles.
+ * Roles can be created by using the create or update roles API or roles files.
  * @rest_spec_name security.put_role_mapping
  * @availability stack since=5.5.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @ext_doc_id mapping-roles
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/security/put_user/SecurityPutUserRequest.ts
+++ b/specification/security/put_user/SecurityPutUserRequest.ts
@@ -21,6 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { Metadata, Password, Refresh, Username } from '@_types/common'
 
 /**
+ * Create or update users.
+ * A password is required for adding a new user but is optional when updating an existing user.
+ * To change a user’s password without updating any other fields, use the change password API.
  * @rest_spec_name security.put_user
  * @availability stack stability=stable
  */

--- a/specification/security/put_user/SecurityPutUserRequest.ts
+++ b/specification/security/put_user/SecurityPutUserRequest.ts
@@ -22,6 +22,7 @@ import { Metadata, Password, Refresh, Username } from '@_types/common'
 
 /**
  * Create or update users.
+ *
  * A password is required for adding a new user but is optional when updating an existing user.
  * To change a user’s password without updating any other fields, use the change password API.
  * @rest_spec_name security.put_user

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -24,8 +24,8 @@ import { Sort, SortResults } from '@_types/sort'
 import { ApiKeyAggregationContainer, ApiKeyQueryContainer } from './types'
 
 /**
- * Query API keys.
- * Retrieves a paginated list of API keys and their information. You can optionally filter the results with a query.
+ * Find API keys with a query.
+ * Get a paginated list of API keys and their information. You can optionally filter the results with a query.
  * @rest_spec_name security.query_api_keys
  * @availability stack since=7.15.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -25,6 +25,7 @@ import { ApiKeyAggregationContainer, ApiKeyQueryContainer } from './types'
 
 /**
  * Find API keys with a query.
+ *
  * Get a paginated list of API keys and their information. You can optionally filter the results with a query.
  * @rest_spec_name security.query_api_keys
  * @availability stack since=7.15.0 stability=stable

--- a/specification/security/query_role/QueryRolesRequest.ts
+++ b/specification/security/query_role/QueryRolesRequest.ts
@@ -24,6 +24,7 @@ import { RoleQueryContainer } from './types'
 
 /**
  * Find roles with a query.
+ *
  * Get roles in a paginated manner. You can optionally filter the results with a query.
  * @rest_spec_name security.query_role
  * @availability stack since=8.15.0 stability=stable

--- a/specification/security/query_role/QueryRolesRequest.ts
+++ b/specification/security/query_role/QueryRolesRequest.ts
@@ -23,7 +23,8 @@ import { Sort, SortResults } from '@_types/sort'
 import { RoleQueryContainer } from './types'
 
 /**
- * Retrieves roles in a paginated manner. You can optionally filter the results with a query.
+ * Find roles with a query.
+ * Get roles in a paginated manner. You can optionally filter the results with a query.
  * @rest_spec_name security.query_role
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/query_user/SecurityQueryUserRequest.ts
+++ b/specification/security/query_user/SecurityQueryUserRequest.ts
@@ -23,7 +23,9 @@ import { Sort, SortResults } from '@_types/sort'
 import { UserQueryContainer } from './types'
 
 /**
- * Retrieves information for Users in a paginated manner. You can optionally filter the results with a query.
+ * Find users with a query.
+ * Get information for users in a paginated manner.
+ * You can optionally filter the results with a query.
  * @rest_spec_name security.query_user
  * @availability stack since=8.14.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/query_user/SecurityQueryUserRequest.ts
+++ b/specification/security/query_user/SecurityQueryUserRequest.ts
@@ -24,6 +24,7 @@ import { UserQueryContainer } from './types'
 
 /**
  * Find users with a query.
+ *
  * Get information for users in a paginated manner.
  * You can optionally filter the results with a query.
  * @rest_spec_name security.query_user

--- a/specification/security/saml_authenticate/Request.ts
+++ b/specification/security/saml_authenticate/Request.ts
@@ -22,6 +22,7 @@ import { Ids } from '@_types/common'
 
 /**
  * Authenticate SAML.
+ *
  * Submits a SAML response message to Elasticsearch for consumption.
  * @rest_spec_name security.saml_authenticate
  * @availability stack since=7.5.0 stability=stable

--- a/specification/security/saml_authenticate/Request.ts
+++ b/specification/security/saml_authenticate/Request.ts
@@ -21,7 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Ids } from '@_types/common'
 
 /**
- * Submits a SAML Response message to Elasticsearch for consumption.
+ * Authenticate SAML.
+ * Submits a SAML response message to Elasticsearch for consumption.
  * @rest_spec_name security.saml_authenticate
  * @availability stack since=7.5.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/saml_complete_logout/Request.ts
+++ b/specification/security/saml_complete_logout/Request.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Ids } from '@_types/common'
 
 /**
+ * Logout of SAML completely.
  * Verifies the logout response sent from the SAML IdP.
  * @rest_spec_name security.saml_complete_logout
  * @availability stack since=7.14.0 stability=stable

--- a/specification/security/saml_complete_logout/Request.ts
+++ b/specification/security/saml_complete_logout/Request.ts
@@ -22,6 +22,7 @@ import { Ids } from '@_types/common'
 
 /**
  * Logout of SAML completely.
+ *
  * Verifies the logout response sent from the SAML IdP.
  * @rest_spec_name security.saml_complete_logout
  * @availability stack since=7.14.0 stability=stable

--- a/specification/security/saml_invalidate/Request.ts
+++ b/specification/security/saml_invalidate/Request.ts
@@ -20,6 +20,7 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Invalidate SAML.
  * Submits a SAML LogoutRequest message to Elasticsearch for consumption.
  * @rest_spec_name security.saml_invalidate
  * @availability stack since=7.5.0 stability=stable

--- a/specification/security/saml_invalidate/Request.ts
+++ b/specification/security/saml_invalidate/Request.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Invalidate SAML.
+ *
  * Submits a SAML LogoutRequest message to Elasticsearch for consumption.
  * @rest_spec_name security.saml_invalidate
  * @availability stack since=7.5.0 stability=stable

--- a/specification/security/saml_logout/Request.ts
+++ b/specification/security/saml_logout/Request.ts
@@ -20,6 +20,7 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Logout of SAML.
  * Submits a request to invalidate an access token and refresh token.
  * @rest_spec_name security.saml_logout
  * @availability stack since=7.5.0 stability=stable

--- a/specification/security/saml_logout/Request.ts
+++ b/specification/security/saml_logout/Request.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Logout of SAML.
+ *
  * Submits a request to invalidate an access token and refresh token.
  * @rest_spec_name security.saml_logout
  * @availability stack since=7.5.0 stability=stable

--- a/specification/security/saml_prepare_authentication/Request.ts
+++ b/specification/security/saml_prepare_authentication/Request.ts
@@ -20,7 +20,8 @@
 import { RequestBase } from '@_types/Base'
 
 /**
- * Creates a SAML authentication request (<AuthnRequest>) as a URL string, based on the configuration of the respective SAML realm in Elasticsearch.
+ * Prepare SAML authentication.
+ * Creates a SAML authentication request (`<AuthnRequest>`) as a URL string, based on the configuration of the respective SAML realm in Elasticsearch.
  * @rest_spec_name security.saml_prepare_authentication
  * @availability stack since=7.5.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/saml_prepare_authentication/Request.ts
+++ b/specification/security/saml_prepare_authentication/Request.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Prepare SAML authentication.
+ *
  * Creates a SAML authentication request (`<AuthnRequest>`) as a URL string, based on the configuration of the respective SAML realm in Elasticsearch.
  * @rest_spec_name security.saml_prepare_authentication
  * @availability stack since=7.5.0 stability=stable

--- a/specification/security/saml_service_provider_metadata/Request.ts
+++ b/specification/security/saml_service_provider_metadata/Request.ts
@@ -21,6 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 
 /**
+ * Create SAML service provider metadata.
  * Generate SAML metadata for a SAML 2.0 Service Provider.
  * @rest_spec_name security.saml_service_provider_metadata
  * @availability stack since=7.11.0 stability=stable

--- a/specification/security/saml_service_provider_metadata/Request.ts
+++ b/specification/security/saml_service_provider_metadata/Request.ts
@@ -22,6 +22,7 @@ import { Name } from '@_types/common'
 
 /**
  * Create SAML service provider metadata.
+ *
  * Generate SAML metadata for a SAML 2.0 Service Provider.
  * @rest_spec_name security.saml_service_provider_metadata
  * @availability stack since=7.11.0 stability=stable

--- a/specification/security/suggest_user_profiles/Request.ts
+++ b/specification/security/suggest_user_profiles/Request.ts
@@ -23,6 +23,7 @@ import { Hint } from './types'
 
 /**
  * Suggest a user profile.
+ *
  * Get suggestions for user profiles that match specified search criteria.
  * @rest_spec_name security.suggest_user_profiles
  * @availability stack since=8.2.0 stability=stable

--- a/specification/security/suggest_user_profiles/Request.ts
+++ b/specification/security/suggest_user_profiles/Request.ts
@@ -22,6 +22,7 @@ import { long } from '@_types/Numeric'
 import { Hint } from './types'
 
 /**
+ * Suggest a user profile.
  * Get suggestions for user profiles that match specified search criteria.
  * @rest_spec_name security.suggest_user_profiles
  * @availability stack since=8.2.0 stability=stable

--- a/specification/security/update_api_key/Request.ts
+++ b/specification/security/update_api_key/Request.ts
@@ -25,6 +25,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * Update an API key.
+ *
  * Updates attributes of an existing API key.
  * Users can only update API keys that they created or that were granted to them.
  * Use this API to update API keys created by the create API Key or grant API Key APIs.

--- a/specification/security/update_user_profile_data/Request.ts
+++ b/specification/security/update_user_profile_data/Request.ts
@@ -25,7 +25,8 @@ import { Refresh, SequenceNumber } from '@_types/common'
 import { long } from '@_types/Numeric'
 
 /**
- * Updates specific data for the user profile that's associated with the specified unique ID.
+ * Update user profile data.
+ * Update specific data for the user profile that is associated with a unique ID.
  * @rest_spec_name security.update_user_profile_data
  * @availability stack since=8.2.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/update_user_profile_data/Request.ts
+++ b/specification/security/update_user_profile_data/Request.ts
@@ -26,6 +26,7 @@ import { long } from '@_types/Numeric'
 
 /**
  * Update user profile data.
+ *
  * Update specific data for the user profile that is associated with a unique ID.
  * @rest_spec_name security.update_user_profile_data
  * @availability stack since=8.2.0 stability=stable


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635, https://github.com/elastic/elasticsearch-specification/pull/3033, https://github.com/elastic/elasticsearch-specification/pull/3035

This PR adds/edits summaries for the remainder of the security APIs. The first phrase is used as the "operation summary" and should basically align with what existed in the table of contents in https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api.html (omitting "API" from the end of the phrase, however). Any subsequent information gets published as the "operation description".
