### PR TITLE
Update doc comments guidelines

### DIFF
--- a/docs/doc-comments-guide.md
+++ b/docs/doc-comments-guide.md
@@ -7,16 +7,20 @@ Documentation of the TypeScript specification is made using [JSDoc](https://jsdo
 The first phrase is used as the mandatory operation summary in the OpenAPI document.
 Refer to [API documentation guidelines](https://docs.elastic.dev/content-architecture/oas#summaries).
 
-NOTE: You must add a period or `\n` at the end of the phrase for it to parse correctly.
-The period will be properly omitted from the output OpenAPI document.
+> [!NOTE] 
+> You must add a period at the end of the phrase for it to parse correctly. The period will be properly omitted from the output OpenAPI document.
 
 Additional lines start with a `*` followed by a space. Long lines are allowed but it's better if text is formatted to a maximum of 120 characters per line.
+
+> [!NOTE] 
+> A blank line must be inserted between the first sentence and all subsequent lines to ensure correct formatting in all places (e.g. in the in-code documentation of the language clients).
 
 ## Example
 
 ```ts
 /**
  * Get ranking evaluation.
+ *
  * Enables you to evaluate the quality of ranked search results over a set of typical search queries.
  * @rest_spec_name rank_eval
  * @availability stack since=6.2.0 stability=stable


### PR DESCRIPTION
Update doc comments guidelines to ensure the best looking output in OpenAPI as well as in all other places which are using Markdown rendering.

The blank line creates a proper paragraph in all places other than the OpenAPI output - e.g. the in-code documentation of the generated clients. Without this, the text looks very squashed.