### PR TITLE
Fix additional property name for `TermsQuery`

### DIFF
--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -236,7 +236,7 @@ export class TermQuery extends QueryBase {
 }
 
 /**
- * @behavior_meta AdditionalProperty key=field value=term
+ * @behavior_meta AdditionalProperty key=field value=terms
  */
 export class TermsQuery
   extends QueryBase


### PR DESCRIPTION
This seems to be a copy/paste mistake made by me when I implemented the `behavior_meta` tag.

@swallez @Anaethelion @ezimuel @picandocodigo @miguelgrinberg @l-trotta @pquentin @JoshMock   Please check, if this is a breaking change in any of your clients. Most likely only the static language clients should be affected - if at all.