### PR TITLE
Improve `DataStreamLifecycle` definitions (and related)

### DIFF
--- a/specification/indices/_types/DataStreamLifecycle.ts
+++ b/specification/indices/_types/DataStreamLifecycle.ts
@@ -26,26 +26,29 @@ import { Duration } from '@_types/Time'
  * Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration.
  */
 export class DataStreamLifecycle {
-  data_retention?: Duration
-  downsampling?: DataStreamLifecycleDownsampling
-}
-
-/**
- * Data stream lifecycle with rollover can be used to display the configuration including the default rollover conditions,
- * if asked.
- */
-export class DataStreamLifecycleWithRollover {
   /**
    * If defined, every document added to this data stream will be stored at least for this time frame.
    * Any time after this duration the document could be deleted.
    * When empty, every document in this data stream will be stored indefinitely.
    */
   data_retention?: Duration
-
   /**
    * The downsampling configuration to execute for the managed backing index after rollover.
    */
   downsampling?: DataStreamLifecycleDownsampling
+  /**
+   * If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle
+   * that's disabled (enabled: `false`) will have no effect on the data stream.
+   * @server_default true
+   */
+  enabled?: boolean
+}
+
+/**
+ * Data stream lifecycle with rollover can be used to display the configuration including the default rollover conditions,
+ * if asked.
+ */
+export class DataStreamLifecycleWithRollover extends DataStreamLifecycle {
   /**
    * The conditions which will trigger the rollover of a backing index as configured by the cluster setting `cluster.lifecycle.default.rollover`.
    * This property is an implementation detail and it will only be retrieved when the query param `include_defaults` is set to true.

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleResponse.ts
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleResponse.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { DataStreamLifecycle } from '@indices/_types/DataStreamLifecycle'
+import { DataStreamLifecycleWithRollover } from '@indices/_types/DataStreamLifecycle'
 import { DataStreamName } from '@_types/common'
 
 export class Response {
@@ -26,5 +26,5 @@ export class Response {
 
 class DataStreamWithLifecycle {
   name: DataStreamName
-  lifecycle?: DataStreamLifecycle
+  lifecycle?: DataStreamLifecycleWithRollover
 }

--- a/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
+++ b/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { DataStreamLifecycleDownsampling } from '@indices/_types/DataStreamLifecycleDownsampling'
+import { DataStreamLifecycle } from '@indices/_types/DataStreamLifecycle'
 import { RequestBase } from '@_types/Base'
 import { DataStreamNames, ExpandWildcards } from '@_types/common'
 import { Duration } from '@_types/Time'
@@ -60,17 +60,8 @@ export interface Request extends RequestBase {
      */
     timeout?: Duration
   }
-  body: {
-    /**
-     * If defined, every document added to this data stream will be stored at least for this time frame.
-     * Any time after this duration the document could be deleted.
-     * When empty, every document in this data stream will be stored indefinitely.
-     */
-    data_retention?: Duration
-    /**
-     * If defined, every backing index will execute the configured downsampling configuration after the backing
-     * index is not the data stream write index anymore.
-     */
-    downsampling?: DataStreamLifecycleDownsampling
-  }
+  /**
+   * @codegen_name lifecycle
+   */
+  body: DataStreamLifecycle
 }


### PR DESCRIPTION
The `enabled` field was missing from `DataStreamLifecycle`.

While working on this, I noticed that the specification can be simplified by re-using the `DataStreamLifecycle` on some places.

Besides that, `DataStreamWithLifecycle` incorrectly used `DataStreamLifecycle` instead of `DataStreamLifecycleWithRollover` for the `lifecycle` field.