### PR TITLE
Improve `SearchApplication` definition (and related)

### DIFF
--- a/specification/search_application/_types/SearchApplication.ts
+++ b/specification/search_application/_types/SearchApplication.ts
@@ -17,36 +17,17 @@
  * under the License.
  */
 
-import { IndexName, Name } from '@_types/common'
-import { Script } from '@_types/Scripting'
+import { Name } from '@_types/common'
 import { EpochTime, UnitMillis } from '@_types/Time'
+import { SearchApplicationParameters } from './SearchApplicationParameters'
 
-export class SearchApplication {
+export class SearchApplication extends SearchApplicationParameters {
   /**
-   * Search Application name.
+   * Search Application name
    */
   name: Name
-  /**
-   * Indices that are part of the Search Application.
-   */
-  indices: IndexName[]
   /**
    * Last time the Search Application was updated.
    */
   updated_at_millis: EpochTime<UnitMillis>
-  /**
-   * Analytics collection associated to the Search Application.
-   */
-  analytics_collection_name?: Name
-  /**
-   * Search template to use on search operations.
-   */
-  template?: SearchApplicationTemplate
-}
-
-export class SearchApplicationTemplate {
-  /**
-   * The associated mustache template.
-   */
-  script: Script
 }

--- a/specification/search_application/_types/SearchApplicationParameters.ts
+++ b/specification/search_application/_types/SearchApplicationParameters.ts
@@ -17,12 +17,20 @@
  * under the License.
  */
 
-import { SearchApplication } from '@search_application/_types/SearchApplication'
-import { long } from '@_types/Numeric'
+import { IndexName, Name } from '@_types/common'
+import { SearchApplicationTemplate } from './SearchApplicationTemplate'
 
-export class Response {
-  body: {
-    count: long
-    results: SearchApplication[]
-  }
+export class SearchApplicationParameters {
+  /**
+   * Indices that are part of the Search Application.
+   */
+  indices: IndexName[]
+  /**
+   * Analytics collection associated to the Search Application.
+   */
+  analytics_collection_name?: Name
+  /**
+   * Search template to use on search operations.
+   */
+  template?: SearchApplicationTemplate
 }

--- a/specification/search_application/_types/SearchApplicationTemplate.ts
+++ b/specification/search_application/_types/SearchApplicationTemplate.ts
@@ -17,12 +17,11 @@
  * under the License.
  */
 
-import { SearchApplication } from '@search_application/_types/SearchApplication'
-import { long } from '@_types/Numeric'
+import { Script } from '@_types/Scripting'
 
-export class Response {
-  body: {
-    count: long
-    results: SearchApplication[]
-  }
+export class SearchApplicationTemplate {
+  /**
+   * The associated mustache template.
+   */
+  script: Script
 }

--- a/specification/search_application/get/SearchApplicationsGetResponse.ts
+++ b/specification/search_application/get/SearchApplicationsGetResponse.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { SearchApplication } from '../_types/SearchApplication'
+import { SearchApplication } from '@search_application/_types/SearchApplication'
 
 export class Response {
   body: SearchApplication

--- a/specification/search_application/put/SearchApplicationsPutRequest.ts
+++ b/specification/search_application/put/SearchApplicationsPutRequest.ts
@@ -18,7 +18,7 @@
  */
 import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
-import { SearchApplication } from '../_types/SearchApplication'
+import { SearchApplicationParameters } from '../_types/SearchApplicationParameters'
 
 /**
  * Create or update a search application.
@@ -44,5 +44,5 @@ export interface Request extends RequestBase {
    * Contains parameters for a search application.
    */
   /** @codegen_name search_application */
-  body: SearchApplication
+  body: SearchApplicationParameters
 }


### PR DESCRIPTION
The `SearchApplication` was used as the body for `search_application.put` as well as `search_application.get`.

This caused problems, because the `name` field was mandatory, but is actually not required in case of `PUT`.

In this PR, I remove `name` from `SearchApplication` and rename this type to `SearchApplicationParameters`.

The current `SearchApplication` now derives from `SearchApplicationParameters` and adds back the `name` field. This type is used as the response for `search_application.get` and `search_application.list` (instead of `SearchApplicationListItem` which became redundant).