### PR TITLE
[OpenAPI] Add more x-model and @ext_doc_id values

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -9,10 +9,14 @@ actions:
     update:
       title: Elasticsearch API
       description: >
+        Elasticsearch provides REST APIs that are used by the UI components and can be called directly to configure and access Elasticsearch features.
+        
         ## Documentation source and versions
         
         This documentation is derived from the `main` branch of the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification) repository.
         It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
+
+        This documentation contains work-in-progress information for future Elastic Stack releases.
       x-doc-license:
         name: Attribution-NonCommercial-NoDerivatives 4.0 International
         url: 'https://creativecommons.org/licenses/by-nc-nd/4.0/'

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -1076,6 +1076,11 @@ actions:
       x-model: true
       externalDocs:
         url: https://www.elastic.co/guide/en/elasticsearch/reference/master/collapse-search-results.html
+  - target: "$.components['schemas']['_global.msearch:MultisearchBody'].properties"
+    description: Add x-model
+    update:
+      aggregations:
+        x-model: true
 # Examples
   - target: "$.components['requestBodies']['async_search.submit']"
     description: "Add example for asynch search submit request"

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -1070,6 +1070,12 @@ actions:
         externalDocs:
           url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
           description: Query DSL
+  - target: "$.components['schemas']['_global.search._types:FieldCollapse']"
+    description: Add x-model and externalDocs
+    update:
+      x-model: true
+      externalDocs:
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/collapse-search-results.html
 # Examples
   - target: "$.components['requestBodies']['async_search.submit']"
     description: "Add example for asynch search submit request"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -64794,6 +64794,9 @@
         "type": "object",
         "properties": {
           "aggregations": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html"
+            },
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/_types.aggregations:AggregationContainer"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -51969,6 +51969,9 @@
         "type": "object",
         "properties": {
           "aggregations": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html"
+            },
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/_types.aggregations:AggregationContainer"

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -80,6 +80,7 @@ cluster,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster
 common-options,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/common-options.html
 community-id-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/community-id-processor.html
 connector-sync-job-cancel,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cancel-connector-sync-job-api.html
+collapse-search-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/collapse-search-results.html
 connector-sync-job-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-connector-sync-job-api.html
 connector-sync-job-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-connector-sync-job-api.html
 connector-sync-job-post,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/create-connector-sync-job-api.html

--- a/specification/_global/msearch/types.ts
+++ b/specification/_global/msearch/types.ts
@@ -68,7 +68,10 @@ export class MultisearchHeader {
 
 // We should keep this in sync with the normal search request body.
 export class MultisearchBody {
-  /** @aliases aggs */ // ES uses "aggregations" in serialization
+  /**
+   * @aliases aggs
+   * @ext_doc_id search-aggregations
+   */ // ES uses "aggregations" in serialization
   aggregations?: Dictionary<string, AggregationContainer>
   collapse?: FieldCollapse
   /**

--- a/specification/_global/search/_types/FieldCollapse.ts
+++ b/specification/_global/search/_types/FieldCollapse.ts
@@ -21,6 +21,9 @@ import { Field } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { InnerHits } from './hits'
 
+/**
+ * @ext_doc_id collapse-search-results
+ */
 export class FieldCollapse {
   /**
    * The field to collapse the result set on


### PR DESCRIPTION
This PR adds more `@ext_doc_id` values and more `x-model` overlays for deeply nested Elasticsearch schema objects.

It also adds a comment in the introduction about the "work-in-progress" state of content on the "main" branch, to match what's in our other docs.