### PR TITLE
[OpenAPI] Edits connector API summaries

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -41,7 +41,7 @@ actions:
             
             This API provides an alternative to relying solely on Kibana UI for connector and sync job management. The API comes with a set of validations and assertions to ensure that the state representation in the internal index remains valid.
           externalDocs:
-            url: https://www.elastic.co/guide/en/enterprise-search/current/connectors-tutorial-api.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/es-connectors-tutorial-api.html
             description: To get started with Connector APIs, check out the tutorial.
         - name: ccr
           x-displayName: Cross-cluster replication
@@ -72,14 +72,14 @@ actions:
           description: >
             Event Query Language (EQL) is a query language for event-based time series data, such as logs, metrics, and traces.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/eql.html
             description: EQL search
         - name: esql
           x-displayName: ES|QL
           description: >
             The Elasticsearch Query Language (ES|QL) provides a powerful way to filter, transform, and analyze data stored in Elasticsearch, and in the future in other runtimes.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/esql.html
             description: ES|QL overview and tutorials
       # F
         - name: features
@@ -93,7 +93,7 @@ actions:
           description: >
             The graph explore API enables you to extract and summarize information about the documents and terms in an Elasticsearch data stream or index.
           externalDocs:
-            url: https://www.elastic.co/guide/en/kibana/current/xpack-graph.html
+            url: https://www.elastic.co/guide/en/kibana/master/xpack-graph.html
             description: Getting started with Graph
       # I
         - name: indices
@@ -105,7 +105,7 @@ actions:
         - name: ilm
           x-displayName: Index lifecycle management
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/index-lifecycle-management.html
             description: Manage the index lifecycle
         - name: inference
           x-displayName: Inference
@@ -127,7 +127,7 @@ actions:
           description: >
             Logstash APIs enable you to manage pipelines that are used by Logstash Central Management.
           externalDocs:
-            url: https://www.elastic.co/guide/en/logstash/current/logstash-centralized-pipeline-management.html
+            url: https://www.elastic.co/guide/en/logstash/master/logstash-centralized-pipeline-management.html
             description: Centralized pipeline management
       # M
         - name: ml
@@ -168,7 +168,7 @@ actions:
             If a query matches one or more rules in the ruleset, the query is re-written to apply the rules before searching.
             This allows pinning documents for only queries that match a specific term.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-rule-query.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-rule-query.html
             description: Rule query
       # R
         - name: rollup
@@ -201,21 +201,21 @@ actions:
           description: >
             Snapshot and restore APIs enable you to set up snapshot repositories, manage snapshot backups, and restore snapshots to a running cluster.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshot-restore.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/snapshot-restore.html
             description: Snapshot and restore
         - name: slm
           x-displayName: Snapshot lifecycle management
           description: >
             Snapshot lifecycle management (SLM) APIs enable you to set up policies to automatically take snapshots and control how long they are retained.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-take-snapshot.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/snapshots-take-snapshot.html
             description: Create a snapshot
         - name: sql
           x-displayName: SQL
           description: >
             Elasticsearch's SQL APIs enable you to run SQL queries on Elasticsearch indices and data streams.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-sql.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/xpack-sql.html
             description: An overview and tutorials for the Elasticsearch SQL features
         - name: synonyms
           x-displayName: Synonyms
@@ -1017,7 +1017,7 @@ actions:
           All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch.
           By default, this property has the following value: `{"match_all": {"boost": 1}}`.
         externalDocs:
-          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl.html
           description: Query DSL
   - target: "$.components['schemas']['ml._types:CategorizationAnalyzerDefinition'].properties.tokenizer"
     description: Remove tokenizer object from ML anomaly detection analysis config
@@ -1038,7 +1038,7 @@ actions:
           Additionally, the `ml_classic` tokenizer is available, which tokenizes in the same way as the non-customizable tokenizer in old versions of the product (before 6.2).
           `ml_classic` was the default categorization tokenizer in versions 6.2 to 7.13, so if you need categorization identical to the default for jobs created in these versions, specify `"tokenizer": "ml_classic"` in your `categorization_analyzer`.
         externalDocs:
-          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-tokenizers.html
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-tokenizers.html
           description: Tokenizer reference
   - target: "$.components['schemas']['ml._types:DataframeAnalyticsSource'].properties.query"
     description: Remove query object from data frame analytics source
@@ -1055,7 +1055,7 @@ actions:
           All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch.
           By default, this property has the following value: `{"match_all": {}}`.
         externalDocs:
-          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl.html
           description: Query DSL
   - target: "$.components['schemas']['transform._types:Source'].properties.query"
     description: Remove query object from transform source
@@ -1069,7 +1069,7 @@ actions:
         description: >
           A query clause that retrieves a subset of data from the source index.
         externalDocs:
-          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl.html
           description: Query DSL
 # Examples
   - target: "$.components['requestBodies']['async_search.submit']"

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -37,7 +37,7 @@ actions:
             
             * Elastic managed connectors (Native connectors) are a managed service on Elastic Cloud
             
-            * Self-managed connectors (Connector clients) are self-managed on your infrastructure
+            * Self-managed connectors (Connector clients) are self-managed on your infrastructure.
             
             This API provides an alternative to relying solely on Kibana UI for connector and sync job management. The API comes with a set of validations and assertions to ensure that the state representation in the internal index remains valid.
           externalDocs:

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -39,6 +39,7 @@ actions:
             
             * Self-managed connectors (Connector clients) are self-managed on your infrastructure.
             
+            
             This API provides an alternative to relying solely on Kibana UI for connector and sync job management. The API comes with a set of validations and assertions to ensure that the state representation in the internal index remains valid.
           externalDocs:
             url: https://www.elastic.co/guide/en/elasticsearch/reference/master/es-connectors-tutorial-api.html

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -42,7 +42,7 @@ actions:
             This API provides an alternative to relying solely on Kibana UI for connector and sync job management. The API comes with a set of validations and assertions to ensure that the state representation in the internal index remains valid.
           externalDocs:
             url: https://www.elastic.co/guide/en/elasticsearch/reference/master/es-connectors-tutorial-api.html
-            description: To get started with Connector APIs, check out the tutorial.
+            description: Connector API tutorial
         - name: ccr
           x-displayName: Cross-cluster replication
       # D

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -36,6 +36,7 @@ actions:
             Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure:
             
             * Native connectors are a managed service on Elastic Cloud
+            
             * Connector clients are self-managed on your infrastructure
             
             This API provides an alternative to relying solely on Kibana UI for connector and sync job management. The API comes with a set of validations and assertions to ensure that the state representation in the internal index remains valid.

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -35,9 +35,9 @@ actions:
             
             Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure:
             
-            * Native connectors are a managed service on Elastic Cloud
+            * Elastic managed connectors (Native connectors) are a managed service on Elastic Cloud
             
-            * Connector clients are self-managed on your infrastructure
+            * Self-managed connectors (Connector clients) are self-managed on your infrastructure
             
             This API provides an alternative to relying solely on Kibana UI for connector and sync job management. The API comes with a set of validations and assertions to ensure that the state representation in the internal index remains valid.
           externalDocs:

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -4388,7 +4388,7 @@
           "connector"
         ],
         "summary": "Create a connector",
-        "description": "Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure.\nNative connectors are a managed service on Elastic Cloud.\nConnector clients are self-managed on your infrastructure.",
+        "description": "Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure.\nElastic managed connectors (Native connectors) are a managed service on Elastic Cloud.\nSelf-managed connectors (Connector clients) are self-managed on your infrastructure.",
         "operationId": "connector-post",
         "requestBody": {
           "content": {
@@ -4762,7 +4762,7 @@
           "connector"
         ],
         "summary": "Update the connector API key ID",
-        "description": "Update the `api_key_id` and `api_key_secret_id` fields of a connector.\nYou can specify the ID of the API key used for authorization and the ID of the connector secret where the API key is stored.\nThe connector secret ID is required only for native connectors.\nConnector clients do not use this field.",
+        "description": "Update the `api_key_id` and `api_key_secret_id` fields of a connector.\nYou can specify the ID of the API key used for authorization and the ID of the connector secret where the API key is stored.\nThe connector secret ID is required only for Elastic managed (native) connectors.\nSelf-managed connectors (connector clients) do not use this field.",
         "operationId": "connector-update-api-key-id",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -4036,7 +4036,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the last_seen field in the connector, and sets it to current timestamp",
+        "summary": "Check in a connector",
+        "description": "Update the `last_seen` field in the connector and set it to the current timestamp.",
         "operationId": "connector-check-in",
         "parameters": [
           {
@@ -4079,7 +4080,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Retrieves a connector",
+        "summary": "Get a connector",
+        "description": "Get the details about a connector.",
         "operationId": "connector-get",
         "parameters": [
           {
@@ -4112,7 +4114,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Creates or updates a connector",
+        "summary": "Create or update a connector",
         "operationId": "connector-put",
         "parameters": [
           {
@@ -4133,7 +4135,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Deletes a connector",
+        "summary": "Delete a connector",
+        "description": "Removes a connector and associated sync jobs.\nThis is a destructive action that is not recoverable.\nNOTE: This action doesn’t delete any API keys, ingest pipelines, or data indices associated with the connector.\nThese need to be removed manually.",
         "operationId": "connector-delete",
         "parameters": [
           {
@@ -4178,7 +4181,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates last sync stats in the connector document",
+        "summary": "Update the connector last sync stats",
+        "description": "Update the fields related to the last sync of a connector.\nThis action is used for analytics and monitoring.",
         "operationId": "connector-last-sync",
         "parameters": [
           {
@@ -4269,7 +4273,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Returns existing connectors",
+        "summary": "Get all connectors",
+        "description": "Get information about all connectors.",
         "operationId": "connector-list",
         "parameters": [
           {
@@ -4366,7 +4371,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Creates or updates a connector",
+        "summary": "Create or update a connector",
         "operationId": "connector-put-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/connector.put"
@@ -4382,7 +4387,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Creates a connector",
+        "summary": "Create a connector",
+        "description": "Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure.\nNative connectors are a managed service on Elastic Cloud.\nConnector clients are self-managed on your infrastructure.",
         "operationId": "connector-post",
         "requestBody": {
           "content": {
@@ -4445,7 +4451,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Cancels a connector sync job",
+        "summary": "Cancel a connector sync job",
+        "description": "Cancel a connector sync job, which sets the status to cancelling and updates `cancellation_requested_at` to the current time.\nThe connector service is then responsible for setting the status of connector sync jobs to cancelled.",
         "operationId": "connector-sync-job-cancel",
         "parameters": [
           {
@@ -4488,7 +4495,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Retrieves a connector sync job",
+        "summary": "Get a connector sync job",
         "operationId": "connector-sync-job-get",
         "parameters": [
           {
@@ -4521,7 +4528,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Deletes a connector sync job",
+        "summary": "Delete a connector sync job",
+        "description": "Remove a connector sync job and its associated data.\nThis is a destructive action that is not recoverable.",
         "operationId": "connector-sync-job-delete",
         "parameters": [
           {
@@ -4556,7 +4564,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Lists connector sync jobs",
+        "summary": "Get all connector sync jobs",
+        "description": "Get information about all stored connector sync jobs listed by their creation date in ascending order.",
         "operationId": "connector-sync-job-list",
         "parameters": [
           {
@@ -4653,7 +4662,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Creates a connector sync job",
+        "summary": "Create a connector sync job",
+        "description": "Create a connector sync job document in the internal index and initialize its counters and timestamps with default values.",
         "operationId": "connector-sync-job-post",
         "requestBody": {
           "content": {
@@ -4707,7 +4717,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Activates the valid draft filtering for a connector",
+        "summary": "Activate the connector draft filter",
+        "description": "Activates the valid draft filtering for a connector.",
         "operationId": "connector-update-active-filtering",
         "parameters": [
           {
@@ -4750,7 +4761,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the API key id in the connector document",
+        "summary": "Update the connector API key ID",
+        "description": "Update the `api_key_id` and `api_key_secret_id` fields of a connector.\nYou can specify the ID of the API key used for authorization and the ID of the connector secret where the API key is stored.\nThe connector secret ID is required only for native connectors.\nConnector clients do not use this field.",
         "operationId": "connector-update-api-key-id",
         "parameters": [
           {
@@ -4811,7 +4823,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the configuration field in the connector document",
+        "summary": "Update the connector configuration",
+        "description": "Update the configuration field in the connector document.",
         "operationId": "connector-update-configuration",
         "parameters": [
           {
@@ -4875,7 +4888,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the filtering field in the connector document",
+        "summary": "Update the connector error field",
+        "description": "Set the error field for the connector.\nIf the error provided in the request body is non-null, the connector’s status is updated to error.\nOtherwise, if the error is reset to null, the connector status is updated to connected.",
         "operationId": "connector-update-error",
         "parameters": [
           {
@@ -4943,7 +4957,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the filtering field in the connector document",
+        "summary": "Update the connector filtering",
+        "description": "Update the draft filtering configuration of a connector and marks the draft validation state as edited.\nThe filtering draft is activated once validated by the running Elastic connector service.\nThe filtering property is used to configure sync rules (both basic and advanced) for a connector.",
         "operationId": "connector-update-filtering",
         "parameters": [
           {
@@ -5013,7 +5028,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the draft filtering validation info for a connector",
+        "summary": "Update the connector draft filtering validation",
+        "description": "Update the draft filtering validation info for a connector.",
         "operationId": "connector-update-filtering-validation",
         "parameters": [
           {
@@ -5074,7 +5090,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the index_name in the connector document",
+        "summary": "Update the connector index name",
+        "description": "Update the `index_name` field of a connector, specifying the index where the data ingested by the connector is stored.",
         "operationId": "connector-update-index-name",
         "parameters": [
           {
@@ -5142,7 +5159,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the name and description fields in the connector document",
+        "summary": "Update the connector name and description",
         "operationId": "connector-update-name",
         "parameters": [
           {
@@ -5203,7 +5220,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the is_native flag in the connector document",
+        "summary": "Update the connector is_native flag",
         "operationId": "connector-update-native",
         "parameters": [
           {
@@ -5264,7 +5281,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the pipeline field in the connector document",
+        "summary": "Update the connector pipeline",
+        "description": "When you create a new connector, the configuration of an ingest pipeline is populated with default settings.",
         "operationId": "connector-update-pipeline",
         "parameters": [
           {
@@ -5325,7 +5343,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the scheduling field in the connector document",
+        "summary": "Update the connector scheduling",
         "operationId": "connector-update-scheduling",
         "parameters": [
           {
@@ -5386,7 +5404,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the service type of the connector",
+        "summary": "Update the connector service type",
         "operationId": "connector-update-service-type",
         "parameters": [
           {
@@ -5447,7 +5465,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the status of the connector",
+        "summary": "Update the connector status",
         "operationId": "connector-update-status",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -1707,7 +1707,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the last_seen field in the connector, and sets it to current timestamp",
+        "summary": "Check in a connector",
+        "description": "Update the `last_seen` field in the connector and set it to the current timestamp.",
         "operationId": "connector-check-in",
         "parameters": [
           {
@@ -1750,7 +1751,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Retrieves a connector",
+        "summary": "Get a connector",
+        "description": "Get the details about a connector.",
         "operationId": "connector-get",
         "parameters": [
           {
@@ -1783,7 +1785,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Creates or updates a connector",
+        "summary": "Create or update a connector",
         "operationId": "connector-put",
         "parameters": [
           {
@@ -1804,7 +1806,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Deletes a connector",
+        "summary": "Delete a connector",
+        "description": "Removes a connector and associated sync jobs.\nThis is a destructive action that is not recoverable.\nNOTE: This action doesn’t delete any API keys, ingest pipelines, or data indices associated with the connector.\nThese need to be removed manually.",
         "operationId": "connector-delete",
         "parameters": [
           {
@@ -1849,7 +1852,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Returns existing connectors",
+        "summary": "Get all connectors",
+        "description": "Get information about all connectors.",
         "operationId": "connector-list",
         "parameters": [
           {
@@ -1946,7 +1950,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Creates or updates a connector",
+        "summary": "Create or update a connector",
         "operationId": "connector-put-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/connector.put"
@@ -1962,7 +1966,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Creates a connector",
+        "summary": "Create a connector",
+        "description": "Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure.\nNative connectors are a managed service on Elastic Cloud.\nConnector clients are self-managed on your infrastructure.",
         "operationId": "connector-post",
         "requestBody": {
           "content": {
@@ -2025,7 +2030,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Cancels a connector sync job",
+        "summary": "Cancel a connector sync job",
+        "description": "Cancel a connector sync job, which sets the status to cancelling and updates `cancellation_requested_at` to the current time.\nThe connector service is then responsible for setting the status of connector sync jobs to cancelled.",
         "operationId": "connector-sync-job-cancel",
         "parameters": [
           {
@@ -2068,7 +2074,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Retrieves a connector sync job",
+        "summary": "Get a connector sync job",
         "operationId": "connector-sync-job-get",
         "parameters": [
           {
@@ -2101,7 +2107,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Deletes a connector sync job",
+        "summary": "Delete a connector sync job",
+        "description": "Remove a connector sync job and its associated data.\nThis is a destructive action that is not recoverable.",
         "operationId": "connector-sync-job-delete",
         "parameters": [
           {
@@ -2136,7 +2143,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Lists connector sync jobs",
+        "summary": "Get all connector sync jobs",
+        "description": "Get information about all stored connector sync jobs listed by their creation date in ascending order.",
         "operationId": "connector-sync-job-list",
         "parameters": [
           {
@@ -2233,7 +2241,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Creates a connector sync job",
+        "summary": "Create a connector sync job",
+        "description": "Create a connector sync job document in the internal index and initialize its counters and timestamps with default values.",
         "operationId": "connector-sync-job-post",
         "requestBody": {
           "content": {
@@ -2287,7 +2296,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Activates the valid draft filtering for a connector",
+        "summary": "Activate the connector draft filter",
+        "description": "Activates the valid draft filtering for a connector.",
         "operationId": "connector-update-active-filtering",
         "parameters": [
           {
@@ -2330,7 +2340,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the API key id in the connector document",
+        "summary": "Update the connector API key ID",
+        "description": "Update the `api_key_id` and `api_key_secret_id` fields of a connector.\nYou can specify the ID of the API key used for authorization and the ID of the connector secret where the API key is stored.\nThe connector secret ID is required only for native connectors.\nConnector clients do not use this field.",
         "operationId": "connector-update-api-key-id",
         "parameters": [
           {
@@ -2391,7 +2402,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the configuration field in the connector document",
+        "summary": "Update the connector configuration",
+        "description": "Update the configuration field in the connector document.",
         "operationId": "connector-update-configuration",
         "parameters": [
           {
@@ -2455,7 +2467,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the filtering field in the connector document",
+        "summary": "Update the connector error field",
+        "description": "Set the error field for the connector.\nIf the error provided in the request body is non-null, the connector’s status is updated to error.\nOtherwise, if the error is reset to null, the connector status is updated to connected.",
         "operationId": "connector-update-error",
         "parameters": [
           {
@@ -2523,7 +2536,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the filtering field in the connector document",
+        "summary": "Update the connector filtering",
+        "description": "Update the draft filtering configuration of a connector and marks the draft validation state as edited.\nThe filtering draft is activated once validated by the running Elastic connector service.\nThe filtering property is used to configure sync rules (both basic and advanced) for a connector.",
         "operationId": "connector-update-filtering",
         "parameters": [
           {
@@ -2593,7 +2607,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the draft filtering validation info for a connector",
+        "summary": "Update the connector draft filtering validation",
+        "description": "Update the draft filtering validation info for a connector.",
         "operationId": "connector-update-filtering-validation",
         "parameters": [
           {
@@ -2654,7 +2669,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the index_name in the connector document",
+        "summary": "Update the connector index name",
+        "description": "Update the `index_name` field of a connector, specifying the index where the data ingested by the connector is stored.",
         "operationId": "connector-update-index-name",
         "parameters": [
           {
@@ -2722,7 +2738,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the name and description fields in the connector document",
+        "summary": "Update the connector name and description",
         "operationId": "connector-update-name",
         "parameters": [
           {
@@ -2783,7 +2799,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the is_native flag in the connector document",
+        "summary": "Update the connector is_native flag",
         "operationId": "connector-update-native",
         "parameters": [
           {
@@ -2844,7 +2860,8 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the pipeline field in the connector document",
+        "summary": "Update the connector pipeline",
+        "description": "When you create a new connector, the configuration of an ingest pipeline is populated with default settings.",
         "operationId": "connector-update-pipeline",
         "parameters": [
           {
@@ -2905,7 +2922,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the scheduling field in the connector document",
+        "summary": "Update the connector scheduling",
         "operationId": "connector-update-scheduling",
         "parameters": [
           {
@@ -2966,7 +2983,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the service type of the connector",
+        "summary": "Update the connector service type",
         "operationId": "connector-update-service-type",
         "parameters": [
           {
@@ -3027,7 +3044,7 @@
         "tags": [
           "connector"
         ],
-        "summary": "Updates the status of the connector",
+        "summary": "Update the connector status",
         "operationId": "connector-update-status",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -1967,7 +1967,7 @@
           "connector"
         ],
         "summary": "Create a connector",
-        "description": "Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure.\nNative connectors are a managed service on Elastic Cloud.\nConnector clients are self-managed on your infrastructure.",
+        "description": "Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure.\nElastic managed connectors (Native connectors) are a managed service on Elastic Cloud.\nSelf-managed connectors (Connector clients) are self-managed on your infrastructure.",
         "operationId": "connector-post",
         "requestBody": {
           "content": {
@@ -2341,7 +2341,7 @@
           "connector"
         ],
         "summary": "Update the connector API key ID",
-        "description": "Update the `api_key_id` and `api_key_secret_id` fields of a connector.\nYou can specify the ID of the API key used for authorization and the ID of the connector secret where the API key is stored.\nThe connector secret ID is required only for native connectors.\nConnector clients do not use this field.",
+        "description": "Update the `api_key_id` and `api_key_secret_id` fields of a connector.\nYou can specify the ID of the API key used for authorization and the ID of the connector secret where the API key is stored.\nThe connector secret ID is required only for Elastic managed (native) connectors.\nSelf-managed connectors (connector clients) do not use this field.",
         "operationId": "connector-update-api-key-id",
         "parameters": [
           {

--- a/specification/connector/check_in/ConnectorCheckInRequest.ts
+++ b/specification/connector/check_in/ConnectorCheckInRequest.ts
@@ -20,7 +20,9 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Updates the last_seen field in the connector, and sets it to current timestamp
+ * Check in a connector.
+ * 
+ * Updates the `last_seen` field in the connector and sets it to the current timestamp.
  * @rest_spec_name connector.check_in
  * @availability stack since=8.12.0 stability=experimental
  * @availability serverless stability=experimental visibility=public

--- a/specification/connector/check_in/ConnectorCheckInRequest.ts
+++ b/specification/connector/check_in/ConnectorCheckInRequest.ts
@@ -21,7 +21,7 @@ import { Id } from '@_types/common'
 
 /**
  * Check in a connector.
- * 
+ *
  * Update the `last_seen` field in the connector and set it to the current timestamp.
  * @rest_spec_name connector.check_in
  * @availability stack since=8.12.0 stability=experimental

--- a/specification/connector/check_in/ConnectorCheckInRequest.ts
+++ b/specification/connector/check_in/ConnectorCheckInRequest.ts
@@ -22,7 +22,7 @@ import { Id } from '@_types/common'
 /**
  * Check in a connector.
  * 
- * Updates the `last_seen` field in the connector and sets it to the current timestamp.
+ * Update the `last_seen` field in the connector and set it to the current timestamp.
  * @rest_spec_name connector.check_in
  * @availability stack since=8.12.0 stability=experimental
  * @availability serverless stability=experimental visibility=public

--- a/specification/connector/delete/ConnectorDeleteRequest.ts
+++ b/specification/connector/delete/ConnectorDeleteRequest.ts
@@ -20,7 +20,12 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes a connector.
+ * Delete a connector.
+ *
+ * Removes a connector and associated sync jobs.
+ * This is a destructive action that is not recoverable.
+ * NOTE: This action doesn’t delete any API keys, ingest pipelines, or data indices associated with the connector.
+ * These need to be removed manually.
  * @rest_spec_name connector.delete
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/get/ConnectorGetRequest.ts
+++ b/specification/connector/get/ConnectorGetRequest.ts
@@ -20,7 +20,9 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Retrieves a connector.
+ * Get a connector.
+ *
+ * Get the details about a connector.
  * @rest_spec_name connector.get
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/last_sync/ConnectorUpdateLastSyncRequest.ts
+++ b/specification/connector/last_sync/ConnectorUpdateLastSyncRequest.ts
@@ -24,7 +24,10 @@ import { DateTime } from '@_types/Time'
 import { SyncStatus } from '../_types/Connector'
 
 /**
- * Updates last sync stats in the connector document
+ * Update the connector last sync stats.
+ *
+ * Update the fields related to the last sync of a connector.
+ * This action is used for analytics and monitoring.
  * @rest_spec_name connector.last_sync
  * @availability stack since=8.12.0 stability=experimental visibility=private
  * @availability serverless stability=experimental visibility=private

--- a/specification/connector/list/ConnectorListRequest.ts
+++ b/specification/connector/list/ConnectorListRequest.ts
@@ -21,7 +21,9 @@ import { Indices, Names } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Returns existing connectors.
+ * Get all connectors.
+ *
+ * Get information about all connectors.
  * @rest_spec_name connector.list
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/post/ConnectorPostRequest.ts
+++ b/specification/connector/post/ConnectorPostRequest.ts
@@ -20,7 +20,11 @@ import { RequestBase } from '@_types/Base'
 import { IndexName } from '@_types/common'
 
 /**
- * Creates a connector.
+ * Create a connector.
+ *
+ * Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure.
+ * Native connectors are a managed service on Elastic Cloud.
+ * Connector clients are self-managed on your infrastructure.
  * @rest_spec_name connector.post
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/post/ConnectorPostRequest.ts
+++ b/specification/connector/post/ConnectorPostRequest.ts
@@ -23,8 +23,8 @@ import { IndexName } from '@_types/common'
  * Create a connector.
  *
  * Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure.
- * Native connectors are a managed service on Elastic Cloud.
- * Connector clients are self-managed on your infrastructure.
+ * Elastic managed connectors (Native connectors) are a managed service on Elastic Cloud.
+ * Self-managed connectors (Connector clients) are self-managed on your infrastructure.
  * @rest_spec_name connector.post
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/put/ConnectorPutRequest.ts
+++ b/specification/connector/put/ConnectorPutRequest.ts
@@ -20,7 +20,7 @@ import { RequestBase } from '@_types/Base'
 import { Id, IndexName } from '@_types/common'
 
 /**
- * Creates or updates a connector.
+ * Create or update a connector.
  * @rest_spec_name connector.put
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/sync_job_cancel/SyncJobCancelRequest.ts
+++ b/specification/connector/sync_job_cancel/SyncJobCancelRequest.ts
@@ -20,7 +20,10 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Cancels a connector sync job.
+ * Cancel a connector sync job.
+ *
+ * Cancel a connector sync job, which sets the status to cancelling and updates `cancellation_requested_at` to the current time.
+ * The connector service is then responsible for setting the status of connector sync jobs to cancelled.
  * @rest_spec_name connector.sync_job_cancel
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/sync_job_delete/SyncJobDeleteRequest.ts
+++ b/specification/connector/sync_job_delete/SyncJobDeleteRequest.ts
@@ -23,7 +23,7 @@ import { Id } from '@_types/common'
  * Delete a connector sync job.
  *
  * Remove a connector sync job and its associated data.
- * This is a destructive action that is not recoverable. 
+ * This is a destructive action that is not recoverable.
  * @rest_spec_name connector.sync_job_delete
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/sync_job_delete/SyncJobDeleteRequest.ts
+++ b/specification/connector/sync_job_delete/SyncJobDeleteRequest.ts
@@ -20,7 +20,10 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes a connector sync job.
+ * Delete a connector sync job.
+ *
+ * Remove a connector sync job and its associated data.
+ * This is a destructive action that is not recoverable. 
  * @rest_spec_name connector.sync_job_delete
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/sync_job_get/SyncJobGetRequest.ts
+++ b/specification/connector/sync_job_get/SyncJobGetRequest.ts
@@ -20,7 +20,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Retrieves a connector sync job.
+ * Get a connector sync job.
  * @rest_spec_name connector.sync_job_get
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/sync_job_list/SyncJobListRequest.ts
+++ b/specification/connector/sync_job_list/SyncJobListRequest.ts
@@ -23,7 +23,9 @@ import { SyncStatus } from '../_types/Connector'
 import { SyncJobType } from '../_types/SyncJob'
 
 /**
- * Lists connector sync jobs.
+ * Get all connector sync jobs.
+ *
+ * Get information about all stored connector sync jobs listed by their creation date in ascending order.
  * @rest_spec_name connector.sync_job_list
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/sync_job_post/SyncJobPostRequest.ts
+++ b/specification/connector/sync_job_post/SyncJobPostRequest.ts
@@ -21,7 +21,9 @@ import { Id } from '@_types/common'
 import { SyncJobTriggerMethod, SyncJobType } from '../_types/SyncJob'
 
 /**
- * Creates a connector sync job.
+ * Create a connector sync job.
+ *
+ * Create a connector sync job document in the internal index and initialize its counters and timestamps with default values.
  * @rest_spec_name connector.sync_job_post
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/update_active_filtering/ConnectorUpdateActiveFilteringRequest.ts
+++ b/specification/connector/update_active_filtering/ConnectorUpdateActiveFilteringRequest.ts
@@ -20,6 +20,8 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
+ * Activate the connector draft filter. 
+ *
  * Activates the valid draft filtering for a connector.
  * @rest_spec_name connector.update_active_filtering
  * @availability stack since=8.12.0 stability=experimental

--- a/specification/connector/update_active_filtering/ConnectorUpdateActiveFilteringRequest.ts
+++ b/specification/connector/update_active_filtering/ConnectorUpdateActiveFilteringRequest.ts
@@ -20,7 +20,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Activate the connector draft filter. 
+ * Activate the connector draft filter.
  *
  * Activates the valid draft filtering for a connector.
  * @rest_spec_name connector.update_active_filtering

--- a/specification/connector/update_api_key_id/ConnectorUpdateAPIKeyIDRequest.ts
+++ b/specification/connector/update_api_key_id/ConnectorUpdateAPIKeyIDRequest.ts
@@ -19,7 +19,12 @@
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 /**
- * Updates the API key id in the connector document
+ * Update the connector API key ID.
+ *
+ * Update the `api_key_id` and `api_key_secret_id` fields of a connector.
+ * You can specify the ID of the API key used for authorization and the ID of the connector secret where the API key is stored.
+ * The connector secret ID is required only for native connectors.
+ * Connector clients do not use this field.
  * @rest_spec_name connector.update_api_key_id
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/update_api_key_id/ConnectorUpdateAPIKeyIDRequest.ts
+++ b/specification/connector/update_api_key_id/ConnectorUpdateAPIKeyIDRequest.ts
@@ -23,8 +23,8 @@ import { Id } from '@_types/common'
  *
  * Update the `api_key_id` and `api_key_secret_id` fields of a connector.
  * You can specify the ID of the API key used for authorization and the ID of the connector secret where the API key is stored.
- * The connector secret ID is required only for native connectors.
- * Connector clients do not use this field.
+ * The connector secret ID is required only for Elastic managed (native) connectors.
+ * Self-managed connectors (connector clients) do not use this field.
  * @rest_spec_name connector.update_api_key_id
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/update_configuration/ConnectorUpdateConfigurationRequest.ts
+++ b/specification/connector/update_configuration/ConnectorUpdateConfigurationRequest.ts
@@ -23,7 +23,9 @@ import { Id } from '@_types/common'
 import { ConnectorConfiguration } from '../_types/Connector'
 
 /**
- * Updates the configuration field in the connector document
+ * Update the connector configuration.
+ *
+ * Update the configuration field in the connector document.
  * @rest_spec_name connector.update_configuration
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/update_error/ConnectorUpdateErrorRequest.ts
+++ b/specification/connector/update_error/ConnectorUpdateErrorRequest.ts
@@ -21,7 +21,11 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Updates the filtering field in the connector document
+ * Update the connector error field.
+ *
+ * Set the error field for the connector.
+ * If the error provided in the request body is non-null, the connector’s status is updated to error.
+ * Otherwise, if the error is reset to null, the connector status is updated to connected.
  * @rest_spec_name connector.update_error
  * @availability stack since=8.12.0 stability=experimental
  * @availability serverless stability=experimental visibility=public

--- a/specification/connector/update_filtering/ConnectorUpdateFilteringRequest.ts
+++ b/specification/connector/update_filtering/ConnectorUpdateFilteringRequest.ts
@@ -25,7 +25,11 @@ import {
 } from '../_types/Connector'
 
 /**
- * Updates the filtering field in the connector document
+ * Update the connector filtering.
+ *
+ * Update the draft filtering configuration of a connector and marks the draft validation state as edited.
+ * The filtering draft is activated once validated by the running Elastic connector service.
+ * The filtering property is used to configure sync rules (both basic and advanced) for a connector.
  * @rest_spec_name connector.update_filtering
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/update_filtering_validation/ConnectorUpdateFilteringValidationRequest.ts
+++ b/specification/connector/update_filtering_validation/ConnectorUpdateFilteringValidationRequest.ts
@@ -21,7 +21,9 @@ import { Id } from '@_types/common'
 import { FilteringRulesValidation } from 'connector/_types/Connector'
 
 /**
- * Updates the draft filtering validation info for a connector.
+ * Update the connector draft filtering validation.
+ *
+ * Update the draft filtering validation info for a connector.
  * @rest_spec_name connector.update_filtering_validation
  * @availability stack since=8.12.0 stability=experimental
  * @availability serverless stability=experimental visibility=public

--- a/specification/connector/update_index_name/ConnectorUpdateIndexNameRequest.ts
+++ b/specification/connector/update_index_name/ConnectorUpdateIndexNameRequest.ts
@@ -21,7 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { Id, IndexName } from '@_types/common'
 
 /**
- * Updates the index_name in the connector document
+ * Update the connector index name.
+ *
+ * Update the `index_name` field of a connector, specifying the index where the data ingested by the connector is stored.
  * @rest_spec_name connector.update_index_name
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/update_name/ConnectorUpdateNameRequest.ts
+++ b/specification/connector/update_name/ConnectorUpdateNameRequest.ts
@@ -20,7 +20,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Updates the name and description fields in the connector document
+ * Update the connector name and description.
  * @rest_spec_name connector.update_name
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/update_native/ConnectorUpdateNativeRequest.ts
+++ b/specification/connector/update_native/ConnectorUpdateNativeRequest.ts
@@ -20,7 +20,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Updates the is_native flag in the connector document
+ * Update the connector is_native flag.
  * @rest_spec_name connector.update_native
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/update_pipeline/ConnectorUpdatePipelineRequest.ts
+++ b/specification/connector/update_pipeline/ConnectorUpdatePipelineRequest.ts
@@ -21,7 +21,9 @@ import { Id } from '@_types/common'
 import { IngestPipelineParams } from '../_types/Connector'
 
 /**
- * Updates the pipeline field in the connector document
+ * Update the connector pipeline.
+ *
+ * When you create a new connector, the configuration of an ingest pipeline is populated with default settings.
  * @rest_spec_name connector.update_pipeline
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/update_scheduling/ConnectorUpdateSchedulingRequest.ts
+++ b/specification/connector/update_scheduling/ConnectorUpdateSchedulingRequest.ts
@@ -21,7 +21,7 @@ import { Id } from '@_types/common'
 import { SchedulingConfiguration } from '../_types/Connector'
 
 /**
- * Updates the scheduling field in the connector document
+ * Update the connector scheduling.
  * @rest_spec_name connector.update_scheduling
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/update_service_type/ConnectorUpdateServiceTypeRequest.ts
+++ b/specification/connector/update_service_type/ConnectorUpdateServiceTypeRequest.ts
@@ -20,7 +20,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Updates the service type of the connector
+ * Update the connector service type.
  * @rest_spec_name connector.update_service_type
  * @availability stack since=8.12.0 stability=beta
  * @availability serverless stability=beta visibility=public

--- a/specification/connector/update_status/ConnectorUpdateStatusRequest.ts
+++ b/specification/connector/update_status/ConnectorUpdateStatusRequest.ts
@@ -21,7 +21,7 @@ import { Id } from '@_types/common'
 import { ConnectorStatus } from '../_types/Connector'
 
 /**
- * Updates the status of the connector
+ * Update the connector status.
  * @rest_spec_name connector.update_status
  * @availability stack since=8.12.0 stability=experimental
  * @availability serverless stability=experimental visibility=public


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR updates the operation summaries and a few operation descriptions with content copied from https://www.elastic.co/guide/en/elasticsearch/reference/master/connector-apis.html

NOTE: I didn't see a difference in the old docs between the "update filtering" and "update active filtering", so I left the text as-is in the latter.