### PR TITLE
[OpenAPI] Edit mget, multi term vectors, and terms enum APIs

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -55,8 +55,6 @@ actions:
           externalDocs:
             description: Reading and writing documents
             url: https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-replication.html
-        - name: mget
-          x-displayName: Document - Multi get
         - name: mtermvectors
           x-displayName: Document - Multi term vectors
         - name: delete_by_query_rethrottle

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -55,8 +55,6 @@ actions:
           externalDocs:
             description: Reading and writing documents
             url: https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-replication.html
-        - name: mtermvectors
-          x-displayName: Document - Multi term vectors
         - name: delete_by_query_rethrottle
           x-displayName: Document - Rethrottle delete by query
         - name: update_by_query_rethrottle

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -55,10 +55,6 @@ actions:
           externalDocs:
             description: Reading and writing documents
             url: https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-replication.html
-        - name: delete_by_query_rethrottle
-          x-displayName: Document - Rethrottle delete by query
-        - name: update_by_query_rethrottle
-          x-displayName: Document - Rethrottle update by query
       # E  
         - name: enrich
           x-displayName: Enrich

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -22678,9 +22678,10 @@
     "/_mtermvectors": {
       "get": {
         "tags": [
-          "mtermvectors"
+          "document"
         ],
-        "summary": "Returns multiple termvectors in one request",
+        "summary": "Get multiple term vectors",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors",
         "parameters": [
           {
@@ -22731,9 +22732,10 @@
       },
       "post": {
         "tags": [
-          "mtermvectors"
+          "document"
         ],
-        "summary": "Returns multiple termvectors in one request",
+        "summary": "Get multiple term vectors",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-1",
         "parameters": [
           {
@@ -22786,9 +22788,10 @@
     "/{index}/_mtermvectors": {
       "get": {
         "tags": [
-          "mtermvectors"
+          "document"
         ],
-        "summary": "Returns multiple termvectors in one request",
+        "summary": "Get multiple term vectors",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-2",
         "parameters": [
           {
@@ -22842,9 +22845,10 @@
       },
       "post": {
         "tags": [
-          "mtermvectors"
+          "document"
         ],
-        "summary": "Returns multiple termvectors in one request",
+        "summary": "Get multiple term vectors",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -15904,9 +15904,10 @@
     "/_mget": {
       "get": {
         "tags": [
-          "mget"
+          "document"
         ],
-        "summary": "Allows to get multiple documents in one request",
+        "summary": "Get multiple documents",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
         "operationId": "mget",
         "parameters": [
           {
@@ -15949,9 +15950,10 @@
       },
       "post": {
         "tags": [
-          "mget"
+          "document"
         ],
-        "summary": "Allows to get multiple documents in one request",
+        "summary": "Get multiple documents",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
         "operationId": "mget-1",
         "parameters": [
           {
@@ -15996,9 +15998,10 @@
     "/{index}/_mget": {
       "get": {
         "tags": [
-          "mget"
+          "document"
         ],
-        "summary": "Allows to get multiple documents in one request",
+        "summary": "Get multiple documents",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
         "operationId": "mget-2",
         "parameters": [
           {
@@ -16044,9 +16047,10 @@
       },
       "post": {
         "tags": [
-          "mget"
+          "document"
         ],
-        "summary": "Allows to get multiple documents in one request",
+        "summary": "Get multiple documents",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
         "operationId": "mget-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -6950,9 +6950,10 @@
     "/_delete_by_query/{task_id}/_rethrottle": {
       "post": {
         "tags": [
-          "delete_by_query_rethrottle"
+          "document"
         ],
-        "summary": "Changes the number of requests per second for a particular Delete By Query operation",
+        "summary": "Throttle a delete by query operation",
+        "description": "Change the number of requests per second for a particular delete by query operation.\nRethrottling that speeds up the query takes effect immediately but rethrotting that slows down the query takes effect after completing the current batch to prevent scroll timeouts.",
         "operationId": "delete-by-query-rethrottle",
         "parameters": [
           {
@@ -24508,7 +24509,8 @@
         "tags": [
           "document"
         ],
-        "summary": "Copies documents from a source to a destination",
+        "summary": "Throttle a reindex operation",
+        "description": "Change the number of requests per second for a particular reindex operation.",
         "operationId": "reindex-rethrottle",
         "parameters": [
           {
@@ -34864,9 +34866,10 @@
     "/_update_by_query/{task_id}/_rethrottle": {
       "post": {
         "tags": [
-          "update_by_query_rethrottle"
+          "document"
         ],
-        "summary": "Changes the number of requests per second for a particular Update By Query operation",
+        "summary": "Throttle an update by query operation",
+        "description": "Change the number of requests per second for a particular update by query operation.\nRethrottling that speeds up the query takes effect immediately but rethrotting that slows down the query takes effect after completing the current batch to prevent scroll timeouts.",
         "operationId": "update-by-query-rethrottle",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -22681,7 +22681,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors",
         "parameters": [
           {
@@ -22735,7 +22735,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-1",
         "parameters": [
           {
@@ -22791,7 +22791,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-2",
         "parameters": [
           {
@@ -22848,7 +22848,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -14007,9 +14007,10 @@
     "/_mtermvectors": {
       "get": {
         "tags": [
-          "mtermvectors"
+          "document"
         ],
-        "summary": "Returns multiple termvectors in one request",
+        "summary": "Get multiple term vectors",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors",
         "parameters": [
           {
@@ -14060,9 +14061,10 @@
       },
       "post": {
         "tags": [
-          "mtermvectors"
+          "document"
         ],
-        "summary": "Returns multiple termvectors in one request",
+        "summary": "Get multiple term vectors",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-1",
         "parameters": [
           {
@@ -14115,9 +14117,10 @@
     "/{index}/_mtermvectors": {
       "get": {
         "tags": [
-          "mtermvectors"
+          "document"
         ],
-        "summary": "Returns multiple termvectors in one request",
+        "summary": "Get multiple term vectors",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-2",
         "parameters": [
           {
@@ -14171,9 +14174,10 @@
       },
       "post": {
         "tags": [
-          "mtermvectors"
+          "document"
         ],
-        "summary": "Returns multiple termvectors in one request",
+        "summary": "Get multiple term vectors",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -14010,7 +14010,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors",
         "parameters": [
           {
@@ -14064,7 +14064,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-1",
         "parameters": [
           {
@@ -14120,7 +14120,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-2",
         "parameters": [
           {
@@ -14177,7 +14177,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -9234,9 +9234,10 @@
     "/_mget": {
       "get": {
         "tags": [
-          "mget"
+          "document"
         ],
-        "summary": "Allows to get multiple documents in one request",
+        "summary": "Get multiple documents",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
         "operationId": "mget",
         "parameters": [
           {
@@ -9276,9 +9277,10 @@
       },
       "post": {
         "tags": [
-          "mget"
+          "document"
         ],
-        "summary": "Allows to get multiple documents in one request",
+        "summary": "Get multiple documents",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
         "operationId": "mget-1",
         "parameters": [
           {
@@ -9320,9 +9322,10 @@
     "/{index}/_mget": {
       "get": {
         "tags": [
-          "mget"
+          "document"
         ],
-        "summary": "Allows to get multiple documents in one request",
+        "summary": "Get multiple documents",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
         "operationId": "mget-2",
         "parameters": [
           {
@@ -9365,9 +9368,10 @@
       },
       "post": {
         "tags": [
-          "mget"
+          "document"
         ],
-        "summary": "Allows to get multiple documents in one request",
+        "summary": "Get multiple documents",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
         "operationId": "mget-3",
         "parameters": [
           {

--- a/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
+++ b/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
@@ -22,9 +22,14 @@ import { TaskId } from '@_types/common'
 import { float } from '@_types/Numeric'
 
 /**
+ * Throttle a delete by query operation.
+ *
+ * Change the number of requests per second for a particular delete by query operation.
+ * Rethrottling that speeds up the query takes effect immediately but rethrotting that slows down the query takes effect after completing the current batch to prevent scroll timeouts.
  * @rest_spec_name delete_by_query_rethrottle
  * @availability stack since=6.5.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @doc_tag document
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -24,7 +24,7 @@ import { Operation } from './types'
 
 /**
  * Get multiple documents.
- * 
+ *
  * Get multiple JSON documents by ID from one or more indices.
  * If you specify an index in the request URI, you only need to specify the document IDs in the request body.
  * To ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -23,10 +23,16 @@ import { Fields, Ids, IndexName, Routing } from '@_types/common'
 import { Operation } from './types'
 
 /**
+ * Get multiple documents.
+ * 
+ * Get multiple JSON documents by ID from one or more indices.
+ * If you specify an index in the request URI, you only need to specify the document IDs in the request body.
+ * To ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.
  * @rest_spec_name mget
  * @availability stack since=1.3.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @index_privileges read
+ * @doc_tag document
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
+++ b/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
@@ -31,7 +31,6 @@ import { Operation } from './types'
 /**
  * Get multiple term vectors.
  *
- * Get multiple term vectors with a single request.
  * You can specify existing documents by index and ID or provide artificial documents in the body of the request.
  * You can specify the index in the request body or request URI.
  * The response contains a `docs` array with all the fetched termvectors.

--- a/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
+++ b/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
@@ -29,9 +29,17 @@ import {
 import { Operation } from './types'
 
 /**
+ * Get multiple term vectors.
+ *
+ * Get multiple term vectors with a single request.
+ * You can specify existing documents by index and ID or provide artificial documents in the body of the request.
+ * You can specify the index in the request body or request URI.
+ * The response contains a `docs` array with all the fetched termvectors.
+ * Each element has the structure provided by the termvectors API.
  * @rest_spec_name mtermvectors
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_tag document
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/reindex_rethrottle/ReindexRethrottleRequest.ts
+++ b/specification/_global/reindex_rethrottle/ReindexRethrottleRequest.ts
@@ -22,7 +22,9 @@ import { Id } from '@_types/common'
 import { float } from '@_types/Numeric'
 
 /**
- * Copies documents from a source to a destination.
+ * Throttle a reindex operation.
+ *
+ * Change the number of requests per second for a particular reindex operation.
  * @rest_spec_name reindex_rethrottle
  * @availability stack since=2.4.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/_global/update_by_query_rethrottle/UpdateByQueryRethrottleRequest.ts
+++ b/specification/_global/update_by_query_rethrottle/UpdateByQueryRethrottleRequest.ts
@@ -22,9 +22,14 @@ import { Id } from '@_types/common'
 import { float } from '@_types/Numeric'
 
 /**
+ * Throttle an update by query operation.
+ *
+ * Change the number of requests per second for a particular update by query operation.
+ * Rethrottling that speeds up the query takes effect immediately but rethrotting that slows down the query takes effect after completing the current batch to prevent scroll timeouts.
  * @rest_spec_name update_by_query_rethrottle
  * @availability stack since=6.5.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @doc_tag document
  */
 export interface Request extends RequestBase {
   path_parts: {


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR adds a summary and description for the mget, multi term vector, and terms enum APIs (copied from https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html,  https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html, and https://www.elastic.co/guide/en/elasticsearch/reference/master/search-terms-enum.html).
It also changes their tags from "mget", "mtermvectors", and "terms_enum" to "search" so that they're grouped with the other document APIs.