### PR TITLE
[OpenAPI] Edit multi search and scroll API

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -181,8 +181,6 @@ actions:
           x-displayName: Script - Get languages
         - name: search
           x-displayName: Search
-        - name: msearch
-          x-displayName: Search - Multi search
         - name: scroll
           x-displayName: Search - Scroll
         - name: terms_enum

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -181,8 +181,6 @@ actions:
           x-displayName: Script - Get languages
         - name: search
           x-displayName: Search
-        - name: terms_enum
-          x-displayName: Search - Terms enum
         - name: search_application
           x-displayName: Search application
         - name: searchable_snapshots

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -181,8 +181,6 @@ actions:
           x-displayName: Script - Get languages
         - name: search
           x-displayName: Search
-        - name: scroll
-          x-displayName: Search - Scroll
         - name: terms_enum
           x-displayName: Search - Terms enum
         - name: search_application

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -32771,10 +32771,10 @@
     "/{index}/_terms_enum": {
       "get": {
         "tags": [
-          "terms_enum"
+          "search"
         ],
-        "summary": "The terms enum API  can be used to discover terms in the index that begin with the provided string",
-        "description": "It is designed for low-latency look-ups used in auto-complete scenarios.",
+        "summary": "Get terms in an index",
+        "description": "Discover terms that match a partial string in an index.\nThis \"terms enum\" API is designed for low-latency look-ups used in auto-complete scenarios.\n\nIf the `complete` property in the response is false, the returned terms set may be incomplete and should be treated as approximate.\nThis can occur due to a few reasons, such as a request timeout or a node error.\n\nNOTE: The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.",
         "operationId": "terms-enum",
         "parameters": [
           {
@@ -32793,10 +32793,10 @@
       },
       "post": {
         "tags": [
-          "terms_enum"
+          "search"
         ],
-        "summary": "The terms enum API  can be used to discover terms in the index that begin with the provided string",
-        "description": "It is designed for low-latency look-ups used in auto-complete scenarios.",
+        "summary": "Get terms in an index",
+        "description": "Discover terms that match a partial string in an index.\nThis \"terms enum\" API is designed for low-latency look-ups used in auto-complete scenarios.\n\nIf the `complete` property in the response is false, the returned terms set may be incomplete and should be treated as approximate.\nThis can occur due to a few reasons, such as a request timeout or a node error.\n\nNOTE: The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.",
         "operationId": "terms-enum-1",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -22294,9 +22294,10 @@
     "/_msearch": {
       "get": {
         "tags": [
-          "msearch"
+          "search"
         ],
-        "summary": "Allows to execute several search operations in one request",
+        "summary": "Run multiple searches",
+        "description": "The format of the request is similar to the bulk API format and makes use of the newline delimited JSON (NDJSON) format.\nThe structure is as follows:\n\n```\nheader\\n\nbody\\n\nheader\\n\nbody\\n\n```\n\nThis structure is specifically optimized to reduce parsing if a specific search ends up redirected to another node.\n\nIMPORTANT: The final line of data must end with a newline character `\\n`.\nEach newline character may be preceded by a carriage return `\\r`.\nWhen sending requests to this endpoint the `Content-Type` header should be set to `application/x-ndjson`.",
         "operationId": "msearch",
         "parameters": [
           {
@@ -22351,9 +22352,10 @@
       },
       "post": {
         "tags": [
-          "msearch"
+          "search"
         ],
-        "summary": "Allows to execute several search operations in one request",
+        "summary": "Run multiple searches",
+        "description": "The format of the request is similar to the bulk API format and makes use of the newline delimited JSON (NDJSON) format.\nThe structure is as follows:\n\n```\nheader\\n\nbody\\n\nheader\\n\nbody\\n\n```\n\nThis structure is specifically optimized to reduce parsing if a specific search ends up redirected to another node.\n\nIMPORTANT: The final line of data must end with a newline character `\\n`.\nEach newline character may be preceded by a carriage return `\\r`.\nWhen sending requests to this endpoint the `Content-Type` header should be set to `application/x-ndjson`.",
         "operationId": "msearch-1",
         "parameters": [
           {
@@ -22410,9 +22412,10 @@
     "/{index}/_msearch": {
       "get": {
         "tags": [
-          "msearch"
+          "search"
         ],
-        "summary": "Allows to execute several search operations in one request",
+        "summary": "Run multiple searches",
+        "description": "The format of the request is similar to the bulk API format and makes use of the newline delimited JSON (NDJSON) format.\nThe structure is as follows:\n\n```\nheader\\n\nbody\\n\nheader\\n\nbody\\n\n```\n\nThis structure is specifically optimized to reduce parsing if a specific search ends up redirected to another node.\n\nIMPORTANT: The final line of data must end with a newline character `\\n`.\nEach newline character may be preceded by a carriage return `\\r`.\nWhen sending requests to this endpoint the `Content-Type` header should be set to `application/x-ndjson`.",
         "operationId": "msearch-2",
         "parameters": [
           {
@@ -22470,9 +22473,10 @@
       },
       "post": {
         "tags": [
-          "msearch"
+          "search"
         ],
-        "summary": "Allows to execute several search operations in one request",
+        "summary": "Run multiple searches",
+        "description": "The format of the request is similar to the bulk API format and makes use of the newline delimited JSON (NDJSON) format.\nThe structure is as follows:\n\n```\nheader\\n\nbody\\n\nheader\\n\nbody\\n\n```\n\nThis structure is specifically optimized to reduce parsing if a specific search ends up redirected to another node.\n\nIMPORTANT: The final line of data must end with a newline character `\\n`.\nEach newline character may be preceded by a carriage return `\\r`.\nWhen sending requests to this endpoint the `Content-Type` header should be set to `application/x-ndjson`.",
         "operationId": "msearch-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -2750,9 +2750,13 @@
     "/_search/scroll": {
       "get": {
         "tags": [
-          "scroll"
+          "search"
         ],
-        "summary": "Allows to retrieve a large numbers of results from a single search request",
+        "summary": "Run a scrolling search",
+        "description": "IMPORTANT: The scroll API is no longer recommend for deep pagination. If you need to preserve the index state while paging through more than 10,000 hits, use the `search_after` parameter with a point in time (PIT).\n\nThe scroll API gets large sets of results from a single scrolling search request.\nTo get the necessary scroll ID, submit a search API request that includes an argument for the `scroll` query parameter.\nThe `scroll` parameter indicates how long Elasticsearch should retain the search context for the request.\nThe search response returns a scroll ID in the `_scroll_id` response body parameter.\nYou can then use the scroll ID with the scroll API to retrieve the next batch of results for the request.\nIf the Elasticsearch security features are enabled, the access to the results of a specific scroll ID is restricted to the user or API key that submitted the search.\n\nYou can also use the scroll API to specify a new scroll parameter that extends or shortens the retention period for the search context.\n\nIMPORTANT: Results from a scrolling search reflect the state of the index at the time of the initial search request. Subsequent indexing or document changes only affect later search and scroll requests.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results"
+        },
         "operationId": "scroll",
         "parameters": [
           {
@@ -2776,9 +2780,13 @@
       },
       "post": {
         "tags": [
-          "scroll"
+          "search"
         ],
-        "summary": "Allows to retrieve a large numbers of results from a single search request",
+        "summary": "Run a scrolling search",
+        "description": "IMPORTANT: The scroll API is no longer recommend for deep pagination. If you need to preserve the index state while paging through more than 10,000 hits, use the `search_after` parameter with a point in time (PIT).\n\nThe scroll API gets large sets of results from a single scrolling search request.\nTo get the necessary scroll ID, submit a search API request that includes an argument for the `scroll` query parameter.\nThe `scroll` parameter indicates how long Elasticsearch should retain the search context for the request.\nThe search response returns a scroll ID in the `_scroll_id` response body parameter.\nYou can then use the scroll ID with the scroll API to retrieve the next batch of results for the request.\nIf the Elasticsearch security features are enabled, the access to the results of a specific scroll ID is restricted to the user or API key that submitted the search.\n\nYou can also use the scroll API to specify a new scroll parameter that extends or shortens the retention period for the search context.\n\nIMPORTANT: Results from a scrolling search reflect the state of the index at the time of the initial search request. Subsequent indexing or document changes only affect later search and scroll requests.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results"
+        },
         "operationId": "scroll-1",
         "parameters": [
           {
@@ -2819,9 +2827,13 @@
     "/_search/scroll/{scroll_id}": {
       "get": {
         "tags": [
-          "scroll"
+          "search"
         ],
-        "summary": "Allows to retrieve a large numbers of results from a single search request",
+        "summary": "Run a scrolling search",
+        "description": "IMPORTANT: The scroll API is no longer recommend for deep pagination. If you need to preserve the index state while paging through more than 10,000 hits, use the `search_after` parameter with a point in time (PIT).\n\nThe scroll API gets large sets of results from a single scrolling search request.\nTo get the necessary scroll ID, submit a search API request that includes an argument for the `scroll` query parameter.\nThe `scroll` parameter indicates how long Elasticsearch should retain the search context for the request.\nThe search response returns a scroll ID in the `_scroll_id` response body parameter.\nYou can then use the scroll ID with the scroll API to retrieve the next batch of results for the request.\nIf the Elasticsearch security features are enabled, the access to the results of a specific scroll ID is restricted to the user or API key that submitted the search.\n\nYou can also use the scroll API to specify a new scroll parameter that extends or shortens the retention period for the search context.\n\nIMPORTANT: Results from a scrolling search reflect the state of the index at the time of the initial search request. Subsequent indexing or document changes only affect later search and scroll requests.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results"
+        },
         "operationId": "scroll-2",
         "parameters": [
           {
@@ -2848,9 +2860,13 @@
       },
       "post": {
         "tags": [
-          "scroll"
+          "search"
         ],
-        "summary": "Allows to retrieve a large numbers of results from a single search request",
+        "summary": "Run a scrolling search",
+        "description": "IMPORTANT: The scroll API is no longer recommend for deep pagination. If you need to preserve the index state while paging through more than 10,000 hits, use the `search_after` parameter with a point in time (PIT).\n\nThe scroll API gets large sets of results from a single scrolling search request.\nTo get the necessary scroll ID, submit a search API request that includes an argument for the `scroll` query parameter.\nThe `scroll` parameter indicates how long Elasticsearch should retain the search context for the request.\nThe search response returns a scroll ID in the `_scroll_id` response body parameter.\nYou can then use the scroll ID with the scroll API to retrieve the next batch of results for the request.\nIf the Elasticsearch security features are enabled, the access to the results of a specific scroll ID is restricted to the user or API key that submitted the search.\n\nYou can also use the scroll API to specify a new scroll parameter that extends or shortens the retention period for the search context.\n\nIMPORTANT: Results from a scrolling search reflect the state of the index at the time of the initial search request. Subsequent indexing or document changes only affect later search and scroll requests.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results"
+        },
         "operationId": "scroll-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -13623,9 +13623,10 @@
     "/_msearch": {
       "get": {
         "tags": [
-          "msearch"
+          "search"
         ],
-        "summary": "Allows to execute several search operations in one request",
+        "summary": "Run multiple searches",
+        "description": "The format of the request is similar to the bulk API format and makes use of the newline delimited JSON (NDJSON) format.\nThe structure is as follows:\n\n```\nheader\\n\nbody\\n\nheader\\n\nbody\\n\n```\n\nThis structure is specifically optimized to reduce parsing if a specific search ends up redirected to another node.\n\nIMPORTANT: The final line of data must end with a newline character `\\n`.\nEach newline character may be preceded by a carriage return `\\r`.\nWhen sending requests to this endpoint the `Content-Type` header should be set to `application/x-ndjson`.",
         "operationId": "msearch",
         "parameters": [
           {
@@ -13680,9 +13681,10 @@
       },
       "post": {
         "tags": [
-          "msearch"
+          "search"
         ],
-        "summary": "Allows to execute several search operations in one request",
+        "summary": "Run multiple searches",
+        "description": "The format of the request is similar to the bulk API format and makes use of the newline delimited JSON (NDJSON) format.\nThe structure is as follows:\n\n```\nheader\\n\nbody\\n\nheader\\n\nbody\\n\n```\n\nThis structure is specifically optimized to reduce parsing if a specific search ends up redirected to another node.\n\nIMPORTANT: The final line of data must end with a newline character `\\n`.\nEach newline character may be preceded by a carriage return `\\r`.\nWhen sending requests to this endpoint the `Content-Type` header should be set to `application/x-ndjson`.",
         "operationId": "msearch-1",
         "parameters": [
           {
@@ -13739,9 +13741,10 @@
     "/{index}/_msearch": {
       "get": {
         "tags": [
-          "msearch"
+          "search"
         ],
-        "summary": "Allows to execute several search operations in one request",
+        "summary": "Run multiple searches",
+        "description": "The format of the request is similar to the bulk API format and makes use of the newline delimited JSON (NDJSON) format.\nThe structure is as follows:\n\n```\nheader\\n\nbody\\n\nheader\\n\nbody\\n\n```\n\nThis structure is specifically optimized to reduce parsing if a specific search ends up redirected to another node.\n\nIMPORTANT: The final line of data must end with a newline character `\\n`.\nEach newline character may be preceded by a carriage return `\\r`.\nWhen sending requests to this endpoint the `Content-Type` header should be set to `application/x-ndjson`.",
         "operationId": "msearch-2",
         "parameters": [
           {
@@ -13799,9 +13802,10 @@
       },
       "post": {
         "tags": [
-          "msearch"
+          "search"
         ],
-        "summary": "Allows to execute several search operations in one request",
+        "summary": "Run multiple searches",
+        "description": "The format of the request is similar to the bulk API format and makes use of the newline delimited JSON (NDJSON) format.\nThe structure is as follows:\n\n```\nheader\\n\nbody\\n\nheader\\n\nbody\\n\n```\n\nThis structure is specifically optimized to reduce parsing if a specific search ends up redirected to another node.\n\nIMPORTANT: The final line of data must end with a newline character `\\n`.\nEach newline character may be preceded by a carriage return `\\r`.\nWhen sending requests to this endpoint the `Content-Type` header should be set to `application/x-ndjson`.",
         "operationId": "msearch-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -18081,10 +18081,10 @@
     "/{index}/_terms_enum": {
       "get": {
         "tags": [
-          "terms_enum"
+          "search"
         ],
-        "summary": "The terms enum API  can be used to discover terms in the index that begin with the provided string",
-        "description": "It is designed for low-latency look-ups used in auto-complete scenarios.",
+        "summary": "Get terms in an index",
+        "description": "Discover terms that match a partial string in an index.\nThis \"terms enum\" API is designed for low-latency look-ups used in auto-complete scenarios.\n\nIf the `complete` property in the response is false, the returned terms set may be incomplete and should be treated as approximate.\nThis can occur due to a few reasons, such as a request timeout or a node error.\n\nNOTE: The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.",
         "operationId": "terms-enum",
         "parameters": [
           {
@@ -18103,10 +18103,10 @@
       },
       "post": {
         "tags": [
-          "terms_enum"
+          "search"
         ],
-        "summary": "The terms enum API  can be used to discover terms in the index that begin with the provided string",
-        "description": "It is designed for low-latency look-ups used in auto-complete scenarios.",
+        "summary": "Get terms in an index",
+        "description": "Discover terms that match a partial string in an index.\nThis \"terms enum\" API is designed for low-latency look-ups used in auto-complete scenarios.\n\nIf the `complete` property in the response is false, the returned terms set may be incomplete and should be treated as approximate.\nThis can occur due to a few reasons, such as a request timeout or a node error.\n\nNOTE: The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.",
         "operationId": "terms-enum-1",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -1223,9 +1223,13 @@
     "/_search/scroll": {
       "get": {
         "tags": [
-          "scroll"
+          "search"
         ],
-        "summary": "Allows to retrieve a large numbers of results from a single search request",
+        "summary": "Run a scrolling search",
+        "description": "IMPORTANT: The scroll API is no longer recommend for deep pagination. If you need to preserve the index state while paging through more than 10,000 hits, use the `search_after` parameter with a point in time (PIT).\n\nThe scroll API gets large sets of results from a single scrolling search request.\nTo get the necessary scroll ID, submit a search API request that includes an argument for the `scroll` query parameter.\nThe `scroll` parameter indicates how long Elasticsearch should retain the search context for the request.\nThe search response returns a scroll ID in the `_scroll_id` response body parameter.\nYou can then use the scroll ID with the scroll API to retrieve the next batch of results for the request.\nIf the Elasticsearch security features are enabled, the access to the results of a specific scroll ID is restricted to the user or API key that submitted the search.\n\nYou can also use the scroll API to specify a new scroll parameter that extends or shortens the retention period for the search context.\n\nIMPORTANT: Results from a scrolling search reflect the state of the index at the time of the initial search request. Subsequent indexing or document changes only affect later search and scroll requests.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results"
+        },
         "operationId": "scroll",
         "parameters": [
           {
@@ -1249,9 +1253,13 @@
       },
       "post": {
         "tags": [
-          "scroll"
+          "search"
         ],
-        "summary": "Allows to retrieve a large numbers of results from a single search request",
+        "summary": "Run a scrolling search",
+        "description": "IMPORTANT: The scroll API is no longer recommend for deep pagination. If you need to preserve the index state while paging through more than 10,000 hits, use the `search_after` parameter with a point in time (PIT).\n\nThe scroll API gets large sets of results from a single scrolling search request.\nTo get the necessary scroll ID, submit a search API request that includes an argument for the `scroll` query parameter.\nThe `scroll` parameter indicates how long Elasticsearch should retain the search context for the request.\nThe search response returns a scroll ID in the `_scroll_id` response body parameter.\nYou can then use the scroll ID with the scroll API to retrieve the next batch of results for the request.\nIf the Elasticsearch security features are enabled, the access to the results of a specific scroll ID is restricted to the user or API key that submitted the search.\n\nYou can also use the scroll API to specify a new scroll parameter that extends or shortens the retention period for the search context.\n\nIMPORTANT: Results from a scrolling search reflect the state of the index at the time of the initial search request. Subsequent indexing or document changes only affect later search and scroll requests.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results"
+        },
         "operationId": "scroll-1",
         "parameters": [
           {
@@ -1292,9 +1300,13 @@
     "/_search/scroll/{scroll_id}": {
       "get": {
         "tags": [
-          "scroll"
+          "search"
         ],
-        "summary": "Allows to retrieve a large numbers of results from a single search request",
+        "summary": "Run a scrolling search",
+        "description": "IMPORTANT: The scroll API is no longer recommend for deep pagination. If you need to preserve the index state while paging through more than 10,000 hits, use the `search_after` parameter with a point in time (PIT).\n\nThe scroll API gets large sets of results from a single scrolling search request.\nTo get the necessary scroll ID, submit a search API request that includes an argument for the `scroll` query parameter.\nThe `scroll` parameter indicates how long Elasticsearch should retain the search context for the request.\nThe search response returns a scroll ID in the `_scroll_id` response body parameter.\nYou can then use the scroll ID with the scroll API to retrieve the next batch of results for the request.\nIf the Elasticsearch security features are enabled, the access to the results of a specific scroll ID is restricted to the user or API key that submitted the search.\n\nYou can also use the scroll API to specify a new scroll parameter that extends or shortens the retention period for the search context.\n\nIMPORTANT: Results from a scrolling search reflect the state of the index at the time of the initial search request. Subsequent indexing or document changes only affect later search and scroll requests.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results"
+        },
         "operationId": "scroll-2",
         "parameters": [
           {
@@ -1321,9 +1333,13 @@
       },
       "post": {
         "tags": [
-          "scroll"
+          "search"
         ],
-        "summary": "Allows to retrieve a large numbers of results from a single search request",
+        "summary": "Run a scrolling search",
+        "description": "IMPORTANT: The scroll API is no longer recommend for deep pagination. If you need to preserve the index state while paging through more than 10,000 hits, use the `search_after` parameter with a point in time (PIT).\n\nThe scroll API gets large sets of results from a single scrolling search request.\nTo get the necessary scroll ID, submit a search API request that includes an argument for the `scroll` query parameter.\nThe `scroll` parameter indicates how long Elasticsearch should retain the search context for the request.\nThe search response returns a scroll ID in the `_scroll_id` response body parameter.\nYou can then use the scroll ID with the scroll API to retrieve the next batch of results for the request.\nIf the Elasticsearch security features are enabled, the access to the results of a specific scroll ID is restricted to the user or API key that submitted the search.\n\nYou can also use the scroll API to specify a new scroll parameter that extends or shortens the retention period for the search context.\n\nIMPORTANT: Results from a scrolling search reflect the state of the index at the time of the initial search request. Subsequent indexing or document changes only affect later search and scroll requests.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#scroll-search-results"
+        },
         "operationId": "scroll-3",
         "parameters": [
           {

--- a/specification/_global/msearch/MultiSearchRequest.ts
+++ b/specification/_global/msearch/MultiSearchRequest.ts
@@ -23,10 +23,28 @@ import { long } from '@_types/Numeric'
 import { RequestItem } from './types'
 
 /**
+ * Run multiple searches.
+ *
+ * The format of the request is similar to the bulk API format and makes use of the newline delimited JSON (NDJSON) format.
+ * The structure is as follows:
+ *
+ * ```
+ * header\n
+ * body\n
+ * header\n
+ * body\n
+ * ```
+ *
+ * This structure is specifically optimized to reduce parsing if a specific search ends up redirected to another node.
+ *
+ * IMPORTANT: The final line of data must end with a newline character `\n`.
+ * Each newline character may be preceded by a carriage return `\r`.
+ * When sending requests to this endpoint the `Content-Type` header should be set to `application/x-ndjson`.
  * @rest_spec_name msearch
  * @availability stack since=1.3.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @index_privileges read
+ * @doc_tag search
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/scroll/ScrollRequest.ts
+++ b/specification/_global/scroll/ScrollRequest.ts
@@ -22,9 +22,25 @@ import { ScrollId } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Run a scrolling search.
+ *
+ * IMPORTANT: The scroll API is no longer recommend for deep pagination. If you need to preserve the index state while paging through more than 10,000 hits, use the `search_after` parameter with a point in time (PIT).
+ *
+ * The scroll API gets large sets of results from a single scrolling search request.
+ * To get the necessary scroll ID, submit a search API request that includes an argument for the `scroll` query parameter.
+ * The `scroll` parameter indicates how long Elasticsearch should retain the search context for the request.
+ * The search response returns a scroll ID in the `_scroll_id` response body parameter.
+ * You can then use the scroll ID with the scroll API to retrieve the next batch of results for the request.
+ * If the Elasticsearch security features are enabled, the access to the results of a specific scroll ID is restricted to the user or API key that submitted the search.
+ *
+ * You can also use the scroll API to specify a new scroll parameter that extends or shortens the retention period for the search context.
+ *
+ * IMPORTANT: Results from a scrolling search reflect the state of the index at the time of the initial search request. Subsequent indexing or document changes only affect later search and scroll requests.
  * @rest_spec_name scroll
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_tag search
+ * @ext_doc_id scroll-search-results
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/terms_enum/TermsEnumRequest.ts
+++ b/specification/_global/terms_enum/TermsEnumRequest.ts
@@ -24,9 +24,19 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Duration } from '@_types/Time'
 
 /**
+ * Get terms in an index.
+ *
+ * Discover terms that match a partial string in an index.
+ * This "terms enum" API is designed for low-latency look-ups used in auto-complete scenarios.
+ *
+ * If the `complete` property in the response is false, the returned terms set may be incomplete and should be treated as approximate.
+ * This can occur due to a few reasons, such as a request timeout or a node error.
+ *
+ * NOTE: The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.
  * @rest_spec_name terms_enum
  * @availability stack since=7.14.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_tag search
  */
 export interface Request extends RequestBase {
   path_parts: {


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR adds a summary and description for the multi search and scroll APIs (copied from https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html and https://www.elastic.co/guide/en/elasticsearch/reference/current/scroll-api.html).
It also changes their tags from "msearch" and "scroll" to "search" so that they're grouped with the other search APIs.