### PR TITLE
[OpenAPI] Edit script language and context APIs

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -175,10 +175,6 @@ actions:
       # S
         - name: script
           x-displayName: Script
-        - name: get_script_context
-          x-displayName: Script - Get contexts
-        - name: get_script_languages
-          x-displayName: Script - Get languages
         - name: search
           x-displayName: Search
         - name: msearch

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -9025,9 +9025,10 @@
     "/_script_context": {
       "get": {
         "tags": [
-          "get_script_context"
+          "script"
         ],
-        "summary": "Returns all script contexts",
+        "summary": "Get script contexts",
+        "description": "Get a list of supported script contexts and their methods.",
         "operationId": "get-script-context",
         "responses": {
           "200": {
@@ -9057,9 +9058,10 @@
     "/_script_language": {
       "get": {
         "tags": [
-          "get_script_languages"
+          "script"
         ],
-        "summary": "Returns available script types, languages and contexts",
+        "summary": "Get script languages",
+        "description": "Get a list of available script types, languages, and contexts.",
         "operationId": "get-script-languages",
         "responses": {
           "200": {

--- a/specification/_global/get_script_context/GetScriptContextRequest.ts
+++ b/specification/_global/get_script_context/GetScriptContextRequest.ts
@@ -20,7 +20,11 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Get script contexts.
+ *
+ * Get a list of supported script contexts and their methods.
  * @rest_spec_name get_script_context
  * @availability stack stability=stable
+ * @doc_tag script
  */
 export interface Request extends RequestBase {}

--- a/specification/_global/get_script_languages/GetScriptLanguagesRequest.ts
+++ b/specification/_global/get_script_languages/GetScriptLanguagesRequest.ts
@@ -20,7 +20,11 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Get script languages.
+ *
+ * Get a list of available script types, languages, and contexts.
  * @rest_spec_name get_script_languages
  * @availability stack stability=stable
+ * @doc_tag script
  */
 export interface Request extends RequestBase {}


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR updates the tags and summaries for the get script language and context APIs (copied from https://www.elastic.co/guide/en/elasticsearch/reference/master/get-script-languages-api.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/get-script-contexts-api.html).
It also adds the `@doc_tag` property so that the APIs are grouped with the other script APIs.