### PR TITLE
[OpenAPI] Edits dangling index APIs

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -99,8 +99,6 @@ actions:
           x-displayName: Index
           description: >
             Index APIs enable you to manage individual indices, index settings, aliases, mappings, and index templates.
-        - name: dangling_indices
-          x-displayName: Index - Import dangling index
         - name: ilm
           x-displayName: Index lifecycle management
           externalDocs:

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -5846,15 +5846,16 @@
     "/_dangling/{index_uuid}": {
       "post": {
         "tags": [
-          "dangling_indices"
+          "indices"
         ],
-        "summary": "Imports the specified dangling index",
+        "summary": "Import a dangling index",
+        "description": "If Elasticsearch encounters index data that is absent from the current cluster state, those indices are considered to be dangling.\nFor example, this can happen if you delete more than `cluster.indices.tombstones.size` indices while an Elasticsearch node is offline.",
         "operationId": "dangling-indices-import-dangling-index",
         "parameters": [
           {
             "in": "path",
             "name": "index_uuid",
-            "description": "The UUID of the dangling index",
+            "description": "The UUID of the index to import. Use the get dangling indices API to locate the UUID.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -5865,7 +5866,7 @@
           {
             "in": "query",
             "name": "accept_data_loss",
-            "description": "Must be set to true in order to import the dangling index",
+            "description": "This parameter must be set to true to import a dangling index.\nBecause Elasticsearch cannot know where the dangling index data came from or determine which shard copies are fresh and which are stale, it cannot guarantee that the imported data represents the latest state of the index when it was last in the cluster.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -5910,15 +5911,16 @@
       },
       "delete": {
         "tags": [
-          "dangling_indices"
+          "indices"
         ],
-        "summary": "Deletes the specified dangling index",
+        "summary": "Delete a dangling index",
+        "description": "If Elasticsearch encounters index data that is absent from the current cluster state, those indices are considered to be dangling.\nFor example, this can happen if you delete more than `cluster.indices.tombstones.size` indices while an Elasticsearch node is offline.",
         "operationId": "dangling-indices-delete-dangling-index",
         "parameters": [
           {
             "in": "path",
             "name": "index_uuid",
-            "description": "The UUID of the dangling index",
+            "description": "The UUID of the index to delete. Use the get dangling indices API to find the UUID.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -5929,7 +5931,7 @@
           {
             "in": "query",
             "name": "accept_data_loss",
-            "description": "Must be set to true in order to delete the dangling index",
+            "description": "This parameter must be set to true to acknowledge that it will no longer be possible to recove data from the dangling index.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -5976,9 +5978,10 @@
     "/_dangling": {
       "get": {
         "tags": [
-          "dangling_indices"
+          "indices"
         ],
-        "summary": "Returns all dangling indices",
+        "summary": "Get the dangling indices",
+        "description": "If Elasticsearch encounters index data that is absent from the current cluster state, those indices are considered to be dangling.\nFor example, this can happen if you delete more than `cluster.indices.tombstones.size` indices while an Elasticsearch node is offline.\n\nUse this API to list dangling indices, which you can then import or delete.",
         "operationId": "dangling-indices-list-dangling-indices",
         "responses": {
           "200": {

--- a/specification/dangling_indices/delete_dangling_index/DeleteDanglingIndexRequest.ts
+++ b/specification/dangling_indices/delete_dangling_index/DeleteDanglingIndexRequest.ts
@@ -22,14 +22,25 @@ import { Uuid } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Delete a dangling index.
+ *
+ * If Elasticsearch encounters index data that is absent from the current cluster state, those indices are considered to be dangling.
+ * For example, this can happen if you delete more than `cluster.indices.tombstones.size` indices while an Elasticsearch node is offline.
  * @rest_spec_name dangling_indices.delete_dangling_index
  * @availability stack since=7.9.0 stability=stable
+ * @doc_tag indices
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * The UUID of the index to delete. Use the get dangling indices API to find the UUID.
+     */
     index_uuid: Uuid
   }
   query_parameters: {
+    /**
+     * This parameter must be set to true to acknowledge that it will no longer be possible to recove data from the dangling index.
+     */
     accept_data_loss: boolean
     master_timeout?: Duration
     timeout?: Duration

--- a/specification/dangling_indices/import_dangling_index/ImportDanglingIndexRequest.ts
+++ b/specification/dangling_indices/import_dangling_index/ImportDanglingIndexRequest.ts
@@ -22,14 +22,26 @@ import { Uuid } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Import a dangling index.
+ *
+ * If Elasticsearch encounters index data that is absent from the current cluster state, those indices are considered to be dangling.
+ * For example, this can happen if you delete more than `cluster.indices.tombstones.size` indices while an Elasticsearch node is offline.
  * @rest_spec_name dangling_indices.import_dangling_index
  * @availability stack since=7.9.0 stability=stable
+ * @doc_tag indices
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * The UUID of the index to import. Use the get dangling indices API to locate the UUID.
+     */
     index_uuid: Uuid
   }
   query_parameters: {
+    /**
+     * This parameter must be set to true to import a dangling index.
+     * Because Elasticsearch cannot know where the dangling index data came from or determine which shard copies are fresh and which are stale, it cannot guarantee that the imported data represents the latest state of the index when it was last in the cluster.
+     */
     accept_data_loss: boolean
     master_timeout?: Duration
     timeout?: Duration

--- a/specification/dangling_indices/list_dangling_indices/ListDanglingIndicesRequest.ts
+++ b/specification/dangling_indices/list_dangling_indices/ListDanglingIndicesRequest.ts
@@ -20,7 +20,14 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Get the dangling indices.
+ *
+ * If Elasticsearch encounters index data that is absent from the current cluster state, those indices are considered to be dangling.
+ * For example, this can happen if you delete more than `cluster.indices.tombstones.size` indices while an Elasticsearch node is offline.
+ *
+ * Use this API to list dangling indices, which you can then import or delete.
  * @rest_spec_name dangling_indices.list_dangling_indices
  * @availability stack since=7.9.0 stability=stable
+ * @doc_tag indices
  */
 export interface Request extends RequestBase {}


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR updates the tags and summaries for the dangling indices APIs (copied from https://www.elastic.co/guide/en/elasticsearch/reference/master/dangling-indices-list.html, https://www.elastic.co/guide/en/elasticsearch/reference/master/dangling-index-delete.html, and https://www.elastic.co/guide/en/elasticsearch/reference/master/dangling-index-import.html).
It also adds the @doc_tag property so that the APIs are grouped with the other index APIs.