### PR TITLE
[OpenAPI] Edit SSL certificate API

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -193,8 +193,6 @@ actions:
           x-displayName: Searchable snapshots
         - name: security
           x-displayName: Security
-        - name: ssl
-          x-displayName: Security - SSL
         - name: snapshot
           x-displayName: Snapshot and restore
           description: >

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -32086,9 +32086,10 @@
     "/_ssl/certificates": {
       "get": {
         "tags": [
-          "ssl"
+          "security"
         ],
-        "summary": "Retrieves information about the X.509 certificates used to encrypt communications in the cluster",
+        "summary": "Get SSL certificates",
+        "description": "Get information about the X.509 certificates that are used to encrypt communications in the cluster.\nThe API returns a list that includes certificates from all TLS contexts including:\n\n- Settings for transport and HTTP interfaces\n- TLS settings that are used within authentication realms\n- TLS settings for remote monitoring exporters\n\nThe list includes certificates that are used for configuring trust, such as those configured in the `xpack.security.transport.ssl.truststore` and `xpack.security.transport.ssl.certificate_authorities` settings.\nIt also includes certificates that are used for configuring server identity, such as `xpack.security.http.ssl.keystore` and `xpack.security.http.ssl.certificate settings`.\n\nThe list does not include certificates that are sourced from the default SSL context of the Java Runtime Environment (JRE), even if those certificates are in use within Elasticsearch.\n\nNOTE: When a PKCS#11 token is configured as the truststore of the JRE, the API returns all the certificates that are included in the PKCS#11 token irrespective of whether these are used in the Elasticsearch TLS configuration.\n\nIf Elasticsearch is configured to use a keystore or truststore, the API output includes all certificates in that store, even though some of the certificates might not be in active use within the cluster.",
         "operationId": "ssl-certificates",
         "responses": {
           "200": {

--- a/specification/ssl/certificates/GetCertificatesRequest.ts
+++ b/specification/ssl/certificates/GetCertificatesRequest.ts
@@ -20,8 +20,26 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Get SSL certificates.
+ *
+ * Get information about the X.509 certificates that are used to encrypt communications in the cluster.
+ * The API returns a list that includes certificates from all TLS contexts including:
+ *
+ * - Settings for transport and HTTP interfaces
+ * - TLS settings that are used within authentication realms
+ * - TLS settings for remote monitoring exporters
+ *
+ * The list includes certificates that are used for configuring trust, such as those configured in the `xpack.security.transport.ssl.truststore` and `xpack.security.transport.ssl.certificate_authorities` settings.
+ * It also includes certificates that are used for configuring server identity, such as `xpack.security.http.ssl.keystore` and `xpack.security.http.ssl.certificate settings`.
+ *
+ * The list does not include certificates that are sourced from the default SSL context of the Java Runtime Environment (JRE), even if those certificates are in use within Elasticsearch.
+ *
+ * NOTE: When a PKCS#11 token is configured as the truststore of the JRE, the API returns all the certificates that are included in the PKCS#11 token irrespective of whether these are used in the Elasticsearch TLS configuration.
+ *
+ * If Elasticsearch is configured to use a keystore or truststore, the API output includes all certificates in that store, even though some of the certificates might not be in active use within the cluster.
  * @rest_spec_name ssl.certificates
  * @availability stack since=6.2.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @doc_tag security
  */
 export interface Request extends RequestBase {}


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR adds a summary and description for the SSL certificate API (copied from https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-ssl.html).
It also adds the @doc_tag property so that the API is grouped with the other security APIs.