### PR TITLE
Remove deprecated local parameter from alias APIs

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -10963,9 +10963,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.get_alias#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.get_alias#local"
           }
         ],
         "responses": {
@@ -11083,9 +11080,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.exists_alias#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.exists_alias#local"
           }
         ],
         "responses": {
@@ -11953,9 +11947,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.get_alias#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.get_alias#local"
           }
         ],
         "responses": {
@@ -11983,9 +11974,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.exists_alias#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.exists_alias#local"
           }
         ],
         "responses": {
@@ -12389,9 +12377,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.get_alias#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.get_alias#local"
           }
         ],
         "responses": {
@@ -12421,9 +12406,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.get_alias#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.get_alias#local"
           }
         ],
         "responses": {
@@ -95168,16 +95150,6 @@
         },
         "style": "form"
       },
-      "indices.exists_alias#local": {
-        "in": "query",
-        "name": "local",
-        "description": "If `true`, the request retrieves information from the local node only.",
-        "deprecated": false,
-        "schema": {
-          "type": "boolean"
-        },
-        "style": "form"
-      },
       "indices.flush#index": {
         "in": "path",
         "name": "index",
@@ -95366,16 +95338,6 @@
         "in": "query",
         "name": "ignore_unavailable",
         "description": "If `false`, the request returns an error if it targets a missing or closed index.",
-        "deprecated": false,
-        "schema": {
-          "type": "boolean"
-        },
-        "style": "form"
-      },
-      "indices.get_alias#local": {
-        "in": "query",
-        "name": "local",
-        "description": "If `true`, the request retrieves information from the local node only.",
         "deprecated": false,
         "schema": {
           "type": "boolean"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -6509,9 +6509,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.get_alias#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.get_alias#local"
           }
         ],
         "responses": {
@@ -6629,9 +6626,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.exists_alias#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.exists_alias#local"
           }
         ],
         "responses": {
@@ -6937,9 +6931,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.get_alias#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.get_alias#local"
           }
         ],
         "responses": {
@@ -6967,9 +6958,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.exists_alias#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.exists_alias#local"
           }
         ],
         "responses": {
@@ -7063,9 +7051,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.get_alias#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.get_alias#local"
           }
         ],
         "responses": {
@@ -7095,9 +7080,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.get_alias#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.get_alias#local"
           }
         ],
         "responses": {
@@ -58449,16 +58431,6 @@
         },
         "style": "form"
       },
-      "indices.exists_alias#local": {
-        "in": "query",
-        "name": "local",
-        "description": "If `true`, the request retrieves information from the local node only.",
-        "deprecated": false,
-        "schema": {
-          "type": "boolean"
-        },
-        "style": "form"
-      },
       "indices.get_alias#name": {
         "in": "path",
         "name": "name",
@@ -58505,16 +58477,6 @@
         "in": "query",
         "name": "ignore_unavailable",
         "description": "If `false`, the request returns an error if it targets a missing or closed index.",
-        "deprecated": false,
-        "schema": {
-          "type": "boolean"
-        },
-        "style": "form"
-      },
-      "indices.get_alias#local": {
-        "in": "query",
-        "name": "local",
-        "description": "If `true`, the request retrieves information from the local node only.",
         "deprecated": false,
         "schema": {
           "type": "boolean"

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -20834,22 +20834,9 @@
               "namespace": "_builtins"
             }
           }
-        },
-        {
-          "description": "If `true`, the request retrieves information from the local node only.",
-          "name": "local",
-          "required": false,
-          "serverDefault": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "_builtins"
-            }
-          }
         }
       ],
-      "specLocation": "indices/exists_alias/IndicesExistsAliasRequest.ts#L23-L68"
+      "specLocation": "indices/exists_alias/IndicesExistsAliasRequest.ts#L23-L63"
     },
     {
       "body": {
@@ -21279,22 +21266,9 @@
               "namespace": "_builtins"
             }
           }
-        },
-        {
-          "description": "If `true`, the request retrieves information from the local node only.",
-          "name": "local",
-          "required": false,
-          "serverDefault": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "_builtins"
-            }
-          }
         }
       ],
-      "specLocation": "indices/get_alias/IndicesGetAliasRequest.ts#L23-L71"
+      "specLocation": "indices/get_alias/IndicesGetAliasRequest.ts#L23-L66"
     },
     {
       "body": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -110,7 +110,6 @@
     "cat.aliases": {
       "request": [
         "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",
         "Request: missing json spec query parameter 's'",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11612,7 +11612,6 @@ export interface IndicesExistsAliasRequest extends RequestBase {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
-  local?: boolean
 }
 
 export type IndicesExistsAliasResponse = boolean
@@ -11767,7 +11766,6 @@ export interface IndicesGetAliasRequest extends RequestBase {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
-  local?: boolean
 }
 
 export type IndicesGetAliasResponse = Record<IndexName, IndicesGetAliasIndexAliases>

--- a/specification/_json_spec/cat.aliases.json
+++ b/specification/_json_spec/cat.aliases.json
@@ -32,10 +32,6 @@
         "type": "string",
         "description": "a short version of the Accept header, e.g. json, yaml"
       },
-      "local": {
-        "type": "boolean",
-        "description": "Return local information, do not retrieve the state from master node (default: false)"
-      },
       "h": {
         "type": "list",
         "description": "Comma-separated list of column names to display"

--- a/specification/_json_spec/indices.exists_alias.json
+++ b/specification/_json_spec/indices.exists_alias.json
@@ -51,10 +51,6 @@
         "options": ["open", "closed", "hidden", "none", "all"],
         "default": "all",
         "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both."
-      },
-      "local": {
-        "type": "boolean",
-        "description": "Return local information, do not retrieve the state from master node (default: false)"
       }
     }
   }

--- a/specification/_json_spec/indices.get_alias.json
+++ b/specification/_json_spec/indices.get_alias.json
@@ -65,10 +65,6 @@
         "options": ["open", "closed", "hidden", "none", "all"],
         "default": "all",
         "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both."
-      },
-      "local": {
-        "type": "boolean",
-        "description": "Return local information, do not retrieve the state from master node (default: false)"
       }
     }
   }

--- a/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
+++ b/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
@@ -59,10 +59,5 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     ignore_unavailable?: boolean
-    /**
-     * If `true`, the request retrieves information from the local node only.
-     * @server_default false
-     */
-    local?: boolean
   }
 }

--- a/specification/indices/get_alias/IndicesGetAliasRequest.ts
+++ b/specification/indices/get_alias/IndicesGetAliasRequest.ts
@@ -62,10 +62,5 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     ignore_unavailable?: boolean
-    /**
-     * If `true`, the request retrieves information from the local node only.
-     * @server_default false
-     */
-    local?: boolean
   }
 }


### PR DESCRIPTION
This updates the specification to reflect the changes in https://github.com/elastic/elasticsearch/pull/115393.