### PR TITLE
Add cross cluster security APIs

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27924,8 +27924,7 @@
                       "type": "string"
                     },
                     "expiration": {
-                      "description": "Expiration in milliseconds for the API key.",
-                      "type": "number"
+                      "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
                     },
                     "id": {
                       "$ref": "#/components/schemas/_types:Id"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -30154,6 +30154,71 @@
         "x-state": "Added in 8.4.0"
       }
     },
+    "/_security/cross_cluster/api_key/{id}": {
+      "put": {
+        "tags": [
+          "security"
+        ],
+        "summary": "Update cross-cluster API key",
+        "description": "Update the attributes of an existing cross-cluster API key, which is used for API key based remote cluster access.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/remote-clusters-api-key.html"
+        },
+        "operationId": "security-update-cross-cluster-api-key",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "description": "The ID of the cross-cluster API key to update.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "expiration": {
+                    "$ref": "#/components/schemas/_types:Duration"
+                  },
+                  "metadata": {
+                    "$ref": "#/components/schemas/_types:Metadata"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "updated": {
+                      "description": "If `true`, the API key was updated.\nIf `false`, the API key didn’t change because no change was detected.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "updated"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/_security/profile/{uid}/_data": {
       "put": {
         "tags": [

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27784,6 +27784,78 @@
         "x-state": "Added in 6.7.0"
       }
     },
+    "/_security/cross_cluster/api_key": {
+      "post": {
+        "tags": [
+          "security"
+        ],
+        "summary": "Create a cross-cluster API key",
+        "description": "Create an API key of the `cross_cluster` type for the API key based remote cluster access.\nA `cross_cluster` API key cannot be used to authenticate through the REST interface.\n\nIMPORTANT: To authenticate this request you must use a credential that is not an API key. Even if you use an API key that has the required privilege, the API returns an error.\n\nCross-cluster API keys are created by the Elasticsearch API key service, which is automatically enabled.\n\nA successful request returns a JSON structure that contains the API key, its unique ID, and its name. If applicable, it also returns expiration information for the API key in milliseconds.\n\nBy default, API keys never expire. You can specify expiration information when you create the API keys.\n\nCross-cluster API keys can only be updated with the update cross-cluster API key API.\nAttempting to update them with the update REST API key API or the bulk update REST API keys API will result in an error.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/remote-clusters-api-key.html"
+        },
+        "operationId": "security-create-cross-cluster-api-key",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "expiration": {
+                    "$ref": "#/components/schemas/_types:Duration"
+                  },
+                  "metadata": {
+                    "$ref": "#/components/schemas/_types:Metadata"
+                  },
+                  "name": {
+                    "$ref": "#/components/schemas/_types:Name"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "api_key": {
+                      "description": "Generated API key.",
+                      "type": "string"
+                    },
+                    "expiration": {
+                      "description": "Expiration in milliseconds for the API key.",
+                      "type": "number"
+                    },
+                    "id": {
+                      "$ref": "#/components/schemas/_types:Id"
+                    },
+                    "name": {
+                      "$ref": "#/components/schemas/_types:Name"
+                    },
+                    "encoded": {
+                      "description": "API key credentials which is the base64-encoding of\nthe UTF-8 representation of `id` and `api_key` joined\nby a colon (`:`).",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "api_key",
+                    "id",
+                    "name",
+                    "encoded"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/_security/service/{namespace}/{service}/credential/token/{name}": {
       "put": {
         "tags": [
@@ -30159,7 +30231,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Update cross-cluster API key",
+        "summary": "Update a cross-cluster API key",
         "description": "Update the attributes of an existing cross-cluster API key, which is used for API key based remote cluster access.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/remote-clusters-api-key.html"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27808,7 +27808,7 @@
           "security"
         ],
         "summary": "Create a cross-cluster API key",
-        "description": "Create an API key of the `cross_cluster` type for the API key based remote cluster access.\nA `cross_cluster` API key cannot be used to authenticate through the REST interface.\n\nIMPORTANT: To authenticate this request you must use a credential that is not an API key. Even if you use an API key that has the required privilege, the API returns an error.\n\nCross-cluster API keys are created by the Elasticsearch API key service, which is automatically enabled.\n\nA successful request returns a JSON structure that contains the API key, its unique ID, and its name. If applicable, it also returns expiration information for the API key in milliseconds.\n\nBy default, API keys never expire. You can specify expiration information when you create the API keys.\n\nCross-cluster API keys can only be updated with the update cross-cluster API key API.\nAttempting to update them with the update REST API key API or the bulk update REST API keys API will result in an error.",
+        "description": "Create an API key of the `cross_cluster` type for the API key based remote cluster access.\nA `cross_cluster` API key cannot be used to authenticate through the REST interface.\n\nIMPORTANT: To authenticate this request you must use a credential that is not an API key. Even if you use an API key that has the required privilege, the API returns an error.\n\nCross-cluster API keys are created by the Elasticsearch API key service, which is automatically enabled.\n\nNOTE: Unlike REST API keys, a cross-cluster API key does not capture permissions of the authenticated user. The API key’s effective permission is exactly as specified with the `access` property.\n\nA successful request returns a JSON structure that contains the API key, its unique ID, and its name. If applicable, it also returns expiration information for the API key in milliseconds.\n\nBy default, API keys never expire. You can specify expiration information when you create the API keys.\n\nCross-cluster API keys can only be updated with the update cross-cluster API key API.\nAttempting to update them with the update REST API key API or the bulk update REST API keys API will result in an error.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/remote-clusters-api-key.html"
         },
@@ -27819,6 +27819,9 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "access": {
+                    "$ref": "#/components/schemas/security._types:Access"
+                  },
                   "expiration": {
                     "$ref": "#/components/schemas/_types:Duration"
                   },
@@ -27828,7 +27831,10 @@
                   "name": {
                     "$ref": "#/components/schemas/_types:Name"
                   }
-                }
+                },
+                "required": [
+                  "access"
+                ]
               }
             }
           },
@@ -30274,13 +30280,19 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "access": {
+                    "$ref": "#/components/schemas/security._types:Access"
+                  },
                   "expiration": {
                     "$ref": "#/components/schemas/_types:Duration"
                   },
                   "metadata": {
                     "$ref": "#/components/schemas/_types:Metadata"
                   }
-                }
+                },
+                "required": [
+                  "access"
+                ]
               }
             }
           },
@@ -81916,6 +81928,77 @@
       "_types:Service": {
         "type": "string"
       },
+      "security._types:Access": {
+        "type": "object",
+        "properties": {
+          "replication": {
+            "description": "A list of indices permission entries for cross-cluster replication.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:ReplicationAccess"
+            }
+          },
+          "search": {
+            "description": "A list of indices permission entries for cross-cluster search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:RemoteIndicesPrivileges"
+            }
+          }
+        }
+      },
+      "security._types:ReplicationAccess": {
+        "type": "object",
+        "properties": {
+          "names": {
+            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:IndexName"
+            }
+          }
+        },
+        "required": [
+          "names"
+        ]
+      },
+      "security._types:RemoteIndicesPrivileges": {
+        "type": "object",
+        "properties": {
+          "clusters": {
+            "$ref": "#/components/schemas/_types:Names"
+          },
+          "field_security": {
+            "$ref": "#/components/schemas/security._types:FieldSecurity"
+          },
+          "names": {
+            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:IndexName"
+            }
+          },
+          "privileges": {
+            "description": "The index level privileges that owners of the role have on the specified indices.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:IndexPrivilege"
+            }
+          },
+          "query": {
+            "$ref": "#/components/schemas/security._types:IndicesPrivilegesQuery"
+          },
+          "allow_restricted_indices": {
+            "description": "Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "clusters",
+          "names",
+          "privileges"
+        ]
+      },
       "security.create_service_token:Token": {
         "type": "object",
         "properties": {
@@ -82590,43 +82673,6 @@
         },
         "required": [
           "created"
-        ]
-      },
-      "security._types:RemoteIndicesPrivileges": {
-        "type": "object",
-        "properties": {
-          "clusters": {
-            "$ref": "#/components/schemas/_types:Names"
-          },
-          "field_security": {
-            "$ref": "#/components/schemas/security._types:FieldSecurity"
-          },
-          "names": {
-            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/_types:IndexName"
-            }
-          },
-          "privileges": {
-            "description": "The index level privileges that owners of the role have on the specified indices.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/security._types:IndexPrivilege"
-            }
-          },
-          "query": {
-            "$ref": "#/components/schemas/security._types:IndicesPrivilegesQuery"
-          },
-          "allow_restricted_indices": {
-            "description": "Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.",
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "clusters",
-          "names",
-          "privileges"
         ]
       },
       "security.query_api_keys:ApiKeyAggregationContainer": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27904,7 +27904,8 @@
                   }
                 },
                 "required": [
-                  "access"
+                  "access",
+                  "name"
                 ]
               }
             }
@@ -82030,7 +82031,7 @@
             "description": "A list of indices permission entries for cross-cluster search.",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/security._types:RemoteIndicesPrivileges"
+              "$ref": "#/components/schemas/security._types:SearchAccess"
             }
           }
         }
@@ -82050,12 +82051,9 @@
           "names"
         ]
       },
-      "security._types:RemoteIndicesPrivileges": {
+      "security._types:SearchAccess": {
         "type": "object",
         "properties": {
-          "clusters": {
-            "$ref": "#/components/schemas/_types:Names"
-          },
           "field_security": {
             "$ref": "#/components/schemas/security._types:FieldSecurity"
           },
@@ -82064,13 +82062,6 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/_types:IndexName"
-            }
-          },
-          "privileges": {
-            "description": "The index level privileges that owners of the role have on the specified indices.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/security._types:IndexPrivilege"
             }
           },
           "query": {
@@ -82082,9 +82073,7 @@
           }
         },
         "required": [
-          "clusters",
-          "names",
-          "privileges"
+          "names"
         ]
       },
       "security.create_service_token:Token": {
@@ -82761,6 +82750,43 @@
         },
         "required": [
           "created"
+        ]
+      },
+      "security._types:RemoteIndicesPrivileges": {
+        "type": "object",
+        "properties": {
+          "clusters": {
+            "$ref": "#/components/schemas/_types:Names"
+          },
+          "field_security": {
+            "$ref": "#/components/schemas/security._types:FieldSecurity"
+          },
+          "names": {
+            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:IndexName"
+            }
+          },
+          "privileges": {
+            "description": "The index level privileges that owners of the role have on the specified indices.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:IndexPrivilege"
+            }
+          },
+          "query": {
+            "$ref": "#/components/schemas/security._types:IndicesPrivilegesQuery"
+          },
+          "allow_restricted_indices": {
+            "description": "Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "clusters",
+          "names",
+          "privileges"
         ]
       },
       "security.query_api_keys:ApiKeyAggregationContainer": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1079,12 +1079,6 @@
       ],
       "response": []
     },
-    "security.create_cross_cluster_api_key": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "security.get_settings": {
       "request": [
         "Missing request & response"

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1123,12 +1123,6 @@
       ],
       "response": []
     },
-    "security.update_cross_cluster_api_key": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "security.update_settings": {
       "request": [
         "Missing request & response"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17569,7 +17569,7 @@ export interface SearchableSnapshotsStatsResponse {
 
 export interface SecurityAccess {
   replication?: SecurityReplicationAccess[]
-  search?: SecurityRemoteIndicesPrivileges[]
+  search?: SecuritySearchAccess[]
 }
 
 export interface SecurityApiKey {
@@ -17720,6 +17720,13 @@ export interface SecurityRoleTemplateScript {
   params?: Record<string, any>
   lang?: ScriptLanguage
   options?: Record<string, string>
+}
+
+export interface SecuritySearchAccess {
+  field_security?: SecurityFieldSecurity
+  names: IndexName[]
+  query?: SecurityIndicesPrivilegesQuery
+  allow_restricted_indices?: boolean
 }
 
 export type SecurityTemplateFormat = 'string' | 'json'
@@ -17919,7 +17926,7 @@ export interface SecurityCreateCrossClusterApiKeyRequest extends RequestBase {
     access: SecurityAccess
     expiration?: Duration
     metadata?: Metadata
-    name?: Name
+    name: Name
   }
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -18605,6 +18605,18 @@ export interface SecurityUpdateApiKeyResponse {
   updated: boolean
 }
 
+export interface SecurityUpdateCrossClusterApiKeyRequest extends RequestBase {
+  id: Id
+  body?: {
+    expiration?: Duration
+    metadata?: Metadata
+  }
+}
+
+export interface SecurityUpdateCrossClusterApiKeyResponse {
+  updated: boolean
+}
+
 export interface SecurityUpdateUserProfileDataRequest extends RequestBase {
   uid: SecurityUserProfileId
   if_seq_no?: SequenceNumber

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17925,7 +17925,7 @@ export interface SecurityCreateCrossClusterApiKeyRequest extends RequestBase {
 
 export interface SecurityCreateCrossClusterApiKeyResponse {
   api_key: string
-  expiration?: long
+  expiration?: DurationValue<UnitMillis>
   id: Id
   name: Name
   encoded: string

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17550,6 +17550,11 @@ export interface SearchableSnapshotsStatsResponse {
   total: any
 }
 
+export interface SecurityAccess {
+  replication?: SecurityReplicationAccess[]
+  search?: SecurityRemoteIndicesPrivileges[]
+}
+
 export interface SecurityApiKey {
   creation?: long
   expiration?: long
@@ -17636,6 +17641,10 @@ export interface SecurityRemoteIndicesPrivileges {
   privileges: SecurityIndexPrivilege[]
   query?: SecurityIndicesPrivilegesQuery
   allow_restricted_indices?: boolean
+}
+
+export interface SecurityReplicationAccess {
+  names: IndexName[]
 }
 
 export interface SecurityRoleDescriptor {
@@ -17890,6 +17899,7 @@ export interface SecurityCreateApiKeyResponse {
 
 export interface SecurityCreateCrossClusterApiKeyRequest extends RequestBase {
   body?: {
+    access: SecurityAccess
     expiration?: Duration
     metadata?: Metadata
     name?: Name
@@ -18624,6 +18634,7 @@ export interface SecurityUpdateApiKeyResponse {
 export interface SecurityUpdateCrossClusterApiKeyRequest extends RequestBase {
   id: Id
   body?: {
+    access: SecurityAccess
     expiration?: Duration
     metadata?: Metadata
   }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17888,6 +17888,22 @@ export interface SecurityCreateApiKeyResponse {
   encoded: string
 }
 
+export interface SecurityCreateCrossClusterApiKeyRequest extends RequestBase {
+  body?: {
+    expiration?: Duration
+    metadata?: Metadata
+    name?: Name
+  }
+}
+
+export interface SecurityCreateCrossClusterApiKeyResponse {
+  api_key: string
+  expiration?: long
+  id: Id
+  name: Name
+  encoded: string
+}
+
 export interface SecurityCreateServiceTokenRequest extends RequestBase {
   namespace: Namespace
   service: Service

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -416,6 +416,7 @@ redact-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch
 regexp-syntax,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/regexp-syntax.html
 registered-domain-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/registered-domain-processor.html
 remove-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/remove-processor.html
+remote-clusters-api-key,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/remote-clusters-api-key.html
 rename-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/rename-processor.html
 reroute-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/reroute-processor.html
 render-search-template-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/render-search-template-api.html

--- a/specification/security/_types/Access.ts
+++ b/specification/security/_types/Access.ts
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RemoteIndicesPrivileges, ReplicationAccess } from './Privileges'
+
+export class Access {
+  /**
+   * A list of indices permission entries for cross-cluster replication.
+   */
+  replication?: ReplicationAccess[]
+  /**
+   * A list of indices permission entries for cross-cluster search.
+   */
+  search?: RemoteIndicesPrivileges[]
+}

--- a/specification/security/_types/Access.ts
+++ b/specification/security/_types/Access.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { RemoteIndicesPrivileges, ReplicationAccess } from './Privileges'
+import { ReplicationAccess, SearchAccess } from './Privileges'
 
 export class Access {
   /**
@@ -27,5 +27,5 @@ export class Access {
   /**
    * A list of indices permission entries for cross-cluster search.
    */
-  search?: RemoteIndicesPrivileges[]
+  search?: SearchAccess[]
 }

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -381,5 +381,5 @@ export class ReplicationAccess {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-   names: IndexName[]
+  names: IndexName[]
 }

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -376,3 +376,10 @@ export class ApplicationGlobalUserPrivileges {
 export class ManageUserPrivileges {
   applications: string[]
 }
+
+export class ReplicationAccess {
+  /**
+   * A list of indices (or index name patterns) to which the permissions in this entry apply.
+   */
+   names: IndexName[]
+}

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -383,3 +383,25 @@ export class ReplicationAccess {
    */
   names: IndexName[]
 }
+
+export class SearchAccess {
+  /**
+   * The document fields that the owners of the role have read access to.
+   * @doc_id field-and-document-access-control
+   */
+  field_security?: FieldSecurity
+  /**
+   * A list of indices (or index name patterns) to which the permissions in this entry apply.
+   */
+  names: IndexName[]
+  /**
+   * A search query that defines the documents the owners of the role have access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.
+   */
+  query?: IndicesPrivilegesQuery
+  /**
+   * Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.
+   * @server_default false
+   * @availability stack
+   */
+  allow_restricted_indices?: boolean
+}

--- a/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyRequest.ts
+++ b/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyRequest.ts
@@ -68,6 +68,6 @@ export interface Request extends RequestBase {
      */
     metadata?: Metadata
     /** Specifies the name for this API key. */
-    name?: Name
+    name: Name
   }
 }

--- a/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyRequest.ts
+++ b/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyRequest.ts
@@ -18,8 +18,10 @@
  */
 
 import { RequestBase } from '@_types/Base'
+import { Dictionary } from '@spec_utils/Dictionary'
 import { Metadata, Name } from '@_types/common'
 import { Duration } from '@_types/Time'
+import { Access } from '@security/_types/Access'
 
 /**
  * Create a cross-cluster API key.
@@ -30,6 +32,8 @@ import { Duration } from '@_types/Time'
  * IMPORTANT: To authenticate this request you must use a credential that is not an API key. Even if you use an API key that has the required privilege, the API returns an error.
  *
  * Cross-cluster API keys are created by the Elasticsearch API key service, which is automatically enabled.
+ * 
+ * NOTE: Unlike REST API keys, a cross-cluster API key does not capture permissions of the authenticated user. The API key’s effective permission is exactly as specified with the `access` property.
  *
  * A successful request returns a JSON structure that contains the API key, its unique ID, and its name. If applicable, it also returns expiration information for the API key in milliseconds.
  *
@@ -44,6 +48,15 @@ import { Duration } from '@_types/Time'
  */
 export interface Request extends RequestBase {
   body: {
+    /**
+     * The access to be granted to this API key.
+     * The access is composed of permissions for cross-cluster search and cross-cluster replication.
+     * At least one of them must be specified.
+     *
+     * NOTE: No explicit privileges should be specified for either search or replication access.
+     * The creation process automatically converts the access specification to a role descriptor which has relevant privileges assigned accordingly.
+     */
+    access: Access
     /**
      * Expiration time for the API key.
      * By default, API keys never expire.

--- a/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyRequest.ts
+++ b/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyRequest.ts
@@ -17,11 +17,10 @@
  * under the License.
  */
 
+import { Access } from '@security/_types/Access'
 import { RequestBase } from '@_types/Base'
-import { Dictionary } from '@spec_utils/Dictionary'
 import { Metadata, Name } from '@_types/common'
 import { Duration } from '@_types/Time'
-import { Access } from '@security/_types/Access'
 
 /**
  * Create a cross-cluster API key.
@@ -32,7 +31,7 @@ import { Access } from '@security/_types/Access'
  * IMPORTANT: To authenticate this request you must use a credential that is not an API key. Even if you use an API key that has the required privilege, the API returns an error.
  *
  * Cross-cluster API keys are created by the Elasticsearch API key service, which is automatically enabled.
- * 
+ *
  * NOTE: Unlike REST API keys, a cross-cluster API key does not capture permissions of the authenticated user. The API key’s effective permission is exactly as specified with the `access` property.
  *
  * A successful request returns a JSON structure that contains the API key, its unique ID, and its name. If applicable, it also returns expiration information for the API key in milliseconds.

--- a/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyRequest.ts
+++ b/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyRequest.ts
@@ -18,36 +18,44 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { Id, Metadata } from '@_types/common'
+import { Metadata, Name } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Update a cross-cluster API key.
+ * Create a cross-cluster API key.
  *
- * Update the attributes of an existing cross-cluster API key, which is used for API key based remote cluster access.
- * @rest_spec_name security.update_cross_cluster_api_key
+ * Create an API key of the `cross_cluster` type for the API key based remote cluster access.
+ * A `cross_cluster` API key cannot be used to authenticate through the REST interface.
+ *
+ * IMPORTANT: To authenticate this request you must use a credential that is not an API key. Even if you use an API key that has the required privilege, the API returns an error.
+ *
+ * Cross-cluster API keys are created by the Elasticsearch API key service, which is automatically enabled.
+ *
+ * A successful request returns a JSON structure that contains the API key, its unique ID, and its name. If applicable, it also returns expiration information for the API key in milliseconds.
+ *
+ * By default, API keys never expire. You can specify expiration information when you create the API keys.
+ *
+ * Cross-cluster API keys can only be updated with the update cross-cluster API key API.
+ * Attempting to update them with the update REST API key API or the bulk update REST API keys API will result in an error.
+ * @rest_spec_name security.create_cross_cluster_api_key
  * @availability stack stability=stable
+ * @cluster_privileges manage_security
  * @ext_doc_id remote-clusters-api-key
  */
 export interface Request extends RequestBase {
-  path_parts: {
-    /**
-     * The ID of the cross-cluster API key to update.
-     */
-    id: Id
-  }
   body: {
     /**
      * Expiration time for the API key.
-     * By default, API keys never expire. This property can be omitted to leave the value unchanged.
+     * By default, API keys never expire.
      */
     expiration?: Duration
     /**
      * Arbitrary metadata that you want to associate with the API key.
      * It supports nested data structure.
      * Within the metadata object, keys beginning with `_` are reserved for system usage.
-     * When specified, this information fully replaces metadata previously associated with the API key.
      */
     metadata?: Metadata
+    /** Specifies the name for this API key. */
+    name?: Name
   }
 }

--- a/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyResponse.ts
+++ b/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyResponse.ts
@@ -29,7 +29,7 @@ export class Response {
     /**
      * Expiration in milliseconds for the API key.
      */
-    expiration?: long
+    expiration?: DurationValue<UnitMillis>
     /**
      * Unique ID for this API key.
      */

--- a/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyResponse.ts
+++ b/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyResponse.ts
@@ -18,7 +18,7 @@
  */
 
 import { Id, Name } from '@_types/common'
-import { long } from '@_types/Numeric'
+import { DurationValue, UnitMillis } from '@_types/Time'
 
 export class Response {
   body: {

--- a/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyResponse.ts
+++ b/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyResponse.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Id, Name } from '@_types/common'
+import { long } from '@_types/Numeric'
+
+export class Response {
+  body: {
+    /**
+     * Generated API key.
+     */
+    api_key: string
+    /**
+     * Expiration in milliseconds for the API key.
+     */
+    expiration?: long
+    /**
+     * Unique ID for this API key.
+     */
+    id: Id
+    /**
+     * Specifies the name for this API key.
+     */
+    name: Name
+    /**
+     * API key credentials which is the base64-encoding of
+     * the UTF-8 representation of `id` and `api_key` joined
+     * by a colon (`:`).
+     */
+    encoded: string
+  }
+}

--- a/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
+++ b/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
@@ -20,6 +20,8 @@
 import { RequestBase } from '@_types/Base'
 import { Id, Metadata } from '@_types/common'
 import { Duration } from '@_types/Time'
+import { Access } from '@security/_types/Access'
+import { Dictionary } from '@spec_utils/Dictionary'
 
 /**
  * Update a cross-cluster API key.
@@ -37,6 +39,13 @@ export interface Request extends RequestBase {
     id: Id
   }
   body: {
+    /**
+     * The access to be granted to this API key.
+     * The access is composed of permissions for cross cluster search and cross cluster replication.
+     * At least one of them must be specified.
+     * When specified, the new access assignment fully replaces the previously assigned access.
+     */
+    access: Access
     /**
      * Expiration time for the API key.
      * By default, API keys never expire. This property can be omitted to leave the value unchanged.

--- a/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
+++ b/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
@@ -17,11 +17,10 @@
  * under the License.
  */
 
+import { Access } from '@security/_types/Access'
 import { RequestBase } from '@_types/Base'
 import { Id, Metadata } from '@_types/common'
 import { Duration } from '@_types/Time'
-import { Access } from '@security/_types/Access'
-import { Dictionary } from '@spec_utils/Dictionary'
 
 /**
  * Update a cross-cluster API key.

--- a/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
+++ b/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Id, Metadata } from '@_types/common'
+import { Duration } from '@_types/Time'
+
+/**
+ * Update cross-cluster API key.
+ *
+ * Update the attributes of an existing cross-cluster API key, which is used for API key based remote cluster access.
+ * @rest_spec_name security.update_cross_cluster_api_key
+ * @availability stack stability=stable
+ * @ext_doc_id remote-clusters-api-key
+ */
+export interface Request extends RequestBase {
+    path_parts: {
+        /**
+         * The ID of the cross-cluster API key to update.
+         */
+        id: Id
+      }
+      body: {
+        /**
+         * Expiration time for the API key.
+         * By default, API keys never expire. This property can be omitted to leave the value unchanged.
+        */
+        expiration?: Duration
+        /**
+         * Arbitrary metadata that you want to associate with the API key.
+         * It supports nested data structure.
+         * Within the metadata object, keys beginning with `_` are reserved for system usage.
+         * When specified, this information fully replaces metadata previously associated with the API key.
+         */
+        metadata?: Metadata
+      }
+}

--- a/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyResponse.ts
+++ b/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyResponse.ts
@@ -1,0 +1,28 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class Response {
+  body: {
+    /**
+     * If `true`, the API key was updated.
+     * If `false`, the API key didn’t change because no change was detected.
+     */
+    updated: boolean
+  }
+}


### PR DESCRIPTION
The create and update cross cluster key APIs were not appearing in the OpenAPI output, so I've created an initial pass at the necessary files per https://github.com/elastic/elasticsearch-specification/blob/main/docs/add-new-api.md

The descriptions are copied from https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-cross-cluster-api-key.html and 