### PR TITLE
[OpenAPI] Edit search API summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -2812,7 +2812,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Clears the search context and results for a scrolling search",
+        "summary": "Clear a scrolling search",
+        "description": "Clear the search context and results for a scrolling search.",
         "operationId": "clear-scroll",
         "requestBody": {
           "$ref": "#/components/requestBodies/clear_scroll"
@@ -2895,7 +2896,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Clears the search context and results for a scrolling search",
+        "summary": "Clear a scrolling search",
+        "description": "Clear the search context and results for a scrolling search.",
         "operationId": "clear-scroll-1",
         "parameters": [
           {
@@ -2917,7 +2919,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Closes a point-in-time",
+        "summary": "Close a point in time",
+        "description": "A point in time must be opened explicitly before being used in search requests.\nThe `keep_alive` parameter tells Elasticsearch how long it should persist.\nA point in time is automatically closed when the `keep_alive` period has elapsed.\nHowever, keeping points in time has a cost; close them as soon as they are no lwonger required for search requests.",
         "operationId": "close-point-in-time",
         "requestBody": {
           "content": {
@@ -8230,8 +8233,8 @@
         "tags": [
           "search"
         ],
-        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
-        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type\nof keyword is returned as any other field that belongs to the `keyword` family.",
+        "summary": "Get the field capabilities",
+        "description": "Get information about the capabilities of fields among multiple indices.\n\nFor data streams, the API returns field capabilities among the stream’s backing indices.\nIt returns runtime fields like any other field.\nFor example, a runtime field with a type of keyword is returned the same as any other field that belongs to the `keyword` family.",
         "operationId": "field-caps",
         "parameters": [
           {
@@ -8273,8 +8276,8 @@
         "tags": [
           "search"
         ],
-        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
-        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type\nof keyword is returned as any other field that belongs to the `keyword` family.",
+        "summary": "Get the field capabilities",
+        "description": "Get information about the capabilities of fields among multiple indices.\n\nFor data streams, the API returns field capabilities among the stream’s backing indices.\nIt returns runtime fields like any other field.\nFor example, a runtime field with a type of keyword is returned the same as any other field that belongs to the `keyword` family.",
         "operationId": "field-caps-1",
         "parameters": [
           {
@@ -8318,8 +8321,8 @@
         "tags": [
           "search"
         ],
-        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
-        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type\nof keyword is returned as any other field that belongs to the `keyword` family.",
+        "summary": "Get the field capabilities",
+        "description": "Get information about the capabilities of fields among multiple indices.\n\nFor data streams, the API returns field capabilities among the stream’s backing indices.\nIt returns runtime fields like any other field.\nFor example, a runtime field with a type of keyword is returned the same as any other field that belongs to the `keyword` family.",
         "operationId": "field-caps-2",
         "parameters": [
           {
@@ -8364,8 +8367,8 @@
         "tags": [
           "search"
         ],
-        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
-        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type\nof keyword is returned as any other field that belongs to the `keyword` family.",
+        "summary": "Get the field capabilities",
+        "description": "Get information about the capabilities of fields among multiple indices.\n\nFor data streams, the API returns field capabilities among the stream’s backing indices.\nIt returns runtime fields like any other field.\nFor example, a runtime field with a type of keyword is returned the same as any other field that belongs to the `keyword` family.",
         "operationId": "field-caps-3",
         "parameters": [
           {
@@ -22582,7 +22585,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs multiple templated searches with a single request",
+        "summary": "Run multiple templated searches",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "msearch-template",
         "parameters": [
           {
@@ -22615,7 +22621,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs multiple templated searches with a single request",
+        "summary": "Run multiple templated searches",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "msearch-template-1",
         "parameters": [
           {
@@ -22650,7 +22659,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs multiple templated searches with a single request",
+        "summary": "Run multiple templated searches",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "msearch-template-2",
         "parameters": [
           {
@@ -22686,7 +22698,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs multiple templated searches with a single request",
+        "summary": "Run multiple templated searches",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "msearch-template-3",
         "parameters": [
           {
@@ -23677,8 +23692,8 @@
         "tags": [
           "search"
         ],
-        "summary": "A search request by default executes against the most recent visible data of the target indices,\n",
-        "description": "which is called point in time. Elasticsearch pit (point in time) is a lightweight view into the\nstate of the data as it existed when initiated. In some cases, it’s preferred to perform multiple\nsearch requests using the same point in time. For example, if refreshes happen between\n`search_after` requests, then the results of those requests might not be consistent as changes happening\nbetween searches are only visible to the more recent point in time.",
+        "summary": "Open a point in time",
+        "description": "A search request by default runs against the most recent visible data of the target indices,\nwhich is called point in time. Elasticsearch pit (point in time) is a lightweight view into the\nstate of the data as it existed when initiated. In some cases, it’s preferred to perform multiple\nsearch requests using the same point in time. For example, if refreshes happen between\n`search_after` requests, then the results of those requests might not be consistent as changes happening\nbetween searches are only visible to the more recent point in time.\n\nA point in time must be opened explicitly before being used in search requests.\nThe `keep_alive` parameter tells Elasticsearch how long it should persist.",
         "operationId": "open-point-in-time",
         "parameters": [
           {
@@ -24300,7 +24315,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Evaluate ranked search results",
+        "description": "Evaluate the quality of ranked search results over a set of typical search queries.",
         "operationId": "rank-eval",
         "parameters": [
           {
@@ -24330,7 +24346,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Evaluate ranked search results",
+        "description": "Evaluate the quality of ranked search results over a set of typical search queries.",
         "operationId": "rank-eval-1",
         "parameters": [
           {
@@ -24362,7 +24379,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Evaluate ranked search results",
+        "description": "Evaluate the quality of ranked search results over a set of typical search queries.",
         "operationId": "rank-eval-2",
         "parameters": [
           {
@@ -24395,7 +24413,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Evaluate ranked search results",
+        "description": "Evaluate the quality of ranked search results over a set of typical search queries.",
         "operationId": "rank-eval-3",
         "parameters": [
           {
@@ -24680,7 +24699,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Renders a search template as a search request body",
+        "summary": "Render a search template",
+        "description": "Render a search template as a search request body.",
         "operationId": "render-search-template",
         "requestBody": {
           "$ref": "#/components/requestBodies/render_search_template"
@@ -24695,7 +24715,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Renders a search template as a search request body",
+        "summary": "Render a search template",
+        "description": "Render a search template as a search request body.",
         "operationId": "render-search-template-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/render_search_template"
@@ -24712,7 +24733,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Renders a search template as a search request body",
+        "summary": "Render a search template",
+        "description": "Render a search template as a search request body.",
         "operationId": "render-search-template-2",
         "parameters": [
           {
@@ -24732,7 +24754,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Renders a search template as a search request body",
+        "summary": "Render a search template",
+        "description": "Render a search template as a search request body.",
         "operationId": "render-search-template-3",
         "parameters": [
           {
@@ -26415,7 +26438,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs a search with a search template",
+        "summary": "Run a search with a search template",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "search-template",
         "parameters": [
           {
@@ -26472,7 +26498,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs a search with a search template",
+        "summary": "Run a search with a search template",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "search-template-1",
         "parameters": [
           {
@@ -26531,7 +26560,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs a search with a search template",
+        "summary": "Run a search with a search template",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "search-template-2",
         "parameters": [
           {
@@ -26591,7 +26623,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs a search with a search template",
+        "summary": "Run a search with a search template",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "search-template-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -114,8 +114,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Get async search status",
-        "description": "Retrieve the status of a previously submitted async search request given its identifier, without retrieving search results.\nIf the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.",
+        "summary": "Get the async search status",
+        "description": "Get the status of a previously submitted async search request given its identifier, without retrieving search results.\nIf the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.",
         "operationId": "async-search-status",
         "parameters": [
           {
@@ -15493,7 +15493,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Performs a kNN search",
+        "summary": "Run a knn search",
+        "description": "NOTE: The kNN search API has been replaced by the `knn` option in the search API.\n\nPerform a k-nearest neighbor (kNN) search on a dense_vector field and return the matching documents.\nGiven a query vector, the API finds the k closest vectors and returns those documents as search hits.\n\nElasticsearch uses the HNSW algorithm to support efficient kNN search.\nLike most kNN algorithms, HNSW is an approximate method that sacrifices result accuracy for improved search speed.\nThis means the results returned are not always the true k closest neighbors.\n\nThe kNN search API supports restricting the search using a filter.\nThe search will return the top k documents that also match the filter query.",
         "operationId": "knn-search",
         "parameters": [
           {
@@ -15518,7 +15519,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Performs a kNN search",
+        "summary": "Run a knn search",
+        "description": "NOTE: The kNN search API has been replaced by the `knn` option in the search API.\n\nPerform a k-nearest neighbor (kNN) search on a dense_vector field and return the matching documents.\nGiven a query vector, the API finds the k closest vectors and returns those documents as search hits.\n\nElasticsearch uses the HNSW algorithm to support efficient kNN search.\nLike most kNN algorithms, HNSW is an approximate method that sacrifices result accuracy for improved search speed.\nThis means the results returned are not always the true k closest neighbors.\n\nThe kNN search API supports restricting the search using a filter.\nThe search will return the top k documents that also match the filter query.",
         "operationId": "knn-search-1",
         "parameters": [
           {
@@ -25213,8 +25215,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns search hits that match the query defined in the request",
-        "description": "You can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "summary": "Run a search",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
         "operationId": "search",
         "parameters": [
           {
@@ -25366,8 +25368,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns search hits that match the query defined in the request",
-        "description": "You can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "summary": "Run a search",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
         "operationId": "search-1",
         "parameters": [
           {
@@ -25521,8 +25523,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns search hits that match the query defined in the request",
-        "description": "You can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "summary": "Run a search",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
         "operationId": "search-2",
         "parameters": [
           {
@@ -25677,8 +25679,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns search hits that match the query defined in the request",
-        "description": "You can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "summary": "Run a search",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
         "operationId": "search-3",
         "parameters": [
           {
@@ -26189,7 +26191,7 @@
           "search"
         ],
         "summary": "Search a vector tile",
-        "description": "Searches a vector tile for geospatial values.",
+        "description": "Search a vector tile for geospatial values.",
         "operationId": "search-mvt-1",
         "parameters": [
           {
@@ -26244,7 +26246,7 @@
           "search"
         ],
         "summary": "Search a vector tile",
-        "description": "Searches a vector tile for geospatial values.",
+        "description": "Search a vector tile for geospatial values.",
         "operationId": "search-mvt",
         "parameters": [
           {
@@ -26300,7 +26302,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns information about the indices and shards that a search request would be executed against",
+        "summary": "Get the search shards",
+        "description": "Get the indices and shards that a search request would be run against.\nThis information can be useful for working out issues or planning optimizations with routing and shard preferences.\nWhen filtered aliases are used, the filter is returned as part of the indices section.",
         "operationId": "search-shards",
         "parameters": [
           {
@@ -26332,7 +26335,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns information about the indices and shards that a search request would be executed against",
+        "summary": "Get the search shards",
+        "description": "Get the indices and shards that a search request would be run against.\nThis information can be useful for working out issues or planning optimizations with routing and shard preferences.\nWhen filtered aliases are used, the filter is returned as part of the indices section.",
         "operationId": "search-shards-1",
         "parameters": [
           {
@@ -26366,7 +26370,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns information about the indices and shards that a search request would be executed against",
+        "summary": "Get the search shards",
+        "description": "Get the indices and shards that a search request would be run against.\nThis information can be useful for working out issues or planning optimizations with routing and shard preferences.\nWhen filtered aliases are used, the filter is returned as part of the indices section.",
         "operationId": "search-shards-2",
         "parameters": [
           {
@@ -26401,7 +26406,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns information about the indices and shards that a search request would be executed against",
+        "summary": "Get the search shards",
+        "description": "Get the indices and shards that a search request would be run against.\nThis information can be useful for working out issues or planning optimizations with routing and shard preferences.\nWhen filtered aliases are used, the filter is returned as part of the indices section.",
         "operationId": "search-shards-3",
         "parameters": [
           {
@@ -32960,7 +32966,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Returns information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.",
         "operationId": "termvectors",
         "parameters": [
           {
@@ -33017,7 +33023,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Returns information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.",
         "operationId": "termvectors-1",
         "parameters": [
           {
@@ -33076,7 +33082,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Returns information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.",
         "operationId": "termvectors-2",
         "parameters": [
           {
@@ -33130,7 +33136,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Returns information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.",
         "operationId": "termvectors-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -2920,7 +2920,7 @@
           "search"
         ],
         "summary": "Close a point in time",
-        "description": "A point in time must be opened explicitly before being used in search requests.\nThe `keep_alive` parameter tells Elasticsearch how long it should persist.\nA point in time is automatically closed when the `keep_alive` period has elapsed.\nHowever, keeping points in time has a cost; close them as soon as they are no lwonger required for search requests.",
+        "description": "A point in time must be opened explicitly before being used in search requests.\nThe `keep_alive` parameter tells Elasticsearch how long it should persist.\nA point in time is automatically closed when the `keep_alive` period has elapsed.\nHowever, keeping points in time has a cost; close them as soon as they are no longer required for search requests.",
         "operationId": "close-point-in-time",
         "requestBody": {
           "content": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -114,8 +114,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Get async search status",
-        "description": "Retrieve the status of a previously submitted async search request given its identifier, without retrieving search results.\nIf the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.",
+        "summary": "Get the async search status",
+        "description": "Get the status of a previously submitted async search request given its identifier, without retrieving search results.\nIf the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.",
         "operationId": "async-search-status",
         "parameters": [
           {
@@ -15351,8 +15351,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns search hits that match the query defined in the request",
-        "description": "You can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "summary": "Run a search",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
         "operationId": "search",
         "parameters": [
           {
@@ -15501,8 +15501,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns search hits that match the query defined in the request",
-        "description": "You can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "summary": "Run a search",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
         "operationId": "search-1",
         "parameters": [
           {
@@ -15653,8 +15653,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns search hits that match the query defined in the request",
-        "description": "You can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "summary": "Run a search",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
         "operationId": "search-2",
         "parameters": [
           {
@@ -15806,8 +15806,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Returns search hits that match the query defined in the request",
-        "description": "You can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "summary": "Run a search",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
         "operationId": "search-3",
         "parameters": [
           {
@@ -16315,7 +16315,7 @@
           "search"
         ],
         "summary": "Search a vector tile",
-        "description": "Searches a vector tile for geospatial values.",
+        "description": "Search a vector tile for geospatial values.",
         "operationId": "search-mvt-1",
         "parameters": [
           {
@@ -16370,7 +16370,7 @@
           "search"
         ],
         "summary": "Search a vector tile",
-        "description": "Searches a vector tile for geospatial values.",
+        "description": "Search a vector tile for geospatial values.",
         "operationId": "search-mvt",
         "parameters": [
           {
@@ -18261,7 +18261,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Returns information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.",
         "operationId": "termvectors",
         "parameters": [
           {
@@ -18318,7 +18318,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Returns information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.",
         "operationId": "termvectors-1",
         "parameters": [
           {
@@ -18377,7 +18377,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Returns information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.",
         "operationId": "termvectors-2",
         "parameters": [
           {
@@ -18431,7 +18431,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Returns information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.",
         "operationId": "termvectors-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -1393,7 +1393,7 @@
           "search"
         ],
         "summary": "Close a point in time",
-        "description": "A point in time must be opened explicitly before being used in search requests.\nThe `keep_alive` parameter tells Elasticsearch how long it should persist.\nA point in time is automatically closed when the `keep_alive` period has elapsed.\nHowever, keeping points in time has a cost; close them as soon as they are no lwonger required for search requests.",
+        "description": "A point in time must be opened explicitly before being used in search requests.\nThe `keep_alive` parameter tells Elasticsearch how long it should persist.\nA point in time is automatically closed when the `keep_alive` period has elapsed.\nHowever, keeping points in time has a cost; close them as soon as they are no longer required for search requests.",
         "operationId": "close-point-in-time",
         "requestBody": {
           "content": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -1285,7 +1285,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Clears the search context and results for a scrolling search",
+        "summary": "Clear a scrolling search",
+        "description": "Clear the search context and results for a scrolling search.",
         "operationId": "clear-scroll",
         "requestBody": {
           "$ref": "#/components/requestBodies/clear_scroll"
@@ -1368,7 +1369,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Clears the search context and results for a scrolling search",
+        "summary": "Clear a scrolling search",
+        "description": "Clear the search context and results for a scrolling search.",
         "operationId": "clear-scroll-1",
         "parameters": [
           {
@@ -1390,7 +1392,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Closes a point-in-time",
+        "summary": "Close a point in time",
+        "description": "A point in time must be opened explicitly before being used in search requests.\nThe `keep_alive` parameter tells Elasticsearch how long it should persist.\nA point in time is automatically closed when the `keep_alive` period has elapsed.\nHowever, keeping points in time has a cost; close them as soon as they are no lwonger required for search requests.",
         "operationId": "close-point-in-time",
         "requestBody": {
           "content": {
@@ -5471,8 +5474,8 @@
         "tags": [
           "search"
         ],
-        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
-        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type\nof keyword is returned as any other field that belongs to the `keyword` family.",
+        "summary": "Get the field capabilities",
+        "description": "Get information about the capabilities of fields among multiple indices.\n\nFor data streams, the API returns field capabilities among the stream’s backing indices.\nIt returns runtime fields like any other field.\nFor example, a runtime field with a type of keyword is returned the same as any other field that belongs to the `keyword` family.",
         "operationId": "field-caps",
         "parameters": [
           {
@@ -5514,8 +5517,8 @@
         "tags": [
           "search"
         ],
-        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
-        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type\nof keyword is returned as any other field that belongs to the `keyword` family.",
+        "summary": "Get the field capabilities",
+        "description": "Get information about the capabilities of fields among multiple indices.\n\nFor data streams, the API returns field capabilities among the stream’s backing indices.\nIt returns runtime fields like any other field.\nFor example, a runtime field with a type of keyword is returned the same as any other field that belongs to the `keyword` family.",
         "operationId": "field-caps-1",
         "parameters": [
           {
@@ -5559,8 +5562,8 @@
         "tags": [
           "search"
         ],
-        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
-        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type\nof keyword is returned as any other field that belongs to the `keyword` family.",
+        "summary": "Get the field capabilities",
+        "description": "Get information about the capabilities of fields among multiple indices.\n\nFor data streams, the API returns field capabilities among the stream’s backing indices.\nIt returns runtime fields like any other field.\nFor example, a runtime field with a type of keyword is returned the same as any other field that belongs to the `keyword` family.",
         "operationId": "field-caps-2",
         "parameters": [
           {
@@ -5605,8 +5608,8 @@
         "tags": [
           "search"
         ],
-        "summary": "The field capabilities API returns the information about the capabilities of fields among multiple indices",
-        "description": "The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type\nof keyword is returned as any other field that belongs to the `keyword` family.",
+        "summary": "Get the field capabilities",
+        "description": "Get information about the capabilities of fields among multiple indices.\n\nFor data streams, the API returns field capabilities among the stream’s backing indices.\nIt returns runtime fields like any other field.\nFor example, a runtime field with a type of keyword is returned the same as any other field that belongs to the `keyword` family.",
         "operationId": "field-caps-3",
         "parameters": [
           {
@@ -13904,7 +13907,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs multiple templated searches with a single request",
+        "summary": "Run multiple templated searches",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "msearch-template",
         "parameters": [
           {
@@ -13937,7 +13943,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs multiple templated searches with a single request",
+        "summary": "Run multiple templated searches",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "msearch-template-1",
         "parameters": [
           {
@@ -13972,7 +13981,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs multiple templated searches with a single request",
+        "summary": "Run multiple templated searches",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "msearch-template-2",
         "parameters": [
           {
@@ -14008,7 +14020,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs multiple templated searches with a single request",
+        "summary": "Run multiple templated searches",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "msearch-template-3",
         "parameters": [
           {
@@ -14272,8 +14287,8 @@
         "tags": [
           "search"
         ],
-        "summary": "A search request by default executes against the most recent visible data of the target indices,\n",
-        "description": "which is called point in time. Elasticsearch pit (point in time) is a lightweight view into the\nstate of the data as it existed when initiated. In some cases, it’s preferred to perform multiple\nsearch requests using the same point in time. For example, if refreshes happen between\n`search_after` requests, then the results of those requests might not be consistent as changes happening\nbetween searches are only visible to the more recent point in time.",
+        "summary": "Open a point in time",
+        "description": "A search request by default runs against the most recent visible data of the target indices,\nwhich is called point in time. Elasticsearch pit (point in time) is a lightweight view into the\nstate of the data as it existed when initiated. In some cases, it’s preferred to perform multiple\nsearch requests using the same point in time. For example, if refreshes happen between\n`search_after` requests, then the results of those requests might not be consistent as changes happening\nbetween searches are only visible to the more recent point in time.\n\nA point in time must be opened explicitly before being used in search requests.\nThe `keep_alive` parameter tells Elasticsearch how long it should persist.",
         "operationId": "open-point-in-time",
         "parameters": [
           {
@@ -14895,7 +14910,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Evaluate ranked search results",
+        "description": "Evaluate the quality of ranked search results over a set of typical search queries.",
         "operationId": "rank-eval",
         "parameters": [
           {
@@ -14925,7 +14941,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Evaluate ranked search results",
+        "description": "Evaluate the quality of ranked search results over a set of typical search queries.",
         "operationId": "rank-eval-1",
         "parameters": [
           {
@@ -14957,7 +14974,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Evaluate ranked search results",
+        "description": "Evaluate the quality of ranked search results over a set of typical search queries.",
         "operationId": "rank-eval-2",
         "parameters": [
           {
@@ -14990,7 +15008,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Enables you to evaluate the quality of ranked search results over a set of typical search queries",
+        "summary": "Evaluate ranked search results",
+        "description": "Evaluate the quality of ranked search results over a set of typical search queries.",
         "operationId": "rank-eval-3",
         "parameters": [
           {
@@ -15218,7 +15237,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Renders a search template as a search request body",
+        "summary": "Render a search template",
+        "description": "Render a search template as a search request body.",
         "operationId": "render-search-template",
         "requestBody": {
           "$ref": "#/components/requestBodies/render_search_template"
@@ -15233,7 +15253,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Renders a search template as a search request body",
+        "summary": "Render a search template",
+        "description": "Render a search template as a search request body.",
         "operationId": "render-search-template-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/render_search_template"
@@ -15250,7 +15271,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Renders a search template as a search request body",
+        "summary": "Render a search template",
+        "description": "Render a search template as a search request body.",
         "operationId": "render-search-template-2",
         "parameters": [
           {
@@ -15270,7 +15292,8 @@
         "tags": [
           "search"
         ],
-        "summary": "Renders a search template as a search request body",
+        "summary": "Render a search template",
+        "description": "Render a search template as a search request body.",
         "operationId": "render-search-template-3",
         "parameters": [
           {
@@ -16403,7 +16426,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs a search with a search template",
+        "summary": "Run a search with a search template",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "search-template",
         "parameters": [
           {
@@ -16460,7 +16486,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs a search with a search template",
+        "summary": "Run a search with a search template",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "search-template-1",
         "parameters": [
           {
@@ -16519,7 +16548,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs a search with a search template",
+        "summary": "Run a search with a search template",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "search-template-2",
         "parameters": [
           {
@@ -16579,7 +16611,10 @@
         "tags": [
           "search"
         ],
-        "summary": "Runs a search with a search template",
+        "summary": "Run a search with a search template",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "search-template-3",
         "parameters": [
           {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -531,6 +531,7 @@ search-validate,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 search-vector-tile-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-vector-tile-api.html
 searchable-snapshots-api-mount-snapshot,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/searchable-snapshots-api-mount-snapshot.html
 searchable-snapshots-apis,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/searchable-snapshots-apis.html
+search-templates,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-template.html
 secure-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/secure-settings.html
 security-api-authenticate,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-authenticate.html
 security-api-change-password,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-change-password.html

--- a/specification/_global/clear_scroll/ClearScrollRequest.ts
+++ b/specification/_global/clear_scroll/ClearScrollRequest.ts
@@ -21,7 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { ScrollIds } from '@_types/common'
 
 /**
- * Clears the search context and results for a scrolling search.
+ * Clear a scrolling search.
+ *
+ * Clear the search context and results for a scrolling search.
  * @rest_spec_name clear_scroll
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/_global/close_point_in_time/ClosePointInTimeRequest.ts
+++ b/specification/_global/close_point_in_time/ClosePointInTimeRequest.ts
@@ -21,7 +21,12 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Closes a point-in-time.
+ * Close a point in time.
+ *
+ * A point in time must be opened explicitly before being used in search requests.
+ * The `keep_alive` parameter tells Elasticsearch how long it should persist.
+ * A point in time is automatically closed when the `keep_alive` period has elapsed.
+ * However, keeping points in time has a cost; close them as soon as they are no lwonger required for search requests.
  * @rest_spec_name close_point_in_time
  * @availability stack since=7.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/_global/close_point_in_time/ClosePointInTimeRequest.ts
+++ b/specification/_global/close_point_in_time/ClosePointInTimeRequest.ts
@@ -26,7 +26,7 @@ import { Id } from '@_types/common'
  * A point in time must be opened explicitly before being used in search requests.
  * The `keep_alive` parameter tells Elasticsearch how long it should persist.
  * A point in time is automatically closed when the `keep_alive` period has elapsed.
- * However, keeping points in time has a cost; close them as soon as they are no lwonger required for search requests.
+ * However, keeping points in time has a cost; close them as soon as they are no longer required for search requests.
  * @rest_spec_name close_point_in_time
  * @availability stack since=7.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/_global/field_caps/FieldCapabilitiesRequest.ts
+++ b/specification/_global/field_caps/FieldCapabilitiesRequest.ts
@@ -23,9 +23,13 @@ import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 
 /**
- * The field capabilities API returns the information about the capabilities of fields among multiple indices.
- * The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type
- * of keyword is returned as any other field that belongs to the `keyword` family.
+ * Get the field capabilities.
+ *
+ * Get information about the capabilities of fields among multiple indices.
+ *
+ * For data streams, the API returns field capabilities among the stream’s backing indices.
+ * It returns runtime fields like any other field.
+ * For example, a runtime field with a type of keyword is returned the same as any other field that belongs to the `keyword` family.
  * @rest_spec_name field_caps
  * @availability stack since=5.4.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/_global/knn_search/KnnSearchRequest.ts
+++ b/specification/_global/knn_search/KnnSearchRequest.ts
@@ -25,7 +25,7 @@ import { Query } from './_types/Knn'
 
 /**
  * Run a knn search.
- * 
+ *
  * NOTE: The kNN search API has been replaced by the `knn` option in the search API.
  *
  * Perform a k-nearest neighbor (kNN) search on a dense_vector field and return the matching documents.

--- a/specification/_global/knn_search/KnnSearchRequest.ts
+++ b/specification/_global/knn_search/KnnSearchRequest.ts
@@ -24,6 +24,19 @@ import { FieldAndFormat, QueryContainer } from '@_types/query_dsl/abstractions'
 import { Query } from './_types/Knn'
 
 /**
+ * Run a knn search.
+ * 
+ * NOTE: The kNN search API has been replaced by the `knn` option in the search API.
+ *
+ * Perform a k-nearest neighbor (kNN) search on a dense_vector field and return the matching documents.
+ * Given a query vector, the API finds the k closest vectors and returns those documents as search hits.
+ *
+ * Elasticsearch uses the HNSW algorithm to support efficient kNN search.
+ * Like most kNN algorithms, HNSW is an approximate method that sacrifices result accuracy for improved search speed.
+ * This means the results returned are not always the true k closest neighbors.
+ *
+ * The kNN search API supports restricting the search using a filter.
+ * The search will return the top k documents that also match the filter query.
  * @rest_spec_name knn_search
  * @availability stack since=8.0.0 stability=experimental
  * @deprecated 8.4.0

--- a/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
@@ -23,12 +23,13 @@ import { long } from '@_types/Numeric'
 import { RequestItem } from './types'
 
 /**
- * Runs multiple templated searches with a single request.
+ * Run multiple templated searches.
  * @rest_spec_name msearch_template
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @index_privileges read
  * @doc_tag search
+ * @ext_doc_id search-templates
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
+++ b/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
@@ -23,12 +23,17 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Duration } from '@_types/Time'
 
 /**
- * A search request by default executes against the most recent visible data of the target indices,
+ * Open a point in time.
+ *
+ * A search request by default runs against the most recent visible data of the target indices,
  * which is called point in time. Elasticsearch pit (point in time) is a lightweight view into the
  * state of the data as it existed when initiated. In some cases, it’s preferred to perform multiple
  * search requests using the same point in time. For example, if refreshes happen between
  * `search_after` requests, then the results of those requests might not be consistent as changes happening
  * between searches are only visible to the more recent point in time.
+ * 
+ * A point in time must be opened explicitly before being used in search requests.
+ * The `keep_alive` parameter tells Elasticsearch how long it should persist.
  * @rest_spec_name open_point_in_time
  * @availability stack since=7.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
+++ b/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
@@ -31,7 +31,7 @@ import { Duration } from '@_types/Time'
  * search requests using the same point in time. For example, if refreshes happen between
  * `search_after` requests, then the results of those requests might not be consistent as changes happening
  * between searches are only visible to the more recent point in time.
- * 
+ *
  * A point in time must be opened explicitly before being used in search requests.
  * The `keep_alive` parameter tells Elasticsearch how long it should persist.
  * @rest_spec_name open_point_in_time

--- a/specification/_global/rank_eval/RankEvalRequest.ts
+++ b/specification/_global/rank_eval/RankEvalRequest.ts
@@ -22,7 +22,9 @@ import { ExpandWildcards, Indices } from '@_types/common'
 import { RankEvalMetric, RankEvalRequestItem } from './types'
 
 /**
- * Enables you to evaluate the quality of ranked search results over a set of typical search queries.
+ * Evaluate ranked search results.
+ *
+ * Evaluate the quality of ranked search results over a set of typical search queries.
  * @rest_spec_name rank_eval
  * @availability stack since=6.2.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
+++ b/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
@@ -23,7 +23,9 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Renders a search template as a search request body.
+ * Render a search template.
+ *
+ * Render a search template as a search request body.
  * @rest_spec_name render_search_template
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -52,7 +52,9 @@ import { SourceConfig, SourceConfigParam } from './_types/SourceFilter'
 import { Suggester } from './_types/suggester'
 
 /**
- * Returns search hits that match the query defined in the request.
+ * Run a search.
+ *
+ * Get search hits that match the query defined in the request.
  * You can provide search queries using the `q` query string parameter or the request body.
  * If both are specified, only the query parameter is used.
  * @rest_spec_name search

--- a/specification/_global/search_mvt/SearchMvtRequest.ts
+++ b/specification/_global/search_mvt/SearchMvtRequest.ts
@@ -32,7 +32,8 @@ import { ZoomLevel } from './_types/ZoomLevel'
 
 /**
  * Search a vector tile.
- * Searches a vector tile for geospatial values.
+ *
+ * Search a vector tile for geospatial values.
  * @rest_spec_name search_mvt
  * @availability stack since=7.15.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/_global/search_shards/SearchShardsRequest.ts
+++ b/specification/_global/search_shards/SearchShardsRequest.ts
@@ -22,7 +22,7 @@ import { ExpandWildcards, Indices, Routing } from '@_types/common'
 
 /**
  * Get the search shards.
- * 
+ *
  * Get the indices and shards that a search request would be run against.
  * This information can be useful for working out issues or planning optimizations with routing and shard preferences.
  * When filtered aliases are used, the filter is returned as part of the indices section.

--- a/specification/_global/search_shards/SearchShardsRequest.ts
+++ b/specification/_global/search_shards/SearchShardsRequest.ts
@@ -21,6 +21,11 @@ import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, Indices, Routing } from '@_types/common'
 
 /**
+ * Get the search shards.
+ * 
+ * Get the indices and shards that a search request would be run against.
+ * This information can be useful for working out issues or planning optimizations with routing and shard preferences.
+ * When filtered aliases are used, the filter is returned as part of the indices section.
  * @rest_spec_name search_shards
  * @availability stack stability=stable
  * @doc_tag search

--- a/specification/_global/search_template/SearchTemplateRequest.ts
+++ b/specification/_global/search_template/SearchTemplateRequest.ts
@@ -35,7 +35,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=2.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag search
- * @ext_doc_id search-teamplate
+ * @ext_doc_id search-template
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/search_template/SearchTemplateRequest.ts
+++ b/specification/_global/search_template/SearchTemplateRequest.ts
@@ -30,11 +30,12 @@ import {
 import { Duration } from '@_types/Time'
 
 /**
- * Runs a search with a search template.
+ * Run a search with a search template.
  * @rest_spec_name search_template
  * @availability stack since=2.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag search
+ * @ext_doc_id search-teamplate
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/_global/termvectors/TermVectorsRequest.ts
+++ b/specification/_global/termvectors/TermVectorsRequest.ts
@@ -32,7 +32,8 @@ import { Filter } from './types'
 
 /**
  * Get term vector information.
- * Returns information and statistics about terms in the fields of a particular document.
+ *
+ * Get information and statistics about terms in the fields of a particular document.
  * @rest_spec_name termvectors
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/async_search/delete/AsyncSearchDeleteRequest.ts
+++ b/specification/async_search/delete/AsyncSearchDeleteRequest.ts
@@ -22,6 +22,7 @@ import { Id } from '@_types/common'
 
 /**
  * Delete an async search.
+ *
  * If the asynchronous search is still running, it is cancelled.
  * Otherwise, the saved search results are deleted.
  * If the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.

--- a/specification/async_search/get/AsyncSearchGetRequest.ts
+++ b/specification/async_search/get/AsyncSearchGetRequest.ts
@@ -23,6 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * Get async search results.
+ *
  * Retrieve the results of a previously submitted asynchronous search request.
  * If the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.
  * @rest_spec_name async_search.get

--- a/specification/async_search/status/AsyncSearchStatusRequest.ts
+++ b/specification/async_search/status/AsyncSearchStatusRequest.ts
@@ -21,8 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Get async search status.
- * Retrieve the status of a previously submitted async search request given its identifier, without retrieving search results.
+ * Get the async search status.
+ *
+ * Get the status of a previously submitted async search request given its identifier, without retrieving search results.
  * If the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.
  * @rest_spec_name async_search.status
  * @availability stack since=7.11.0 stability=stable

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -54,6 +54,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * Run an async search.
+ *
  * When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field. Partial results become available following the sort criteria that was requested.
  *
  * Warning: Asynchronous search does not support scroll or search requests that include only the suggest section.


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR edits the summaries for a subset of search APIs, such that they more closely align with our style recommendations and the titles from https://www.elastic.co/guide/en/elasticsearch/reference/master/search.html

### Reviewer notes

Since the openAPI document is too big for previews and not hooked into buildkite previews yet, if reviewers are wanting to review the strings, they all appear in the output/openapi/elasticsearch-openapi.json file. The serverless file in that folder is the same or smaller subset so it's not necessary to compare both output for the purposes of these text edits.