### PR TITLE
Remove `?verbose` from `_segments` API

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -13708,9 +13708,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.segments#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.segments#verbose"
           }
         ],
         "responses": {
@@ -13740,9 +13737,6 @@
           },
           {
             "$ref": "#/components/parameters/indices.segments#ignore_unavailable"
-          },
-          {
-            "$ref": "#/components/parameters/indices.segments#verbose"
           }
         ],
         "responses": {
@@ -96282,16 +96276,6 @@
         "in": "query",
         "name": "ignore_unavailable",
         "description": "If `false`, the request returns an error if it targets a missing or closed index.",
-        "deprecated": false,
-        "schema": {
-          "type": "boolean"
-        },
-        "style": "form"
-      },
-      "indices.segments#verbose": {
-        "in": "query",
-        "name": "verbose",
-        "description": "If `true`, the request returns a verbose response.",
         "deprecated": false,
         "schema": {
           "type": "boolean"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12277,7 +12277,6 @@ export interface IndicesSegmentsRequest extends RequestBase {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
-  verbose?: boolean
 }
 
 export interface IndicesSegmentsResponse {

--- a/specification/_json_spec/indices.segments.json
+++ b/specification/_json_spec/indices.segments.json
@@ -41,15 +41,6 @@
         "options": ["open", "closed", "hidden", "none", "all"],
         "default": "open",
         "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both."
-      },
-      "verbose": {
-        "type": "boolean",
-        "description": "Includes detailed memory usage by Lucene.",
-        "default": false,
-        "deprecated": {
-          "version": "8.0.0",
-          "description": "lucene no longer keeps track of segment memory overhead as it is largely off-heap"
-        }
       }
     }
   }

--- a/specification/indices/segments/IndicesSegmentsRequest.ts
+++ b/specification/indices/segments/IndicesSegmentsRequest.ts
@@ -55,10 +55,5 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     ignore_unavailable?: boolean
-    /**
-     * If `true`, the request returns a verbose response.
-     * @server_default false
-     */
-    verbose?: boolean
   }
 }


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/pull/116030.
