### PR TITLE
[8.x] Add specification for query rules retriever

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2703,6 +2703,8 @@ export interface RetrieverContainer {
   standard?: StandardRetriever
   knn?: KnnRetriever
   rrf?: RRFRetriever
+  text_similarity_reranker?: TextSimilarityReranker
+  rule?: RuleRetriever
 }
 
 export type Routing = string
@@ -2710,6 +2712,13 @@ export type Routing = string
 export interface RrfRank {
   rank_constant?: long
   rank_window_size?: long
+}
+
+export interface RuleRetriever extends RetrieverBase {
+  ruleset_ids: Id[]
+  match_criteria: any
+  retriever: RetrieverContainer
+  rank_window_size?: integer
 }
 
 export type ScalarValue = long | double | string | boolean | null
@@ -2902,6 +2911,14 @@ export type TaskId = string | integer
 export interface TextEmbedding {
   model_id: string
   model_text: string
+}
+
+export interface TextSimilarityReranker extends RetrieverBase {
+  retriever: RetrieverContainer
+  rank_window_size?: integer
+  inference_id?: string
+  inference_text?: string
+  field?: string
 }
 
 export type ThreadType = 'cpu' | 'wait' | 'block' | 'gpu' | 'mem'

--- a/specification/_types/Retriever.ts
+++ b/specification/_types/Retriever.ts
@@ -18,9 +18,11 @@
  */
 
 import { FieldCollapse } from '@global/search/_types/FieldCollapse'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { QueryVector, QueryVectorBuilder } from '@_types/Knn'
 import { float, integer } from '@_types/Numeric'
 import { Sort, SortResults } from '@_types/sort'
+import { Id } from './common'
 import { QueryContainer } from './query_dsl/abstractions'
 
 /**
@@ -33,6 +35,10 @@ export class RetrieverContainer {
   knn?: KnnRetriever
   /** A retriever that produces top documents from reciprocal rank fusion (RRF). */
   rrf?: RRFRetriever
+  /** A retriever that reranks the top documents based on a reranking model using the InferenceAPI */
+  text_similarity_reranker?: TextSimilarityReranker
+  /** A retriever that replaces the functionality of a rule query. */
+  rule?: RuleRetriever
 }
 
 export class RetrieverBase {
@@ -76,5 +82,29 @@ export class RRFRetriever extends RetrieverBase {
   /** This value determines how much influence documents in individual result sets per query have over the final ranked result set. */
   rank_constant?: integer
   /** This value determines the size of the individual result sets per query.  */
+  rank_window_size?: integer
+}
+
+export class TextSimilarityReranker extends RetrieverBase {
+  /** The nested retriever which will produce the first-level results, that will later be used for reranking. */
+  retriever: RetrieverContainer
+  /** This value determines how many documents we will consider from the nested retriever.  */
+  rank_window_size?: integer
+  /** Unique identifier of the inference endpoint created using the inference API. */
+  inference_id?: string
+  /** The text snippet used as the basis for similarity comparison */
+  inference_text?: string
+  /** The document field to be used for text similarity comparisons. This field should contain the text that will be evaluated against the inference_text */
+  field?: string
+}
+
+export class RuleRetriever extends RetrieverBase {
+  /** The ruleset IDs containing the rules this retriever is evaluating against. */
+  ruleset_ids: Id[]
+  /** The match criteria that will determine if a rule in the provided rulesets should be applied. */
+  match_criteria: UserDefinedValue
+  /** The retriever whose results rules should be applied to. */
+  retriever: RetrieverContainer
+  /** This value determines the size of the individual result set.  */
   rank_window_size?: integer
 }


### PR DESCRIPTION

Backports https://github.com/elastic/elasticsearch-specification/pull/3078 to 8.x. 

Text similarity came with it, but since it's in 8.15 that's probably OK 