### PR TITLE
deprecating local param from alias req

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -95191,7 +95191,7 @@
         "in": "query",
         "name": "local",
         "description": "If `true`, the request retrieves information from the local node only.",
-        "deprecated": false,
+        "deprecated": true,
         "schema": {
           "type": "boolean"
         },
@@ -95395,7 +95395,7 @@
         "in": "query",
         "name": "local",
         "description": "If `true`, the request retrieves information from the local node only.",
-        "deprecated": false,
+        "deprecated": true,
         "schema": {
           "type": "boolean"
         },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -58591,7 +58591,7 @@
         "in": "query",
         "name": "local",
         "description": "If `true`, the request retrieves information from the local node only.",
-        "deprecated": false,
+        "deprecated": true,
         "schema": {
           "type": "boolean"
         },
@@ -58653,7 +58653,7 @@
         "in": "query",
         "name": "local",
         "description": "If `true`, the request retrieves information from the local node only.",
-        "deprecated": false,
+        "deprecated": true,
         "schema": {
           "type": "boolean"
         },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -21128,6 +21128,10 @@
           }
         },
         {
+          "deprecation": {
+            "description": "",
+            "version": "8.12.0"
+          },
           "description": "If `true`, the request retrieves information from the local node only.",
           "name": "local",
           "required": false,
@@ -21141,7 +21145,7 @@
           }
         }
       ],
-      "specLocation": "indices/exists_alias/IndicesExistsAliasRequest.ts#L23-L68"
+      "specLocation": "indices/exists_alias/IndicesExistsAliasRequest.ts#L23-L69"
     },
     {
       "body": {
@@ -21573,6 +21577,10 @@
           }
         },
         {
+          "deprecation": {
+            "description": "",
+            "version": "8.12.0"
+          },
           "description": "If `true`, the request retrieves information from the local node only.",
           "name": "local",
           "required": false,
@@ -21586,7 +21594,7 @@
           }
         }
       ],
-      "specLocation": "indices/get_alias/IndicesGetAliasRequest.ts#L23-L71"
+      "specLocation": "indices/get_alias/IndicesGetAliasRequest.ts#L23-L72"
     },
     {
       "body": {

--- a/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
+++ b/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
@@ -62,6 +62,7 @@ export interface Request extends RequestBase {
     /**
      * If `true`, the request retrieves information from the local node only.
      * @server_default false
+     * @deprecated 8.12.0
      */
     local?: boolean
   }

--- a/specification/indices/get_alias/IndicesGetAliasRequest.ts
+++ b/specification/indices/get_alias/IndicesGetAliasRequest.ts
@@ -65,6 +65,7 @@ export interface Request extends RequestBase {
     /**
      * If `true`, the request retrieves information from the local node only.
      * @server_default false
+     * @deprecated 8.12.0
      */
     local?: boolean
   }


### PR DESCRIPTION
Following https://github.com/elastic/elasticsearch-specification/pull/3059, which removes the `local` parameter from alias requests in version 9, we should mark it as deprecated in 8
