### PR TITLE
"local" parameter only in compatible cat requests

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -858,6 +858,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.allocation#bytes"
+          },
+          {
+            "$ref": "#/components/parameters/cat.allocation#local"
           }
         ],
         "responses": {
@@ -881,6 +884,9 @@
           },
           {
             "$ref": "#/components/parameters/cat.allocation#bytes"
+          },
+          {
+            "$ref": "#/components/parameters/cat.allocation#local"
           }
         ],
         "responses": {
@@ -898,6 +904,11 @@
         "summary": "Get component templates",
         "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "operationId": "cat-component-templates",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cat.component_templates#local"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/cat.component_templates#200"
@@ -917,6 +928,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.component_templates#name"
+          },
+          {
+            "$ref": "#/components/parameters/cat.component_templates#local"
           }
         ],
         "responses": {
@@ -1109,6 +1123,9 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices#time"
+          },
+          {
+            "$ref": "#/components/parameters/cat.indices#local"
           }
         ],
         "responses": {
@@ -1147,6 +1164,9 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices#time"
+          },
+          {
+            "$ref": "#/components/parameters/cat.indices#local"
           }
         ],
         "responses": {
@@ -1164,6 +1184,18 @@
         "summary": "Returns information about the master node, including the ID, bound IP address, and name",
         "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-master",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "local",
+            "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -1465,6 +1497,18 @@
         "summary": "Returns information about custom node attributes",
         "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-nodeattrs",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "local",
+            "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -1554,6 +1598,18 @@
         "summary": "Returns cluster-level changes that have not yet been executed",
         "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the pending cluster tasks API.",
         "operationId": "cat-pending-tasks",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "local",
+            "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -1579,6 +1635,18 @@
         "summary": "Returns a list of plugins running on each node of a cluster",
         "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-plugins",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "local",
+            "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -1688,6 +1756,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.segments#bytes"
+          },
+          {
+            "$ref": "#/components/parameters/cat.segments#local"
           }
         ],
         "responses": {
@@ -1711,6 +1782,9 @@
           },
           {
             "$ref": "#/components/parameters/cat.segments#bytes"
+          },
+          {
+            "$ref": "#/components/parameters/cat.segments#local"
           }
         ],
         "responses": {
@@ -1890,6 +1964,11 @@
         "summary": "Returns information about index templates in a cluster",
         "description": "You can use index templates to apply index settings and field mappings to new indices at creation.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index template API.",
         "operationId": "cat-templates",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cat.templates#local"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/cat.templates#200"
@@ -1909,6 +1988,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.templates#name"
+          },
+          {
+            "$ref": "#/components/parameters/cat.templates#local"
           }
         ],
         "responses": {
@@ -1930,6 +2012,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.thread_pool#time"
+          },
+          {
+            "$ref": "#/components/parameters/cat.thread_pool#local"
           }
         ],
         "responses": {
@@ -1953,6 +2038,9 @@
           },
           {
             "$ref": "#/components/parameters/cat.thread_pool#time"
+          },
+          {
+            "$ref": "#/components/parameters/cat.thread_pool#local"
           }
         ],
         "responses": {
@@ -92808,6 +92896,16 @@
         },
         "style": "form"
       },
+      "cat.allocation#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
       "cat.component_templates#name": {
         "in": "path",
         "name": "name",
@@ -92818,6 +92916,16 @@
           "type": "string"
         },
         "style": "simple"
+      },
+      "cat.component_templates#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
       },
       "cat.count#index": {
         "in": "path",
@@ -92929,6 +93037,16 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:TimeUnit"
+        },
+        "style": "form"
+      },
+      "cat.indices#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
         },
         "style": "form"
       },
@@ -93238,6 +93356,16 @@
         },
         "style": "form"
       },
+      "cat.segments#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
       "cat.shards#index": {
         "in": "path",
         "name": "index",
@@ -93291,6 +93419,16 @@
         },
         "style": "simple"
       },
+      "cat.templates#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
       "cat.thread_pool#thread_pool_patterns": {
         "in": "path",
         "name": "thread_pool_patterns",
@@ -93309,6 +93447,16 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:TimeUnit"
+        },
+        "style": "form"
+      },
+      "cat.thread_pool#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
         },
         "style": "form"
       },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -1123,9 +1123,6 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices#time"
-          },
-          {
-            "$ref": "#/components/parameters/cat.indices#local"
           }
         ],
         "responses": {
@@ -1164,9 +1161,6 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices#time"
-          },
-          {
-            "$ref": "#/components/parameters/cat.indices#local"
           }
         ],
         "responses": {
@@ -93037,16 +93031,6 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:TimeUnit"
-        },
-        "style": "form"
-      },
-      "cat.indices#local": {
-        "in": "query",
-        "name": "local",
-        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
-        "deprecated": false,
-        "schema": {
-          "type": "boolean"
         },
         "style": "form"
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -707,6 +707,11 @@
         "summary": "Get component templates",
         "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "operationId": "cat-component-templates",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cat.component_templates#local"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/cat.component_templates#200"
@@ -726,6 +731,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.component_templates#name"
+          },
+          {
+            "$ref": "#/components/parameters/cat.component_templates#local"
           }
         ],
         "responses": {
@@ -822,6 +830,9 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices#time"
+          },
+          {
+            "$ref": "#/components/parameters/cat.indices#local"
           }
         ],
         "responses": {
@@ -860,6 +871,9 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices#time"
+          },
+          {
+            "$ref": "#/components/parameters/cat.indices#local"
           }
         ],
         "responses": {
@@ -57178,6 +57192,16 @@
         },
         "style": "simple"
       },
+      "cat.component_templates#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
       "cat.count#index": {
         "in": "path",
         "name": "index",
@@ -57257,6 +57281,16 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:TimeUnit"
+        },
+        "style": "form"
+      },
+      "cat.indices#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
         },
         "style": "form"
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -830,9 +830,6 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices#time"
-          },
-          {
-            "$ref": "#/components/parameters/cat.indices#local"
           }
         ],
         "responses": {
@@ -871,9 +868,6 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices#time"
-          },
-          {
-            "$ref": "#/components/parameters/cat.indices#local"
           }
         ],
         "responses": {
@@ -57281,16 +57275,6 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:TimeUnit"
-        },
-        "style": "form"
-      },
-      "cat.indices#local": {
-        "in": "query",
-        "name": "local",
-        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
-        "deprecated": false,
-        "schema": {
-          "type": "boolean"
         },
         "style": "form"
       },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -11642,8 +11642,22 @@
           }
         }
       ],
-      "query": [],
-      "specLocation": "cat/component_templates/CatComponentTemplatesRequest.ts#L22-L39"
+      "query": [
+        {
+          "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+          "name": "local",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        }
+      ],
+      "specLocation": "cat/component_templates/CatComponentTemplatesRequest.ts#L22-L49"
     },
     {
       "body": {
@@ -11877,9 +11891,22 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+          "name": "local",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
         }
       ],
-      "specLocation": "cat/indices/CatIndicesRequest.ts#L24-L77"
+      "specLocation": "cat/indices/CatIndicesRequest.ts#L24-L85"
     },
     {
       "body": {
@@ -106911,19 +106938,6 @@
           }
         },
         {
-          "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
-          "name": "local",
-          "required": false,
-          "serverDefault": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
           "description": "Period to wait for a connection to the master node.",
           "name": "master_timeout",
           "required": false,
@@ -106962,7 +106976,7 @@
           }
         }
       ],
-      "specLocation": "_spec_utils/behaviors.ts#L86-L132"
+      "specLocation": "_spec_utils/behaviors.ts#L86-L124"
     },
     {
       "kind": "interface",
@@ -135697,7 +135711,7 @@
         "namespace": "_spec_utils"
       },
       "properties": [],
-      "specLocation": "_spec_utils/behaviors.ts#L134-L140"
+      "specLocation": "_spec_utils/behaviors.ts#L126-L132"
     },
     {
       "attachedBehaviors": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -11891,22 +11891,9 @@
               "namespace": "_types"
             }
           }
-        },
-        {
-          "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
-          "name": "local",
-          "required": false,
-          "serverDefault": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "_builtins"
-            }
-          }
         }
       ],
-      "specLocation": "cat/indices/CatIndicesRequest.ts#L24-L85"
+      "specLocation": "cat/indices/CatIndicesRequest.ts#L24-L77"
     },
     {
       "body": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -187,7 +187,6 @@
     },
     "cat.indices": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: missing json spec query parameter 'format'",
         "Request: missing json spec query parameter 'master_timeout'",
         "Request: missing json spec query parameter 'h'",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -121,7 +121,6 @@
     "cat.allocation": {
       "request": [
         "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
         "Request: missing json spec query parameter 'master_timeout'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",
@@ -136,7 +135,6 @@
     "cat.component_templates": {
       "request": [
         "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
         "Request: missing json spec query parameter 'master_timeout'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",
@@ -189,6 +187,7 @@
     },
     "cat.indices": {
       "request": [
+        "Request: query parameter 'local' does not exist in the json spec",
         "Request: missing json spec query parameter 'format'",
         "Request: missing json spec query parameter 'master_timeout'",
         "Request: missing json spec query parameter 'h'",
@@ -202,7 +201,6 @@
     "cat.master": {
       "request": [
         "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
         "Request: missing json spec query parameter 'master_timeout'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",
@@ -260,7 +258,6 @@
     "cat.nodeattrs": {
       "request": [
         "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
         "Request: missing json spec query parameter 'master_timeout'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",
@@ -286,7 +283,6 @@
     "cat.pending_tasks": {
       "request": [
         "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
         "Request: missing json spec query parameter 'master_timeout'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",
@@ -300,7 +296,6 @@
     "cat.plugins": {
       "request": [
         "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
         "Request: missing json spec query parameter 'master_timeout'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",
@@ -339,6 +334,7 @@
     },
     "cat.segments": {
       "request": [
+        "Request: query parameter 'local' does not exist in the json spec",
         "Request: missing json spec query parameter 'format'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",
@@ -391,7 +387,6 @@
     "cat.templates": {
       "request": [
         "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
         "Request: missing json spec query parameter 'master_timeout'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",
@@ -404,7 +399,6 @@
     "cat.thread_pool": {
       "request": [
         "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
         "Request: missing json spec query parameter 'master_timeout'",
         "Request: missing json spec query parameter 'h'",
         "Request: missing json spec query parameter 'help'",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6981,6 +6981,7 @@ export interface CatAllocationAllocationRecord {
 export interface CatAllocationRequest extends CatCatRequestBase {
   node_id?: NodeIds
   bytes?: Bytes
+  local?: boolean
 }
 
 export type CatAllocationResponse = CatAllocationAllocationRecord[]
@@ -6997,6 +6998,7 @@ export interface CatComponentTemplatesComponentTemplate {
 
 export interface CatComponentTemplatesRequest extends CatCatRequestBase {
   name?: string
+  local?: boolean
 }
 
 export type CatComponentTemplatesResponse = CatComponentTemplatesComponentTemplate[]
@@ -7408,6 +7410,7 @@ export interface CatIndicesRequest extends CatCatRequestBase {
   include_unloaded_segments?: boolean
   pri?: boolean
   time?: TimeUnit
+  local?: boolean
 }
 
 export type CatIndicesResponse = CatIndicesIndicesRecord[]
@@ -7422,6 +7425,7 @@ export interface CatMasterMasterRecord {
 }
 
 export interface CatMasterRequest extends CatCatRequestBase {
+  local?: boolean
 }
 
 export type CatMasterResponse = CatMasterMasterRecord[]
@@ -7789,6 +7793,7 @@ export interface CatNodeattrsNodeAttributesRecord {
 }
 
 export interface CatNodeattrsRequest extends CatCatRequestBase {
+  local?: boolean
 }
 
 export type CatNodeattrsResponse = CatNodeattrsNodeAttributesRecord[]
@@ -8083,6 +8088,7 @@ export interface CatPendingTasksPendingTasksRecord {
 }
 
 export interface CatPendingTasksRequest extends CatCatRequestBase {
+  local?: boolean
 }
 
 export type CatPendingTasksResponse = CatPendingTasksPendingTasksRecord[]
@@ -8102,6 +8108,7 @@ export interface CatPluginsPluginsRecord {
 }
 
 export interface CatPluginsRequest extends CatCatRequestBase {
+  local?: boolean
 }
 
 export type CatPluginsResponse = CatPluginsPluginsRecord[]
@@ -8188,6 +8195,7 @@ export type CatRepositoriesResponse = CatRepositoriesRepositoriesRecord[]
 export interface CatSegmentsRequest extends CatCatRequestBase {
   index?: Indices
   bytes?: Bytes
+  local?: boolean
 }
 
 export type CatSegmentsResponse = CatSegmentsSegmentsRecord[]
@@ -8543,6 +8551,7 @@ export interface CatTasksTasksRecord {
 
 export interface CatTemplatesRequest extends CatCatRequestBase {
   name?: Name
+  local?: boolean
 }
 
 export type CatTemplatesResponse = CatTemplatesTemplatesRecord[]
@@ -8564,6 +8573,7 @@ export interface CatTemplatesTemplatesRecord {
 export interface CatThreadPoolRequest extends CatCatRequestBase {
   thread_pool_patterns?: Names
   time?: TimeUnit
+  local?: boolean
 }
 
 export type CatThreadPoolResponse = CatThreadPoolThreadPoolRecord[]
@@ -21134,7 +21144,6 @@ export interface SpecUtilsCommonCatQueryParameters {
   format?: string
   h?: Names
   help?: boolean
-  local?: boolean
   master_timeout?: Duration
   s?: Names
   v?: boolean

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -7410,7 +7410,6 @@ export interface CatIndicesRequest extends CatCatRequestBase {
   include_unloaded_segments?: boolean
   pri?: boolean
   time?: TimeUnit
-  local?: boolean
 }
 
 export type CatIndicesResponse = CatIndicesIndicesRecord[]

--- a/specification/_spec_utils/behaviors.ts
+++ b/specification/_spec_utils/behaviors.ts
@@ -106,14 +106,6 @@ export interface CommonCatQueryParameters {
    */
   help?: boolean
   /**
-   * If `true`, the request computes the list of selected nodes from the
-   * local cluster state. If `false` the list of selected nodes are computed
-   * from the cluster state of the master node. In both cases the coordinating
-   * node will send requests for further information to each selected node.
-   * @server_default false
-   */
-  local?: boolean
-  /**
    * Period to wait for a connection to the master node.
    * @server_default 30s
    */

--- a/specification/cat/allocation/CatAllocationRequest.ts
+++ b/specification/cat/allocation/CatAllocationRequest.ts
@@ -37,5 +37,13 @@ export interface Request extends CatRequestBase {
   query_parameters: {
     /** The unit used to display byte values. */
     bytes?: Bytes
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
   }
 }

--- a/specification/cat/component_templates/CatComponentTemplatesRequest.ts
+++ b/specification/cat/component_templates/CatComponentTemplatesRequest.ts
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-import { CatRequestBase } from '@cat/_types/CatBase'
-import {Bytes, ExpandWildcards, HealthStatus} from "@_types/common";
-import {TimeUnit} from "@_types/Time";
+import {CatRequestBase} from '@cat/_types/CatBase'
 
 /**
  * Get component templates.
@@ -34,18 +32,18 @@ import {TimeUnit} from "@_types/Time";
  * @cluster_privileges monitor
  */
 export interface Request extends CatRequestBase {
-  path_parts: {
-    /** The name of the component template. Accepts wildcard expressions. If omitted, all component templates are returned. */
-    name?: string
-  }
-  query_parameters: {
-    /**
-     * If `true`, the request computes the list of selected nodes from the
-     * local cluster state. If `false` the list of selected nodes are computed
-     * from the cluster state of the master node. In both cases the coordinating
-     * node will send requests for further information to each selected node.
-     * @server_default false
-     */
-    local?: boolean
-  }
+    path_parts: {
+        /** The name of the component template. Accepts wildcard expressions. If omitted, all component templates are returned. */
+        name?: string
+    }
+    query_parameters: {
+        /**
+         * If `true`, the request computes the list of selected nodes from the
+         * local cluster state. If `false` the list of selected nodes are computed
+         * from the cluster state of the master node. In both cases the coordinating
+         * node will send requests for further information to each selected node.
+         * @server_default false
+         */
+        local?: boolean
+    }
 }

--- a/specification/cat/component_templates/CatComponentTemplatesRequest.ts
+++ b/specification/cat/component_templates/CatComponentTemplatesRequest.ts
@@ -18,6 +18,8 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
+import {Bytes, ExpandWildcards, HealthStatus} from "@_types/common";
+import {TimeUnit} from "@_types/Time";
 
 /**
  * Get component templates.
@@ -35,5 +37,15 @@ export interface Request extends CatRequestBase {
   path_parts: {
     /** The name of the component template. Accepts wildcard expressions. If omitted, all component templates are returned. */
     name?: string
+  }
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
   }
 }

--- a/specification/cat/component_templates/CatComponentTemplatesRequest.ts
+++ b/specification/cat/component_templates/CatComponentTemplatesRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import {CatRequestBase} from '@cat/_types/CatBase'
+import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
  * Get component templates.
@@ -32,18 +32,18 @@ import {CatRequestBase} from '@cat/_types/CatBase'
  * @cluster_privileges monitor
  */
 export interface Request extends CatRequestBase {
-    path_parts: {
-        /** The name of the component template. Accepts wildcard expressions. If omitted, all component templates are returned. */
-        name?: string
-    }
-    query_parameters: {
-        /**
-         * If `true`, the request computes the list of selected nodes from the
-         * local cluster state. If `false` the list of selected nodes are computed
-         * from the cluster state of the master node. In both cases the coordinating
-         * node will send requests for further information to each selected node.
-         * @server_default false
-         */
-        local?: boolean
-    }
+  path_parts: {
+    /** The name of the component template. Accepts wildcard expressions. If omitted, all component templates are returned. */
+    name?: string
+  }
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
+  }
 }

--- a/specification/cat/indices/CatIndicesRequest.ts
+++ b/specification/cat/indices/CatIndicesRequest.ts
@@ -73,5 +73,13 @@ export interface Request extends CatRequestBase {
     pri?: boolean
     /** The unit used to display time values. */
     time?: TimeUnit
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
   }
 }

--- a/specification/cat/indices/CatIndicesRequest.ts
+++ b/specification/cat/indices/CatIndicesRequest.ts
@@ -73,13 +73,5 @@ export interface Request extends CatRequestBase {
     pri?: boolean
     /** The unit used to display time values. */
     time?: TimeUnit
-    /**
-     * If `true`, the request computes the list of selected nodes from the
-     * local cluster state. If `false` the list of selected nodes are computed
-     * from the cluster state of the master node. In both cases the coordinating
-     * node will send requests for further information to each selected node.
-     * @server_default false
-     */
-    local?: boolean
   }
 }

--- a/specification/cat/master/CatMasterRequest.ts
+++ b/specification/cat/master/CatMasterRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { CatRequestBase } from '@cat/_types/CatBase'
+import {CatRequestBase} from '@cat/_types/CatBase'
 
 /**
  * Returns information about the master node, including the ID, bound IP address, and name.
@@ -28,4 +28,15 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @doc_id cat-master
  * @cluster_privileges monitor
  */
-export interface Request extends CatRequestBase {}
+export interface Request extends CatRequestBase {
+    query_parameters: {
+        /**
+         * If `true`, the request computes the list of selected nodes from the
+         * local cluster state. If `false` the list of selected nodes are computed
+         * from the cluster state of the master node. In both cases the coordinating
+         * node will send requests for further information to each selected node.
+         * @server_default false
+         */
+        local?: boolean
+    }
+}

--- a/specification/cat/master/CatMasterRequest.ts
+++ b/specification/cat/master/CatMasterRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import {CatRequestBase} from '@cat/_types/CatBase'
+import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
  * Returns information about the master node, including the ID, bound IP address, and name.
@@ -29,14 +29,14 @@ import {CatRequestBase} from '@cat/_types/CatBase'
  * @cluster_privileges monitor
  */
 export interface Request extends CatRequestBase {
-    query_parameters: {
-        /**
-         * If `true`, the request computes the list of selected nodes from the
-         * local cluster state. If `false` the list of selected nodes are computed
-         * from the cluster state of the master node. In both cases the coordinating
-         * node will send requests for further information to each selected node.
-         * @server_default false
-         */
-        local?: boolean
-    }
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
+  }
 }

--- a/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
+++ b/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
@@ -28,4 +28,15 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @doc_id cat-nodeattrs
  * @cluster_privileges monitor
  */
-export interface Request extends CatRequestBase {}
+export interface Request extends CatRequestBase {
+    query_parameters: {
+        /**
+         * If `true`, the request computes the list of selected nodes from the
+         * local cluster state. If `false` the list of selected nodes are computed
+         * from the cluster state of the master node. In both cases the coordinating
+         * node will send requests for further information to each selected node.
+         * @server_default false
+         */
+        local?: boolean
+    }
+}

--- a/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
+++ b/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
@@ -29,14 +29,14 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @cluster_privileges monitor
  */
 export interface Request extends CatRequestBase {
-    query_parameters: {
-        /**
-         * If `true`, the request computes the list of selected nodes from the
-         * local cluster state. If `false` the list of selected nodes are computed
-         * from the cluster state of the master node. In both cases the coordinating
-         * node will send requests for further information to each selected node.
-         * @server_default false
-         */
-        local?: boolean
-    }
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
+  }
 }

--- a/specification/cat/pending_tasks/CatPendingTasksRequest.ts
+++ b/specification/cat/pending_tasks/CatPendingTasksRequest.ts
@@ -28,4 +28,15 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @doc_id cat-pending-tasks
  * @cluster_privileges monitor
  */
-export interface Request extends CatRequestBase {}
+export interface Request extends CatRequestBase {
+    query_parameters: {
+        /**
+         * If `true`, the request computes the list of selected nodes from the
+         * local cluster state. If `false` the list of selected nodes are computed
+         * from the cluster state of the master node. In both cases the coordinating
+         * node will send requests for further information to each selected node.
+         * @server_default false
+         */
+        local?: boolean
+    }
+}

--- a/specification/cat/pending_tasks/CatPendingTasksRequest.ts
+++ b/specification/cat/pending_tasks/CatPendingTasksRequest.ts
@@ -29,14 +29,14 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @cluster_privileges monitor
  */
 export interface Request extends CatRequestBase {
-    query_parameters: {
-        /**
-         * If `true`, the request computes the list of selected nodes from the
-         * local cluster state. If `false` the list of selected nodes are computed
-         * from the cluster state of the master node. In both cases the coordinating
-         * node will send requests for further information to each selected node.
-         * @server_default false
-         */
-        local?: boolean
-    }
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
+  }
 }

--- a/specification/cat/plugins/CatPluginsRequest.ts
+++ b/specification/cat/plugins/CatPluginsRequest.ts
@@ -29,14 +29,14 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @cluster_privileges monitor
  */
 export interface Request extends CatRequestBase {
-    query_parameters: {
-        /**
-         * If `true`, the request computes the list of selected nodes from the
-         * local cluster state. If `false` the list of selected nodes are computed
-         * from the cluster state of the master node. In both cases the coordinating
-         * node will send requests for further information to each selected node.
-         * @server_default false
-         */
-        local?: boolean
-    }
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
+  }
 }

--- a/specification/cat/plugins/CatPluginsRequest.ts
+++ b/specification/cat/plugins/CatPluginsRequest.ts
@@ -28,4 +28,15 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @doc_id cat-plugins
  * @cluster_privileges monitor
  */
-export interface Request extends CatRequestBase {}
+export interface Request extends CatRequestBase {
+    query_parameters: {
+        /**
+         * If `true`, the request computes the list of selected nodes from the
+         * local cluster state. If `false` the list of selected nodes are computed
+         * from the cluster state of the master node. In both cases the coordinating
+         * node will send requests for further information to each selected node.
+         * @server_default false
+         */
+        local?: boolean
+    }
+}

--- a/specification/cat/segments/CatSegmentsRequest.ts
+++ b/specification/cat/segments/CatSegmentsRequest.ts
@@ -45,5 +45,13 @@ export interface Request extends CatRequestBase {
      * The unit used to display byte values.
      */
     bytes?: Bytes
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
   }
 }

--- a/specification/cat/templates/CatTemplatesRequest.ts
+++ b/specification/cat/templates/CatTemplatesRequest.ts
@@ -38,4 +38,14 @@ export interface Request extends CatRequestBase {
      */
     name?: Name
   }
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
+  }
 }

--- a/specification/cat/thread_pool/CatThreadPoolRequest.ts
+++ b/specification/cat/thread_pool/CatThreadPoolRequest.ts
@@ -44,5 +44,13 @@ export interface Request extends CatRequestBase {
      * The unit used to display time values.
      */
     time?: TimeUnit
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
   }
 }


### PR DESCRIPTION
Followup of #3059, removing `local` from common cat parameters and adding it only to those requests which allow it. 
I can't test it with java because it has its own handcrafted test types, but it seems straightforward enough.