### PR TITLE
Fix knn_search deprecation message

### DIFF
--- a/specification/_global/knn_search/KnnSearchRequest.ts
+++ b/specification/_global/knn_search/KnnSearchRequest.ts
@@ -39,7 +39,7 @@ import { Query } from './_types/Knn'
  * The search will return the top k documents that also match the filter query.
  * @rest_spec_name knn_search
  * @availability stack since=8.0.0 stability=experimental
- * @deprecated 8.4.0
+ * @deprecated 8.4.0 The kNN search API has been replaced by the `knn` option in the search API.
  * @doc_tag search
  */
 export interface Request extends RequestBase {


### PR DESCRIPTION
The message is defined in the rest-api-spec, but schema.json uses the value from the specification request, so I copied it from there:

https://github.com/elastic/elasticsearch-specification/blob/b59191910c29f38113114ba7336a812eb7cc87e7/specification/_json_spec/knn_search.json#L10