### PR TITLE
Mark data lifecycle APIs as stable

### DIFF
--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -3703,6 +3703,9 @@
         "namespace": "indices.put_data_lifecycle"
       },
       "requestBodyRequired": true,
+      "requestMediaType": [
+        "application/json"
+      ],
       "response": {
         "name": "Response",
         "namespace": "indices.put_data_lifecycle"

--- a/specification/_json_spec/indices.delete_data_lifecycle.json
+++ b/specification/_json_spec/indices.delete_data_lifecycle.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html",
       "description": "Deletes the data stream lifecycle of the selected data streams."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/indices.explain_data_lifecycle.json
+++ b/specification/_json_spec/indices.explain_data_lifecycle.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams-explain-lifecycle.html",
       "description": "Retrieves information about the index's current data stream lifecycle, such as any potential encountered error, time since creation etc."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/indices.get_data_lifecycle.json
+++ b/specification/_json_spec/indices.get_data_lifecycle.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle.html",
       "description": "Returns the data stream lifecycle of the selected data streams."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/indices.put_data_lifecycle.json
+++ b/specification/_json_spec/indices.put_data_lifecycle.json
@@ -4,10 +4,11 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-put-lifecycle.html",
       "description": "Updates the data stream lifecycle of the selected data streams."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
-      "accept": ["application/json"]
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
     },
     "url": {
       "paths": [


### PR DESCRIPTION
As noticed in https://github.com/elastic/elasticsearch-specification/pull/3019, but extracting it into its own pull request is easier until the IP location APIs are merged. This also include an unrelated fix to the same APIs that I submitted to Elasticsearch: https://github.com/elastic/elasticsearch/pull/116292