### PR TITLE
Set parameter nodes instead of node_id on task.list

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -33046,10 +33046,7 @@
             "description": "Comma-separated list of node IDs or names used to limit returned information.",
             "deprecated": false,
             "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "$ref": "#/components/schemas/_types:NodeIds"
             },
             "style": "form"
           },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -33042,7 +33042,7 @@
           },
           {
             "in": "query",
-            "name": "node_id",
+            "name": "nodes",
             "description": "Comma-separated list of node IDs or names used to limit returned information.",
             "deprecated": false,
             "schema": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1180,9 +1180,7 @@
     },
     "tasks.list": {
       "request": [
-        "Request: query parameter 'node_id' does not exist in the json spec",
-        "Request: query parameter 'master_timeout' does not exist in the json spec",
-        "Request: missing json spec query parameter 'nodes'"
+        "Request: query parameter 'master_timeout' does not exist in the json spec"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -19562,7 +19562,7 @@ export interface TasksListRequest extends RequestBase {
   actions?: string | string[]
   detailed?: boolean
   group_by?: TasksGroupBy
-  nodes?: string[]
+  nodes?: NodeIds
   parent_task_id?: Id
   master_timeout?: Duration
   timeout?: Duration

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -19562,7 +19562,7 @@ export interface TasksListRequest extends RequestBase {
   actions?: string | string[]
   detailed?: boolean
   group_by?: TasksGroupBy
-  node_id?: string[]
+  nodes?: string[]
   parent_task_id?: Id
   master_timeout?: Duration
   timeout?: Duration

--- a/specification/tasks/list/ListTasksRequest.ts
+++ b/specification/tasks/list/ListTasksRequest.ts
@@ -19,7 +19,7 @@
 
 import { GroupBy } from '@tasks/_types/GroupBy'
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
+import { Id, NodeIds } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
@@ -48,7 +48,7 @@ export interface Request extends RequestBase {
     /**
      * Comma-separated list of node IDs or names used to limit returned information.
      */
-    nodes?: string[]
+    nodes?: NodeIds
     /**
      * Parent task ID used to limit returned information. To return all tasks, omit this parameter or use a value of `-1`.
      */

--- a/specification/tasks/list/ListTasksRequest.ts
+++ b/specification/tasks/list/ListTasksRequest.ts
@@ -48,7 +48,7 @@ export interface Request extends RequestBase {
     /**
      * Comma-separated list of node IDs or names used to limit returned information.
      */
-    node_id?: string[]
+    nodes?: string[]
     /**
      * Parent task ID used to limit returned information. To return all tasks, omit this parameter or use a value of `-1`.
      */


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-specification/issues/3112, closes https://github.com/elastic/elasticsearch-specification/pull/3114


Use parameter `nodes` instead of `node_id` on `task.list`.

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
