### PR TITLE
Set parameter nodes instead of node_id on task.list

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -33046,10 +33046,7 @@
             "description": "Comma-separated list of node IDs or names used to limit returned information.",
             "deprecated": false,
             "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "$ref": "#/components/schemas/_types:NodeIds"
             },
             "style": "form"
           },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -33042,7 +33042,7 @@
           },
           {
             "in": "query",
-            "name": "node_id",
+            "name": "nodes",
             "description": "Comma-separated list of node IDs or names used to limit returned information.",
             "deprecated": false,
             "schema": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1180,9 +1180,7 @@
     },
     "tasks.list": {
       "request": [
-        "Request: query parameter 'node_id' does not exist in the json spec",
-        "Request: query parameter 'master_timeout' does not exist in the json spec",
-        "Request: missing json spec query parameter 'nodes'"
+        "Request: query parameter 'master_timeout' does not exist in the json spec"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -19562,7 +19562,7 @@ export interface TasksListRequest extends RequestBase {
   actions?: string | string[]
   detailed?: boolean
   group_by?: TasksGroupBy
-  nodes?: string[]
+  nodes?: NodeIds
   parent_task_id?: Id
   master_timeout?: Duration
   timeout?: Duration

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -19562,7 +19562,7 @@ export interface TasksListRequest extends RequestBase {
   actions?: string | string[]
   detailed?: boolean
   group_by?: TasksGroupBy
-  node_id?: string[]
+  nodes?: string[]
   parent_task_id?: Id
   master_timeout?: Duration
   timeout?: Duration

--- a/specification/tasks/list/ListTasksRequest.ts
+++ b/specification/tasks/list/ListTasksRequest.ts
@@ -19,7 +19,7 @@
 
 import { GroupBy } from '@tasks/_types/GroupBy'
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
+import { Id, NodeIds } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
@@ -48,7 +48,7 @@ export interface Request extends RequestBase {
     /**
      * Comma-separated list of node IDs or names used to limit returned information.
      */
-    nodes?: string[]
+    nodes?: NodeIds
     /**
      * Parent task ID used to limit returned information. To return all tasks, omit this parameter or use a value of `-1`.
      */

--- a/specification/tasks/list/ListTasksRequest.ts
+++ b/specification/tasks/list/ListTasksRequest.ts
@@ -48,7 +48,7 @@ export interface Request extends RequestBase {
     /**
      * Comma-separated list of node IDs or names used to limit returned information.
      */
-    node_id?: string[]
+    nodes?: string[]
     /**
      * Parent task ID used to limit returned information. To return all tasks, omit this parameter or use a value of `-1`.
      */


### PR DESCRIPTION
This is only used to run CI in https://github.com/elastic/elasticsearch-specification/pull/3113.