### PR TITLE
[Backport 8.16] Mark data lifecycle APIs as stable (#3109)

### DIFF
--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -3820,6 +3820,9 @@
         "namespace": "indices.put_data_lifecycle"
       },
       "requestBodyRequired": false,
+      "requestMediaType": [
+        "application/json"
+      ],
       "response": {
         "name": "Response",
         "namespace": "indices.put_data_lifecycle"

--- a/specification/_json_spec/indices.delete_data_lifecycle.json
+++ b/specification/_json_spec/indices.delete_data_lifecycle.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-delete-lifecycle.html",
       "description": "Deletes the data stream lifecycle of the selected data streams."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/indices.explain_data_lifecycle.json
+++ b/specification/_json_spec/indices.explain_data_lifecycle.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams-explain-lifecycle.html",
       "description": "Retrieves information about the index's current data stream lifecycle, such as any potential encountered error, time since creation etc."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/indices.get_data_lifecycle.json
+++ b/specification/_json_spec/indices.get_data_lifecycle.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-get-lifecycle.html",
       "description": "Returns the data stream lifecycle of the selected data streams."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": ["application/json"]

--- a/specification/_json_spec/indices.put_data_lifecycle.json
+++ b/specification/_json_spec/indices.put_data_lifecycle.json
@@ -4,10 +4,11 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-put-lifecycle.html",
       "description": "Updates the data stream lifecycle of the selected data streams."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
-      "accept": ["application/json"]
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
     },
     "url": {
       "paths": [


### PR DESCRIPTION
(cherry picked from commit 17693a6ccd679cb943c952838a700c673b13b9ad)