### PR TITLE
Allow index name patterns in Privileges index fields

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -81966,11 +81966,7 @@
             "$ref": "#/components/schemas/security._types:FieldSecurity"
           },
           "names": {
-            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/_types:IndexName"
-            }
+            "$ref": "#/components/schemas/_types:Indices"
           },
           "privileges": {
             "description": "The index level privileges that owners of the role have on the specified indices.",
@@ -82249,11 +82245,7 @@
         "type": "object",
         "properties": {
           "names": {
-            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/_types:IndexName"
-            }
+            "$ref": "#/components/schemas/_types:Indices"
           }
         },
         "required": [
@@ -82267,11 +82259,7 @@
             "$ref": "#/components/schemas/security._types:FieldSecurity"
           },
           "names": {
-            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/_types:IndexName"
-            }
+            "$ref": "#/components/schemas/_types:Indices"
           },
           "query": {
             "$ref": "#/components/schemas/security._types:IndicesPrivilegesQuery"
@@ -82746,11 +82734,7 @@
             }
           },
           "names": {
-            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/_types:IndexName"
-            }
+            "$ref": "#/components/schemas/_types:Indices"
           },
           "privileges": {
             "description": "The index level privileges that owners of the role have on the specified indices.",
@@ -82971,11 +82955,7 @@
             "$ref": "#/components/schemas/security._types:FieldSecurity"
           },
           "names": {
-            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/_types:IndexName"
-            }
+            "$ref": "#/components/schemas/_types:Indices"
           },
           "privileges": {
             "description": "The index level privileges that owners of the role have on the specified indices.",

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -81966,7 +81966,18 @@
             "$ref": "#/components/schemas/security._types:FieldSecurity"
           },
           "names": {
-            "$ref": "#/components/schemas/_types:Indices"
+            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/_types:IndexName"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/_types:IndexName"
+                }
+              }
+            ]
           },
           "privileges": {
             "description": "The index level privileges that owners of the role have on the specified indices.",
@@ -82245,7 +82256,18 @@
         "type": "object",
         "properties": {
           "names": {
-            "$ref": "#/components/schemas/_types:Indices"
+            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/_types:IndexName"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/_types:IndexName"
+                }
+              }
+            ]
           }
         },
         "required": [
@@ -82259,7 +82281,18 @@
             "$ref": "#/components/schemas/security._types:FieldSecurity"
           },
           "names": {
-            "$ref": "#/components/schemas/_types:Indices"
+            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/_types:IndexName"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/_types:IndexName"
+                }
+              }
+            ]
           },
           "query": {
             "$ref": "#/components/schemas/security._types:IndicesPrivilegesQuery"
@@ -82734,7 +82767,18 @@
             }
           },
           "names": {
-            "$ref": "#/components/schemas/_types:Indices"
+            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/_types:IndexName"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/_types:IndexName"
+                }
+              }
+            ]
           },
           "privileges": {
             "description": "The index level privileges that owners of the role have on the specified indices.",
@@ -82955,7 +82999,18 @@
             "$ref": "#/components/schemas/security._types:FieldSecurity"
           },
           "names": {
-            "$ref": "#/components/schemas/_types:Indices"
+            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/_types:IndexName"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/_types:IndexName"
+                }
+              }
+            ]
           },
           "privileges": {
             "description": "The index level privileges that owners of the role have on the specified indices.",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -53707,11 +53707,7 @@
             "$ref": "#/components/schemas/security._types:FieldSecurity"
           },
           "names": {
-            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/_types:IndexName"
-            }
+            "$ref": "#/components/schemas/_types:Indices"
           },
           "privileges": {
             "description": "The index level privileges that owners of the role have on the specified indices.",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -53707,7 +53707,18 @@
             "$ref": "#/components/schemas/security._types:FieldSecurity"
           },
           "names": {
-            "$ref": "#/components/schemas/_types:Indices"
+            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/_types:IndexName"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/_types:IndexName"
+                }
+              }
+            ]
           },
           "privileges": {
             "description": "The index level privileges that owners of the role have on the specified indices.",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -103066,7 +103066,7 @@
         "name": "IndexPrivilege",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L360-L402"
+      "specLocation": "security/_types/Privileges.ts#L362-L404"
     },
     {
       "codegenNames": [
@@ -103080,7 +103080,7 @@
         "name": "IndicesPrivilegesQuery",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L315-L323",
+      "specLocation": "security/_types/Privileges.ts#L317-L325",
       "type": {
         "items": [
           {
@@ -103130,7 +103130,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/Privileges.ts#L325-L335"
+      "specLocation": "security/_types/Privileges.ts#L327-L337"
     },
     {
       "kind": "interface",
@@ -103218,7 +103218,7 @@
         }
       ],
       "shortcutProperty": "source",
-      "specLocation": "security/_types/Privileges.ts#L337-L355"
+      "specLocation": "security/_types/Privileges.ts#L339-L357"
     },
     {
       "codegenNames": [
@@ -103230,7 +103230,7 @@
         "name": "RoleTemplateInlineQuery",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L357-L358",
+      "specLocation": "security/_types/Privileges.ts#L359-L360",
       "type": {
         "items": [
           {
@@ -139773,7 +139773,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/Privileges.ts#L217-L241"
+      "specLocation": "security/_types/Privileges.ts#L217-L243"
     },
     {
       "kind": "interface",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -139664,11 +139664,26 @@
           "name": "names",
           "required": true,
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Indices",
-              "namespace": "_types"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "IndexName",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "array_of",
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "IndexName",
+                    "namespace": "_types"
+                  }
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -139664,13 +139664,10 @@
           "name": "names",
           "required": true,
           "type": {
-            "kind": "array_of",
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "IndexName",
-                "namespace": "_types"
-              }
+            "kind": "instance_of",
+            "type": {
+              "name": "Indices",
+              "namespace": "_types"
             }
           }
         },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17665,7 +17665,7 @@ export type SecurityIndexPrivilege = 'all' | 'auto_configure' | 'create' | 'crea
 
 export interface SecurityIndicesPrivileges {
   field_security?: SecurityFieldSecurity
-  names: IndexName[]
+  names: Indices
   privileges: SecurityIndexPrivilege[]
   query?: SecurityIndicesPrivilegesQuery
   allow_restricted_indices?: boolean
@@ -17685,14 +17685,14 @@ export interface SecurityRealmInfo {
 export interface SecurityRemoteIndicesPrivileges {
   clusters: Names
   field_security?: SecurityFieldSecurity
-  names: IndexName[]
+  names: Indices
   privileges: SecurityIndexPrivilege[]
   query?: SecurityIndicesPrivilegesQuery
   allow_restricted_indices?: boolean
 }
 
 export interface SecurityReplicationAccess {
-  names: IndexName[]
+  names: Indices
 }
 
 export interface SecurityRoleDescriptor {
@@ -17755,7 +17755,7 @@ export interface SecurityRoleTemplateScript {
 
 export interface SecuritySearchAccess {
   field_security?: SecurityFieldSecurity
-  names: IndexName[]
+  names: Indices
   query?: SecurityIndicesPrivilegesQuery
   allow_restricted_indices?: boolean
 }
@@ -17774,7 +17774,7 @@ export interface SecurityUser {
 
 export interface SecurityUserIndicesPrivileges {
   field_security?: SecurityFieldSecurity[]
-  names: IndexName[]
+  names: Indices
   privileges: SecurityIndexPrivilege[]
   query?: SecurityIndicesPrivilegesQuery[]
   allow_restricted_indices: boolean

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17665,7 +17665,7 @@ export type SecurityIndexPrivilege = 'all' | 'auto_configure' | 'create' | 'crea
 
 export interface SecurityIndicesPrivileges {
   field_security?: SecurityFieldSecurity
-  names: Indices
+  names: IndexName | IndexName[]
   privileges: SecurityIndexPrivilege[]
   query?: SecurityIndicesPrivilegesQuery
   allow_restricted_indices?: boolean
@@ -17685,14 +17685,14 @@ export interface SecurityRealmInfo {
 export interface SecurityRemoteIndicesPrivileges {
   clusters: Names
   field_security?: SecurityFieldSecurity
-  names: Indices
+  names: IndexName | IndexName[]
   privileges: SecurityIndexPrivilege[]
   query?: SecurityIndicesPrivilegesQuery
   allow_restricted_indices?: boolean
 }
 
 export interface SecurityReplicationAccess {
-  names: Indices
+  names: IndexName | IndexName[]
 }
 
 export interface SecurityRoleDescriptor {
@@ -17755,7 +17755,7 @@ export interface SecurityRoleTemplateScript {
 
 export interface SecuritySearchAccess {
   field_security?: SecurityFieldSecurity
-  names: Indices
+  names: IndexName | IndexName[]
   query?: SecurityIndicesPrivilegesQuery
   allow_restricted_indices?: boolean
 }
@@ -17774,7 +17774,7 @@ export interface SecurityUser {
 
 export interface SecurityUserIndicesPrivileges {
   field_security?: SecurityFieldSecurity[]
-  names: Indices
+  names: IndexName | IndexName[]
   privileges: SecurityIndexPrivilege[]
   query?: SecurityIndicesPrivilegesQuery[]
   allow_restricted_indices: boolean

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -19,7 +19,7 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { Id, Indices, Names } from '@_types/common'
+import { Id, IndexName, Names } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { ScriptLanguage } from '@_types/Scripting'
 import { FieldSecurity } from './FieldSecurity'
@@ -204,7 +204,7 @@ export class IndicesPrivileges {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: Indices
+  names: IndexName | IndexName[]
   /**
    * The index level privileges that owners of the role have on the specified indices.
    */
@@ -235,7 +235,7 @@ export class RemoteIndicesPrivileges {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: Indices
+  names: IndexName | IndexName[]
   /**
    * The index level privileges that owners of the role have on the specified indices.
    */
@@ -261,7 +261,7 @@ export class UserIndicesPrivileges {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: Indices
+  names: IndexName | IndexName[]
   /**
    * The index level privileges that owners of the role have on the specified indices.
    */
@@ -381,7 +381,7 @@ export class ReplicationAccess {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: Indices
+  names: IndexName | IndexName[]
 }
 
 export class SearchAccess {
@@ -393,7 +393,7 @@ export class SearchAccess {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: Indices
+  names: IndexName | IndexName[]
   /**
    * A search query that defines the documents the owners of the role have access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.
    */

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -220,6 +220,8 @@ export class IndicesPrivileges {
    * @doc_id field-and-document-access-control
    */
   field_security?: FieldSecurity
+  // We're using IndexName | IndexName[] instead of Indices in this file on purpose:
+  // https://github.com/elastic/elasticsearch-specification/pull/3127
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -19,7 +19,7 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { Id, IndexName, Names } from '@_types/common'
+import { Id, Indices, Names } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { ScriptLanguage } from '@_types/Scripting'
 import { FieldSecurity } from './FieldSecurity'
@@ -204,7 +204,7 @@ export class IndicesPrivileges {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: IndexName[]
+  names: Indices
   /**
    * The index level privileges that owners of the role have on the specified indices.
    */
@@ -235,7 +235,7 @@ export class RemoteIndicesPrivileges {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: IndexName[]
+  names: Indices
   /**
    * The index level privileges that owners of the role have on the specified indices.
    */
@@ -261,7 +261,7 @@ export class UserIndicesPrivileges {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: IndexName[]
+  names: Indices
   /**
    * The index level privileges that owners of the role have on the specified indices.
    */
@@ -381,7 +381,7 @@ export class ReplicationAccess {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: IndexName[]
+  names: Indices
 }
 
 export class SearchAccess {
@@ -393,7 +393,7 @@ export class SearchAccess {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: IndexName[]
+  names: Indices
   /**
    * A search query that defines the documents the owners of the role have access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.
    */


### PR DESCRIPTION
Motivated by [this YAML test](https://github.com/elastic/elasticsearch/blob/a04fd2668b82e0c4324b2cc8afe03eb9b0113ac2/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/roles/60_bulk_roles.yml#L39-L46) I realized that `index` in various privileges classes can always be an index pattern, ie. a string.

For references, here is how IndexName and Indices are defined:

```ts
export type IndexName = string
export type Indices = IndexName | IndexName[]
```

This fixes `security.bulk_put_role`, as can be tested with `make validate api=security.bulk_put_role branch=main`.
