### PR TITLE
Add missing allow_restricted_indices to cross cluster api key APIs

### DIFF
--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -382,6 +382,11 @@ export class ReplicationAccess {
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
   names: IndexName[]
+  /**
+   * This needs to be set to true if the patterns in the names field should cover system indices.
+   * @server_default false
+   */
+  allow_restricted_indices?: boolean
 }
 
 export class SearchAccess {


### PR DESCRIPTION
* Documented in https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-cross-cluster-api-key.html#security-api-create-cross-cluster-api-key-request-body
* Implemented in https://github.com/elastic/elasticsearch/blob/a04fd2668b82e0c4324b2cc8afe03eb9b0113ac2/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java#L949-L960
* Tested in https://github.com/elastic/elasticsearch/blob/a04fd2668b82e0c4324b2cc8afe03eb9b0113ac2/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/api_key/50_cross_cluster.yml#L62C20-L62C44