### PR TITLE
Add missing fields to `IndexTemplate`

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -67492,6 +67492,13 @@
           },
           "data_stream": {
             "$ref": "#/components/schemas/indices._types:IndexTemplateDataStreamConfiguration"
+          },
+          "deprecated": {
+            "description": "Marks this index template as deprecated.\nWhen creating or updating a non-deprecated index template that uses deprecated components,\nElasticsearch will emit a deprecation warning.",
+            "type": "boolean"
+          },
+          "ignore_missing_component_templates": {
+            "$ref": "#/components/schemas/_types:Names"
           }
         },
         "required": [

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -45088,6 +45088,13 @@
           },
           "data_stream": {
             "$ref": "#/components/schemas/indices._types:IndexTemplateDataStreamConfiguration"
+          },
+          "deprecated": {
+            "description": "Marks this index template as deprecated.\nWhen creating or updating a non-deprecated index template that uses deprecated components,\nElasticsearch will emit a deprecation warning.",
+            "type": "boolean"
+          },
+          "ignore_missing_component_templates": {
+            "$ref": "#/components/schemas/_types:Names"
           }
         },
         "required": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -119221,9 +119221,45 @@
               "namespace": "indices._types"
             }
           }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.12.0"
+            }
+          },
+          "description": "Marks this index template as deprecated.\nWhen creating or updating a non-deprecated index template that uses deprecated components,\nElasticsearch will emit a deprecation warning.",
+          "name": "deprecated",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.7.0"
+            }
+          },
+          "description": "A list of component template names that are allowed to be absent.",
+          "name": "ignore_missing_component_templates",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Names",
+              "namespace": "_types"
+            }
+          }
         }
       ],
-      "specLocation": "indices/_types/IndexTemplate.ts#L28-L67"
+      "specLocation": "indices/_types/IndexTemplate.ts#L28-L81"
     },
     {
       "kind": "interface",
@@ -119300,7 +119336,7 @@
           }
         }
       ],
-      "specLocation": "indices/_types/IndexTemplate.ts#L82-L104"
+      "specLocation": "indices/_types/IndexTemplate.ts#L96-L118"
     },
     {
       "kind": "interface",
@@ -119336,7 +119372,7 @@
           }
         }
       ],
-      "specLocation": "indices/_types/IndexTemplate.ts#L69-L80"
+      "specLocation": "indices/_types/IndexTemplate.ts#L83-L94"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11122,6 +11122,8 @@ export interface IndicesIndexTemplate {
   _meta?: Metadata
   allow_auto_create?: boolean
   data_stream?: IndicesIndexTemplateDataStreamConfiguration
+  deprecated?: boolean
+  ignore_missing_component_templates?: Names
 }
 
 export interface IndicesIndexTemplateDataStreamConfiguration {

--- a/specification/indices/_types/IndexTemplate.ts
+++ b/specification/indices/_types/IndexTemplate.ts
@@ -64,6 +64,16 @@ export class IndexTemplate {
    * Data streams require a matching index template with a `data_stream` object.
    */
   data_stream?: IndexTemplateDataStreamConfiguration
+  /**
+   * Marks this index template as deprecated.
+   * When creating or updating a non-deprecated index template that uses deprecated components,
+   * Elasticsearch will emit a deprecation warning.
+   */
+  deprecated?: boolean
+  /**
+   * A list of component template names that are allowed to be absent.
+   */
+  ignore_missing_component_templates?: Names
 }
 
 export class IndexTemplateDataStreamConfiguration {

--- a/specification/indices/_types/IndexTemplate.ts
+++ b/specification/indices/_types/IndexTemplate.ts
@@ -68,10 +68,14 @@ export class IndexTemplate {
    * Marks this index template as deprecated.
    * When creating or updating a non-deprecated index template that uses deprecated components,
    * Elasticsearch will emit a deprecation warning.
+   * @availability stack since=8.12.0
+   * @availability serverless
    */
   deprecated?: boolean
   /**
    * A list of component template names that are allowed to be absent.
+   * @availability stack since=8.7.0
+   * @availability serverless
    */
   ignore_missing_component_templates?: Names
 }


### PR DESCRIPTION
Adds the missing `deprecated` and `ignore_missing_component_templates` fields to `IndexTemplate`.

Closes https://github.com/elastic/elasticsearch-specification/pull/3135