### PR TITLE
Adding data_streams to the deprecation info api response

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -90402,6 +90402,15 @@
                     }
                   }
                 },
+                "data_streams": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/migration.deprecations:Deprecation"
+                    }
+                  }
+                },
                 "node_settings": {
                   "type": "array",
                   "items": {
@@ -90418,6 +90427,7 @@
               "required": [
                 "cluster_settings",
                 "index_settings",
+                "data_streams",
                 "node_settings",
                 "ml_settings"
               ]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13565,6 +13565,7 @@ export interface MigrationDeprecationsRequest extends RequestBase {
 export interface MigrationDeprecationsResponse {
   cluster_settings: MigrationDeprecationsDeprecation[]
   index_settings: Record<string, MigrationDeprecationsDeprecation[]>
+  data_streams: Record<string, MigrationDeprecationsDeprecation[]>
   node_settings: MigrationDeprecationsDeprecation[]
   ml_settings: MigrationDeprecationsDeprecation[]
 }

--- a/specification/migration/deprecations/DeprecationInfoResponse.ts
+++ b/specification/migration/deprecations/DeprecationInfoResponse.ts
@@ -24,6 +24,7 @@ export class Response {
   body: {
     cluster_settings: Deprecation[]
     index_settings: Dictionary<string, Deprecation[]>
+    data_streams: Dictionary<string, Deprecation[]>
     node_settings: Deprecation[]
     ml_settings: Deprecation[]
   }


### PR DESCRIPTION
This is only to get CI results in https://github.com/elastic/elasticsearch-specification/pull/3130.