### PR TITLE
[8.x] Support for security remote_cluster and associated privileges (#3125)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -28920,16 +28920,23 @@
                     "cluster": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/security._types:ClusterPrivilege"
                       }
                     },
                     "index": {
                       "$ref": "#/components/schemas/_types:Indices"
+                    },
+                    "remote_cluster": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/security._types:RemoteClusterPrivilege"
+                      }
                     }
                   },
                   "required": [
                     "cluster",
-                    "index"
+                    "index",
+                    "remote_cluster"
                   ]
                 }
               }
@@ -81775,6 +81782,20 @@
               "$ref": "#/components/schemas/security._types:IndicesPrivileges"
             }
           },
+          "remote_indices": {
+            "description": "A list of indices permissions for remote clusters.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:RemoteIndicesPrivileges"
+            }
+          },
+          "remote_cluster": {
+            "description": "A list of cluster permissions for remote clusters. Note - this is limited a subset of the cluster permissions.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:RemoteClusterPrivileges"
+            }
+          },
           "global": {
             "description": "An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges.",
             "oneOf": [
@@ -81867,6 +81888,7 @@
               "monitor_ml",
               "monitor_rollup",
               "monitor_snapshot",
+              "monitor_stats",
               "monitor_text_structure",
               "monitor_transform",
               "monitor_watcher",
@@ -82019,6 +82041,65 @@
           {
             "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
           }
+        ]
+      },
+      "security._types:RemoteIndicesPrivileges": {
+        "type": "object",
+        "properties": {
+          "clusters": {
+            "$ref": "#/components/schemas/_types:Names"
+          },
+          "field_security": {
+            "$ref": "#/components/schemas/security._types:FieldSecurity"
+          },
+          "names": {
+            "$ref": "#/components/schemas/_types:Indices"
+          },
+          "privileges": {
+            "description": "The index level privileges that owners of the role have on the specified indices.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:IndexPrivilege"
+            }
+          },
+          "query": {
+            "$ref": "#/components/schemas/security._types:IndicesPrivilegesQuery"
+          },
+          "allow_restricted_indices": {
+            "description": "Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "clusters",
+          "names",
+          "privileges"
+        ]
+      },
+      "security._types:RemoteClusterPrivileges": {
+        "type": "object",
+        "properties": {
+          "clusters": {
+            "$ref": "#/components/schemas/_types:Names"
+          },
+          "privileges": {
+            "description": "The cluster level privileges that owners of the role have on the remote cluster.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:RemoteClusterPrivilege"
+            }
+          }
+        },
+        "required": [
+          "clusters",
+          "privileges"
+        ]
+      },
+      "security._types:RemoteClusterPrivilege": {
+        "type": "string",
+        "enum": [
+          "monitor_enrich",
+          "monitor_stats"
         ]
       },
       "security._types:GlobalPrivilege": {
@@ -82284,13 +82365,25 @@
           "cluster": {
             "type": "array",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/security._types:ClusterPrivilege"
             }
           },
           "indices": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/security._types:IndicesPrivileges"
+            }
+          },
+          "remote_indices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:RemoteIndicesPrivileges"
+            }
+          },
+          "remote_cluster": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:RemoteClusterPrivileges"
             }
           },
           "metadata": {
@@ -82463,6 +82556,20 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/security._types:IndicesPrivileges"
+            }
+          },
+          "remote_indices": {
+            "description": "A list of indices permissions for remote clusters.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:RemoteIndicesPrivileges"
+            }
+          },
+          "remote_cluster": {
+            "description": "A list of cluster permissions for remote clusters. Note - this is limited a subset of the cluster permissions.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:RemoteClusterPrivileges"
             }
           },
           "global": {
@@ -82884,39 +82991,6 @@
         },
         "required": [
           "created"
-        ]
-      },
-      "security._types:RemoteIndicesPrivileges": {
-        "type": "object",
-        "properties": {
-          "clusters": {
-            "$ref": "#/components/schemas/_types:Names"
-          },
-          "field_security": {
-            "$ref": "#/components/schemas/security._types:FieldSecurity"
-          },
-          "names": {
-            "$ref": "#/components/schemas/_types:Indices"
-          },
-          "privileges": {
-            "description": "The index level privileges that owners of the role have on the specified indices.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/security._types:IndexPrivilege"
-            }
-          },
-          "query": {
-            "$ref": "#/components/schemas/security._types:IndicesPrivilegesQuery"
-          },
-          "allow_restricted_indices": {
-            "description": "Set to `true` if using wildcard or regular expressions for patterns that cover restricted indices. Implicitly, restricted indices have limited privileges that can cause pattern tests to fail. If restricted indices are explicitly included in the `names` list, Elasticsearch checks privileges against these indices regardless of the value set for `allow_restricted_indices`.",
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "clusters",
-          "names",
-          "privileges"
         ]
       },
       "security.query_api_keys:ApiKeyAggregationContainer": {
@@ -103679,6 +103753,13 @@
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/security._types:RemoteIndicesPrivileges"
+                  }
+                },
+                "remote_cluster": {
+                  "description": "A list of remote cluster permissions entries.",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/security._types:RemoteClusterPrivileges"
                   }
                 },
                 "metadata": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -103055,7 +103055,7 @@
         "name": "ClusterPrivilege",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L42-L195"
+      "specLocation": "security/_types/Privileges.ts#L42-L199"
     },
     {
       "kind": "enum",
@@ -103132,7 +103132,7 @@
         "name": "IndexPrivilege",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L324-L366"
+      "specLocation": "security/_types/Privileges.ts#L360-L402"
     },
     {
       "codegenNames": [
@@ -103146,7 +103146,7 @@
         "name": "IndicesPrivilegesQuery",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L279-L287",
+      "specLocation": "security/_types/Privileges.ts#L315-L323",
       "type": {
         "items": [
           {
@@ -103196,7 +103196,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/Privileges.ts#L289-L299"
+      "specLocation": "security/_types/Privileges.ts#L325-L335"
     },
     {
       "kind": "interface",
@@ -103284,7 +103284,7 @@
         }
       ],
       "shortcutProperty": "source",
-      "specLocation": "security/_types/Privileges.ts#L301-L319"
+      "specLocation": "security/_types/Privileges.ts#L337-L355"
     },
     {
       "codegenNames": [
@@ -103296,7 +103296,7 @@
         "name": "RoleTemplateInlineQuery",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/Privileges.ts#L321-L322",
+      "specLocation": "security/_types/Privileges.ts#L357-L358",
       "type": {
         "items": [
           {
@@ -103316,6 +103316,15 @@
         ],
         "kind": "union_of"
       }
+    },
+    {
+      "kind": "enum",
+      "members": [],
+      "name": {
+        "name": "RemoteClusterPrivilege",
+        "namespace": "security._types"
+      },
+      "specLocation": "security/_types/Privileges.ts#L201-L214"
     },
     {
       "kind": "enum",
@@ -140076,7 +140085,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/RoleDescriptor.ts#L31-L64"
+      "specLocation": "security/_types/RoleDescriptor.ts#L33-L79"
     },
     {
       "kind": "interface",
@@ -140139,7 +140148,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/Privileges.ts#L198-L222"
+      "specLocation": "security/_types/Privileges.ts#L217-L241"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17634,7 +17634,7 @@ export interface SecurityClusterNode {
   name: Name
 }
 
-export type SecurityClusterPrivilege = 'all' | 'cancel_task' | 'create_snapshot' | 'cross_cluster_replication' | 'cross_cluster_search' | 'delegate_pki' | 'grant_api_key' | 'manage' | 'manage_api_key' | 'manage_autoscaling' | 'manage_behavioral_analytics' | 'manage_ccr' | 'manage_data_frame_transforms' | 'manage_data_stream_global_retention' | 'manage_enrich' | 'manage_ilm' | 'manage_index_templates' | 'manage_inference' | 'manage_ingest_pipelines' | 'manage_logstash_pipelines' | 'manage_ml' | 'manage_oidc' | 'manage_own_api_key' | 'manage_pipeline' | 'manage_rollup' | 'manage_saml' | 'manage_search_application' | 'manage_search_query_rules' | 'manage_search_synonyms' | 'manage_security' | 'manage_service_account' | 'manage_slm' | 'manage_token' | 'manage_transform' | 'manage_user_profile' | 'manage_watcher' | 'monitor' | 'monitor_data_frame_transforms' | 'monitor_data_stream_global_retention' | 'monitor_enrich' | 'monitor_inference' | 'monitor_ml' | 'monitor_rollup' | 'monitor_snapshot' | 'monitor_text_structure' | 'monitor_transform' | 'monitor_watcher' | 'none' | 'post_behavioral_analytics_event' | 'read_ccr' | 'read_fleet_secrets' | 'read_ilm' | 'read_pipeline' | 'read_security' | 'read_slm' | 'transport_client' | 'write_connector_secrets' | 'write_fleet_secrets'| string
+export type SecurityClusterPrivilege = 'all' | 'cancel_task' | 'create_snapshot' | 'cross_cluster_replication' | 'cross_cluster_search' | 'delegate_pki' | 'grant_api_key' | 'manage' | 'manage_api_key' | 'manage_autoscaling' | 'manage_behavioral_analytics' | 'manage_ccr' | 'manage_data_frame_transforms' | 'manage_data_stream_global_retention' | 'manage_enrich' | 'manage_ilm' | 'manage_index_templates' | 'manage_inference' | 'manage_ingest_pipelines' | 'manage_logstash_pipelines' | 'manage_ml' | 'manage_oidc' | 'manage_own_api_key' | 'manage_pipeline' | 'manage_rollup' | 'manage_saml' | 'manage_search_application' | 'manage_search_query_rules' | 'manage_search_synonyms' | 'manage_security' | 'manage_service_account' | 'manage_slm' | 'manage_token' | 'manage_transform' | 'manage_user_profile' | 'manage_watcher' | 'monitor' | 'monitor_data_frame_transforms' | 'monitor_data_stream_global_retention' | 'monitor_enrich' | 'monitor_inference' | 'monitor_ml' | 'monitor_rollup' | 'monitor_snapshot' | 'monitor_stats' | 'monitor_text_structure' | 'monitor_transform' | 'monitor_watcher' | 'none' | 'post_behavioral_analytics_event' | 'read_ccr' | 'read_fleet_secrets' | 'read_ilm' | 'read_pipeline' | 'read_security' | 'read_slm' | 'transport_client' | 'write_connector_secrets' | 'write_fleet_secrets'| string
 
 export interface SecurityCreatedStatus {
   created: boolean
@@ -17678,6 +17678,13 @@ export interface SecurityRealmInfo {
   type: string
 }
 
+export type SecurityRemoteClusterPrivilege = 'monitor_enrich' | 'monitor_stats'
+
+export interface SecurityRemoteClusterPrivileges {
+  clusters: Names
+  privileges: SecurityRemoteClusterPrivilege[]
+}
+
 export interface SecurityRemoteIndicesPrivileges {
   clusters: Names
   field_security?: SecurityFieldSecurity
@@ -17696,6 +17703,8 @@ export interface SecurityRoleDescriptor {
   cluster?: SecurityClusterPrivilege[]
   indices?: SecurityIndicesPrivileges[]
   index?: SecurityIndicesPrivileges[]
+  remote_indices?: SecurityRemoteIndicesPrivileges[]
+  remote_cluster?: SecurityRemoteClusterPrivileges[]
   global?: SecurityGlobalPrivilege[] | SecurityGlobalPrivilege
   applications?: SecurityApplicationPrivileges[]
   metadata?: Metadata
@@ -17708,6 +17717,8 @@ export interface SecurityRoleDescriptorRead {
   cluster: SecurityClusterPrivilege[]
   indices: SecurityIndicesPrivileges[]
   index: SecurityIndicesPrivileges[]
+  remote_indices?: SecurityRemoteIndicesPrivileges[]
+  remote_cluster?: SecurityRemoteClusterPrivileges[]
   global?: SecurityGlobalPrivilege[] | SecurityGlobalPrivilege
   applications?: SecurityApplicationPrivileges[]
   metadata?: Metadata
@@ -18107,8 +18118,9 @@ export interface SecurityGetBuiltinPrivilegesRequest extends RequestBase {
 }
 
 export interface SecurityGetBuiltinPrivilegesResponse {
-  cluster: string[]
+  cluster: SecurityClusterPrivilege[]
   index: Indices
+  remote_cluster: SecurityRemoteClusterPrivilege[]
 }
 
 export interface SecurityGetPrivilegesRequest extends RequestBase {
@@ -18125,8 +18137,10 @@ export interface SecurityGetRoleRequest extends RequestBase {
 export type SecurityGetRoleResponse = Record<string, SecurityGetRoleRole>
 
 export interface SecurityGetRoleRole {
-  cluster: string[]
+  cluster: SecurityClusterPrivilege[]
   indices: SecurityIndicesPrivileges[]
+  remote_indices?: SecurityRemoteIndicesPrivileges[]
+  remote_cluster?: SecurityRemoteClusterPrivileges[]
   metadata: Metadata
   run_as: string[]
   transient_metadata?: Record<string, any>
@@ -18392,6 +18406,7 @@ export interface SecurityPutRoleRequest extends RequestBase {
     global?: Record<string, any>
     indices?: SecurityIndicesPrivileges[]
     remote_indices?: SecurityRemoteIndicesPrivileges[]
+    remote_cluster?: SecurityRemoteClusterPrivileges[]
     metadata?: Metadata
     run_as?: string[]
     description?: string

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -152,6 +152,10 @@ export enum ClusterPrivilege {
    */
   monitor_snapshot,
   /**
+   * @availability stack since=8.17.0
+   */
+  monitor_stats,
+  /**
    * @availability stack
    */
   monitor_text_structure,
@@ -194,6 +198,21 @@ export enum ClusterPrivilege {
   write_fleet_secrets
 }
 
+/**
+ * The subset of cluster level privileges that can be defined for remote clusters.
+ * @availability stack
+ */
+export enum RemoteClusterPrivilege {
+  /**
+   * @availability stack since=8.14.0
+   */
+  monitor_enrich,
+  /**
+   * @availability stack since=8.17.0
+   */
+  monitor_stats
+}
+
 // Keep in sync with RemoteIndicesPrivileges
 export class IndicesPrivileges {
   /**
@@ -221,6 +240,9 @@ export class IndicesPrivileges {
   allow_restricted_indices?: boolean
 }
 
+/**
+ * The subset of index level privileges that can be defined for remote clusters.
+ */
 // Keep in sync with IndicesPrivileges
 export class RemoteIndicesPrivileges {
   /**
@@ -250,6 +272,20 @@ export class RemoteIndicesPrivileges {
    * @availability stack
    */
   allow_restricted_indices?: boolean
+}
+
+/**
+ * The subset of cluster level privileges that can be defined for remote clusters.
+ */
+export class RemoteClusterPrivileges {
+  /**
+   *  A list of cluster aliases to which the permissions in this entry apply.
+   */
+  clusters: Names
+  /**
+   * The cluster level privileges that owners of the role have on the remote cluster.
+   */
+  privileges: RemoteClusterPrivilege[]
 }
 
 export class UserIndicesPrivileges {

--- a/specification/security/_types/RoleDescriptor.ts
+++ b/specification/security/_types/RoleDescriptor.ts
@@ -25,7 +25,9 @@ import {
   ApplicationPrivileges,
   ClusterPrivilege,
   GlobalPrivilege,
-  IndicesPrivileges
+  IndicesPrivileges,
+  RemoteClusterPrivileges,
+  RemoteIndicesPrivileges
 } from './Privileges'
 
 export class RoleDescriptor {
@@ -38,6 +40,19 @@ export class RoleDescriptor {
    * @aliases index
    */
   indices?: IndicesPrivileges[]
+
+  /**
+   * A list of indices permissions for remote clusters.
+   * @availability stack since=8.14.0
+   */
+  remote_indices?: RemoteIndicesPrivileges[]
+
+  /**
+   * A list of cluster permissions for remote clusters. Note - this is limited a subset of the cluster permissions.
+   * @availability stack since=8.15.0
+   */
+  remote_cluster?: RemoteClusterPrivileges[]
+
   /**
    * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges.
    * @availability stack
@@ -73,6 +88,17 @@ export class RoleDescriptorRead implements OverloadOf<RoleDescriptor> {
    * @aliases index
    */
   indices: IndicesPrivileges[]
+  /**
+   * A list of indices permissions for remote clusters.
+   * @availability stack since=8.14.0
+   */
+  remote_indices?: RemoteIndicesPrivileges[]
+
+  /**
+   * A list of cluster permissions for remote clusters. Note - this is limited a subset of the cluster permissions.
+   * @availability stack since=8.15.0
+   */
+  remote_cluster?: RemoteClusterPrivileges[]
   /**
    * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges.
    */

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
@@ -17,8 +17,16 @@
  * under the License.
  */
 
+import {
+  ClusterPrivilege,
+  RemoteClusterPrivilege
+} from '@security/_types/Privileges'
 import { Indices } from '@_types/common'
 
 export class Response {
-  body: { cluster: string[]; index: Indices }
+  body: {
+    cluster: ClusterPrivilege[]
+    index: Indices
+    remote_cluster: RemoteClusterPrivilege[]
+  }
 }

--- a/specification/security/get_role/types.ts
+++ b/specification/security/get_role/types.ts
@@ -19,7 +19,10 @@
 
 import {
   ApplicationPrivileges,
-  IndicesPrivileges
+  ClusterPrivilege,
+  IndicesPrivileges,
+  RemoteClusterPrivileges,
+  RemoteIndicesPrivileges
 } from '@security/_types/Privileges'
 import { RoleTemplate } from '@security/_types/RoleTemplate'
 import { Dictionary } from '@spec_utils/Dictionary'
@@ -27,8 +30,16 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Metadata } from '@_types/common'
 
 export class Role {
-  cluster: string[]
+  cluster: ClusterPrivilege[]
   indices: IndicesPrivileges[]
+  /**
+   * @availability stack since=8.14.0
+   */
+  remote_indices?: RemoteIndicesPrivileges[]
+  /**
+   * @availability stack since=8.15.0
+   */
+  remote_cluster?: RemoteClusterPrivileges[]
   metadata: Metadata
   run_as: string[]
   transient_metadata?: Dictionary<string, UserDefinedValue>

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -21,6 +21,7 @@ import {
   ApplicationPrivileges,
   ClusterPrivilege,
   IndicesPrivileges,
+  RemoteClusterPrivileges,
   RemoteIndicesPrivileges
 } from '@security/_types/Privileges'
 import { Dictionary } from '@spec_utils/Dictionary'
@@ -74,6 +75,12 @@ export interface Request extends RequestBase {
      *
      */
     remote_indices?: RemoteIndicesPrivileges[]
+    /**
+     * A list of remote cluster permissions entries.
+     * @availability stack since=8.15.0
+     *
+     */
+    remote_cluster?: RemoteClusterPrivileges[]
     /**
      * Optional metadata. Within the metadata object, keys that begin with an underscore (`_`) are reserved for system use.
      */


### PR DESCRIPTION
This commit adds support for the remote_cluster in the role and role descriptors. Additionally:

* adds missing references to remote_indices
* add new cluster privilege monitor_stats
* adds related version information where applicable
* updates references to cluster from string[] to proper enumeration

(cherry picked from commit dac7201aa2a52228954f70195c478647caeae7c1)