### PR TITLE
Add restriction to RoleDescriptor

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -81909,6 +81909,9 @@
             "description": "Optional description of the role descriptor",
             "type": "string"
           },
+          "restriction": {
+            "$ref": "#/components/schemas/security._types:Restriction"
+          },
           "transient_metadata": {
             "type": "object",
             "additionalProperties": {
@@ -82264,6 +82267,33 @@
           "application",
           "privileges",
           "resources"
+        ]
+      },
+      "security._types:Restriction": {
+        "type": "object",
+        "properties": {
+          "workflows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:RestrictionWorkflow"
+            }
+          }
+        },
+        "required": [
+          "workflows"
+        ]
+      },
+      "security._types:RestrictionWorkflow": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "search_application_query"
+            ]
+          },
+          {
+            "type": "string"
+          }
         ]
       },
       "security._types:RealmInfo": {
@@ -82720,6 +82750,9 @@
           "description": {
             "description": "Optional description of the role descriptor",
             "type": "string"
+          },
+          "restriction": {
+            "$ref": "#/components/schemas/security._types:Restriction"
           },
           "transient_metadata": {
             "type": "object",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -53667,6 +53667,9 @@
             "description": "Optional description of the role descriptor",
             "type": "string"
           },
+          "restriction": {
+            "$ref": "#/components/schemas/security._types:Restriction"
+          },
           "transient_metadata": {
             "type": "object",
             "additionalProperties": {
@@ -53874,6 +53877,33 @@
           "application",
           "privileges",
           "resources"
+        ]
+      },
+      "security._types:Restriction": {
+        "type": "object",
+        "properties": {
+          "workflows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:RestrictionWorkflow"
+            }
+          }
+        },
+        "required": [
+          "workflows"
+        ]
+      },
+      "security._types:RestrictionWorkflow": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "search_application_query"
+            ]
+          },
+          {
+            "type": "string"
+          }
         ]
       },
       "security._types:RealmInfo": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -103261,6 +103261,20 @@
       "specLocation": "security/_types/Privileges.ts#L201-L214"
     },
     {
+      "isOpen": true,
+      "kind": "enum",
+      "members": [
+        {
+          "name": "search_application_query"
+        }
+      ],
+      "name": {
+        "name": "RestrictionWorkflow",
+        "namespace": "security._types"
+      },
+      "specLocation": "security/_types/RoleDescriptor.ts#L134-L137"
+    },
+    {
       "kind": "enum",
       "members": [
         {
@@ -139677,6 +139691,18 @@
           }
         },
         {
+          "description": "Restriction for when the role descriptor is allowed to be effective.",
+          "name": "restriction",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Restriction",
+              "namespace": "security._types"
+            }
+          }
+        },
+        {
           "name": "transient_metadata",
           "required": false,
           "type": {
@@ -139695,7 +139721,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/RoleDescriptor.ts#L33-L79"
+      "specLocation": "security/_types/RoleDescriptor.ts#L33-L80"
     },
     {
       "kind": "interface",
@@ -139858,6 +139884,30 @@
         }
       ],
       "specLocation": "security/_types/Privileges.ts#L27-L40"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "Restriction",
+        "namespace": "security._types"
+      },
+      "properties": [
+        {
+          "name": "workflows",
+          "required": true,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "RestrictionWorkflow",
+                "namespace": "security._types"
+              }
+            }
+          }
+        }
+      ],
+      "specLocation": "security/_types/RoleDescriptor.ts#L130-L132"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17706,6 +17706,12 @@ export interface SecurityReplicationAccess {
   allow_restricted_indices?: boolean
 }
 
+export interface SecurityRestriction {
+  workflows: SecurityRestrictionWorkflow[]
+}
+
+export type SecurityRestrictionWorkflow = 'search_application_query'| string
+
 export interface SecurityRoleDescriptor {
   cluster?: SecurityClusterPrivilege[]
   indices?: SecurityIndicesPrivileges[]
@@ -17717,6 +17723,7 @@ export interface SecurityRoleDescriptor {
   metadata?: Metadata
   run_as?: string[]
   description?: string
+  restriction?: SecurityRestriction
   transient_metadata?: Record<string, any>
 }
 
@@ -17731,6 +17738,7 @@ export interface SecurityRoleDescriptorRead {
   metadata?: Metadata
   run_as?: string[]
   description?: string
+  restriction?: SecurityRestriction
   transient_metadata?: Record<string, any>
 }
 

--- a/specification/security/_types/RoleDescriptor.ts
+++ b/specification/security/_types/RoleDescriptor.ts
@@ -40,19 +40,16 @@ export class RoleDescriptor {
    * @aliases index
    */
   indices?: IndicesPrivileges[]
-
   /**
    * A list of indices permissions for remote clusters.
    * @availability stack since=8.14.0
    */
   remote_indices?: RemoteIndicesPrivileges[]
-
   /**
    * A list of cluster permissions for remote clusters. Note - this is limited a subset of the cluster permissions.
    * @availability stack since=8.15.0
    */
   remote_cluster?: RemoteClusterPrivileges[]
-
   /**
    * An object defining global privileges. A global privilege is a form of cluster privilege that is request-aware. Support for global privileges is currently limited to the management of application privileges.
    * @availability stack
@@ -75,6 +72,10 @@ export class RoleDescriptor {
    * Optional description of the role descriptor
    */
   description?: string
+  /**
+   * Restriction for when the role descriptor is allowed to be effective.
+   */
+  restriction?: Restriction
   transient_metadata?: Dictionary<string, UserDefinedValue>
 }
 
@@ -93,7 +94,6 @@ export class RoleDescriptorRead implements OverloadOf<RoleDescriptor> {
    * @availability stack since=8.14.0
    */
   remote_indices?: RemoteIndicesPrivileges[]
-
   /**
    * A list of cluster permissions for remote clusters. Note - this is limited a subset of the cluster permissions.
    * @availability stack since=8.15.0
@@ -120,5 +120,18 @@ export class RoleDescriptorRead implements OverloadOf<RoleDescriptor> {
    * Optional description of the role descriptor
    */
   description?: string
+  /**
+   * Restriction for when the role descriptor is allowed to be effective.
+   */
+  restriction?: Restriction
   transient_metadata?: Dictionary<string, UserDefinedValue>
+}
+
+export class Restriction {
+  workflows: RestrictionWorkflow[]
+}
+
+/** @non_exhaustive */
+export enum RestrictionWorkflow {
+  search_application_query
 }


### PR DESCRIPTION
This allows representing the following YAML test:

```typescript
// Test file: /test/platinum/entsearch/search/56_search_application_search_with_apikey.yml
// Test name: Query Search Application with API key

import { expectAssignable } from 'tsd'
import * as T from '../types'

expectAssignable<T.SecurityCreateApiKeyRequest>({
  "body": {
    "name": "search-application-1-api-key",
    "role_descriptors": {
      "role": {
        "index": [
          {
            "names": [
              "test-search-application-1"
            ],
            "privileges": [
              "read"
            ]
          }
        ],
        "restriction": {
          "workflows": [
            "search_application_query"
          ]
        }
      }
    }
  }
})
```