### PR TITLE
Fix `RemoteClusterPrivilege` availability

### DIFF
--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -200,7 +200,6 @@ export enum ClusterPrivilege {
 
 /**
  * The subset of cluster level privileges that can be defined for remote clusters.
- * @availability stack
  */
 export enum RemoteClusterPrivilege {
   /**

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
@@ -27,6 +27,9 @@ export class Response {
   body: {
     cluster: ClusterPrivilege[]
     index: IndexName[]
+    /**
+     * @availability stack since=8.15.0
+     */
     remote_cluster: RemoteClusterPrivilege[]
   }
 }

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -78,7 +78,6 @@ export interface Request extends RequestBase {
     /**
      * A list of remote cluster permissions entries.
      * @availability stack since=8.15.0
-     *
      */
     remote_cluster?: RemoteClusterPrivileges[]
     /**


### PR DESCRIPTION
Availability on types should not be used (see #2643 and #2830).

The PR moves the `@availability` tag from the type itself to the place(s) where the type is used.

Without this change, the .NET generator produced an enum without a member for the `serverless` flavor.