### PR TITLE
Fix security.get_api_key and security.query_api_keys APIs

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27816,7 +27816,7 @@
                     "api_keys": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/security._types:ApiKey"
+                        "$ref": "#/components/schemas/security._types:ApiKeyRead"
                       }
                     }
                   },
@@ -81796,6 +81796,9 @@
             "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
             "type": "boolean"
           },
+          "invalidation": {
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+          },
           "name": {
             "$ref": "#/components/schemas/_types:Name"
           },
@@ -81806,6 +81809,9 @@
           "realm_type": {
             "description": "Realm type of the principal for which this API key was created",
             "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/security._types:ApiKeyType"
           },
           "username": {
             "$ref": "#/components/schemas/_types:Username"
@@ -81834,6 +81840,9 @@
               }
             }
           },
+          "access": {
+            "$ref": "#/components/schemas/security._types:Access"
+          },
           "_sort": {
             "$ref": "#/components/schemas/_types:SortResults"
           }
@@ -81841,6 +81850,13 @@
         "required": [
           "id",
           "name"
+        ]
+      },
+      "security._types:ApiKeyType": {
+        "type": "string",
+        "enum": [
+          "rest",
+          "cross_cluster"
         ]
       },
       "security._types:RoleDescriptor": {
@@ -82266,72 +82282,6 @@
           "resources"
         ]
       },
-      "security._types:RealmInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "type"
-        ]
-      },
-      "security.authenticate:Token": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name"
-        ]
-      },
-      "security._types:BulkError": {
-        "type": "object",
-        "properties": {
-          "count": {
-            "description": "The number of errors",
-            "type": "number"
-          },
-          "details": {
-            "description": "Details about the errors, keyed by role name",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/_types:ErrorCause"
-            }
-          }
-        },
-        "required": [
-          "count",
-          "details"
-        ]
-      },
-      "security._types:ClusterNode": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          }
-        },
-        "required": [
-          "name"
-        ]
-      },
-      "_types:Namespace": {
-        "type": "string"
-      },
-      "_types:Service": {
-        "type": "string"
-      },
       "security._types:Access": {
         "type": "object",
         "properties": {
@@ -82409,6 +82359,72 @@
           "names"
         ]
       },
+      "security._types:RealmInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ]
+      },
+      "security.authenticate:Token": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "security._types:BulkError": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The number of errors",
+            "type": "number"
+          },
+          "details": {
+            "description": "Details about the errors, keyed by role name",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/_types:ErrorCause"
+            }
+          }
+        },
+        "required": [
+          "count",
+          "details"
+        ]
+      },
+      "security._types:ClusterNode": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "_types:Namespace": {
+        "type": "string"
+      },
+      "_types:Service": {
+        "type": "string"
+      },
       "security.create_service_token:Token": {
         "type": "object",
         "properties": {
@@ -82448,6 +82464,85 @@
         "required": [
           "name",
           "value"
+        ]
+      },
+      "security._types:ApiKeyRead": {
+        "type": "object",
+        "properties": {
+          "creation": {
+            "description": "Creation time for the API key in milliseconds.",
+            "type": "number"
+          },
+          "expiration": {
+            "description": "Expiration time for the API key in milliseconds.",
+            "type": "number"
+          },
+          "id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "invalidated": {
+            "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
+            "type": "boolean"
+          },
+          "invalidation": {
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+          },
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "realm": {
+            "description": "Realm name of the principal for which this API key was created.",
+            "type": "string"
+          },
+          "realm_type": {
+            "description": "Realm type of the principal for which this API key was created",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/security._types:ApiKeyType"
+          },
+          "username": {
+            "$ref": "#/components/schemas/_types:Username"
+          },
+          "profile_uid": {
+            "description": "The profile uid for the API key owner principal, if requested and if it exists",
+            "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/_types:Metadata"
+          },
+          "role_descriptors": {
+            "description": "The role descriptors assigned to this API key when it was created or last updated.\nAn empty role descriptor means the API key inherits the owner user’s permissions.",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/security._types:RoleDescriptor"
+            }
+          },
+          "limited_by": {
+            "description": "The owner user’s permissions associated with the API key.\nIt is a point-in-time snapshot captured at creation and subsequent updates.\nAn API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/security._types:RoleDescriptor"
+              }
+            }
+          },
+          "access": {
+            "$ref": "#/components/schemas/security._types:Access"
+          },
+          "_sort": {
+            "$ref": "#/components/schemas/_types:SortResults"
+          }
+        },
+        "required": [
+          "creation",
+          "id",
+          "invalidated",
+          "name",
+          "type",
+          "username",
+          "metadata"
         ]
       },
       "security.put_privileges:Actions": {
@@ -91857,7 +91952,7 @@
                   "description": "A list of API key information.",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/security._types:ApiKey"
+                    "$ref": "#/components/schemas/security._types:ApiKeyRead"
                   }
                 },
                 "aggregations": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27072,7 +27072,7 @@
                   "type": "object",
                   "properties": {
                     "api_key": {
-                      "$ref": "#/components/schemas/security._types:ApiKey"
+                      "$ref": "#/components/schemas/security.authenticate:AuthenticateApiKey"
                     },
                     "authentication_realm": {
                       "$ref": "#/components/schemas/security._types:RealmInfo"
@@ -27816,7 +27816,7 @@
                     "api_keys": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/security._types:ApiKeyRead"
+                        "$ref": "#/components/schemas/security._types:ApiKey"
                       }
                     }
                   },
@@ -81778,85 +81778,67 @@
           "username"
         ]
       },
-      "security._types:ApiKey": {
+      "security.authenticate:AuthenticateApiKey": {
         "type": "object",
         "properties": {
-          "creation": {
-            "description": "Creation time for the API key in milliseconds.",
-            "type": "number"
-          },
-          "expiration": {
-            "description": "Expiration time for the API key in milliseconds.",
-            "type": "number"
-          },
           "id": {
             "$ref": "#/components/schemas/_types:Id"
           },
-          "invalidated": {
-            "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
-            "type": "boolean"
-          },
-          "invalidation": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
-          },
           "name": {
             "$ref": "#/components/schemas/_types:Name"
-          },
-          "realm": {
-            "description": "Realm name of the principal for which this API key was created.",
-            "type": "string"
-          },
-          "realm_type": {
-            "description": "Realm type of the principal for which this API key was created",
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/security._types:ApiKeyType"
-          },
-          "username": {
-            "$ref": "#/components/schemas/_types:Username"
-          },
-          "profile_uid": {
-            "description": "The profile uid for the API key owner principal, if requested and if it exists",
-            "type": "string"
-          },
-          "metadata": {
-            "$ref": "#/components/schemas/_types:Metadata"
-          },
-          "role_descriptors": {
-            "description": "The role descriptors assigned to this API key when it was created or last updated.\nAn empty role descriptor means the API key inherits the owner user’s permissions.",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/security._types:RoleDescriptor"
-            }
-          },
-          "limited_by": {
-            "description": "The owner user’s permissions associated with the API key.\nIt is a point-in-time snapshot captured at creation and subsequent updates.\nAn API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/components/schemas/security._types:RoleDescriptor"
-              }
-            }
-          },
-          "access": {
-            "$ref": "#/components/schemas/security._types:Access"
-          },
-          "_sort": {
-            "$ref": "#/components/schemas/_types:SortResults"
           }
         },
         "required": [
-          "id",
+          "id"
+        ]
+      },
+      "security._types:RealmInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ]
+      },
+      "security.authenticate:Token": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
           "name"
         ]
       },
-      "security._types:ApiKeyType": {
-        "type": "string",
-        "enum": [
-          "rest",
-          "cross_cluster"
+      "security._types:BulkError": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "description": "The number of errors",
+            "type": "number"
+          },
+          "details": {
+            "description": "Details about the errors, keyed by role name",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/_types:ErrorCause"
+            }
+          }
+        },
+        "required": [
+          "count",
+          "details"
         ]
       },
       "security._types:RoleDescriptor": {
@@ -82312,6 +82294,23 @@
           }
         ]
       },
+      "security._types:ClusterNode": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "_types:Namespace": {
+        "type": "string"
+      },
+      "_types:Service": {
+        "type": "string"
+      },
       "security._types:Access": {
         "type": "object",
         "properties": {
@@ -82389,72 +82388,6 @@
           "names"
         ]
       },
-      "security._types:RealmInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "type"
-        ]
-      },
-      "security.authenticate:Token": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name"
-        ]
-      },
-      "security._types:BulkError": {
-        "type": "object",
-        "properties": {
-          "count": {
-            "description": "The number of errors",
-            "type": "number"
-          },
-          "details": {
-            "description": "Details about the errors, keyed by role name",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/_types:ErrorCause"
-            }
-          }
-        },
-        "required": [
-          "count",
-          "details"
-        ]
-      },
-      "security._types:ClusterNode": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          }
-        },
-        "required": [
-          "name"
-        ]
-      },
-      "_types:Namespace": {
-        "type": "string"
-      },
-      "_types:Service": {
-        "type": "string"
-      },
       "security.create_service_token:Token": {
         "type": "object",
         "properties": {
@@ -82496,9 +82429,18 @@
           "value"
         ]
       },
-      "security._types:ApiKeyRead": {
+      "security._types:ApiKey": {
         "type": "object",
         "properties": {
+          "id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "type": {
+            "$ref": "#/components/schemas/security._types:ApiKeyType"
+          },
           "creation": {
             "description": "Creation time for the API key in milliseconds.",
             "type": "number"
@@ -82507,9 +82449,6 @@
             "description": "Expiration time for the API key in milliseconds.",
             "type": "number"
           },
-          "id": {
-            "$ref": "#/components/schemas/_types:Id"
-          },
           "invalidated": {
             "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
             "type": "boolean"
@@ -82517,8 +82456,8 @@
           "invalidation": {
             "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
+          "username": {
+            "$ref": "#/components/schemas/_types:Username"
           },
           "realm": {
             "description": "Realm name of the principal for which this API key was created.",
@@ -82526,16 +82465,6 @@
           },
           "realm_type": {
             "description": "Realm type of the principal for which this API key was created",
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/security._types:ApiKeyType"
-          },
-          "username": {
-            "$ref": "#/components/schemas/_types:Username"
-          },
-          "profile_uid": {
-            "description": "The profile uid for the API key owner principal, if requested and if it exists",
             "type": "string"
           },
           "metadata": {
@@ -82561,18 +82490,30 @@
           "access": {
             "$ref": "#/components/schemas/security._types:Access"
           },
+          "profile_uid": {
+            "description": "The profile uid for the API key owner principal, if requested and if it exists",
+            "type": "string"
+          },
           "_sort": {
             "$ref": "#/components/schemas/_types:SortResults"
           }
         },
         "required": [
-          "creation",
           "id",
-          "invalidated",
           "name",
           "type",
+          "creation",
+          "invalidated",
           "username",
+          "realm",
           "metadata"
+        ]
+      },
+      "security._types:ApiKeyType": {
+        "type": "string",
+        "enum": [
+          "rest",
+          "cross_cluster"
         ]
       },
       "security.put_privileges:Actions": {
@@ -91985,7 +91926,7 @@
                   "description": "A list of API key information.",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/security._types:ApiKeyRead"
+                    "$ref": "#/components/schemas/security._types:ApiKey"
                   }
                 },
                 "aggregations": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -82442,12 +82442,10 @@
             "$ref": "#/components/schemas/security._types:ApiKeyType"
           },
           "creation": {
-            "description": "Creation time for the API key in milliseconds.",
-            "type": "number"
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
           "expiration": {
-            "description": "Expiration time for the API key in milliseconds.",
-            "type": "number"
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
           "invalidated": {
             "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -16830,7 +16830,7 @@
                     "api_keys": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/security._types:ApiKey"
+                        "$ref": "#/components/schemas/security._types:ApiKeyRead"
                       }
                     }
                   },
@@ -53582,6 +53582,9 @@
             "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
             "type": "boolean"
           },
+          "invalidation": {
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+          },
           "name": {
             "$ref": "#/components/schemas/_types:Name"
           },
@@ -53592,6 +53595,9 @@
           "realm_type": {
             "description": "Realm type of the principal for which this API key was created",
             "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/security._types:ApiKeyType"
           },
           "username": {
             "$ref": "#/components/schemas/_types:Username"
@@ -53620,6 +53626,9 @@
               }
             }
           },
+          "access": {
+            "$ref": "#/components/schemas/security._types:Access"
+          },
           "_sort": {
             "$ref": "#/components/schemas/_types:SortResults"
           }
@@ -53627,6 +53636,13 @@
         "required": [
           "id",
           "name"
+        ]
+      },
+      "security._types:ApiKeyType": {
+        "type": "string",
+        "enum": [
+          "rest",
+          "cross_cluster"
         ]
       },
       "security._types:RoleDescriptor": {
@@ -53876,6 +53892,79 @@
           "resources"
         ]
       },
+      "security._types:Access": {
+        "type": "object",
+        "properties": {
+          "replication": {
+            "description": "A list of indices permission entries for cross-cluster replication.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:ReplicationAccess"
+            }
+          },
+          "search": {
+            "description": "A list of indices permission entries for cross-cluster search.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/security._types:SearchAccess"
+            }
+          }
+        }
+      },
+      "security._types:ReplicationAccess": {
+        "type": "object",
+        "properties": {
+          "names": {
+            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/_types:IndexName"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/_types:IndexName"
+                }
+              }
+            ]
+          },
+          "allow_restricted_indices": {
+            "description": "This needs to be set to true if the patterns in the names field should cover system indices.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "names"
+        ]
+      },
+      "security._types:SearchAccess": {
+        "type": "object",
+        "properties": {
+          "field_security": {
+            "$ref": "#/components/schemas/security._types:FieldSecurity"
+          },
+          "names": {
+            "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/_types:IndexName"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/_types:IndexName"
+                }
+              }
+            ]
+          },
+          "query": {
+            "$ref": "#/components/schemas/security._types:IndicesPrivilegesQuery"
+          }
+        },
+        "required": [
+          "names"
+        ]
+      },
       "security._types:RealmInfo": {
         "type": "object",
         "properties": {
@@ -53903,6 +53992,85 @@
         },
         "required": [
           "name"
+        ]
+      },
+      "security._types:ApiKeyRead": {
+        "type": "object",
+        "properties": {
+          "creation": {
+            "description": "Creation time for the API key in milliseconds.",
+            "type": "number"
+          },
+          "expiration": {
+            "description": "Expiration time for the API key in milliseconds.",
+            "type": "number"
+          },
+          "id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "invalidated": {
+            "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
+            "type": "boolean"
+          },
+          "invalidation": {
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+          },
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "realm": {
+            "description": "Realm name of the principal for which this API key was created.",
+            "type": "string"
+          },
+          "realm_type": {
+            "description": "Realm type of the principal for which this API key was created",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/security._types:ApiKeyType"
+          },
+          "username": {
+            "$ref": "#/components/schemas/_types:Username"
+          },
+          "profile_uid": {
+            "description": "The profile uid for the API key owner principal, if requested and if it exists",
+            "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/_types:Metadata"
+          },
+          "role_descriptors": {
+            "description": "The role descriptors assigned to this API key when it was created or last updated.\nAn empty role descriptor means the API key inherits the owner user’s permissions.",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/security._types:RoleDescriptor"
+            }
+          },
+          "limited_by": {
+            "description": "The owner user’s permissions associated with the API key.\nIt is a point-in-time snapshot captured at creation and subsequent updates.\nAn API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/security._types:RoleDescriptor"
+              }
+            }
+          },
+          "access": {
+            "$ref": "#/components/schemas/security._types:Access"
+          },
+          "_sort": {
+            "$ref": "#/components/schemas/_types:SortResults"
+          }
+        },
+        "required": [
+          "creation",
+          "id",
+          "invalidated",
+          "name",
+          "type",
+          "username",
+          "metadata"
         ]
       },
       "security._types:RemoteClusterPrivilege": {
@@ -56440,7 +56608,7 @@
                   "description": "A list of API key information.",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/security._types:ApiKey"
+                    "$ref": "#/components/schemas/security._types:ApiKeyRead"
                   }
                 },
                 "aggregations": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -53897,12 +53897,10 @@
             "$ref": "#/components/schemas/security._types:ApiKeyType"
           },
           "creation": {
-            "description": "Creation time for the API key in milliseconds.",
-            "type": "number"
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
           "expiration": {
-            "description": "Expiration time for the API key in milliseconds.",
-            "type": "number"
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
           "invalidated": {
             "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -16660,7 +16660,7 @@
                   "type": "object",
                   "properties": {
                     "api_key": {
-                      "$ref": "#/components/schemas/security._types:ApiKey"
+                      "$ref": "#/components/schemas/security.authenticate:AuthenticateApiKey"
                     },
                     "authentication_realm": {
                       "$ref": "#/components/schemas/security._types:RealmInfo"
@@ -16830,7 +16830,7 @@
                     "api_keys": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/security._types:ApiKeyRead"
+                        "$ref": "#/components/schemas/security._types:ApiKey"
                       }
                     }
                   },
@@ -53564,85 +53564,47 @@
       "_types:MapboxVectorTiles": {
         "type": "object"
       },
-      "security._types:ApiKey": {
+      "security.authenticate:AuthenticateApiKey": {
         "type": "object",
         "properties": {
-          "creation": {
-            "description": "Creation time for the API key in milliseconds.",
-            "type": "number"
-          },
-          "expiration": {
-            "description": "Expiration time for the API key in milliseconds.",
-            "type": "number"
-          },
           "id": {
             "$ref": "#/components/schemas/_types:Id"
           },
-          "invalidated": {
-            "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
-            "type": "boolean"
-          },
-          "invalidation": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
-          },
           "name": {
             "$ref": "#/components/schemas/_types:Name"
-          },
-          "realm": {
-            "description": "Realm name of the principal for which this API key was created.",
-            "type": "string"
-          },
-          "realm_type": {
-            "description": "Realm type of the principal for which this API key was created",
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/security._types:ApiKeyType"
-          },
-          "username": {
-            "$ref": "#/components/schemas/_types:Username"
-          },
-          "profile_uid": {
-            "description": "The profile uid for the API key owner principal, if requested and if it exists",
-            "type": "string"
-          },
-          "metadata": {
-            "$ref": "#/components/schemas/_types:Metadata"
-          },
-          "role_descriptors": {
-            "description": "The role descriptors assigned to this API key when it was created or last updated.\nAn empty role descriptor means the API key inherits the owner user’s permissions.",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/security._types:RoleDescriptor"
-            }
-          },
-          "limited_by": {
-            "description": "The owner user’s permissions associated with the API key.\nIt is a point-in-time snapshot captured at creation and subsequent updates.\nAn API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/components/schemas/security._types:RoleDescriptor"
-              }
-            }
-          },
-          "access": {
-            "$ref": "#/components/schemas/security._types:Access"
-          },
-          "_sort": {
-            "$ref": "#/components/schemas/_types:SortResults"
           }
         },
         "required": [
-          "id",
-          "name"
+          "id"
         ]
       },
-      "security._types:ApiKeyType": {
-        "type": "string",
-        "enum": [
-          "rest",
-          "cross_cluster"
+      "security._types:RealmInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ]
+      },
+      "security.authenticate:Token": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
         ]
       },
       "security._types:RoleDescriptor": {
@@ -53922,6 +53884,93 @@
           }
         ]
       },
+      "security._types:ApiKey": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "type": {
+            "$ref": "#/components/schemas/security._types:ApiKeyType"
+          },
+          "creation": {
+            "description": "Creation time for the API key in milliseconds.",
+            "type": "number"
+          },
+          "expiration": {
+            "description": "Expiration time for the API key in milliseconds.",
+            "type": "number"
+          },
+          "invalidated": {
+            "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
+            "type": "boolean"
+          },
+          "invalidation": {
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+          },
+          "username": {
+            "$ref": "#/components/schemas/_types:Username"
+          },
+          "realm": {
+            "description": "Realm name of the principal for which this API key was created.",
+            "type": "string"
+          },
+          "realm_type": {
+            "description": "Realm type of the principal for which this API key was created",
+            "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/_types:Metadata"
+          },
+          "role_descriptors": {
+            "description": "The role descriptors assigned to this API key when it was created or last updated.\nAn empty role descriptor means the API key inherits the owner user’s permissions.",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/security._types:RoleDescriptor"
+            }
+          },
+          "limited_by": {
+            "description": "The owner user’s permissions associated with the API key.\nIt is a point-in-time snapshot captured at creation and subsequent updates.\nAn API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/security._types:RoleDescriptor"
+              }
+            }
+          },
+          "access": {
+            "$ref": "#/components/schemas/security._types:Access"
+          },
+          "profile_uid": {
+            "description": "The profile uid for the API key owner principal, if requested and if it exists",
+            "type": "string"
+          },
+          "_sort": {
+            "$ref": "#/components/schemas/_types:SortResults"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "creation",
+          "invalidated",
+          "username",
+          "realm",
+          "metadata"
+        ]
+      },
+      "security._types:ApiKeyType": {
+        "type": "string",
+        "enum": [
+          "rest",
+          "cross_cluster"
+        ]
+      },
       "security._types:Access": {
         "type": "object",
         "properties": {
@@ -53993,114 +54042,6 @@
         },
         "required": [
           "names"
-        ]
-      },
-      "security._types:RealmInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name",
-          "type"
-        ]
-      },
-      "security.authenticate:Token": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "type": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "name"
-        ]
-      },
-      "security._types:ApiKeyRead": {
-        "type": "object",
-        "properties": {
-          "creation": {
-            "description": "Creation time for the API key in milliseconds.",
-            "type": "number"
-          },
-          "expiration": {
-            "description": "Expiration time for the API key in milliseconds.",
-            "type": "number"
-          },
-          "id": {
-            "$ref": "#/components/schemas/_types:Id"
-          },
-          "invalidated": {
-            "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
-            "type": "boolean"
-          },
-          "invalidation": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
-          },
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "realm": {
-            "description": "Realm name of the principal for which this API key was created.",
-            "type": "string"
-          },
-          "realm_type": {
-            "description": "Realm type of the principal for which this API key was created",
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/security._types:ApiKeyType"
-          },
-          "username": {
-            "$ref": "#/components/schemas/_types:Username"
-          },
-          "profile_uid": {
-            "description": "The profile uid for the API key owner principal, if requested and if it exists",
-            "type": "string"
-          },
-          "metadata": {
-            "$ref": "#/components/schemas/_types:Metadata"
-          },
-          "role_descriptors": {
-            "description": "The role descriptors assigned to this API key when it was created or last updated.\nAn empty role descriptor means the API key inherits the owner user’s permissions.",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/security._types:RoleDescriptor"
-            }
-          },
-          "limited_by": {
-            "description": "The owner user’s permissions associated with the API key.\nIt is a point-in-time snapshot captured at creation and subsequent updates.\nAn API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/components/schemas/security._types:RoleDescriptor"
-              }
-            }
-          },
-          "access": {
-            "$ref": "#/components/schemas/security._types:Access"
-          },
-          "_sort": {
-            "$ref": "#/components/schemas/_types:SortResults"
-          }
-        },
-        "required": [
-          "creation",
-          "id",
-          "invalidated",
-          "name",
-          "type",
-          "username",
-          "metadata"
         ]
       },
       "security._types:RemoteClusterPrivilege": {
@@ -56638,7 +56579,7 @@
                   "description": "A list of API key information.",
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/security._types:ApiKeyRead"
+                    "$ref": "#/components/schemas/security._types:ApiKey"
                   }
                 },
                 "aggregations": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -102913,7 +102913,7 @@
         "name": "ApiKeyType",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/ApiKey.ts#L117-L120"
+      "specLocation": "security/_types/ApiKey.ts#L116-L119"
     },
     {
       "isOpen": true,
@@ -139867,9 +139867,18 @@
           "name": "creation",
           "required": true,
           "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "EpochTime",
               "namespace": "_types"
             }
           }
@@ -139879,9 +139888,18 @@
           "name": "expiration",
           "required": false,
           "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "EpochTime",
               "namespace": "_types"
             }
           }
@@ -140089,7 +140107,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/ApiKey.ts#L29-L115"
+      "specLocation": "security/_types/ApiKey.ts#L28-L114"
     },
     {
       "kind": "interface",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -38522,8 +38522,8 @@
             "type": {
               "kind": "instance_of",
               "type": {
-                "name": "ApiKey",
-                "namespace": "security._types"
+                "name": "AuthenticateApiKey",
+                "namespace": "security.authenticate"
               }
             }
           },
@@ -38677,7 +38677,7 @@
         "name": "Response",
         "namespace": "security.authenticate"
       },
-      "specLocation": "security/authenticate/SecurityAuthenticateResponse.ts#L25-L43"
+      "specLocation": "security/authenticate/SecurityAuthenticateResponse.ts#L24-L42"
     },
     {
       "attachedBehaviors": [
@@ -39090,7 +39090,7 @@
               "value": {
                 "kind": "instance_of",
                 "type": {
-                  "name": "ApiKeyRead",
+                  "name": "ApiKey",
                   "namespace": "security._types"
                 }
               }
@@ -39974,7 +39974,7 @@
               "value": {
                 "kind": "instance_of",
                 "type": {
-                  "name": "ApiKeyRead",
+                  "name": "ApiKey",
                   "namespace": "security._types"
                 }
               }
@@ -102913,7 +102913,7 @@
         "name": "ApiKeyType",
         "namespace": "security._types"
       },
-      "specLocation": "security/_types/ApiKey.ts#L114-L117"
+      "specLocation": "security/_types/ApiKey.ts#L117-L120"
     },
     {
       "isOpen": true,
@@ -139399,36 +139399,11 @@
     {
       "kind": "interface",
       "name": {
-        "name": "ApiKey",
-        "namespace": "security._types"
+        "name": "AuthenticateApiKey",
+        "namespace": "security.authenticate"
       },
       "properties": [
         {
-          "description": "Creation time for the API key in milliseconds.",
-          "name": "creation",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Expiration time for the API key in milliseconds.",
-          "name": "expiration",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Id for the API key",
           "name": "id",
           "required": true,
           "type": {
@@ -139440,46 +139415,27 @@
           }
         },
         {
-          "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
-          "name": "invalidated",
+          "name": "name",
           "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "boolean",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "8.12.0"
-            }
-          },
-          "description": "If the key has been invalidated, invalidation time in milliseconds.",
-          "name": "invalidation",
-          "required": false,
-          "type": {
-            "generics": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "UnitMillis",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "EpochTime",
+              "name": "Name",
               "namespace": "_types"
             }
           }
-        },
+        }
+      ],
+      "specLocation": "security/authenticate/SecurityAuthenticateResponse.ts#L44-L47"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "RealmInfo",
+        "namespace": "security._types"
+      },
+      "properties": [
         {
-          "description": "Name of the API key.",
           "name": "name",
           "required": true,
           "type": {
@@ -139491,9 +139447,8 @@
           }
         },
         {
-          "description": "Realm name of the principal for which this API key was created.",
-          "name": "realm",
-          "required": false,
+          "name": "type",
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -139501,22 +139456,25 @@
               "namespace": "_builtins"
             }
           }
-        },
+        }
+      ],
+      "specLocation": "security/_types/RealmInfo.ts#L22-L25"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "Token",
+        "namespace": "security.authenticate"
+      },
+      "properties": [
         {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "8.14.0"
-            }
-          },
-          "description": "Realm type of the principal for which this API key was created",
-          "name": "realm_type",
-          "required": false,
+          "name": "name",
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "_builtins"
+              "name": "Name",
+              "namespace": "_types"
             }
           }
         },
@@ -139524,154 +139482,21 @@
           "availability": {
             "serverless": {},
             "stack": {
-              "since": "8.10.0"
+              "since": "7.14.0"
             }
           },
-          "description": "The type of the API key (e.g. `rest` or `cross_cluster`).",
           "name": "type",
           "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "ApiKeyType",
-              "namespace": "security._types"
-            }
-          }
-        },
-        {
-          "description": "Principal for which this API key was created",
-          "name": "username",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Username",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "8.14.0"
-            }
-          },
-          "description": "The profile uid for the API key owner principal, if requested and if it exists",
-          "name": "profile_uid",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
               "name": "string",
               "namespace": "_builtins"
             }
           }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "7.13.0"
-            }
-          },
-          "description": "Metadata of the API key",
-          "name": "metadata",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Metadata",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "The role descriptors assigned to this API key when it was created or last updated.\nAn empty role descriptor means the API key inherits the owner user’s permissions.",
-          "name": "role_descriptors",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "_builtins"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "RoleDescriptor",
-                "namespace": "security._types"
-              }
-            }
-          }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "8.5.0"
-            }
-          },
-          "description": "The owner user’s permissions associated with the API key.\nIt is a point-in-time snapshot captured at creation and subsequent updates.\nAn API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.",
-          "name": "limited_by",
-          "required": false,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "_builtins"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "RoleDescriptor",
-                  "namespace": "security._types"
-                }
-              }
-            }
-          }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "8.10.0"
-            }
-          },
-          "description": "The access granted to cross-cluster API keys.\nThe access is composed of permissions for cross cluster search and cross cluster replication.\nAt least one of them must be specified.\nWhen specified, the new access assignment fully replaces the previously assigned access.",
-          "name": "access",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Access",
-              "namespace": "security._types"
-            }
-          }
-        },
-        {
-          "name": "_sort",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "SortResults",
-              "namespace": "_types"
-            }
-          }
         }
       ],
-      "specLocation": "security/_types/ApiKey.ts#L29-L112"
+      "specLocation": "security/authenticate/types.ts#L22-L29"
     },
     {
       "kind": "interface",
@@ -139991,6 +139816,284 @@
     {
       "kind": "interface",
       "name": {
+        "name": "ApiKey",
+        "namespace": "security._types"
+      },
+      "properties": [
+        {
+          "description": "Id for the API key",
+          "name": "id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Name of the API key.",
+          "name": "name",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Name",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.10.0"
+            }
+          },
+          "description": "The type of the API key (e.g. `rest` or `cross_cluster`).",
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ApiKeyType",
+              "namespace": "security._types"
+            }
+          }
+        },
+        {
+          "description": "Creation time for the API key in milliseconds.",
+          "name": "creation",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Expiration time for the API key in milliseconds.",
+          "name": "expiration",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
+          "name": "invalidated",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.12.0"
+            }
+          },
+          "description": "If the key has been invalidated, invalidation time in milliseconds.",
+          "name": "invalidation",
+          "required": false,
+          "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "instance_of",
+            "type": {
+              "name": "EpochTime",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Principal for which this API key was created",
+          "name": "username",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Username",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Realm name of the principal for which this API key was created.",
+          "name": "realm",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.14.0"
+            }
+          },
+          "description": "Realm type of the principal for which this API key was created",
+          "name": "realm_type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "7.13.0"
+            }
+          },
+          "description": "Metadata of the API key",
+          "name": "metadata",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The role descriptors assigned to this API key when it was created or last updated.\nAn empty role descriptor means the API key inherits the owner user’s permissions.",
+          "name": "role_descriptors",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "_builtins"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "RoleDescriptor",
+                "namespace": "security._types"
+              }
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.5.0"
+            }
+          },
+          "description": "The owner user’s permissions associated with the API key.\nIt is a point-in-time snapshot captured at creation and subsequent updates.\nAn API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.",
+          "name": "limited_by",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "key": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "_builtins"
+                }
+              },
+              "kind": "dictionary_of",
+              "singleKey": false,
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "RoleDescriptor",
+                  "namespace": "security._types"
+                }
+              }
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.10.0"
+            }
+          },
+          "description": "The access granted to cross-cluster API keys.\nThe access is composed of permissions for cross cluster search and cross cluster replication.\nAt least one of them must be specified.\nWhen specified, the new access assignment fully replaces the previously assigned access.",
+          "name": "access",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Access",
+              "namespace": "security._types"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.14.0"
+            }
+          },
+          "description": "The profile uid for the API key owner principal, if requested and if it exists",
+          "name": "profile_uid",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "description": "Sorting values when using the `sort` parameter with the `security.query_api_keys` API.",
+          "name": "_sort",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "SortResults",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "specLocation": "security/_types/ApiKey.ts#L29-L115"
+    },
+    {
+      "kind": "interface",
+      "name": {
         "name": "Access",
         "namespace": "security._types"
       },
@@ -140140,373 +140243,6 @@
         }
       ],
       "specLocation": "security/_types/Privileges.ts#L430-L450"
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "RealmInfo",
-        "namespace": "security._types"
-      },
-      "properties": [
-        {
-          "name": "name",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Name",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "type",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
-        }
-      ],
-      "specLocation": "security/_types/RealmInfo.ts#L22-L25"
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "Token",
-        "namespace": "security.authenticate"
-      },
-      "properties": [
-        {
-          "name": "name",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Name",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "7.14.0"
-            }
-          },
-          "name": "type",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
-        }
-      ],
-      "specLocation": "security/authenticate/types.ts#L22-L29"
-    },
-    {
-      "attachedBehaviors": [
-        "OverloadOf"
-      ],
-      "behaviors": [
-        {
-          "generics": [
-            {
-              "kind": "instance_of",
-              "type": {
-                "name": "ApiKey",
-                "namespace": "security._types"
-              }
-            }
-          ],
-          "type": {
-            "name": "OverloadOf",
-            "namespace": "_spec_utils"
-          }
-        }
-      ],
-      "kind": "interface",
-      "name": {
-        "name": "ApiKeyRead",
-        "namespace": "security._types"
-      },
-      "properties": [
-        {
-          "description": "Creation time for the API key in milliseconds.",
-          "name": "creation",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Expiration time for the API key in milliseconds.",
-          "name": "expiration",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Id for the API key",
-          "name": "id",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Id",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
-          "name": "invalidated",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "8.12.0"
-            }
-          },
-          "description": "If the key has been invalidated, invalidation time in milliseconds.",
-          "name": "invalidation",
-          "required": false,
-          "type": {
-            "generics": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "UnitMillis",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "instance_of",
-            "type": {
-              "name": "EpochTime",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Name of the API key.",
-          "name": "name",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Name",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Realm name of the principal for which this API key was created.",
-          "name": "realm",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "8.14.0"
-            }
-          },
-          "description": "Realm type of the principal for which this API key was created",
-          "name": "realm_type",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "8.10.0"
-            }
-          },
-          "description": "The type of the API key (e.g. `rest` or `cross_cluster`).",
-          "name": "type",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "ApiKeyType",
-              "namespace": "security._types"
-            }
-          }
-        },
-        {
-          "description": "Principal for which this API key was created",
-          "name": "username",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Username",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "8.14.0"
-            }
-          },
-          "description": "The profile uid for the API key owner principal, if requested and if it exists",
-          "name": "profile_uid",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "7.13.0"
-            }
-          },
-          "description": "Metadata of the API key",
-          "name": "metadata",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Metadata",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "The role descriptors assigned to this API key when it was created or last updated.\nAn empty role descriptor means the API key inherits the owner user’s permissions.",
-          "name": "role_descriptors",
-          "required": false,
-          "type": {
-            "key": {
-              "kind": "instance_of",
-              "type": {
-                "name": "string",
-                "namespace": "_builtins"
-              }
-            },
-            "kind": "dictionary_of",
-            "singleKey": false,
-            "value": {
-              "kind": "instance_of",
-              "type": {
-                "name": "RoleDescriptor",
-                "namespace": "security._types"
-              }
-            }
-          }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "8.5.0"
-            }
-          },
-          "description": "The owner user’s permissions associated with the API key.\nIt is a point-in-time snapshot captured at creation and subsequent updates.\nAn API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.",
-          "name": "limited_by",
-          "required": false,
-          "type": {
-            "kind": "array_of",
-            "value": {
-              "key": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "_builtins"
-                }
-              },
-              "kind": "dictionary_of",
-              "singleKey": false,
-              "value": {
-                "kind": "instance_of",
-                "type": {
-                  "name": "RoleDescriptor",
-                  "namespace": "security._types"
-                }
-              }
-            }
-          }
-        },
-        {
-          "availability": {
-            "serverless": {},
-            "stack": {
-              "since": "8.10.0"
-            }
-          },
-          "description": "The access granted to cross-cluster API keys.\nThe access is composed of permissions for cross cluster search and cross cluster replication.\nAt least one of them must be specified.\nWhen specified, the new access assignment fully replaces the previously assigned access.",
-          "name": "access",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Access",
-              "namespace": "security._types"
-            }
-          }
-        },
-        {
-          "name": "_sort",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "SortResults",
-              "namespace": "_types"
-            }
-          }
-        }
-      ],
-      "specLocation": "security/_types/ApiKey.ts#L119-L202"
     },
     {
       "kind": "interface",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -39090,7 +39090,7 @@
               "value": {
                 "kind": "instance_of",
                 "type": {
-                  "name": "ApiKey",
+                  "name": "ApiKeyRead",
                   "namespace": "security._types"
                 }
               }
@@ -39974,7 +39974,7 @@
               "value": {
                 "kind": "instance_of",
                 "type": {
-                  "name": "ApiKey",
+                  "name": "ApiKeyRead",
                   "namespace": "security._types"
                 }
               }
@@ -102900,6 +102900,22 @@
       "specLocation": "searchable_snapshots/_types/stats.ts#L20-L24"
     },
     {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "rest"
+        },
+        {
+          "name": "cross_cluster"
+        }
+      ],
+      "name": {
+        "name": "ApiKeyType",
+        "namespace": "security._types"
+      },
+      "specLocation": "security/_types/ApiKey.ts#L114-L117"
+    },
+    {
       "isOpen": true,
       "kind": "enum",
       "members": [
@@ -139422,6 +139438,33 @@
           }
         },
         {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.12.0"
+            }
+          },
+          "description": "If the key has been invalidated, invalidation time in milliseconds.",
+          "name": "invalidation",
+          "required": false,
+          "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "instance_of",
+            "type": {
+              "name": "EpochTime",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "description": "Name of the API key.",
           "name": "name",
           "required": true,
@@ -139460,6 +139503,24 @@
             "type": {
               "name": "string",
               "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.10.0"
+            }
+          },
+          "description": "The type of the API key (e.g. `rest` or `cross_cluster`).",
+          "name": "type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ApiKeyType",
+              "namespace": "security._types"
             }
           }
         },
@@ -139567,6 +139628,24 @@
           }
         },
         {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.10.0"
+            }
+          },
+          "description": "The access granted to cross-cluster API keys.\nThe access is composed of permissions for cross cluster search and cross cluster replication.\nAt least one of them must be specified.\nWhen specified, the new access assignment fully replaces the previously assigned access.",
+          "name": "access",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Access",
+              "namespace": "security._types"
+            }
+          }
+        },
+        {
           "name": "_sort",
           "required": false,
           "type": {
@@ -139578,7 +139657,7 @@
           }
         }
       ],
-      "specLocation": "security/_types/ApiKey.ts#L26-L88"
+      "specLocation": "security/_types/ApiKey.ts#L29-L112"
     },
     {
       "kind": "interface",
@@ -139862,6 +139941,159 @@
     {
       "kind": "interface",
       "name": {
+        "name": "Access",
+        "namespace": "security._types"
+      },
+      "properties": [
+        {
+          "description": "A list of indices permission entries for cross-cluster replication.",
+          "name": "replication",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "ReplicationAccess",
+                "namespace": "security._types"
+              }
+            }
+          }
+        },
+        {
+          "description": "A list of indices permission entries for cross-cluster search.",
+          "name": "search",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "SearchAccess",
+                "namespace": "security._types"
+              }
+            }
+          }
+        }
+      ],
+      "specLocation": "security/_types/Access.ts#L22-L31"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "ReplicationAccess",
+        "namespace": "security._types"
+      },
+      "properties": [
+        {
+          "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+          "name": "names",
+          "required": true,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "IndexName",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "array_of",
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "IndexName",
+                    "namespace": "_types"
+                  }
+                }
+              }
+            ],
+            "kind": "union_of"
+          }
+        },
+        {
+          "description": "This needs to be set to true if the patterns in the names field should cover system indices.",
+          "name": "allow_restricted_indices",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        }
+      ],
+      "specLocation": "security/_types/Privileges.ts#L418-L428"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "SearchAccess",
+        "namespace": "security._types"
+      },
+      "properties": [
+        {
+          "description": "The document fields that the owners of the role have read access to.",
+          "docId": "field-and-document-access-control",
+          "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/field-and-document-access-control.html",
+          "name": "field_security",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "FieldSecurity",
+              "namespace": "security._types"
+            }
+          }
+        },
+        {
+          "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
+          "name": "names",
+          "required": true,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "IndexName",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "array_of",
+                "value": {
+                  "kind": "instance_of",
+                  "type": {
+                    "name": "IndexName",
+                    "namespace": "_types"
+                  }
+                }
+              }
+            ],
+            "kind": "union_of"
+          }
+        },
+        {
+          "description": "A search query that defines the documents the owners of the role have access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.",
+          "name": "query",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndicesPrivilegesQuery",
+              "namespace": "security._types"
+            }
+          }
+        }
+      ],
+      "specLocation": "security/_types/Privileges.ts#L430-L450"
+    },
+    {
+      "kind": "interface",
+      "name": {
         "name": "RealmInfo",
         "namespace": "security._types"
       },
@@ -139928,6 +140160,303 @@
         }
       ],
       "specLocation": "security/authenticate/types.ts#L22-L29"
+    },
+    {
+      "attachedBehaviors": [
+        "OverloadOf"
+      ],
+      "behaviors": [
+        {
+          "generics": [
+            {
+              "kind": "instance_of",
+              "type": {
+                "name": "ApiKey",
+                "namespace": "security._types"
+              }
+            }
+          ],
+          "type": {
+            "name": "OverloadOf",
+            "namespace": "_spec_utils"
+          }
+        }
+      ],
+      "kind": "interface",
+      "name": {
+        "name": "ApiKeyRead",
+        "namespace": "security._types"
+      },
+      "properties": [
+        {
+          "description": "Creation time for the API key in milliseconds.",
+          "name": "creation",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Expiration time for the API key in milliseconds.",
+          "name": "expiration",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Id for the API key",
+          "name": "id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Invalidation status for the API key.\nIf the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.",
+          "name": "invalidated",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.12.0"
+            }
+          },
+          "description": "If the key has been invalidated, invalidation time in milliseconds.",
+          "name": "invalidation",
+          "required": false,
+          "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "instance_of",
+            "type": {
+              "name": "EpochTime",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Name of the API key.",
+          "name": "name",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Name",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "Realm name of the principal for which this API key was created.",
+          "name": "realm",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.14.0"
+            }
+          },
+          "description": "Realm type of the principal for which this API key was created",
+          "name": "realm_type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.10.0"
+            }
+          },
+          "description": "The type of the API key (e.g. `rest` or `cross_cluster`).",
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ApiKeyType",
+              "namespace": "security._types"
+            }
+          }
+        },
+        {
+          "description": "Principal for which this API key was created",
+          "name": "username",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Username",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.14.0"
+            }
+          },
+          "description": "The profile uid for the API key owner principal, if requested and if it exists",
+          "name": "profile_uid",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "7.13.0"
+            }
+          },
+          "description": "Metadata of the API key",
+          "name": "metadata",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The role descriptors assigned to this API key when it was created or last updated.\nAn empty role descriptor means the API key inherits the owner user’s permissions.",
+          "name": "role_descriptors",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "_builtins"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "RoleDescriptor",
+                "namespace": "security._types"
+              }
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.5.0"
+            }
+          },
+          "description": "The owner user’s permissions associated with the API key.\nIt is a point-in-time snapshot captured at creation and subsequent updates.\nAn API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.",
+          "name": "limited_by",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "key": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "_builtins"
+                }
+              },
+              "kind": "dictionary_of",
+              "singleKey": false,
+              "value": {
+                "kind": "instance_of",
+                "type": {
+                  "name": "RoleDescriptor",
+                  "namespace": "security._types"
+                }
+              }
+            }
+          }
+        },
+        {
+          "availability": {
+            "serverless": {},
+            "stack": {
+              "since": "8.10.0"
+            }
+          },
+          "description": "The access granted to cross-cluster API keys.\nThe access is composed of permissions for cross cluster search and cross cluster replication.\nAt least one of them must be specified.\nWhen specified, the new access assignment fully replaces the previously assigned access.",
+          "name": "access",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Access",
+              "namespace": "security._types"
+            }
+          }
+        },
+        {
+          "name": "_sort",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "SortResults",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "specLocation": "security/_types/ApiKey.ts#L119-L196"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17611,16 +17611,40 @@ export interface SecurityApiKey {
   expiration?: long
   id: Id
   invalidated?: boolean
+  invalidation?: EpochTime<UnitMillis>
   name: Name
   realm?: string
   realm_type?: string
+  type?: SecurityApiKeyType
   username?: Username
   profile_uid?: string
   metadata?: Metadata
   role_descriptors?: Record<string, SecurityRoleDescriptor>
   limited_by?: Record<string, SecurityRoleDescriptor>[]
+  access?: SecurityAccess
   _sort?: SortResults
 }
+
+export interface SecurityApiKeyRead {
+  creation: long
+  expiration?: long
+  id: Id
+  invalidated: boolean
+  invalidation?: EpochTime<UnitMillis>
+  name: Name
+  realm?: string
+  realm_type?: string
+  type: SecurityApiKeyType
+  username: Username
+  profile_uid?: string
+  metadata: Metadata
+  role_descriptors?: Record<string, SecurityRoleDescriptor>
+  limited_by?: Record<string, SecurityRoleDescriptor>[]
+  access?: SecurityAccess
+  _sort?: SortResults
+}
+
+export type SecurityApiKeyType = 'rest' | 'cross_cluster'
 
 export interface SecurityApplicationGlobalUserPrivileges {
   manage: SecurityManageUserPrivileges
@@ -18118,7 +18142,7 @@ export interface SecurityGetApiKeyRequest extends RequestBase {
 }
 
 export interface SecurityGetApiKeyResponse {
-  api_keys: SecurityApiKey[]
+  api_keys: SecurityApiKeyRead[]
 }
 
 export interface SecurityGetBuiltinPrivilegesRequest extends RequestBase {
@@ -18518,7 +18542,7 @@ export interface SecurityQueryApiKeysRequest extends RequestBase {
 export interface SecurityQueryApiKeysResponse {
   total: integer
   count: integer
-  api_keys: SecurityApiKey[]
+  api_keys: SecurityApiKeyRead[]
   aggregations?: Record<AggregateName, SecurityQueryApiKeysApiKeyAggregate>
 }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17610,8 +17610,8 @@ export interface SecurityApiKey {
   id: Id
   name: Name
   type: SecurityApiKeyType
-  creation: long
-  expiration?: long
+  creation: EpochTime<UnitMillis>
+  expiration?: EpochTime<UnitMillis>
   invalidated: boolean
   invalidation?: EpochTime<UnitMillis>
   username: Username

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17607,40 +17607,21 @@ export interface SecurityAccess {
 }
 
 export interface SecurityApiKey {
-  creation?: long
-  expiration?: long
   id: Id
-  invalidated?: boolean
-  invalidation?: EpochTime<UnitMillis>
   name: Name
-  realm?: string
-  realm_type?: string
-  type?: SecurityApiKeyType
-  username?: Username
-  profile_uid?: string
-  metadata?: Metadata
-  role_descriptors?: Record<string, SecurityRoleDescriptor>
-  limited_by?: Record<string, SecurityRoleDescriptor>[]
-  access?: SecurityAccess
-  _sort?: SortResults
-}
-
-export interface SecurityApiKeyRead {
+  type: SecurityApiKeyType
   creation: long
   expiration?: long
-  id: Id
   invalidated: boolean
   invalidation?: EpochTime<UnitMillis>
-  name: Name
-  realm?: string
-  realm_type?: string
-  type: SecurityApiKeyType
   username: Username
-  profile_uid?: string
+  realm: string
+  realm_type?: string
   metadata: Metadata
   role_descriptors?: Record<string, SecurityRoleDescriptor>
   limited_by?: Record<string, SecurityRoleDescriptor>[]
   access?: SecurityAccess
+  profile_uid?: string
   _sort?: SortResults
 }
 
@@ -17867,11 +17848,16 @@ export interface SecurityActivateUserProfileRequest extends RequestBase {
 
 export type SecurityActivateUserProfileResponse = SecurityUserProfileWithMetadata
 
+export interface SecurityAuthenticateAuthenticateApiKey {
+  id: Id
+  name?: Name
+}
+
 export interface SecurityAuthenticateRequest extends RequestBase {
 }
 
 export interface SecurityAuthenticateResponse {
-  api_key?: SecurityApiKey
+  api_key?: SecurityAuthenticateAuthenticateApiKey
   authentication_realm: SecurityRealmInfo
   email?: string | null
   full_name?: Name | null
@@ -18150,7 +18136,7 @@ export interface SecurityGetApiKeyRequest extends RequestBase {
 }
 
 export interface SecurityGetApiKeyResponse {
-  api_keys: SecurityApiKeyRead[]
+  api_keys: SecurityApiKey[]
 }
 
 export interface SecurityGetBuiltinPrivilegesRequest extends RequestBase {
@@ -18550,7 +18536,7 @@ export interface SecurityQueryApiKeysRequest extends RequestBase {
 export interface SecurityQueryApiKeysResponse {
   total: integer
   count: integer
-  api_keys: SecurityApiKeyRead[]
+  api_keys: SecurityApiKey[]
   aggregations?: Record<AggregateName, SecurityQueryApiKeysApiKeyAggregate>
 }
 

--- a/specification/security/_types/ApiKey.ts
+++ b/specification/security/_types/ApiKey.ts
@@ -19,7 +19,6 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { Id, Metadata, Name, Username } from '@_types/common'
-import { long } from '@_types/Numeric'
 import { SortResults } from '@_types/sort'
 import { EpochTime, UnitMillis } from '@_types/Time'
 import { Access } from './Access'
@@ -43,11 +42,11 @@ export class ApiKey {
   /**
    * Creation time for the API key in milliseconds.
    */
-  creation: long
+  creation: EpochTime<UnitMillis>
   /**
    * Expiration time for the API key in milliseconds.
    */
-  expiration?: long
+  expiration?: EpochTime<UnitMillis>
   /**
    * Invalidation status for the API key.
    * If the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.

--- a/specification/security/_types/ApiKey.ts
+++ b/specification/security/_types/ApiKey.ts
@@ -17,10 +17,13 @@
  * under the License.
  */
 
+import { OverloadOf } from '@spec_utils/behaviors'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { Id, Metadata, Name, Username } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { SortResults } from '@_types/sort'
+import { EpochTime, UnitMillis } from '@_types/Time'
+import { Access } from './Access'
 import { RoleDescriptor } from './RoleDescriptor'
 
 export class ApiKey {
@@ -42,6 +45,12 @@ export class ApiKey {
    */
   invalidated?: boolean
   /**
+   * If the key has been invalidated, invalidation time in milliseconds.
+   * @availability stack since=8.12.0
+   * @availability serverless
+   */
+  invalidation?: EpochTime<UnitMillis>
+  /**
    * Name of the API key.
    */
   name: Name
@@ -55,6 +64,12 @@ export class ApiKey {
    * @availability serverless
    */
   realm_type?: string
+  /**
+   * The type of the API key (e.g. `rest` or `cross_cluster`).
+   * @availability stack since=8.10.0
+   * @availability serverless
+   */
+  type?: ApiKeyType
   /**
    * Principal for which this API key was created
    */
@@ -84,5 +99,104 @@ export class ApiKey {
    * @availability serverless
    */
   limited_by?: Array<Dictionary<string, RoleDescriptor>>
+  /**
+   * The access granted to cross-cluster API keys.
+   * The access is composed of permissions for cross cluster search and cross cluster replication.
+   * At least one of them must be specified.
+   * When specified, the new access assignment fully replaces the previously assigned access.
+   * @availability stack since=8.10.0
+   * @availability serverless
+   */
+  access?: Access
+  _sort?: SortResults
+}
+
+export enum ApiKeyType {
+  rest,
+  cross_cluster
+}
+
+export class ApiKeyRead implements OverloadOf<ApiKey> {
+  /**
+   * Creation time for the API key in milliseconds.
+   */
+  creation: long
+  /**
+   * Expiration time for the API key in milliseconds.
+   */
+  expiration?: long
+  /**
+   * Id for the API key
+   */
+  id: Id
+  /**
+   * Invalidation status for the API key.
+   * If the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.
+   */
+  invalidated: boolean
+  /**
+   * If the key has been invalidated, invalidation time in milliseconds.
+   * @availability stack since=8.12.0
+   * @availability serverless
+   */
+  invalidation?: EpochTime<UnitMillis>
+  /**
+   * Name of the API key.
+   */
+  name: Name
+  /**
+   * Realm name of the principal for which this API key was created.
+   */
+  realm?: string
+  /**
+   * Realm type of the principal for which this API key was created
+   * @availability stack since=8.14.0
+   * @availability serverless
+   */
+  realm_type?: string
+  /**
+   * The type of the API key (e.g. `rest` or `cross_cluster`).
+   * @availability stack since=8.10.0
+   * @availability serverless
+   */
+  type: ApiKeyType
+  /**
+   * Principal for which this API key was created
+   */
+  username: Username
+  /**
+   * The profile uid for the API key owner principal, if requested and if it exists
+   * @availability stack since=8.14.0
+   * @availability serverless
+   */
+  profile_uid?: string
+  /**
+   * Metadata of the API key
+   * @availability stack since=7.13.0
+   * @availability serverless
+   */
+  metadata: Metadata
+  /**
+   * The role descriptors assigned to this API key when it was created or last updated.
+   * An empty role descriptor means the API key inherits the owner user’s permissions.
+   */
+  role_descriptors?: Dictionary<string, RoleDescriptor>
+  /**
+   * The owner user’s permissions associated with the API key.
+   * It is a point-in-time snapshot captured at creation and subsequent updates.
+   * An API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.
+   * @availability stack since=8.5.0
+   * @availability serverless
+   */
+  limited_by?: Array<Dictionary<string, RoleDescriptor>>
+  /**
+   * The access granted to cross-cluster API keys.
+   * The access is composed of permissions for cross cluster search and cross cluster replication.
+   * At least one of them must be specified.
+   * When specified, the new access assignment fully replaces the previously assigned access.
+   * @availability stack since=8.10.0
+   * @availability serverless
+   */
+  access?: Access
   _sort?: SortResults
 }

--- a/specification/security/_types/ApiKey.ts
+++ b/specification/security/_types/ApiKey.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { OverloadOf } from '@spec_utils/behaviors'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { Id, Metadata, Name, Username } from '@_types/common'
 import { long } from '@_types/Numeric'
@@ -28,95 +27,19 @@ import { RoleDescriptor } from './RoleDescriptor'
 
 export class ApiKey {
   /**
-   * Creation time for the API key in milliseconds.
-   */
-  creation?: long
-  /**
-   * Expiration time for the API key in milliseconds.
-   */
-  expiration?: long
-  /**
    * Id for the API key
    */
   id: Id
-  /**
-   * Invalidation status for the API key.
-   * If the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.
-   */
-  invalidated?: boolean
-  /**
-   * If the key has been invalidated, invalidation time in milliseconds.
-   * @availability stack since=8.12.0
-   * @availability serverless
-   */
-  invalidation?: EpochTime<UnitMillis>
   /**
    * Name of the API key.
    */
   name: Name
   /**
-   * Realm name of the principal for which this API key was created.
-   */
-  realm?: string
-  /**
-   * Realm type of the principal for which this API key was created
-   * @availability stack since=8.14.0
-   * @availability serverless
-   */
-  realm_type?: string
-  /**
    * The type of the API key (e.g. `rest` or `cross_cluster`).
    * @availability stack since=8.10.0
    * @availability serverless
    */
-  type?: ApiKeyType
-  /**
-   * Principal for which this API key was created
-   */
-  username?: Username
-  /**
-   * The profile uid for the API key owner principal, if requested and if it exists
-   * @availability stack since=8.14.0
-   * @availability serverless
-   */
-  profile_uid?: string
-  /**
-   * Metadata of the API key
-   * @availability stack since=7.13.0
-   * @availability serverless
-   */
-  metadata?: Metadata
-  /**
-   * The role descriptors assigned to this API key when it was created or last updated.
-   * An empty role descriptor means the API key inherits the owner user’s permissions.
-   */
-  role_descriptors?: Dictionary<string, RoleDescriptor>
-  /**
-   * The owner user’s permissions associated with the API key.
-   * It is a point-in-time snapshot captured at creation and subsequent updates.
-   * An API key’s effective permissions are an intersection of its assigned privileges and the owner user’s permissions.
-   * @availability stack since=8.5.0
-   * @availability serverless
-   */
-  limited_by?: Array<Dictionary<string, RoleDescriptor>>
-  /**
-   * The access granted to cross-cluster API keys.
-   * The access is composed of permissions for cross cluster search and cross cluster replication.
-   * At least one of them must be specified.
-   * When specified, the new access assignment fully replaces the previously assigned access.
-   * @availability stack since=8.10.0
-   * @availability serverless
-   */
-  access?: Access
-  _sort?: SortResults
-}
-
-export enum ApiKeyType {
-  rest,
-  cross_cluster
-}
-
-export class ApiKeyRead implements OverloadOf<ApiKey> {
+  type: ApiKeyType
   /**
    * Creation time for the API key in milliseconds.
    */
@@ -125,10 +48,6 @@ export class ApiKeyRead implements OverloadOf<ApiKey> {
    * Expiration time for the API key in milliseconds.
    */
   expiration?: long
-  /**
-   * Id for the API key
-   */
-  id: Id
   /**
    * Invalidation status for the API key.
    * If the key has been invalidated, it has a value of `true`. Otherwise, it is `false`.
@@ -141,35 +60,19 @@ export class ApiKeyRead implements OverloadOf<ApiKey> {
    */
   invalidation?: EpochTime<UnitMillis>
   /**
-   * Name of the API key.
+   * Principal for which this API key was created
    */
-  name: Name
+  username: Username
   /**
    * Realm name of the principal for which this API key was created.
    */
-  realm?: string
+  realm: string
   /**
    * Realm type of the principal for which this API key was created
    * @availability stack since=8.14.0
    * @availability serverless
    */
   realm_type?: string
-  /**
-   * The type of the API key (e.g. `rest` or `cross_cluster`).
-   * @availability stack since=8.10.0
-   * @availability serverless
-   */
-  type: ApiKeyType
-  /**
-   * Principal for which this API key was created
-   */
-  username: Username
-  /**
-   * The profile uid for the API key owner principal, if requested and if it exists
-   * @availability stack since=8.14.0
-   * @availability serverless
-   */
-  profile_uid?: string
   /**
    * Metadata of the API key
    * @availability stack since=7.13.0
@@ -198,5 +101,19 @@ export class ApiKeyRead implements OverloadOf<ApiKey> {
    * @availability serverless
    */
   access?: Access
+  /**
+   * The profile uid for the API key owner principal, if requested and if it exists
+   * @availability stack since=8.14.0
+   * @availability serverless
+   */
+  profile_uid?: string
+  /**
+   * Sorting values when using the `sort` parameter with the `security.query_api_keys` API.
+   */
   _sort?: SortResults
+}
+
+export enum ApiKeyType {
+  rest,
+  cross_cluster
 }

--- a/specification/security/authenticate/SecurityAuthenticateResponse.ts
+++ b/specification/security/authenticate/SecurityAuthenticateResponse.ts
@@ -17,14 +17,13 @@
  * under the License.
  */
 
-import { ApiKey } from '@security/_types/ApiKey'
 import { RealmInfo } from '@security/_types/RealmInfo'
-import { Metadata, Name, Username } from '@_types/common'
+import { Id, Metadata, Name, Username } from '@_types/common'
 import { Token } from './types'
 
 export class Response {
   body: {
-    api_key?: ApiKey
+    api_key?: AuthenticateApiKey
     authentication_realm: RealmInfo
     email?: string | null
     full_name?: Name | null
@@ -40,4 +39,9 @@ export class Response {
      */
     token?: Token
   }
+}
+
+export class AuthenticateApiKey {
+  id: Id
+  name?: Name
 }

--- a/specification/security/get_api_key/SecurityGetApiKeyResponse.ts
+++ b/specification/security/get_api_key/SecurityGetApiKeyResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { ApiKey } from '@security/_types/ApiKey'
+import { ApiKeyRead } from '@security/_types/ApiKey'
 
 export class Response {
-  body: { api_keys: ApiKey[] }
+  body: { api_keys: ApiKeyRead[] }
 }

--- a/specification/security/get_api_key/SecurityGetApiKeyResponse.ts
+++ b/specification/security/get_api_key/SecurityGetApiKeyResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { ApiKeyRead } from '@security/_types/ApiKey'
+import { ApiKey } from '@security/_types/ApiKey'
 
 export class Response {
-  body: { api_keys: ApiKeyRead[] }
+  body: { api_keys: ApiKey[] }
 }

--- a/specification/security/query_api_keys/QueryApiKeysResponse.ts
+++ b/specification/security/query_api_keys/QueryApiKeysResponse.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ApiKey } from '@security/_types/ApiKey'
+import { ApiKeyRead } from '@security/_types/ApiKey'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregateName } from '@_types/common'
 import { integer } from '@_types/Numeric'
@@ -36,7 +36,7 @@ export class Response {
     /**
      * A list of API key information.
      */
-    api_keys: ApiKey[]
+    api_keys: ApiKeyRead[]
     /**
      * The aggregations result, if requested.
      */

--- a/specification/security/query_api_keys/QueryApiKeysResponse.ts
+++ b/specification/security/query_api_keys/QueryApiKeysResponse.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ApiKeyRead } from '@security/_types/ApiKey'
+import { ApiKey } from '@security/_types/ApiKey'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregateName } from '@_types/common'
 import { integer } from '@_types/Numeric'
@@ -36,7 +36,7 @@ export class Response {
     /**
      * A list of API key information.
      */
-    api_keys: ApiKeyRead[]
+    api_keys: ApiKey[]
     /**
      * The aggregations result, if requested.
      */


### PR DESCRIPTION
* Added missing fields invalidation, access and type.
* Added ApiKeyRead using the [OverloadOf](https://github.com/elastic/elasticsearch-specification/blob/c80b3fd2c3df8d5ecabaa6ad7884faa68312f261/docs/behaviors.md#overloadof) behavior as some fields are optional with the Authenticate API but always defined when reading API keys.