### PR TITLE
Add rule_type_counts to QueryRulesetListResponse spec

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17197,6 +17197,7 @@ export interface QueryRulesListRulesetsQueryRulesetListItem {
   ruleset_id: Id
   rule_total_count: integer
   rule_criteria_types_counts: Record<string, integer>
+  rule_type_counts: Record<string, integer>
 }
 
 export interface QueryRulesListRulesetsRequest extends RequestBase {

--- a/specification/query_rules/list_rulesets/types.ts
+++ b/specification/query_rules/list_rulesets/types.ts
@@ -31,7 +31,12 @@ export class QueryRulesetListItem {
   rule_total_count: integer
 
   /**
-   * A map of criteria type to the number of rules of that type
+   * A map of criteria type (e.g. exact) to the number of rules of that type
    */
   rule_criteria_types_counts: Dictionary<string, integer>
+
+  /**
+   * A map of rule type (e.g. pinned) to the number of rules of that type
+   */
+  rule_type_counts: Dictionary<string, integer>
 }


### PR DESCRIPTION
Adds the `rule_type_counts` added in https://github.com/elastic/elasticsearch/pull/116357 to the specification 