### PR TITLE
Fix most ML APIs

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -17734,8 +17734,38 @@
           },
           {
             "in": "query",
+            "name": "allow_no_indices",
+            "description": "If `true`, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the\n`_all` string or when no indices are specified.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "expand_wildcards",
+            "description": "Type of index that wildcard patterns can match. If the request can target data streams, this argument determines\nwhether wildcard expressions match hidden data streams. Supports comma-separated values. Valid values are:\n\n* `all`: Match any data stream or index, including hidden ones.\n* `closed`: Match closed, non-hidden indices. Also matches any non-hidden data stream. Data streams cannot be closed.\n* `hidden`: Match hidden data streams and hidden indices. Must be combined with `open`, `closed`, or both.\n* `none`: Wildcard patterns are not accepted.\n* `open`: Match open, non-hidden indices. Also matches any non-hidden data stream.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:ExpandWildcards"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "ignore_throttled",
-            "description": "Ignore indices that are marked as throttled (default: true). Only set if datafeed_config is provided.",
+            "description": "If `true`, concrete, expanded or aliased indices are ignored when frozen.",
+            "deprecated": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "ignore_unavailable",
+            "description": "If `true`, unavailable indices (missing or closed) are ignored.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -20343,13 +20373,13 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "bucket_count": {
+                    "job_id": {
+                      "$ref": "#/components/schemas/_types:Id"
+                    },
+                    "processed_record_count": {
                       "type": "number"
                     },
-                    "earliest_record_timestamp": {
-                      "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
-                    },
-                    "empty_bucket_count": {
+                    "processed_field_count": {
                       "type": "number"
                     },
                     "input_bytes": {
@@ -20358,20 +20388,8 @@
                     "input_field_count": {
                       "type": "number"
                     },
-                    "input_record_count": {
-                      "type": "number"
-                    },
                     "invalid_date_count": {
                       "type": "number"
-                    },
-                    "job_id": {
-                      "$ref": "#/components/schemas/_types:Id"
-                    },
-                    "last_data_time": {
-                      "type": "number"
-                    },
-                    "latest_record_timestamp": {
-                      "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
                     },
                     "missing_field_count": {
                       "type": "number"
@@ -20379,29 +20397,50 @@
                     "out_of_order_timestamp_count": {
                       "type": "number"
                     },
-                    "processed_field_count": {
-                      "type": "number"
-                    },
-                    "processed_record_count": {
+                    "empty_bucket_count": {
                       "type": "number"
                     },
                     "sparse_bucket_count": {
                       "type": "number"
+                    },
+                    "bucket_count": {
+                      "type": "number"
+                    },
+                    "earliest_record_timestamp": {
+                      "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+                    },
+                    "latest_record_timestamp": {
+                      "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+                    },
+                    "last_data_time": {
+                      "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+                    },
+                    "latest_empty_bucket_timestamp": {
+                      "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+                    },
+                    "latest_sparse_bucket_timestamp": {
+                      "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+                    },
+                    "input_record_count": {
+                      "type": "number"
+                    },
+                    "log_time": {
+                      "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
                     }
                   },
                   "required": [
-                    "bucket_count",
-                    "empty_bucket_count",
+                    "job_id",
+                    "processed_record_count",
+                    "processed_field_count",
                     "input_bytes",
                     "input_field_count",
-                    "input_record_count",
                     "invalid_date_count",
-                    "job_id",
                     "missing_field_count",
                     "out_of_order_timestamp_count",
-                    "processed_field_count",
-                    "processed_record_count",
-                    "sparse_bucket_count"
+                    "empty_bucket_count",
+                    "sparse_bucket_count",
+                    "bucket_count",
+                    "input_record_count"
                   ]
                 }
               }
@@ -75740,26 +75779,36 @@
         "maxProperties": 1
       },
       "ml._types:NlpBertTokenizationConfig": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ml._types:CommonTokenizationConfig"
+          },
+          {
+            "type": "object"
+          }
+        ]
+      },
+      "ml._types:CommonTokenizationConfig": {
         "type": "object",
         "properties": {
           "do_lower_case": {
             "description": "Should the tokenizer lower case the text",
             "type": "boolean"
           },
-          "with_special_tokens": {
-            "description": "Is tokenization completed with special tokens",
-            "type": "boolean"
-          },
           "max_sequence_length": {
             "description": "Maximum input sequence length for the model",
+            "type": "number"
+          },
+          "span": {
+            "description": "Tokenization spanning options. Special value of -1 indicates no spanning takes place",
             "type": "number"
           },
           "truncate": {
             "$ref": "#/components/schemas/ml._types:TokenizationTruncate"
           },
-          "span": {
-            "description": "Tokenization spanning options. Special value of -1 indicates no spanning takes place",
-            "type": "number"
+          "with_special_tokens": {
+            "description": "Is tokenization completed with special tokens",
+            "type": "boolean"
           }
         }
       },
@@ -75772,32 +75821,20 @@
         ]
       },
       "ml._types:NlpRobertaTokenizationConfig": {
-        "type": "object",
-        "properties": {
-          "do_lower_case": {
-            "description": "Should the tokenizer lower case the text",
-            "type": "boolean"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ml._types:CommonTokenizationConfig"
           },
-          "add_prefix_space": {
-            "description": "Should the tokenizer prefix input with a space character",
-            "type": "boolean"
-          },
-          "with_special_tokens": {
-            "description": "Is tokenization completed with special tokens",
-            "type": "boolean"
-          },
-          "max_sequence_length": {
-            "description": "Maximum input sequence length for the model",
-            "type": "number"
-          },
-          "truncate": {
-            "$ref": "#/components/schemas/ml._types:TokenizationTruncate"
-          },
-          "span": {
-            "description": "Tokenization spanning options. Special value of -1 indicates no spanning takes place",
-            "type": "number"
+          {
+            "type": "object",
+            "properties": {
+              "add_prefix_space": {
+                "description": "Should the tokenizer prefix input with a space character",
+                "type": "boolean"
+              }
+            }
           }
-        }
+        ]
       },
       "ml._types:ZeroShotClassificationInferenceOptions": {
         "type": "object",
@@ -75857,7 +75894,10 @@
           "vocabulary": {
             "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
-        }
+        },
+        "required": [
+          "vocabulary"
+        ]
       },
       "ml._types:Vocabulary": {
         "type": "object",
@@ -75924,7 +75964,10 @@
           "vocabulary": {
             "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
-        }
+        },
+        "required": [
+          "vocabulary"
+        ]
       },
       "ml._types:TextExpansionInferenceOptions": {
         "type": "object",
@@ -75939,7 +75982,10 @@
           "vocabulary": {
             "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
-        }
+        },
+        "required": [
+          "vocabulary"
+        ]
       },
       "ml._types:QuestionAnsweringInferenceOptions": {
         "type": "object",
@@ -76924,6 +76970,9 @@
           "max_single_ml_node_processors": {
             "type": "number"
           },
+          "total_ml_processors": {
+            "type": "number"
+          },
           "max_model_memory_limit": {
             "$ref": "#/components/schemas/_types:ByteSize"
           },
@@ -76931,14 +76980,10 @@
             "$ref": "#/components/schemas/_types:ByteSize"
           },
           "total_ml_memory": {
-            "type": "string"
-          },
-          "total_ml_processors": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:ByteSize"
           }
         },
         "required": [
-          "effective_max_model_memory_limit",
           "total_ml_memory"
         ]
       },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -74384,14 +74384,6 @@
           "expand_wildcards": {
             "$ref": "#/components/schemas/_types:ExpandWildcards"
           },
-          "exclude": {
-            "deprecated": true,
-            "type": "string"
-          },
-          "failure_store": {
-            "deprecated": true,
-            "type": "string"
-          },
           "ignore_unavailable": {
             "description": "If true, missing or closed indices are not included in the response.",
             "type": "boolean"
@@ -74399,14 +74391,6 @@
           "ignore_throttled": {
             "description": "If true, concrete, expanded or aliased indices are ignored when frozen.",
             "type": "boolean"
-          },
-          "include": {
-            "deprecated": true,
-            "type": "string"
-          },
-          "only": {
-            "deprecated": true,
-            "type": "string"
           }
         }
       },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -16919,6 +16919,9 @@
                     "description": "The maximum number of threads to be used by the analysis. Using more\nthreads may decrease the time necessary to complete the analysis at the\ncost of using more CPU. Note that the process may use additional threads\nfor operational functionality other than the analysis itself.",
                     "type": "number"
                   },
+                  "_meta": {
+                    "$ref": "#/components/schemas/_types:Metadata"
+                  },
                   "model_memory_limit": {
                     "description": "The approximate maximum amount of memory resources that are permitted for\nanalytical processing. If your `elasticsearch.yml` file contains an\n`xpack.ml.max_model_memory_limit` setting, an error occurs when you try\nto create data frame analytics jobs that have `model_memory_limit` values\ngreater than that setting.",
                     "type": "string"
@@ -16977,6 +16980,9 @@
                     },
                     "max_num_threads": {
                       "type": "number"
+                    },
+                    "_meta": {
+                      "$ref": "#/components/schemas/_types:Metadata"
                     },
                     "model_memory_limit": {
                       "type": "string"
@@ -17763,6 +17769,9 @@
                     "description": "A description of the job.",
                     "type": "string"
                   },
+                  "job_id": {
+                    "$ref": "#/components/schemas/_types:Id"
+                  },
                   "groups": {
                     "description": "A list of job groups. A job can belong to no groups or many.",
                     "type": "array",
@@ -18111,6 +18120,9 @@
           },
           {
             "$ref": "#/components/parameters/ml.get_trained_models#include"
+          },
+          {
+            "$ref": "#/components/parameters/ml.get_trained_models#include_model_definition"
           },
           {
             "$ref": "#/components/parameters/ml.get_trained_models#size"
@@ -20018,6 +20030,9 @@
             "$ref": "#/components/parameters/ml.get_trained_models#include"
           },
           {
+            "$ref": "#/components/parameters/ml.get_trained_models#include_model_definition"
+          },
+          {
             "$ref": "#/components/parameters/ml.get_trained_models#size"
           },
           {
@@ -20366,15 +20381,12 @@
                   },
                   "required": [
                     "bucket_count",
-                    "earliest_record_timestamp",
                     "empty_bucket_count",
                     "input_bytes",
                     "input_field_count",
                     "input_record_count",
                     "invalid_date_count",
                     "job_id",
-                    "last_data_time",
-                    "latest_record_timestamp",
                     "missing_field_count",
                     "out_of_order_timestamp_count",
                     "processed_field_count",
@@ -74885,7 +74897,14 @@
           },
           "model_memory_limit": {
             "description": "The approximate maximum amount of memory resources that are required for analytical processing. Once this limit is approached, data pruning becomes more aggressive. Upon exceeding this limit, new entities are not modeled. If the `xpack.ml.max_model_memory_limit` setting has a value greater than 0 and less than 1024mb, that value is used instead of the default. The default value is relatively small to ensure that high resource usage is a conscious decision. If you have jobs that are expected to analyze high cardinality fields, you will likely need to use a higher value. If you specify a number instead of a string, the units are assumed to be MiB. Specifying a string is recommended for clarity. If you specify a byte size unit of `b` or `kb` and the number does not equate to a discrete number of megabytes, it is rounded down to the closest MiB. The minimum valid value is 1 MiB. If you specify a value less than 1 MiB, an error occurs. If you specify a value for the `xpack.ml.max_model_memory_limit` setting, an error occurs when you try to create jobs that have `model_memory_limit` values greater than that setting value.",
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           }
         }
       },
@@ -76882,6 +76901,9 @@
       "ml.info:Limits": {
         "type": "object",
         "properties": {
+          "max_single_ml_node_processors": {
+            "type": "number"
+          },
           "max_model_memory_limit": {
             "type": "string"
           },
@@ -76890,6 +76912,9 @@
           },
           "total_ml_memory": {
             "type": "string"
+          },
+          "total_ml_processors": {
+            "type": "number"
           }
         },
         "required": [
@@ -98970,6 +98995,16 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/ml._types:Include"
+        },
+        "style": "form"
+      },
+      "ml.get_trained_models#include_model_definition": {
+        "in": "query",
+        "name": "include_model_definition",
+        "description": "parameter is deprecated! Use [include=definition] instead",
+        "deprecated": true,
+        "schema": {
+          "type": "boolean"
         },
         "style": "form"
       },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -74073,11 +74073,7 @@
             "$ref": "#/components/schemas/_types:Id"
           },
           "node": {
-            "description": "For started datafeeds only, this information pertains to the node upon which the datafeed is started.",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ml._types:DiscoveryNode"
-            }
+            "$ref": "#/components/schemas/ml._types:DiscoveryNode"
           },
           "state": {
             "$ref": "#/components/schemas/ml._types:DatafeedState"
@@ -74101,6 +74097,9 @@
             "$ref": "#/components/schemas/_types:Name"
           },
           "ephemeral_id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "id": {
             "$ref": "#/components/schemas/_types:Id"
           },
           "transport_address": {
@@ -74133,8 +74132,7 @@
         },
         "required": [
           "ephemeral_id",
-          "transport_address",
-          "roles"
+          "transport_address"
         ]
       },
       "ml._types:DatafeedTimingStats": {
@@ -74146,6 +74144,9 @@
           },
           "exponential_average_search_time_per_hour_ms": {
             "$ref": "#/components/schemas/_types:DurationValueUnitFloatMillis"
+          },
+          "exponential_average_calculation_context": {
+            "$ref": "#/components/schemas/ml._types:ExponentialAverageCalculationContext"
           },
           "job_id": {
             "$ref": "#/components/schemas/_types:Id"
@@ -74179,6 +74180,23 @@
       "_types:UnitFloatMillis": {
         "description": "Time unit for fractional milliseconds",
         "type": "number"
+      },
+      "ml._types:ExponentialAverageCalculationContext": {
+        "type": "object",
+        "properties": {
+          "incremental_metric_value_ms": {
+            "type": "number"
+          },
+          "latest_timestamp": {
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+          },
+          "previous_exponential_average_ms": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitFloatMillis"
+          }
+        },
+        "required": [
+          "incremental_metric_value_ms"
+        ]
       },
       "ml._types:DatafeedRunningState": {
         "type": "object",
@@ -74470,11 +74488,7 @@
             "$ref": "#/components/schemas/ml._types:ModelSizeStats"
           },
           "node": {
-            "description": "Contains properties for the node that runs the job.\nThis information is available only for open jobs.",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ml._types:DiscoveryNode"
-            }
+            "$ref": "#/components/schemas/ml._types:DiscoveryNode"
           },
           "open_time": {
             "$ref": "#/components/schemas/_types:DateTime"
@@ -75077,10 +75091,7 @@
             "$ref": "#/components/schemas/ml._types:SnapshotUpgradeState"
           },
           "node": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ml._types:DiscoveryNode"
-            }
+            "$ref": "#/components/schemas/ml._types:DiscoveryNode"
           },
           "assignment_explanation": {
             "type": "string"
@@ -76233,11 +76244,7 @@
             "type": "number"
           },
           "node": {
-            "description": "Information pertaining to the node.",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ml._types:DiscoveryNode"
-            }
+            "$ref": "#/components/schemas/ml._types:DiscoveryNode"
           },
           "number_of_allocations": {
             "description": "The number of allocations assigned to this node.",
@@ -77324,11 +77331,25 @@
       "ml._types:TrainedModelAssignment": {
         "type": "object",
         "properties": {
+          "adaptive_allocations": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ml._types:AdaptiveAllocationsSettings"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
+          },
           "assignment_state": {
             "$ref": "#/components/schemas/ml._types:DeploymentAssignmentState"
           },
           "max_assigned_allocations": {
             "type": "number"
+          },
+          "reason": {
+            "type": "string"
           },
           "routing_table": {
             "description": "The allocation state for each node.",
@@ -77374,6 +77395,12 @@
           "priority": {
             "$ref": "#/components/schemas/ml._types:TrainingPriority"
           },
+          "per_deployment_memory_bytes": {
+            "type": "number"
+          },
+          "per_allocation_memory_bytes": {
+            "type": "number"
+          },
           "queue_capacity": {
             "description": "Number of inference requests are allowed in the queue at a time.",
             "type": "number"
@@ -77387,9 +77414,10 @@
           "model_bytes",
           "model_id",
           "deployment_id",
-          "cache_size",
           "number_of_allocations",
           "priority",
+          "per_deployment_memory_bytes",
+          "per_allocation_memory_bytes",
           "queue_capacity",
           "threads_per_allocation"
         ]

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -74138,7 +74138,8 @@
           "name",
           "ephemeral_id",
           "id",
-          "transport_address"
+          "transport_address",
+          "attributes"
         ]
       },
       "ml._types:DatafeedTimingStats": {
@@ -75193,7 +75194,13 @@
         },
         "required": [
           "ephemeral_id",
-          "transport_address"
+          "transport_address",
+          "external_id",
+          "attributes",
+          "roles",
+          "version",
+          "min_index_version",
+          "max_index_version"
         ]
       },
       "ml._types:ModelSnapshot": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -21914,7 +21914,7 @@
                     "description": "An array of detector update objects.",
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/ml._types:Detector"
+                      "$ref": "#/components/schemas/ml._types:DetectorUpdate"
                     }
                   },
                   "per_partition_categorization": {
@@ -74377,6 +74377,14 @@
           "expand_wildcards": {
             "$ref": "#/components/schemas/_types:ExpandWildcards"
           },
+          "exclude": {
+            "deprecated": true,
+            "type": "string"
+          },
+          "failure_store": {
+            "deprecated": true,
+            "type": "string"
+          },
           "ignore_unavailable": {
             "description": "If true, missing or closed indices are not included in the response.",
             "type": "boolean"
@@ -74384,6 +74392,14 @@
           "ignore_throttled": {
             "description": "If true, concrete, expanded or aliased indices are ignored when frozen.",
             "type": "boolean"
+          },
+          "include": {
+            "deprecated": true,
+            "type": "string"
+          },
+          "only": {
+            "deprecated": true,
+            "type": "string"
           }
         }
       },
@@ -75570,6 +75586,9 @@
           "model_size_bytes": {
             "$ref": "#/components/schemas/_types:ByteSize"
           },
+          "model_package": {
+            "$ref": "#/components/schemas/ml._types:ModelPackageConfig"
+          },
           "location": {
             "$ref": "#/components/schemas/ml._types:TrainedModelLocation"
           },
@@ -75659,6 +75678,9 @@
           "bert": {
             "$ref": "#/components/schemas/ml._types:NlpBertTokenizationConfig"
           },
+          "bert_ja": {
+            "$ref": "#/components/schemas/ml._types:NlpBertTokenizationConfig"
+          },
           "mpnet": {
             "$ref": "#/components/schemas/ml._types:NlpBertTokenizationConfig"
           },
@@ -75704,6 +75726,10 @@
       "ml._types:NlpRobertaTokenizationConfig": {
         "type": "object",
         "properties": {
+          "do_lower_case": {
+            "description": "Should the tokenizer lower case the text",
+            "type": "boolean"
+          },
           "add_prefix_space": {
             "description": "Should the tokenizer prefix input with a space character",
             "type": "boolean"
@@ -75779,8 +75805,22 @@
           "results_field": {
             "description": "The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.",
             "type": "string"
+          },
+          "vocabulary": {
+            "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
         }
+      },
+      "ml._types:Vocabulary": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "$ref": "#/components/schemas/_types:IndexName"
+          }
+        },
+        "required": [
+          "index"
+        ]
       },
       "ml._types:NerInferenceOptions": {
         "type": "object",
@@ -75803,17 +75843,6 @@
             "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
         }
-      },
-      "ml._types:Vocabulary": {
-        "type": "object",
-        "properties": {
-          "index": {
-            "$ref": "#/components/schemas/_types:IndexName"
-          }
-        },
-        "required": [
-          "index"
-        ]
       },
       "ml._types:PassThroughInferenceOptions": {
         "type": "object",
@@ -75843,6 +75872,9 @@
           "results_field": {
             "description": "The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.",
             "type": "string"
+          },
+          "vocabulary": {
+            "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
         }
       },
@@ -75855,6 +75887,9 @@
           "results_field": {
             "description": "The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.",
             "type": "string"
+          },
+          "vocabulary": {
+            "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
         }
       },
@@ -76022,6 +76057,78 @@
           "importance"
         ]
       },
+      "ml._types:ModelPackageConfig": {
+        "type": "object",
+        "properties": {
+          "create_time": {
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+          },
+          "description": {
+            "type": "string"
+          },
+          "inference_config": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/_types:Metadata"
+          },
+          "minimum_version": {
+            "type": "string"
+          },
+          "model_repository": {
+            "type": "string"
+          },
+          "model_type": {
+            "type": "string"
+          },
+          "packaged_model_id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "platform_architecture": {
+            "type": "string"
+          },
+          "prefix_strings": {
+            "$ref": "#/components/schemas/ml._types:TrainedModelPrefixStrings"
+          },
+          "size": {
+            "type": "number"
+          },
+          "sha256": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "vocabulary_file": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packaged_model_id"
+        ]
+      },
+      "ml._types:TrainedModelPrefixStrings": {
+        "type": "object",
+        "properties": {
+          "ingest": {
+            "description": "String prepended to input at ingest",
+            "type": "string"
+          },
+          "search": {
+            "description": "String prepended to input at search",
+            "type": "string"
+          },
+          "none": {
+            "type": "string"
+          }
+        }
+      },
       "ml._types:TrainedModelLocation": {
         "type": "object",
         "properties": {
@@ -76043,19 +76150,6 @@
         "required": [
           "name"
         ]
-      },
-      "ml._types:TrainedModelPrefixStrings": {
-        "type": "object",
-        "properties": {
-          "ingest": {
-            "description": "String prepended to input at ingest",
-            "type": "string"
-          },
-          "search": {
-            "description": "String prepended to input at search",
-            "type": "string"
-          }
-        }
       },
       "ml._types:TrainedModelStats": {
         "type": "object",
@@ -77432,6 +77526,29 @@
         },
         "required": [
           "model_memory_limit"
+        ]
+      },
+      "ml._types:DetectorUpdate": {
+        "type": "object",
+        "properties": {
+          "detector_index": {
+            "description": "A unique identifier for the detector.\nThis identifier is based on the order of the detectors in the `analysis_config`, starting at zero.",
+            "type": "number"
+          },
+          "description": {
+            "description": "A description of the detector.",
+            "type": "string"
+          },
+          "custom_rules": {
+            "description": "An array of custom rule objects, which enable you to customize the way detectors operate.\nFor example, a rule may dictate to the detector conditions under which results should be skipped.\nKibana refers to custom rules as job rules.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ml._types:DetectionRule"
+            }
+          }
+        },
+        "required": [
+          "detector_index"
         ]
       },
       "_global.msearch:MultiSearchResult": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -74682,6 +74682,9 @@
           "model_bytes_memory_limit": {
             "$ref": "#/components/schemas/_types:ByteSize"
           },
+          "output_memory_allocator_bytes": {
+            "type": "number"
+          },
           "peak_model_bytes": {
             "$ref": "#/components/schemas/_types:ByteSize"
           },
@@ -75217,8 +75220,7 @@
           "jobs",
           "overall_score",
           "result_type",
-          "timestamp",
-          "timestamp_string"
+          "timestamp"
         ]
       },
       "ml._types:OverallBucketJob": {
@@ -76221,6 +76223,9 @@
             "description": "The number of allocations requested.",
             "type": "number"
           },
+          "peak_throughput_per_minute": {
+            "type": "number"
+          },
           "priority": {
             "$ref": "#/components/schemas/ml._types:TrainingPriority"
           },
@@ -76256,6 +76261,7 @@
           "deployment_id",
           "model_id",
           "nodes",
+          "peak_throughput_per_minute",
           "priority",
           "start_time",
           "state"
@@ -76338,7 +76344,11 @@
             "type": "number"
           },
           "node": {
-            "$ref": "#/components/schemas/ml._types:DiscoveryNode"
+            "description": "Information pertaining to the node.",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ml._types:DiscoveryNode"
+            }
           },
           "number_of_allocations": {
             "description": "The number of allocations assigned to this node.",

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -74091,31 +74091,44 @@
       "ml._types:DiscoveryNode": {
         "type": "object",
         "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "ephemeral_id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "transport_address": {
+            "$ref": "#/components/schemas/_types:TransportAddress"
+          },
+          "external_id": {
+            "type": "string"
+          },
           "attributes": {
             "type": "object",
             "additionalProperties": {
               "type": "string"
             }
           },
-          "ephemeral_id": {
-            "$ref": "#/components/schemas/_types:Id"
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
-          "id": {
-            "$ref": "#/components/schemas/_types:Id"
+          "version": {
+            "$ref": "#/components/schemas/_types:VersionString"
           },
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
+          "min_index_version": {
+            "type": "number"
           },
-          "transport_address": {
-            "$ref": "#/components/schemas/_types:TransportAddress"
+          "max_index_version": {
+            "type": "number"
           }
         },
         "required": [
-          "attributes",
           "ephemeral_id",
-          "id",
-          "name",
-          "transport_address"
+          "transport_address",
+          "roles"
         ]
       },
       "ml._types:DatafeedTimingStats": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -17731,6 +17731,16 @@
               "$ref": "#/components/schemas/_types:Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "ignore_throttled",
+            "description": "Ignore indices that are marked as throttled (default: true). Only set if datafeed_config is provided.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -74085,7 +74095,7 @@
             "$ref": "#/components/schemas/_types:Id"
           },
           "node": {
-            "$ref": "#/components/schemas/ml._types:DiscoveryNode"
+            "$ref": "#/components/schemas/ml._types:DiscoveryNodeCompact"
           },
           "state": {
             "$ref": "#/components/schemas/ml._types:DatafeedState"
@@ -74102,7 +74112,7 @@
           "state"
         ]
       },
-      "ml._types:DiscoveryNode": {
+      "ml._types:DiscoveryNodeCompact": {
         "type": "object",
         "properties": {
           "name": {
@@ -74117,33 +74127,17 @@
           "transport_address": {
             "$ref": "#/components/schemas/_types:TransportAddress"
           },
-          "external_id": {
-            "type": "string"
-          },
           "attributes": {
             "type": "object",
             "additionalProperties": {
               "type": "string"
             }
-          },
-          "roles": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "version": {
-            "$ref": "#/components/schemas/_types:VersionString"
-          },
-          "min_index_version": {
-            "type": "number"
-          },
-          "max_index_version": {
-            "type": "number"
           }
         },
         "required": [
+          "name",
           "ephemeral_id",
+          "id",
           "transport_address"
         ]
       },
@@ -74516,7 +74510,7 @@
             "$ref": "#/components/schemas/ml._types:ModelSizeStats"
           },
           "node": {
-            "$ref": "#/components/schemas/ml._types:DiscoveryNode"
+            "$ref": "#/components/schemas/ml._types:DiscoveryNodeCompact"
           },
           "open_time": {
             "$ref": "#/components/schemas/_types:DateTime"
@@ -75150,6 +75144,56 @@
           "saving_new_state",
           "stopped",
           "failed"
+        ]
+      },
+      "ml._types:DiscoveryNode": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/ml._types:DiscoveryNodeContent"
+        },
+        "minProperties": 1,
+        "maxProperties": 1
+      },
+      "ml._types:DiscoveryNodeContent": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "ephemeral_id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "transport_address": {
+            "$ref": "#/components/schemas/_types:TransportAddress"
+          },
+          "external_id": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "version": {
+            "$ref": "#/components/schemas/_types:VersionString"
+          },
+          "min_index_version": {
+            "type": "number"
+          },
+          "max_index_version": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "ephemeral_id",
+          "transport_address"
         ]
       },
       "ml._types:ModelSnapshot": {
@@ -76363,11 +76407,7 @@
             "type": "number"
           },
           "node": {
-            "description": "Information pertaining to the node.",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/ml._types:DiscoveryNode"
-            }
+            "$ref": "#/components/schemas/ml._types:DiscoveryNode"
           },
           "number_of_allocations": {
             "description": "The number of allocations assigned to this node.",

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -73683,6 +73683,9 @@
           },
           "version": {
             "$ref": "#/components/schemas/_types:VersionString"
+          },
+          "_meta": {
+            "$ref": "#/components/schemas/_types:Metadata"
           }
         },
         "required": [
@@ -74070,7 +74073,11 @@
             "$ref": "#/components/schemas/_types:Id"
           },
           "node": {
-            "$ref": "#/components/schemas/ml._types:DiscoveryNode"
+            "description": "For started datafeeds only, this information pertains to the node upon which the datafeed is started.",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ml._types:DiscoveryNode"
+            }
           },
           "state": {
             "$ref": "#/components/schemas/ml._types:DatafeedState"
@@ -74084,8 +74091,7 @@
         },
         "required": [
           "datafeed_id",
-          "state",
-          "timing_stats"
+          "state"
         ]
       },
       "ml._types:DiscoveryNode": {
@@ -74464,7 +74470,11 @@
             "$ref": "#/components/schemas/ml._types:ModelSizeStats"
           },
           "node": {
-            "$ref": "#/components/schemas/ml._types:DiscoveryNode"
+            "description": "Contains properties for the node that runs the job.\nThis information is available only for open jobs.",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ml._types:DiscoveryNode"
+            }
           },
           "open_time": {
             "$ref": "#/components/schemas/_types:DateTime"
@@ -75067,7 +75077,10 @@
             "$ref": "#/components/schemas/ml._types:SnapshotUpgradeState"
           },
           "node": {
-            "$ref": "#/components/schemas/ml._types:DiscoveryNode"
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ml._types:DiscoveryNode"
+            }
           },
           "assignment_explanation": {
             "type": "string"
@@ -76069,6 +76082,9 @@
       "ml._types:TrainedModelDeploymentStats": {
         "type": "object",
         "properties": {
+          "adaptive_allocations": {
+            "$ref": "#/components/schemas/ml._types:AdaptiveAllocationsSettings"
+          },
           "allocation_status": {
             "$ref": "#/components/schemas/ml._types:TrainedModelDeploymentAllocationStatus"
           },
@@ -76100,6 +76116,9 @@
             "description": "The number of allocations requested.",
             "type": "number"
           },
+          "priority": {
+            "$ref": "#/components/schemas/ml._types:TrainingPriority"
+          },
           "queue_capacity": {
             "description": "The number of inference requests that can be queued before new requests are rejected.",
             "type": "number"
@@ -76130,18 +76149,28 @@
         "required": [
           "allocation_status",
           "deployment_id",
-          "error_count",
-          "inference_count",
           "model_id",
           "nodes",
-          "number_of_allocations",
-          "queue_capacity",
-          "rejected_execution_count",
-          "reason",
+          "priority",
           "start_time",
-          "state",
-          "threads_per_allocation",
-          "timeout_count"
+          "state"
+        ]
+      },
+      "ml._types:AdaptiveAllocationsSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "min_number_of_allocations": {
+            "type": "number"
+          },
+          "max_number_of_allocations": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "enabled"
         ]
       },
       "ml._types:TrainedModelDeploymentAllocationStatus": {
@@ -76179,6 +76208,12 @@
           "average_inference_time_ms": {
             "$ref": "#/components/schemas/_types:DurationValueUnitFloatMillis"
           },
+          "average_inference_time_ms_last_minute": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitFloatMillis"
+          },
+          "average_inference_time_ms_excluding_cache_hits": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitFloatMillis"
+          },
           "error_count": {
             "description": "The number of errors when evaluating the trained model.",
             "type": "number"
@@ -76187,12 +76222,22 @@
             "description": "The total number of inference calls made against this node for this model.",
             "type": "number"
           },
+          "inference_cache_hit_count": {
+            "type": "number"
+          },
+          "inference_cache_hit_count_last_minute": {
+            "type": "number"
+          },
           "last_access": {
             "description": "The epoch time stamp of the last inference call for the model on this node.",
             "type": "number"
           },
           "node": {
-            "$ref": "#/components/schemas/ml._types:DiscoveryNode"
+            "description": "Information pertaining to the node.",
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ml._types:DiscoveryNode"
+            }
           },
           "number_of_allocations": {
             "description": "The number of allocations assigned to this node.",
@@ -76200,6 +76245,9 @@
           },
           "number_of_pending_requests": {
             "description": "The number of inference requests queued to be processed.",
+            "type": "number"
+          },
+          "peak_throughput_per_minute": {
             "type": "number"
           },
           "rejection_execution_count": {
@@ -76216,24 +76264,17 @@
             "description": "The number of threads used by each allocation during inference.",
             "type": "number"
           },
+          "throughput_last_minute": {
+            "type": "number"
+          },
           "timeout_count": {
             "description": "The number of inference requests that timed out before being processed.",
             "type": "number"
           }
         },
         "required": [
-          "average_inference_time_ms",
-          "error_count",
-          "inference_count",
-          "last_access",
-          "node",
-          "number_of_allocations",
-          "number_of_pending_requests",
-          "rejection_execution_count",
-          "routing_state",
-          "start_time",
-          "threads_per_allocation",
-          "timeout_count"
+          "peak_throughput_per_minute",
+          "routing_state"
         ]
       },
       "ml._types:TrainedModelAssignmentRoutingTable": {
@@ -76256,10 +76297,7 @@
           }
         },
         "required": [
-          "reason",
-          "routing_state",
-          "current_allocations",
-          "target_allocations"
+          "routing_state"
         ]
       },
       "ml._types:RoutingState": {
@@ -76270,6 +76308,13 @@
           "starting",
           "stopped",
           "stopping"
+        ]
+      },
+      "ml._types:TrainingPriority": {
+        "type": "string",
+        "enum": [
+          "normal",
+          "low"
         ]
       },
       "ml._types:DeploymentAssignmentState": {
@@ -77274,13 +77319,6 @@
         },
         "required": [
           "field_names"
-        ]
-      },
-      "ml._types:TrainingPriority": {
-        "type": "string",
-        "enum": [
-          "normal",
-          "low"
         ]
       },
       "ml._types:TrainedModelAssignment": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -76171,9 +76171,6 @@
           "search": {
             "description": "String prepended to input at search",
             "type": "string"
-          },
-          "none": {
-            "type": "string"
           }
         }
       },
@@ -76303,14 +76300,12 @@
           }
         },
         "required": [
-          "allocation_status",
           "deployment_id",
           "model_id",
           "nodes",
           "peak_throughput_per_minute",
           "priority",
-          "start_time",
-          "state"
+          "start_time"
         ]
       },
       "ml._types:AdaptiveAllocationsSettings": {
@@ -76386,7 +76381,7 @@
             "type": "number"
           },
           "last_access": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitNanos"
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
           "node": {
             "$ref": "#/components/schemas/ml._types:DiscoveryNode"
@@ -76410,7 +76405,7 @@
             "$ref": "#/components/schemas/ml._types:TrainedModelAssignmentRoutingTable"
           },
           "start_time": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitNanos"
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
           "threads_per_allocation": {
             "description": "The number of threads used by each allocation during inference.",
@@ -76426,14 +76421,8 @@
         },
         "required": [
           "peak_throughput_per_minute",
-          "routing_state"
-        ]
-      },
-      "_types:EpochTimeUnitNanos": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/_types:UnitNanos"
-          }
+          "routing_state",
+          "throughput_last_minute"
         ]
       },
       "ml._types:TrainedModelAssignmentRoutingTable": {
@@ -76456,7 +76445,9 @@
           }
         },
         "required": [
-          "routing_state"
+          "routing_state",
+          "current_allocations",
+          "target_allocations"
         ]
       },
       "ml._types:RoutingState": {
@@ -77534,8 +77525,7 @@
         "type": "object",
         "properties": {
           "model_bytes": {
-            "description": "The size of the trained model in bytes.",
-            "type": "number"
+            "$ref": "#/components/schemas/_types:ByteSize"
           },
           "model_id": {
             "$ref": "#/components/schemas/_types:Id"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -20347,7 +20347,7 @@
                       "type": "number"
                     },
                     "earliest_record_timestamp": {
-                      "type": "number"
+                      "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
                     },
                     "empty_bucket_count": {
                       "type": "number"
@@ -20371,7 +20371,7 @@
                       "type": "number"
                     },
                     "latest_record_timestamp": {
-                      "type": "number"
+                      "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
                     },
                     "missing_field_count": {
                       "type": "number"
@@ -74192,7 +74192,7 @@
         "type": "object",
         "properties": {
           "incremental_metric_value_ms": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:DurationValueUnitFloatMillis"
           },
           "latest_timestamp": {
             "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
@@ -74690,7 +74690,7 @@
             "$ref": "#/components/schemas/_types:ByteSize"
           },
           "output_memory_allocator_bytes": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:ByteSize"
           },
           "peak_model_bytes": {
             "$ref": "#/components/schemas/_types:ByteSize"
@@ -74891,15 +74891,7 @@
             "type": "number"
           },
           "model_memory_limit": {
-            "description": "The approximate maximum amount of memory resources that are required for analytical processing. Once this limit is approached, data pruning becomes more aggressive. Upon exceeding this limit, new entities are not modeled. If the `xpack.ml.max_model_memory_limit` setting has a value greater than 0 and less than 1024mb, that value is used instead of the default. The default value is relatively small to ensure that high resource usage is a conscious decision. If you have jobs that are expected to analyze high cardinality fields, you will likely need to use a higher value. If you specify a number instead of a string, the units are assumed to be MiB. Specifying a string is recommended for clarity. If you specify a byte size unit of `b` or `kb` and the number does not equate to a discrete number of megabytes, it is rounded down to the closest MiB. The minimum valid value is 1 MiB. If you specify a value less than 1 MiB, an error occurs. If you specify a value for the `xpack.ml.max_model_memory_limit` setting, an error occurs when you try to create jobs that have `model_memory_limit` values greater than that setting value.",
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "number"
-              }
-            ]
+            "$ref": "#/components/schemas/_types:ByteSize"
           }
         }
       },
@@ -76166,7 +76158,7 @@
             "$ref": "#/components/schemas/ml._types:TrainedModelPrefixStrings"
           },
           "size": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:ByteSize"
           },
           "sha256": {
             "type": "string"
@@ -76410,8 +76402,7 @@
             "type": "number"
           },
           "last_access": {
-            "description": "The epoch time stamp of the last inference call for the model on this node.",
-            "type": "number"
+            "$ref": "#/components/schemas/_types:EpochTimeUnitNanos"
           },
           "node": {
             "$ref": "#/components/schemas/ml._types:DiscoveryNode"
@@ -76435,7 +76426,7 @@
             "$ref": "#/components/schemas/ml._types:TrainedModelAssignmentRoutingTable"
           },
           "start_time": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+            "$ref": "#/components/schemas/_types:EpochTimeUnitNanos"
           },
           "threads_per_allocation": {
             "description": "The number of threads used by each allocation during inference.",
@@ -76452,6 +76443,13 @@
         "required": [
           "peak_throughput_per_minute",
           "routing_state"
+        ]
+      },
+      "_types:EpochTimeUnitNanos": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/_types:UnitNanos"
+          }
         ]
       },
       "ml._types:TrainedModelAssignmentRoutingTable": {
@@ -76952,10 +76950,10 @@
             "type": "number"
           },
           "max_model_memory_limit": {
-            "type": "string"
+            "$ref": "#/components/schemas/_types:ByteSize"
           },
           "effective_max_model_memory_limit": {
-            "type": "string"
+            "$ref": "#/components/schemas/_types:ByteSize"
           },
           "total_ml_memory": {
             "type": "string"
@@ -77572,10 +77570,10 @@
             "$ref": "#/components/schemas/ml._types:TrainingPriority"
           },
           "per_deployment_memory_bytes": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:ByteSize"
           },
           "per_allocation_memory_bytes": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:ByteSize"
           },
           "queue_capacity": {
             "description": "Number of inference requests are allowed in the queue at a time.",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -49538,6 +49538,9 @@
           "exponential_average_search_time_per_hour_ms": {
             "$ref": "#/components/schemas/_types:DurationValueUnitFloatMillis"
           },
+          "exponential_average_calculation_context": {
+            "$ref": "#/components/schemas/ml._types:ExponentialAverageCalculationContext"
+          },
           "job_id": {
             "$ref": "#/components/schemas/_types:Id"
           },
@@ -49570,6 +49573,23 @@
       "_types:UnitFloatMillis": {
         "description": "Time unit for fractional milliseconds",
         "type": "number"
+      },
+      "ml._types:ExponentialAverageCalculationContext": {
+        "type": "object",
+        "properties": {
+          "incremental_metric_value_ms": {
+            "type": "number"
+          },
+          "latest_timestamp": {
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+          },
+          "previous_exponential_average_ms": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitFloatMillis"
+          }
+        },
+        "required": [
+          "incremental_metric_value_ms"
+        ]
       },
       "ml._types:DatafeedRunningState": {
         "type": "object",
@@ -52071,11 +52091,25 @@
       "ml._types:TrainedModelAssignment": {
         "type": "object",
         "properties": {
+          "adaptive_allocations": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ml._types:AdaptiveAllocationsSettings"
+              },
+              {
+                "nullable": true,
+                "type": "string"
+              }
+            ]
+          },
           "assignment_state": {
             "$ref": "#/components/schemas/ml._types:DeploymentAssignmentState"
           },
           "max_assigned_allocations": {
             "type": "number"
+          },
+          "reason": {
+            "type": "string"
           },
           "routing_table": {
             "description": "The allocation state for each node.",
@@ -52121,6 +52155,12 @@
           "priority": {
             "$ref": "#/components/schemas/ml._types:TrainingPriority"
           },
+          "per_deployment_memory_bytes": {
+            "type": "number"
+          },
+          "per_allocation_memory_bytes": {
+            "type": "number"
+          },
           "queue_capacity": {
             "description": "Number of inference requests are allowed in the queue at a time.",
             "type": "number"
@@ -52134,9 +52174,10 @@
           "model_bytes",
           "model_id",
           "deployment_id",
-          "cache_size",
           "number_of_allocations",
           "priority",
+          "per_deployment_memory_bytes",
+          "per_allocation_memory_bytes",
           "queue_capacity",
           "threads_per_allocation"
         ]

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -50015,6 +50015,9 @@
           "model_bytes_memory_limit": {
             "$ref": "#/components/schemas/_types:ByteSize"
           },
+          "output_memory_allocator_bytes": {
+            "type": "number"
+          },
           "peak_model_bytes": {
             "$ref": "#/components/schemas/_types:ByteSize"
           },
@@ -50318,8 +50321,7 @@
           "jobs",
           "overall_score",
           "result_type",
-          "timestamp",
-          "timestamp_string"
+          "timestamp"
         ]
       },
       "_types:DurationValueUnitSeconds": {
@@ -51057,6 +51059,9 @@
             "description": "The number of allocations requested.",
             "type": "number"
           },
+          "peak_throughput_per_minute": {
+            "type": "number"
+          },
           "priority": {
             "$ref": "#/components/schemas/ml._types:TrainingPriority"
           },
@@ -51092,6 +51097,7 @@
           "deployment_id",
           "model_id",
           "nodes",
+          "peak_throughput_per_minute",
           "priority",
           "start_time",
           "state"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -9941,6 +9941,9 @@
                     "description": "The maximum number of threads to be used by the analysis. Using more\nthreads may decrease the time necessary to complete the analysis at the\ncost of using more CPU. Note that the process may use additional threads\nfor operational functionality other than the analysis itself.",
                     "type": "number"
                   },
+                  "_meta": {
+                    "$ref": "#/components/schemas/_types:Metadata"
+                  },
                   "model_memory_limit": {
                     "description": "The approximate maximum amount of memory resources that are permitted for\nanalytical processing. If your `elasticsearch.yml` file contains an\n`xpack.ml.max_model_memory_limit` setting, an error occurs when you try\nto create data frame analytics jobs that have `model_memory_limit` values\ngreater than that setting.",
                     "type": "string"
@@ -9999,6 +10002,9 @@
                     },
                     "max_num_threads": {
                       "type": "number"
+                    },
+                    "_meta": {
+                      "$ref": "#/components/schemas/_types:Metadata"
                     },
                     "model_memory_limit": {
                       "type": "string"
@@ -10574,6 +10580,9 @@
                     "description": "A description of the job.",
                     "type": "string"
                   },
+                  "job_id": {
+                    "$ref": "#/components/schemas/_types:Id"
+                  },
                   "groups": {
                     "description": "A list of job groups. A job can belong to no groups or many.",
                     "type": "array",
@@ -10791,6 +10800,9 @@
           },
           {
             "$ref": "#/components/parameters/ml.get_trained_models#include"
+          },
+          {
+            "$ref": "#/components/parameters/ml.get_trained_models#include_model_definition"
           },
           {
             "$ref": "#/components/parameters/ml.get_trained_models#size"
@@ -11882,6 +11894,9 @@
           },
           {
             "$ref": "#/components/parameters/ml.get_trained_models#include"
+          },
+          {
+            "$ref": "#/components/parameters/ml.get_trained_models#include_model_definition"
           },
           {
             "$ref": "#/components/parameters/ml.get_trained_models#size"
@@ -50218,7 +50233,14 @@
           },
           "model_memory_limit": {
             "description": "The approximate maximum amount of memory resources that are required for analytical processing. Once this limit is approached, data pruning becomes more aggressive. Upon exceeding this limit, new entities are not modeled. If the `xpack.ml.max_model_memory_limit` setting has a value greater than 0 and less than 1024mb, that value is used instead of the default. The default value is relatively small to ensure that high resource usage is a conscious decision. If you have jobs that are expected to analyze high cardinality fields, you will likely need to use a higher value. If you specify a number instead of a string, the units are assumed to be MiB. Specifying a string is recommended for clarity. If you specify a byte size unit of `b` or `kb` and the number does not equate to a discrete number of megabytes, it is rounded down to the closest MiB. The minimum valid value is 1 MiB. If you specify a value less than 1 MiB, an error occurs. If you specify a value for the `xpack.ml.max_model_memory_limit` setting, an error occurs when you try to create jobs that have `model_memory_limit` values greater than that setting value.",
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
           }
         }
       },
@@ -60435,6 +60457,16 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/ml._types:Include"
+        },
+        "style": "form"
+      },
+      "ml.get_trained_models#include_model_definition": {
+        "in": "query",
+        "name": "include_model_definition",
+        "description": "parameter is deprecated! Use [include=definition] instead",
+        "deprecated": true,
+        "schema": {
+          "type": "boolean"
         },
         "style": "form"
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -50969,9 +50969,6 @@
           "search": {
             "description": "String prepended to input at search",
             "type": "string"
-          },
-          "none": {
-            "type": "string"
           }
         }
       },
@@ -51101,14 +51098,12 @@
           }
         },
         "required": [
-          "allocation_status",
           "deployment_id",
           "model_id",
           "nodes",
           "peak_throughput_per_minute",
           "priority",
-          "start_time",
-          "state"
+          "start_time"
         ]
       },
       "ml._types:AdaptiveAllocationsSettings": {
@@ -51184,7 +51179,7 @@
             "type": "number"
           },
           "last_access": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitNanos"
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
           "number_of_allocations": {
             "description": "The number of allocations assigned to this node.",
@@ -51205,7 +51200,7 @@
             "$ref": "#/components/schemas/ml._types:TrainedModelAssignmentRoutingTable"
           },
           "start_time": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitNanos"
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
           "threads_per_allocation": {
             "description": "The number of threads used by each allocation during inference.",
@@ -51221,14 +51216,8 @@
         },
         "required": [
           "peak_throughput_per_minute",
-          "routing_state"
-        ]
-      },
-      "_types:EpochTimeUnitNanos": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/_types:UnitNanos"
-          }
+          "routing_state",
+          "throughput_last_minute"
         ]
       },
       "ml._types:TrainedModelAssignmentRoutingTable": {
@@ -51251,7 +51240,9 @@
           }
         },
         "required": [
-          "routing_state"
+          "routing_state",
+          "current_allocations",
+          "target_allocations"
         ]
       },
       "ml._types:RoutingState": {
@@ -52250,8 +52241,7 @@
         "type": "object",
         "properties": {
           "model_bytes": {
-            "description": "The size of the trained model in bytes.",
-            "type": "number"
+            "$ref": "#/components/schemas/_types:ByteSize"
           },
           "model_id": {
             "$ref": "#/components/schemas/_types:Id"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -49603,7 +49603,7 @@
         "type": "object",
         "properties": {
           "incremental_metric_value_ms": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:DurationValueUnitFloatMillis"
           },
           "latest_timestamp": {
             "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
@@ -50041,7 +50041,7 @@
             "$ref": "#/components/schemas/_types:ByteSize"
           },
           "output_memory_allocator_bytes": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:ByteSize"
           },
           "peak_model_bytes": {
             "$ref": "#/components/schemas/_types:ByteSize"
@@ -50242,15 +50242,7 @@
             "type": "number"
           },
           "model_memory_limit": {
-            "description": "The approximate maximum amount of memory resources that are required for analytical processing. Once this limit is approached, data pruning becomes more aggressive. Upon exceeding this limit, new entities are not modeled. If the `xpack.ml.max_model_memory_limit` setting has a value greater than 0 and less than 1024mb, that value is used instead of the default. The default value is relatively small to ensure that high resource usage is a conscious decision. If you have jobs that are expected to analyze high cardinality fields, you will likely need to use a higher value. If you specify a number instead of a string, the units are assumed to be MiB. Specifying a string is recommended for clarity. If you specify a byte size unit of `b` or `kb` and the number does not equate to a discrete number of megabytes, it is rounded down to the closest MiB. The minimum valid value is 1 MiB. If you specify a value less than 1 MiB, an error occurs. If you specify a value for the `xpack.ml.max_model_memory_limit` setting, an error occurs when you try to create jobs that have `model_memory_limit` values greater than that setting value.",
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "number"
-              }
-            ]
+            "$ref": "#/components/schemas/_types:ByteSize"
           }
         }
       },
@@ -50964,7 +50956,7 @@
             "$ref": "#/components/schemas/ml._types:TrainedModelPrefixStrings"
           },
           "size": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:ByteSize"
           },
           "sha256": {
             "type": "string"
@@ -51208,8 +51200,7 @@
             "type": "number"
           },
           "last_access": {
-            "description": "The epoch time stamp of the last inference call for the model on this node.",
-            "type": "number"
+            "$ref": "#/components/schemas/_types:EpochTimeUnitNanos"
           },
           "number_of_allocations": {
             "description": "The number of allocations assigned to this node.",
@@ -51230,7 +51221,7 @@
             "$ref": "#/components/schemas/ml._types:TrainedModelAssignmentRoutingTable"
           },
           "start_time": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+            "$ref": "#/components/schemas/_types:EpochTimeUnitNanos"
           },
           "threads_per_allocation": {
             "description": "The number of threads used by each allocation during inference.",
@@ -51247,6 +51238,13 @@
         "required": [
           "peak_throughput_per_minute",
           "routing_state"
+        ]
+      },
+      "_types:EpochTimeUnitNanos": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/_types:UnitNanos"
+          }
         ]
       },
       "ml._types:TrainedModelAssignmentRoutingTable": {
@@ -52288,10 +52286,10 @@
             "$ref": "#/components/schemas/ml._types:TrainingPriority"
           },
           "per_deployment_memory_bytes": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:ByteSize"
           },
           "per_allocation_memory_bytes": {
-            "type": "number"
+            "$ref": "#/components/schemas/_types:ByteSize"
           },
           "queue_capacity": {
             "description": "Number of inference requests are allowed in the queue at a time.",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -49795,14 +49795,6 @@
           "expand_wildcards": {
             "$ref": "#/components/schemas/_types:ExpandWildcards"
           },
-          "exclude": {
-            "deprecated": true,
-            "type": "string"
-          },
-          "failure_store": {
-            "deprecated": true,
-            "type": "string"
-          },
           "ignore_unavailable": {
             "description": "If true, missing or closed indices are not included in the response.",
             "type": "boolean"
@@ -49810,14 +49802,6 @@
           "ignore_throttled": {
             "description": "If true, concrete, expanded or aliased indices are ignored when frozen.",
             "type": "boolean"
-          },
-          "include": {
-            "deprecated": true,
-            "type": "string"
-          },
-          "only": {
-            "deprecated": true,
-            "type": "string"
           }
         }
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -10545,8 +10545,38 @@
           },
           {
             "in": "query",
+            "name": "allow_no_indices",
+            "description": "If `true`, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the\n`_all` string or when no indices are specified.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "expand_wildcards",
+            "description": "Type of index that wildcard patterns can match. If the request can target data streams, this argument determines\nwhether wildcard expressions match hidden data streams. Supports comma-separated values. Valid values are:\n\n* `all`: Match any data stream or index, including hidden ones.\n* `closed`: Match closed, non-hidden indices. Also matches any non-hidden data stream. Data streams cannot be closed.\n* `hidden`: Match hidden data streams and hidden indices. Must be combined with `open`, `closed`, or both.\n* `none`: Wildcard patterns are not accepted.\n* `open`: Match open, non-hidden indices. Also matches any non-hidden data stream.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:ExpandWildcards"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "ignore_throttled",
-            "description": "Ignore indices that are marked as throttled (default: true). Only set if datafeed_config is provided.",
+            "description": "If `true`, concrete, expanded or aliased indices are ignored when frozen.",
+            "deprecated": true,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "ignore_unavailable",
+            "description": "If `true`, unavailable indices (missing or closed) are ignored.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -50538,26 +50568,36 @@
         "maxProperties": 1
       },
       "ml._types:NlpBertTokenizationConfig": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ml._types:CommonTokenizationConfig"
+          },
+          {
+            "type": "object"
+          }
+        ]
+      },
+      "ml._types:CommonTokenizationConfig": {
         "type": "object",
         "properties": {
           "do_lower_case": {
             "description": "Should the tokenizer lower case the text",
             "type": "boolean"
           },
-          "with_special_tokens": {
-            "description": "Is tokenization completed with special tokens",
-            "type": "boolean"
-          },
           "max_sequence_length": {
             "description": "Maximum input sequence length for the model",
+            "type": "number"
+          },
+          "span": {
+            "description": "Tokenization spanning options. Special value of -1 indicates no spanning takes place",
             "type": "number"
           },
           "truncate": {
             "$ref": "#/components/schemas/ml._types:TokenizationTruncate"
           },
-          "span": {
-            "description": "Tokenization spanning options. Special value of -1 indicates no spanning takes place",
-            "type": "number"
+          "with_special_tokens": {
+            "description": "Is tokenization completed with special tokens",
+            "type": "boolean"
           }
         }
       },
@@ -50570,32 +50610,20 @@
         ]
       },
       "ml._types:NlpRobertaTokenizationConfig": {
-        "type": "object",
-        "properties": {
-          "do_lower_case": {
-            "description": "Should the tokenizer lower case the text",
-            "type": "boolean"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ml._types:CommonTokenizationConfig"
           },
-          "add_prefix_space": {
-            "description": "Should the tokenizer prefix input with a space character",
-            "type": "boolean"
-          },
-          "with_special_tokens": {
-            "description": "Is tokenization completed with special tokens",
-            "type": "boolean"
-          },
-          "max_sequence_length": {
-            "description": "Maximum input sequence length for the model",
-            "type": "number"
-          },
-          "truncate": {
-            "$ref": "#/components/schemas/ml._types:TokenizationTruncate"
-          },
-          "span": {
-            "description": "Tokenization spanning options. Special value of -1 indicates no spanning takes place",
-            "type": "number"
+          {
+            "type": "object",
+            "properties": {
+              "add_prefix_space": {
+                "description": "Should the tokenizer prefix input with a space character",
+                "type": "boolean"
+              }
+            }
           }
-        }
+        ]
       },
       "ml._types:ZeroShotClassificationInferenceOptions": {
         "type": "object",
@@ -50655,7 +50683,10 @@
           "vocabulary": {
             "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
-        }
+        },
+        "required": [
+          "vocabulary"
+        ]
       },
       "ml._types:Vocabulary": {
         "type": "object",
@@ -50722,7 +50753,10 @@
           "vocabulary": {
             "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
-        }
+        },
+        "required": [
+          "vocabulary"
+        ]
       },
       "ml._types:TextExpansionInferenceOptions": {
         "type": "object",
@@ -50737,7 +50771,10 @@
           "vocabulary": {
             "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
-        }
+        },
+        "required": [
+          "vocabulary"
+        ]
       },
       "ml._types:QuestionAnsweringInferenceOptions": {
         "type": "object",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -13468,7 +13468,7 @@
                     "description": "An array of detector update objects.",
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/ml._types:Detector"
+                      "$ref": "#/components/schemas/ml._types:DetectorUpdate"
                     }
                   },
                   "per_partition_categorization": {
@@ -49770,6 +49770,14 @@
           "expand_wildcards": {
             "$ref": "#/components/schemas/_types:ExpandWildcards"
           },
+          "exclude": {
+            "deprecated": true,
+            "type": "string"
+          },
+          "failure_store": {
+            "deprecated": true,
+            "type": "string"
+          },
           "ignore_unavailable": {
             "description": "If true, missing or closed indices are not included in the response.",
             "type": "boolean"
@@ -49777,6 +49785,14 @@
           "ignore_throttled": {
             "description": "If true, concrete, expanded or aliased indices are ignored when frozen.",
             "type": "boolean"
+          },
+          "include": {
+            "deprecated": true,
+            "type": "string"
+          },
+          "only": {
+            "deprecated": true,
+            "type": "string"
           }
         }
       },
@@ -50406,6 +50422,9 @@
           "model_size_bytes": {
             "$ref": "#/components/schemas/_types:ByteSize"
           },
+          "model_package": {
+            "$ref": "#/components/schemas/ml._types:ModelPackageConfig"
+          },
           "location": {
             "$ref": "#/components/schemas/ml._types:TrainedModelLocation"
           },
@@ -50495,6 +50514,9 @@
           "bert": {
             "$ref": "#/components/schemas/ml._types:NlpBertTokenizationConfig"
           },
+          "bert_ja": {
+            "$ref": "#/components/schemas/ml._types:NlpBertTokenizationConfig"
+          },
           "mpnet": {
             "$ref": "#/components/schemas/ml._types:NlpBertTokenizationConfig"
           },
@@ -50540,6 +50562,10 @@
       "ml._types:NlpRobertaTokenizationConfig": {
         "type": "object",
         "properties": {
+          "do_lower_case": {
+            "description": "Should the tokenizer lower case the text",
+            "type": "boolean"
+          },
           "add_prefix_space": {
             "description": "Should the tokenizer prefix input with a space character",
             "type": "boolean"
@@ -50615,8 +50641,22 @@
           "results_field": {
             "description": "The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.",
             "type": "string"
+          },
+          "vocabulary": {
+            "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
         }
+      },
+      "ml._types:Vocabulary": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "$ref": "#/components/schemas/_types:IndexName"
+          }
+        },
+        "required": [
+          "index"
+        ]
       },
       "ml._types:NerInferenceOptions": {
         "type": "object",
@@ -50639,17 +50679,6 @@
             "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
         }
-      },
-      "ml._types:Vocabulary": {
-        "type": "object",
-        "properties": {
-          "index": {
-            "$ref": "#/components/schemas/_types:IndexName"
-          }
-        },
-        "required": [
-          "index"
-        ]
       },
       "ml._types:PassThroughInferenceOptions": {
         "type": "object",
@@ -50679,6 +50708,9 @@
           "results_field": {
             "description": "The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.",
             "type": "string"
+          },
+          "vocabulary": {
+            "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
         }
       },
@@ -50691,6 +50723,9 @@
           "results_field": {
             "description": "The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.",
             "type": "string"
+          },
+          "vocabulary": {
+            "$ref": "#/components/schemas/ml._types:Vocabulary"
           }
         }
       },
@@ -50858,6 +50893,78 @@
           "importance"
         ]
       },
+      "ml._types:ModelPackageConfig": {
+        "type": "object",
+        "properties": {
+          "create_time": {
+            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+          },
+          "description": {
+            "type": "string"
+          },
+          "inference_config": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/_types:Metadata"
+          },
+          "minimum_version": {
+            "type": "string"
+          },
+          "model_repository": {
+            "type": "string"
+          },
+          "model_type": {
+            "type": "string"
+          },
+          "packaged_model_id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "platform_architecture": {
+            "type": "string"
+          },
+          "prefix_strings": {
+            "$ref": "#/components/schemas/ml._types:TrainedModelPrefixStrings"
+          },
+          "size": {
+            "type": "number"
+          },
+          "sha256": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "vocabulary_file": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "packaged_model_id"
+        ]
+      },
+      "ml._types:TrainedModelPrefixStrings": {
+        "type": "object",
+        "properties": {
+          "ingest": {
+            "description": "String prepended to input at ingest",
+            "type": "string"
+          },
+          "search": {
+            "description": "String prepended to input at search",
+            "type": "string"
+          },
+          "none": {
+            "type": "string"
+          }
+        }
+      },
       "ml._types:TrainedModelLocation": {
         "type": "object",
         "properties": {
@@ -50879,19 +50986,6 @@
         "required": [
           "name"
         ]
-      },
-      "ml._types:TrainedModelPrefixStrings": {
-        "type": "object",
-        "properties": {
-          "ingest": {
-            "description": "String prepended to input at ingest",
-            "type": "string"
-          },
-          "search": {
-            "description": "String prepended to input at search",
-            "type": "string"
-          }
-        }
       },
       "ml._types:TrainedModelStats": {
         "type": "object",
@@ -52192,6 +52286,29 @@
         },
         "required": [
           "model_memory_limit"
+        ]
+      },
+      "ml._types:DetectorUpdate": {
+        "type": "object",
+        "properties": {
+          "detector_index": {
+            "description": "A unique identifier for the detector.\nThis identifier is based on the order of the detectors in the `analysis_config`, starting at zero.",
+            "type": "number"
+          },
+          "description": {
+            "description": "A description of the detector.",
+            "type": "string"
+          },
+          "custom_rules": {
+            "description": "An array of custom rule objects, which enable you to customize the way detectors operate.\nFor example, a rule may dictate to the detector conditions under which results should be skipped.\nKibana refers to custom rules as job rules.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ml._types:DetectionRule"
+            }
+          }
+        },
+        "required": [
+          "detector_index"
         ]
       },
       "_global.msearch:RequestItem": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -10542,6 +10542,16 @@
               "$ref": "#/components/schemas/_types:Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "ignore_throttled",
+            "description": "Ignore indices that are marked as throttled (default: true). Only set if datafeed_config is provided.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -48787,6 +48787,9 @@
           },
           "version": {
             "$ref": "#/components/schemas/_types:VersionString"
+          },
+          "_meta": {
+            "$ref": "#/components/schemas/_types:Metadata"
           }
         },
         "required": [
@@ -49522,8 +49525,7 @@
         },
         "required": [
           "datafeed_id",
-          "state",
-          "timing_stats"
+          "state"
         ]
       },
       "ml._types:DatafeedTimingStats": {
@@ -50907,6 +50909,9 @@
       "ml._types:TrainedModelDeploymentStats": {
         "type": "object",
         "properties": {
+          "adaptive_allocations": {
+            "$ref": "#/components/schemas/ml._types:AdaptiveAllocationsSettings"
+          },
           "allocation_status": {
             "$ref": "#/components/schemas/ml._types:TrainedModelDeploymentAllocationStatus"
           },
@@ -50938,6 +50943,9 @@
             "description": "The number of allocations requested.",
             "type": "number"
           },
+          "priority": {
+            "$ref": "#/components/schemas/ml._types:TrainingPriority"
+          },
           "queue_capacity": {
             "description": "The number of inference requests that can be queued before new requests are rejected.",
             "type": "number"
@@ -50968,18 +50976,28 @@
         "required": [
           "allocation_status",
           "deployment_id",
-          "error_count",
-          "inference_count",
           "model_id",
           "nodes",
-          "number_of_allocations",
-          "queue_capacity",
-          "rejected_execution_count",
-          "reason",
+          "priority",
           "start_time",
-          "state",
-          "threads_per_allocation",
-          "timeout_count"
+          "state"
+        ]
+      },
+      "ml._types:AdaptiveAllocationsSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "min_number_of_allocations": {
+            "type": "number"
+          },
+          "max_number_of_allocations": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "enabled"
         ]
       },
       "ml._types:TrainedModelDeploymentAllocationStatus": {
@@ -51017,12 +51035,24 @@
           "average_inference_time_ms": {
             "$ref": "#/components/schemas/_types:DurationValueUnitFloatMillis"
           },
+          "average_inference_time_ms_last_minute": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitFloatMillis"
+          },
+          "average_inference_time_ms_excluding_cache_hits": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitFloatMillis"
+          },
           "error_count": {
             "description": "The number of errors when evaluating the trained model.",
             "type": "number"
           },
           "inference_count": {
             "description": "The total number of inference calls made against this node for this model.",
+            "type": "number"
+          },
+          "inference_cache_hit_count": {
+            "type": "number"
+          },
+          "inference_cache_hit_count_last_minute": {
             "type": "number"
           },
           "last_access": {
@@ -51035,6 +51065,9 @@
           },
           "number_of_pending_requests": {
             "description": "The number of inference requests queued to be processed.",
+            "type": "number"
+          },
+          "peak_throughput_per_minute": {
             "type": "number"
           },
           "rejection_execution_count": {
@@ -51051,23 +51084,17 @@
             "description": "The number of threads used by each allocation during inference.",
             "type": "number"
           },
+          "throughput_last_minute": {
+            "type": "number"
+          },
           "timeout_count": {
             "description": "The number of inference requests that timed out before being processed.",
             "type": "number"
           }
         },
         "required": [
-          "average_inference_time_ms",
-          "error_count",
-          "inference_count",
-          "last_access",
-          "number_of_allocations",
-          "number_of_pending_requests",
-          "rejection_execution_count",
-          "routing_state",
-          "start_time",
-          "threads_per_allocation",
-          "timeout_count"
+          "peak_throughput_per_minute",
+          "routing_state"
         ]
       },
       "ml._types:TrainedModelAssignmentRoutingTable": {
@@ -51090,10 +51117,7 @@
           }
         },
         "required": [
-          "reason",
-          "routing_state",
-          "current_allocations",
-          "target_allocations"
+          "routing_state"
         ]
       },
       "ml._types:RoutingState": {
@@ -51104,6 +51128,13 @@
           "starting",
           "stopped",
           "stopping"
+        ]
+      },
+      "ml._types:TrainingPriority": {
+        "type": "string",
+        "enum": [
+          "normal",
+          "low"
         ]
       },
       "ml._types:DeploymentAssignmentState": {
@@ -52035,13 +52066,6 @@
               "$ref": "#/components/schemas/_types:NodeId"
             }
           }
-        ]
-      },
-      "ml._types:TrainingPriority": {
-        "type": "string",
-        "enum": [
-          "normal",
-          "low"
         ]
       },
       "ml._types:TrainedModelAssignment": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -30412,9 +30412,53 @@
       ],
       "query": [
         {
-          "description": "Ignore indices that are marked as throttled (default: true). Only set if datafeed_config is provided.",
+          "description": "If `true`, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the\n`_all` string or when no indices are specified.",
+          "name": "allow_no_indices",
+          "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "description": "Type of index that wildcard patterns can match. If the request can target data streams, this argument determines\nwhether wildcard expressions match hidden data streams. Supports comma-separated values. Valid values are:\n\n* `all`: Match any data stream or index, including hidden ones.\n* `closed`: Match closed, non-hidden indices. Also matches any non-hidden data stream. Data streams cannot be closed.\n* `hidden`: Match hidden data streams and hidden indices. Must be combined with `open`, `closed`, or both.\n* `none`: Wildcard patterns are not accepted.\n* `open`: Match open, non-hidden indices. Also matches any non-hidden data stream.",
+          "name": "expand_wildcards",
+          "required": false,
+          "serverDefault": "open",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ExpandWildcards",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "deprecation": {
+            "description": "",
+            "version": "7.16.0"
+          },
+          "description": "If `true`, concrete, expanded or aliased indices are ignored when frozen.",
           "name": "ignore_throttled",
           "required": false,
+          "serverDefault": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "description": "If `true`, unavailable indices (missing or closed) are ignored.",
+          "name": "ignore_unavailable",
+          "required": false,
+          "serverDefault": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -30424,7 +30468,7 @@
           }
         }
       ],
-      "specLocation": "ml/put_job/MlPutJobRequest.ts#L30-L120"
+      "specLocation": "ml/put_job/MlPutJobRequest.ts#L30-L148"
     },
     {
       "body": {
@@ -95443,7 +95487,7 @@
         "name": "PredictedValue",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/inference.ts#L468-L468",
+      "specLocation": "ml/_types/inference.ts#L445-L445",
       "type": {
         "items": [
           {
@@ -95554,7 +95598,7 @@
         "name": "TokenizationTruncate",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/inference.ts#L361-L365"
+      "specLocation": "ml/_types/inference.ts#L338-L342"
     },
     {
       "kind": "enum",
@@ -132983,7 +133027,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L196-L206"
+      "specLocation": "ml/_types/inference.ts#L173-L183"
     },
     {
       "description": "Tokenization options stored in inference configuration",
@@ -133061,9 +133105,24 @@
     },
     {
       "description": "BERT and MPNet tokenization configuration options",
+      "inherits": {
+        "type": {
+          "name": "CommonTokenizationConfig",
+          "namespace": "ml._types"
+        }
+      },
       "kind": "interface",
       "name": {
         "name": "NlpBertTokenizationConfig",
+        "namespace": "ml._types"
+      },
+      "properties": [],
+      "specLocation": "ml/_types/inference.ts#L161-L162"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "CommonTokenizationConfig",
         "namespace": "ml._types"
       },
       "properties": [
@@ -133072,19 +133131,6 @@
           "name": "do_lower_case",
           "required": false,
           "serverDefault": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
-          "description": "Is tokenization completed with special tokens",
-          "name": "with_special_tokens",
-          "required": false,
-          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133107,6 +133153,19 @@
           }
         },
         {
+          "description": "Tokenization spanning options. Special value of -1 indicates no spanning takes place",
+          "name": "span",
+          "required": false,
+          "serverDefault": -1,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "description": "Should tokenization input be automatically truncated before sending to the model for inference",
           "name": "truncate",
           "required": false,
@@ -133120,34 +133179,10 @@
           }
         },
         {
-          "description": "Tokenization spanning options. Special value of -1 indicates no spanning takes place",
-          "name": "span",
+          "description": "Is tokenization completed with special tokens",
+          "name": "with_special_tokens",
           "required": false,
-          "serverDefault": -1,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        }
-      ],
-      "specLocation": "ml/_types/inference.ts#L133-L160"
-    },
-    {
-      "description": "RoBERTa tokenization configuration options",
-      "kind": "interface",
-      "name": {
-        "name": "NlpRobertaTokenizationConfig",
-        "namespace": "ml._types"
-      },
-      "properties": [
-        {
-          "description": "Should the tokenizer lower case the text",
-          "name": "do_lower_case",
-          "required": false,
-          "serverDefault": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133155,7 +133190,24 @@
               "namespace": "_builtins"
             }
           }
-        },
+        }
+      ],
+      "specLocation": "ml/_types/inference.ts#L133-L159"
+    },
+    {
+      "description": "RoBERTa tokenization configuration options",
+      "inherits": {
+        "type": {
+          "name": "CommonTokenizationConfig",
+          "namespace": "ml._types"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "NlpRobertaTokenizationConfig",
+        "namespace": "ml._types"
+      },
+      "properties": [
         {
           "description": "Should the tokenizer prefix input with a space character",
           "name": "add_prefix_space",
@@ -133168,61 +133220,9 @@
               "namespace": "_builtins"
             }
           }
-        },
-        {
-          "description": "Is tokenization completed with special tokens",
-          "name": "with_special_tokens",
-          "required": false,
-          "serverDefault": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
-          "description": "Maximum input sequence length for the model",
-          "name": "max_sequence_length",
-          "required": false,
-          "serverDefault": 512,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "description": "Should tokenization input be automatically truncated before sending to the model for inference",
-          "name": "truncate",
-          "required": false,
-          "serverDefault": "first",
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "TokenizationTruncate",
-              "namespace": "ml._types"
-            }
-          }
-        },
-        {
-          "description": "Tokenization spanning options. Special value of -1 indicates no spanning takes place",
-          "name": "span",
-          "required": false,
-          "serverDefault": -1,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L162-L194"
+      "specLocation": "ml/_types/inference.ts#L164-L171"
     },
     {
       "description": "Zero shot classification configuration options",
@@ -133313,7 +133313,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L208-L229"
+      "specLocation": "ml/_types/inference.ts#L185-L206"
     },
     {
       "description": "Fill mask inference options",
@@ -133373,7 +133373,7 @@
         },
         {
           "name": "vocabulary",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133383,7 +133383,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L276-L291"
+      "specLocation": "ml/_types/inference.ts#L253-L268"
     },
     {
       "kind": "interface",
@@ -133404,7 +133404,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L240-L242"
+      "specLocation": "ml/_types/inference.ts#L217-L219"
     },
     {
       "description": "Named entity recognition options",
@@ -133465,7 +133465,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L265-L274"
+      "specLocation": "ml/_types/inference.ts#L242-L251"
     },
     {
       "description": "Pass through configuration options",
@@ -133511,7 +133511,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L231-L238"
+      "specLocation": "ml/_types/inference.ts#L208-L215"
     },
     {
       "description": "Text embedding inference options",
@@ -133559,7 +133559,7 @@
         },
         {
           "name": "vocabulary",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133569,7 +133569,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L244-L254"
+      "specLocation": "ml/_types/inference.ts#L221-L231"
     },
     {
       "description": "Text expansion inference options",
@@ -133605,7 +133605,7 @@
         },
         {
           "name": "vocabulary",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133615,7 +133615,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L256-L263"
+      "specLocation": "ml/_types/inference.ts#L233-L240"
     },
     {
       "description": "Question answering inference options",
@@ -133674,7 +133674,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L293-L303"
+      "specLocation": "ml/_types/inference.ts#L270-L280"
     },
     {
       "kind": "interface",
@@ -135213,7 +135213,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L307-L329",
+      "specLocation": "ml/_types/inference.ts#L284-L306",
       "variants": {
         "kind": "container"
       }
@@ -135277,7 +135277,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L374-L383"
+      "specLocation": "ml/_types/inference.ts#L351-L360"
     },
     {
       "kind": "interface",
@@ -135311,7 +135311,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L367-L372"
+      "specLocation": "ml/_types/inference.ts#L344-L349"
     },
     {
       "kind": "interface",
@@ -135372,7 +135372,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L385-L394"
+      "specLocation": "ml/_types/inference.ts#L362-L371"
     },
     {
       "kind": "interface",
@@ -135418,7 +135418,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L422-L429"
+      "specLocation": "ml/_types/inference.ts#L399-L406"
     },
     {
       "kind": "interface",
@@ -135452,7 +135452,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L415-L420"
+      "specLocation": "ml/_types/inference.ts#L392-L397"
     },
     {
       "kind": "interface",
@@ -135486,7 +135486,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L396-L401"
+      "specLocation": "ml/_types/inference.ts#L373-L378"
     },
     {
       "kind": "interface",
@@ -135519,7 +135519,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L403-L407"
+      "specLocation": "ml/_types/inference.ts#L380-L384"
     },
     {
       "kind": "interface",
@@ -135552,7 +135552,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L409-L413"
+      "specLocation": "ml/_types/inference.ts#L386-L390"
     },
     {
       "kind": "interface",
@@ -135622,7 +135622,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L431-L442"
+      "specLocation": "ml/_types/inference.ts#L408-L419"
     },
     {
       "kind": "interface",
@@ -135764,7 +135764,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L470-L518"
+      "specLocation": "ml/_types/inference.ts#L447-L495"
     },
     {
       "kind": "interface",
@@ -135829,7 +135829,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L444-L450"
+      "specLocation": "ml/_types/inference.ts#L421-L427"
     },
     {
       "kind": "interface",
@@ -135872,7 +135872,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L451-L455"
+      "specLocation": "ml/_types/inference.ts#L428-L432"
     },
     {
       "kind": "interface",
@@ -135918,7 +135918,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L462-L466"
+      "specLocation": "ml/_types/inference.ts#L439-L443"
     },
     {
       "kind": "interface",
@@ -135950,7 +135950,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L457-L460"
+      "specLocation": "ml/_types/inference.ts#L434-L437"
     },
     {
       "kind": "interface",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -94936,7 +94936,7 @@
         "name": "CategorizationStatus",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/Model.ts#L83-L86"
+      "specLocation": "ml/_types/Model.ts#L84-L87"
     },
     {
       "kind": "enum",
@@ -95058,7 +95058,7 @@
         "name": "DeploymentAllocationState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L316-L329"
+      "specLocation": "ml/_types/TrainedModel.ts#L318-L331"
     },
     {
       "kind": "enum",
@@ -95084,7 +95084,7 @@
         "name": "DeploymentAssignmentState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L331-L348"
+      "specLocation": "ml/_types/TrainedModel.ts#L333-L350"
     },
     {
       "kind": "enum",
@@ -95220,7 +95220,7 @@
         "name": "MemoryStatus",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/Model.ts#L88-L92"
+      "specLocation": "ml/_types/Model.ts#L89-L93"
     },
     {
       "kind": "type_alias",
@@ -95280,7 +95280,7 @@
         "name": "RoutingState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L393-L414"
+      "specLocation": "ml/_types/TrainedModel.ts#L395-L416"
     },
     {
       "kind": "enum",
@@ -95320,7 +95320,7 @@
         "name": "SnapshotUpgradeState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/Model.ts#L94-L99"
+      "specLocation": "ml/_types/Model.ts#L95-L100"
     },
     {
       "kind": "enum",
@@ -95361,7 +95361,7 @@
         "name": "TrainedModelType",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L300-L314"
+      "specLocation": "ml/_types/TrainedModel.ts#L302-L316"
     },
     {
       "kind": "enum",
@@ -95377,7 +95377,7 @@
         "name": "TrainingPriority",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L350-L353"
+      "specLocation": "ml/_types/TrainedModel.ts#L352-L355"
     },
     {
       "codegenNames": [
@@ -131378,6 +131378,17 @@
           }
         },
         {
+          "name": "output_memory_allocator_bytes",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "name": "peak_model_bytes",
           "required": false,
           "type": {
@@ -131532,7 +131543,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/Model.ts#L59-L81"
+      "specLocation": "ml/_types/Model.ts#L59-L82"
     },
     {
       "kind": "interface",
@@ -132263,7 +132274,7 @@
         {
           "description": "The start time of the bucket for which these results were calculated.",
           "name": "timestamp_string",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -132564,7 +132575,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L189-L225"
+      "specLocation": "ml/_types/TrainedModel.ts#L191-L227"
     },
     {
       "description": "Inference configuration provided when storing the model config",
@@ -133524,7 +133535,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L227-L230"
+      "specLocation": "ml/_types/TrainedModel.ts#L229-L232"
     },
     {
       "kind": "interface",
@@ -133601,7 +133612,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L232-L240"
+      "specLocation": "ml/_types/TrainedModel.ts#L234-L242"
     },
     {
       "kind": "interface",
@@ -133673,7 +133684,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L259-L273"
+      "specLocation": "ml/_types/TrainedModel.ts#L261-L275"
     },
     {
       "kind": "interface",
@@ -133725,7 +133736,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L275-L282"
+      "specLocation": "ml/_types/TrainedModel.ts#L277-L284"
     },
     {
       "kind": "interface",
@@ -133771,7 +133782,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L291-L298"
+      "specLocation": "ml/_types/TrainedModel.ts#L293-L300"
     },
     {
       "kind": "interface",
@@ -133808,7 +133819,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L284-L289"
+      "specLocation": "ml/_types/TrainedModel.ts#L286-L291"
     },
     {
       "kind": "interface",
@@ -133991,7 +134002,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L242-L257"
+      "specLocation": "ml/_types/TrainedModel.ts#L244-L259"
     },
     {
       "kind": "interface",
@@ -134036,7 +134047,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L472-L483"
+      "specLocation": "ml/_types/TrainedModel.ts#L474-L485"
     },
     {
       "kind": "interface",
@@ -134057,7 +134068,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L464-L466"
+      "specLocation": "ml/_types/TrainedModel.ts#L466-L468"
     },
     {
       "kind": "interface",
@@ -134078,7 +134089,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L468-L470"
+      "specLocation": "ml/_types/TrainedModel.ts#L470-L472"
     },
     {
       "kind": "interface",
@@ -134288,6 +134299,17 @@
           }
         },
         {
+          "name": "peak_throughput_per_minute",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "name": "priority",
           "required": true,
           "type": {
@@ -134392,7 +134414,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L62-L105"
+      "specLocation": "ml/_types/TrainedModel.ts#L62-L107"
     },
     {
       "kind": "interface",
@@ -134435,7 +134457,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L107-L111"
+      "specLocation": "ml/_types/TrainedModel.ts#L109-L113"
     },
     {
       "kind": "interface",
@@ -134481,7 +134503,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L436-L443"
+      "specLocation": "ml/_types/TrainedModel.ts#L438-L445"
     },
     {
       "kind": "interface",
@@ -134726,7 +134748,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L142-L187"
+      "specLocation": "ml/_types/TrainedModel.ts#L144-L189"
     },
     {
       "kind": "interface",
@@ -134784,7 +134806,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L416-L434"
+      "specLocation": "ml/_types/TrainedModel.ts#L418-L436"
     },
     {
       "kind": "interface",
@@ -134865,7 +134887,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L113-L133"
+      "specLocation": "ml/_types/TrainedModel.ts#L115-L135"
     },
     {
       "kind": "interface",
@@ -134899,7 +134921,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L135-L140"
+      "specLocation": "ml/_types/TrainedModel.ts#L137-L142"
     },
     {
       "kind": "interface",
@@ -137351,7 +137373,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L445-L462"
+      "specLocation": "ml/_types/TrainedModel.ts#L447-L464"
     },
     {
       "kind": "interface",
@@ -137484,7 +137506,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L355-L391"
+      "specLocation": "ml/_types/TrainedModel.ts#L357-L393"
     },
     {
       "kind": "interface",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -28289,6 +28289,22 @@
           }
         },
         {
+          "deprecation": {
+            "description": "",
+            "version": "7.10.0"
+          },
+          "description": "parameter is deprecated! Use [include=definition] instead",
+          "name": "include_model_definition",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
           "description": "Specifies the maximum number of models to obtain.",
           "name": "size",
           "required": false,
@@ -28329,7 +28345,7 @@
           }
         }
       ],
-      "specLocation": "ml/get_trained_models/MlGetTrainedModelRequest.ts#L25-L92"
+      "specLocation": "ml/get_trained_models/MlGetTrainedModelRequest.ts#L25-L99"
     },
     {
       "body": {
@@ -29280,6 +29296,17 @@
             }
           },
           {
+            "name": "_meta",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Metadata",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
             "description": "The approximate maximum amount of memory resources that are permitted for\nanalytical processing. If your `elasticsearch.yml` file contains an\n`xpack.ml.max_model_memory_limit` setting, an error occurs when you try\nto create data frame analytics jobs that have `model_memory_limit` values\ngreater than that setting.",
             "name": "model_memory_limit",
             "required": false,
@@ -29367,7 +29394,7 @@
         }
       ],
       "query": [],
-      "specLocation": "ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts#L30-L142"
+      "specLocation": "ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts#L30-L144"
     },
     {
       "body": {
@@ -29482,6 +29509,17 @@
             }
           },
           {
+            "name": "_meta",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Metadata",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
             "name": "model_memory_limit",
             "required": true,
             "type": {
@@ -29521,7 +29559,7 @@
         "name": "Response",
         "namespace": "ml.put_data_frame_analytics"
       },
-      "specLocation": "ml/put_data_frame_analytics/MlPutDataFrameAnalyticsResponse.ts#L31-L46"
+      "specLocation": "ml/put_data_frame_analytics/MlPutDataFrameAnalyticsResponse.ts#L31-L47"
     },
     {
       "attachedBehaviors": [
@@ -29531,6 +29569,9 @@
         "kind": "properties",
         "properties": [
           {
+            "aliases": [
+              "aggs"
+            ],
             "description": "If set, the datafeed performs aggregation searches.\nSupport for aggregations is limited and should be used only with low cardinality data.",
             "name": "aggregations",
             "required": false,
@@ -29816,7 +29857,7 @@
           }
         }
       ],
-      "specLocation": "ml/put_datafeed/MlPutDatafeedRequest.ts#L37-L173"
+      "specLocation": "ml/put_datafeed/MlPutDatafeedRequest.ts#L37-L175"
     },
     {
       "body": {
@@ -30253,6 +30294,18 @@
             }
           },
           {
+            "description": "The identifier for the anomaly detection job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters.",
+            "name": "job_id",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "Id",
+                "namespace": "_types"
+              }
+            }
+          },
+          {
             "description": "A list of job groups. A job can belong to no groups or many.",
             "name": "groups",
             "required": false,
@@ -30358,7 +30411,7 @@
         }
       ],
       "query": [],
-      "specLocation": "ml/put_job/MlPutJobRequest.ts#L30-L113"
+      "specLocation": "ml/put_job/MlPutJobRequest.ts#L30-L117"
     },
     {
       "body": {
@@ -132010,11 +132063,23 @@
           "required": false,
           "serverDefault": "1024mb",
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "_builtins"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "long",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         }
       ],

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -30410,8 +30410,21 @@
           }
         }
       ],
-      "query": [],
-      "specLocation": "ml/put_job/MlPutJobRequest.ts#L30-L117"
+      "query": [
+        {
+          "description": "Ignore indices that are marked as throttled (default: true). Only set if datafeed_config is provided.",
+          "name": "ignore_throttled",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        }
+      ],
+      "specLocation": "ml/put_job/MlPutJobRequest.ts#L30-L120"
     },
     {
       "body": {
@@ -95138,6 +95151,155 @@
         "namespace": "ml._types"
       },
       "specLocation": "ml/_types/TrainedModel.ts#L333-L350"
+    },
+    {
+      "kind": "type_alias",
+      "name": {
+        "name": "DiscoveryNode",
+        "namespace": "ml._types"
+      },
+      "specLocation": "ml/_types/DiscoveryNode.ts#L25-L25",
+      "type": {
+        "key": {
+          "kind": "instance_of",
+          "type": {
+            "name": "Id",
+            "namespace": "_types"
+          }
+        },
+        "kind": "dictionary_of",
+        "singleKey": true,
+        "value": {
+          "kind": "instance_of",
+          "type": {
+            "name": "DiscoveryNodeContent",
+            "namespace": "ml._types"
+          }
+        }
+      }
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "DiscoveryNodeContent",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "name",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Name",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "ephemeral_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "transport_address",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TransportAddress",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "external_id",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "name": "attributes",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "_builtins"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "_builtins"
+              }
+            }
+          }
+        },
+        {
+          "name": "roles",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "_builtins"
+              }
+            }
+          }
+        },
+        {
+          "name": "version",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "VersionString",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "min_index_version",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "max_index_version",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "specLocation": "ml/_types/DiscoveryNode.ts#L27-L37"
     },
     {
       "kind": "enum",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -32960,7 +32960,7 @@
               "value": {
                 "kind": "instance_of",
                 "type": {
-                  "name": "Detector",
+                  "name": "DetectorUpdate",
                   "namespace": "ml._types"
                 }
               }
@@ -76439,7 +76439,7 @@
         "name": "ClusterInfoTarget",
         "namespace": "_types"
       },
-      "specLocation": "_types/common.ts#L382-L388"
+      "specLocation": "_types/common.ts#L401-L407"
     },
     {
       "kind": "type_alias",
@@ -76447,7 +76447,7 @@
         "name": "ClusterInfoTargets",
         "namespace": "_types"
       },
-      "specLocation": "_types/common.ts#L390-L390",
+      "specLocation": "_types/common.ts#L409-L409",
       "type": {
         "items": [
           {
@@ -77368,7 +77368,7 @@
         "name": "Slices",
         "namespace": "_types"
       },
-      "specLocation": "_types/common.ts#L365-L370",
+      "specLocation": "_types/common.ts#L384-L389",
       "type": {
         "items": [
           {
@@ -77401,7 +77401,7 @@
         "name": "SlicesCalculation",
         "namespace": "_types"
       },
-      "specLocation": "_types/common.ts#L372-L380"
+      "specLocation": "_types/common.ts#L391-L399"
     },
     {
       "kind": "type_alias",
@@ -95058,7 +95058,7 @@
         "name": "DeploymentAllocationState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L297-L310"
+      "specLocation": "ml/_types/TrainedModel.ts#L316-L329"
     },
     {
       "kind": "enum",
@@ -95084,7 +95084,7 @@
         "name": "DeploymentAssignmentState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L312-L329"
+      "specLocation": "ml/_types/TrainedModel.ts#L331-L348"
     },
     {
       "kind": "enum",
@@ -95106,7 +95106,7 @@
         "name": "ExcludeFrequent",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/Detector.ts#L127-L132"
+      "specLocation": "ml/_types/Detector.ts#L145-L150"
     },
     {
       "kind": "enum",
@@ -95228,7 +95228,7 @@
         "name": "PredictedValue",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/inference.ts#L457-L457",
+      "specLocation": "ml/_types/inference.ts#L468-L468",
       "type": {
         "items": [
           {
@@ -95280,7 +95280,7 @@
         "name": "RoutingState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L374-L395"
+      "specLocation": "ml/_types/TrainedModel.ts#L393-L414"
     },
     {
       "kind": "enum",
@@ -95339,7 +95339,7 @@
         "name": "TokenizationTruncate",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/inference.ts#L350-L354"
+      "specLocation": "ml/_types/inference.ts#L361-L365"
     },
     {
       "kind": "enum",
@@ -95361,7 +95361,7 @@
         "name": "TrainedModelType",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L281-L295"
+      "specLocation": "ml/_types/TrainedModel.ts#L300-L314"
     },
     {
       "kind": "enum",
@@ -95377,7 +95377,7 @@
         "name": "TrainingPriority",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L331-L334"
+      "specLocation": "ml/_types/TrainedModel.ts#L350-L353"
     },
     {
       "codegenNames": [
@@ -130678,6 +130678,36 @@
           }
         },
         {
+          "deprecation": {
+            "description": "this value will be replaced by the selector `::*` on the expression level",
+            "version": "8.16.0"
+          },
+          "name": "exclude",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "deprecation": {
+            "description": "this query param will be replaced by the selector `::` on the expression level",
+            "version": "8.16.0"
+          },
+          "name": "failure_store",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
           "description": "If true, missing or closed indices are not included in the response.",
           "name": "ignore_unavailable",
           "required": false,
@@ -130702,9 +130732,39 @@
               "namespace": "_builtins"
             }
           }
+        },
+        {
+          "deprecation": {
+            "description": "this value will be replaced by the selector `::*` on the expression level",
+            "version": "8.16.0"
+          },
+          "name": "include",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "deprecation": {
+            "description": "this value will be replaced by the selector `::*` on the expression level",
+            "version": "8.16.0"
+          },
+          "name": "only",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
         }
       ],
-      "specLocation": "_types/common.ts#L336-L363"
+      "specLocation": "_types/common.ts#L336-L382"
     },
     {
       "kind": "interface",
@@ -132471,6 +132531,17 @@
           }
         },
         {
+          "name": "model_package",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ModelPackageConfig",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
           "name": "location",
           "required": false,
           "type": {
@@ -132493,7 +132564,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L188-L223"
+      "specLocation": "ml/_types/TrainedModel.ts#L189-L225"
     },
     {
       "description": "Inference configuration provided when storing the model config",
@@ -132737,7 +132808,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L189-L199"
+      "specLocation": "ml/_types/inference.ts#L196-L206"
     },
     {
       "description": "Tokenization options stored in inference configuration",
@@ -132750,6 +132821,18 @@
         {
           "description": "Indicates BERT tokenization and its options",
           "name": "bert",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "NlpBertTokenizationConfig",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "description": "Indicates BERT Japanese tokenization and its options",
+          "name": "bert_ja",
           "required": false,
           "type": {
             "kind": "instance_of",
@@ -132796,7 +132879,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L110-L129",
+      "specLocation": "ml/_types/inference.ts#L110-L131",
       "variants": {
         "kind": "container"
       }
@@ -132875,7 +132958,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L131-L158"
+      "specLocation": "ml/_types/inference.ts#L133-L160"
     },
     {
       "description": "RoBERTa tokenization configuration options",
@@ -132885,6 +132968,19 @@
         "namespace": "ml._types"
       },
       "properties": [
+        {
+          "description": "Should the tokenizer lower case the text",
+          "name": "do_lower_case",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
         {
           "description": "Should the tokenizer prefix input with a space character",
           "name": "add_prefix_space",
@@ -132951,7 +133047,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L160-L187"
+      "specLocation": "ml/_types/inference.ts#L162-L194"
     },
     {
       "description": "Zero shot classification configuration options",
@@ -133042,7 +133138,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L201-L222"
+      "specLocation": "ml/_types/inference.ts#L208-L229"
     },
     {
       "description": "Fill mask inference options",
@@ -133099,9 +133195,41 @@
               "namespace": "_builtins"
             }
           }
+        },
+        {
+          "name": "vocabulary",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Vocabulary",
+              "namespace": "ml._types"
+            }
+          }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L266-L280"
+      "specLocation": "ml/_types/inference.ts#L276-L291"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "Vocabulary",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "index",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "specLocation": "ml/_types/inference.ts#L240-L242"
     },
     {
       "description": "Named entity recognition options",
@@ -133162,28 +133290,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L255-L264"
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "Vocabulary",
-        "namespace": "ml._types"
-      },
-      "properties": [
-        {
-          "name": "index",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "IndexName",
-              "namespace": "_types"
-            }
-          }
-        }
-      ],
-      "specLocation": "ml/_types/inference.ts#L233-L235"
+      "specLocation": "ml/_types/inference.ts#L265-L274"
     },
     {
       "description": "Pass through configuration options",
@@ -133229,7 +133336,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L224-L231"
+      "specLocation": "ml/_types/inference.ts#L231-L238"
     },
     {
       "description": "Text embedding inference options",
@@ -133274,9 +133381,20 @@
               "namespace": "_builtins"
             }
           }
+        },
+        {
+          "name": "vocabulary",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Vocabulary",
+              "namespace": "ml._types"
+            }
+          }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L237-L245"
+      "specLocation": "ml/_types/inference.ts#L244-L254"
     },
     {
       "description": "Text expansion inference options",
@@ -133309,9 +133427,20 @@
               "namespace": "_builtins"
             }
           }
+        },
+        {
+          "name": "vocabulary",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Vocabulary",
+              "namespace": "ml._types"
+            }
+          }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L247-L253"
+      "specLocation": "ml/_types/inference.ts#L256-L263"
     },
     {
       "description": "Question answering inference options",
@@ -133370,7 +133499,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L282-L292"
+      "specLocation": "ml/_types/inference.ts#L293-L303"
     },
     {
       "kind": "interface",
@@ -133395,7 +133524,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L225-L228"
+      "specLocation": "ml/_types/TrainedModel.ts#L227-L230"
     },
     {
       "kind": "interface",
@@ -133472,7 +133601,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L230-L238"
+      "specLocation": "ml/_types/TrainedModel.ts#L232-L240"
     },
     {
       "kind": "interface",
@@ -133544,7 +133673,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L240-L254"
+      "specLocation": "ml/_types/TrainedModel.ts#L259-L273"
     },
     {
       "kind": "interface",
@@ -133596,7 +133725,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L256-L263"
+      "specLocation": "ml/_types/TrainedModel.ts#L275-L282"
     },
     {
       "kind": "interface",
@@ -133642,7 +133771,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L272-L279"
+      "specLocation": "ml/_types/TrainedModel.ts#L291-L298"
     },
     {
       "kind": "interface",
@@ -133679,49 +133808,190 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L265-L270"
+      "specLocation": "ml/_types/TrainedModel.ts#L284-L289"
     },
     {
       "kind": "interface",
       "name": {
-        "name": "TrainedModelLocation",
+        "name": "ModelPackageConfig",
         "namespace": "ml._types"
       },
       "properties": [
         {
-          "name": "index",
-          "required": true,
+          "name": "create_time",
+          "required": false,
           "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
             "kind": "instance_of",
             "type": {
-              "name": "TrainedModelLocationIndex",
-              "namespace": "ml._types"
-            }
-          }
-        }
-      ],
-      "specLocation": "ml/_types/TrainedModel.ts#L445-L447"
-    },
-    {
-      "kind": "interface",
-      "name": {
-        "name": "TrainedModelLocationIndex",
-        "namespace": "ml._types"
-      },
-      "properties": [
-        {
-          "name": "name",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "IndexName",
+              "name": "EpochTime",
               "namespace": "_types"
             }
           }
+        },
+        {
+          "name": "description",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "name": "inference_config",
+          "required": false,
+          "type": {
+            "key": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "_builtins"
+              }
+            },
+            "kind": "dictionary_of",
+            "singleKey": false,
+            "value": {
+              "kind": "user_defined_value"
+            }
+          }
+        },
+        {
+          "name": "metadata",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "minimum_version",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "name": "model_repository",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "name": "model_type",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "name": "packaged_model_id",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Id",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "platform_architecture",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "name": "prefix_strings",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TrainedModelPrefixStrings",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
+          "name": "size",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "sha256",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "name": "tags",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "string",
+                "namespace": "_builtins"
+              }
+            }
+          }
+        },
+        {
+          "name": "vocabulary_file",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L449-L451"
+      "specLocation": "ml/_types/TrainedModel.ts#L242-L257"
     },
     {
       "kind": "interface",
@@ -133753,9 +134023,62 @@
               "namespace": "_builtins"
             }
           }
+        },
+        {
+          "name": "none",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L453-L462"
+      "specLocation": "ml/_types/TrainedModel.ts#L472-L483"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "TrainedModelLocation",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "index",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TrainedModelLocationIndex",
+              "namespace": "ml._types"
+            }
+          }
+        }
+      ],
+      "specLocation": "ml/_types/TrainedModel.ts#L464-L466"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "TrainedModelLocationIndex",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "name",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "IndexName",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "specLocation": "ml/_types/TrainedModel.ts#L468-L470"
     },
     {
       "kind": "interface",
@@ -133846,7 +134169,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L41-L59"
+      "specLocation": "ml/_types/TrainedModel.ts#L42-L60"
     },
     {
       "kind": "interface",
@@ -134069,7 +134392,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L61-L104"
+      "specLocation": "ml/_types/TrainedModel.ts#L62-L105"
     },
     {
       "kind": "interface",
@@ -134112,7 +134435,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L106-L110"
+      "specLocation": "ml/_types/TrainedModel.ts#L107-L111"
     },
     {
       "kind": "interface",
@@ -134158,7 +134481,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L417-L424"
+      "specLocation": "ml/_types/TrainedModel.ts#L436-L443"
     },
     {
       "kind": "interface",
@@ -134403,7 +134726,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L141-L186"
+      "specLocation": "ml/_types/TrainedModel.ts#L142-L187"
     },
     {
       "kind": "interface",
@@ -134461,7 +134784,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L397-L415"
+      "specLocation": "ml/_types/TrainedModel.ts#L416-L434"
     },
     {
       "kind": "interface",
@@ -134542,7 +134865,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L112-L132"
+      "specLocation": "ml/_types/TrainedModel.ts#L113-L133"
     },
     {
       "kind": "interface",
@@ -134576,7 +134899,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L134-L139"
+      "specLocation": "ml/_types/TrainedModel.ts#L135-L140"
     },
     {
       "kind": "interface",
@@ -134706,7 +135029,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L296-L318",
+      "specLocation": "ml/_types/inference.ts#L307-L329",
       "variants": {
         "kind": "container"
       }
@@ -134770,7 +135093,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L363-L372"
+      "specLocation": "ml/_types/inference.ts#L374-L383"
     },
     {
       "kind": "interface",
@@ -134804,7 +135127,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L356-L361"
+      "specLocation": "ml/_types/inference.ts#L367-L372"
     },
     {
       "kind": "interface",
@@ -134865,7 +135188,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L374-L383"
+      "specLocation": "ml/_types/inference.ts#L385-L394"
     },
     {
       "kind": "interface",
@@ -134911,7 +135234,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L411-L418"
+      "specLocation": "ml/_types/inference.ts#L422-L429"
     },
     {
       "kind": "interface",
@@ -134945,7 +135268,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L404-L409"
+      "specLocation": "ml/_types/inference.ts#L415-L420"
     },
     {
       "kind": "interface",
@@ -134979,7 +135302,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L385-L390"
+      "specLocation": "ml/_types/inference.ts#L396-L401"
     },
     {
       "kind": "interface",
@@ -135012,7 +135335,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L392-L396"
+      "specLocation": "ml/_types/inference.ts#L403-L407"
     },
     {
       "kind": "interface",
@@ -135045,7 +135368,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L398-L402"
+      "specLocation": "ml/_types/inference.ts#L409-L413"
     },
     {
       "kind": "interface",
@@ -135115,7 +135438,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L420-L431"
+      "specLocation": "ml/_types/inference.ts#L431-L442"
     },
     {
       "kind": "interface",
@@ -135257,7 +135580,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L459-L507"
+      "specLocation": "ml/_types/inference.ts#L470-L518"
     },
     {
       "kind": "interface",
@@ -135322,7 +135645,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L433-L439"
+      "specLocation": "ml/_types/inference.ts#L444-L450"
     },
     {
       "kind": "interface",
@@ -135365,7 +135688,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L440-L444"
+      "specLocation": "ml/_types/inference.ts#L451-L455"
     },
     {
       "kind": "interface",
@@ -135411,7 +135734,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L451-L455"
+      "specLocation": "ml/_types/inference.ts#L462-L466"
     },
     {
       "kind": "interface",
@@ -135443,7 +135766,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/inference.ts#L446-L449"
+      "specLocation": "ml/_types/inference.ts#L457-L460"
     },
     {
       "kind": "interface",
@@ -137028,7 +137351,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L426-L443"
+      "specLocation": "ml/_types/TrainedModel.ts#L445-L462"
     },
     {
       "kind": "interface",
@@ -137161,7 +137484,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L336-L372"
+      "specLocation": "ml/_types/TrainedModel.ts#L355-L391"
     },
     {
       "kind": "interface",
@@ -137184,6 +137507,55 @@
         }
       ],
       "specLocation": "ml/_types/Analysis.ts#L174-L179"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "DetectorUpdate",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "description": "A unique identifier for the detector.\nThis identifier is based on the order of the detectors in the `analysis_config`, starting at zero.",
+          "name": "detector_index",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "A description of the detector.",
+          "name": "description",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "description": "An array of custom rule objects, which enable you to customize the way detectors operate.\nFor example, a rule may dictate to the detector conditions under which results should be skipped.\nKibana refers to custom rules as job rules.",
+          "name": "custom_rules",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "DetectionRule",
+                "namespace": "ml._types"
+              }
+            }
+          }
+        }
+      ],
+      "specLocation": "ml/_types/Detector.ts#L127-L143"
     },
     {
       "generics": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -95124,7 +95124,7 @@
         "name": "DeploymentAllocationState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L318-L331"
+      "specLocation": "ml/_types/TrainedModel.ts#L319-L332"
     },
     {
       "kind": "enum",
@@ -95150,7 +95150,7 @@
         "name": "DeploymentAssignmentState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L333-L350"
+      "specLocation": "ml/_types/TrainedModel.ts#L334-L351"
     },
     {
       "kind": "type_alias",
@@ -95495,7 +95495,7 @@
         "name": "RoutingState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L395-L416"
+      "specLocation": "ml/_types/TrainedModel.ts#L396-L417"
     },
     {
       "kind": "enum",
@@ -95576,7 +95576,7 @@
         "name": "TrainedModelType",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L302-L316"
+      "specLocation": "ml/_types/TrainedModel.ts#L303-L317"
     },
     {
       "kind": "enum",
@@ -95592,7 +95592,7 @@
         "name": "TrainingPriority",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L352-L355"
+      "specLocation": "ml/_types/TrainedModel.ts#L353-L356"
     },
     {
       "codegenNames": [
@@ -130350,9 +130350,18 @@
           "name": "incremental_metric_value_ms",
           "required": true,
           "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitFloatMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
             "kind": "instance_of",
             "type": {
-              "name": "double",
+              "name": "DurationValue",
               "namespace": "_types"
             }
           }
@@ -130894,7 +130903,7 @@
         },
         {
           "deprecation": {
-            "description": "this value will be replaced by the selector `::*` on the expression level",
+            "description": "this value will be replaced by the selector `::*` on the expression level.",
             "version": "8.16.0"
           },
           "name": "exclude",
@@ -130909,7 +130918,7 @@
         },
         {
           "deprecation": {
-            "description": "this query param will be replaced by the selector `::` on the expression level",
+            "description": "this query param will be replaced by the selector `::` on the expression level.",
             "version": "8.16.0"
           },
           "name": "failure_store",
@@ -130950,7 +130959,7 @@
         },
         {
           "deprecation": {
-            "description": "this value will be replaced by the selector `::*` on the expression level",
+            "description": "this value will be replaced by the selector `::*` on the expression level.",
             "version": "8.16.0"
           },
           "name": "include",
@@ -130965,7 +130974,7 @@
         },
         {
           "deprecation": {
-            "description": "this value will be replaced by the selector `::*` on the expression level",
+            "description": "this value will be replaced by the selector `::*` on the expression level.",
             "version": "8.16.0"
           },
           "name": "only",
@@ -131598,7 +131607,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "ByteSize",
               "namespace": "_types"
             }
           }
@@ -132225,23 +132234,11 @@
           "required": false,
           "serverDefault": "1024mb",
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "string",
-                  "namespace": "_builtins"
-                }
-              },
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "long",
-                  "namespace": "_types"
-                }
-              }
-            ],
-            "kind": "union_of"
+            "kind": "instance_of",
+            "type": {
+              "name": "ByteSize",
+              "namespace": "_types"
+            }
           }
         }
       ],
@@ -132802,7 +132799,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L191-L227"
+      "specLocation": "ml/_types/TrainedModel.ts#L192-L228"
     },
     {
       "description": "Inference configuration provided when storing the model config",
@@ -133762,7 +133759,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L229-L232"
+      "specLocation": "ml/_types/TrainedModel.ts#L230-L233"
     },
     {
       "kind": "interface",
@@ -133839,7 +133836,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L234-L242"
+      "specLocation": "ml/_types/TrainedModel.ts#L235-L243"
     },
     {
       "kind": "interface",
@@ -133911,7 +133908,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L261-L275"
+      "specLocation": "ml/_types/TrainedModel.ts#L262-L276"
     },
     {
       "kind": "interface",
@@ -133963,7 +133960,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L277-L284"
+      "specLocation": "ml/_types/TrainedModel.ts#L278-L285"
     },
     {
       "kind": "interface",
@@ -134009,7 +134006,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L293-L300"
+      "specLocation": "ml/_types/TrainedModel.ts#L294-L301"
     },
     {
       "kind": "interface",
@@ -134046,7 +134043,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L286-L291"
+      "specLocation": "ml/_types/TrainedModel.ts#L287-L292"
     },
     {
       "kind": "interface",
@@ -134187,7 +134184,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "ByteSize",
               "namespace": "_types"
             }
           }
@@ -134229,7 +134226,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L244-L259"
+      "specLocation": "ml/_types/TrainedModel.ts#L245-L260"
     },
     {
       "kind": "interface",
@@ -134274,7 +134271,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L474-L485"
+      "specLocation": "ml/_types/TrainedModel.ts#L475-L486"
     },
     {
       "kind": "interface",
@@ -134295,7 +134292,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L466-L468"
+      "specLocation": "ml/_types/TrainedModel.ts#L467-L469"
     },
     {
       "kind": "interface",
@@ -134316,7 +134313,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L470-L472"
+      "specLocation": "ml/_types/TrainedModel.ts#L471-L473"
     },
     {
       "kind": "interface",
@@ -134407,7 +134404,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L42-L60"
+      "specLocation": "ml/_types/TrainedModel.ts#L43-L61"
     },
     {
       "kind": "interface",
@@ -134641,7 +134638,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L62-L107"
+      "specLocation": "ml/_types/TrainedModel.ts#L63-L108"
     },
     {
       "kind": "interface",
@@ -134684,7 +134681,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L109-L113"
+      "specLocation": "ml/_types/TrainedModel.ts#L110-L114"
     },
     {
       "kind": "interface",
@@ -134730,7 +134727,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L438-L445"
+      "specLocation": "ml/_types/TrainedModel.ts#L439-L446"
     },
     {
       "kind": "interface",
@@ -134852,9 +134849,18 @@
           "name": "last_access",
           "required": false,
           "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitNanos",
+                  "namespace": "_types"
+                }
+              }
+            ],
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "EpochTime",
               "namespace": "_types"
             }
           }
@@ -134927,7 +134933,7 @@
               {
                 "kind": "instance_of",
                 "type": {
-                  "name": "UnitMillis",
+                  "name": "UnitNanos",
                   "namespace": "_types"
                 }
               }
@@ -134975,7 +134981,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L144-L189"
+      "specLocation": "ml/_types/TrainedModel.ts#L145-L190"
     },
     {
       "kind": "interface",
@@ -135033,7 +135039,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L418-L436"
+      "specLocation": "ml/_types/TrainedModel.ts#L419-L437"
     },
     {
       "kind": "interface",
@@ -135114,7 +135120,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L115-L135"
+      "specLocation": "ml/_types/TrainedModel.ts#L116-L136"
     },
     {
       "kind": "interface",
@@ -135148,7 +135154,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L137-L142"
+      "specLocation": "ml/_types/TrainedModel.ts#L138-L143"
     },
     {
       "kind": "interface",
@@ -137600,7 +137606,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L447-L464"
+      "specLocation": "ml/_types/TrainedModel.ts#L448-L465"
     },
     {
       "kind": "interface",
@@ -137692,7 +137698,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "ByteSize",
               "namespace": "_types"
             }
           }
@@ -137703,7 +137709,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "long",
+              "name": "ByteSize",
               "namespace": "_types"
             }
           }
@@ -137733,7 +137739,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L357-L393"
+      "specLocation": "ml/_types/TrainedModel.ts#L358-L394"
     },
     {
       "kind": "interface",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -76505,7 +76505,7 @@
         "name": "ClusterInfoTarget",
         "namespace": "_types"
       },
-      "specLocation": "_types/common.ts#L401-L407"
+      "specLocation": "_types/common.ts#L382-L388"
     },
     {
       "kind": "type_alias",
@@ -76513,7 +76513,7 @@
         "name": "ClusterInfoTargets",
         "namespace": "_types"
       },
-      "specLocation": "_types/common.ts#L409-L409",
+      "specLocation": "_types/common.ts#L390-L390",
       "type": {
         "items": [
           {
@@ -77434,7 +77434,7 @@
         "name": "Slices",
         "namespace": "_types"
       },
-      "specLocation": "_types/common.ts#L384-L389",
+      "specLocation": "_types/common.ts#L365-L370",
       "type": {
         "items": [
           {
@@ -77467,7 +77467,7 @@
         "name": "SlicesCalculation",
         "namespace": "_types"
       },
-      "specLocation": "_types/common.ts#L391-L399"
+      "specLocation": "_types/common.ts#L372-L380"
     },
     {
       "kind": "type_alias",
@@ -130902,36 +130902,6 @@
           }
         },
         {
-          "deprecation": {
-            "description": "this value will be replaced by the selector `::*` on the expression level.",
-            "version": "8.16.0"
-          },
-          "name": "exclude",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
-          "deprecation": {
-            "description": "this query param will be replaced by the selector `::` on the expression level.",
-            "version": "8.16.0"
-          },
-          "name": "failure_store",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
           "description": "If true, missing or closed indices are not included in the response.",
           "name": "ignore_unavailable",
           "required": false,
@@ -130956,39 +130926,9 @@
               "namespace": "_builtins"
             }
           }
-        },
-        {
-          "deprecation": {
-            "description": "this value will be replaced by the selector `::*` on the expression level.",
-            "version": "8.16.0"
-          },
-          "name": "include",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
-          "deprecation": {
-            "description": "this value will be replaced by the selector `::*` on the expression level.",
-            "version": "8.16.0"
-          },
-          "name": "only",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
         }
       ],
-      "specLocation": "_types/common.ts#L336-L382"
+      "specLocation": "_types/common.ts#L336-L363"
     },
     {
       "kind": "interface",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -95124,7 +95124,7 @@
         "name": "DeploymentAllocationState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L319-L332"
+      "specLocation": "ml/_types/TrainedModel.ts#L318-L331"
     },
     {
       "kind": "enum",
@@ -95150,7 +95150,7 @@
         "name": "DeploymentAssignmentState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L334-L351"
+      "specLocation": "ml/_types/TrainedModel.ts#L333-L350"
     },
     {
       "kind": "type_alias",
@@ -95495,7 +95495,7 @@
         "name": "RoutingState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L396-L417"
+      "specLocation": "ml/_types/TrainedModel.ts#L395-L416"
     },
     {
       "kind": "enum",
@@ -95576,7 +95576,7 @@
         "name": "TrainedModelType",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L303-L317"
+      "specLocation": "ml/_types/TrainedModel.ts#L302-L316"
     },
     {
       "kind": "enum",
@@ -95592,7 +95592,7 @@
         "name": "TrainingPriority",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L353-L356"
+      "specLocation": "ml/_types/TrainedModel.ts#L352-L355"
     },
     {
       "codegenNames": [
@@ -132739,7 +132739,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L192-L228"
+      "specLocation": "ml/_types/TrainedModel.ts#L191-L227"
     },
     {
       "description": "Inference configuration provided when storing the model config",
@@ -133699,7 +133699,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L230-L233"
+      "specLocation": "ml/_types/TrainedModel.ts#L229-L232"
     },
     {
       "kind": "interface",
@@ -133776,7 +133776,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L235-L243"
+      "specLocation": "ml/_types/TrainedModel.ts#L234-L242"
     },
     {
       "kind": "interface",
@@ -133848,7 +133848,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L262-L276"
+      "specLocation": "ml/_types/TrainedModel.ts#L261-L275"
     },
     {
       "kind": "interface",
@@ -133900,7 +133900,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L278-L285"
+      "specLocation": "ml/_types/TrainedModel.ts#L277-L284"
     },
     {
       "kind": "interface",
@@ -133946,7 +133946,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L294-L301"
+      "specLocation": "ml/_types/TrainedModel.ts#L293-L300"
     },
     {
       "kind": "interface",
@@ -133983,7 +133983,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L287-L292"
+      "specLocation": "ml/_types/TrainedModel.ts#L286-L291"
     },
     {
       "kind": "interface",
@@ -134166,7 +134166,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L245-L260"
+      "specLocation": "ml/_types/TrainedModel.ts#L244-L259"
     },
     {
       "kind": "interface",
@@ -134198,20 +134198,9 @@
               "namespace": "_builtins"
             }
           }
-        },
-        {
-          "name": "none",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L475-L486"
+      "specLocation": "ml/_types/TrainedModel.ts#L474-L483"
     },
     {
       "kind": "interface",
@@ -134232,7 +134221,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L467-L469"
+      "specLocation": "ml/_types/TrainedModel.ts#L466-L468"
     },
     {
       "kind": "interface",
@@ -134253,7 +134242,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L471-L473"
+      "specLocation": "ml/_types/TrainedModel.ts#L470-L472"
     },
     {
       "kind": "interface",
@@ -134344,7 +134333,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L43-L61"
+      "specLocation": "ml/_types/TrainedModel.ts#L42-L60"
     },
     {
       "kind": "interface",
@@ -134367,7 +134356,7 @@
         {
           "description": "The detailed allocation status for the deployment.",
           "name": "allocation_status",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134544,7 +134533,7 @@
         {
           "description": "The overall state of the deployment.",
           "name": "state",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134578,7 +134567,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L63-L108"
+      "specLocation": "ml/_types/TrainedModel.ts#L62-L107"
     },
     {
       "kind": "interface",
@@ -134621,7 +134610,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L110-L114"
+      "specLocation": "ml/_types/TrainedModel.ts#L109-L113"
     },
     {
       "kind": "interface",
@@ -134667,7 +134656,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L439-L446"
+      "specLocation": "ml/_types/TrainedModel.ts#L438-L445"
     },
     {
       "kind": "interface",
@@ -134793,7 +134782,7 @@
               {
                 "kind": "instance_of",
                 "type": {
-                  "name": "UnitNanos",
+                  "name": "UnitMillis",
                   "namespace": "_types"
                 }
               }
@@ -134873,7 +134862,7 @@
               {
                 "kind": "instance_of",
                 "type": {
-                  "name": "UnitNanos",
+                  "name": "UnitMillis",
                   "namespace": "_types"
                 }
               }
@@ -134899,7 +134888,7 @@
         },
         {
           "name": "throughput_last_minute",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134921,7 +134910,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L145-L190"
+      "specLocation": "ml/_types/TrainedModel.ts#L144-L189"
     },
     {
       "kind": "interface",
@@ -134957,7 +134946,7 @@
         {
           "description": "Current number of allocations.",
           "name": "current_allocations",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134969,7 +134958,7 @@
         {
           "description": "Target number of allocations.",
           "name": "target_allocations",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134979,7 +134968,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L419-L437"
+      "specLocation": "ml/_types/TrainedModel.ts#L418-L436"
     },
     {
       "kind": "interface",
@@ -135060,7 +135049,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L116-L136"
+      "specLocation": "ml/_types/TrainedModel.ts#L115-L135"
     },
     {
       "kind": "interface",
@@ -135094,7 +135083,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L138-L143"
+      "specLocation": "ml/_types/TrainedModel.ts#L137-L142"
     },
     {
       "kind": "interface",
@@ -137546,7 +137535,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L448-L465"
+      "specLocation": "ml/_types/TrainedModel.ts#L447-L464"
     },
     {
       "kind": "interface",
@@ -137562,7 +137551,7 @@
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "ByteSize",
               "namespace": "_types"
             }
           }
@@ -137679,7 +137668,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L358-L394"
+      "specLocation": "ml/_types/TrainedModel.ts#L357-L393"
     },
     {
       "kind": "interface",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -94936,7 +94936,7 @@
         "name": "CategorizationStatus",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/Model.ts#L84-L87"
+      "specLocation": "ml/_types/Model.ts#L83-L86"
     },
     {
       "kind": "enum",
@@ -94955,7 +94955,7 @@
         "name": "ChunkingMode",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/Datafeed.ts#L235-L239"
+      "specLocation": "ml/_types/Datafeed.ts#L245-L249"
     },
     {
       "kind": "enum",
@@ -95011,7 +95011,7 @@
         "name": "DatafeedState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/Datafeed.ts#L135-L140"
+      "specLocation": "ml/_types/Datafeed.ts#L136-L141"
     },
     {
       "kind": "enum",
@@ -95220,7 +95220,7 @@
         "name": "MemoryStatus",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/Model.ts#L89-L93"
+      "specLocation": "ml/_types/Model.ts#L88-L92"
     },
     {
       "kind": "type_alias",
@@ -95280,7 +95280,7 @@
         "name": "RoutingState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L371-L392"
+      "specLocation": "ml/_types/TrainedModel.ts#L374-L395"
     },
     {
       "kind": "enum",
@@ -95320,7 +95320,7 @@
         "name": "SnapshotUpgradeState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/Model.ts#L95-L100"
+      "specLocation": "ml/_types/Model.ts#L94-L99"
     },
     {
       "kind": "enum",
@@ -130002,7 +130002,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/Datafeed.ts#L142-L171"
+      "specLocation": "ml/_types/Datafeed.ts#L143-L172"
     },
     {
       "kind": "interface",
@@ -130041,6 +130041,17 @@
             "type": {
               "name": "DurationValue",
               "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "exponential_average_calculation_context",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "ExponentialAverageCalculationContext",
+              "namespace": "ml._types"
             }
           }
         },
@@ -130111,7 +130122,68 @@
           }
         }
       ],
-      "specLocation": "ml/_types/Datafeed.ts#L173-L198"
+      "specLocation": "ml/_types/Datafeed.ts#L174-L202"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "ExponentialAverageCalculationContext",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "incremental_metric_value_ms",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "double",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "latest_timestamp",
+          "required": false,
+          "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "instance_of",
+            "type": {
+              "name": "EpochTime",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "previous_exponential_average_ms",
+          "required": false,
+          "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitFloatMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "instance_of",
+            "type": {
+              "name": "DurationValue",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "specLocation": "ml/_types/Datafeed.ts#L204-L208"
     },
     {
       "kind": "interface",
@@ -130157,7 +130229,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/Datafeed.ts#L200-L214"
+      "specLocation": "ml/_types/Datafeed.ts#L210-L224"
     },
     {
       "kind": "interface",
@@ -130233,7 +130305,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/Datafeed.ts#L216-L233"
+      "specLocation": "ml/_types/Datafeed.ts#L226-L243"
     },
     {
       "kind": "interface",
@@ -130453,7 +130525,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/Datafeed.ts#L36-L60"
+      "specLocation": "ml/_types/Datafeed.ts#L37-L61"
     },
     {
       "kind": "interface",
@@ -130537,7 +130609,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/Datafeed.ts#L241-L254"
+      "specLocation": "ml/_types/Datafeed.ts#L251-L264"
     },
     {
       "kind": "interface",
@@ -130571,7 +130643,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/Datafeed.ts#L121-L132"
+      "specLocation": "ml/_types/Datafeed.ts#L122-L133"
     },
     {
       "description": "Controls how to deal with unavailable concrete indices (closed or missing), how wildcard expressions are expanded\nto actual indices (all, closed or open indices) and how to deal with wildcard expressions that resolve to no indices.",
@@ -131400,7 +131472,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/Model.ts#L60-L82"
+      "specLocation": "ml/_types/Model.ts#L59-L81"
     },
     {
       "kind": "interface",
@@ -133628,7 +133700,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L440-L442"
+      "specLocation": "ml/_types/TrainedModel.ts#L445-L447"
     },
     {
       "kind": "interface",
@@ -133649,7 +133721,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L444-L446"
+      "specLocation": "ml/_types/TrainedModel.ts#L449-L451"
     },
     {
       "kind": "interface",
@@ -133683,7 +133755,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L448-L457"
+      "specLocation": "ml/_types/TrainedModel.ts#L453-L462"
     },
     {
       "kind": "interface",
@@ -134086,7 +134158,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L414-L421"
+      "specLocation": "ml/_types/TrainedModel.ts#L417-L424"
     },
     {
       "kind": "interface",
@@ -134389,7 +134461,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L394-L412"
+      "specLocation": "ml/_types/TrainedModel.ts#L397-L415"
     },
     {
       "kind": "interface",
@@ -135642,7 +135714,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/Datafeed.ts#L62-L119"
+      "specLocation": "ml/_types/Datafeed.ts#L63-L120"
     },
     {
       "kind": "interface",
@@ -136853,6 +136925,29 @@
       },
       "properties": [
         {
+          "name": "adaptive_allocations",
+          "required": false,
+          "type": {
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "AdaptiveAllocationsSettings",
+                  "namespace": "ml._types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "null",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
+          }
+        },
+        {
           "description": "The overall assignment state.",
           "name": "assignment_state",
           "required": true,
@@ -136872,6 +136967,17 @@
             "type": {
               "name": "integer",
               "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "reason",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
             }
           }
         },
@@ -136922,7 +137028,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L423-L438"
+      "specLocation": "ml/_types/TrainedModel.ts#L426-L443"
     },
     {
       "kind": "interface",
@@ -136976,7 +137082,7 @@
           },
           "description": "The size of the trained model cache.",
           "name": "cache_size",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -137009,6 +137115,28 @@
           }
         },
         {
+          "name": "per_deployment_memory_bytes",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "per_allocation_memory_bytes",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "description": "Number of inference requests are allowed in the queue at a time.",
           "name": "queue_capacity",
           "required": true,
@@ -137033,7 +137161,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L336-L369"
+      "specLocation": "ml/_types/TrainedModel.ts#L336-L372"
     },
     {
       "kind": "interface",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -94936,7 +94936,7 @@
         "name": "CategorizationStatus",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/Model.ts#L83-L86"
+      "specLocation": "ml/_types/Model.ts#L84-L87"
     },
     {
       "kind": "enum",
@@ -95058,7 +95058,7 @@
         "name": "DeploymentAllocationState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L273-L286"
+      "specLocation": "ml/_types/TrainedModel.ts#L297-L310"
     },
     {
       "kind": "enum",
@@ -95084,7 +95084,7 @@
         "name": "DeploymentAssignmentState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L288-L305"
+      "specLocation": "ml/_types/TrainedModel.ts#L312-L329"
     },
     {
       "kind": "enum",
@@ -95220,7 +95220,7 @@
         "name": "MemoryStatus",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/Model.ts#L88-L92"
+      "specLocation": "ml/_types/Model.ts#L89-L93"
     },
     {
       "kind": "type_alias",
@@ -95280,7 +95280,7 @@
         "name": "RoutingState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L347-L368"
+      "specLocation": "ml/_types/TrainedModel.ts#L371-L392"
     },
     {
       "kind": "enum",
@@ -95320,7 +95320,7 @@
         "name": "SnapshotUpgradeState",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/Model.ts#L94-L99"
+      "specLocation": "ml/_types/Model.ts#L95-L100"
     },
     {
       "kind": "enum",
@@ -95361,7 +95361,7 @@
         "name": "TrainedModelType",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L257-L271"
+      "specLocation": "ml/_types/TrainedModel.ts#L281-L295"
     },
     {
       "kind": "enum",
@@ -95377,7 +95377,7 @@
         "name": "TrainingPriority",
         "namespace": "ml._types"
       },
-      "specLocation": "ml/_types/TrainedModel.ts#L307-L310"
+      "specLocation": "ml/_types/TrainedModel.ts#L331-L334"
     },
     {
       "codegenNames": [
@@ -128128,9 +128128,20 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "name": "_meta",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Metadata",
+              "namespace": "_types"
+            }
+          }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L305-L321"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L306-L323"
     },
     {
       "kind": "interface",
@@ -128182,7 +128193,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L83-L100",
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L84-L101",
       "variants": {
         "kind": "container"
       }
@@ -128225,7 +128236,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L226-L235"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L227-L236"
     },
     {
       "kind": "interface",
@@ -128460,7 +128471,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L133-L212"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L134-L213"
     },
     {
       "kind": "interface",
@@ -128530,7 +128541,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L245-L257",
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L246-L258",
       "variants": {
         "kind": "container"
       }
@@ -128589,7 +128600,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L259-L266"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L260-L267"
     },
     {
       "kind": "interface",
@@ -128614,7 +128625,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L268-L271"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L269-L272"
     },
     {
       "kind": "interface",
@@ -128698,7 +128709,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L273-L285"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L274-L286"
     },
     {
       "kind": "interface",
@@ -128732,7 +128743,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L287-L292"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L288-L293"
     },
     {
       "kind": "interface",
@@ -128797,7 +128808,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L294-L303"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L295-L304"
     },
     {
       "kind": "interface",
@@ -128883,7 +128894,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L102-L131"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L103-L132"
     },
     {
       "inherits": {
@@ -128924,7 +128935,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L214-L224"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L215-L225"
     },
     {
       "kind": "interface",
@@ -128965,7 +128976,7 @@
         }
       ],
       "shortcutProperty": "includes",
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L237-L243"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L238-L244"
     },
     {
       "kind": "interface",
@@ -129082,7 +129093,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L76-L81"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L77-L82"
     },
     {
       "kind": "interface",
@@ -129142,7 +129153,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L38-L52"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L39-L53"
     },
     {
       "kind": "interface",
@@ -129239,7 +129250,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L323-L343"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L325-L345"
     },
     {
       "kind": "interface",
@@ -129285,7 +129296,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L372-L380",
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L374-L382",
       "variants": {
         "kind": "container"
       }
@@ -129367,7 +129378,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L382-L401"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L384-L403"
     },
     {
       "kind": "interface",
@@ -129545,7 +129556,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L418-L524"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L420-L526"
     },
     {
       "kind": "interface",
@@ -129597,7 +129608,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L562-L567"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L564-L569"
     },
     {
       "kind": "interface",
@@ -129634,7 +129645,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L569-L574"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L571-L576"
     },
     {
       "kind": "interface",
@@ -129689,7 +129700,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L403-L416"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L405-L418"
     },
     {
       "kind": "interface",
@@ -129774,7 +129785,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L526-L560"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L528-L562"
     },
     {
       "kind": "interface",
@@ -129820,7 +129831,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L363-L370"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L365-L372"
     },
     {
       "kind": "interface",
@@ -129887,7 +129898,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L352-L361"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L354-L363"
     },
     {
       "kind": "interface",
@@ -129921,7 +129932,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/DataframeAnalytics.ts#L345-L350"
+      "specLocation": "ml/_types/DataframeAnalytics.ts#L347-L352"
     },
     {
       "kind": "interface",
@@ -129969,7 +129980,7 @@
         {
           "description": "An object that provides statistical information about timing aspect of this datafeed.",
           "name": "timing_stats",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -131389,7 +131400,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/Model.ts#L59-L81"
+      "specLocation": "ml/_types/Model.ts#L60-L82"
     },
     {
       "kind": "interface",
@@ -132410,7 +132421,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L164-L199"
+      "specLocation": "ml/_types/TrainedModel.ts#L188-L223"
     },
     {
       "description": "Inference configuration provided when storing the model config",
@@ -133312,7 +133323,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L201-L204"
+      "specLocation": "ml/_types/TrainedModel.ts#L225-L228"
     },
     {
       "kind": "interface",
@@ -133389,7 +133400,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L206-L214"
+      "specLocation": "ml/_types/TrainedModel.ts#L230-L238"
     },
     {
       "kind": "interface",
@@ -133461,7 +133472,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L216-L230"
+      "specLocation": "ml/_types/TrainedModel.ts#L240-L254"
     },
     {
       "kind": "interface",
@@ -133513,7 +133524,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L232-L239"
+      "specLocation": "ml/_types/TrainedModel.ts#L256-L263"
     },
     {
       "kind": "interface",
@@ -133559,7 +133570,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L248-L255"
+      "specLocation": "ml/_types/TrainedModel.ts#L272-L279"
     },
     {
       "kind": "interface",
@@ -133596,7 +133607,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L241-L246"
+      "specLocation": "ml/_types/TrainedModel.ts#L265-L270"
     },
     {
       "kind": "interface",
@@ -133617,7 +133628,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L416-L418"
+      "specLocation": "ml/_types/TrainedModel.ts#L440-L442"
     },
     {
       "kind": "interface",
@@ -133638,7 +133649,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L420-L422"
+      "specLocation": "ml/_types/TrainedModel.ts#L444-L446"
     },
     {
       "kind": "interface",
@@ -133672,7 +133683,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L424-L433"
+      "specLocation": "ml/_types/TrainedModel.ts#L448-L457"
     },
     {
       "kind": "interface",
@@ -133773,6 +133784,17 @@
       },
       "properties": [
         {
+          "name": "adaptive_allocations",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "AdaptiveAllocationsSettings",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
           "description": "The detailed allocation status for the deployment.",
           "name": "allocation_status",
           "required": true,
@@ -133810,7 +133832,7 @@
         {
           "description": "The sum of `error_count` for all nodes in the deployment.",
           "name": "error_count",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133822,7 +133844,7 @@
         {
           "description": "The sum of `inference_count` for all nodes in the deployment.",
           "name": "inference_count",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133861,7 +133883,7 @@
         {
           "description": "The number of allocations requested.",
           "name": "number_of_allocations",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133871,9 +133893,20 @@
           }
         },
         {
+          "name": "priority",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "TrainingPriority",
+              "namespace": "ml._types"
+            }
+          }
+        },
+        {
           "description": "The number of inference requests that can be queued before new requests are rejected.",
           "name": "queue_capacity",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133885,7 +133918,7 @@
         {
           "description": "The sum of `rejected_execution_count` for all nodes in the deployment.\nIndividual nodes reject an inference request if the inference queue is full.\nThe queue size is controlled by the `queue_capacity` setting in the start\ntrained model deployment API.",
           "name": "rejected_execution_count",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133897,7 +133930,7 @@
         {
           "description": "The reason for the current deployment state. Usually only populated when\nthe model is not deployed to a node.",
           "name": "reason",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133942,7 +133975,7 @@
         {
           "description": "The number of threads used be each allocation during inference.",
           "name": "threads_per_allocation",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133954,7 +133987,7 @@
         {
           "description": "The sum of `timeout_count` for all nodes in the deployment.",
           "name": "timeout_count",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -133964,7 +133997,50 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L61-L101"
+      "specLocation": "ml/_types/TrainedModel.ts#L61-L104"
+    },
+    {
+      "kind": "interface",
+      "name": {
+        "name": "AdaptiveAllocationsSettings",
+        "namespace": "ml._types"
+      },
+      "properties": [
+        {
+          "name": "enabled",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "name": "min_number_of_allocations",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "max_number_of_allocations",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "specLocation": "ml/_types/TrainedModel.ts#L106-L110"
     },
     {
       "kind": "interface",
@@ -134010,7 +134086,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L390-L397"
+      "specLocation": "ml/_types/TrainedModel.ts#L414-L421"
     },
     {
       "kind": "interface",
@@ -134022,7 +134098,48 @@
         {
           "description": "The average time for each inference call to complete on this node.",
           "name": "average_inference_time_ms",
-          "required": true,
+          "required": false,
+          "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitFloatMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "instance_of",
+            "type": {
+              "name": "DurationValue",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "average_inference_time_ms_last_minute",
+          "required": false,
+          "type": {
+            "generics": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "UnitFloatMillis",
+                  "namespace": "_types"
+                }
+              }
+            ],
+            "kind": "instance_of",
+            "type": {
+              "name": "DurationValue",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The average time for each inference call to complete on this node, excluding cache",
+          "name": "average_inference_time_ms_excluding_cache_hits",
+          "required": false,
           "type": {
             "generics": [
               {
@@ -134043,7 +134160,7 @@
         {
           "description": "The number of errors when evaluating the trained model.",
           "name": "error_count",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134055,11 +134172,33 @@
         {
           "description": "The total number of inference calls made against this node for this model.",
           "name": "inference_count",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "integer",
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "inference_cache_hit_count",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "inference_cache_hit_count_last_minute",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
               "namespace": "_types"
             }
           }
@@ -134067,7 +134206,7 @@
         {
           "description": "The epoch time stamp of the last inference call for the model on this node.",
           "name": "last_access",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134079,7 +134218,7 @@
         {
           "description": "The number of allocations assigned to this node.",
           "name": "number_of_allocations",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134091,7 +134230,7 @@
         {
           "description": "The number of inference requests queued to be processed.",
           "name": "number_of_pending_requests",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134101,9 +134240,20 @@
           }
         },
         {
+          "name": "peak_throughput_per_minute",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "long",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
           "description": "The number of inference requests that were not processed because the queue was full.",
           "name": "rejection_execution_count",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134127,7 +134277,7 @@
         {
           "description": "The epoch timestamp when the allocation started.",
           "name": "start_time",
-          "required": true,
+          "required": false,
           "type": {
             "generics": [
               {
@@ -134148,7 +134298,18 @@
         {
           "description": "The number of threads used by each allocation during inference.",
           "name": "threads_per_allocation",
-          "required": true,
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "throughput_last_minute",
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134160,7 +134321,7 @@
         {
           "description": "The number of inference requests that timed out before being processed.",
           "name": "timeout_count",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134170,7 +134331,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L132-L162"
+      "specLocation": "ml/_types/TrainedModel.ts#L141-L186"
     },
     {
       "kind": "interface",
@@ -134182,7 +134343,7 @@
         {
           "description": "The reason for the current state. It is usually populated only when the\n`routing_state` is `failed`.",
           "name": "reason",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134206,7 +134367,7 @@
         {
           "description": "Current number of allocations.",
           "name": "current_allocations",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134218,7 +134379,7 @@
         {
           "description": "Target number of allocations.",
           "name": "target_allocations",
-          "required": true,
+          "required": false,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -134228,7 +134389,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L370-L388"
+      "specLocation": "ml/_types/TrainedModel.ts#L394-L412"
     },
     {
       "kind": "interface",
@@ -134309,7 +134470,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L103-L123"
+      "specLocation": "ml/_types/TrainedModel.ts#L112-L132"
     },
     {
       "kind": "interface",
@@ -134343,7 +134504,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L125-L130"
+      "specLocation": "ml/_types/TrainedModel.ts#L134-L139"
     },
     {
       "kind": "interface",
@@ -136761,7 +136922,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L399-L414"
+      "specLocation": "ml/_types/TrainedModel.ts#L423-L438"
     },
     {
       "kind": "interface",
@@ -136872,7 +137033,7 @@
           }
         }
       ],
-      "specLocation": "ml/_types/TrainedModel.ts#L312-L345"
+      "specLocation": "ml/_types/TrainedModel.ts#L336-L369"
     },
     {
       "kind": "interface",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -95220,7 +95220,7 @@
         },
         {
           "name": "external_id",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -95231,7 +95231,7 @@
         },
         {
           "name": "attributes",
-          "required": false,
+          "required": true,
           "type": {
             "key": {
               "kind": "instance_of",
@@ -95253,7 +95253,7 @@
         },
         {
           "name": "roles",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "array_of",
             "value": {
@@ -95267,7 +95267,7 @@
         },
         {
           "name": "version",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -95278,7 +95278,7 @@
         },
         {
           "name": "min_index_version",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -95289,7 +95289,7 @@
         },
         {
           "name": "max_index_version",
-          "required": false,
+          "required": true,
           "type": {
             "kind": "instance_of",
             "type": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -854,12 +854,6 @@
       ],
       "response": []
     },
-    "ml.get_trained_models": {
-      "request": [
-        "Request: missing json spec query parameter 'include_model_definition'"
-      ],
-      "response": []
-    },
     "ml.put_job": {
       "request": [
         "Request: missing json spec query parameter 'ignore_unavailable'",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -858,7 +858,6 @@
       "request": [
         "Request: missing json spec query parameter 'ignore_unavailable'",
         "Request: missing json spec query parameter 'allow_no_indices'",
-        "Request: missing json spec query parameter 'ignore_throttled'",
         "Request: missing json spec query parameter 'expand_wildcards'"
       ],
       "response": []

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -854,14 +854,6 @@
       ],
       "response": []
     },
-    "ml.put_job": {
-      "request": [
-        "Request: missing json spec query parameter 'ignore_unavailable'",
-        "Request: missing json spec query parameter 'allow_no_indices'",
-        "Request: missing json spec query parameter 'expand_wildcards'"
-      ],
-      "response": []
-    },
     "ml.stop_datafeed": {
       "request": [
         "Request: missing json spec query parameter 'allow_no_datafeeds'"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13812,6 +13812,14 @@ export interface MlClassificationInferenceOptions {
   top_classes_results_field?: string
 }
 
+export interface MlCommonTokenizationConfig {
+  do_lower_case?: boolean
+  max_sequence_length?: integer
+  span?: integer
+  truncate?: MlTokenizationTruncate
+  with_special_tokens?: boolean
+}
+
 export type MlConditionOperator = 'gt' | 'gte' | 'lt' | 'lte'
 
 export type MlCustomSettings = any
@@ -14249,7 +14257,7 @@ export interface MlFillMaskInferenceOptions {
   num_top_classes?: integer
   tokenization?: MlTokenizationConfigContainer
   results_field?: string
-  vocabulary?: MlVocabulary
+  vocabulary: MlVocabulary
 }
 
 export interface MlFillMaskInferenceUpdateOptions {
@@ -14538,21 +14546,11 @@ export interface MlNerInferenceUpdateOptions {
   results_field?: string
 }
 
-export interface MlNlpBertTokenizationConfig {
-  do_lower_case?: boolean
-  with_special_tokens?: boolean
-  max_sequence_length?: integer
-  truncate?: MlTokenizationTruncate
-  span?: integer
+export interface MlNlpBertTokenizationConfig extends MlCommonTokenizationConfig {
 }
 
-export interface MlNlpRobertaTokenizationConfig {
-  do_lower_case?: boolean
+export interface MlNlpRobertaTokenizationConfig extends MlCommonTokenizationConfig {
   add_prefix_space?: boolean
-  with_special_tokens?: boolean
-  max_sequence_length?: integer
-  truncate?: MlTokenizationTruncate
-  span?: integer
 }
 
 export interface MlNlpTokenizationUpdateOptions {
@@ -14664,7 +14662,7 @@ export interface MlTextEmbeddingInferenceOptions {
   embedding_size?: integer
   tokenization?: MlTokenizationConfigContainer
   results_field?: string
-  vocabulary?: MlVocabulary
+  vocabulary: MlVocabulary
 }
 
 export interface MlTextEmbeddingInferenceUpdateOptions {
@@ -14675,7 +14673,7 @@ export interface MlTextEmbeddingInferenceUpdateOptions {
 export interface MlTextExpansionInferenceOptions {
   tokenization?: MlTokenizationConfigContainer
   results_field?: string
-  vocabulary?: MlVocabulary
+  vocabulary: MlVocabulary
 }
 
 export interface MlTextExpansionInferenceUpdateOptions {
@@ -15582,10 +15580,10 @@ export interface MlInfoDefaults {
 
 export interface MlInfoLimits {
   max_single_ml_node_processors?: integer
-  max_model_memory_limit?: ByteSize
-  effective_max_model_memory_limit: ByteSize
-  total_ml_memory: string
   total_ml_processors?: integer
+  max_model_memory_limit?: ByteSize
+  effective_max_model_memory_limit?: ByteSize
+  total_ml_memory: ByteSize
 }
 
 export interface MlInfoNativeCode {
@@ -15635,21 +15633,24 @@ export interface MlPostDataRequest<TData = unknown> extends RequestBase {
 }
 
 export interface MlPostDataResponse {
-  bucket_count: long
-  earliest_record_timestamp?: EpochTime<UnitMillis>
-  empty_bucket_count: long
+  job_id: Id
+  processed_record_count: long
+  processed_field_count: long
   input_bytes: long
   input_field_count: long
-  input_record_count: long
   invalid_date_count: long
-  job_id: Id
-  last_data_time?: integer
-  latest_record_timestamp?: EpochTime<UnitMillis>
   missing_field_count: long
   out_of_order_timestamp_count: long
-  processed_field_count: long
-  processed_record_count: long
+  empty_bucket_count: long
   sparse_bucket_count: long
+  bucket_count: long
+  earliest_record_timestamp?: EpochTime<UnitMillis>
+  latest_record_timestamp?: EpochTime<UnitMillis>
+  last_data_time?: EpochTime<UnitMillis>
+  latest_empty_bucket_timestamp?: EpochTime<UnitMillis>
+  latest_sparse_bucket_timestamp?: EpochTime<UnitMillis>
+  input_record_count: long
+  log_time?: EpochTime<UnitMillis>
 }
 
 export interface MlPreviewDataFrameAnalyticsDataframePreviewConfig {
@@ -15801,7 +15802,10 @@ export interface MlPutFilterResponse {
 
 export interface MlPutJobRequest extends RequestBase {
   job_id: Id
+  allow_no_indices?: boolean
+  expand_wildcards?: ExpandWildcards
   ignore_throttled?: boolean
+  ignore_unavailable?: boolean
   body?: {
     allow_lazy_open?: boolean
     analysis_config: MlAnalysisConfig

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13664,7 +13664,7 @@ export interface MlAnalysisConfigRead {
 
 export interface MlAnalysisLimits {
   categorization_examples_limit?: long
-  model_memory_limit?: string | long
+  model_memory_limit?: ByteSize
 }
 
 export interface MlAnalysisMemoryLimit {
@@ -14243,7 +14243,7 @@ export interface MlDiscoveryNodeContent {
 export type MlExcludeFrequent = 'all' | 'none' | 'by' | 'over'
 
 export interface MlExponentialAverageCalculationContext {
-  incremental_metric_value_ms: double
+  incremental_metric_value_ms: DurationValue<UnitFloatMillis>
   latest_timestamp?: EpochTime<UnitMillis>
   previous_exponential_average_ms?: DurationValue<UnitFloatMillis>
 }
@@ -14472,7 +14472,7 @@ export interface MlModelPackageConfig {
   packaged_model_id: Id
   platform_architecture?: string
   prefix_strings?: MlTrainedModelPrefixStrings
-  size?: long
+  size?: ByteSize
   sha256?: string
   tags?: string[]
   vocabulary_file?: string
@@ -14492,7 +14492,7 @@ export interface MlModelSizeStats {
   model_bytes: ByteSize
   model_bytes_exceeded?: ByteSize
   model_bytes_memory_limit?: ByteSize
-  output_memory_allocator_bytes?: long
+  output_memory_allocator_bytes?: ByteSize
   peak_model_bytes?: ByteSize
   assignment_memory_basis?: string
   result_type: string
@@ -14748,8 +14748,8 @@ export interface MlTrainedModelAssignmentTaskParameters {
   cache_size?: ByteSize
   number_of_allocations: integer
   priority: MlTrainingPriority
-  per_deployment_memory_bytes: long
-  per_allocation_memory_bytes: long
+  per_deployment_memory_bytes: ByteSize
+  per_allocation_memory_bytes: ByteSize
   queue_capacity: integer
   threads_per_allocation: integer
 }
@@ -14802,14 +14802,14 @@ export interface MlTrainedModelDeploymentNodesStats {
   inference_count?: long
   inference_cache_hit_count?: long
   inference_cache_hit_count_last_minute?: long
-  last_access?: long
+  last_access?: EpochTime<UnitNanos>
   node?: MlDiscoveryNode
   number_of_allocations?: integer
   number_of_pending_requests?: integer
   peak_throughput_per_minute: long
   rejection_execution_count?: integer
   routing_state: MlTrainedModelAssignmentRoutingTable
-  start_time?: EpochTime<UnitMillis>
+  start_time?: EpochTime<UnitNanos>
   threads_per_allocation?: integer
   throughput_last_minute?: integer
   timeout_count?: integer
@@ -15587,8 +15587,8 @@ export interface MlInfoDefaults {
 
 export interface MlInfoLimits {
   max_single_ml_node_processors?: integer
-  max_model_memory_limit?: string
-  effective_max_model_memory_limit: string
+  max_model_memory_limit?: ByteSize
+  effective_max_model_memory_limit: ByteSize
   total_ml_memory: string
   total_ml_processors?: integer
 }
@@ -15641,7 +15641,7 @@ export interface MlPostDataRequest<TData = unknown> extends RequestBase {
 
 export interface MlPostDataResponse {
   bucket_count: long
-  earliest_record_timestamp?: long
+  earliest_record_timestamp?: EpochTime<UnitMillis>
   empty_bucket_count: long
   input_bytes: long
   input_field_count: long
@@ -15649,7 +15649,7 @@ export interface MlPostDataResponse {
   invalid_date_count: long
   job_id: Id
   last_data_time?: integer
-  latest_record_timestamp?: long
+  latest_record_timestamp?: EpochTime<UnitMillis>
   missing_field_count: long
   out_of_order_timestamp_count: long
   processed_field_count: long

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14201,11 +14201,15 @@ export interface MlDetectorRead {
 }
 
 export interface MlDiscoveryNode {
-  attributes: Record<string, string>
+  name?: Name
   ephemeral_id: Id
-  id: Id
-  name: Name
   transport_address: TransportAddress
+  external_id?: string
+  attributes?: Record<string, string>
+  roles: string[]
+  version?: VersionString
+  min_index_version?: integer
+  max_index_version?: integer
 }
 
 export type MlExcludeFrequent = 'all' | 'none' | 'by' | 'over'

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14225,19 +14225,19 @@ export interface MlDiscoveryNodeCompact {
   ephemeral_id: Id
   id: Id
   transport_address: TransportAddress
-  attributes?: Record<string, string>
+  attributes: Record<string, string>
 }
 
 export interface MlDiscoveryNodeContent {
   name?: Name
   ephemeral_id: Id
   transport_address: TransportAddress
-  external_id?: string
-  attributes?: Record<string, string>
-  roles?: string[]
-  version?: VersionString
-  min_index_version?: integer
-  max_index_version?: integer
+  external_id: string
+  attributes: Record<string, string>
+  roles: string[]
+  version: VersionString
+  min_index_version: integer
+  max_index_version: integer
 }
 
 export type MlExcludeFrequent = 'all' | 'none' | 'by' | 'over'

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2468,12 +2468,8 @@ export type Indices = IndexName | IndexName[]
 export interface IndicesOptions {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
-  exclude?: string
-  failure_store?: string
   ignore_unavailable?: boolean
   ignore_throttled?: boolean
-  include?: string
-  only?: string
 }
 
 export interface IndicesResponseBase extends AcknowledgedResponseBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13901,7 +13901,7 @@ export type MlDatafeedState = 'started' | 'stopped' | 'starting' | 'stopping'
 export interface MlDatafeedStats {
   assignment_explanation?: string
   datafeed_id: Id
-  node?: Record<Id, MlDiscoveryNode>
+  node?: MlDiscoveryNode
   state: MlDatafeedState
   timing_stats?: MlDatafeedTimingStats
   running_state?: MlDatafeedRunningState
@@ -13910,6 +13910,7 @@ export interface MlDatafeedStats {
 export interface MlDatafeedTimingStats {
   bucket_count: long
   exponential_average_search_time_per_hour_ms: DurationValue<UnitFloatMillis>
+  exponential_average_calculation_context?: MlExponentialAverageCalculationContext
   job_id: Id
   search_count: long
   total_search_time_ms: DurationValue<UnitFloatMillis>
@@ -14210,16 +14211,23 @@ export interface MlDetectorRead {
 export interface MlDiscoveryNode {
   name?: Name
   ephemeral_id: Id
+  id?: Id
   transport_address: TransportAddress
   external_id?: string
   attributes?: Record<string, string>
-  roles: string[]
+  roles?: string[]
   version?: VersionString
   min_index_version?: integer
   max_index_version?: integer
 }
 
 export type MlExcludeFrequent = 'all' | 'none' | 'by' | 'over'
+
+export interface MlExponentialAverageCalculationContext {
+  incremental_metric_value_ms: double
+  latest_timestamp?: EpochTime<UnitMillis>
+  previous_exponential_average_ms?: DurationValue<UnitFloatMillis>
+}
 
 export interface MlFillMaskInferenceOptions {
   mask_token?: string
@@ -14413,7 +14421,7 @@ export interface MlJobStats {
   forecasts_stats: MlJobForecastStatistics
   job_id: string
   model_size_stats: MlModelSizeStats
-  node?: Record<Id, MlDiscoveryNode>
+  node?: MlDiscoveryNode
   open_time?: DateTime
   state: MlJobState
   timing_stats: MlJobTimingStats
@@ -14480,7 +14488,7 @@ export interface MlModelSnapshotUpgrade {
   job_id: Id
   snapshot_id: Id
   state: MlSnapshotUpgradeState
-  node: Record<Id, MlDiscoveryNode>
+  node: MlDiscoveryNode
   assignment_explanation: string
 }
 
@@ -14675,8 +14683,10 @@ export interface MlTotalFeatureImportanceStatistics {
 }
 
 export interface MlTrainedModelAssignment {
+  adaptive_allocations?: MlAdaptiveAllocationsSettings | null
   assignment_state: MlDeploymentAssignmentState
   max_assigned_allocations?: integer
+  reason?: string
   routing_table: Record<string, MlTrainedModelAssignmentRoutingTable>
   start_time: DateTime
   task_parameters: MlTrainedModelAssignmentTaskParameters
@@ -14693,9 +14703,11 @@ export interface MlTrainedModelAssignmentTaskParameters {
   model_bytes: integer
   model_id: Id
   deployment_id: Id
-  cache_size: ByteSize
+  cache_size?: ByteSize
   number_of_allocations: integer
   priority: MlTrainingPriority
+  per_deployment_memory_bytes: long
+  per_allocation_memory_bytes: long
   queue_capacity: integer
   threads_per_allocation: integer
 }
@@ -14748,7 +14760,7 @@ export interface MlTrainedModelDeploymentNodesStats {
   inference_cache_hit_count?: long
   inference_cache_hit_count_last_minute?: long
   last_access?: long
-  node?: Record<Id, MlDiscoveryNode>
+  node?: MlDiscoveryNode
   number_of_allocations?: integer
   number_of_pending_requests?: integer
   peak_throughput_per_minute: long

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13664,7 +13664,7 @@ export interface MlAnalysisConfigRead {
 
 export interface MlAnalysisLimits {
   categorization_examples_limit?: long
-  model_memory_limit?: string
+  model_memory_limit?: string | long
 }
 
 export interface MlAnalysisMemoryLimit {
@@ -15524,6 +15524,7 @@ export interface MlGetTrainedModelsRequest extends RequestBase {
   exclude_generated?: boolean
   from?: integer
   include?: MlInclude
+  include_model_definition?: boolean
   size?: integer
   tags?: string | string[]
 }
@@ -15576,9 +15577,11 @@ export interface MlInfoDefaults {
 }
 
 export interface MlInfoLimits {
+  max_single_ml_node_processors?: integer
   max_model_memory_limit?: string
   effective_max_model_memory_limit: string
   total_ml_memory: string
+  total_ml_processors?: integer
 }
 
 export interface MlInfoNativeCode {
@@ -15629,15 +15632,15 @@ export interface MlPostDataRequest<TData = unknown> extends RequestBase {
 
 export interface MlPostDataResponse {
   bucket_count: long
-  earliest_record_timestamp: long
+  earliest_record_timestamp?: long
   empty_bucket_count: long
   input_bytes: long
   input_field_count: long
   input_record_count: long
   invalid_date_count: long
   job_id: Id
-  last_data_time: integer
-  latest_record_timestamp: long
+  last_data_time?: integer
+  latest_record_timestamp?: long
   missing_field_count: long
   out_of_order_timestamp_count: long
   processed_field_count: long
@@ -15710,6 +15713,7 @@ export interface MlPutDataFrameAnalyticsRequest extends RequestBase {
     description?: string
     dest: MlDataframeAnalyticsDestination
     max_num_threads?: integer
+    _meta?: Metadata
     model_memory_limit?: string
     source: MlDataframeAnalyticsSource
     headers?: HttpHeaders
@@ -15727,6 +15731,7 @@ export interface MlPutDataFrameAnalyticsResponse {
   dest: MlDataframeAnalyticsDestination
   id: Id
   max_num_threads: integer
+  _meta?: Metadata
   model_memory_limit: string
   source: MlDataframeAnalyticsSource
   version: VersionString
@@ -15740,6 +15745,7 @@ export interface MlPutDatafeedRequest extends RequestBase {
   ignore_unavailable?: boolean
   body?: {
     aggregations?: Record<string, AggregationsAggregationContainer>
+    aggs?: Record<string, AggregationsAggregationContainer>
     chunking_config?: MlChunkingConfig
     delayed_data_check_config?: MlDelayedDataCheckConfig
     frequency?: Duration
@@ -15801,6 +15807,7 @@ export interface MlPutJobRequest extends RequestBase {
     data_description: MlDataDescription
     datafeed_config?: MlDatafeedConfig
     description?: string
+    job_id?: Id
     groups?: string[]
     model_plot_config?: MlModelPlotConfig
     model_snapshot_retention_days?: long

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14483,6 +14483,7 @@ export interface MlModelSizeStats {
   model_bytes: ByteSize
   model_bytes_exceeded?: ByteSize
   model_bytes_memory_limit?: ByteSize
+  output_memory_allocator_bytes?: long
   peak_model_bytes?: ByteSize
   assignment_memory_basis?: string
   result_type: string
@@ -14570,7 +14571,7 @@ export interface MlOverallBucket {
   overall_score: double
   result_type: string
   timestamp: EpochTime<UnitMillis>
-  timestamp_string: DateTime
+  timestamp_string?: DateTime
 }
 
 export interface MlOverallBucketJob {
@@ -14793,7 +14794,7 @@ export interface MlTrainedModelDeploymentNodesStats {
   inference_cache_hit_count?: long
   inference_cache_hit_count_last_minute?: long
   last_access?: long
-  node?: MlDiscoveryNode
+  node?: Record<Id, MlDiscoveryNode>
   number_of_allocations?: integer
   number_of_pending_requests?: integer
   peak_throughput_per_minute: long
@@ -14815,6 +14816,7 @@ export interface MlTrainedModelDeploymentStats {
   model_id: Id
   nodes: MlTrainedModelDeploymentNodesStats[]
   number_of_allocations?: integer
+  peak_throughput_per_minute: long
   priority: MlTrainingPriority
   queue_capacity?: integer
   rejected_execution_count?: integer

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -14733,12 +14733,12 @@ export interface MlTrainedModelAssignment {
 export interface MlTrainedModelAssignmentRoutingTable {
   reason?: string
   routing_state: MlRoutingState
-  current_allocations?: integer
-  target_allocations?: integer
+  current_allocations: integer
+  target_allocations: integer
 }
 
 export interface MlTrainedModelAssignmentTaskParameters {
-  model_bytes: integer
+  model_bytes: ByteSize
   model_id: Id
   deployment_id: Id
   cache_size?: ByteSize
@@ -14798,22 +14798,22 @@ export interface MlTrainedModelDeploymentNodesStats {
   inference_count?: long
   inference_cache_hit_count?: long
   inference_cache_hit_count_last_minute?: long
-  last_access?: EpochTime<UnitNanos>
+  last_access?: EpochTime<UnitMillis>
   node?: MlDiscoveryNode
   number_of_allocations?: integer
   number_of_pending_requests?: integer
   peak_throughput_per_minute: long
   rejection_execution_count?: integer
   routing_state: MlTrainedModelAssignmentRoutingTable
-  start_time?: EpochTime<UnitNanos>
+  start_time?: EpochTime<UnitMillis>
   threads_per_allocation?: integer
-  throughput_last_minute?: integer
+  throughput_last_minute: integer
   timeout_count?: integer
 }
 
 export interface MlTrainedModelDeploymentStats {
   adaptive_allocations?: MlAdaptiveAllocationsSettings
-  allocation_status: MlTrainedModelDeploymentAllocationStatus
+  allocation_status?: MlTrainedModelDeploymentAllocationStatus
   cache_size?: ByteSize
   deployment_id: Id
   error_count?: integer
@@ -14827,7 +14827,7 @@ export interface MlTrainedModelDeploymentStats {
   rejected_execution_count?: integer
   reason?: string
   start_time: EpochTime<UnitMillis>
-  state: MlDeploymentAssignmentState
+  state?: MlDeploymentAssignmentState
   threads_per_allocation?: integer
   timeout_count?: integer
 }
@@ -14870,7 +14870,6 @@ export interface MlTrainedModelLocationIndex {
 export interface MlTrainedModelPrefixStrings {
   ingest?: string
   search?: string
-  none?: string
 }
 
 export interface MlTrainedModelSizeStats {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2468,8 +2468,12 @@ export type Indices = IndexName | IndexName[]
 export interface IndicesOptions {
   allow_no_indices?: boolean
   expand_wildcards?: ExpandWildcards
+  exclude?: string
+  failure_store?: string
   ignore_unavailable?: boolean
   ignore_throttled?: boolean
+  include?: string
+  only?: string
 }
 
 export interface IndicesResponseBase extends AcknowledgedResponseBase {
@@ -14208,6 +14212,12 @@ export interface MlDetectorRead {
   use_null?: boolean
 }
 
+export interface MlDetectorUpdate {
+  detector_index: integer
+  description?: string
+  custom_rules?: MlDetectionRule[]
+}
+
 export interface MlDiscoveryNode {
   name?: Name
   ephemeral_id: Id
@@ -14234,6 +14244,7 @@ export interface MlFillMaskInferenceOptions {
   num_top_classes?: integer
   tokenization?: MlTokenizationConfigContainer
   results_field?: string
+  vocabulary?: MlVocabulary
 }
 
 export interface MlFillMaskInferenceUpdateOptions {
@@ -14441,6 +14452,23 @@ export interface MlJobTimingStats {
 
 export type MlMemoryStatus = 'ok' | 'soft_limit' | 'hard_limit'
 
+export interface MlModelPackageConfig {
+  create_time?: EpochTime<UnitMillis>
+  description?: string
+  inference_config?: Record<string, any>
+  metadata?: Metadata
+  minimum_version?: string
+  model_repository?: string
+  model_type?: string
+  packaged_model_id: Id
+  platform_architecture?: string
+  prefix_strings?: MlTrainedModelPrefixStrings
+  size?: long
+  sha256?: string
+  tags?: string[]
+  vocabulary_file?: string
+}
+
 export interface MlModelPlotConfig {
   annotations_enabled?: boolean
   enabled?: boolean
@@ -14513,6 +14541,7 @@ export interface MlNlpBertTokenizationConfig {
 }
 
 export interface MlNlpRobertaTokenizationConfig {
+  do_lower_case?: boolean
   add_prefix_space?: boolean
   with_special_tokens?: boolean
   max_sequence_length?: integer
@@ -14629,6 +14658,7 @@ export interface MlTextEmbeddingInferenceOptions {
   embedding_size?: integer
   tokenization?: MlTokenizationConfigContainer
   results_field?: string
+  vocabulary?: MlVocabulary
 }
 
 export interface MlTextEmbeddingInferenceUpdateOptions {
@@ -14639,6 +14669,7 @@ export interface MlTextEmbeddingInferenceUpdateOptions {
 export interface MlTextExpansionInferenceOptions {
   tokenization?: MlTokenizationConfigContainer
   results_field?: string
+  vocabulary?: MlVocabulary
 }
 
 export interface MlTextExpansionInferenceUpdateOptions {
@@ -14653,6 +14684,7 @@ export interface MlTimingStats {
 
 export interface MlTokenizationConfigContainer {
   bert?: MlNlpBertTokenizationConfig
+  bert_ja?: MlNlpBertTokenizationConfig
   mpnet?: MlNlpBertTokenizationConfig
   roberta?: MlNlpRobertaTokenizationConfig
 }
@@ -14730,6 +14762,7 @@ export interface MlTrainedModelConfig {
   license_level?: string
   metadata?: MlTrainedModelConfigMetadata
   model_size_bytes?: ByteSize
+  model_package?: MlModelPackageConfig
   location?: MlTrainedModelLocation
   prefix_strings?: MlTrainedModelPrefixStrings
 }
@@ -14830,6 +14863,7 @@ export interface MlTrainedModelLocationIndex {
 export interface MlTrainedModelPrefixStrings {
   ingest?: string
   search?: string
+  none?: string
 }
 
 export interface MlTrainedModelSizeStats {
@@ -16132,7 +16166,7 @@ export interface MlUpdateJobRequest extends RequestBase {
     renormalization_window_days?: long
     results_retention_days?: long
     groups?: string[]
-    detectors?: MlDetector[]
+    detectors?: MlDetectorUpdate[]
     per_partition_categorization?: MlPerPartitionCategorization
   }
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13905,7 +13905,7 @@ export type MlDatafeedState = 'started' | 'stopped' | 'starting' | 'stopping'
 export interface MlDatafeedStats {
   assignment_explanation?: string
   datafeed_id: Id
-  node?: MlDiscoveryNode
+  node?: MlDiscoveryNodeCompact
   state: MlDatafeedState
   timing_stats?: MlDatafeedTimingStats
   running_state?: MlDatafeedRunningState
@@ -14218,10 +14218,19 @@ export interface MlDetectorUpdate {
   custom_rules?: MlDetectionRule[]
 }
 
-export interface MlDiscoveryNode {
+export type MlDiscoveryNode = Partial<Record<Id, MlDiscoveryNodeContent>>
+
+export interface MlDiscoveryNodeCompact {
+  name: Name
+  ephemeral_id: Id
+  id: Id
+  transport_address: TransportAddress
+  attributes?: Record<string, string>
+}
+
+export interface MlDiscoveryNodeContent {
   name?: Name
   ephemeral_id: Id
-  id?: Id
   transport_address: TransportAddress
   external_id?: string
   attributes?: Record<string, string>
@@ -14432,7 +14441,7 @@ export interface MlJobStats {
   forecasts_stats: MlJobForecastStatistics
   job_id: string
   model_size_stats: MlModelSizeStats
-  node?: MlDiscoveryNode
+  node?: MlDiscoveryNodeCompact
   open_time?: DateTime
   state: MlJobState
   timing_stats: MlJobTimingStats
@@ -14794,7 +14803,7 @@ export interface MlTrainedModelDeploymentNodesStats {
   inference_cache_hit_count?: long
   inference_cache_hit_count_last_minute?: long
   last_access?: long
-  node?: Record<Id, MlDiscoveryNode>
+  node?: MlDiscoveryNode
   number_of_allocations?: integer
   number_of_pending_requests?: integer
   peak_throughput_per_minute: long
@@ -15797,6 +15806,7 @@ export interface MlPutFilterResponse {
 
 export interface MlPutJobRequest extends RequestBase {
   job_id: Id
+  ignore_throttled?: boolean
   body?: {
     allow_lazy_open?: boolean
     analysis_config: MlAnalysisConfig

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13624,6 +13624,12 @@ export interface MigrationPostFeatureUpgradeResponse {
   features: MigrationPostFeatureUpgradeMigrationFeature[]
 }
 
+export interface MlAdaptiveAllocationsSettings {
+  enabled: boolean
+  min_number_of_allocations?: integer
+  max_number_of_allocations?: integer
+}
+
 export interface MlAnalysisConfig {
   bucket_span?: Duration
   categorization_analyzer?: MlCategorizationAnalyzer
@@ -13895,9 +13901,9 @@ export type MlDatafeedState = 'started' | 'stopped' | 'starting' | 'stopping'
 export interface MlDatafeedStats {
   assignment_explanation?: string
   datafeed_id: Id
-  node?: MlDiscoveryNode
+  node?: Record<Id, MlDiscoveryNode>
   state: MlDatafeedState
-  timing_stats: MlDatafeedTimingStats
+  timing_stats?: MlDatafeedTimingStats
   running_state?: MlDatafeedRunningState
 }
 
@@ -14095,6 +14101,7 @@ export interface MlDataframeAnalyticsSummary {
   model_memory_limit?: string
   source: MlDataframeAnalyticsSource
   version?: VersionString
+  _meta?: Metadata
 }
 
 export interface MlDataframeEvaluationClassification {
@@ -14406,7 +14413,7 @@ export interface MlJobStats {
   forecasts_stats: MlJobForecastStatistics
   job_id: string
   model_size_stats: MlModelSizeStats
-  node?: MlDiscoveryNode
+  node?: Record<Id, MlDiscoveryNode>
   open_time?: DateTime
   state: MlJobState
   timing_stats: MlJobTimingStats
@@ -14473,7 +14480,7 @@ export interface MlModelSnapshotUpgrade {
   job_id: Id
   snapshot_id: Id
   state: MlSnapshotUpgradeState
-  node: MlDiscoveryNode
+  node: Record<Id, MlDiscoveryNode>
   assignment_explanation: string
 }
 
@@ -14676,10 +14683,10 @@ export interface MlTrainedModelAssignment {
 }
 
 export interface MlTrainedModelAssignmentRoutingTable {
-  reason: string
+  reason?: string
   routing_state: MlRoutingState
-  current_allocations: integer
-  target_allocations: integer
+  current_allocations?: integer
+  target_allocations?: integer
 }
 
 export interface MlTrainedModelAssignmentTaskParameters {
@@ -14733,36 +14740,44 @@ export interface MlTrainedModelDeploymentAllocationStatus {
 }
 
 export interface MlTrainedModelDeploymentNodesStats {
-  average_inference_time_ms: DurationValue<UnitFloatMillis>
-  error_count: integer
-  inference_count: integer
-  last_access: long
-  node: MlDiscoveryNode
-  number_of_allocations: integer
-  number_of_pending_requests: integer
-  rejection_execution_count: integer
+  average_inference_time_ms?: DurationValue<UnitFloatMillis>
+  average_inference_time_ms_last_minute?: DurationValue<UnitFloatMillis>
+  average_inference_time_ms_excluding_cache_hits?: DurationValue<UnitFloatMillis>
+  error_count?: integer
+  inference_count?: long
+  inference_cache_hit_count?: long
+  inference_cache_hit_count_last_minute?: long
+  last_access?: long
+  node?: Record<Id, MlDiscoveryNode>
+  number_of_allocations?: integer
+  number_of_pending_requests?: integer
+  peak_throughput_per_minute: long
+  rejection_execution_count?: integer
   routing_state: MlTrainedModelAssignmentRoutingTable
-  start_time: EpochTime<UnitMillis>
-  threads_per_allocation: integer
-  timeout_count: integer
+  start_time?: EpochTime<UnitMillis>
+  threads_per_allocation?: integer
+  throughput_last_minute?: integer
+  timeout_count?: integer
 }
 
 export interface MlTrainedModelDeploymentStats {
+  adaptive_allocations?: MlAdaptiveAllocationsSettings
   allocation_status: MlTrainedModelDeploymentAllocationStatus
   cache_size?: ByteSize
   deployment_id: Id
-  error_count: integer
-  inference_count: integer
+  error_count?: integer
+  inference_count?: integer
   model_id: Id
   nodes: MlTrainedModelDeploymentNodesStats[]
-  number_of_allocations: integer
-  queue_capacity: integer
-  rejected_execution_count: integer
-  reason: string
+  number_of_allocations?: integer
+  priority: MlTrainingPriority
+  queue_capacity?: integer
+  rejected_execution_count?: integer
+  reason?: string
   start_time: EpochTime<UnitMillis>
   state: MlDeploymentAssignmentState
-  threads_per_allocation: integer
-  timeout_count: integer
+  threads_per_allocation?: integer
+  timeout_count?: integer
 }
 
 export interface MlTrainedModelEntities {

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -352,12 +352,12 @@ export class IndicesOptions {
   expand_wildcards?: ExpandWildcards
 
   /**
-   * @deprecated 8.16.0 this value will be replaced by the selector `::*` on the expression level
+   * @deprecated 8.16.0 this value will be replaced by the selector `::*` on the expression level.
    */
   exclude?: string
 
   /**
-   * @deprecated 8.16.0 this query param will be replaced by the selector `::` on the expression level
+   * @deprecated 8.16.0 this query param will be replaced by the selector `::` on the expression level.
    */
   failure_store?: string
   /**
@@ -371,12 +371,12 @@ export class IndicesOptions {
    */
   ignore_throttled?: boolean
   /**
-   * @deprecated 8.16.0 this value will be replaced by the selector `::*` on the expression level
+   * @deprecated 8.16.0 this value will be replaced by the selector `::*` on the expression level.
    */
   include?: string
 
   /**
-   * @deprecated 8.16.0 this value will be replaced by the selector `::*` on the expression level
+   * @deprecated 8.16.0 this value will be replaced by the selector `::*` on the expression level.
    */
   only?: string
 }

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -350,6 +350,16 @@ export class IndicesOptions {
    * such as `open,hidden`.
    */
   expand_wildcards?: ExpandWildcards
+
+  /**
+   * @deprecated 8.16.0 this value will be replaced by the selector `::*` on the expression level
+   */
+  exclude?: string
+
+  /**
+   * @deprecated 8.16.0 this query param will be replaced by the selector `::` on the expression level
+   */
+  failure_store?: string
   /**
    * If true, missing or closed indices are not included in the response.
    * @server_default false
@@ -360,6 +370,15 @@ export class IndicesOptions {
    * @server_default true
    */
   ignore_throttled?: boolean
+  /**
+   * @deprecated 8.16.0 this value will be replaced by the selector `::*` on the expression level
+   */
+  include?: string
+
+  /**
+   * @deprecated 8.16.0 this value will be replaced by the selector `::*` on the expression level
+   */
+  only?: string
 }
 
 /**

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -350,16 +350,6 @@ export class IndicesOptions {
    * such as `open,hidden`.
    */
   expand_wildcards?: ExpandWildcards
-
-  /**
-   * @deprecated 8.16.0 this value will be replaced by the selector `::*` on the expression level.
-   */
-  exclude?: string
-
-  /**
-   * @deprecated 8.16.0 this query param will be replaced by the selector `::` on the expression level.
-   */
-  failure_store?: string
   /**
    * If true, missing or closed indices are not included in the response.
    * @server_default false
@@ -370,15 +360,6 @@ export class IndicesOptions {
    * @server_default true
    */
   ignore_throttled?: boolean
-  /**
-   * @deprecated 8.16.0 this value will be replaced by the selector `::*` on the expression level.
-   */
-  include?: string
-
-  /**
-   * @deprecated 8.16.0 this value will be replaced by the selector `::*` on the expression level.
-   */
-  only?: string
 }
 
 /**

--- a/specification/ml/_types/Analysis.ts
+++ b/specification/ml/_types/Analysis.ts
@@ -21,7 +21,7 @@ import { OverloadOf } from '@spec_utils/behaviors'
 import { CharFilter } from '@_types/analysis/char_filters'
 import { Tokenizer } from '@_types/analysis/tokenizers'
 import { TokenFilter } from '@_types/analysis/token_filters'
-import { Field } from '@_types/common'
+import { ByteSize, Field } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 import { Detector, DetectorRead } from './Detector'
@@ -168,7 +168,7 @@ export class AnalysisLimits {
    * The approximate maximum amount of memory resources that are required for analytical processing. Once this limit is approached, data pruning becomes more aggressive. Upon exceeding this limit, new entities are not modeled. If the `xpack.ml.max_model_memory_limit` setting has a value greater than 0 and less than 1024mb, that value is used instead of the default. The default value is relatively small to ensure that high resource usage is a conscious decision. If you have jobs that are expected to analyze high cardinality fields, you will likely need to use a higher value. If you specify a number instead of a string, the units are assumed to be MiB. Specifying a string is recommended for clarity. If you specify a byte size unit of `b` or `kb` and the number does not equate to a discrete number of megabytes, it is rounded down to the closest MiB. The minimum valid value is 1 MiB. If you specify a value less than 1 MiB, an error occurs. If you specify a value for the `xpack.ml.max_model_memory_limit` setting, an error occurs when you try to create jobs that have `model_memory_limit` values greater than that setting value.
    * @server_default 1024mb
    */
-  model_memory_limit?: string | long
+  model_memory_limit?: ByteSize
 }
 
 export class AnalysisMemoryLimit {

--- a/specification/ml/_types/Analysis.ts
+++ b/specification/ml/_types/Analysis.ts
@@ -168,7 +168,7 @@ export class AnalysisLimits {
    * The approximate maximum amount of memory resources that are required for analytical processing. Once this limit is approached, data pruning becomes more aggressive. Upon exceeding this limit, new entities are not modeled. If the `xpack.ml.max_model_memory_limit` setting has a value greater than 0 and less than 1024mb, that value is used instead of the default. The default value is relatively small to ensure that high resource usage is a conscious decision. If you have jobs that are expected to analyze high cardinality fields, you will likely need to use a higher value. If you specify a number instead of a string, the units are assumed to be MiB. Specifying a string is recommended for clarity. If you specify a byte size unit of `b` or `kb` and the number does not equate to a discrete number of megabytes, it is rounded down to the closest MiB. The minimum valid value is 1 MiB. If you specify a value less than 1 MiB, an error occurs. If you specify a value for the `xpack.ml.max_model_memory_limit` setting, an error occurs when you try to create jobs that have `model_memory_limit` values greater than that setting value.
    * @server_default 1024mb
    */
-  model_memory_limit?: string
+  model_memory_limit?: string | long
 }
 
 export class AnalysisMemoryLimit {

--- a/specification/ml/_types/Bucket.ts
+++ b/specification/ml/_types/Bucket.ts
@@ -140,7 +140,7 @@ export class OverallBucket {
   /** The start time of the bucket for which these results were calculated. */
   timestamp: EpochTime<UnitMillis>
   /** The start time of the bucket for which these results were calculated. */
-  timestamp_string: DateTime
+  timestamp_string?: DateTime
 }
 export class OverallBucketJob {
   job_id: Id

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -32,7 +32,7 @@ import {
   UnitFloatMillis,
   UnitMillis
 } from '@_types/Time'
-import { DiscoveryNode } from './DiscoveryNode'
+import { DiscoveryNodeCompact } from './DiscoveryNode'
 
 export class Datafeed {
   /** @aliases aggs */
@@ -155,7 +155,7 @@ export class DatafeedStats {
    * For started datafeeds only, this information pertains to the node upon which the datafeed is started.
    * @availability stack
    */
-  node?: DiscoveryNode
+  node?: DiscoveryNodeCompact
   /**
    * The status of the datafeed, which can be one of the following values: `starting`, `started`, `stopping`, `stopped`.
    */

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -154,7 +154,7 @@ export class DatafeedStats {
    * For started datafeeds only, this information pertains to the node upon which the datafeed is started.
    * @availability stack
    */
-  node?: DiscoveryNode
+  node?: Dictionary<Id, DiscoveryNode>
   /**
    * The status of the datafeed, which can be one of the following values: `starting`, `started`, `stopping`, `stopped`.
    */
@@ -162,7 +162,7 @@ export class DatafeedStats {
   /**
    * An object that provides statistical information about timing aspect of this datafeed.
    */
-  timing_stats: DatafeedTimingStats
+  timing_stats?: DatafeedTimingStats
   /**
    * An object containing the running state for this datafeed.
    * It is only provided if the datafeed is started.

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -22,12 +22,13 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import { Id, Indices, IndicesOptions } from '@_types/common'
 import { RuntimeFields } from '@_types/mapping/RuntimeFields'
-import { integer, long } from '@_types/Numeric'
+import { double, integer, long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { ScriptField } from '@_types/Scripting'
 import {
   Duration,
   DurationValue,
+  EpochTime,
   UnitFloatMillis,
   UnitMillis
 } from '@_types/Time'
@@ -154,7 +155,7 @@ export class DatafeedStats {
    * For started datafeeds only, this information pertains to the node upon which the datafeed is started.
    * @availability stack
    */
-  node?: Dictionary<Id, DiscoveryNode>
+  node?: DiscoveryNode
   /**
    * The status of the datafeed, which can be one of the following values: `starting`, `started`, `stopping`, `stopped`.
    */
@@ -179,6 +180,9 @@ export class DatafeedTimingStats {
    * The exponential average search time per hour, in milliseconds.
    */
   exponential_average_search_time_per_hour_ms: DurationValue<UnitFloatMillis>
+
+  exponential_average_calculation_context?: ExponentialAverageCalculationContext
+
   /**
    * Identifier for the anomaly detection job.
    */
@@ -195,6 +199,12 @@ export class DatafeedTimingStats {
    * The average search time per bucket, in milliseconds.
    */
   average_search_time_per_bucket_ms?: DurationValue<UnitFloatMillis>
+}
+
+export class ExponentialAverageCalculationContext {
+  incremental_metric_value_ms: double
+  latest_timestamp?: EpochTime<UnitMillis>
+  previous_exponential_average_ms?: DurationValue<UnitFloatMillis>
 }
 
 export class DatafeedRunningState {

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -22,7 +22,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { AggregationContainer } from '@_types/aggregations/AggregationContainer'
 import { Id, Indices, IndicesOptions } from '@_types/common'
 import { RuntimeFields } from '@_types/mapping/RuntimeFields'
-import { double, integer, long } from '@_types/Numeric'
+import { integer, long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { ScriptField } from '@_types/Scripting'
 import {
@@ -202,7 +202,7 @@ export class DatafeedTimingStats {
 }
 
 export class ExponentialAverageCalculationContext {
-  incremental_metric_value_ms: double
+  incremental_metric_value_ms: DurationValue<UnitFloatMillis>
   latest_timestamp?: EpochTime<UnitMillis>
   previous_exponential_average_ms?: DurationValue<UnitFloatMillis>
 }

--- a/specification/ml/_types/DataframeAnalytics.ts
+++ b/specification/ml/_types/DataframeAnalytics.ts
@@ -25,6 +25,7 @@ import {
   Id,
   IndexName,
   Indices,
+  Metadata,
   Name,
   VersionString
 } from '@_types/common'
@@ -318,6 +319,7 @@ export class DataframeAnalyticsSummary {
   model_memory_limit?: string
   source: DataframeAnalyticsSource
   version?: VersionString
+  _meta?: Metadata
 }
 
 export class DataframeAnalytics {

--- a/specification/ml/_types/Detector.ts
+++ b/specification/ml/_types/Detector.ts
@@ -124,6 +124,24 @@ export class DetectorRead implements OverloadOf<Detector> {
   use_null?: boolean
 }
 
+export class DetectorUpdate {
+  /**
+   * A unique identifier for the detector.
+   * This identifier is based on the order of the detectors in the `analysis_config`, starting at zero.
+   */
+  detector_index: integer
+  /**
+   * A description of the detector.
+   */
+  description?: string
+  /**
+   * An array of custom rule objects, which enable you to customize the way detectors operate.
+   * For example, a rule may dictate to the detector conditions under which results should be skipped.
+   * Kibana refers to custom rules as job rules.
+   */
+  custom_rules?: DetectionRule[]
+}
+
 export enum ExcludeFrequent {
   all,
   none,

--- a/specification/ml/_types/DiscoveryNode.ts
+++ b/specification/ml/_types/DiscoveryNode.ts
@@ -17,15 +17,16 @@
  * under the License.
  */
 
-import { Dictionary } from '@spec_utils/Dictionary'
+import { Dictionary, SingleKeyDictionary } from '@spec_utils/Dictionary'
 import { Id, Name, VersionString } from '@_types/common'
 import { TransportAddress } from '@_types/Networking'
 import { integer } from '@_types/Numeric'
 
-export class DiscoveryNode {
+export type DiscoveryNode = SingleKeyDictionary<Id, DiscoveryNodeContent>
+
+export class DiscoveryNodeContent {
   name?: Name
   ephemeral_id: Id
-  id?: Id
   transport_address: TransportAddress
   external_id?: string
   attributes?: Dictionary<string, string>
@@ -33,4 +34,15 @@ export class DiscoveryNode {
   version?: VersionString
   min_index_version?: integer
   max_index_version?: integer
+}
+
+/**
+ * Alternative representation of DiscoveryNode used in ml.get_job_stats and ml.get_datafeed_stats
+ */
+export class DiscoveryNodeCompact {
+  name: Name
+  ephemeral_id: Id
+  id: Id
+  transport_address: TransportAddress
+  attributes?: Dictionary<string, string>
 }

--- a/specification/ml/_types/DiscoveryNode.ts
+++ b/specification/ml/_types/DiscoveryNode.ts
@@ -20,11 +20,17 @@
 import { Dictionary } from '@spec_utils/Dictionary'
 import { Id, Name } from '@_types/common'
 import { TransportAddress } from '@_types/Networking'
+import { integer } from '@_types/Numeric'
+import { VersionString } from '../../../output/typescript/types'
 
 export class DiscoveryNode {
-  attributes: Dictionary<string, string>
+  name?: Name
   ephemeral_id: Id
-  id: Id
-  name: Name
   transport_address: TransportAddress
+  external_id?: string
+  attributes?: Dictionary<string, string>
+  roles: string[]
+  version?: VersionString
+  min_index_version?: integer
+  max_index_version?: integer
 }

--- a/specification/ml/_types/DiscoveryNode.ts
+++ b/specification/ml/_types/DiscoveryNode.ts
@@ -25,10 +25,11 @@ import { integer } from '@_types/Numeric'
 export class DiscoveryNode {
   name?: Name
   ephemeral_id: Id
+  id?: Id
   transport_address: TransportAddress
   external_id?: string
   attributes?: Dictionary<string, string>
-  roles: string[]
+  roles?: string[]
   version?: VersionString
   min_index_version?: integer
   max_index_version?: integer

--- a/specification/ml/_types/DiscoveryNode.ts
+++ b/specification/ml/_types/DiscoveryNode.ts
@@ -28,12 +28,12 @@ export class DiscoveryNodeContent {
   name?: Name
   ephemeral_id: Id
   transport_address: TransportAddress
-  external_id?: string
-  attributes?: Dictionary<string, string>
-  roles?: string[]
-  version?: VersionString
-  min_index_version?: integer
-  max_index_version?: integer
+  external_id: string
+  attributes: Dictionary<string, string>
+  roles: string[]
+  version: VersionString
+  min_index_version: integer
+  max_index_version: integer
 }
 
 /**
@@ -44,5 +44,5 @@ export class DiscoveryNodeCompact {
   ephemeral_id: Id
   id: Id
   transport_address: TransportAddress
-  attributes?: Dictionary<string, string>
+  attributes: Dictionary<string, string>
 }

--- a/specification/ml/_types/DiscoveryNode.ts
+++ b/specification/ml/_types/DiscoveryNode.ts
@@ -18,10 +18,9 @@
  */
 
 import { Dictionary } from '@spec_utils/Dictionary'
-import { Id, Name } from '@_types/common'
+import { Id, Name, VersionString } from '@_types/common'
 import { TransportAddress } from '@_types/Networking'
 import { integer } from '@_types/Numeric'
-import { VersionString } from '../../../output/typescript/types'
 
 export class DiscoveryNode {
   name?: Name

--- a/specification/ml/_types/Job.ts
+++ b/specification/ml/_types/Job.ts
@@ -30,7 +30,7 @@ import {
   DurationValue,
   UnitFloatMillis
 } from '@_types/Time'
-import { DiscoveryNode } from './DiscoveryNode'
+import { DiscoveryNodeCompact } from './DiscoveryNode'
 import { ModelSizeStats } from './Model'
 
 export enum JobState {
@@ -310,7 +310,7 @@ export class JobStats {
    * This information is available only for open jobs.
    * @availability stack
    */
-  node?: DiscoveryNode
+  node?: DiscoveryNodeCompact
   /**
    * For open jobs only, the elapsed time for which the job has been open.
    */

--- a/specification/ml/_types/Job.ts
+++ b/specification/ml/_types/Job.ts
@@ -310,7 +310,7 @@ export class JobStats {
    * This information is available only for open jobs.
    * @availability stack
    */
-  node?: DiscoveryNode
+  node?: Dictionary<Id, DiscoveryNode>
   /**
    * For open jobs only, the elapsed time for which the job has been open.
    */

--- a/specification/ml/_types/Job.ts
+++ b/specification/ml/_types/Job.ts
@@ -310,7 +310,7 @@ export class JobStats {
    * This information is available only for open jobs.
    * @availability stack
    */
-  node?: Dictionary<Id, DiscoveryNode>
+  node?: DiscoveryNode
   /**
    * For open jobs only, the elapsed time for which the job has been open.
    */

--- a/specification/ml/_types/Model.ts
+++ b/specification/ml/_types/Model.ts
@@ -18,7 +18,6 @@
  */
 
 import { DiscoveryNode } from '@ml/_types/DiscoveryNode'
-import { Dictionary } from '@spec_utils/Dictionary'
 import { ByteSize, Id, VersionString } from '@_types/common'
 import { integer, long } from '@_types/Numeric'
 import { DateTime } from '@_types/Time'
@@ -53,7 +52,7 @@ export class ModelSnapshotUpgrade {
   /**
    * @availability stack
    */
-  node: Dictionary<Id, DiscoveryNode>
+  node: DiscoveryNode
   assignment_explanation: string
 }
 

--- a/specification/ml/_types/Model.ts
+++ b/specification/ml/_types/Model.ts
@@ -64,7 +64,7 @@ export class ModelSizeStats {
   model_bytes: ByteSize
   model_bytes_exceeded?: ByteSize
   model_bytes_memory_limit?: ByteSize
-  output_memory_allocator_bytes?: long
+  output_memory_allocator_bytes?: ByteSize
   peak_model_bytes?: ByteSize
   assignment_memory_basis?: string
   result_type: string

--- a/specification/ml/_types/Model.ts
+++ b/specification/ml/_types/Model.ts
@@ -64,6 +64,7 @@ export class ModelSizeStats {
   model_bytes: ByteSize
   model_bytes_exceeded?: ByteSize
   model_bytes_memory_limit?: ByteSize
+  output_memory_allocator_bytes?: long
   peak_model_bytes?: ByteSize
   assignment_memory_basis?: string
   result_type: string

--- a/specification/ml/_types/Model.ts
+++ b/specification/ml/_types/Model.ts
@@ -18,6 +18,7 @@
  */
 
 import { DiscoveryNode } from '@ml/_types/DiscoveryNode'
+import { Dictionary } from '@spec_utils/Dictionary'
 import { ByteSize, Id, VersionString } from '@_types/common'
 import { integer, long } from '@_types/Numeric'
 import { DateTime } from '@_types/Time'
@@ -52,7 +53,7 @@ export class ModelSnapshotUpgrade {
   /**
    * @availability stack
    */
-  node: DiscoveryNode
+  node: Dictionary<Id, DiscoveryNode>
   assignment_explanation: string
 }
 

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -100,7 +100,7 @@ export class TrainedModelDeploymentStats {
   /** The epoch timestamp when the deployment started. */
   start_time: EpochTime<UnitMillis>
   /** The overall state of the deployment. */
-  state: DeploymentAssignmentState
+  state?: DeploymentAssignmentState
   /** The number of threads used be each allocation during inference. */
   threads_per_allocation?: integer
   /** The sum of `timeout_count` for all nodes in the deployment. */

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -63,7 +63,7 @@ export class TrainedModelStats {
 export class TrainedModelDeploymentStats {
   adaptive_allocations?: AdaptiveAllocationsSettings
   /** The detailed allocation status for the deployment. */
-  allocation_status: TrainedModelDeploymentAllocationStatus
+  allocation_status?: TrainedModelDeploymentAllocationStatus
   cache_size?: ByteSize
   /** The unique identifier for the trained model deployment. */
   deployment_id: Id

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -165,7 +165,7 @@ export class TrainedModelDeploymentNodesStats {
    * Information pertaining to the node.
    * @availability stack
    */
-  node?: Dictionary<Id, DiscoveryNode>
+  node?: DiscoveryNode
   /**
    * The number of allocations assigned to this node.
    */

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -80,6 +80,8 @@ export class TrainedModelDeploymentStats {
   /** The number of allocations requested. */
   number_of_allocations?: integer
 
+  peak_throughput_per_minute: long
+
   priority: TrainingPriority
   /** The number of inference requests that can be queued before new requests are rejected. */
   queue_capacity?: integer
@@ -163,7 +165,7 @@ export class TrainedModelDeploymentNodesStats {
    * Information pertaining to the node.
    * @availability stack
    */
-  node?: DiscoveryNode
+  node?: Dictionary<Id, DiscoveryNode>
   /**
    * The number of allocations assigned to this node.
    */

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -180,7 +180,7 @@ export class TrainedModelDeploymentNodesStats {
   /** The current routing state and reason for the current routing state for this allocation. */
   routing_state: TrainedModelAssignmentRoutingTable
   /** The epoch timestamp when the allocation started. */
-  start_time?: EpochTime<UnitNanos>
+  start_time?: EpochTime<UnitMillis>
   /** The number of threads used by each allocation during inference. */
   threads_per_allocation?: integer
 

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -34,7 +34,8 @@ import {
   DurationValue,
   EpochTime,
   UnitFloatMillis,
-  UnitMillis
+  UnitMillis,
+  UnitNanos
 } from '@_types/Time'
 import { DiscoveryNode } from './DiscoveryNode'
 import { InferenceConfigCreateContainer } from './inference'
@@ -160,7 +161,7 @@ export class TrainedModelDeploymentNodesStats {
   inference_cache_hit_count_last_minute?: long
 
   /** The epoch time stamp of the last inference call for the model on this node. */
-  last_access?: long
+  last_access?: EpochTime<UnitNanos>
   /**
    * Information pertaining to the node.
    * @availability stack
@@ -179,7 +180,7 @@ export class TrainedModelDeploymentNodesStats {
   /** The current routing state and reason for the current routing state for this allocation. */
   routing_state: TrainedModelAssignmentRoutingTable
   /** The epoch timestamp when the allocation started. */
-  start_time?: EpochTime<UnitMillis>
+  start_time?: EpochTime<UnitNanos>
   /** The number of threads used by each allocation during inference. */
   threads_per_allocation?: integer
 
@@ -252,7 +253,7 @@ export class ModelPackageConfig {
   packaged_model_id: Id
   platform_architecture?: string
   prefix_strings?: TrainedModelPrefixStrings
-  size?: long
+  size?: ByteSize
   sha256?: string
   tags?: string[]
   vocabulary_file?: string
@@ -379,8 +380,8 @@ export class TrainedModelAssignmentTaskParameters {
   number_of_allocations: integer
   priority: TrainingPriority
 
-  per_deployment_memory_bytes: long
-  per_allocation_memory_bytes: long
+  per_deployment_memory_bytes: ByteSize
+  per_allocation_memory_bytes: ByteSize
 
   /**
    * Number of inference requests are allowed in the queue at a time.

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -34,8 +34,7 @@ import {
   DurationValue,
   EpochTime,
   UnitFloatMillis,
-  UnitMillis,
-  UnitNanos
+  UnitMillis
 } from '@_types/Time'
 import { DiscoveryNode } from './DiscoveryNode'
 import { InferenceConfigCreateContainer } from './inference'
@@ -359,7 +358,7 @@ export class TrainedModelAssignmentTaskParameters {
   /**
    * The size of the trained model in bytes.
    */
-  model_bytes: integer
+  model_bytes: ByteSize
   /**
    * The unique identifier for the trained model.
    */
@@ -429,11 +428,11 @@ export class TrainedModelAssignmentRoutingTable {
   /**
    * Current number of allocations.
    */
-  current_allocations?: integer
+  current_allocations: integer
   /**
    * Target number of allocations.
    */
-  target_allocations?: integer
+  target_allocations: integer
 }
 
 export class TrainedModelDeploymentAllocationStatus {
@@ -481,6 +480,4 @@ export class TrainedModelPrefixStrings {
    * String prepended to input at search
    */
   search?: string
-
-  none?: string
 }

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -162,7 +162,7 @@ export class TrainedModelDeploymentNodesStats {
    * Information pertaining to the node.
    * @availability stack
    */
-  node?: Dictionary<Id, DiscoveryNode>
+  node?: DiscoveryNode
   /**
    * The number of allocations assigned to this node.
    */
@@ -351,12 +351,15 @@ export class TrainedModelAssignmentTaskParameters {
    * @availability stack since=8.4.0
    * @availability serverless
    */
-  cache_size: ByteSize
+  cache_size?: ByteSize
   /**
    * The total number of allocations this model is assigned across ML nodes.
    */
   number_of_allocations: integer
   priority: TrainingPriority
+
+  per_deployment_memory_bytes: long
+  per_allocation_memory_bytes: long
 
   /**
    * Number of inference requests are allowed in the queue at a time.
@@ -421,11 +424,13 @@ export class TrainedModelDeploymentAllocationStatus {
 }
 
 export class TrainedModelAssignment {
+  adaptive_allocations?: AdaptiveAllocationsSettings | null
   /**
    * The overall assignment state.
    */
   assignment_state: DeploymentAssignmentState
   max_assigned_allocations?: integer
+  reason?: string
   /**
    * The allocation state for each node.
    */

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -59,15 +59,16 @@ export class TrainedModelStats {
 }
 
 export class TrainedModelDeploymentStats {
+  adaptive_allocations?: AdaptiveAllocationsSettings
   /** The detailed allocation status for the deployment. */
   allocation_status: TrainedModelDeploymentAllocationStatus
   cache_size?: ByteSize
   /** The unique identifier for the trained model deployment. */
   deployment_id: Id
   /** The sum of `error_count` for all nodes in the deployment. */
-  error_count: integer
+  error_count?: integer
   /** The sum of `inference_count` for all nodes in the deployment. */
-  inference_count: integer
+  inference_count?: integer
   /** The unique identifier for the trained model. */
   model_id: Id
   /**
@@ -76,28 +77,36 @@ export class TrainedModelDeploymentStats {
    */
   nodes: TrainedModelDeploymentNodesStats[]
   /** The number of allocations requested. */
-  number_of_allocations: integer
+  number_of_allocations?: integer
+
+  priority: TrainingPriority
   /** The number of inference requests that can be queued before new requests are rejected. */
-  queue_capacity: integer
+  queue_capacity?: integer
   /**
    * The sum of `rejected_execution_count` for all nodes in the deployment.
    * Individual nodes reject an inference request if the inference queue is full.
    * The queue size is controlled by the `queue_capacity` setting in the start
    * trained model deployment API.
    */
-  rejected_execution_count: integer
+  rejected_execution_count?: integer
   /** The reason for the current deployment state. Usually only populated when
    * the model is not deployed to a node.
    */
-  reason: string
+  reason?: string
   /** The epoch timestamp when the deployment started. */
   start_time: EpochTime<UnitMillis>
   /** The overall state of the deployment. */
   state: DeploymentAssignmentState
   /** The number of threads used be each allocation during inference. */
-  threads_per_allocation: integer
+  threads_per_allocation?: integer
   /** The sum of `timeout_count` for all nodes in the deployment. */
-  timeout_count: integer
+  timeout_count?: integer
+}
+
+export class AdaptiveAllocationsSettings {
+  enabled: boolean
+  min_number_of_allocations?: integer
+  max_number_of_allocations?: integer
 }
 
 export class TrainedModelInferenceStats {
@@ -131,34 +140,49 @@ export class TrainedModelSizeStats {
 
 export class TrainedModelDeploymentNodesStats {
   /** The average time for each inference call to complete on this node. */
-  average_inference_time_ms: DurationValue<UnitFloatMillis>
+  average_inference_time_ms?: DurationValue<UnitFloatMillis>
+
+  average_inference_time_ms_last_minute?: DurationValue<UnitFloatMillis>
+
+  /** The average time for each inference call to complete on this node, excluding cache */
+  average_inference_time_ms_excluding_cache_hits?: DurationValue<UnitFloatMillis>
+
   /** The number of errors when evaluating the trained model. */
-  error_count: integer
+  error_count?: integer
   /** The total number of inference calls made against this node for this model. */
-  inference_count: integer
+  inference_count?: long
+
+  inference_cache_hit_count?: long
+
+  inference_cache_hit_count_last_minute?: long
+
   /** The epoch time stamp of the last inference call for the model on this node. */
-  last_access: long
+  last_access?: long
   /**
    * Information pertaining to the node.
    * @availability stack
    */
-  node: DiscoveryNode
+  node?: Dictionary<Id, DiscoveryNode>
   /**
    * The number of allocations assigned to this node.
    */
-  number_of_allocations: integer
+  number_of_allocations?: integer
   /** The number of inference requests queued to be processed. */
-  number_of_pending_requests: integer
+  number_of_pending_requests?: integer
+
+  peak_throughput_per_minute: long
   /** The number of inference requests that were not processed because the queue was full. */
-  rejection_execution_count: integer
+  rejection_execution_count?: integer
   /** The current routing state and reason for the current routing state for this allocation. */
   routing_state: TrainedModelAssignmentRoutingTable
   /** The epoch timestamp when the allocation started. */
-  start_time: EpochTime<UnitMillis>
+  start_time?: EpochTime<UnitMillis>
   /** The number of threads used by each allocation during inference. */
-  threads_per_allocation: integer
+  threads_per_allocation?: integer
+
+  throughput_last_minute?: integer
   /** The number of inference requests that timed out before being processed. */
-  timeout_count: integer
+  timeout_count?: integer
 }
 
 export class TrainedModelConfig {
@@ -372,7 +396,7 @@ export class TrainedModelAssignmentRoutingTable {
    * The reason for the current state. It is usually populated only when the
    * `routing_state` is `failed`.
    */
-  reason: string
+  reason?: string
   /**
    * The current routing state.
    */
@@ -380,11 +404,11 @@ export class TrainedModelAssignmentRoutingTable {
   /**
    * Current number of allocations.
    */
-  current_allocations: integer
+  current_allocations?: integer
   /**
    * Target number of allocations.
    */
-  target_allocations: integer
+  target_allocations?: integer
 }
 
 export class TrainedModelDeploymentAllocationStatus {

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -24,6 +24,7 @@ import {
   Field,
   Id,
   IndexName,
+  Metadata,
   Name,
   VersionString
 } from '@_types/common'
@@ -218,6 +219,7 @@ export class TrainedModelConfig {
   /** An object containing metadata about the trained model. For example, models created by data frame analytics contain analysis_config and input objects. */
   metadata?: TrainedModelConfigMetadata
   model_size_bytes?: ByteSize
+  model_package?: ModelPackageConfig
   location?: TrainedModelLocation
   prefix_strings?: TrainedModelPrefixStrings
 }
@@ -235,6 +237,23 @@ export class TrainedModelConfigMetadata {
   hyperparameters?: Hyperparameter[]
   /** An array of the total feature importance for each feature used from the training data set. This array of objects is returned if data frame analytics trained the model and the request includes total_feature_importance in the include request parameter. */
   total_feature_importance?: TotalFeatureImportance[]
+}
+
+export class ModelPackageConfig {
+  create_time?: EpochTime<UnitMillis>
+  description?: string
+  inference_config?: Dictionary<string, UserDefinedValue>
+  metadata?: Metadata
+  minimum_version?: string
+  model_repository?: string
+  model_type?: string
+  packaged_model_id: Id
+  platform_architecture?: string
+  prefix_strings?: TrainedModelPrefixStrings
+  size?: long
+  sha256?: string
+  tags?: string[]
+  vocabulary_file?: string
 }
 
 export class Hyperparameter {
@@ -459,4 +478,6 @@ export class TrainedModelPrefixStrings {
    * String prepended to input at search
    */
   search?: string
+
+  none?: string
 }

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -184,7 +184,7 @@ export class TrainedModelDeploymentNodesStats {
   /** The number of threads used by each allocation during inference. */
   threads_per_allocation?: integer
 
-  throughput_last_minute?: integer
+  throughput_last_minute: integer
   /** The number of inference requests that timed out before being processed. */
   timeout_count?: integer
 }

--- a/specification/ml/_types/TrainedModel.ts
+++ b/specification/ml/_types/TrainedModel.ts
@@ -161,7 +161,7 @@ export class TrainedModelDeploymentNodesStats {
   inference_cache_hit_count_last_minute?: long
 
   /** The epoch time stamp of the last inference call for the model on this node. */
-  last_access?: EpochTime<UnitNanos>
+  last_access?: EpochTime<UnitMillis>
   /**
    * Information pertaining to the node.
    * @availability stack

--- a/specification/ml/_types/inference.ts
+++ b/specification/ml/_types/inference.ts
@@ -287,7 +287,7 @@ export class FillMaskInferenceOptions {
   tokenization?: TokenizationConfigContainer
   /** The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value. */
   results_field?: string
-  vocabulary?: Vocabulary
+  vocabulary: Vocabulary
 }
 
 /** Question answering inference options */

--- a/specification/ml/_types/inference.ts
+++ b/specification/ml/_types/inference.ts
@@ -259,7 +259,7 @@ export class TextExpansionInferenceOptions {
   tokenization?: TokenizationConfigContainer
   /** The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value. */
   results_field?: string
-  vocabulary?: Vocabulary
+  vocabulary: Vocabulary
 }
 
 /** Named entity recognition options */

--- a/specification/ml/_types/inference.ts
+++ b/specification/ml/_types/inference.ts
@@ -114,6 +114,8 @@ export class ClassificationInferenceOptions {
 export class TokenizationConfigContainer {
   /** Indicates BERT tokenization and its options */
   bert?: NlpBertTokenizationConfig
+  /** Indicates BERT Japanese tokenization and its options */
+  bert_ja?: NlpBertTokenizationConfig
   /**
    * Indicates MPNET tokenization and its options
    * @availability stack since=8.1.0
@@ -159,6 +161,11 @@ export class NlpBertTokenizationConfig {
 
 /** RoBERTa tokenization configuration options */
 export class NlpRobertaTokenizationConfig {
+  /**
+   * Should the tokenizer lower case the text
+   * @server_default false
+   */
+  do_lower_case?: boolean
   /**
    * Should the tokenizer prefix input with a space character
    * @server_default false
@@ -242,6 +249,8 @@ export class TextEmbeddingInferenceOptions {
   tokenization?: TokenizationConfigContainer
   /** The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value. */
   results_field?: string
+
+  vocabulary?: Vocabulary
 }
 
 /** Text expansion inference options */
@@ -250,6 +259,7 @@ export class TextExpansionInferenceOptions {
   tokenization?: TokenizationConfigContainer
   /** The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value. */
   results_field?: string
+  vocabulary?: Vocabulary
 }
 
 /** Named entity recognition options */
@@ -277,6 +287,7 @@ export class FillMaskInferenceOptions {
   tokenization?: TokenizationConfigContainer
   /** The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value. */
   results_field?: string
+  vocabulary?: Vocabulary
 }
 
 /** Question answering inference options */

--- a/specification/ml/_types/inference.ts
+++ b/specification/ml/_types/inference.ts
@@ -250,7 +250,7 @@ export class TextEmbeddingInferenceOptions {
   /** The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value. */
   results_field?: string
 
-  vocabulary?: Vocabulary
+  vocabulary: Vocabulary
 }
 
 /** Text expansion inference options */

--- a/specification/ml/_types/inference.ts
+++ b/specification/ml/_types/inference.ts
@@ -130,67 +130,44 @@ export class TokenizationConfigContainer {
   roberta?: NlpRobertaTokenizationConfig
 }
 
-/** BERT and MPNet tokenization configuration options */
-export class NlpBertTokenizationConfig {
+export class CommonTokenizationConfig {
   /**
    * Should the tokenizer lower case the text
    * @server_default false
    */
   do_lower_case?: boolean
-  /**
-   * Is tokenization completed with special tokens
-   * @server_default true
-   */
-  with_special_tokens?: boolean
   /**
    * Maximum input sequence length for the model
    * @server_default 512
    */
   max_sequence_length?: integer
   /**
+   * Tokenization spanning options. Special value of -1 indicates no spanning takes place
+   * @server_default -1
+   */
+  span?: integer
+  /**
    * Should tokenization input be automatically truncated before sending to the model for inference
    * @server_default first
    */
   truncate?: TokenizationTruncate
   /**
-   * Tokenization spanning options. Special value of -1 indicates no spanning takes place
-   * @server_default -1
+   * Is tokenization completed with special tokens
+   * @server_default true
    */
-  span?: integer
+  with_special_tokens?: boolean
 }
 
+/** BERT and MPNet tokenization configuration options */
+export class NlpBertTokenizationConfig extends CommonTokenizationConfig {}
+
 /** RoBERTa tokenization configuration options */
-export class NlpRobertaTokenizationConfig {
-  /**
-   * Should the tokenizer lower case the text
-   * @server_default false
-   */
-  do_lower_case?: boolean
+export class NlpRobertaTokenizationConfig extends CommonTokenizationConfig {
   /**
    * Should the tokenizer prefix input with a space character
    * @server_default false
    */
   add_prefix_space?: boolean
-  /**
-   * Is tokenization completed with special tokens
-   * @server_default true
-   */
-  with_special_tokens?: boolean
-  /**
-   * Maximum input sequence length for the model
-   * @server_default 512
-   */
-  max_sequence_length?: integer
-  /**
-   * Should tokenization input be automatically truncated before sending to the model for inference
-   * @server_default first
-   */
-  truncate?: TokenizationTruncate
-  /**
-   * Tokenization spanning options. Special value of -1 indicates no spanning takes place
-   * @server_default -1
-   */
-  span?: integer
 }
 
 /** Text classification configuration options */

--- a/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
+++ b/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
@@ -77,6 +77,13 @@ export interface Request extends RequestBase {
      * body.
      */
     include?: Include
+
+    /**
+     * parameter is deprecated! Use [include=definition] instead
+     * @deprecated 7.10.0
+     */
+    include_model_definition?: boolean
+
     /**
      * Specifies the maximum number of models to obtain.
      * @server_default 100

--- a/specification/ml/info/types.ts
+++ b/specification/ml/info/types.ts
@@ -33,10 +33,10 @@ export class NativeCode {
 
 export class Limits {
   max_single_ml_node_processors?: integer
-  max_model_memory_limit?: ByteSize
-  effective_max_model_memory_limit: ByteSize
-  total_ml_memory: string
   total_ml_processors?: integer
+  max_model_memory_limit?: ByteSize
+  effective_max_model_memory_limit?: ByteSize
+  total_ml_memory: ByteSize
 }
 
 export class Datafeeds {

--- a/specification/ml/info/types.ts
+++ b/specification/ml/info/types.ts
@@ -32,9 +32,11 @@ export class NativeCode {
 }
 
 export class Limits {
+  max_single_ml_node_processors?: integer
   max_model_memory_limit?: string
   effective_max_model_memory_limit: string
   total_ml_memory: string
+  total_ml_processors?: integer
 }
 
 export class Datafeeds {

--- a/specification/ml/info/types.ts
+++ b/specification/ml/info/types.ts
@@ -18,7 +18,7 @@
  */
 
 import { CategorizationAnalyzer } from '@ml/_types/Analysis'
-import { VersionString } from '@_types/common'
+import { ByteSize, VersionString } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 export class Defaults {
@@ -33,8 +33,8 @@ export class NativeCode {
 
 export class Limits {
   max_single_ml_node_processors?: integer
-  max_model_memory_limit?: string
-  effective_max_model_memory_limit: string
+  max_model_memory_limit?: ByteSize
+  effective_max_model_memory_limit: ByteSize
   total_ml_memory: string
   total_ml_processors?: integer
 }

--- a/specification/ml/post_data/MlPostJobDataResponse.ts
+++ b/specification/ml/post_data/MlPostJobDataResponse.ts
@@ -29,9 +29,6 @@ export class Response {
     input_bytes: long
     input_field_count: long
     invalid_date_count: long
-    job_id: Id
-    last_data_time?: EpochTime<UnitMillis>
-    latest_record_timestamp?: EpochTime<UnitMillis>
     missing_field_count: long
     out_of_order_timestamp_count: long
     empty_bucket_count: long

--- a/specification/ml/post_data/MlPostJobDataResponse.ts
+++ b/specification/ml/post_data/MlPostJobDataResponse.ts
@@ -19,11 +19,12 @@
 
 import { Id } from '@_types/common'
 import { integer, long } from '@_types/Numeric'
+import { EpochTime, UnitMillis } from '@_types/Time'
 
 export class Response {
   body: {
     bucket_count: long
-    earliest_record_timestamp?: long
+    earliest_record_timestamp?: EpochTime<UnitMillis>
     empty_bucket_count: long
     input_bytes: long
     input_field_count: long
@@ -31,7 +32,7 @@ export class Response {
     invalid_date_count: long
     job_id: Id
     last_data_time?: integer
-    latest_record_timestamp?: long
+    latest_record_timestamp?: EpochTime<UnitMillis>
     missing_field_count: long
     out_of_order_timestamp_count: long
     processed_field_count: long

--- a/specification/ml/post_data/MlPostJobDataResponse.ts
+++ b/specification/ml/post_data/MlPostJobDataResponse.ts
@@ -18,25 +18,28 @@
  */
 
 import { Id } from '@_types/common'
-import { integer, long } from '@_types/Numeric'
+import { long } from '@_types/Numeric'
 import { EpochTime, UnitMillis } from '@_types/Time'
 
 export class Response {
   body: {
-    bucket_count: long
-    earliest_record_timestamp?: EpochTime<UnitMillis>
-    empty_bucket_count: long
+    job_id: Id
+    processed_record_count: long
+    processed_field_count: long
     input_bytes: long
     input_field_count: long
-    input_record_count: long
     invalid_date_count: long
-    job_id: Id
-    last_data_time?: integer
-    latest_record_timestamp?: EpochTime<UnitMillis>
     missing_field_count: long
     out_of_order_timestamp_count: long
-    processed_field_count: long
-    processed_record_count: long
+    empty_bucket_count: long
     sparse_bucket_count: long
+    bucket_count: long
+    earliest_record_timestamp?: EpochTime<UnitMillis>
+    latest_record_timestamp?: EpochTime<UnitMillis>
+    last_data_time?: EpochTime<UnitMillis>
+    latest_empty_bucket_timestamp?: EpochTime<UnitMillis>
+    latest_sparse_bucket_timestamp?: EpochTime<UnitMillis>
+    input_record_count: long
+    log_time?: EpochTime<UnitMillis>
   }
 }

--- a/specification/ml/post_data/MlPostJobDataResponse.ts
+++ b/specification/ml/post_data/MlPostJobDataResponse.ts
@@ -23,15 +23,15 @@ import { integer, long } from '@_types/Numeric'
 export class Response {
   body: {
     bucket_count: long
-    earliest_record_timestamp: long
+    earliest_record_timestamp?: long
     empty_bucket_count: long
     input_bytes: long
     input_field_count: long
     input_record_count: long
     invalid_date_count: long
     job_id: Id
-    last_data_time: integer
-    latest_record_timestamp: long
+    last_data_time?: integer
+    latest_record_timestamp?: long
     missing_field_count: long
     out_of_order_timestamp_count: long
     processed_field_count: long

--- a/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
+++ b/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
@@ -24,7 +24,7 @@ import {
   DataframeAnalyticsSource
 } from '@ml/_types/DataframeAnalytics'
 import { RequestBase } from '@_types/Base'
-import { HttpHeaders, Id, VersionString } from '@_types/common'
+import { HttpHeaders, Id, Metadata, VersionString } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
@@ -115,6 +115,8 @@ export interface Request extends RequestBase {
      * @server_default 1
      */
     max_num_threads?: integer
+
+    _meta?: Metadata
     /**
      * The approximate maximum amount of memory resources that are permitted for
      * analytical processing. If your `elasticsearch.yml` file contains an

--- a/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsResponse.ts
+++ b/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsResponse.ts
@@ -24,7 +24,7 @@ import {
   DataframeAnalyticsDestination,
   DataframeAnalyticsSource
 } from '@ml/_types/DataframeAnalytics'
-import { Id, VersionString } from '@_types/common'
+import { Id, Metadata, VersionString } from '@_types/common'
 import { integer } from '@_types/Numeric'
 import { EpochTime, UnitMillis } from '@_types/Time'
 
@@ -39,6 +39,7 @@ export class Response {
     dest: DataframeAnalyticsDestination
     id: Id
     max_num_threads: integer
+    _meta?: Metadata
     model_memory_limit: string
     source: DataframeAnalyticsSource
     version: VersionString

--- a/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
@@ -87,8 +87,10 @@ export interface Request extends RequestBase {
     ignore_unavailable?: boolean
   }
   body: {
-    /** If set, the datafeed performs aggregation searches.
+    /**
+     * If set, the datafeed performs aggregation searches.
      * Support for aggregations is limited and should be used only with low cardinality data.
+     * @aliases aggs
      */
     aggregations?: Dictionary<string, AggregationContainer>
     /**

--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -23,7 +23,7 @@ import { DataDescription } from '@ml/_types/Job'
 import { ModelPlotConfig } from '@ml/_types/ModelPlot'
 import { CustomSettings } from '@ml/_types/Settings'
 import { RequestBase } from '@_types/Base'
-import { Id, IndexName } from '@_types/common'
+import { ExpandWildcards, Id, IndexName } from '@_types/common'
 import { long } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
@@ -45,7 +45,35 @@ export interface Request extends RequestBase {
     job_id: Id
   }
   query_parameters: {
+    /**
+     * If `true`, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the
+     * `_all` string or when no indices are specified.
+     * @server_default true
+     */
+    allow_no_indices?: boolean
+    /**
+     * Type of index that wildcard patterns can match. If the request can target data streams, this argument determines
+     * whether wildcard expressions match hidden data streams. Supports comma-separated values. Valid values are:
+     *
+     * * `all`: Match any data stream or index, including hidden ones.
+     * * `closed`: Match closed, non-hidden indices. Also matches any non-hidden data stream. Data streams cannot be closed.
+     * * `hidden`: Match hidden data streams and hidden indices. Must be combined with `open`, `closed`, or both.
+     * * `none`: Wildcard patterns are not accepted.
+     * * `open`: Match open, non-hidden indices. Also matches any non-hidden data stream.
+     * @server_default open
+     */
+    expand_wildcards?: ExpandWildcards
+    /**
+     * If `true`, concrete, expanded or aliased indices are ignored when frozen.
+     * @server_default true
+     * @deprecated 7.16.0
+     */
     ignore_throttled?: boolean
+    /**
+     * If `true`, unavailable indices (missing or closed) are ignored.
+     * @server_default false
+     */
+    ignore_unavailable?: boolean
   }
   body: {
     /**

--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -84,6 +84,10 @@ export interface Request extends RequestBase {
      */
     description?: string
     /**
+     * The identifier for the anomaly detection job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters.
+     */
+    job_id?: Id
+    /**
      * A list of job groups. A job can belong to no groups or many.
      */
     groups?: string[]

--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -44,6 +44,9 @@ export interface Request extends RequestBase {
      */
     job_id: Id
   }
+  query_parameters: {
+    ignore_throttled?: boolean
+  }
   body: {
     /**
      * Advanced configuration option. Specifies whether this job can open when there is insufficient machine learning node capacity for it to be immediately assigned to a node. By default, if a machine learning node with capacity to run the job cannot immediately be found, the open anomaly detection jobs API returns an error. However, this is also subject to the cluster-wide `xpack.ml.max_lazy_ml_nodes` setting. If this option is set to true, the open anomaly detection jobs API does not return an error and the job waits in the opening state until sufficient machine learning node capacity is available.

--- a/specification/ml/update_job/MlUpdateJobRequest.ts
+++ b/specification/ml/update_job/MlUpdateJobRequest.ts
@@ -21,7 +21,7 @@ import {
   AnalysisMemoryLimit,
   PerPartitionCategorization
 } from '@ml/_types/Analysis'
-import { Detector } from '@ml/_types/Detector'
+import { DetectorUpdate } from '@ml/_types/Detector'
 import { ModelPlotConfig } from '@ml/_types/ModelPlot'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
@@ -131,7 +131,7 @@ export interface Request extends RequestBase {
     /**
      * An array of detector update objects.
      */
-    detectors?: Detector[]
+    detectors?: DetectorUpdate[]
     /**
      * Settings related to how categorization interacts with partition fields.
      */


### PR DESCRIPTION
References for the fixes:

- [x] [DiscoveryNode](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java#L45): two possible representation, one is the [standard one](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java#L566), the other is the "compact one" (can discuss naming of course) used by [ml.get_job_stats](https://github.com/elastic/elasticsearch/blob/b17674b48ab2abd8dd75108e9771e6144d704862/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsStatsAction.java#L258) and [ml.get_datafeed_stats](https://github.com/elastic/elasticsearch/blob/b17674b48ab2abd8dd75108e9771e6144d704862/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java#L195)
- [x] [IndicesOptions](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java#L53) - adding missing parameters
- [x] [AnalysisLimit](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisLimits.java#L31) - [model_memory_limit](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisLimits.java#L85) can accept both string and long
- [x] [Bucket](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Bucket.java#L32) - [timestamp_string](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/Bucket.java#L178) is nullable (depends on "humanReadable")
- [x] [DatafeedTimingStats](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java#L30) - added missing field [ExponentialAverageCalculationContext](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedTimingStats.java#L75)
- [x] [Datafeed](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java#L130) (response) - [timing_stats](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java#L218) is optional
- [x] [DataframeAnalyticsSummary](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java#L43) (or "config" in the server) - added missing [metadata](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java#L71)
- [x] [UpdateJob](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java#L33) (request) -  added missing field `detectors` - [DetectorUpdate](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java#L79)
- [x] [Model](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStats.java#L31) - added missing field [output_memory_allocator_bytes](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStats.java#L52)
- [x] [TrainedModelDeploymentStats](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java#L29) (AssignmentStatsin the server code) - several [missing properties](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java#L582) and optional ones
- [x] [TrainedModelDeploymentNodesStats](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java#L31) (inner class of AssignmentStats in the server code) - many [missing/optional properties](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStats.java#L276)
- [x] [TrainedModelConfig](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java#L64C14-L64C32) - missing [model_package](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java#L100) field, implemented as [ModelPackageConfig](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ModelPackageConfig.java#L33)
- [x] [TrainedModelAssignmentTaskParameters](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java#L446) (inner class in the server code) - missing [2 parameters, another one optional](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java#L676)
- [x] [TrainedModelAssignmentRoutingTable](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/RoutingInfo.java#L25) (RoutingInfo in server code) - some [optional parameters](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/RoutingInfo.java#L123) 
- [x] [TrainedModelAssignment](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java#L45) - missing [fields](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java#L56)
- [x] TokenizationConfigContainer -  added [bert_ja](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/BertJapaneseTokenization.java#L19) option 
- [x] [NlpRobertaTokenizationConfig](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RobertaTokenization.java#L24) - missing [do_lower_case](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/RobertaTokenization.java#L59)
- [x] [TextEmbeddingInferenceOptions](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfig.java#L28) - missing [vocabulary](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfig.java#L70)
- [x] [TextExpansionInferenceOptions](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfig.java#L28) -  missing [vocabulary](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfig.java#L67)
- [x] [FillMaskInferenceOptions](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfig.java#L30) - missing [vocabulary](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/FillMaskConfig.java#L70)
- [x] [MlGetTrainedModelRequest](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsAction.java#L47) - missing [include_model_definition](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestGetTrainedModelsAction.java#L94)
- [x] [Limits](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java#L133) (inner structure in server code) - missing [properties](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportMlInfoAction.java#L158)
- [x] [MlPostJobDataResponse](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCounts.java#L38) (DataCounts in server code) - multiple [optional properties](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCounts.java#L585)
- [x] [MlPutDataFrameAnalyticsRequest](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java#L43) - added missing [metadata](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java#L71)
- [x] MlPutDataFrameAnalyticsResponse - added missing metadata (same object as the request)
- [x] [MlPutDatafeedRequest](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java#L87) - added `aggs` as alias for `aggregations`, [both accepted](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java#L123)
- [x] [MlPutJobRequest](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutJobAction.java#L25) - added query parameter `ignore_throttled` (could not find server proof), body parameter [job_id](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutJobAction.java#L39)
- [x] [MlUpdateJobRequest](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java#L33) - `detectors` uses different class, [DetectorUpdate](https://github.com/elastic/elasticsearch/blob/045f6a31f994f51d87a217be60251e060132c8a1/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java#L79)

The only thins missing server-side proof is `ignore_throttled` as query parameter in `MlPutJobRequest`, I couldn't find it in parent classes either, so I'm trusting the validation on that one.
