### PR TITLE
Adding allow_partial_search_results parameter to OpenPointInTime action

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -23821,7 +23821,7 @@
           {
             "in": "query",
             "name": "allow_partial_search_results",
-            "description": "If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception. \nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
+            "description": "If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception.\nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
             "deprecated": false,
             "schema": {
               "type": "boolean"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -23817,6 +23817,16 @@
               "$ref": "#/components/schemas/_types:ExpandWildcards"
             },
             "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "allow_partial_search_results",
+            "description": "If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception. \nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -14336,6 +14336,16 @@
               "$ref": "#/components/schemas/_types:ExpandWildcards"
             },
             "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "allow_partial_search_results",
+            "description": "If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception. \nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -14340,7 +14340,7 @@
           {
             "in": "query",
             "name": "allow_partial_search_results",
-            "description": "If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception. \nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
+            "description": "If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception.\nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
             "deprecated": false,
             "schema": {
               "type": "boolean"

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -34121,7 +34121,7 @@
           }
         },
         {
-          "description": "If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception. \nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
+          "description": "If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception.\nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
           "name": "allow_partial_search_results",
           "required": false,
           "serverDefault": false,

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -34119,9 +34119,22 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "description": "If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception. \nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
+          "name": "allow_partial_search_results",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
         }
       ],
-      "specLocation": "_global/open_point_in_time/OpenPointInTimeRequest.ts#L25-L81"
+      "specLocation": "_global/open_point_in_time/OpenPointInTimeRequest.ts#L25-L87"
     },
     {
       "body": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -895,6 +895,7 @@ export interface OpenPointInTimeRequest extends RequestBase {
   preference?: string
   routing?: Routing
   expand_wildcards?: ExpandWildcards
+  allow_partial_search_results?: boolean
   body?: {
     index_filter?: QueryDslQueryContainer
   }

--- a/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
+++ b/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
@@ -71,6 +71,12 @@ export interface Request extends RequestBase {
      * @server_default open
      */
     expand_wildcards?: ExpandWildcards
+    /**
+     * If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception.
+     * If `true`, the point in time will contain all the shards that are available at the time of the request.
+     * @server_default false
+     */
+    allow_partial_search_results?: boolean
   }
   body: {
     /**

--- a/specification/_json_spec/open_point_in_time.json
+++ b/specification/_json_spec/open_point_in_time.json
@@ -50,7 +50,7 @@
       },
       "allow_partial_search_results": {
         "type": "boolean",
-        "description": "Specifiy whether to tolerate shards missing from the point in time creation, or throw an exception if any shard is missing. (default: false)"
+        "description": "Specify whether to tolerate shards missing when creating the point-in-time, or otherwise throw an exception. (default: false)"
       }
     },
     "body": {

--- a/specification/_json_spec/open_point_in_time.json
+++ b/specification/_json_spec/open_point_in_time.json
@@ -47,6 +47,10 @@
         "type": "string",
         "description": "Specific the time to live for the point in time",
         "required": true
+      },
+      "allow_partial_search_results": {
+        "type": "boolean",
+        "description": "Specifiy whether to tolerate shards missing from the point in time creation, or throw an exception if any shard is missing. (default: false)"
       }
     },
     "body": {


### PR DESCRIPTION
`allow_partial_search_results` was made available for the `OpenPointInTime` request in https://github.com/elastic/elasticsearch/pull/111516 but the specs weren't properly updated. This PR adds a new `allow_partial_search_results` parameter to the `OpenPointInTime` spec, which default to `false`, and specifies whether we should be lenient if a shard is missing when creating a point in time reference, or if we should throw.  

Closes https://github.com/elastic/elasticsearch-specification/issues/3144