### PR TITLE
[DOCS] Remove technical preview from serverless APIs

### DIFF
--- a/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
@@ -19,8 +19,3 @@ actions:
       x-feedbackLink:
         label: Feedback
         url: https://github.com/elastic/docs-content/issues/new?assignees=&labels=feedback%2Ccommunity&projects=&template=api-feedback.yaml&title=%5BFeedback%5D%3A+
-  # Temporarily mark all operations as beta
-  - target: "$.paths[*]['get','put','post','delete','options','head','patch','trace']"
-    description: Add x-beta
-    update:
-      x-beta: true

--- a/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-serverless-openapi-overlays.yaml
@@ -9,10 +9,6 @@ actions:
     update:
       title: Elasticsearch Serverless API
       description: >
-        **Technical preview**  
-        This functionality is in technical preview and may be changed or removed in a future release.
-        Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
-
         ## Documentation source and versions
         
         This documentation is derived from the `main` branch of the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification) repository.


### PR DESCRIPTION
This PR removes the "technical preview" text from the introduction of the Elasticsearch Serverless API docs.