### PR TITLE
Add missing autoscaling timeout parameters

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -482,6 +482,16 @@
               "$ref": "#/components/schemas/_types:Name"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "master_timeout",
+            "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
           }
         ],
         "responses": {
@@ -519,6 +529,26 @@
               "$ref": "#/components/schemas/_types:Name"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "master_timeout",
+            "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -566,6 +596,26 @@
               "$ref": "#/components/schemas/_types:Name"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "master_timeout",
+            "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
           }
         ],
         "responses": {
@@ -594,6 +644,18 @@
           "url": "https://www.elastic.co/guide/en/cloud/current/ec-autoscaling.html"
         },
         "operationId": "autoscaling-get-autoscaling-capacity",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "master_timeout",
+            "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "200": {
             "description": "",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -66,32 +66,6 @@
       ],
       "response": []
     },
-    "autoscaling.delete_autoscaling_policy": {
-      "request": [
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'timeout'"
-      ],
-      "response": []
-    },
-    "autoscaling.get_autoscaling_capacity": {
-      "request": [
-        "Request: missing json spec query parameter 'master_timeout'"
-      ],
-      "response": []
-    },
-    "autoscaling.get_autoscaling_policy": {
-      "request": [
-        "Request: missing json spec query parameter 'master_timeout'"
-      ],
-      "response": []
-    },
-    "autoscaling.put_autoscaling_policy": {
-      "request": [
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'timeout'"
-      ],
-      "response": []
-    },
     "bulk": {
       "request": [
         "Request: missing json spec query parameter 'type'",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6840,6 +6840,8 @@ export interface AutoscalingAutoscalingPolicy {
 
 export interface AutoscalingDeleteAutoscalingPolicyRequest extends RequestBase {
   name: Name
+  master_timeout?: Duration
+  timeout?: Duration
 }
 
 export type AutoscalingDeleteAutoscalingPolicyResponse = AcknowledgedResponseBase
@@ -6872,6 +6874,7 @@ export interface AutoscalingGetAutoscalingCapacityAutoscalingResources {
 }
 
 export interface AutoscalingGetAutoscalingCapacityRequest extends RequestBase {
+  master_timeout?: Duration
 }
 
 export interface AutoscalingGetAutoscalingCapacityResponse {
@@ -6880,12 +6883,15 @@ export interface AutoscalingGetAutoscalingCapacityResponse {
 
 export interface AutoscalingGetAutoscalingPolicyRequest extends RequestBase {
   name: Name
+  master_timeout?: Duration
 }
 
 export type AutoscalingGetAutoscalingPolicyResponse = AutoscalingAutoscalingPolicy
 
 export interface AutoscalingPutAutoscalingPolicyRequest extends RequestBase {
   name: Name
+  master_timeout?: Duration
+  timeout?: Duration
   body?: AutoscalingAutoscalingPolicy
 }
 

--- a/specification/autoscaling/delete_autoscaling_policy/DeleteAutoscalingPolicyRequest.ts
+++ b/specification/autoscaling/delete_autoscaling_policy/DeleteAutoscalingPolicyRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
+import { Duration } from '@_types/Time'
 
 /**
  * Delete an autoscaling policy.
@@ -32,5 +33,16 @@ import { Name } from '@_types/common'
 export interface Request extends RequestBase {
   path_parts: {
     name: Name
+  }
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s */
+    master_timeout?: Duration
+    /**
+     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s */
+    timeout?: Duration
   }
 }

--- a/specification/autoscaling/get_autoscaling_capacity/GetAutoscalingCapacityRequest.ts
+++ b/specification/autoscaling/get_autoscaling_capacity/GetAutoscalingCapacityRequest.ts
@@ -18,6 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
+import { Duration } from '@_types/Time'
 
 /**
  * Get the autoscaling capacity.
@@ -39,4 +40,12 @@ import { RequestBase } from '@_types/Base'
  * @doc_id autoscaling-get-autoscaling-capacity
  * @ext_doc_id autoscaling
  */
-export interface Request extends RequestBase {}
+export interface Request extends RequestBase {
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s */
+    master_timeout?: Duration
+  }
+}

--- a/specification/autoscaling/get_autoscaling_policy/GetAutoscalingPolicyRequest.ts
+++ b/specification/autoscaling/get_autoscaling_policy/GetAutoscalingPolicyRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
+import { Duration } from '@_types/Time'
 
 /**
  * Get an autoscaling policy.
@@ -32,5 +33,12 @@ import { Name } from '@_types/common'
 export interface Request extends RequestBase {
   path_parts: {
     name: Name
+  }
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s */
+    master_timeout?: Duration
   }
 }

--- a/specification/autoscaling/put_autoscaling_policy/PutAutoscalingPolicyRequest.ts
+++ b/specification/autoscaling/put_autoscaling_policy/PutAutoscalingPolicyRequest.ts
@@ -20,6 +20,7 @@
 import { AutoscalingPolicy } from '@autoscaling/_types/AutoscalingPolicy'
 import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
+import { Duration } from '@_types/Time'
 
 /**
  * Create or update an autoscaling policy.
@@ -33,6 +34,17 @@ import { Name } from '@_types/common'
 export interface Request extends RequestBase {
   path_parts: {
     name: Name
+  }
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s */
+    master_timeout?: Duration
+    /**
+     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * @server_default 30s */
+    timeout?: Duration
   }
   /** @codegen_name policy */
   body: AutoscalingPolicy


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/108759, @DaveCTurner added `master_timeout` support for autoscaling APIs. We were also already misssing `timeout` parameters. Note that adding those entries removes all the `autoscaling` entries in `output/schema/validation-errors.json`.