### PR TITLE
Silence formatting output

### DIFF
--- a/compiler/package.json
+++ b/compiler/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "lint": "ts-standard src",
     "lint:fix": "ts-standard --fix src",
-    "format:check": "prettier --config .prettierrc.json --check ../specification/",
-    "format:fix": "prettier --config .prettierrc.json --write ../specification/",
+    "format:check": "prettier --config .prettierrc.json --loglevel warn --check ../specification/",
+    "format:fix": "prettier --config .prettierrc.json --loglevel warn --write ../specification/",
     "generate-schema": "ts-node src/index.ts",
     "transform-expand-generics": "ts-node src/transform/expand-generics.ts",
     "transform-to-openapi": "ts-node src/transform/schema-to-openapi.ts",


### PR DESCRIPTION
Today, `make spec-format-fix` (a dependency of make contrib) nearly prints 2000 lines of output, which isn't useful while making the validation errors less visible.
