### PR TITLE
Use git recordings when running `make validate`

### DIFF
--- a/compiler/run-validations.js
+++ b/compiler/run-validations.js
@@ -174,7 +174,7 @@ async function run () {
     metadata.branchName = branchName
 
     spinner.text = 'Downloading recordings'
-    await $`node ${path.join(uploadRecordingsPath, 'download.js')} --branch ${branchName}`
+    await $`node ${path.join(uploadRecordingsPath, 'download.js')} --branch ${branchName} --git`
 
     spinner.text = 'Fetching artifacts'
     await $`node ${path.join(cloneEsPath, 'index.js')} --branch ${argv['branch']}`


### PR DESCRIPTION
With the corresponding clients-flight-recorder pull request, this requires running `make validate-no-cache` instead of simply `make validate`. For example:

```bash
❯ make validate-no-cache api=xpack.info branch=main
Validating endpoints
Validating xpack.info
xpack.info request has been successfully validated!

✔ 8 out of 8 test request cases are passing.
✔ 4 out of 4 test response cases are passing.
```