### PR TITLE
[8.x] Add support for new timezone field in watch schedules (#3181)

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -20328,6 +20328,7 @@ export interface WatcherReportingEmailAttachment {
 export type WatcherResponseContentType = 'json' | 'yaml' | 'text'
 
 export interface WatcherScheduleContainer {
+  timezone?: string
   cron?: WatcherCronExpression
   daily?: WatcherDailySchedule
   hourly?: WatcherHourlySchedule

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@stoplight/spectral-cli": "^6.13.0"
+        "@stoplight/spectral-cli": "^6.14.2"
       }
     },
     "node_modules/@asyncapi/specs": {
@@ -17,10 +17,23 @@
         "@types/json-schema": "^7.0.11"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@jsep-plugin/regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.3.tgz",
-      "integrity": "sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -29,9 +42,10 @@
       }
     },
     "node_modules/@jsep-plugin/ternary": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@jsep-plugin/ternary/-/ternary-1.1.3.tgz",
-      "integrity": "sha512-qtLGzCNzPVJ3kdH6/zoLWDPjauHIKiLSBAR71Wa0+PWvGA8wODUQvRgxtpUA5YqAYL3CQ8S4qXhd/9WuWTZirg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/ternary/-/ternary-1.1.4.tgz",
+      "integrity": "sha512-ck5wiqIbqdMX6WRQztBL7ASDty9YLgJ3sSAK5ZpBzXeySvFGCzIvM6UiAI4hTZ22fEcYQVV/zhUbNscggW+Ukg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
       },
@@ -200,19 +214,19 @@
       }
     },
     "node_modules/@stoplight/spectral-cli": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.13.0.tgz",
-      "integrity": "sha512-qofxmVN4czNNJdfq0OB8Qj1ihpIhyR0IgyQpJFda9FvWWn9vJqDuIsoGKWP7xIHwv3E31q3iviDIX3Ejy9tNcg==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.14.2.tgz",
+      "integrity": "sha512-yn49Tkin/Zzjwt39CbQvj3NZVolvXrjO3OLNn+Yd+LhQE5C96QNsULuE4q98e7+WRcLu4gK+Z0l5CxYNtsoPtw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/json": "~3.21.0",
         "@stoplight/path": "1.3.2",
-        "@stoplight/spectral-core": "^1.18.3",
-        "@stoplight/spectral-formatters": "^1.3.0",
-        "@stoplight/spectral-parsers": "^1.0.3",
+        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-formatters": "^1.4.1",
+        "@stoplight/spectral-parsers": "^1.0.4",
         "@stoplight/spectral-ref-resolver": "^1.0.4",
-        "@stoplight/spectral-ruleset-bundler": "^1.5.4",
-        "@stoplight/spectral-ruleset-migrator": "^1.9.6",
+        "@stoplight/spectral-ruleset-bundler": "^1.6.0",
+        "@stoplight/spectral-ruleset-migrator": "^1.11.0",
         "@stoplight/spectral-rulesets": ">=1",
         "@stoplight/spectral-runtime": "^1.1.2",
         "@stoplight/types": "^13.6.0",
@@ -220,47 +234,48 @@
         "fast-glob": "~3.2.12",
         "hpagent": "~1.2.0",
         "lodash": "~4.17.21",
-        "pony-cause": "^1.0.0",
-        "stacktracey": "^2.1.7",
-        "tslib": "^2.3.0",
+        "pony-cause": "^1.1.1",
+        "stacktracey": "^2.1.8",
+        "tslib": "^2.8.1",
         "yargs": "~17.7.2"
       },
       "bin": {
         "spectral": "dist/index.js"
       },
       "engines": {
-        "node": "^12.20 || >= 14.13"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-core": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.18.3.tgz",
-      "integrity": "sha512-YY8x7X2SWJIhGTLPol+eFiQpWPz0D0mJdkK2i4A0QJG68KkNhypP6+JBC7/Kz3XWjqr0L/RqAd+N5cQLPOKZGQ==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.19.4.tgz",
+      "integrity": "sha512-8hnZXfssTlV99SKo8J8BwMt5LsiBFHkCh0V3P7j8IPcCNl//bpG92U4TpYy7AwmUms/zCLX7sxNQC6AZ+bkfzg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "~3.21.0",
         "@stoplight/path": "1.3.2",
         "@stoplight/spectral-parsers": "^1.0.0",
-        "@stoplight/spectral-ref-resolver": "^1.0.0",
-        "@stoplight/spectral-runtime": "^1.0.0",
+        "@stoplight/spectral-ref-resolver": "^1.0.4",
+        "@stoplight/spectral-runtime": "^1.1.2",
         "@stoplight/types": "~13.6.0",
         "@types/es-aggregate-error": "^1.0.2",
         "@types/json-schema": "^7.0.11",
-        "ajv": "^8.6.0",
+        "ajv": "^8.17.1",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
         "es-aggregate-error": "^1.0.7",
-        "jsonpath-plus": "7.1.0",
+        "jsonpath-plus": "10.2.0",
         "lodash": "~4.17.21",
         "lodash.topath": "^4.5.2",
         "minimatch": "3.1.2",
-        "nimma": "0.2.2",
-        "pony-cause": "^1.0.0",
-        "simple-eval": "1.0.0",
-        "tslib": "^2.3.0"
+        "nimma": "0.2.3",
+        "pony-cause": "^1.1.1",
+        "simple-eval": "1.0.1",
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": "^12.20 || >= 14.13"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-core/node_modules/@stoplight/types": {
@@ -276,61 +291,64 @@
       }
     },
     "node_modules/@stoplight/spectral-formats": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.7.0.tgz",
-      "integrity": "sha512-vJ1vIkA2s96fdJp0d3AJBGuPAW3sj8yMamyzR+dquEFO6ZAoYBo/BVsKKQskYzZi/nwljlRqUmGVmcf2PncIaA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.8.2.tgz",
+      "integrity": "sha512-c06HB+rOKfe7tuxg0IdKDEA5XnjL2vrn/m/OVIIxtINtBzphZrOgtRn7epQ5bQF5SWp84Ue7UJWaGgDwVngMFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/json": "^3.17.0",
-        "@stoplight/spectral-core": "^1.8.0",
+        "@stoplight/spectral-core": "^1.19.2",
         "@types/json-schema": "^7.0.7",
-        "tslib": "^2.3.1"
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-formatters": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formatters/-/spectral-formatters-1.3.0.tgz",
-      "integrity": "sha512-ryuMwlzbPUuyn7ybSEbFYsljYmvTaTyD51wyCQs4ROzgfm3Yo5QDD0IsiJUzUpKK/Ml61ZX8ebgiPiRFEJtBpg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formatters/-/spectral-formatters-1.4.3.tgz",
+      "integrity": "sha512-03Nc6nhjMO9aHhJPgBH4zDwMPklKLWEMtvx+PMmzfStCndMjJkf8ki7O/55u3myZ1TwxBzln9z9tXPLSL3KKhw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/path": "^1.3.2",
-        "@stoplight/spectral-core": "^1.15.1",
-        "@stoplight/spectral-runtime": "^1.1.0",
+        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-runtime": "^1.1.2",
         "@stoplight/types": "^13.15.0",
+        "@types/markdown-escape": "^1.1.3",
         "chalk": "4.1.2",
         "cliui": "7.0.4",
         "lodash": "^4.17.21",
+        "markdown-escape": "^2.0.0",
         "node-sarif-builder": "^2.0.3",
         "strip-ansi": "6.0",
         "text-table": "^0.2.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": "^12.20 || >=14.13"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-functions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.9.0.tgz",
-      "integrity": "sha512-T+xl93ji8bpus4wUsTq8Qr2DSu2X9PO727rbxW61tTCG0s17CbsXOLYI+Ezjg5P6aaQlgXszGX8khtc57xk8Yw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-functions/-/spectral-functions-1.9.3.tgz",
+      "integrity": "sha512-jy4mguk0Ddz0Vr76PHervOZeyXTUW650zVfNT2Vt9Ji3SqtTVziHjq913CBVEGFS+IQw1McUXuHVLM6YKVZ6fQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "^3.17.1",
-        "@stoplight/spectral-core": "^1.7.0",
-        "@stoplight/spectral-formats": "^1.7.0",
-        "@stoplight/spectral-runtime": "^1.1.0",
+        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-formats": "^1.8.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
         "ajv": "^8.17.1",
         "ajv-draft-04": "~1.0.0",
         "ajv-errors": "~3.0.0",
         "ajv-formats": "~2.1.0",
         "lodash": "~4.17.21",
-        "tslib": "^2.3.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-parsers": {
@@ -402,28 +420,28 @@
       }
     },
     "node_modules/@stoplight/spectral-ruleset-migrator": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.10.0.tgz",
-      "integrity": "sha512-nDfkVfYeWWv0UvILC4TWZSnRqQ4rHgeOJO1/lHQ7XHeG5iONanQ639B1aK6ZS6vuUc8gwuyQsrPF67b4sHIyYw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.11.1.tgz",
+      "integrity": "sha512-z2A1Ual3bU7zLDxYqdHaxYgyirb7TVDaWXc9ONEBAo5W1isio0EHV59ujAUEOUHCLcY5ubd0eYeqgSjqPIQe8w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/json": "~3.21.0",
         "@stoplight/ordered-object-literal": "~1.0.4",
         "@stoplight/path": "1.3.2",
-        "@stoplight/spectral-functions": "^1.0.0",
-        "@stoplight/spectral-runtime": "^1.1.0",
+        "@stoplight/spectral-functions": "^1.9.1",
+        "@stoplight/spectral-runtime": "^1.1.2",
         "@stoplight/types": "^13.6.0",
         "@stoplight/yaml": "~4.2.3",
         "@types/node": "*",
         "ajv": "^8.17.1",
         "ast-types": "0.14.2",
-        "astring": "^1.7.5",
+        "astring": "^1.9.0",
         "reserved": "0.1.2",
-        "tslib": "^2.3.1",
+        "tslib": "^2.8.1",
         "validate-npm-package-name": "3.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^16.20 || ^18.18 || >= 20.17"
       }
     },
     "node_modules/@stoplight/spectral-ruleset-migrator/node_modules/@stoplight/yaml": {
@@ -564,6 +582,12 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
+    "node_modules/@types/markdown-escape": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-escape/-/markdown-escape-1.1.3.tgz",
+      "integrity": "sha512-JIc1+s3y5ujKnt/+N+wq6s/QdL2qZ11fP79MijrVXsAAnzSxCbT2j/3prHRouJdZ2yFLN3vkP0HytfnoCczjOw==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.14.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.7.tgz",
@@ -575,7 +599,8 @@
     "node_modules/@types/sarif": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
-      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ=="
+      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "license": "MIT"
     },
     "node_modules/@types/urijs": {
       "version": "1.19.25",
@@ -726,9 +751,10 @@
       }
     },
     "node_modules/astring": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/astring/-/astring-1.8.6.tgz",
-      "integrity": "sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
       "bin": {
         "astring": "bin/astring"
       }
@@ -800,6 +826,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -815,6 +842,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1169,6 +1197,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1343,7 +1372,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
@@ -1357,6 +1387,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1718,9 +1749,10 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/jsep": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.3.8.tgz",
-      "integrity": "sha512-qofGylTGgYj9gZFsHuyWAN4jr35eJ66qJCK4eKDnldohuUoQFbU3iZn2zjvEbd9wOAhP9Wx5DsAAduTyE1PSWQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -1739,6 +1771,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1747,11 +1780,21 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.1.0.tgz",
-      "integrity": "sha512-gTaNRsPWO/K2KY6MrqaUFClF9kmuM6MFH5Dhg1VYDODgFbByw1yb7xu3hrViE/sz+dGOeMWgCzwUwQtAnCTE9g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
+      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsonpointer": {
@@ -1778,7 +1821,8 @@
     "node_modules/lodash.topath": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
-      "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg=="
+      "integrity": "sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==",
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.25.9",
@@ -1788,6 +1832,12 @@
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       }
+    },
+    "node_modules/markdown-escape": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-escape/-/markdown-escape-2.0.0.tgz",
+      "integrity": "sha512-Trz4v0+XWlwy68LJIyw3bLbsJiC8XAbRCKF9DbEtZjyndKOGVx6n+wNB0VfoRmY2LKboQLeniap3xrb6LGSJ8A==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1821,9 +1871,10 @@
       }
     },
     "node_modules/nimma": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.2.tgz",
-      "integrity": "sha512-V52MLl7BU+tH2Np9tDrIXK8bql3MVUadnMIl/0/oZSGC9keuro0O9UUv9QKp0aMvtN8HRew4G7byY7H4eWsxaQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.2.3.tgz",
+      "integrity": "sha512-1ZOI8J+1PKKGceo/5CT5GfQOG6H8I2BencSK06YarZ2wXwH37BSSUWldqJmMJYA5JfqDqffxDXynt6f11AyKcA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@jsep-plugin/regex": "^1.0.1",
         "@jsep-plugin/ternary": "^1.0.2",
@@ -1834,17 +1885,8 @@
         "node": "^12.20 || >=14.13"
       },
       "optionalDependencies": {
-        "jsonpath-plus": "^6.0.1",
+        "jsonpath-plus": "^6.0.1 || ^10.1.0",
         "lodash.topath": "^4.5.2"
-      }
-    },
-    "node_modules/nimma/node_modules/jsonpath-plus": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-6.0.1.tgz",
-      "integrity": "sha512-EvGovdvau6FyLexFH2OeXfIITlgIbgZoAZe3usiySeaIDm5QS+A10DKNpaPBBqqRSZr2HN6HVNXxtwUAr2apEw==",
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/node-fetch": {
@@ -1870,6 +1912,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-2.0.3.tgz",
       "integrity": "sha512-Pzr3rol8fvhG/oJjIq2NTVB0vmdNNlz22FENhhPojYRZ4/ee08CfK4YuKmuL54V9MLhI1kpzxfOJ/63LzmZzDg==",
+      "license": "MIT",
       "dependencies": {
         "@types/sarif": "^2.1.4",
         "fs-extra": "^10.0.0"
@@ -2176,11 +2219,12 @@
       }
     },
     "node_modules/simple-eval": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.0.tgz",
-      "integrity": "sha512-kpKJR+bqTscgC0xuAl2xHN6bB12lHjC2DCUfqjAx19bQyO3R2EVLOurm3H9AUltv/uFVcSCVNc6faegR+8NYLw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-eval/-/simple-eval-1.0.1.tgz",
+      "integrity": "sha512-LH7FpTAkeD+y5xQC4fzS+tFtaNlvt3Ib1zKzvhjv/Y+cioV4zIuw4IZr2yhRLu67CWL7FR9/6KXKnjRoZTvGGQ==",
+      "license": "MIT",
       "dependencies": {
-        "jsep": "^1.1.2"
+        "jsep": "^1.3.6"
       },
       "engines": {
         "node": ">=12"
@@ -2284,6 +2328,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2306,7 +2351,8 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -2325,9 +2371,10 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.2",
@@ -2421,6 +2468,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "elasticsearch-specification",
       "dependencies": {
         "@stoplight/spectral-cli": "^6.14.2"
       }
@@ -2097,9 +2098,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@stoplight/spectral-cli": "^6.13.0"
+    "@stoplight/spectral-cli": "^6.14.2"
   }
 }

--- a/specification/watcher/_types/Schedule.ts
+++ b/specification/watcher/_types/Schedule.ts
@@ -81,6 +81,7 @@ export enum Month {
  * @variants container
  */
 export class ScheduleContainer {
+  timezone?: string
   cron?: CronExpression
   daily?: DailySchedule
   hourly?: HourlySchedule


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add support for new timezone field in watch schedules (#3181)](https://github.com/elastic/elasticsearch-specification/pull/3181)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)