### PR TITLE
[8.x] Fix async_search query parameter validation (#3167)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -128,6 +128,16 @@
               "$ref": "#/components/schemas/_types:Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "keep_alive",
+            "description": "Specifies how long the async search needs to be available.\nOngoing async searches and any saved search results are deleted after this period.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
           }
         ],
         "responses": {
@@ -222,9 +232,6 @@
           },
           {
             "$ref": "#/components/parameters/async_search.submit#routing"
-          },
-          {
-            "$ref": "#/components/parameters/async_search.submit#scroll"
           },
           {
             "$ref": "#/components/parameters/async_search.submit#search_type"
@@ -384,9 +391,6 @@
           },
           {
             "$ref": "#/components/parameters/async_search.submit#routing"
-          },
-          {
-            "$ref": "#/components/parameters/async_search.submit#scroll"
           },
           {
             "$ref": "#/components/parameters/async_search.submit#search_type"
@@ -86572,6 +86576,9 @@
       "watcher._types:ScheduleContainer": {
         "type": "object",
         "properties": {
+          "timezone": {
+            "type": "string"
+          },
           "cron": {
             "$ref": "#/components/schemas/watcher._types:CronExpression"
           },
@@ -92782,15 +92789,6 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
-        },
-        "style": "form"
-      },
-      "async_search.submit#scroll": {
-        "in": "query",
-        "name": "scroll",
-        "deprecated": false,
-        "schema": {
-          "$ref": "#/components/schemas/_types:Duration"
         },
         "style": "form"
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -128,6 +128,16 @@
               "$ref": "#/components/schemas/_types:Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "keep_alive",
+            "description": "Specifies how long the async search needs to be available.\nOngoing async searches and any saved search results are deleted after this period.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
           }
         ],
         "responses": {
@@ -222,9 +232,6 @@
           },
           {
             "$ref": "#/components/parameters/async_search.submit#routing"
-          },
-          {
-            "$ref": "#/components/parameters/async_search.submit#scroll"
           },
           {
             "$ref": "#/components/parameters/async_search.submit#search_type"
@@ -384,9 +391,6 @@
           },
           {
             "$ref": "#/components/parameters/async_search.submit#routing"
-          },
-          {
-            "$ref": "#/components/parameters/async_search.submit#scroll"
           },
           {
             "$ref": "#/components/parameters/async_search.submit#search_type"
@@ -57116,15 +57120,6 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
-        },
-        "style": "form"
-      },
-      "async_search.submit#scroll": {
-        "in": "query",
-        "name": "scroll",
-        "deprecated": false,
-        "schema": {
-          "$ref": "#/components/schemas/_types:Duration"
         },
         "style": "form"
       },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -10117,8 +10117,22 @@
           }
         }
       ],
-      "query": [],
-      "specLocation": "async_search/status/AsyncSearchStatusRequest.ts#L23-L39"
+      "query": [
+        {
+          "description": "Specifies how long the async search needs to be available.\nOngoing async searches and any saved search results are deleted after this period.",
+          "name": "keep_alive",
+          "required": false,
+          "serverDefault": "5d",
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "Duration",
+              "namespace": "_types"
+            }
+          }
+        }
+      ],
+      "specLocation": "async_search/status/AsyncSearchStatusRequest.ts#L24-L48"
     },
     {
       "body": {
@@ -10930,17 +10944,6 @@
           }
         },
         {
-          "name": "scroll",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "Duration",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
           "description": "Search operation type",
           "name": "search_type",
           "required": false,
@@ -11223,7 +11226,7 @@
           }
         }
       ],
-      "specLocation": "async_search/submit/AsyncSearchSubmitRequest.ts#L55-L290"
+      "specLocation": "async_search/submit/AsyncSearchSubmitRequest.ts#L55-L291"
     },
     {
       "body": {
@@ -105532,7 +105535,7 @@
         "name": "ScheduleTimeOfDay",
         "namespace": "watcher._types"
       },
-      "specLocation": "watcher/_types/Schedule.ts#L98-L103",
+      "specLocation": "watcher/_types/Schedule.ts#L99-L104",
       "type": {
         "items": [
           {
@@ -105589,7 +105592,7 @@
           }
         }
       ],
-      "specLocation": "watcher/_types/Schedule.ts#L105-L108"
+      "specLocation": "watcher/_types/Schedule.ts#L106-L109"
     },
     {
       "kind": "enum",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -49,16 +49,9 @@
         "type_alias definition _global.search._types:Suggest - Expected 1 generic parameters but got 0"
       ]
     },
-    "async_search.status": {
-      "request": [
-        "Request: missing json spec query parameter 'keep_alive'"
-      ],
-      "response": []
-    },
     "async_search.submit": {
       "request": [
         "Request: query parameter 'min_compatible_shard_node' does not exist in the json spec",
-        "Request: query parameter 'scroll' does not exist in the json spec",
         "interface definition _types:QueryVectorBuilder - Property text_embedding is a single-variant and must be required",
         "type_alias definition _spec_utils:PipeSeparatedFlags / union_of / instance_of - No type definition for '_spec_utils.PipeSeparatedFlags:T'"
       ],

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6732,6 +6732,7 @@ export type AsyncSearchGetResponse<TDocument = unknown> = AsyncSearchAsyncSearch
 
 export interface AsyncSearchStatusRequest extends RequestBase {
   id: Id
+  keep_alive?: Duration
 }
 
 export type AsyncSearchStatusResponse = AsyncSearchStatusStatusResponseBase
@@ -6767,7 +6768,6 @@ export interface AsyncSearchSubmitRequest extends RequestBase {
   pre_filter_shard_size?: long
   request_cache?: boolean
   routing?: Routing
-  scroll?: Duration
   search_type?: SearchType
   stats?: string[]
   stored_fields?: Fields

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "elasticsearch-specification",
       "dependencies": {
         "@stoplight/spectral-cli": "^6.14.2"
       }

--- a/specification/async_search/status/AsyncSearchStatusRequest.ts
+++ b/specification/async_search/status/AsyncSearchStatusRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 
 /**
  * Get the async search status.
@@ -35,5 +36,13 @@ export interface Request extends RequestBase {
   path_parts: {
     /** A unique identifier for the async search. */
     id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies how long the async search needs to be available.
+     * Ongoing async searches and any saved search results are deleted after this period.
+     * @server_default 5d
+     */
+    keep_alive?: Duration
   }
 }

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -67,7 +67,9 @@ import { Duration } from '@_types/Time'
  * @doc_id async-search
  * @doc_tag search
  */
-// NOTE: this is a SearchRequest with 3 added parameters: wait_for_completion_timeout, keep_on_completion and keep_alive
+// NOTE: this is a SearchRequest with:
+//  * 3 added parameters: wait_for_completion_timeout, keep_on_completion and keep_alive
+//  * 1 removed parameters: scroll
 export interface Request extends RequestBase {
   path_parts: {
     index?: Indices
@@ -124,7 +126,6 @@ export interface Request extends RequestBase {
     /** @server_default true */
     request_cache?: boolean
     routing?: Routing
-    scroll?: Duration
     search_type?: SearchType
     stats?: string[]
     stored_fields?: Fields


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix async_search query parameter validation (#3167)](https://github.com/elastic/elasticsearch-specification/pull/3167)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)