### PR TITLE
[Nodes.Info] Fix NodeInfoPath data

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -78352,10 +78352,17 @@
             }
           },
           "data": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
           }
         }
       },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -16857,7 +16857,7 @@ export interface NodesInfoNodeInfoPath {
   logs?: string
   home?: string
   repo?: string[]
-  data?: string[]
+  data?: string | string[]
 }
 
 export interface NodesInfoNodeInfoRepositories {

--- a/specification/nodes/info/types.ts
+++ b/specification/nodes/info/types.ts
@@ -159,7 +159,7 @@ export class NodeInfoPath {
   logs?: string
   home?: string
   repo?: string[]
-  data?: string[]
+  data?: string | string[]
 }
 
 export class NodeInfoRepositories {


### PR DESCRIPTION
Reported in https://github.com/elastic/go-elasticsearch/issues/911

Turns out the `data` key is in fact a union over a string and an array. [server code for reference.](https://github.com/elastic/elasticsearch/blob/e5bcb0c5b3563044edf96ee9c57f03733cd888a8/server/src/main/java/org/elasticsearch/env/Environment.java#L131)