### PR TITLE
Adding resolve_during_rolling_upgrade and _meta to the deprecation info API response

### DIFF
--- a/specification/migration/deprecations/types.ts
+++ b/specification/migration/deprecations/types.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+import { Dictionary } from '@spec_utils/Dictionary'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+
 export enum DeprecationLevel {
   none,
   info,
@@ -27,9 +30,11 @@ export enum DeprecationLevel {
 }
 
 export class Deprecation {
-  details: string
+  details?: string
   /** The level property describes the significance of the issue. */
   level: DeprecationLevel
   message: string
   url: string
+  resolve_during_rolling_upgrade: boolean
+  _meta?: Dictionary<string, UserDefinedValue>
 }


### PR DESCRIPTION
The resolve_during_rolling_upgrade and _meta fields (added sometime in 7.x) had been missing from the deprecation info api response definition. This also clarifies that the details field in the response is optional.