### PR TITLE
[DOCS] Add ES|QL search operation summary

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -7808,7 +7808,11 @@
         "tags": [
           "esql"
         ],
-        "summary": "Executes an ES|QL request",
+        "summary": "Run an ES|QL query",
+        "description": "Get search results for an ES|QL (Elasticsearch query language) query.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html"
+        },
         "operationId": "esql-query",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -4967,7 +4967,11 @@
         "tags": [
           "esql"
         ],
-        "summary": "Executes an ES|QL request",
+        "summary": "Run an ES|QL query",
+        "description": "Get search results for an ES|QL (Elasticsearch query language) query.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html"
+        },
         "operationId": "esql-query",
         "parameters": [
           {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -151,6 +151,7 @@ eql-sequences,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/e
 eql-missing-events,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/eql-syntax.html#eql-missing-events
 eql-syntax,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/eql-syntax.html
 eql,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/eql.html
+esql,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/esql.html
 esql-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/esql-rest.html
 esql-query-params,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/esql-rest.html#esql-rest-params
 esql-returning-localized-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/esql-rest.html#esql-locale-param

--- a/specification/esql/query/QueryRequest.ts
+++ b/specification/esql/query/QueryRequest.ts
@@ -24,11 +24,13 @@ import { FieldValue } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 
 /**
- * Executes an ES|QL request
+ * Run an ES|QL query.
+ * Get search results for an ES|QL (Elasticsearch query language) query.
  * @rest_spec_name esql.query
  * @availability stack since=8.11.0
  * @availability serverless
  * @doc_id esql-query
+ * @ext_doc_id esql
  */
 export interface Request extends RequestBase {
   query_parameters: {


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR edits the summary in https://www.elastic.co/docs/api/doc/elasticsearch-serverless/group/endpoint-esql based on https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-apis.html

