### PR TITLE
Allow string for total_fields index settings

### DIFF
--- a/specification/indices/_types/IndexSettings.ts
+++ b/specification/indices/_types/IndexSettings.ts
@@ -430,7 +430,7 @@ export class MappingLimitSettingsTotalFields {
    * degradations and memory issues, especially in clusters with a high load or few resources.
    * @server_default 1000
    */
-  limit?: long
+  limit?: long | string
   /**
    * This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set
    * to false (the default), the index request of the document that tries to add a dynamic field to the mapping will fail
@@ -439,7 +439,7 @@ export class MappingLimitSettingsTotalFields {
    * The fields that were not added to the mapping will be added to the _ignored field.
    * @server_default false
    */
-  ignore_dynamic_beyond_limit?: boolean
+  ignore_dynamic_beyond_limit?: boolean | string
 }
 
 export class MappingLimitSettingsDepth {


### PR DESCRIPTION
All index settings can be strings, as can be seen in https://github.com/elastic/elasticsearch/blame/6d155fcc5af670638be4961ac1e17f4d0a217658/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/logsdb/10_settings.yml#L623-L624.