### PR TITLE
[DOCS] Add graph explore operation summary

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -9277,7 +9277,11 @@
         "tags": [
           "graph"
         ],
-        "summary": "Extracts and summarizes information about the documents and terms in an Elasticsearch data stream or index",
+        "summary": "Explore graph analytics",
+        "description": "Extract and summarize information about the documents and terms in an Elasticsearch data stream or index.\nThe easiest way to understand the behaviour of this API is to use the Graph UI to explore connections.\nAn initial request to the `_explore` API contains a seed query that identifies the documents of interest and specifies the fields that define the vertices and connections you want to include in the graph.\nSubsequent requests enable you to spider out from one more vertices of interest.\nYou can exclude vertices that have already been returned.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/kibana/current/xpack-graph.html"
+        },
         "operationId": "graph-explore",
         "parameters": [
           {
@@ -9303,7 +9307,11 @@
         "tags": [
           "graph"
         ],
-        "summary": "Extracts and summarizes information about the documents and terms in an Elasticsearch data stream or index",
+        "summary": "Explore graph analytics",
+        "description": "Extract and summarize information about the documents and terms in an Elasticsearch data stream or index.\nThe easiest way to understand the behaviour of this API is to use the Graph UI to explore connections.\nAn initial request to the `_explore` API contains a seed query that identifies the documents of interest and specifies the fields that define the vertices and connections you want to include in the graph.\nSubsequent requests enable you to spider out from one more vertices of interest.\nYou can exclude vertices that have already been returned.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/kibana/current/xpack-graph.html"
+        },
         "operationId": "graph-explore-1",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -5650,7 +5650,11 @@
         "tags": [
           "graph"
         ],
-        "summary": "Extracts and summarizes information about the documents and terms in an Elasticsearch data stream or index",
+        "summary": "Explore graph analytics",
+        "description": "Extract and summarize information about the documents and terms in an Elasticsearch data stream or index.\nThe easiest way to understand the behaviour of this API is to use the Graph UI to explore connections.\nAn initial request to the `_explore` API contains a seed query that identifies the documents of interest and specifies the fields that define the vertices and connections you want to include in the graph.\nSubsequent requests enable you to spider out from one more vertices of interest.\nYou can exclude vertices that have already been returned.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/kibana/current/xpack-graph.html"
+        },
         "operationId": "graph-explore",
         "parameters": [
           {
@@ -5676,7 +5680,11 @@
         "tags": [
           "graph"
         ],
-        "summary": "Extracts and summarizes information about the documents and terms in an Elasticsearch data stream or index",
+        "summary": "Explore graph analytics",
+        "description": "Extract and summarize information about the documents and terms in an Elasticsearch data stream or index.\nThe easiest way to understand the behaviour of this API is to use the Graph UI to explore connections.\nAn initial request to the `_explore` API contains a seed query that identifies the documents of interest and specifies the fields that define the vertices and connections you want to include in the graph.\nSubsequent requests enable you to spider out from one more vertices of interest.\nYou can exclude vertices that have already been returned.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/kibana/current/xpack-graph.html"
+        },
         "operationId": "graph-explore-1",
         "parameters": [
           {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -187,6 +187,7 @@ get-trained-models,https://www.elastic.co/guide/en/elasticsearch/reference/{bran
 get-transform-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-transform-stats.html
 get-transform,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-transform.html
 get-trial-status,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-trial-status.html
+graph,https://www.elastic.co/guide/en/kibana/current/xpack-graph.html
 graph-explore-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/graph-explore-api.html
 grok-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/grok-processor.html
 gsub-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/gsub-processor.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -187,7 +187,7 @@ get-trained-models,https://www.elastic.co/guide/en/elasticsearch/reference/{bran
 get-transform-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-transform-stats.html
 get-transform,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-transform.html
 get-trial-status,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-trial-status.html
-graph,https://www.elastic.co/guide/en/kibana/current/xpack-graph.html
+graph,https://www.elastic.co/guide/en/kibana/{branch}/xpack-graph.html
 graph-explore-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/graph-explore-api.html
 grok-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/grok-processor.html
 gsub-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/gsub-processor.html

--- a/specification/graph/explore/GraphExploreRequest.ts
+++ b/specification/graph/explore/GraphExploreRequest.ts
@@ -28,7 +28,7 @@ import { Hop } from '../_types/Hop'
 /**
  * Explore graph analytics.
  * Extract and summarize information about the documents and terms in an Elasticsearch data stream or index.
- * The easiest way to understand the behaviour of this API is to use the Graph UI to explore connections.
+ * The easiest way to understand the behavior of this API is to use the Graph UI to explore connections.
  * An initial request to the `_explore` API contains a seed query that identifies the documents of interest and specifies the fields that define the vertices and connections you want to include in the graph.
  * Subsequent requests enable you to spider out from one more vertices of interest.
  * You can exclude vertices that have already been returned.

--- a/specification/graph/explore/GraphExploreRequest.ts
+++ b/specification/graph/explore/GraphExploreRequest.ts
@@ -26,11 +26,17 @@ import { ExploreControls } from '../_types/ExploreControls'
 import { Hop } from '../_types/Hop'
 
 /**
- * Extracts and summarizes information about the documents and terms in an Elasticsearch data stream or index.
+ * Explore graph analytics.
+ * Extract and summarize information about the documents and terms in an Elasticsearch data stream or index.
+ * The easiest way to understand the behaviour of this API is to use the Graph UI to explore connections.
+ * An initial request to the `_explore` API contains a seed query that identifies the documents of interest and specifies the fields that define the vertices and connections you want to include in the graph.
+ * Subsequent requests enable you to spider out from one more vertices of interest.
+ * You can exclude vertices that have already been returned.
  * @doc_id graph-explore-api
  * @rest_spec_name graph.explore
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @ext_doc_id graph
  */
 export interface Request extends RequestBase {
   path_parts: {


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR edits the summary in https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-graph-explore based on https://www.elastic.co/guide/en/elasticsearch/reference/current/graph-explore-api.html