### PR TITLE
[DOCS] Add ingest operation summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -15060,7 +15060,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Returns information about one or more geoip database configurations",
+        "summary": "Get GeoIP database configurations",
+        "description": "Get information about one or more IP geolocation database configurations.",
         "operationId": "ingest-get-geoip-database-1",
         "parameters": [
           {
@@ -15081,7 +15082,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Returns information about one or more geoip database configurations",
+        "summary": "Create or update GeoIP database configurations",
+        "description": "Create or update IP geolocation database configurations.",
         "operationId": "ingest-put-geoip-database",
         "parameters": [
           {
@@ -15156,7 +15158,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Deletes a geoip database configuration",
+        "summary": "Delete GeoIP database configurations",
+        "description": "Delete one or more IP geolocation database configurations.",
         "operationId": "ingest-delete-geoip-database",
         "parameters": [
           {
@@ -15211,8 +15214,11 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Returns information about one or more ingest pipelines",
-        "description": "This API returns a local reference of the pipeline.",
+        "summary": "Get pipelines",
+        "description": "Get information about one or more ingest pipelines.\nThis API returns a local reference of the pipeline.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html"
+        },
         "operationId": "ingest-get-pipeline-1",
         "parameters": [
           {
@@ -15236,8 +15242,11 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Creates or updates an ingest pipeline",
+        "summary": "Create or update a pipeline",
         "description": "Changes made using this API take effect immediately.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html"
+        },
         "operationId": "ingest-put-pipeline",
         "parameters": [
           {
@@ -15340,7 +15349,11 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Deletes one or more existing ingest pipeline",
+        "summary": "Delete pipelines",
+        "description": "Delete one or more ingest pipelines.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html"
+        },
         "operationId": "ingest-delete-pipeline",
         "parameters": [
           {
@@ -15395,7 +15408,11 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Gets download statistics for GeoIP2 databases used with the geoip processor",
+        "summary": "Get GeoIP statistics",
+        "description": "Get download statistics for GeoIP2 databases that are used with the GeoIP processor.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/geoip-processor.html"
+        },
         "operationId": "ingest-geo-ip-stats",
         "responses": {
           "200": {
@@ -15433,7 +15450,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Returns information about one or more geoip database configurations",
+        "summary": "Get GeoIP database configurations",
+        "description": "Get information about one or more IP geolocation database configurations.",
         "operationId": "ingest-get-geoip-database",
         "parameters": [
           {
@@ -15453,8 +15471,11 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Returns information about one or more ingest pipelines",
-        "description": "This API returns a local reference of the pipeline.",
+        "summary": "Get pipelines",
+        "description": "Get information about one or more ingest pipelines.\nThis API returns a local reference of the pipeline.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html"
+        },
         "operationId": "ingest-get-pipeline",
         "parameters": [
           {
@@ -15477,8 +15498,11 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Extracts structured fields out of a single text field within a document",
-        "description": "You choose which field to extract matched fields from, as well as the grok pattern you expect will match.\nA grok pattern is like a regular expression that supports aliased expressions that can be reused.",
+        "summary": "Run a grok processor",
+        "description": "Extract structured fields out of a single text field within a document.\nYou must choose which field to extract matched fields from, as well as the grok pattern you expect will match.\nA grok pattern is like a regular expression that supports aliased expressions that can be reused.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/grok-processor.html"
+        },
         "operationId": "ingest-processor-grok",
         "responses": {
           "200": {
@@ -15511,7 +15535,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Executes an ingest pipeline against a set of provided documents",
+        "summary": "Simulate a pipeline",
+        "description": "Run an ingest pipeline against a set of provided documents.\nYou can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.",
         "operationId": "ingest-simulate",
         "parameters": [
           {
@@ -15532,7 +15557,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Executes an ingest pipeline against a set of provided documents",
+        "summary": "Simulate a pipeline",
+        "description": "Run an ingest pipeline against a set of provided documents.\nYou can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.",
         "operationId": "ingest-simulate-1",
         "parameters": [
           {
@@ -15555,7 +15581,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Executes an ingest pipeline against a set of provided documents",
+        "summary": "Simulate a pipeline",
+        "description": "Run an ingest pipeline against a set of provided documents.\nYou can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.",
         "operationId": "ingest-simulate-2",
         "parameters": [
           {
@@ -15579,7 +15606,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Executes an ingest pipeline against a set of provided documents",
+        "summary": "Simulate a pipeline",
+        "description": "Run an ingest pipeline against a set of provided documents.\nYou can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.",
         "operationId": "ingest-simulate-3",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -8757,8 +8757,11 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Returns information about one or more ingest pipelines",
-        "description": "This API returns a local reference of the pipeline.",
+        "summary": "Get pipelines",
+        "description": "Get information about one or more ingest pipelines.\nThis API returns a local reference of the pipeline.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html"
+        },
         "operationId": "ingest-get-pipeline-1",
         "parameters": [
           {
@@ -8782,8 +8785,11 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Creates or updates an ingest pipeline",
+        "summary": "Create or update a pipeline",
         "description": "Changes made using this API take effect immediately.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html"
+        },
         "operationId": "ingest-put-pipeline",
         "parameters": [
           {
@@ -8886,7 +8892,11 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Deletes one or more existing ingest pipeline",
+        "summary": "Delete pipelines",
+        "description": "Delete one or more ingest pipelines.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html"
+        },
         "operationId": "ingest-delete-pipeline",
         "parameters": [
           {
@@ -8941,8 +8951,11 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Returns information about one or more ingest pipelines",
-        "description": "This API returns a local reference of the pipeline.",
+        "summary": "Get pipelines",
+        "description": "Get information about one or more ingest pipelines.\nThis API returns a local reference of the pipeline.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html"
+        },
         "operationId": "ingest-get-pipeline",
         "parameters": [
           {
@@ -8965,8 +8978,11 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Extracts structured fields out of a single text field within a document",
-        "description": "You choose which field to extract matched fields from, as well as the grok pattern you expect will match.\nA grok pattern is like a regular expression that supports aliased expressions that can be reused.",
+        "summary": "Run a grok processor",
+        "description": "Extract structured fields out of a single text field within a document.\nYou must choose which field to extract matched fields from, as well as the grok pattern you expect will match.\nA grok pattern is like a regular expression that supports aliased expressions that can be reused.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/grok-processor.html"
+        },
         "operationId": "ingest-processor-grok",
         "responses": {
           "200": {
@@ -8999,7 +9015,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Executes an ingest pipeline against a set of provided documents",
+        "summary": "Simulate a pipeline",
+        "description": "Run an ingest pipeline against a set of provided documents.\nYou can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.",
         "operationId": "ingest-simulate",
         "parameters": [
           {
@@ -9020,7 +9037,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Executes an ingest pipeline against a set of provided documents",
+        "summary": "Simulate a pipeline",
+        "description": "Run an ingest pipeline against a set of provided documents.\nYou can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.",
         "operationId": "ingest-simulate-1",
         "parameters": [
           {
@@ -9043,7 +9061,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Executes an ingest pipeline against a set of provided documents",
+        "summary": "Simulate a pipeline",
+        "description": "Run an ingest pipeline against a set of provided documents.\nYou can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.",
         "operationId": "ingest-simulate-2",
         "parameters": [
           {
@@ -9067,7 +9086,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Executes an ingest pipeline against a set of provided documents",
+        "summary": "Simulate a pipeline",
+        "description": "Run an ingest pipeline against a set of provided documents.\nYou can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.",
         "operationId": "ingest-simulate-3",
         "parameters": [
           {

--- a/specification/ingest/delete_geoip_database/DeleteGeoipDatabaseRequest.ts
+++ b/specification/ingest/delete_geoip_database/DeleteGeoipDatabaseRequest.ts
@@ -22,7 +22,7 @@ import { Ids } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Deletes a geoip database configuration.
+ * Delete an IP geolocation database configuration.
  * @rest_spec_name ingest.delete_geoip_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private

--- a/specification/ingest/delete_geoip_database/DeleteGeoipDatabaseRequest.ts
+++ b/specification/ingest/delete_geoip_database/DeleteGeoipDatabaseRequest.ts
@@ -22,7 +22,8 @@ import { Ids } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Delete an IP geolocation database configuration.
+ * Delete GeoIP database configurations.
+ * Delete one or more IP geolocation database configurations.
  * @rest_spec_name ingest.delete_geoip_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private

--- a/specification/ingest/delete_pipeline/DeletePipelineRequest.ts
+++ b/specification/ingest/delete_pipeline/DeletePipelineRequest.ts
@@ -22,10 +22,12 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Deletes one or more existing ingest pipeline.
+ * Delete pipelines.
+ * Delete one or more ingest pipelines.
  * @rest_spec_name ingest.delete_pipeline
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @ext_doc_id ingest
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ingest/geo_ip_stats/IngestGeoIpStatsRequest.ts
+++ b/specification/ingest/geo_ip_stats/IngestGeoIpStatsRequest.ts
@@ -20,10 +20,12 @@
 import { RequestBase } from '@_types/Base'
 
 /**
- * Gets download statistics for GeoIP2 databases used with the geoip processor.
+ * Get GeoIP statistics.
+ * Get download statistics for GeoIP2 databases that are used with the GeoIP processor.
  * @doc_id geoip-processor
  * @rest_spec_name ingest.geo_ip_stats
  * @availability stack since=7.13.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @ext_doc_id geoip-processor
  */
 export interface Request extends RequestBase {}

--- a/specification/ingest/get_geoip_database/GetGeoipDatabaseRequest.ts
+++ b/specification/ingest/get_geoip_database/GetGeoipDatabaseRequest.ts
@@ -22,7 +22,8 @@ import { Ids } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Returns information about one or more geoip database configurations.
+ * Get IP geolocation data configuration.
+ * Get information about one or more IP geoip database configurations.
  * @rest_spec_name ingest.get_geoip_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private

--- a/specification/ingest/get_geoip_database/GetGeoipDatabaseRequest.ts
+++ b/specification/ingest/get_geoip_database/GetGeoipDatabaseRequest.ts
@@ -22,8 +22,8 @@ import { Ids } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Get IP geolocation data configuration.
- * Get information about one or more IP geoip database configurations.
+ * Get GeoIP database configurations.
+ * Get information about one or more IP geolocation database configurations.
  * @rest_spec_name ingest.get_geoip_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private

--- a/specification/ingest/get_pipeline/GetPipelineRequest.ts
+++ b/specification/ingest/get_pipeline/GetPipelineRequest.ts
@@ -22,11 +22,13 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Returns information about one or more ingest pipelines.
+ * Get pipelines.
+ * Get information about one or more ingest pipelines.
  * This API returns a local reference of the pipeline.
  * @rest_spec_name ingest.get_pipeline
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @ext_doc_id ingest
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ingest/processor_grok/GrokProcessorPatternsRequest.ts
+++ b/specification/ingest/processor_grok/GrokProcessorPatternsRequest.ts
@@ -20,12 +20,14 @@
 import { RequestBase } from '@_types/Base'
 
 /**
- * Extracts structured fields out of a single text field within a document.
- * You choose which field to extract matched fields from, as well as the grok pattern you expect will match.
+ * Run a grok processor. 
+ * Extract structured fields out of a single text field within a document.
+ * You must choose which field to extract matched fields from, as well as the grok pattern you expect will match.
  * A grok pattern is like a regular expression that supports aliased expressions that can be reused.
  * @doc_id grok-processor
  * @rest_spec_name ingest.processor_grok
  * @availability stack since=6.1.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @ext_doc_id grok-processor
  */
 export interface Request extends RequestBase {}

--- a/specification/ingest/processor_grok/GrokProcessorPatternsRequest.ts
+++ b/specification/ingest/processor_grok/GrokProcessorPatternsRequest.ts
@@ -20,7 +20,7 @@
 import { RequestBase } from '@_types/Base'
 
 /**
- * Run a grok processor. 
+ * Run a grok processor.
  * Extract structured fields out of a single text field within a document.
  * You must choose which field to extract matched fields from, as well as the grok pattern you expect will match.
  * A grok pattern is like a regular expression that supports aliased expressions that can be reused.

--- a/specification/ingest/put_geoip_database/PutGeoipDatabaseRequest.ts
+++ b/specification/ingest/put_geoip_database/PutGeoipDatabaseRequest.ts
@@ -23,7 +23,7 @@ import { Id, Name } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Returns information about one or more geoip database configurations.
+ * Create or update IP geolocation database configurations.
  * @rest_spec_name ingest.put_geoip_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private

--- a/specification/ingest/put_geoip_database/PutGeoipDatabaseRequest.ts
+++ b/specification/ingest/put_geoip_database/PutGeoipDatabaseRequest.ts
@@ -23,6 +23,7 @@ import { Id, Name } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Create or update GeoIP database configurations.
  * Create or update IP geolocation database configurations.
  * @rest_spec_name ingest.put_geoip_database
  * @availability stack since=8.15.0 stability=stable

--- a/specification/ingest/put_pipeline/PutPipelineRequest.ts
+++ b/specification/ingest/put_pipeline/PutPipelineRequest.ts
@@ -23,12 +23,13 @@ import { Id, Metadata, VersionNumber } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Creates or updates an ingest pipeline.
+ * Create or update a pipeline.
  * Changes made using this API take effect immediately.
  * @doc_id ingest
  * @rest_spec_name ingest.put_pipeline
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @ext_doc_id ingest
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ingest/simulate/SimulatePipelineRequest.ts
+++ b/specification/ingest/simulate/SimulatePipelineRequest.ts
@@ -23,7 +23,9 @@ import { Id } from '@_types/common'
 import { Document } from './types'
 
 /**
- * Executes an ingest pipeline against a set of provided documents.
+ * Simulate a pipeline.
+ * Run an ingest pipeline against a set of provided documents.
+ * You can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.
  * @rest_spec_name ingest.simulate
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR edits the summaries in https://www.elastic.co/docs/api/doc/elasticsearch-serverless/group/endpoint-ingest based on https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest-apis.html