### PR TITLE
[DOCS] Add query rule operation summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -23991,7 +23991,11 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Returns the details about a query rule within a query ruleset",
+        "summary": "Get a query rule",
+        "description": "Get details about a query rule within a query ruleset.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-using-query-rules.html"
+        },
         "operationId": "query-rules-get-rule",
         "parameters": [
           {
@@ -24035,7 +24039,8 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Creates or updates a query rule within a query ruleset",
+        "summary": "Create or update a query rule",
+        "description": "Create or update a query rule within a query ruleset.",
         "operationId": "query-rules-put-rule",
         "parameters": [
           {
@@ -24126,7 +24131,8 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Deletes a query rule within a query ruleset",
+        "summary": "Delete a query rule",
+        "description": "Delete a query rule within a query ruleset.",
         "operationId": "query-rules-delete-rule",
         "parameters": [
           {
@@ -24172,7 +24178,8 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Returns the details about a query ruleset",
+        "summary": "Get a query ruleset",
+        "description": "Get details about a query ruleset.",
         "operationId": "query-rules-get-ruleset",
         "parameters": [
           {
@@ -24205,7 +24212,10 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Creates or updates a query ruleset",
+        "summary": "Create or update a query ruleset",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-using-query-rules.html"
+        },
         "operationId": "query-rules-put-ruleset",
         "parameters": [
           {
@@ -24274,7 +24284,7 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Deletes a query ruleset",
+        "summary": "Delete a query ruleset",
         "operationId": "query-rules-delete-ruleset",
         "parameters": [
           {
@@ -24309,7 +24319,8 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Returns summarized information about existing query rulesets",
+        "summary": "Get all query rulesets",
+        "description": "Get summarized information about the query rulesets.",
         "operationId": "query-rules-list-rulesets",
         "parameters": [
           {
@@ -24368,7 +24379,8 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Creates or updates a query ruleset",
+        "summary": "Test a query ruleset",
+        "description": "Evaluate match criteria against a query ruleset to identify the rules that would match that criteria.",
         "operationId": "query-rules-test",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -14448,7 +14448,11 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Returns the details about a query rule within a query ruleset",
+        "summary": "Get a query rule",
+        "description": "Get details about a query rule within a query ruleset.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-using-query-rules.html"
+        },
         "operationId": "query-rules-get-rule",
         "parameters": [
           {
@@ -14492,7 +14496,8 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Creates or updates a query rule within a query ruleset",
+        "summary": "Create or update a query rule",
+        "description": "Create or update a query rule within a query ruleset.",
         "operationId": "query-rules-put-rule",
         "parameters": [
           {
@@ -14583,7 +14588,8 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Deletes a query rule within a query ruleset",
+        "summary": "Delete a query rule",
+        "description": "Delete a query rule within a query ruleset.",
         "operationId": "query-rules-delete-rule",
         "parameters": [
           {
@@ -14629,7 +14635,8 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Returns the details about a query ruleset",
+        "summary": "Get a query ruleset",
+        "description": "Get details about a query ruleset.",
         "operationId": "query-rules-get-ruleset",
         "parameters": [
           {
@@ -14662,7 +14669,10 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Creates or updates a query ruleset",
+        "summary": "Create or update a query ruleset",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-using-query-rules.html"
+        },
         "operationId": "query-rules-put-ruleset",
         "parameters": [
           {
@@ -14731,7 +14741,7 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Deletes a query ruleset",
+        "summary": "Delete a query ruleset",
         "operationId": "query-rules-delete-ruleset",
         "parameters": [
           {
@@ -14766,7 +14776,8 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Returns summarized information about existing query rulesets",
+        "summary": "Get all query rulesets",
+        "description": "Get summarized information about the query rulesets.",
         "operationId": "query-rules-list-rulesets",
         "parameters": [
           {
@@ -14825,7 +14836,8 @@
         "tags": [
           "query_rules"
         ],
-        "summary": "Creates or updates a query ruleset",
+        "summary": "Test a query ruleset",
+        "description": "Evaluate match criteria against a query ruleset to identify the rules that would match that criteria.",
         "operationId": "query-rules-test",
         "parameters": [
           {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -414,6 +414,7 @@ query-dsl-weighted-tokens-query,https://www.elastic.co/guide/en/elasticsearch/re
 query-dsl-wildcard-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-wildcard-query.html
 query-dsl-wrapper-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-wrapper-query.html
 query-dsl,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
+query-rule,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-using-query-rules.html
 realtime,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-get.html#realtime
 redact-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/redact-processor.html
 regexp-syntax,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/regexp-syntax.html

--- a/specification/query_rules/delete_rule/QueryRuleDeleteRequest.ts
+++ b/specification/query_rules/delete_rule/QueryRuleDeleteRequest.ts
@@ -20,7 +20,8 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes a query rule within a query ruleset.
+ * Delete a query rule.
+ * Delete a query rule within a query ruleset.
  * @rest_spec_name query_rules.delete_rule
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/query_rules/delete_ruleset/QueryRulesetDeleteRequest.ts
+++ b/specification/query_rules/delete_ruleset/QueryRulesetDeleteRequest.ts
@@ -20,7 +20,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes a query ruleset.
+ * Delete a query ruleset.
  * @rest_spec_name query_rules.delete_ruleset
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/query_rules/get_rule/QueryRuleGetRequest.ts
+++ b/specification/query_rules/get_rule/QueryRuleGetRequest.ts
@@ -20,10 +20,12 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Returns the details about a query rule within a query ruleset
+ * Get a query rule.
+ * Get details about a query rule within a query ruleset.
  * @rest_spec_name query_rules.get_rule
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @ext_doc_id query-rule
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/query_rules/get_ruleset/QueryRulesetGetRequest.ts
+++ b/specification/query_rules/get_ruleset/QueryRulesetGetRequest.ts
@@ -20,7 +20,8 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Returns the details about a query ruleset
+ * Get a query ruleset.
+ * Get details about a query ruleset.
  * @rest_spec_name query_rules.get_ruleset
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/query_rules/list_rulesets/QueryRulesetListRequest.ts
+++ b/specification/query_rules/list_rulesets/QueryRulesetListRequest.ts
@@ -20,7 +20,8 @@ import { RequestBase } from '@_types/Base'
 import { integer } from '@_types/Numeric'
 
 /**
- * Returns summarized information about existing query rulesets.
+ * Get all query rulesets.
+ * Get summarized information about the query rulesets.
  * @rest_spec_name query_rules.list_rulesets
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/query_rules/put_rule/QueryRulePutRequest.ts
+++ b/specification/query_rules/put_rule/QueryRulePutRequest.ts
@@ -26,7 +26,8 @@ import {
 } from '../_types/QueryRuleset'
 
 /**
- * Creates or updates a query rule within a query ruleset.
+ * Create or update a query rule.
+ * Create or update a query rule within a query ruleset.
  * @rest_spec_name query_rules.put_rule
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/query_rules/put_ruleset/QueryRulesetPutRequest.ts
+++ b/specification/query_rules/put_ruleset/QueryRulesetPutRequest.ts
@@ -21,10 +21,11 @@ import { Id } from '@_types/common'
 import { QueryRule } from '../_types/QueryRuleset'
 
 /**
- * Creates or updates a query ruleset.
+ * Create or update a query ruleset.
  * @rest_spec_name query_rules.put_ruleset
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @ext_doc_id query-rule
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/query_rules/test/QueryRulesetTestRequest.ts
+++ b/specification/query_rules/test/QueryRulesetTestRequest.ts
@@ -22,7 +22,8 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Creates or updates a query ruleset.
+ * Test a query ruleset.
+ * Evaluate match criteria against a query ruleset to identify the rules that would match that criteria.
  * @rest_spec_name query_rules.test
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

This PR edits the summaries in https://www.elastic.co/docs/api/doc/elasticsearch-serverless/group/endpoint-query_rules based on https://www.elastic.co/guide/en/elasticsearch/reference/current/query-rules-apis.html