### PR TITLE
[DOCS] Add synonym operation summaries

### DIFF
--- a/specification/synonyms/delete_synonym/SynonymsDeleteRequest.ts
+++ b/specification/synonyms/delete_synonym/SynonymsDeleteRequest.ts
@@ -20,7 +20,7 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes a synonym set
+ * Delete a synonym set.
  * @rest_spec_name synonyms.delete_synonym
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/synonyms/delete_synonym_rule/SynonymRuleDeleteRequest.ts
+++ b/specification/synonyms/delete_synonym_rule/SynonymRuleDeleteRequest.ts
@@ -20,7 +20,8 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes a synonym rule in a synonym set
+ * Delete a synonym rule.
+ * Delete a synonym rule from a synonym set.
  * @rest_spec_name synonyms.delete_synonym_rule
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/synonyms/get_synonym/SynonymsGetRequest.ts
+++ b/specification/synonyms/get_synonym/SynonymsGetRequest.ts
@@ -21,7 +21,7 @@ import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
 
 /**
- * Retrieves a synonym set
+ * Get a synonym set.
  * @rest_spec_name synonyms.get_synonym
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/synonyms/get_synonym_rule/SynonymRuleGetRequest.ts
+++ b/specification/synonyms/get_synonym_rule/SynonymRuleGetRequest.ts
@@ -20,7 +20,8 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Retrieves a synonym rule from a synonym set
+ * Get a synonym rule.
+ * Get a synonym rule from a synonym set.
  * @rest_spec_name synonyms.get_synonym_rule
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/synonyms/get_synonyms_sets/SynonymsSetsGetRequest.ts
+++ b/specification/synonyms/get_synonyms_sets/SynonymsSetsGetRequest.ts
@@ -20,7 +20,8 @@ import { RequestBase } from '@_types/Base'
 import { integer } from '@_types/Numeric'
 
 /**
- * Retrieves a summary of all defined synonym sets
+ * Get all synonym sets.
+ * Get a summary of all defined synonym sets.
  * @rest_spec_name synonyms.get_synonyms_sets
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/synonyms/put_synonym/SynonymsPutRequest.ts
+++ b/specification/synonyms/put_synonym/SynonymsPutRequest.ts
@@ -21,7 +21,9 @@ import { Id } from '@_types/common'
 import { SynonymRule } from '../_types/SynonymRule'
 
 /**
- * Creates or updates a synonym set.
+ * Create or update a synonym set.
+ * Synonyms sets are limited to a maximum of 10000 synonym rules per set.
+ * If you need to manage more synonym rules, you can create multiple synonym sets.
  * @rest_spec_name synonyms.put_synonym
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/synonyms/put_synonym_rule/SynonymRulePutRequest.ts
+++ b/specification/synonyms/put_synonym_rule/SynonymRulePutRequest.ts
@@ -21,7 +21,8 @@ import { Id } from '@_types/common'
 import { SynonymString } from '../_types/SynonymRule'
 
 /**
- * Creates or updates a synonym rule in a synonym set
+ * Create or update a synonym rule.
+ * Create or update a synonym rule in a synonym set.
  * @rest_spec_name synonyms.put_synonym_rule
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

Adds operation summaries for https://www.elastic.co/docs/api/doc/elasticsearch-serverless/group/endpoint-synonyms based on https://www.elastic.co/guide/en/elasticsearch/reference/current/synonyms-apis.html