### PR TITLE
[DOCS] Add SQL operation summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -32179,7 +32179,7 @@
         "tags": [
           "sql"
         ],
-        "summary": "Clears the SQL cursor",
+        "summary": "Clear an SQL search cursor",
         "operationId": "sql-clear-cursor",
         "requestBody": {
           "content": {
@@ -32228,8 +32228,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Deletes an async SQL search or a stored synchronous SQL search",
-        "description": "If the search is still running, the API cancels it.",
+        "summary": "Delete an async SQL search",
+        "description": "Delete an async SQL search or a stored synchronous SQL search.\nIf the search is still running, the API cancels it.",
         "operationId": "sql-delete-async",
         "parameters": [
           {
@@ -32264,7 +32264,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Returns the current status and available results for an async SQL search or stored synchronous SQL search",
+        "summary": "Get async SQL search results",
+        "description": "Get the current status and available results for an async SQL search or stored synchronous SQL search.",
         "operationId": "sql-get-async",
         "parameters": [
           {
@@ -32376,7 +32377,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Returns the current status of an async SQL search or a stored synchronous SQL search",
+        "summary": "Get the async SQL search status",
+        "description": "Get the current status of an async SQL search or a stored synchronous SQL search.",
         "operationId": "sql-get-async-status",
         "parameters": [
           {
@@ -32441,7 +32443,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Executes a SQL request",
+        "summary": "Get SQL search results",
+        "description": "Run an SQL request.",
         "operationId": "sql-query-1",
         "parameters": [
           {
@@ -32462,7 +32465,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Executes a SQL request",
+        "summary": "Get SQL search results",
+        "description": "Run an SQL request.",
         "operationId": "sql-query",
         "parameters": [
           {
@@ -32485,7 +32489,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Translates SQL into Elasticsearch queries",
+        "summary": "Translate SQL into Elasticsearch queries",
+        "description": "Translate an SQL search into a search API request containing Query DSL.",
         "operationId": "sql-translate-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/sql.translate"
@@ -32501,7 +32506,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Translates SQL into Elasticsearch queries",
+        "summary": "Translate SQL into Elasticsearch queries",
+        "description": "Translate an SQL search into a search API request containing Query DSL.",
         "operationId": "sql-translate",
         "requestBody": {
           "$ref": "#/components/requestBodies/sql.translate"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -17386,7 +17386,7 @@
         "tags": [
           "sql"
         ],
-        "summary": "Clears the SQL cursor",
+        "summary": "Clear an SQL search cursor",
         "operationId": "sql-clear-cursor",
         "requestBody": {
           "content": {
@@ -17435,8 +17435,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Deletes an async SQL search or a stored synchronous SQL search",
-        "description": "If the search is still running, the API cancels it.",
+        "summary": "Delete an async SQL search",
+        "description": "Delete an async SQL search or a stored synchronous SQL search.\nIf the search is still running, the API cancels it.",
         "operationId": "sql-delete-async",
         "parameters": [
           {
@@ -17471,7 +17471,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Returns the current status and available results for an async SQL search or stored synchronous SQL search",
+        "summary": "Get async SQL search results",
+        "description": "Get the current status and available results for an async SQL search or stored synchronous SQL search.",
         "operationId": "sql-get-async",
         "parameters": [
           {
@@ -17583,7 +17584,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Returns the current status of an async SQL search or a stored synchronous SQL search",
+        "summary": "Get the async SQL search status",
+        "description": "Get the current status of an async SQL search or a stored synchronous SQL search.",
         "operationId": "sql-get-async-status",
         "parameters": [
           {
@@ -17648,7 +17650,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Executes a SQL request",
+        "summary": "Get SQL search results",
+        "description": "Run an SQL request.",
         "operationId": "sql-query-1",
         "parameters": [
           {
@@ -17669,7 +17672,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Executes a SQL request",
+        "summary": "Get SQL search results",
+        "description": "Run an SQL request.",
         "operationId": "sql-query",
         "parameters": [
           {
@@ -17692,7 +17696,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Translates SQL into Elasticsearch queries",
+        "summary": "Translate SQL into Elasticsearch queries",
+        "description": "Translate an SQL search into a search API request containing Query DSL.",
         "operationId": "sql-translate-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/sql.translate"
@@ -17708,7 +17713,8 @@
         "tags": [
           "sql"
         ],
-        "summary": "Translates SQL into Elasticsearch queries",
+        "summary": "Translate SQL into Elasticsearch queries",
+        "description": "Translate an SQL search into a search API request containing Query DSL.",
         "operationId": "sql-translate",
         "requestBody": {
           "$ref": "#/components/requestBodies/sql.translate"

--- a/specification/sql/clear_cursor/ClearSqlCursorRequest.ts
+++ b/specification/sql/clear_cursor/ClearSqlCursorRequest.ts
@@ -20,6 +20,7 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Clear an SQL search cursor.
  * @rest_spec_name sql.clear_cursor
  * @availability stack since=6.3.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/sql/delete_async/SqlDeleteAsyncRequest.ts
+++ b/specification/sql/delete_async/SqlDeleteAsyncRequest.ts
@@ -21,6 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
+ * Delete an async SQL search.
+ * Delete an async SQL search or a stored synchronous SQL search.
+ * If the search is still running, the API cancels it.
  * @rest_spec_name sql.delete_async
  * @availability stack since=7.15.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/sql/get_async/SqlGetAsyncRequest.ts
+++ b/specification/sql/get_async/SqlGetAsyncRequest.ts
@@ -22,6 +22,8 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Get async SQL search results.
+ * Get the current status and available results for an async SQL search or stored synchronous SQL search.
  * @rest_spec_name sql.get_async
  * @availability stack since=7.15.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/sql/get_async_status/SqlGetAsyncStatusRequest.ts
+++ b/specification/sql/get_async_status/SqlGetAsyncStatusRequest.ts
@@ -21,6 +21,8 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
+ * Get the async SQL search status.
+ * Get the current status of an async SQL search or a stored synchronous SQL search.
  * @rest_spec_name sql.get_async_status
  * @availability stack since=7.15.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/sql/query/QuerySqlRequest.ts
+++ b/specification/sql/query/QuerySqlRequest.ts
@@ -26,6 +26,8 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Duration, TimeZone } from '@_types/Time'
 
 /**
+ * Get SQL search results.
+ * Run an SQL request.
  * @rest_spec_name sql.query
  * @availability stack since=6.3.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/sql/translate/TranslateSqlRequest.ts
+++ b/specification/sql/translate/TranslateSqlRequest.ts
@@ -24,7 +24,7 @@ import { TimeZone } from '@_types/Time'
 
 /**
  * Translate SQL into Elasticsearch queries.
- * Translate an SQL search into a search API request containing Query DSL. 
+ * Translate an SQL search into a search API request containing Query DSL.
  * @rest_spec_name sql.translate
  * @availability stack since=6.3.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/sql/translate/TranslateSqlRequest.ts
+++ b/specification/sql/translate/TranslateSqlRequest.ts
@@ -23,6 +23,8 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { TimeZone } from '@_types/Time'
 
 /**
+ * Translate SQL into Elasticsearch queries.
+ * Translate an SQL search into a search API request containing Query DSL. 
  * @rest_spec_name sql.translate
  * @availability stack since=6.3.0 stability=stable
  * @availability serverless stability=stable visibility=public


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2635

Adds summaries to https://www.elastic.co/docs/api/doc/elasticsearch-serverless/group/endpoint-sql based on https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-apis.html