### PR TITLE
[DOCS] Edit Fleet operation summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -8557,8 +8557,8 @@
         "tags": [
           "fleet"
         ],
-        "summary": "Returns the current global checkpoints for an index",
-        "description": "This API is design for internal use by the fleet server project.",
+        "summary": "Get global checkpoints",
+        "description": "Get the current global checkpoints for an index.\nThis API is design for internal use by the Fleet server project.",
         "operationId": "fleet-global-checkpoints",
         "parameters": [
           {
@@ -8658,8 +8658,8 @@
         "tags": [
           "fleet"
         ],
-        "summary": "Executes several [fleet searches](https://www.elastic.co/guide/en/elasticsearch/reference/current/fleet-search.html) with a single API request",
-        "description": "The API follows the same structure as the [multi search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html) API. However, similar to the fleet search API, it\nsupports the wait_for_checkpoints parameter.",
+        "summary": "Run multiple Fleet searches",
+        "description": "Run several Fleet searches with a single API request.\nThe API follows the same structure as the multi search API.\nHowever, similar to the Fleet search API, it supports the `wait_for_checkpoints` parameter.",
         "operationId": "fleet-msearch",
         "parameters": [
           {
@@ -8716,8 +8716,8 @@
         "tags": [
           "fleet"
         ],
-        "summary": "Executes several [fleet searches](https://www.elastic.co/guide/en/elasticsearch/reference/current/fleet-search.html) with a single API request",
-        "description": "The API follows the same structure as the [multi search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html) API. However, similar to the fleet search API, it\nsupports the wait_for_checkpoints parameter.",
+        "summary": "Run multiple Fleet searches",
+        "description": "Run several Fleet searches with a single API request.\nThe API follows the same structure as the multi search API.\nHowever, similar to the Fleet search API, it supports the `wait_for_checkpoints` parameter.",
         "operationId": "fleet-msearch-1",
         "parameters": [
           {
@@ -8776,8 +8776,8 @@
         "tags": [
           "fleet"
         ],
-        "summary": "Executes several [fleet searches](https://www.elastic.co/guide/en/elasticsearch/reference/current/fleet-search.html) with a single API request",
-        "description": "The API follows the same structure as the [multi search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html) API. However, similar to the fleet search API, it\nsupports the wait_for_checkpoints parameter.",
+        "summary": "Run multiple Fleet searches",
+        "description": "Run several Fleet searches with a single API request.\nThe API follows the same structure as the multi search API.\nHowever, similar to the Fleet search API, it supports the `wait_for_checkpoints` parameter.",
         "operationId": "fleet-msearch-2",
         "parameters": [
           {
@@ -8837,8 +8837,8 @@
         "tags": [
           "fleet"
         ],
-        "summary": "Executes several [fleet searches](https://www.elastic.co/guide/en/elasticsearch/reference/current/fleet-search.html) with a single API request",
-        "description": "The API follows the same structure as the [multi search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html) API. However, similar to the fleet search API, it\nsupports the wait_for_checkpoints parameter.",
+        "summary": "Run multiple Fleet searches",
+        "description": "Run several Fleet searches with a single API request.\nThe API follows the same structure as the multi search API.\nHowever, similar to the Fleet search API, it supports the `wait_for_checkpoints` parameter.",
         "operationId": "fleet-msearch-3",
         "parameters": [
           {
@@ -8900,8 +8900,8 @@
         "tags": [
           "fleet"
         ],
-        "summary": "The purpose of the fleet search api is to provide a search api where the search will only be executed\n",
-        "description": "after provided checkpoint has been processed and is visible for searches inside of Elasticsearch.",
+        "summary": "Run a Fleet search",
+        "description": "The purpose of the Fleet search API is to provide a search api where the search will be run only\nafter the provided checkpoint has been processed and is visible for searches inside of Elasticsearch.",
         "operationId": "fleet-search",
         "parameters": [
           {
@@ -9051,8 +9051,8 @@
         "tags": [
           "fleet"
         ],
-        "summary": "The purpose of the fleet search api is to provide a search api where the search will only be executed\n",
-        "description": "after provided checkpoint has been processed and is visible for searches inside of Elasticsearch.",
+        "summary": "Run a Fleet search",
+        "description": "The purpose of the Fleet search API is to provide a search api where the search will be run only\nafter the provided checkpoint has been processed and is visible for searches inside of Elasticsearch.",
         "operationId": "fleet-search-1",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -8558,7 +8558,7 @@
           "fleet"
         ],
         "summary": "Get global checkpoints",
-        "description": "Get the current global checkpoints for an index.\nThis API is design for internal use by the Fleet server project.",
+        "description": "Get the current global checkpoints for an index.\nThis API is designed for internal use by the Fleet server project.",
         "operationId": "fleet-global-checkpoints",
         "parameters": [
           {
@@ -8901,7 +8901,7 @@
           "fleet"
         ],
         "summary": "Run a Fleet search",
-        "description": "The purpose of the Fleet search API is to provide a search api where the search will be run only\nafter the provided checkpoint has been processed and is visible for searches inside of Elasticsearch.",
+        "description": "The purpose of the Fleet search API is to provide an API where the search will be run only\nafter the provided checkpoint has been processed and is visible for searches inside of Elasticsearch.",
         "operationId": "fleet-search",
         "parameters": [
           {
@@ -9052,7 +9052,7 @@
           "fleet"
         ],
         "summary": "Run a Fleet search",
-        "description": "The purpose of the Fleet search API is to provide a search api where the search will be run only\nafter the provided checkpoint has been processed and is visible for searches inside of Elasticsearch.",
+        "description": "The purpose of the Fleet search API is to provide an API where the search will be run only\nafter the provided checkpoint has been processed and is visible for searches inside of Elasticsearch.",
         "operationId": "fleet-search-1",
         "parameters": [
           {

--- a/specification/fleet/global_checkpoints/GlobalCheckpointsRequest.ts
+++ b/specification/fleet/global_checkpoints/GlobalCheckpointsRequest.ts
@@ -23,6 +23,9 @@ import { Duration } from '@_types/Time'
 import { Checkpoint } from '../_types/Checkpoints'
 
 /**
+ * Get global checkpoints.
+ * Get the current global checkpoints for an index.
+ * This API is design for internal use by the Fleet server project.
  * @rest_spec_name fleet.global_checkpoints
  * @availability stack since=7.13.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/fleet/global_checkpoints/GlobalCheckpointsRequest.ts
+++ b/specification/fleet/global_checkpoints/GlobalCheckpointsRequest.ts
@@ -25,7 +25,7 @@ import { Checkpoint } from '../_types/Checkpoints'
 /**
  * Get global checkpoints.
  * Get the current global checkpoints for an index.
- * This API is design for internal use by the Fleet server project.
+ * This API is designed for internal use by the Fleet server project.
  * @rest_spec_name fleet.global_checkpoints
  * @availability stack since=7.13.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/fleet/msearch/MultiSearchRequest.ts
+++ b/specification/fleet/msearch/MultiSearchRequest.ts
@@ -29,9 +29,10 @@ import { long } from '@_types/Numeric'
 import { Checkpoint } from '../_types/Checkpoints'
 
 /**
- * Executes several [fleet searches](https://www.elastic.co/guide/en/elasticsearch/reference/current/fleet-search.html) with a single API request.
- * The API follows the same structure as the [multi search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html) API. However, similar to the fleet search API, it
- * supports the wait_for_checkpoints parameter.
+ * Run multiple Fleet searches.
+ * Run several Fleet searches with a single API request.
+ * The API follows the same structure as the multi search API.
+ * However, similar to the Fleet search API, it supports the `wait_for_checkpoints` parameter.
  * @rest_spec_name fleet.msearch
  * @availability stack since=7.16.0 stability=experimental
  * @availability serverless stability=experimental visibility=private

--- a/specification/fleet/search/SearchRequest.ts
+++ b/specification/fleet/search/SearchRequest.ts
@@ -53,7 +53,7 @@ import { Checkpoint } from '../_types/Checkpoints'
 
 /**
  * Run a Fleet search.
- * The purpose of the Fleet search API is to provide a search api where the search will be run only
+ * The purpose of the Fleet search API is to provide a search API where the search will be run only
  * after the provided checkpoint has been processed and is visible for searches inside of Elasticsearch.
  * @rest_spec_name fleet.search
  * @availability stack since=7.16.0 stability=experimental

--- a/specification/fleet/search/SearchRequest.ts
+++ b/specification/fleet/search/SearchRequest.ts
@@ -53,7 +53,7 @@ import { Checkpoint } from '../_types/Checkpoints'
 
 /**
  * Run a Fleet search.
- * The purpose of the Fleet search API is to provide a search API where the search will be run only
+ * The purpose of the Fleet search API is to provide an API where the search will be run only
  * after the provided checkpoint has been processed and is visible for searches inside of Elasticsearch.
  * @rest_spec_name fleet.search
  * @availability stack since=7.16.0 stability=experimental

--- a/specification/fleet/search/SearchRequest.ts
+++ b/specification/fleet/search/SearchRequest.ts
@@ -52,8 +52,9 @@ import { Duration } from '@_types/Time'
 import { Checkpoint } from '../_types/Checkpoints'
 
 /**
- * The purpose of the fleet search api is to provide a search api where the search will only be executed
- * after provided checkpoint has been processed and is visible for searches inside of Elasticsearch.
+ * Run a Fleet search.
+ * The purpose of the Fleet search API is to provide a search api where the search will be run only
+ * after the provided checkpoint has been processed and is visible for searches inside of Elasticsearch.
  * @rest_spec_name fleet.search
  * @availability stack since=7.16.0 stability=experimental
  * @availability serverless stability=experimental visibility=private


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3226

This PR edits the Fleet summaries in https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-fleet based on content from https://www.elastic.co/guide/en/elasticsearch/reference/current/fleet-apis.html