### PR TITLE
[8.x] Consider CommonCatQueryParameters to validate query parameters (#3260)

### DIFF
--- a/compiler/src/steps/validate-rest-spec.ts
+++ b/compiler/src/steps/validate-rest-spec.ts
@@ -160,27 +160,27 @@ export default async function validateRestSpec (model: model.Model, jsonSpec: Ma
       if (definition.body.kind !== 'no_body') {
         body = Body.yesBody
       }
+
+      if (definition.attachedBehaviors != null) {
+        for (const attachedBehavior of definition.attachedBehaviors) {
+          const type_ = getDefinition({
+            namespace: '_spec_utils',
+            name: attachedBehavior
+          })
+          if (
+            type_.kind === 'interface' &&
+            // allowing CommonQueryParameters too generates many errors
+            attachedBehavior === 'CommonCatQueryParameters'
+          ) {
+            for (const prop of type_.properties) {
+              query.push(prop)
+            }
+          }
+        }
+      }
     } else {
       if (definition.properties.length > 0) {
         query.push(...definition.properties)
-      }
-    }
-
-    if (Array.isArray(definition.inherits)) {
-      const inherits = definition.inherits.map(inherit => getDefinition(inherit.type))
-      for (const inherit of inherits) {
-        const properties = getProperties(inherit)
-        if (properties.path.length > 0) {
-          path.push(...properties.path)
-        }
-
-        if (properties.query.length > 0) {
-          query.push(...properties.query)
-        }
-
-        if (properties.body === Body.yesBody) {
-          body = properties.body
-        }
       }
     }
 

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -58714,11 +58714,25 @@
         "properties": {
           "limit": {
             "description": "The maximum number of fields in an index. Field and object mappings, as well as field aliases count towards this limit.\nThe limit is in place to prevent mappings and searches from becoming too large. Higher values can lead to performance\ndegradations and memory issues, especially in clusters with a high load or few resources.",
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "ignore_dynamic_beyond_limit": {
             "description": "This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set\nto false (the default), the index request of the document that tries to add a dynamic field to the mapping will fail\nwith the message Limit of total fields [X] has been exceeded. When set to true, the index request will not fail.\nInstead, fields that would exceed the limit are not added to the mapping, similar to dynamic: false.\nThe fields that were not added to the mapping will be added to the _ignored field.",
-            "type": "boolean"
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string"
+              }
+            ]
           }
         }
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -40139,11 +40139,25 @@
         "properties": {
           "limit": {
             "description": "The maximum number of fields in an index. Field and object mappings, as well as field aliases count towards this limit.\nThe limit is in place to prevent mappings and searches from becoming too large. Higher values can lead to performance\ndegradations and memory issues, especially in clusters with a high load or few resources.",
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "ignore_dynamic_beyond_limit": {
             "description": "This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set\nto false (the default), the index request of the document that tries to add a dynamic field to the mapping will fail\nwith the message Limit of total fields [X] has been exceeded. When set to true, the index request will not fail.\nInstead, fields that would exceed the limit are not added to the mapping, similar to dynamic: false.\nThe fields that were not added to the mapping will be added to the _ignored field.",
-            "type": "boolean"
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string"
+              }
+            ]
           }
         }
       },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -114061,26 +114061,50 @@
           "description": "The maximum number of fields in an index. Field and object mappings, as well as field aliases count towards this limit.\nThe limit is in place to prevent mappings and searches from becoming too large. Higher values can lead to performance\ndegradations and memory issues, especially in clusters with a high load or few resources.",
           "name": "limit",
           "required": false,
-          "serverDefault": 1000,
+          "serverDefault": "1000",
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "long",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
           "description": "This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set\nto false (the default), the index request of the document that tries to add a dynamic field to the mapping will fail\nwith the message Limit of total fields [X] has been exceeded. When set to true, the index request will not fail.\nInstead, fields that would exceed the limit are not added to the mapping, similar to dynamic: false.\nThe fields that were not added to the mapping will be added to the _ignored field.",
           "name": "ignore_dynamic_beyond_limit",
           "required": false,
-          "serverDefault": false,
+          "serverDefault": "false",
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "_builtins"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "boolean",
+                  "namespace": "_builtins"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         }
       ],

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -73,25 +73,13 @@
     },
     "cat.aliases": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.aliases:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.allocation": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.allocation:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": [
@@ -100,88 +88,62 @@
     },
     "cat.component_templates": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.component_templates:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.count": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
+        "Request: query parameter 'local' does not exist in the json spec",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.count:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.fielddata": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
+        "Request: query parameter 'local' does not exist in the json spec",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.fielddata:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.health": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
+        "Request: query parameter 'local' does not exist in the json spec",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.health:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.help": {
       "request": [
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
+        "Request: query parameter 'format' does not exist in the json spec",
+        "Request: query parameter 'h' does not exist in the json spec",
+        "Request: query parameter 'local' does not exist in the json spec",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
+        "Request: query parameter 'v' does not exist in the json spec",
         "request definition cat.help:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.indices": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
+        "Request: query parameter 'local' does not exist in the json spec",
         "request definition cat.indices:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.master": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.master:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.ml_data_frame_analytics": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 'v'",
+        "Request: query parameter 'local' does not exist in the json spec",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.ml_data_frame_analytics:Request / query - Property 'h' is already defined in an ancestor class",
         "request definition cat.ml_data_frame_analytics:Request / query - Property 's' is already defined in an ancestor class",
         "request definition cat.ml_data_frame_analytics:Request / body - A request with inherited properties must have a PropertyBody"
@@ -190,9 +152,8 @@
     },
     "cat.ml_datafeeds": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 'v'",
+        "Request: query parameter 'local' does not exist in the json spec",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.ml_datafeeds:Request / query - Property 'h' is already defined in an ancestor class",
         "request definition cat.ml_datafeeds:Request / query - Property 's' is already defined in an ancestor class",
         "request definition cat.ml_datafeeds:Request / body - A request with inherited properties must have a PropertyBody"
@@ -201,9 +162,8 @@
     },
     "cat.ml_jobs": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 'v'",
+        "Request: query parameter 'local' does not exist in the json spec",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.ml_jobs:Request / query - Property 'h' is already defined in an ancestor class",
         "request definition cat.ml_jobs:Request / query - Property 's' is already defined in an ancestor class",
         "request definition cat.ml_jobs:Request / body - A request with inherited properties must have a PropertyBody"
@@ -212,10 +172,9 @@
     },
     "cat.ml_trained_models": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'help'",
+        "Request: query parameter 'local' does not exist in the json spec",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
         "Request: missing json spec query parameter 'time'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.ml_trained_models:Request / query - Property 'h' is already defined in an ancestor class",
         "request definition cat.ml_trained_models:Request / query - Property 's' is already defined in an ancestor class",
         "request definition cat.ml_trained_models:Request / body - A request with inherited properties must have a PropertyBody"
@@ -224,117 +183,68 @@
     },
     "cat.nodeattrs": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.nodeattrs:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.nodes": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
+        "Request: query parameter 'local' does not exist in the json spec",
         "Request: missing json spec query parameter 'time'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.nodes:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.pending_tasks": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
         "Request: missing json spec query parameter 'time'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.pending_tasks:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.plugins": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
         "Request: missing json spec query parameter 'include_bootstrap'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.plugins:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.recovery": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
+        "Request: query parameter 'local' does not exist in the json spec",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
         "Request: missing json spec query parameter 'index'",
-        "Request: missing json spec query parameter 's'",
         "Request: missing json spec query parameter 'time'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.recovery:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.repositories": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.repositories:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.segments": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
+        "Request: query parameter 'local' does not exist in the json spec",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.segments:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.shards": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
+        "Request: query parameter 'local' does not exist in the json spec",
         "Request: missing json spec query parameter 'time'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.shards:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.snapshots": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
+        "Request: query parameter 'local' does not exist in the json spec",
         "Request: missing json spec query parameter 'time'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.snapshots:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
@@ -342,48 +252,30 @@
     "cat.tasks": {
       "request": [
         "Request: query parameter 'node_id' does not exist in the json spec",
-        "Request: missing json spec query parameter 'format'",
+        "Request: query parameter 'local' does not exist in the json spec",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
         "Request: missing json spec query parameter 'nodes'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
         "Request: missing json spec query parameter 'time'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.tasks:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.templates": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.templates:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.thread_pool": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'local'",
-        "Request: missing json spec query parameter 'master_timeout'",
-        "Request: missing json spec query parameter 'h'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 's'",
-        "Request: missing json spec query parameter 'v'",
         "request definition cat.thread_pool:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.transforms": {
       "request": [
-        "Request: missing json spec query parameter 'format'",
-        "Request: missing json spec query parameter 'help'",
-        "Request: missing json spec query parameter 'v'",
+        "Request: query parameter 'local' does not exist in the json spec",
+        "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.transforms:Request / query - Property 'h' is already defined in an ancestor class",
         "request definition cat.transforms:Request / query - Property 's' is already defined in an ancestor class",
         "request definition cat.transforms:Request / body - A request with inherited properties must have a PropertyBody"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11187,8 +11187,8 @@ export interface IndicesMappingLimitSettingsNestedObjects {
 }
 
 export interface IndicesMappingLimitSettingsTotalFields {
-  limit?: long
-  ignore_dynamic_beyond_limit?: boolean
+  limit?: long | string
+  ignore_dynamic_beyond_limit?: boolean | string
 }
 
 export interface IndicesMerge {


### PR DESCRIPTION
The JSON rest-api-spec generally encodes this parameters, so that reduces the number of validation errors.

(cherry picked from commit d9bf86fe712f25f7ef5c0037eab484a22008c896)

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
