### PR TITLE
[8.x] Ignore missing query parameters in fleet rest-api-spec (#3166)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -233,5 +233,6 @@ dist/*            binary
 ### Linguist Overrides #############################################################################
 
 output/** linguist-generated=true
+output/schema/validation-errors.json linguist-generated=false
 
 ####################################################################################################

--- a/compiler/src/steps/validate-rest-spec.ts
+++ b/compiler/src/steps/validate-rest-spec.ts
@@ -97,7 +97,8 @@ export default async function validateRestSpec (model: model.Model, jsonSpec: Ma
         }
       }
 
-      if (spec.params != null) {
+      // fleet API are deliberately undocumented in rest-api-spec)
+      if (spec.params != null && !endpoint.name.startsWith('fleet.')) {
         const params = Object.keys(spec.params)
         const queryProperties = requestProperties.query.map(property => property.name)
         // are all the parameters in the request definition present in the json spec?

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -58714,11 +58714,25 @@
         "properties": {
           "limit": {
             "description": "The maximum number of fields in an index. Field and object mappings, as well as field aliases count towards this limit.\nThe limit is in place to prevent mappings and searches from becoming too large. Higher values can lead to performance\ndegradations and memory issues, especially in clusters with a high load or few resources.",
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "ignore_dynamic_beyond_limit": {
             "description": "This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set\nto false (the default), the index request of the document that tries to add a dynamic field to the mapping will fail\nwith the message Limit of total fields [X] has been exceeded. When set to true, the index request will not fail.\nInstead, fields that would exceed the limit are not added to the mapping, similar to dynamic: false.\nThe fields that were not added to the mapping will be added to the _ignored field.",
-            "type": "boolean"
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string"
+              }
+            ]
           }
         }
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -40139,11 +40139,25 @@
         "properties": {
           "limit": {
             "description": "The maximum number of fields in an index. Field and object mappings, as well as field aliases count towards this limit.\nThe limit is in place to prevent mappings and searches from becoming too large. Higher values can lead to performance\ndegradations and memory issues, especially in clusters with a high load or few resources.",
-            "type": "number"
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
           },
           "ignore_dynamic_beyond_limit": {
             "description": "This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set\nto false (the default), the index request of the document that tries to add a dynamic field to the mapping will fail\nwith the message Limit of total fields [X] has been exceeded. When set to true, the index request will not fail.\nInstead, fields that would exceed the limit are not added to the mapping, similar to dynamic: false.\nThe fields that were not added to the mapping will be added to the _ignored field.",
-            "type": "boolean"
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string"
+              }
+            ]
           }
         }
       },

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -114061,26 +114061,50 @@
           "description": "The maximum number of fields in an index. Field and object mappings, as well as field aliases count towards this limit.\nThe limit is in place to prevent mappings and searches from becoming too large. Higher values can lead to performance\ndegradations and memory issues, especially in clusters with a high load or few resources.",
           "name": "limit",
           "required": false,
-          "serverDefault": 1000,
+          "serverDefault": "1000",
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "long",
-              "namespace": "_types"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "long",
+                  "namespace": "_types"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         },
         {
           "description": "This setting determines what happens when a dynamically mapped field would exceed the total fields limit. When set\nto false (the default), the index request of the document that tries to add a dynamic field to the mapping will fail\nwith the message Limit of total fields [X] has been exceeded. When set to true, the index request will not fail.\nInstead, fields that would exceed the limit are not added to the mapping, similar to dynamic: false.\nThe fields that were not added to the mapping will be added to the _ignored field.",
           "name": "ignore_dynamic_beyond_limit",
           "required": false,
-          "serverDefault": false,
+          "serverDefault": "false",
           "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "_builtins"
-            }
+            "items": [
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "boolean",
+                  "namespace": "_builtins"
+                }
+              },
+              {
+                "kind": "instance_of",
+                "type": {
+                  "name": "string",
+                  "namespace": "_builtins"
+                }
+              }
+            ],
+            "kind": "union_of"
           }
         }
       ],

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -640,21 +640,7 @@
       "response": []
     },
     "fleet.msearch": {
-      "request": [
-        "Request: query parameter 'allow_no_indices' does not exist in the json spec",
-        "Request: query parameter 'ccs_minimize_roundtrips' does not exist in the json spec",
-        "Request: query parameter 'expand_wildcards' does not exist in the json spec",
-        "Request: query parameter 'ignore_throttled' does not exist in the json spec",
-        "Request: query parameter 'ignore_unavailable' does not exist in the json spec",
-        "Request: query parameter 'max_concurrent_searches' does not exist in the json spec",
-        "Request: query parameter 'max_concurrent_shard_requests' does not exist in the json spec",
-        "Request: query parameter 'pre_filter_shard_size' does not exist in the json spec",
-        "Request: query parameter 'search_type' does not exist in the json spec",
-        "Request: query parameter 'rest_total_hits_as_int' does not exist in the json spec",
-        "Request: query parameter 'typed_keys' does not exist in the json spec",
-        "Request: query parameter 'wait_for_checkpoints' does not exist in the json spec",
-        "Request: query parameter 'allow_partial_search_results' does not exist in the json spec"
-      ],
+      "request": [],
       "response": [
         "type_alias definition _global.msearch:ResponseItem / union_of / instance_of / Generics / instance_of - No type definition for '_global.msearch.ResponseItem:TDocument'"
       ]
@@ -662,54 +648,6 @@
     "fleet.post_secret": {
       "request": [
         "Missing request & response"
-      ],
-      "response": []
-    },
-    "fleet.search": {
-      "request": [
-        "Request: query parameter 'allow_no_indices' does not exist in the json spec",
-        "Request: query parameter 'analyzer' does not exist in the json spec",
-        "Request: query parameter 'analyze_wildcard' does not exist in the json spec",
-        "Request: query parameter 'batched_reduce_size' does not exist in the json spec",
-        "Request: query parameter 'ccs_minimize_roundtrips' does not exist in the json spec",
-        "Request: query parameter 'default_operator' does not exist in the json spec",
-        "Request: query parameter 'df' does not exist in the json spec",
-        "Request: query parameter 'docvalue_fields' does not exist in the json spec",
-        "Request: query parameter 'expand_wildcards' does not exist in the json spec",
-        "Request: query parameter 'explain' does not exist in the json spec",
-        "Request: query parameter 'ignore_throttled' does not exist in the json spec",
-        "Request: query parameter 'ignore_unavailable' does not exist in the json spec",
-        "Request: query parameter 'lenient' does not exist in the json spec",
-        "Request: query parameter 'max_concurrent_shard_requests' does not exist in the json spec",
-        "Request: query parameter 'min_compatible_shard_node' does not exist in the json spec",
-        "Request: query parameter 'preference' does not exist in the json spec",
-        "Request: query parameter 'pre_filter_shard_size' does not exist in the json spec",
-        "Request: query parameter 'request_cache' does not exist in the json spec",
-        "Request: query parameter 'routing' does not exist in the json spec",
-        "Request: query parameter 'scroll' does not exist in the json spec",
-        "Request: query parameter 'search_type' does not exist in the json spec",
-        "Request: query parameter 'stats' does not exist in the json spec",
-        "Request: query parameter 'stored_fields' does not exist in the json spec",
-        "Request: query parameter 'suggest_field' does not exist in the json spec",
-        "Request: query parameter 'suggest_mode' does not exist in the json spec",
-        "Request: query parameter 'suggest_size' does not exist in the json spec",
-        "Request: query parameter 'suggest_text' does not exist in the json spec",
-        "Request: query parameter 'terminate_after' does not exist in the json spec",
-        "Request: query parameter 'timeout' does not exist in the json spec",
-        "Request: query parameter 'track_total_hits' does not exist in the json spec",
-        "Request: query parameter 'track_scores' does not exist in the json spec",
-        "Request: query parameter 'typed_keys' does not exist in the json spec",
-        "Request: query parameter 'rest_total_hits_as_int' does not exist in the json spec",
-        "Request: query parameter 'version' does not exist in the json spec",
-        "Request: query parameter '_source' does not exist in the json spec",
-        "Request: query parameter '_source_excludes' does not exist in the json spec",
-        "Request: query parameter '_source_includes' does not exist in the json spec",
-        "Request: query parameter 'seq_no_primary_term' does not exist in the json spec",
-        "Request: query parameter 'q' does not exist in the json spec",
-        "Request: query parameter 'size' does not exist in the json spec",
-        "Request: query parameter 'from' does not exist in the json spec",
-        "Request: query parameter 'sort' does not exist in the json spec",
-        "Request: missing json spec query parameter 'wait_for_checkpoints_timeout'"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -11187,8 +11187,8 @@ export interface IndicesMappingLimitSettingsNestedObjects {
 }
 
 export interface IndicesMappingLimitSettingsTotalFields {
-  limit?: long
-  ignore_dynamic_beyond_limit?: boolean
+  limit?: long | string
+  ignore_dynamic_beyond_limit?: boolean | string
 }
 
 export interface IndicesMerge {


### PR DESCRIPTION
(cherry picked from commit 7dc96a367df1eef610e42414659899d0983f609d)

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
