### PR TITLE
[8.x] Adds index API requests and responses - part 2 (#2993)

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -163,7 +163,6 @@ actions:
   - target: "$.paths['/_ilm/policy/{policy}']['put']"
     description: "Add examples for create a lifecycle operation"
     update:
-      update: 
       requestBody: 
         content: 
           application/json: 
@@ -188,7 +187,6 @@ actions:
   - target: "$.paths['/_ilm/migrate_to_data_tiers']['post']"
     description: "Add examples for migrate to data tiers routing operation"
     update:
-      update: 
       requestBody: 
         content: 
           application/json: 
@@ -205,7 +203,6 @@ actions:
   - target: "$.paths['/_ilm/move/{index}']['post']"
     description: "Add examples for move to lifecycle step operation"
     update:
-      update: 
       requestBody: 
         content: 
           application/json: 
@@ -338,7 +335,6 @@ actions:
   - target: "$.paths['/_autoscaling/policy/{name}']['put']"
     description: "Add examples for create autoscaling policy operation"
     update:
-      update: 
       requestBody: 
         content: 
           application/json: 
@@ -354,3 +350,45 @@ actions:
               examples:
                 createAutoscalingPolicyResponseExample1:
                   $ref: "../../specification/autoscaling/put_autoscaling_policy/autoscalingApisPutAutoscalingPolicyResponseExample1.yaml"
+  - target: "$.components['responses']['indices.recovery#200']"
+    description: "Add example for get index recovery response"
+    update: 
+      content:
+        application/json:
+          examples:
+            getIndicesRecoveryResponseExample1:
+                  $ref: "../../specification/indices/recovery/indicesRecoveryResponseExample1.yaml"
+  - target: "$.paths['/_resolve/cluster/{name}']['get']"
+    description: "Add examples for resolve cluster operation"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                resolveClusterResponseExample1:
+                  $ref: "../../specification/indices/resolve_cluster/ResolveClusterResponseExample1.yaml"
+  - target: "$.components['requestBodies']['indices.shrink']"
+    description: "Add example for shrink index request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesShrinkRequestExample1:
+              $ref: "../../specification/indices/shrink/indicesShrinkRequestExample1.yaml"
+  - target: "$.components['requestBodies']['indices.split']"
+    description: "Add example for split index request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesSplitRequestExample1:
+              $ref: "../../specification/indices/split/indicesSplitRequestExample1.yaml"
+  - target: "$.components['requestBodies']['indices.put_template']"
+    description: "Add example for legacy create template request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesLegacyPutTemplateRequestExample1:
+              $ref: "../../specification/indices/put_template/indicesPutTemplateRequestExample1.yaml"

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -1258,3 +1258,88 @@ actions:
               examples:
                 indicesExplainDataLifecycleResponseExample:
                   $ref: "../../specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleResponseExample1.yaml"
+  - target: "$.components['responses']['ingest.get_pipeline#200']"
+    description: "Add example for get pipeline response"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesGetDataStreamResponseExample:
+              $ref: "../../specification/ingest/get_pipeline/GetPipelineResponseExample1.yaml"
+  - target: "$.paths['/_ingest/pipeline/{id}']['put']"
+    description: "Add examples for create pipeline"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              putPipelineRequestExample1: 
+                $ref: "../../specification/ingest/put_pipeline/PutPipelineRequestExample1.yaml"
+              putPipelineRequestExample2: 
+                $ref: "../../specification/ingest/put_pipeline/PutPipelineRequestExample2.yaml"
+  - target: "$.components['requestBodies']['ingest.simulate']"
+    description: "Add example for simulate pipeline request"
+    update: 
+      content:
+        application/json:
+          examples:
+            simulatePipelineRequestExample1:
+              $ref: "../../specification/ingest/simulate/SimulatePipelineRequestExample1.yaml"
+  - target: "$.components['responses']['ingest.simulate#200']"
+    description: "Add example for simulate pipeline response"
+    update: 
+      content:
+        application/json:
+          examples:
+            simulatePipelineResponseExample1:
+              $ref: "../../specification/ingest/simulate/SimulatePipelineResponseExample1.yaml"
+  - target: "$.components['requestBodies']['indices.put_index_template']"
+    description: "Add example for create index template request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesPutIndexTemplateRequestExample1:
+              $ref: "../../specification/indices/put_index_template/indicesPutIndexTemplateRequestExample1.yaml"
+  - target: "$.components['requestBodies']['indices.put_mapping']"
+    description: "Add example for update mapping request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesPutSettingRequestExample1:
+              $ref: "../../specification/indices/put_mapping/indicesPutMappingRequestExample1.yaml"
+  - target: "$.components['requestBodies']['indices.put_settings']"
+    description: "Add example for update index settings request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesPutSettingRequestExample1:
+              $ref: "../../specification/indices/put_settings/IndicesPutSettingsRequestExample1.yaml"
+  - target: "$.paths['/_resolve/index/{name}']['get']"
+    description: "Add examples for resolve index operation"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                indicesResolveResponseExample1:
+                  $ref: "../../specification/indices/resolve_index/indicesResolveResponseExample1.yaml"
+  - target: "$.components['requestBodies']['indices.rollover']"
+    description: "Add example for rollover index request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesRolloverRequestExample1:
+              $ref: "../../specification/indices/rollover/indicesRolloverRequestExample1.yaml"
+  - target: "$.components['responses']['indices.rollover#200']"
+    description: "Add example for rollover index response"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesRolloverResponseExample1:
+              $ref: "../../specification/indices/rollover/indicesRolloverResponseExample1.yaml"

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequestExample1.yaml
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequestExample1.yaml
@@ -1,0 +1,7 @@
+summary: Create an index template.
+# method_request: PUT /_index_template/template_1
+# description: ''
+# type: request
+value:
+  "{\n  \"index_patterns\" : [\"template*\"],\n  \"priority\" : 1,\n  \"template\"\
+  : {\n    \"settings\" : {\n      \"number_of_shards\" : 2\n    }\n  }\n}"

--- a/specification/indices/put_mapping/indicesPutMappingRequestExample1.yaml
+++ b/specification/indices/put_mapping/indicesPutMappingRequestExample1.yaml
@@ -1,0 +1,7 @@
+summary: Create or update the mapping of an index.
+# method_request: PUT /my-index-000001/_mapping
+# description: ''
+# type: request
+value:
+  "{\n  \"properties\": {\n    \"email\": {\n      \"type\": \"keyword\"\n  \
+  \  }\n  }\n}"

--- a/specification/indices/put_settings/IndicesPutSettingsRequestExample1.yaml
+++ b/specification/indices/put_settings/IndicesPutSettingsRequestExample1.yaml
@@ -1,0 +1,5 @@
+summary: Change a dynamic index setting in real time.
+# method_request: PUT /my-index-000001/_settings
+# description: ''
+# type: request
+value: "{\n  \"index\" : {\n    \"number_of_replicas\" : 2\n  }\n}"

--- a/specification/indices/put_template/indicesPutTemplateRequestExample1.yaml
+++ b/specification/indices/put_template/indicesPutTemplateRequestExample1.yaml
@@ -1,0 +1,19 @@
+summary: Create or update an index template.
+# method_request: PUT _template/template_1
+# description: ''
+# type: request
+value:
+  index_patterns:
+    - 'te*'
+    - 'bar*'
+  settings:
+    number_of_shards: 1
+  mappings:
+    _source:
+      enabled: false
+  properties:
+    host_name:
+      type: keyword
+    created_at:
+      type: date
+      format: 'EEE MMM dd HH:mm:ss Z yyyy'

--- a/specification/indices/recovery/indicesRecoveryResponseExample1.yaml
+++ b/specification/indices/recovery/indicesRecoveryResponseExample1.yaml
@@ -1,0 +1,32 @@
+summary: A successful response for retrieving information about ongoing and completed shard recoveries for an index.
+# description: ''
+# type: response
+response_code: 200
+value:
+  "{\n  \"index1\" : {\n    \"shards\" : [ {\n      \"id\" : 0,\n      \"type\"\
+  \ : \"SNAPSHOT\",\n      \"stage\" : \"INDEX\",\n      \"primary\" : true,\n   \
+  \   \"start_time\" : \"2014-02-24T12:15:59.716\",\n      \"start_time_in_millis\"\
+  : 1393244159716,\n      \"stop_time\" : \"0s\",\n      \"stop_time_in_millis\" :\
+  \ 0,\n      \"total_time\" : \"2.9m\",\n      \"total_time_in_millis\" : 175576,\n\
+  \      \"source\" : {\n        \"repository\" : \"my_repository\",\n        \"snapshot\"\
+  \ : \"my_snapshot\",\n        \"index\" : \"index1\",\n        \"version\" : \"\
+  {version}\",\n        \"restoreUUID\": \"PDh1ZAOaRbiGIVtCvZOMww\"\n      },\n  \
+  \    \"target\" : {\n        \"id\" : \"ryqJ5lO5S4-lSFbGntkEkg\",\n        \"host\"\
+  \ : \"my.fqdn\",\n        \"transport_address\" : \"my.fqdn\",\n        \"ip\" :\
+  \ \"10.0.1.7\",\n        \"name\" : \"my_es_node\"\n      },\n      \"index\" :\
+  \ {\n        \"size\" : {\n          \"total\" : \"75.4mb\",\n          \"total_in_bytes\"\
+  \ : 79063092,\n          \"reused\" : \"0b\",\n          \"reused_in_bytes\" : 0,\n\
+  \          \"recovered\" : \"65.7mb\",\n          \"recovered_in_bytes\" : 68891939,\n\
+  \          \"recovered_from_snapshot\" : \"0b\",\n          \"recovered_from_snapshot_in_bytes\"\
+  \ : 0,\n          \"percent\" : \"87.1%\"\n        },\n        \"files\" : {\n \
+  \         \"total\" : 73,\n          \"reused\" : 0,\n          \"recovered\" :\
+  \ 69,\n          \"percent\" : \"94.5%\"\n        },\n        \"total_time\" : \"\
+  0s\",\n        \"total_time_in_millis\" : 0,\n        \"source_throttle_time\" :\
+  \ \"0s\",\n        \"source_throttle_time_in_millis\" : 0,\n        \"target_throttle_time\"\
+  \ : \"0s\",\n        \"target_throttle_time_in_millis\" : 0\n      },\n      \"\
+  translog\" : {\n        \"recovered\" : 0,\n        \"total\" : 0,\n        \"percent\"\
+  \ : \"100.0%\",\n        \"total_on_start\" : 0,\n        \"total_time\" : \"0s\"\
+  ,\n        \"total_time_in_millis\" : 0\n      },\n      \"verify_index\" : {\n\
+  \        \"check_index_time\" : \"0s\",\n        \"check_index_time_in_millis\"\
+  \ : 0,\n        \"total_time\" : \"0s\",\n        \"total_time_in_millis\" : 0\n\
+  \      }\n    } ]\n  }\n}"

--- a/specification/indices/resolve_cluster/ResolveClusterResponseExample1.yaml
+++ b/specification/indices/resolve_cluster/ResolveClusterResponseExample1.yaml
@@ -1,0 +1,18 @@
+summary: A successful response for resolving a specified index expression to return information about each cluster.
+# description: ''
+# type: response
+response_code: 200
+value:
+  "{\n  \"(local)\": {\n    \"connected\": true,\n    \"skip_unavailable\": false,\n\
+  \    \"matching_indices\": true,\n    \"version\": {\n      \"number\": \"8.13.0\"\
+  ,\n      \"build_flavor\": \"default\",\n      \"minimum_wire_compatibility_version\"\
+  : \"7.17.0\",\n      \"minimum_index_compatibility_version\": \"7.0.0\"\n    }\n\
+  \  },\n  \"cluster_one\": {\n    \"connected\": true,\n    \"skip_unavailable\"\
+  : true,\n    \"matching_indices\": true,\n    \"version\": {\n      \"number\":\
+  \ \"8.13.0\",\n      \"build_flavor\": \"default\",\n      \"minimum_wire_compatibility_version\"\
+  : \"7.17.0\",\n      \"minimum_index_compatibility_version\": \"7.0.0\"\n    }\n\
+  \  },\n  \"cluster_two\": {\n    \"connected\": true,\n    \"skip_unavailable\"\
+  : false,\n    \"matching_indices\": true,\n    \"version\": {\n      \"number\"\
+  : \"8.13.0\",\n      \"build_flavor\": \"default\",\n      \"minimum_wire_compatibility_version\"\
+  : \"7.17.0\",\n      \"minimum_index_compatibility_version\": \"7.0.0\"\n    }\n\
+  \  }\n}"

--- a/specification/indices/resolve_index/indicesResolveResponseExample1.yaml
+++ b/specification/indices/resolve_index/indicesResolveResponseExample1.yaml
@@ -1,0 +1,14 @@
+summary: A successful response for resolving the specified name for an index.
+# description: ''
+# type: response
+response_code: 200
+value:
+  "{\n  \"indices\": [\n    {\n      \"name\": \"foo_closed\",\n      \"attributes\"\
+  : [\n        \"closed\"\n      ]\n    },\n    {\n      \"name\": \"freeze-index\"\
+  ,\n      \"aliases\": [\n        \"f-alias\"\n      ],\n      \"attributes\": [\n\
+  \        \"open\"\n      ]\n    },\n    {\n      \"name\": \"remoteCluster1:bar-01\"\
+  ,\n      \"attributes\": [\n        \"open\"\n      ]\n    }\n  ],\n  \"aliases\"\
+  : [\n    {\n      \"name\": \"f-alias\",\n      \"indices\": [\n        \"freeze-index\"\
+  ,\n        \"my-index-000001\"\n      ]\n    }\n  ],\n  \"data_streams\": [\n  \
+  \  {\n      \"name\": \"foo\",\n      \"backing_indices\": [\n        \".ds-foo-2099.03.07-000001\"\
+  \n      ],\n      \"timestamp_field\": \"@timestamp\"\n    }\n  ]\n}"

--- a/specification/indices/rollover/indicesRolloverRequestExample1.yaml
+++ b/specification/indices/rollover/indicesRolloverRequestExample1.yaml
@@ -1,0 +1,8 @@
+summary: Create a new index for a data stream.
+# method_request: POST my-data-stream/_rollover
+# description: ''
+# type: request
+value:
+  "{\n  \"conditions\": {\n    \"max_age\": \"7d\",\n    \"max_docs\": 1000,\n\
+  \    \"max_primary_shard_size\": \"50gb\",\n    \"max_primary_shard_docs\": \"2000\"\
+  \n  }\n}"

--- a/specification/indices/rollover/indicesRolloverResponseExample1.yaml
+++ b/specification/indices/rollover/indicesRolloverResponseExample1.yaml
@@ -1,0 +1,10 @@
+summary: A successful response for creating a new index for a data stream.
+# description: ''
+# type: response
+response_code: 200
+value:
+  "{\n  \"acknowledged\": true,\n  \"shards_acknowledged\": true,\n  \"old_index\"\
+  : \".ds-my-data-stream-2099.05.06-000001\",\n  \"new_index\": \".ds-my-data-stream-2099.05.07-000002\"\
+  ,\n  \"rolled_over\": true,\n  \"dry_run\": false,\n  \"lazy\": false,\n  \"conditions\"\
+  : {\n    \"[max_age: 7d]\": false,\n    \"[max_docs: 1000]\": true,\n    \"[max_primary_shard_size:\
+  \ 50gb]\": false,\n    \"[max_primary_shard_docs: 2000]\": false\n  }\n}"

--- a/specification/indices/shrink/indicesShrinkRequestExample1.yaml
+++ b/specification/indices/shrink/indicesShrinkRequestExample1.yaml
@@ -1,0 +1,7 @@
+summary: Shrink an existing index into a new index with fewer primary shards.
+# method_request: POST /my_source_index/_shrink/my_target_index
+# description: ''
+# type: request
+value:
+  "{\n  \"settings\": {\n    \"index.routing.allocation.require._name\": null,\n\
+  \    \"index.blocks.write\": null\n  }\n}"

--- a/specification/indices/split/indicesSplitRequestExample1.yaml
+++ b/specification/indices/split/indicesSplitRequestExample1.yaml
@@ -1,0 +1,5 @@
+summary: Split an existing index into a new index with more primary shards.
+# method_request: POST /my-index-000001/_split/split-my-index-000001
+# description: ''
+# type: request
+value: "{\n  \"settings\": {\n    \"index.number_of_shards\": 2\n  }\n}"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Adds index API requests and responses - part 2 (#2993)](https://github.com/elastic/elasticsearch-specification/pull/2993)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)