### PR TITLE
Fix validation errors for bulk API

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -56,14 +56,6 @@
       ],
       "response": []
     },
-    "bulk": {
-      "request": [
-        "Request: missing json spec query parameter 'type'",
-        "Request: missing json spec query parameter 'require_data_stream'",
-        "Request: missing json spec query parameter 'list_executed_pipelines'"
-      ],
-      "response": []
-    },
     "capabilities": {
       "request": [
         "Missing request & response"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -47,6 +47,7 @@ export type BulkOperationType = 'index' | 'create' | 'update' | 'delete'
 
 export interface BulkRequest<TDocument = unknown, TPartialDocument = unknown> extends RequestBase {
   index?: IndexName
+  list_executed_pipelines?: boolean
   pipeline?: string
   refresh?: Refresh
   routing?: Routing
@@ -56,6 +57,7 @@ export interface BulkRequest<TDocument = unknown, TPartialDocument = unknown> ex
   timeout?: Duration
   wait_for_active_shards?: WaitForActiveShards
   require_alias?: boolean
+  require_data_stream?: boolean
   body?: (BulkOperationContainer | BulkUpdateAction<TDocument, TPartialDocument> | TDocument)[]
 }
 

--- a/specification/_global/bulk/BulkRequest.ts
+++ b/specification/_global/bulk/BulkRequest.ts
@@ -49,6 +49,11 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
   }
   query_parameters: {
     /**
+     * If `true`, the response will include the ingest pipelines that were executed for each index or create.
+     * @server_default false
+     */
+    list_executed_pipelines?: boolean
+    /**
      * ID of the pipeline to use to preprocess incoming documents.
      * If the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request.
      * If a final pipeline is configured it will always run, regardless of the value of this parameter.
@@ -92,6 +97,11 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
      * @server_default false
      */
     require_alias?: boolean
+    /**
+     * If `true`, the request's actions must target a data stream (existing or to-be-created).
+     * @server_default false
+     */
+    require_data_stream?: boolean
   }
   /**
    * The request body contains a newline-delimited list of `create`, `delete`, `index`, and `update` actions and their associated source data.

--- a/specification/_json_spec/bulk.json
+++ b/specification/_json_spec/bulk.json
@@ -46,10 +46,6 @@
         "type": "time",
         "description": "Explicit operation timeout"
       },
-      "type": {
-        "type": "string",
-        "description": "Default document type for items which don't provide one"
-      },
       "_source": {
         "type": "list",
         "description": "True or false to return the _source field or not, or default list of fields to return, can be overridden on each sub-request"
@@ -68,11 +64,11 @@
       },
       "require_alias": {
         "type": "boolean",
-        "description": "Sets require_alias for all incoming documents. Defaults to unset (false)"
+        "description": "If true, the request’s actions must target an index alias. Defaults to false."
       },
       "require_data_stream": {
         "type": "boolean",
-        "description": "When true, requires the destination to be a data stream (existing or to-be-created). Default is false"
+        "description": "If true, the request's actions must target a data stream (existing or to-be-created). Default to false"
       },
       "list_executed_pipelines": {
         "type": "boolean",


### PR DESCRIPTION
Depends on https://github.com/elastic/elasticsearch/pull/118415. Unlike the Elasticsearch pull request, it can be backported, because the `type` parameter is only used by v7 clients.