### PR TITLE
[8.x] [DOCS] Edit CCR operation summaries (#3266)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -2108,8 +2108,11 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Gets configured auto-follow patterns",
-        "description": "Returns the specified auto-follow pattern collection.",
+        "summary": "Get auto-follow patterns",
+        "description": "Get cross-cluster replication auto-follow patterns.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-auto-follow.html"
+        },
         "operationId": "ccr-get-auto-follow-pattern-1",
         "parameters": [
           {
@@ -2127,8 +2130,11 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Creates a new named collection of auto-follow patterns against a specified remote cluster",
-        "description": "Newly created indices on the remote cluster matching any of the specified patterns will be automatically configured as follower indices.",
+        "summary": "Create or update auto-follow patterns",
+        "description": "Create a collection of cross-cluster replication auto-follow patterns for a remote cluster.\nNewly created indices on the remote cluster that match any of the patterns are automatically configured as follower indices.\nIndices on the remote cluster that were created before the auto-follow pattern was created will not be auto-followed even if they match the pattern.\n\nThis API can also be used to update auto-follow patterns.\nNOTE: Follower indices that were configured automatically before updating an auto-follow pattern will remain unchanged even if they do not match against the new patterns.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-auto-follow.html"
+        },
         "operationId": "ccr-put-auto-follow-pattern",
         "parameters": [
           {
@@ -2231,7 +2237,11 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Deletes auto-follow patterns",
+        "summary": "Delete auto-follow patterns",
+        "description": "Delete a collection of cross-cluster replication auto-follow patterns.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-auto-follow.html"
+        },
         "operationId": "ccr-delete-auto-follow-pattern",
         "parameters": [
           {
@@ -2266,7 +2276,8 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Creates a new follower index configured to follow the referenced leader index",
+        "summary": "Create a follower",
+        "description": "Create a cross-cluster replication follower index that follows a specific leader index.\nWhen the API returns, the follower index exists and cross-cluster replication starts replicating operations from the leader index to the follower index.",
         "operationId": "ccr-follow",
         "parameters": [
           {
@@ -2375,7 +2386,11 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Retrieves information about all follower indices, including parameters and status for each follower index",
+        "summary": "Get follower information",
+        "description": "Get information about all cross-cluster replication follower indices.\nFor example, the results include follower index names, leader index names, replication options, and whether the follower indices are active or paused.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-ccr.html"
+        },
         "operationId": "ccr-follow-info",
         "parameters": [
           {
@@ -2421,7 +2436,11 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Retrieves follower stats. return shard-level stats about the following tasks associated with each shard for the specified indices",
+        "summary": "Get follower stats",
+        "description": "Get cross-cluster replication follower stats.\nThe API returns shard-level stats about the \"following tasks\" associated with each shard for the specified indices.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-ccr.html"
+        },
         "operationId": "ccr-follow-stats",
         "parameters": [
           {
@@ -2467,7 +2486,11 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Removes the follower retention leases from the leader",
+        "summary": "Forget a follower",
+        "description": "Remove the cross-cluster replication follower retention leases from the leader.\n\nA following index takes out retention leases on its leader index.\nThese leases are used to increase the likelihood that the shards of the leader index retain the history of operations that the shards of the following index need to run replication.\nWhen a follower index is converted to a regular index by the unfollow API (either by directly calling the API or by index lifecycle management tasks), these leases are removed.\nHowever, removal of the leases can fail, for example when the remote cluster containing the leader index is unavailable.\nWhile the leases will eventually expire on their own, their extended existence can cause the leader index to hold more history than necessary and prevent index lifecycle management from performing some operations on the leader index.\nThis API exists to enable manually removing the leases when the unfollow API is unable to do so.\n\nNOTE: This API does not stop replication by a following index. If you use this API with a follower index that is still actively following, the following index will add back retention leases on the leader.\nThe only purpose of this API is to handle the case of failure to remove the following retention leases after the unfollow API is invoked.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-ccr.html"
+        },
         "operationId": "ccr-forget-follower",
         "parameters": [
           {
@@ -2534,8 +2557,11 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Gets configured auto-follow patterns",
-        "description": "Returns the specified auto-follow pattern collection.",
+        "summary": "Get auto-follow patterns",
+        "description": "Get cross-cluster replication auto-follow patterns.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-auto-follow.html"
+        },
         "operationId": "ccr-get-auto-follow-pattern",
         "responses": {
           "200": {
@@ -2550,7 +2576,11 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Pauses an auto-follow pattern",
+        "summary": "Pause an auto-follow pattern",
+        "description": "Pause a cross-cluster replication auto-follow pattern.\nWhen the API returns, the auto-follow pattern is inactive.\nNew indices that are created on the remote cluster and match the auto-follow patterns are ignored.\n\nYou can resume auto-following with the resume auto-follow pattern API.\nWhen it resumes, the auto-follow pattern is active again and automatically configures follower indices for newly created indices on the remote cluster that match its patterns.\nRemote indices that were created while the pattern was paused will also be followed, unless they have been deleted or closed in the interim.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-auto-follow.html"
+        },
         "operationId": "ccr-pause-auto-follow-pattern",
         "parameters": [
           {
@@ -2585,8 +2615,8 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Pauses a follower index",
-        "description": "The follower index will not fetch any additional operations from the leader index.",
+        "summary": "Pause a follower",
+        "description": "Pause a cross-cluster replication follower index.\nThe follower index will not fetch any additional operations from the leader index.\nYou can resume following with the resume follower API.\nYou can pause and resume a follower index to change the configuration of the following task.",
         "operationId": "ccr-pause-follow",
         "parameters": [
           {
@@ -2621,7 +2651,11 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Resumes an auto-follow pattern that has been paused",
+        "summary": "Resume an auto-follow pattern",
+        "description": "Resume a cross-cluster replication auto-follow pattern that was paused.\nThe auto-follow pattern will resume configuring following indices for newly created indices that match its patterns on the remote cluster.\nRemote indices created while the pattern was paused will also be followed unless they have been deleted or closed in the interim.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/ccr-auto-follow.html"
+        },
         "operationId": "ccr-resume-auto-follow-pattern",
         "parameters": [
           {
@@ -2656,7 +2690,11 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Resumes a follower index that has been paused",
+        "summary": "Resume a follower",
+        "description": "Resume a cross-cluster replication follower index that was paused.\nThe follower index could have been paused with the pause follower API.\nAlternatively it could be paused due to replication that cannot be retried due to failures during following tasks.\nWhen this API returns, the follower index will resume fetching operations from the leader index.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-ccr.html"
+        },
         "operationId": "ccr-resume-follow",
         "parameters": [
           {
@@ -2732,7 +2770,8 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Gets all stats related to cross-cluster replication",
+        "summary": "Get cross-cluster replication stats",
+        "description": "This API returns stats about auto-following and the same shard-level stats as the get follower stats API.",
         "operationId": "ccr-stats",
         "responses": {
           "200": {
@@ -2766,7 +2805,11 @@
         "tags": [
           "ccr"
         ],
-        "summary": "Stops the following task associated with a follower index and removes index metadata and settings associated with cross-cluster replication",
+        "summary": "Unfollow an index",
+        "description": "Convert a cross-cluster replication follower index to a regular index.\nThe API stops the following task associated with a follower index and removes index metadata and settings associated with cross-cluster replication.\nThe follower index must be paused and closed before you call the unfollow API.\n\nNOTE: Currently cross-cluster replication does not support converting an existing regular index to a follower index. Converting a follower index to a regular index is an irreversible operation.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-ccr.html"
+        },
         "operationId": "ccr-unfollow",
         "parameters": [
           {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -45,6 +45,8 @@ cat-thread-pool,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 cat-trained-model,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-trained-model.html
 cat-transforms,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-transforms.html
 cat,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat.html
+ccr,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/xpack-ccr.html
+ccr-auto-follow,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ccr-auto-follow.html
 ccr-delete-auto-follow-pattern,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ccr-delete-auto-follow-pattern.html
 ccr-get-auto-follow-pattern,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ccr-get-auto-follow-pattern.html
 ccr-get-follow-info,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ccr-get-follow-info.html

--- a/specification/ccr/delete_auto_follow_pattern/DeleteAutoFollowPatternRequest.ts
+++ b/specification/ccr/delete_auto_follow_pattern/DeleteAutoFollowPatternRequest.ts
@@ -21,9 +21,12 @@ import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 
 /**
+ * Delete auto-follow patterns.
+ * Delete a collection of cross-cluster replication auto-follow patterns.
  * @rest_spec_name ccr.delete_auto_follow_pattern
  * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-delete-auto-follow-pattern
+ * @ext_doc_id ccr-auto-follow
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ccr/follow/CreateFollowIndexRequest.ts
+++ b/specification/ccr/follow/CreateFollowIndexRequest.ts
@@ -23,6 +23,9 @@ import { long } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 /**
+ * Create a follower.
+ * Create a cross-cluster replication follower index that follows a specific leader index.
+ * When the API returns, the follower index exists and cross-cluster replication starts replicating operations from the leader index to the follower index.
  * @rest_spec_name ccr.follow
  * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-put-follow

--- a/specification/ccr/follow_info/FollowInfoRequest.ts
+++ b/specification/ccr/follow_info/FollowInfoRequest.ts
@@ -21,9 +21,13 @@ import { RequestBase } from '@_types/Base'
 import { Indices } from '@_types/common'
 
 /**
+ * Get follower information.
+ * Get information about all cross-cluster replication follower indices.
+ * For example, the results include follower index names, leader index names, replication options, and whether the follower indices are active or paused.
  * @rest_spec_name ccr.follow_info
  * @availability stack since=6.7.0 stability=stable
  * @doc_id ccr-get-follow-info
+ * @ext_doc_id ccr
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ccr/follow_stats/FollowIndexStatsRequest.ts
+++ b/specification/ccr/follow_stats/FollowIndexStatsRequest.ts
@@ -21,9 +21,13 @@ import { RequestBase } from '@_types/Base'
 import { Indices } from '@_types/common'
 
 /**
+ * Get follower stats.
+ * Get cross-cluster replication follower stats.
+ * The API returns shard-level stats about the "following tasks" associated with each shard for the specified indices.
  * @rest_spec_name ccr.follow_stats
  * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-get-follow-stats
+ * @ext_doc_id ccr
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ccr/forget_follower/ForgetFollowerIndexRequest.ts
+++ b/specification/ccr/forget_follower/ForgetFollowerIndexRequest.ts
@@ -21,9 +21,22 @@ import { RequestBase } from '@_types/Base'
 import { IndexName, Uuid } from '@_types/common'
 
 /**
+ * Forget a follower.
+ * Remove the cross-cluster replication follower retention leases from the leader.
+ *
+ * A following index takes out retention leases on its leader index.
+ * These leases are used to increase the likelihood that the shards of the leader index retain the history of operations that the shards of the following index need to run replication.
+ * When a follower index is converted to a regular index by the unfollow API (either by directly calling the API or by index lifecycle management tasks), these leases are removed.
+ * However, removal of the leases can fail, for example when the remote cluster containing the leader index is unavailable.
+ * While the leases will eventually expire on their own, their extended existence can cause the leader index to hold more history than necessary and prevent index lifecycle management from performing some operations on the leader index.
+ * This API exists to enable manually removing the leases when the unfollow API is unable to do so.
+ *
+ * NOTE: This API does not stop replication by a following index. If you use this API with a follower index that is still actively following, the following index will add back retention leases on the leader.
+ * The only purpose of this API is to handle the case of failure to remove the following retention leases after the unfollow API is invoked.
  * @rest_spec_name ccr.forget_follower
  * @availability stack since=6.7.0 stability=stable
  * @doc_id ccr-post-forget-follower
+ * @ext_doc_id ccr
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ccr/get_auto_follow_pattern/GetAutoFollowPatternRequest.ts
+++ b/specification/ccr/get_auto_follow_pattern/GetAutoFollowPatternRequest.ts
@@ -21,9 +21,12 @@ import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 
 /**
+ * Get auto-follow patterns.
+ * Get cross-cluster replication auto-follow patterns.
  * @rest_spec_name ccr.get_auto_follow_pattern
  * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-get-auto-follow-pattern
+ * @ext_doc_id ccr-auto-follow
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ccr/pause_auto_follow_pattern/PauseAutoFollowPatternRequest.ts
+++ b/specification/ccr/pause_auto_follow_pattern/PauseAutoFollowPatternRequest.ts
@@ -21,9 +21,18 @@ import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 
 /**
+ * Pause an auto-follow pattern.
+ * Pause a cross-cluster replication auto-follow pattern.
+ * When the API returns, the auto-follow pattern is inactive.
+ * New indices that are created on the remote cluster and match the auto-follow patterns are ignored.
+ *
+ * You can resume auto-following with the resume auto-follow pattern API.
+ * When it resumes, the auto-follow pattern is active again and automatically configures follower indices for newly created indices on the remote cluster that match its patterns.
+ * Remote indices that were created while the pattern was paused will also be followed, unless they have been deleted or closed in the interim.
  * @rest_spec_name ccr.pause_auto_follow_pattern
  * @availability stack since=7.5.0 stability=stable
  * @doc_id ccr-pause-auto-follow-pattern
+ * @ext_doc_id ccr-auto-follow
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ccr/pause_follow/PauseFollowIndexRequest.ts
+++ b/specification/ccr/pause_follow/PauseFollowIndexRequest.ts
@@ -21,6 +21,11 @@ import { RequestBase } from '@_types/Base'
 import { IndexName } from '@_types/common'
 
 /**
+ * Pause a follower.
+ * Pause a cross-cluster replication follower index.
+ * The follower index will not fetch any additional operations from the leader index.
+ * You can resume following with the resume follower API.
+ * You can pause and resume a follower index to change the configuration of the following task.
  * @rest_spec_name ccr.pause_follow
  * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-post-pause-follow

--- a/specification/ccr/put_auto_follow_pattern/PutAutoFollowPatternRequest.ts
+++ b/specification/ccr/put_auto_follow_pattern/PutAutoFollowPatternRequest.ts
@@ -25,9 +25,17 @@ import { integer } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 /**
+ * Create or update auto-follow patterns.
+ * Create a collection of cross-cluster replication auto-follow patterns for a remote cluster.
+ * Newly created indices on the remote cluster that match any of the patterns are automatically configured as follower indices.
+ * Indices on the remote cluster that were created before the auto-follow pattern was created will not be auto-followed even if they match the pattern.
+ *
+ * This API can also be used to update auto-follow patterns.
+ * NOTE: Follower indices that were configured automatically before updating an auto-follow pattern will remain unchanged even if they do not match against the new patterns.
  * @rest_spec_name ccr.put_auto_follow_pattern
  * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-put-auto-follow-pattern
+ * @ext_doc_id ccr-auto-follow
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ccr/resume_auto_follow_pattern/ResumeAutoFollowPatternRequest.ts
+++ b/specification/ccr/resume_auto_follow_pattern/ResumeAutoFollowPatternRequest.ts
@@ -21,9 +21,14 @@ import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 
 /**
+ * Resume an auto-follow pattern.
+ * Resume a cross-cluster replication auto-follow pattern that was paused.
+ * The auto-follow pattern will resume configuring following indices for newly created indices that match its patterns on the remote cluster.
+ * Remote indices created while the pattern was paused will also be followed unless they have been deleted or closed in the interim.
  * @rest_spec_name ccr.resume_auto_follow_pattern
  * @availability stack since=7.5.0 stability=stable
  * @doc_id ccr-resume-auto-follow-pattern
+ * @ext_doc_id ccr-auto-follow
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ccr/resume_follow/ResumeFollowIndexRequest.ts
+++ b/specification/ccr/resume_follow/ResumeFollowIndexRequest.ts
@@ -23,9 +23,15 @@ import { long } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 /**
+ * Resume a follower.
+ * Resume a cross-cluster replication follower index that was paused.
+ * The follower index could have been paused with the pause follower API.
+ * Alternatively it could be paused due to replication that cannot be retried due to failures during following tasks.
+ * When this API returns, the follower index will resume fetching operations from the leader index.
  * @rest_spec_name ccr.resume_follow
  * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-post-resume-follow
+ * @ext_doc_id ccr
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/ccr/stats/CcrStatsRequest.ts
+++ b/specification/ccr/stats/CcrStatsRequest.ts
@@ -20,6 +20,8 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Get cross-cluster replication stats.
+ * This API returns stats about auto-following and the same shard-level stats as the get follower stats API.
  * @rest_spec_name ccr.stats
  * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-get-stats

--- a/specification/ccr/unfollow/UnfollowIndexRequest.ts
+++ b/specification/ccr/unfollow/UnfollowIndexRequest.ts
@@ -21,9 +21,16 @@ import { RequestBase } from '@_types/Base'
 import { IndexName } from '@_types/common'
 
 /**
+ * Unfollow an index.
+ * Convert a cross-cluster replication follower index to a regular index.
+ * The API stops the following task associated with a follower index and removes index metadata and settings associated with cross-cluster replication.
+ * The follower index must be paused and closed before you call the unfollow API.
+ *
+ * NOTE: Currently cross-cluster replication does not support converting an existing regular index to a follower index. Converting a follower index to a regular index is an irreversible operation.
  * @rest_spec_name ccr.unfollow
  * @availability stack since=6.5.0 stability=stable
  * @doc_id ccr-post-unfollow
+ * @ext_doc_id ccr
  */
 export interface Request extends RequestBase {
   path_parts: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Edit CCR operation summaries (#3266)](https://github.com/elastic/elasticsearch-specification/pull/3266)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)