### PR TITLE
[DOCS] Edit licensing API summaries

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -113,6 +113,9 @@ actions:
         - name: license
           x-displayName: Licensing
           description: Licensing APIs enable you to manage your licenses.
+          externalDocs:
+            url: https://www.elastic.co/subscriptions
+            description: For more information about the different types of licenses, refer to Elastic subscriptions
         - name: logstash
           x-displayName: Logstash
           description: >

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -15849,7 +15849,7 @@
           "license"
         ],
         "summary": "Get license information",
-        "description": "Returns information about your Elastic license, including its type, its status, when it was issued, and when it expires.\nFor more information about the different types of licenses, refer to [Elastic Stack subscriptions](https://www.elastic.co/subscriptions).",
+        "description": "Get information about your Elastic license including its type, its status, when it was issued, and when it expires.\n\nNOTE: If the master node is generating a new cluster state, the get license API may return a `404 Not Found` response.\nIf you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.",
         "operationId": "license-get",
         "parameters": [
           {
@@ -15898,7 +15898,8 @@
         "tags": [
           "license"
         ],
-        "summary": "Updates the license for the cluster",
+        "summary": "Update the license",
+        "description": "You can update your license at runtime without shutting down your nodes.\nLicense updates take effect immediately.\nIf the license you are installing does not support all of the features that were available with your previous license, however, you are notified in the response.\nYou must then re-submit the API request with the acknowledge parameter set to true.\n\nNOTE: If Elasticsearch security features are enabled and you are installing a gold or higher license, you must enable TLS on the transport networking layer before you install the license.\nIf the operator privileges feature is enabled, only operator users can use this API.",
         "operationId": "license-post",
         "parameters": [
           {
@@ -15918,7 +15919,8 @@
         "tags": [
           "license"
         ],
-        "summary": "Updates the license for the cluster",
+        "summary": "Update the license",
+        "description": "You can update your license at runtime without shutting down your nodes.\nLicense updates take effect immediately.\nIf the license you are installing does not support all of the features that were available with your previous license, however, you are notified in the response.\nYou must then re-submit the API request with the acknowledge parameter set to true.\n\nNOTE: If Elasticsearch security features are enabled and you are installing a gold or higher license, you must enable TLS on the transport networking layer before you install the license.\nIf the operator privileges feature is enabled, only operator users can use this API.",
         "operationId": "license-post-1",
         "parameters": [
           {
@@ -15938,7 +15940,11 @@
         "tags": [
           "license"
         ],
-        "summary": "Deletes licensing information for the cluster",
+        "summary": "Delete the license",
+        "description": "When the license expires, your subscription level reverts to Basic.\n\nIf the operator privileges feature is enabled, only operator users can use this API.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/kibana/current/managing-licenses.html"
+        },
         "operationId": "license-delete",
         "responses": {
           "200": {
@@ -15959,7 +15965,7 @@
         "tags": [
           "license"
         ],
-        "summary": "Retrieves information about the status of the basic license",
+        "summary": "Get the basic license status",
         "operationId": "license-get-basic-status",
         "responses": {
           "200": {
@@ -15989,7 +15995,7 @@
         "tags": [
           "license"
         ],
-        "summary": "Retrieves information about the status of the trial license",
+        "summary": "Get the trial status",
         "operationId": "license-get-trial-status",
         "responses": {
           "200": {
@@ -16019,8 +16025,8 @@
         "tags": [
           "license"
         ],
-        "summary": "The start basic API enables you to initiate an indefinite basic license, which gives access to all the basic features",
-        "description": "If the basic license does not support all of the features that are available with your current license, however, you are notified in the response. You must then re-submit the API request with the acknowledge parameter set to true.\nTo check the status of your basic license, use the following API: [Get basic status](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-basic-status.html).",
+        "summary": "Start a basic license",
+        "description": "Start an indefinite basic license, which gives access to all the basic features.\n\nNOTE: In order to start a basic license, you must not currently have a basic license.\n\nIf the basic license does not support all of the features that are available with your current license, however, you are notified in the response.\nYou must then re-submit the API request with the `acknowledge` parameter set to `true`.\n\nTo check the status of your basic license, use the get basic license API.",
         "operationId": "license-post-start-basic",
         "parameters": [
           {
@@ -16088,7 +16094,8 @@
         "tags": [
           "license"
         ],
-        "summary": "The start trial API enables you to start a 30-day trial, which gives access to all subscription features",
+        "summary": "Start a trial",
+        "description": "Start a 30-day trial, which gives access to all subscription features.\n\nNOTE: You are allowed to start a trial only if your cluster has not already activated a trial for the current major product version.\nFor example, if you have already activated a trial for v8.0, you cannot start a new trial until v9.0. You can, however, request an extended trial at https://www.elastic.co/trialextension.\n\nTo check the status of your trial, use the get trial status API.",
         "operationId": "license-post-start-trial",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -9160,7 +9160,7 @@
           "license"
         ],
         "summary": "Get license information",
-        "description": "Returns information about your Elastic license, including its type, its status, when it was issued, and when it expires.\nFor more information about the different types of licenses, refer to [Elastic Stack subscriptions](https://www.elastic.co/subscriptions).",
+        "description": "Get information about your Elastic license including its type, its status, when it was issued, and when it expires.\n\nNOTE: If the master node is generating a new cluster state, the get license API may return a `404 Not Found` response.\nIf you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.",
         "operationId": "license-get",
         "parameters": [
           {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -261,6 +261,7 @@ k-precision,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/sea
 k-recall,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#k-recall
 kv-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/kv-processor.html
 knn-inner-hits,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/knn-search.html#nested-knn-search-inner-hits
+license-management,https://www.elastic.co/guide/en/kibana/{branch}/managing-licenses.html
 logstash-api-delete-pipeline,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/logstash-api-delete-pipeline.html
 logstash-api-get-pipeline,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/logstash-api-get-pipeline.html
 logstash-api-put-pipeline,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/logstash-api-put-pipeline.html

--- a/specification/license/delete/DeleteLicenseRequest.ts
+++ b/specification/license/delete/DeleteLicenseRequest.ts
@@ -27,6 +27,6 @@ import { RequestBase } from '@_types/Base'
  * @rest_spec_name license.delete
  * @availability stack stability=stable
  * @cluster_privileges manage
- * @ext_doc_id licence-management
+ * @ext_doc_id license-management
  */
 export interface Request extends RequestBase {}

--- a/specification/license/delete/DeleteLicenseRequest.ts
+++ b/specification/license/delete/DeleteLicenseRequest.ts
@@ -20,7 +20,13 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Delete the license.
+ * When the license expires, your subscription level reverts to Basic.
+ *
+ * If the operator privileges feature is enabled, only operator users can use this API.
  * @rest_spec_name license.delete
  * @availability stack stability=stable
+ * @cluster_privileges manage
+ * @ext_doc_id licence-management
  */
 export interface Request extends RequestBase {}

--- a/specification/license/get/GetLicenseRequest.ts
+++ b/specification/license/get/GetLicenseRequest.ts
@@ -21,8 +21,10 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Get license information.
- * Returns information about your Elastic license, including its type, its status, when it was issued, and when it expires.
- * For more information about the different types of licenses, refer to [Elastic Stack subscriptions](https://www.elastic.co/subscriptions).
+ * Get information about your Elastic license including its type, its status, when it was issued, and when it expires.
+ *
+ * NOTE: If the master node is generating a new cluster state, the get license API may return a `404 Not Found` response.
+ * If you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.
  * @rest_spec_name license.get
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/license/get_basic_status/GetBasicLicenseStatusRequest.ts
+++ b/specification/license/get_basic_status/GetBasicLicenseStatusRequest.ts
@@ -20,7 +20,9 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Get the basic license status.
  * @rest_spec_name license.get_basic_status
  * @availability stack since=6.3.0 stability=stable
+ * @cluster_privileges monitor
  */
 export interface Request extends RequestBase {}

--- a/specification/license/get_trial_status/GetTrialLicenseStatusRequest.ts
+++ b/specification/license/get_trial_status/GetTrialLicenseStatusRequest.ts
@@ -20,7 +20,9 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Get the trial status.
  * @rest_spec_name license.get_trial_status
  * @availability stack since=6.1.0 stability=stable
+ * @cluster_privileges monitor
  */
 export interface Request extends RequestBase {}

--- a/specification/license/post/PostLicenseRequest.ts
+++ b/specification/license/post/PostLicenseRequest.ts
@@ -21,6 +21,14 @@ import { License } from '@license/_types/License'
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Update the license.
+ * You can update your license at runtime without shutting down your nodes.
+ * License updates take effect immediately.
+ * If the license you are installing does not support all of the features that were available with your previous license, however, you are notified in the response.
+ * You must then re-submit the API request with the acknowledge parameter set to true.
+ *
+ * NOTE: If Elasticsearch security features are enabled and you are installing a gold or higher license, you must enable TLS on the transport networking layer before you install the license.
+ * If the operator privileges feature is enabled, only operator users can use this API.
  * @rest_spec_name license.post
  * @availability stack stability=stable
  * @cluster_privileges manage

--- a/specification/license/post_start_basic/StartBasicLicenseRequest.ts
+++ b/specification/license/post_start_basic/StartBasicLicenseRequest.ts
@@ -22,9 +22,9 @@ import { RequestBase } from '@_types/Base'
 /**
  * Start a basic license.
  * Start an indefinite basic license, which gives access to all the basic features.
- * 
+ *
  * NOTE: In order to start a basic license, you must not currently have a basic license.
- * 
+ *
  * If the basic license does not support all of the features that are available with your current license, however, you are notified in the response.
  * You must then re-submit the API request with the `acknowledge` parameter set to `true`.
  *

--- a/specification/license/post_start_basic/StartBasicLicenseRequest.ts
+++ b/specification/license/post_start_basic/StartBasicLicenseRequest.ts
@@ -20,10 +20,18 @@
 import { RequestBase } from '@_types/Base'
 
 /**
- * The start basic API enables you to initiate an indefinite basic license, which gives access to all the basic features. If the basic license does not support all of the features that are available with your current license, however, you are notified in the response. You must then re-submit the API request with the acknowledge parameter set to true.
- * To check the status of your basic license, use the following API: [Get basic status](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-basic-status.html).
+ * Start a basic license.
+ * Start an indefinite basic license, which gives access to all the basic features.
+ * 
+ * NOTE: In order to start a basic license, you must not currently have a basic license.
+ * 
+ * If the basic license does not support all of the features that are available with your current license, however, you are notified in the response.
+ * You must then re-submit the API request with the `acknowledge` parameter set to `true`.
+ *
+ * To check the status of your basic license, use the get basic license API.
  * @rest_spec_name license.post_start_basic
  * @availability stack since=6.3.0 stability=stable
+ * @cluster_privileges manage
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/license/post_start_trial/StartTrialLicenseRequest.ts
+++ b/specification/license/post_start_trial/StartTrialLicenseRequest.ts
@@ -20,7 +20,13 @@
 import { RequestBase } from '@_types/Base'
 
 /**
- * The start trial API enables you to start a 30-day trial, which gives access to all subscription features.
+ * Start a trial.
+ * Start a 30-day trial, which gives access to all subscription features.
+ *
+ * NOTE: You are allowed to start a trial only if your cluster has not already activated a trial for the current major product version.
+ * For example, if you have already activated a trial for v8.0, you cannot start a new trial until v9.0. You can, however, request an extended trial at https://www.elastic.co/trialextension.
+ *
+ * To check the status of your trial, use the get trial status API.
  * @rest_spec_name license.post_start_trial
  * @availability stack since=6.1.0 stability=stable
  * @cluster_privileges manage


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3226

This PR edits the summaries and descriptions in https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-license based on information from https://www.elastic.co/guide/en/elasticsearch/reference/master/licensing-apis.html