### PR TITLE
Fix update-rest-api-spec for 7.17 branch

### DIFF
--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['main', '8.x', '8.16', '8.17', 7.17']
+        branch: ['main', '8.x', '8.16', '8.17', '7.17']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Example failure:https://github.com/elastic/elasticsearch-specification/actions/runs/12289629442/job/34298075094