### PR TITLE
[DOCS] Update branch information in overlay

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -14,7 +14,7 @@ actions:
         
         ## Documentation source and versions
         
-        This documentation is derived from the `8.x` branch of the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification) repository.
+        This documentation is derived from the `8.17` branch of the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification) repository.
         It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
 
         This documentation contains work-in-progress information for future Elastic Stack releases.


### PR DESCRIPTION
This PR fixes the branch information in the introductory content for the OpenAPI document.
It ultimately appears in https://www.elastic.co/docs/api/doc/elasticsearch/v8#topic-documentation-source-and-versions