### PR TITLE
[DOCS] Edit migration summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -16477,7 +16477,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "Retrieves information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version",
+        "summary": "Get deprecation information",
+        "description": "Get information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.\n\nTIP: This APIs is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.",
         "operationId": "migration-deprecations",
         "responses": {
           "200": {
@@ -16492,7 +16493,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "Retrieves information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version",
+        "summary": "Get deprecation information",
+        "description": "Get information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.\n\nTIP: This APIs is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.",
         "operationId": "migration-deprecations-1",
         "parameters": [
           {
@@ -16512,7 +16514,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "Find out whether system features need to be upgraded or not",
+        "summary": "Get feature migration information",
+        "description": "Version upgrades sometimes require changes to how features store configuration information and data in system indices.\nCheck which features need to be migrated and the status of any migrations that are in progress.\n\nTIP: This API is designed for indirect use by the Upgrade Assistant.\nWe strongly recommend you use the Upgrade Assistant.",
         "operationId": "migration-get-feature-upgrade-status",
         "responses": {
           "200": {
@@ -16547,7 +16550,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "Begin upgrades for system features",
+        "summary": "Start the feature migration",
+        "description": "Version upgrades sometimes require changes to how features store configuration information and data in system indices.\nThis API starts the automatic migration process.\n\nSome functionality might be temporarily unavailable during the migration process.\n\nTIP: The API is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.",
         "operationId": "migration-post-feature-upgrade",
         "responses": {
           "200": {

--- a/specification/migration/deprecations/DeprecationInfoRequest.ts
+++ b/specification/migration/deprecations/DeprecationInfoRequest.ts
@@ -21,8 +21,13 @@ import { RequestBase } from '@_types/Base'
 import { IndexName } from '@_types/common'
 
 /**
+ * Get deprecation information.
+ * Get information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.
+ *
+ * TIP: This APIs is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.
  * @rest_spec_name migration.deprecations
  * @availability stack since=6.1.0 stability=stable
+ * @cluster_privileges manage
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/migration/get_feature_upgrade_status/GetFeatureUpgradeStatusRequest.ts
+++ b/specification/migration/get_feature_upgrade_status/GetFeatureUpgradeStatusRequest.ts
@@ -20,8 +20,15 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Get feature migration information.
+ * Version upgrades sometimes require changes to how features store configuration information and data in system indices.
+ * Check which features need to be migrated and the status of any migrations that are in progress.
+ *
+ * TIP: This API is designed for indirect use by the Upgrade Assistant.
+ * We strongly recommend you use the Upgrade Assistant.
  * @rest_spec_name migration.get_feature_upgrade_status
  * @availability stack since=7.16.0 stability=stable
  * @index_privileges manage
+ * @cluster_privileges manage
  */
 export interface Request extends RequestBase {}

--- a/specification/migration/post_feature_upgrade/PostFeatureUpgradeRequest.ts
+++ b/specification/migration/post_feature_upgrade/PostFeatureUpgradeRequest.ts
@@ -20,8 +20,16 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Start the feature migration.
+ * Version upgrades sometimes require changes to how features store configuration information and data in system indices.
+ * This API starts the automatic migration process.
+ *
+ * Some functionality might be temporarily unavailable during the migration process.
+ *
+ * TIP: The API is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.
  * @rest_spec_name migration.post_feature_upgrade
  * @availability stack since=7.16.0 stability=stable
  * @index_privileges manage
+ * @cluster_privileges manage
  */
 export interface Request extends RequestBase {}


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3226

This PR edits the migration API summaries (https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-migration) based on information from https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api.html