### PR TITLE
[DOCS] Edit machine learning summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -20409,8 +20409,8 @@
         "tags": [
           "ml"
         ],
-        "summary": "Return ML defaults and limits",
-        "description": "Returns defaults and limits used by machine learning.\nThis endpoint is designed to be used by a user interface that needs to fully\nunderstand machine learning configurations where some options are not\nspecified, meaning that the defaults should be used. This endpoint may be\nused to find out what those defaults are. It also provides information about\nthe maximum size of machine learning jobs that could run in the current\ncluster configuration.",
+        "summary": "Get machine learning information",
+        "description": "Get defaults and limits used by machine learning.\nThis endpoint is designed to be used by a user interface that needs to fully\nunderstand machine learning configurations where some options are not\nspecified, meaning that the defaults should be used. This endpoint may be\nused to find out what those defaults are. It also provides information about\nthe maximum size of machine learning jobs that could run in the current\ncluster configuration.",
         "operationId": "ml-info",
         "responses": {
           "200": {
@@ -22586,9 +22586,9 @@
     "/_ml/anomaly_detectors/_validate/detector": {
       "post": {
         "tags": [
-          "ml"
+          "ml anomaly"
         ],
-        "summary": "Validates an anomaly detection detector",
+        "summary": "Validate an anomaly detection job",
         "operationId": "ml-validate-detector",
         "requestBody": {
           "content": {

--- a/specification/ml/info/MlInfoRequest.ts
+++ b/specification/ml/info/MlInfoRequest.ts
@@ -20,8 +20,8 @@
 import { RequestBase } from '@_types/Base'
 
 /**
- * Return ML defaults and limits.
- * Returns defaults and limits used by machine learning.
+ * Get machine learning information.
+ * Get defaults and limits used by machine learning.
  * This endpoint is designed to be used by a user interface that needs to fully
  * understand machine learning configurations where some options are not
  * specified, meaning that the defaults should be used. This endpoint may be

--- a/specification/ml/validate_detector/MlValidateDetectorRequest.ts
+++ b/specification/ml/validate_detector/MlValidateDetectorRequest.ts
@@ -21,9 +21,11 @@ import { Detector } from '@ml/_types/Detector'
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Validate an anomaly detection job.
  * @rest_spec_name ml.validate_detector
  * @availability stack since=5.4.0 stability=stable visibility=private
  * @availability serverless stability=stable visibility=private
+ * @doc_tag ml anomaly
  */
 export interface Request extends RequestBase {
   /** @codegen_name detector */


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3226

This PR edits some machine learning API summaries (https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-ml) based on https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-apis.html

FYI After https://github.com/elastic/elasticsearch-specification/issues/3300 is fixed any of these operations that have visibility set to "private" will not be included in the OpenAPI document.