### PR TITLE
[DOCS] Fix monitoring operation summary and visibility

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -22620,7 +22620,8 @@
         "tags": [
           "monitoring"
         ],
-        "summary": "Used by the monitoring features to send monitoring data",
+        "summary": "Send monitoring data",
+        "description": "This API is used by the monitoring features to send monitoring data.",
         "operationId": "monitoring-bulk-1",
         "parameters": [
           {
@@ -22647,7 +22648,8 @@
         "tags": [
           "monitoring"
         ],
-        "summary": "Used by the monitoring features to send monitoring data",
+        "summary": "Send monitoring data",
+        "description": "This API is used by the monitoring features to send monitoring data.",
         "operationId": "monitoring-bulk",
         "parameters": [
           {
@@ -22676,7 +22678,8 @@
         "tags": [
           "monitoring"
         ],
-        "summary": "Used by the monitoring features to send monitoring data",
+        "summary": "Send monitoring data",
+        "description": "This API is used by the monitoring features to send monitoring data.",
         "operationId": "monitoring-bulk-3",
         "parameters": [
           {
@@ -22706,7 +22709,8 @@
         "tags": [
           "monitoring"
         ],
-        "summary": "Used by the monitoring features to send monitoring data",
+        "summary": "Send monitoring data",
+        "description": "This API is used by the monitoring features to send monitoring data.",
         "operationId": "monitoring-bulk-2",
         "parameters": [
           {

--- a/specification/monitoring/bulk/BulkMonitoringRequest.ts
+++ b/specification/monitoring/bulk/BulkMonitoringRequest.ts
@@ -22,8 +22,10 @@ import { RequestBase } from '@_types/Base'
 import { Duration } from '@_types/Time'
 
 /**
+ * Send monitoring data.
+ * This API is used by the monitoring features to send monitoring data.
  * @rest_spec_name monitoring.bulk
- * @availability stack since=6.3.0 stability=stable
+ * @availability stack since=6.3.0 stability=stable visibility=private
  */
 export interface Request<TDocument, TPartialDocument> extends RequestBase {
   path_parts: {


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3226, https://github.com/elastic/elasticsearch-specification/issues/3300

This PR edits the monitoring API summaries (https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-monitoring) and copies the "visibility=private" from the JSON spec so that it can be properly excluded from the OpenAPI document.

