### PR TITLE
[8.x] Fix spec validator bugs (#3295)

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -36,24 +36,10 @@
       ],
       "response": []
     },
-    "async_search.get": {
-      "request": [],
-      "response": [
-        "type_alias definition _types:EpochTime / instance_of - No type definition for '_types.EpochTime:Unit'",
-        "type_alias definition _types.aggregations:Buckets / union_of / dictionary_of / instance_of - No type definition for '_types.aggregations.Buckets:TBucket'",
-        "type_alias definition _types.aggregations:Buckets / union_of / array_of / instance_of - No type definition for '_types.aggregations.Buckets:TBucket'",
-        "type_alias definition _spec_utils:Void / instance_of - No type definition for '_builtins:void'",
-        "type_alias definition _types:DurationValue / instance_of - No type definition for '_types.DurationValue:Unit'",
-        "type_alias definition _global.search._types:Suggest - A tagged union should not have generic parameters",
-        "type_alias definition _global.search._types:Suggest / instance_of / Generics / instance_of - No type definition for '_global.search._types.Suggest:TDocument'",
-        "type_alias definition _global.search._types:Suggest - Expected 1 generic parameters but got 0"
-      ]
-    },
     "async_search.submit": {
       "request": [
         "Request: query parameter 'min_compatible_shard_node' does not exist in the json spec",
-        "interface definition _types:QueryVectorBuilder - Property text_embedding is a single-variant and must be required",
-        "type_alias definition _spec_utils:PipeSeparatedFlags / union_of / instance_of - No type definition for '_spec_utils.PipeSeparatedFlags:T'"
+        "interface definition _types:QueryVectorBuilder - Property text_embedding is a single-variant and must be required"
       ],
       "response": []
     },
@@ -74,9 +60,7 @@
       "request": [
         "request definition cat.allocation:Request / body - A request with inherited properties must have a PropertyBody"
       ],
-      "response": [
-        "type_alias definition _spec_utils:Stringified / union_of / instance_of - No type definition for '_spec_utils.Stringified:T'"
-      ]
+      "response": []
     },
     "cat.component_templates": {
       "request": [
@@ -431,12 +415,6 @@
       ],
       "response": []
     },
-    "connector.update_error": {
-      "request": [
-        "type_alias definition _spec_utils:WithNullValue / union_of / instance_of - No type definition for '_spec_utils.WithNullValue:T'"
-      ],
-      "response": []
-    },
     "connector.update_features": {
       "request": [
         "Missing request & response"
@@ -493,12 +471,6 @@
       ],
       "response": []
     },
-    "esql.query": {
-      "request": [],
-      "response": [
-        "type_alias definition _types:EsqlColumns / instance_of - No type definition for '_builtins:binary'"
-      ]
-    },
     "features.get_features": {
       "request": [
         "Request: missing json spec query parameter 'master_timeout'"
@@ -522,12 +494,6 @@
         "Missing request & response"
       ],
       "response": []
-    },
-    "fleet.msearch": {
-      "request": [],
-      "response": [
-        "type_alias definition _global.msearch:ResponseItem / union_of / instance_of / Generics / instance_of - No type definition for '_global.msearch.ResponseItem:TDocument'"
-      ]
     },
     "fleet.post_secret": {
       "request": [
@@ -728,12 +694,6 @@
       ],
       "response": []
     },
-    "mget": {
-      "request": [],
-      "response": [
-        "type_alias definition _global.mget:ResponseItem / union_of / instance_of / Generics / instance_of - No type definition for '_global.mget.ResponseItem:TDocument'"
-      ]
-    },
     "ml.delete_trained_model": {
       "request": [
         "Request: missing json spec query parameter 'timeout'"
@@ -842,9 +802,7 @@
         "Request: query parameter 'grid_agg' does not exist in the json spec",
         "Request: missing json spec query parameter 'track_total_hits'"
       ],
-      "response": [
-        "type_alias definition _types:MapboxVectorTiles / instance_of - No type definition for '_builtins:binary'"
-      ]
+      "response": []
     },
     "search_shards": {
       "request": [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix spec validator bugs (#3295)](https://github.com/elastic/elasticsearch-specification/pull/3295)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)