### PR TITLE
[DOCS] Edits rollup summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -25207,7 +25207,8 @@
         "tags": [
           "rollup"
         ],
-        "summary": "Retrieves the configuration, stats, and status of rollup jobs",
+        "summary": "Get rollup job information",
+        "description": "Get the configuration, stats, and status of rollup jobs.\n\nNOTE: This API returns only active (both `STARTED` and `STOPPED`) jobs.\nIf a job was created, ran for a while, then was deleted, the API does not return any details about it.\nFor details about a historical rollup job, the rollup capabilities API may be more useful.",
         "operationId": "rollup-get-jobs",
         "parameters": [
           {
@@ -25225,7 +25226,8 @@
         "tags": [
           "rollup"
         ],
-        "summary": "Creates a rollup job",
+        "summary": "Create a rollup job",
+        "description": "WARNING: From 8.15.0, calling this API in a cluster with no rollup usage will fail with a message about the deprecation and planned removal of rollup features. A cluster either needs to contain a rollup job or a rollup index in order for this API to be allowed to run.\n\nThe rollup job configuration contains all the details about how the job should run, when it indexes documents, and what future queries will be able to run against the rollup index.\n\nThere are three main sections to the job configuration: the logistical details about the job (for example, the cron schedule), the fields that are used for grouping, and what metrics to collect for each group.\n\nJobs are created in a `STOPPED` state. You can start them with the start rollup jobs API.",
         "operationId": "rollup-put-job",
         "parameters": [
           {
@@ -25308,7 +25310,8 @@
         "tags": [
           "rollup"
         ],
-        "summary": "Deletes an existing rollup job",
+        "summary": "Delete a rollup job",
+        "description": "A job must be stopped first before it can be deleted.\nIf you attempt to delete a started job, an error occurs.\nSimilarly, if you attempt to delete a nonexistent job, an exception occurs.\n\nIMPORTANT: When you delete a job, you remove only the process that is actively monitoring and rolling up data.\nThe API does not delete any previously rolled up data.\nThis is by design; a user may wish to roll up a static data set.\nBecause the data set is static, after it has been fully rolled up there is no need to keep the indexing rollup job around (as there will be no new data).\nThus the job can be deleted, leaving behind the rolled up data for analysis.\nIf you wish to also remove the rollup data and the rollup index contains the data for only a single job, you can delete the whole rollup index.\nIf the rollup index stores data from several jobs, you must issue a delete-by-query that targets the rollup job's identifier in the rollup index. For example:\n\n```\nPOST my_rollup_index/_delete_by_query\n{\n  \"query\": {\n    \"term\": {\n      \"_rollup.id\": \"the_rollup_job_id\"\n    }\n  }\n}\n```",
         "operationId": "rollup-delete-job",
         "parameters": [
           {
@@ -25357,7 +25360,8 @@
         "tags": [
           "rollup"
         ],
-        "summary": "Retrieves the configuration, stats, and status of rollup jobs",
+        "summary": "Get rollup job information",
+        "description": "Get the configuration, stats, and status of rollup jobs.\n\nNOTE: This API returns only active (both `STARTED` and `STOPPED`) jobs.\nIf a job was created, ran for a while, then was deleted, the API does not return any details about it.\nFor details about a historical rollup job, the rollup capabilities API may be more useful.",
         "operationId": "rollup-get-jobs-1",
         "responses": {
           "200": {
@@ -25372,7 +25376,8 @@
         "tags": [
           "rollup"
         ],
-        "summary": "Returns the capabilities of any rollup jobs that have been configured for a specific index or index pattern",
+        "summary": "Get the rollup job capabilities",
+        "description": "Get the capabilities of any rollup jobs that have been configured for a specific index or index pattern.\n\nThis API is useful because a rollup job is often configured to rollup only a subset of fields from the source index. \nFurthermore, only certain aggregations can be configured for various fields, leading to a limited subset of functionality depending on that configuration.\nThis API enables you to inspect an index and determine:\n\n1. Does this index have associated rollup data somewhere in the cluster?\n2. If yes to the first question, what fields were rolled up, what aggregations can be performed, and where does the data live?",
         "operationId": "rollup-get-rollup-caps",
         "parameters": [
           {
@@ -25392,7 +25397,8 @@
         "tags": [
           "rollup"
         ],
-        "summary": "Returns the capabilities of any rollup jobs that have been configured for a specific index or index pattern",
+        "summary": "Get the rollup job capabilities",
+        "description": "Get the capabilities of any rollup jobs that have been configured for a specific index or index pattern.\n\nThis API is useful because a rollup job is often configured to rollup only a subset of fields from the source index. \nFurthermore, only certain aggregations can be configured for various fields, leading to a limited subset of functionality depending on that configuration.\nThis API enables you to inspect an index and determine:\n\n1. Does this index have associated rollup data somewhere in the cluster?\n2. If yes to the first question, what fields were rolled up, what aggregations can be performed, and where does the data live?",
         "operationId": "rollup-get-rollup-caps-1",
         "responses": {
           "200": {
@@ -25407,7 +25413,8 @@
         "tags": [
           "rollup"
         ],
-        "summary": "Returns the rollup capabilities of all jobs inside of a rollup index (for example, the index where rollup data is stored)",
+        "summary": "Get the rollup index capabilities",
+        "description": "Get the rollup capabilities of all jobs inside of a rollup index.\nA single rollup index may store the data for multiple rollup jobs and may have a variety of capabilities depending on those jobs. This API enables you to determine:\n\n* What jobs are stored in an index (or indices specified via a pattern)?\n* What target indices were rolled up, what fields were used in those rollups, and what aggregations can be performed on each job?",
         "operationId": "rollup-get-rollup-index-caps",
         "parameters": [
           {
@@ -25445,7 +25452,8 @@
         "tags": [
           "rollup"
         ],
-        "summary": "Enables searching rolled-up data using the standard Query DSL",
+        "summary": "Search rolled-up data",
+        "description": "The rollup search endpoint is needed because, internally, rolled-up documents utilize a different document structure than the original data.\nIt rewrites standard Query DSL into a format that matches the rollup documents then takes the response and rewrites it back to what a client would expect given the original query.",
         "operationId": "rollup-rollup-search",
         "parameters": [
           {
@@ -25472,7 +25480,8 @@
         "tags": [
           "rollup"
         ],
-        "summary": "Enables searching rolled-up data using the standard Query DSL",
+        "summary": "Search rolled-up data",
+        "description": "The rollup search endpoint is needed because, internally, rolled-up documents utilize a different document structure than the original data.\nIt rewrites standard Query DSL into a format that matches the rollup documents then takes the response and rewrites it back to what a client would expect given the original query.",
         "operationId": "rollup-rollup-search-1",
         "parameters": [
           {
@@ -25501,7 +25510,8 @@
         "tags": [
           "rollup"
         ],
-        "summary": "Starts an existing, stopped rollup job",
+        "summary": "Start rollup jobs",
+        "description": "If you try to start a job that does not exist, an exception occurs.\nIf you try to start a job that is already started, nothing happens.",
         "operationId": "rollup-start-job",
         "parameters": [
           {
@@ -25544,7 +25554,8 @@
         "tags": [
           "rollup"
         ],
-        "summary": "Stops an existing, started rollup job",
+        "summary": "Stop rollup jobs",
+        "description": "If you try to stop a job that does not exist, an exception occurs.\nIf you try to stop a job that is already stopped, nothing happens.",
         "operationId": "rollup-stop-job",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -25377,7 +25377,7 @@
           "rollup"
         ],
         "summary": "Get the rollup job capabilities",
-        "description": "Get the capabilities of any rollup jobs that have been configured for a specific index or index pattern.\n\nThis API is useful because a rollup job is often configured to rollup only a subset of fields from the source index. \nFurthermore, only certain aggregations can be configured for various fields, leading to a limited subset of functionality depending on that configuration.\nThis API enables you to inspect an index and determine:\n\n1. Does this index have associated rollup data somewhere in the cluster?\n2. If yes to the first question, what fields were rolled up, what aggregations can be performed, and where does the data live?",
+        "description": "Get the capabilities of any rollup jobs that have been configured for a specific index or index pattern.\n\nThis API is useful because a rollup job is often configured to rollup only a subset of fields from the source index.\nFurthermore, only certain aggregations can be configured for various fields, leading to a limited subset of functionality depending on that configuration.\nThis API enables you to inspect an index and determine:\n\n1. Does this index have associated rollup data somewhere in the cluster?\n2. If yes to the first question, what fields were rolled up, what aggregations can be performed, and where does the data live?",
         "operationId": "rollup-get-rollup-caps",
         "parameters": [
           {
@@ -25398,7 +25398,7 @@
           "rollup"
         ],
         "summary": "Get the rollup job capabilities",
-        "description": "Get the capabilities of any rollup jobs that have been configured for a specific index or index pattern.\n\nThis API is useful because a rollup job is often configured to rollup only a subset of fields from the source index. \nFurthermore, only certain aggregations can be configured for various fields, leading to a limited subset of functionality depending on that configuration.\nThis API enables you to inspect an index and determine:\n\n1. Does this index have associated rollup data somewhere in the cluster?\n2. If yes to the first question, what fields were rolled up, what aggregations can be performed, and where does the data live?",
+        "description": "Get the capabilities of any rollup jobs that have been configured for a specific index or index pattern.\n\nThis API is useful because a rollup job is often configured to rollup only a subset of fields from the source index.\nFurthermore, only certain aggregations can be configured for various fields, leading to a limited subset of functionality depending on that configuration.\nThis API enables you to inspect an index and determine:\n\n1. Does this index have associated rollup data somewhere in the cluster?\n2. If yes to the first question, what fields were rolled up, what aggregations can be performed, and where does the data live?",
         "operationId": "rollup-get-rollup-caps-1",
         "responses": {
           "200": {

--- a/specification/rollup/delete_job/DeleteRollupJobRequest.ts
+++ b/specification/rollup/delete_job/DeleteRollupJobRequest.ts
@@ -21,9 +21,33 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Deletes an existing rollup job.
+ * Delete a rollup job.
+ *
+ * A job must be stopped first before it can be deleted.
+ * If you attempt to delete a started job, an error occurs.
+ * Similarly, if you attempt to delete a nonexistent job, an exception occurs.
+ *
+ * IMPORTANT: When you delete a job, you remove only the process that is actively monitoring and rolling up data.
+ * The API does not delete any previously rolled up data.
+ * This is by design; a user may wish to roll up a static data set.
+ * Because the data set is static, after it has been fully rolled up there is no need to keep the indexing rollup job around (as there will be no new data).
+ * Thus the job can be deleted, leaving behind the rolled up data for analysis.
+ * If you wish to also remove the rollup data and the rollup index contains the data for only a single job, you can delete the whole rollup index.
+ * If the rollup index stores data from several jobs, you must issue a delete-by-query that targets the rollup job's identifier in the rollup index. For example:
+ *
+ * ```
+ * POST my_rollup_index/_delete_by_query
+ * {
+ *   "query": {
+ *     "term": {
+ *       "_rollup.id": "the_rollup_job_id"
+ *     }
+ *   }
+ * }
+ * ```
  * @rest_spec_name rollup.delete_job
  * @availability stack since=6.3.0 stability=experimental
+ * @cluster_privileges manage_rollup
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/rollup/delete_job/DeleteRollupJobRequest.ts
+++ b/specification/rollup/delete_job/DeleteRollupJobRequest.ts
@@ -23,7 +23,7 @@ import { Id } from '@_types/common'
 /**
  * Delete a rollup job.
  *
- * A job must be stopped first before it can be deleted.
+ * A job must be stopped before it can be deleted.
  * If you attempt to delete a started job, an error occurs.
  * Similarly, if you attempt to delete a nonexistent job, an exception occurs.
  *

--- a/specification/rollup/get_jobs/GetRollupJobRequest.ts
+++ b/specification/rollup/get_jobs/GetRollupJobRequest.ts
@@ -21,9 +21,15 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Retrieves the configuration, stats, and status of rollup jobs.
+ * Get rollup job information.
+ * Get the configuration, stats, and status of rollup jobs.
+ *
+ * NOTE: This API returns only active (both `STARTED` and `STOPPED`) jobs.
+ * If a job was created, ran for a while, then was deleted, the API does not return any details about it.
+ * For details about a historical rollup job, the rollup capabilities API may be more useful.
  * @rest_spec_name rollup.get_jobs
  * @availability stack since=6.3.0 stability=experimental
+ * @cluster_privileges monitor_rollup
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/rollup/get_rollup_caps/GetRollupCapabilitiesRequest.ts
+++ b/specification/rollup/get_rollup_caps/GetRollupCapabilitiesRequest.ts
@@ -21,9 +21,18 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Returns the capabilities of any rollup jobs that have been configured for a specific index or index pattern.
+ * Get the rollup job capabilities.
+ * Get the capabilities of any rollup jobs that have been configured for a specific index or index pattern.
+ *
+ * This API is useful because a rollup job is often configured to rollup only a subset of fields from the source index. 
+ * Furthermore, only certain aggregations can be configured for various fields, leading to a limited subset of functionality depending on that configuration.
+ * This API enables you to inspect an index and determine:
+ *
+ * 1. Does this index have associated rollup data somewhere in the cluster?
+ * 2. If yes to the first question, what fields were rolled up, what aggregations can be performed, and where does the data live?
  * @rest_spec_name rollup.get_rollup_caps
  * @availability stack since=6.3.0 stability=experimental
+ * @cluster_privileges monitor_rollup
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/rollup/get_rollup_caps/GetRollupCapabilitiesRequest.ts
+++ b/specification/rollup/get_rollup_caps/GetRollupCapabilitiesRequest.ts
@@ -24,7 +24,7 @@ import { Id } from '@_types/common'
  * Get the rollup job capabilities.
  * Get the capabilities of any rollup jobs that have been configured for a specific index or index pattern.
  *
- * This API is useful because a rollup job is often configured to rollup only a subset of fields from the source index. 
+ * This API is useful because a rollup job is often configured to rollup only a subset of fields from the source index.
  * Furthermore, only certain aggregations can be configured for various fields, leading to a limited subset of functionality depending on that configuration.
  * This API enables you to inspect an index and determine:
  *

--- a/specification/rollup/get_rollup_index_caps/GetRollupIndexCapabilitiesRequest.ts
+++ b/specification/rollup/get_rollup_index_caps/GetRollupIndexCapabilitiesRequest.ts
@@ -21,9 +21,15 @@ import { RequestBase } from '@_types/Base'
 import { Ids } from '@_types/common'
 
 /**
- * Returns the rollup capabilities of all jobs inside of a rollup index (for example, the index where rollup data is stored).
+ * Get the rollup index capabilities.
+ * Get the rollup capabilities of all jobs inside of a rollup index.
+ * A single rollup index may store the data for multiple rollup jobs and may have a variety of capabilities depending on those jobs. This API enables you to determine:
+ *
+ * * What jobs are stored in an index (or indices specified via a pattern)?
+ * * What target indices were rolled up, what fields were used in those rollups, and what aggregations can be performed on each job?
  * @rest_spec_name rollup.get_rollup_index_caps
  * @availability stack since=6.4.0 stability=experimental
+ * @index_privileges read
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/rollup/put_job/CreateRollupJobRequest.ts
+++ b/specification/rollup/put_job/CreateRollupJobRequest.ts
@@ -27,7 +27,7 @@ import { Duration } from '@_types/Time'
 /**
  * Create a rollup job.
  *
- * WARNING: From 8.15.0, calling this API in a cluster with no rollup usage will fail with a message about the deprecation and planned removal of rollup features. A cluster either needs to contain a rollup job or a rollup index in order for this API to be allowed to run.
+ * WARNING: From 8.15.0, calling this API in a cluster with no rollup usage will fail with a message about the deprecation and planned removal of rollup features. A cluster needs to contain either a rollup job or a rollup index in order for this API to be allowed to run.
  *
  * The rollup job configuration contains all the details about how the job should run, when it indexes documents, and what future queries will be able to run against the rollup index.
  *

--- a/specification/rollup/put_job/CreateRollupJobRequest.ts
+++ b/specification/rollup/put_job/CreateRollupJobRequest.ts
@@ -25,7 +25,15 @@ import { integer } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 /**
- * Creates a rollup job.
+ * Create a rollup job.
+ *
+ * WARNING: From 8.15.0, calling this API in a cluster with no rollup usage will fail with a message about the deprecation and planned removal of rollup features. A cluster either needs to contain a rollup job or a rollup index in order for this API to be allowed to run.
+ *
+ * The rollup job configuration contains all the details about how the job should run, when it indexes documents, and what future queries will be able to run against the rollup index.
+ *
+ * There are three main sections to the job configuration: the logistical details about the job (for example, the cron schedule), the fields that are used for grouping, and what metrics to collect for each group.
+ *
+ * Jobs are created in a `STOPPED` state. You can start them with the start rollup jobs API.
  * @rest_spec_name rollup.put_job
  * @availability stack since=6.3.0 stability=experimental
  * @cluster_privileges manage, manage_rollup

--- a/specification/rollup/rollup_search/RollupSearchRequest.ts
+++ b/specification/rollup/rollup_search/RollupSearchRequest.ts
@@ -25,7 +25,9 @@ import { integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 
 /**
- * Enables searching rolled-up data using the standard Query DSL.
+ * Search rolled-up data.
+ * The rollup search endpoint is needed because, internally, rolled-up documents utilize a different document structure than the original data.
+ * It rewrites standard Query DSL into a format that matches the rollup documents then takes the response and rewrites it back to what a client would expect given the original query.
  * @rest_spec_name rollup.rollup_search
  * @availability stack since=6.3.0 stability=experimental
  */

--- a/specification/rollup/start_job/StartRollupJobRequest.ts
+++ b/specification/rollup/start_job/StartRollupJobRequest.ts
@@ -21,9 +21,12 @@ import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 
 /**
- * Starts an existing, stopped rollup job.
+ * Start rollup jobs.
+ * If you try to start a job that does not exist, an exception occurs.
+ * If you try to start a job that is already started, nothing happens.
  * @rest_spec_name rollup.start_job
  * @availability stack since=6.3.0 stability=experimental
+ * @cluster_privileges manage_rollup
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/rollup/stop_job/StopRollupJobRequest.ts
+++ b/specification/rollup/stop_job/StopRollupJobRequest.ts
@@ -22,9 +22,12 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Stops an existing, started rollup job.
+ * Stop rollup jobs.
+ * If you try to stop a job that does not exist, an exception occurs.
+ * If you try to stop a job that is already stopped, nothing happens.
  * @rest_spec_name rollup.stop_job
  * @availability stack since=6.3.0 stability=experimental
+ * @cluster_privileges manage_rollup
  */
 export interface Request extends RequestBase {
   path_parts: {


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3226

This PR edits the rollup APIs in https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-rollup based on the information from https://www.elastic.co/guide/en/elasticsearch/reference/master/rollup-apis.html

### Preview

The extra content copied into the description of the "delete a rollup job" API looks like this in Bump.sh:

![image](https://github.com/user-attachments/assets/ec92cf29-50a5-4d60-b6e3-6713653edc08)
