### PR TITLE
[DOCS] Edit searchable snapshot summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27110,7 +27110,8 @@
         "tags": [
           "searchable_snapshots"
         ],
-        "summary": "Retrieve node-level cache statistics about searchable snapshots",
+        "summary": "Get cache statistics",
+        "description": "Get statistics about the shared cache for partially mounted indices.",
         "operationId": "searchable-snapshots-cache-stats",
         "parameters": [
           {
@@ -27130,7 +27131,8 @@
         "tags": [
           "searchable_snapshots"
         ],
-        "summary": "Retrieve node-level cache statistics about searchable snapshots",
+        "summary": "Get cache statistics",
+        "description": "Get statistics about the shared cache for partially mounted indices.",
         "operationId": "searchable-snapshots-cache-stats-1",
         "parameters": [
           {
@@ -27153,7 +27155,8 @@
         "tags": [
           "searchable_snapshots"
         ],
-        "summary": "Clear the cache of searchable snapshots",
+        "summary": "Clear the cache",
+        "description": "Clear indices and data streams from the shared cache for partially mounted indices.",
         "operationId": "searchable-snapshots-clear-cache",
         "parameters": [
           {
@@ -27185,7 +27188,8 @@
         "tags": [
           "searchable_snapshots"
         ],
-        "summary": "Clear the cache of searchable snapshots",
+        "summary": "Clear the cache",
+        "description": "Clear indices and data streams from the shared cache for partially mounted indices.",
         "operationId": "searchable-snapshots-clear-cache-1",
         "parameters": [
           {
@@ -27220,7 +27224,8 @@
         "tags": [
           "searchable_snapshots"
         ],
-        "summary": "Mount a snapshot as a searchable index",
+        "summary": "Mount a snapshot",
+        "description": "Mount a snapshot as a searchable snapshot index.\nDo not use this API for snapshots managed by index lifecycle management (ILM).\nManually mounting ILM-managed snapshots can interfere with ILM processes.",
         "operationId": "searchable-snapshots-mount",
         "parameters": [
           {
@@ -27337,7 +27342,7 @@
         "tags": [
           "searchable_snapshots"
         ],
-        "summary": "Retrieve shard-level statistics about searchable snapshots",
+        "summary": "Get searchable snapshot statistics",
         "operationId": "searchable-snapshots-stats",
         "parameters": [
           {
@@ -27357,7 +27362,7 @@
         "tags": [
           "searchable_snapshots"
         ],
-        "summary": "Retrieve shard-level statistics about searchable snapshots",
+        "summary": "Get searchable snapshot statistics",
         "operationId": "searchable-snapshots-stats-1",
         "parameters": [
           {

--- a/specification/searchable_snapshots/cache_stats/Request.ts
+++ b/specification/searchable_snapshots/cache_stats/Request.ts
@@ -26,7 +26,7 @@ import { Duration } from '@_types/Time'
  * Get statistics about the shared cache for partially mounted indices.
  * @rest_spec_name searchable_snapshots.cache_stats
  * @availability stack since=7.13.0 stability=experimental
- * @clsuter_privileges manage
+ * @cluster_privileges manage
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/searchable_snapshots/cache_stats/Request.ts
+++ b/specification/searchable_snapshots/cache_stats/Request.ts
@@ -22,8 +22,11 @@ import { NodeIds } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Get cache statistics.
+ * Get statistics about the shared cache for partially mounted indices.
  * @rest_spec_name searchable_snapshots.cache_stats
  * @availability stack since=7.13.0 stability=experimental
+ * @clsuter_privileges manage
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheRequest.ts
+++ b/specification/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheRequest.ts
@@ -21,8 +21,12 @@ import { RequestBase } from '@_types/Base'
 import { ExpandWildcards, Indices } from '@_types/common'
 
 /**
+ * Clear the cache.
+ * Clear indices and data streams from the shared cache for partially mounted indices.
  * @rest_spec_name searchable_snapshots.clear_cache
  * @availability stack since=7.10.0 stability=experimental
+ * @cluster_privileges manage
+ * @index_privileges manage
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/searchable_snapshots/mount/SearchableSnapshotsMountRequest.ts
+++ b/specification/searchable_snapshots/mount/SearchableSnapshotsMountRequest.ts
@@ -24,8 +24,14 @@ import { IndexName, Name } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
+ * Mount a snapshot.
+ * Mount a snapshot as a searchable snapshot index.
+ * Do not use this API for snapshots managed by index lifecycle management (ILM).
+ * Manually mounting ILM-managed snapshots can interfere with ILM processes.
  * @rest_spec_name searchable_snapshots.mount
  * @availability stack since=7.10.0 stability=stable
+ * @cluster_privileges manage
+ * @index_privileges manage
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/searchable_snapshots/stats/SearchableSnapshotsStatsRequest.ts
+++ b/specification/searchable_snapshots/stats/SearchableSnapshotsStatsRequest.ts
@@ -22,8 +22,11 @@ import { Indices } from '@_types/common'
 import { StatsLevel } from '../_types/stats'
 
 /**
+ * Get searchable snapshot statistics.
  * @rest_spec_name searchable_snapshots.stats
  * @availability stack since=7.10.0 stability=stable
+ * @cluster_privileges manage
+ * @index_privileges manage
  */
 export interface Request extends RequestBase {
   path_parts: {


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3226

This PR edits the searchable snapshot summaries and descriptions in https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-searchable_snapshots based on https://www.elastic.co/guide/en/elasticsearch/reference/master/searchable-snapshots-apis.html