### PR TITLE
[8.x] [DOCS] Edit migration summaries (#3298)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -16379,7 +16379,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "Retrieves information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version",
+        "summary": "Get deprecation information",
+        "description": "Get information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.\n\nTIP: This APIs is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.",
         "operationId": "migration-deprecations",
         "responses": {
           "200": {
@@ -16394,7 +16395,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "Retrieves information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version",
+        "summary": "Get deprecation information",
+        "description": "Get information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.\n\nTIP: This APIs is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.",
         "operationId": "migration-deprecations-1",
         "parameters": [
           {
@@ -16414,7 +16416,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "Find out whether system features need to be upgraded or not",
+        "summary": "Get feature migration information",
+        "description": "Version upgrades sometimes require changes to how features store configuration information and data in system indices.\nCheck which features need to be migrated and the status of any migrations that are in progress.\n\nTIP: This API is designed for indirect use by the Upgrade Assistant.\nWe strongly recommend you use the Upgrade Assistant.",
         "operationId": "migration-get-feature-upgrade-status",
         "responses": {
           "200": {
@@ -16449,7 +16452,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "Begin upgrades for system features",
+        "summary": "Start the feature migration",
+        "description": "Version upgrades sometimes require changes to how features store configuration information and data in system indices.\nThis API starts the automatic migration process.\n\nSome functionality might be temporarily unavailable during the migration process.\n\nTIP: The API is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.",
         "operationId": "migration-post-feature-upgrade",
         "responses": {
           "200": {

--- a/specification/migration/deprecations/DeprecationInfoRequest.ts
+++ b/specification/migration/deprecations/DeprecationInfoRequest.ts
@@ -21,8 +21,13 @@ import { RequestBase } from '@_types/Base'
 import { IndexName } from '@_types/common'
 
 /**
+ * Get deprecation information.
+ * Get information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.
+ *
+ * TIP: This APIs is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.
  * @rest_spec_name migration.deprecations
  * @availability stack since=6.1.0 stability=stable
+ * @cluster_privileges manage
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/migration/get_feature_upgrade_status/GetFeatureUpgradeStatusRequest.ts
+++ b/specification/migration/get_feature_upgrade_status/GetFeatureUpgradeStatusRequest.ts
@@ -20,8 +20,15 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Get feature migration information.
+ * Version upgrades sometimes require changes to how features store configuration information and data in system indices.
+ * Check which features need to be migrated and the status of any migrations that are in progress.
+ *
+ * TIP: This API is designed for indirect use by the Upgrade Assistant.
+ * We strongly recommend you use the Upgrade Assistant.
  * @rest_spec_name migration.get_feature_upgrade_status
  * @availability stack since=7.16.0 stability=stable
  * @index_privileges manage
+ * @cluster_privileges manage
  */
 export interface Request extends RequestBase {}

--- a/specification/migration/post_feature_upgrade/PostFeatureUpgradeRequest.ts
+++ b/specification/migration/post_feature_upgrade/PostFeatureUpgradeRequest.ts
@@ -20,8 +20,16 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Start the feature migration.
+ * Version upgrades sometimes require changes to how features store configuration information and data in system indices.
+ * This API starts the automatic migration process.
+ *
+ * Some functionality might be temporarily unavailable during the migration process.
+ *
+ * TIP: The API is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.
  * @rest_spec_name migration.post_feature_upgrade
  * @availability stack since=7.16.0 stability=stable
  * @index_privileges manage
+ * @cluster_privileges manage
  */
 export interface Request extends RequestBase {}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Edit migration summaries (#3298)](https://github.com/elastic/elasticsearch-specification/pull/3298)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)