### PR TITLE
[DOCS] Edit task management summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -33335,7 +33335,8 @@
         "tags": [
           "tasks"
         ],
-        "summary": "Cancels a task, if it can be cancelled through an API",
+        "summary": "Cancel a task",
+        "description": "A task may continue to run for some time after it has been cancelled because it may not be able to safely stop its current activity straight away.\nIt is also possible that Elasticsearch must complete its work on other tasks before it can process the cancellation.\nThe get task information API will continue to list these cancelled tasks until they complete.\nThe cancelled flag in the response indicates that the cancellation command has been processed and the task will stop as soon as possible.\n\nTo troubleshoot why a cancelled task does not complete promptly, use the get task information API with the `?detailed` parameter to identify the other tasks the system is running.\nYou can also use the node hot threads API to obtain detailed information about the work the system is doing instead of completing the cancelled task.",
         "operationId": "tasks-cancel",
         "parameters": [
           {
@@ -33364,7 +33365,8 @@
         "tags": [
           "tasks"
         ],
-        "summary": "Cancels a task, if it can be cancelled through an API",
+        "summary": "Cancel a task",
+        "description": "A task may continue to run for some time after it has been cancelled because it may not be able to safely stop its current activity straight away.\nIt is also possible that Elasticsearch must complete its work on other tasks before it can process the cancellation.\nThe get task information API will continue to list these cancelled tasks until they complete.\nThe cancelled flag in the response indicates that the cancellation command has been processed and the task will stop as soon as possible.\n\nTo troubleshoot why a cancelled task does not complete promptly, use the get task information API with the `?detailed` parameter to identify the other tasks the system is running.\nYou can also use the node hot threads API to obtain detailed information about the work the system is doing instead of completing the cancelled task.",
         "operationId": "tasks-cancel-1",
         "parameters": [
           {
@@ -33397,7 +33399,7 @@
           "tasks"
         ],
         "summary": "Get task information",
-        "description": "Returns information about the tasks currently executing in the cluster.",
+        "description": "Get information about a task currently running in the cluster.",
         "operationId": "tasks-get",
         "parameters": [
           {
@@ -33470,7 +33472,8 @@
         "tags": [
           "tasks"
         ],
-        "summary": "The task management API returns information about tasks currently executing on one or more nodes in the cluster",
+        "summary": "Get all tasks",
+        "description": "Get information about the tasks currently running on one or more nodes in the cluster.",
         "operationId": "tasks-list",
         "parameters": [
           {
@@ -33496,7 +33499,7 @@
           {
             "in": "query",
             "name": "detailed",
-            "description": "If `true`, the response includes detailed information about shard recoveries.",
+            "description": "If `true`, the response includes detailed information about shard recoveries.\nThis information is useful to distinguish tasks from each other but is more costly to run.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -65175,6 +65178,7 @@
             "type": "boolean"
           },
           "description": {
+            "description": "Human readable text that identifies the particular request that the task is performing.\nFor example, it might identify the search request being performed by a search task.\nOther kinds of tasks have different descriptions, like `_reindex` which has the source and the destination, or `_bulk` which just has the number of requests and the destination indices.\nMany requests will have only an empty description because more detailed information about the request is not easily available or particularly helpful in identifying the request.",
             "type": "string"
           },
           "headers": {
@@ -65199,7 +65203,7 @@
             "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
           "status": {
-            "description": "Task status information can vary wildly from task to task.",
+            "description": "The internal status of the task, which varies from task to task.\nThe format also varies.\nWhile the goal is to keep the status for a particular task consistent from version to version, this is not always possible because sometimes the implementation changes.\nFields might be removed from the status for a particular request so any parsing you do of the status might break in minor releases.",
             "type": "object"
           },
           "type": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -18301,7 +18301,7 @@
           "tasks"
         ],
         "summary": "Get task information",
-        "description": "Returns information about the tasks currently executing in the cluster.",
+        "description": "Get information about a task currently running in the cluster.",
         "operationId": "tasks-get",
         "parameters": [
           {
@@ -54951,6 +54951,7 @@
             "type": "boolean"
           },
           "description": {
+            "description": "Human readable text that identifies the particular request that the task is performing.\nFor example, it might identify the search request being performed by a search task.\nOther kinds of tasks have different descriptions, like `_reindex` which has the source and the destination, or `_bulk` which just has the number of requests and the destination indices.\nMany requests will have only an empty description because more detailed information about the request is not easily available or particularly helpful in identifying the request.",
             "type": "string"
           },
           "headers": {
@@ -54975,7 +54976,7 @@
             "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
           "status": {
-            "description": "Task status information can vary wildly from task to task.",
+            "description": "The internal status of the task, which varies from task to task.\nThe format also varies.\nWhile the goal is to keep the status for a particular task consistent from version to version, this is not always possible because sometimes the implementation changes.\nFields might be removed from the status for a particular request so any parsing you do of the status might break in minor releases.",
             "type": "object"
           },
           "type": {

--- a/specification/tasks/_types/TaskInfo.ts
+++ b/specification/tasks/_types/TaskInfo.ts
@@ -33,6 +33,12 @@ export class TaskInfo {
   action: string
   cancelled?: boolean
   cancellable: boolean
+  /**
+   * Human readable text that identifies the particular request that the task is performing.
+   * For example, it might identify the search request being performed by a search task.
+   * Other kinds of tasks have different descriptions, like `_reindex` which has the source and the destination, or `_bulk` which just has the number of requests and the destination indices.
+   * Many requests will have only an empty description because more detailed information about the request is not easily available or particularly helpful in identifying the request.
+   */
   description?: string
   headers: Dictionary<string, string>
   id: long
@@ -40,7 +46,12 @@ export class TaskInfo {
   running_time?: Duration
   running_time_in_nanos: DurationValue<UnitNanos>
   start_time_in_millis: EpochTime<UnitMillis>
-  /** Task status information can vary wildly from task to task. */
+  /**
+   * The internal status of the task, which varies from task to task.
+   * The format also varies.
+   * While the goal is to keep the status for a particular task consistent from version to version, this is not always possible because sometimes the implementation changes.
+   * Fields might be removed from the status for a particular request so any parsing you do of the status might break in minor releases.
+   */
   status?: UserDefinedValue
   type: string
   parent_task_id?: TaskId

--- a/specification/tasks/cancel/CancelTasksRequest.ts
+++ b/specification/tasks/cancel/CancelTasksRequest.ts
@@ -21,6 +21,14 @@ import { RequestBase } from '@_types/Base'
 import { TaskId } from '@_types/common'
 
 /**
+ * Cancel a task.
+ * A task may continue to run for some time after it has been cancelled because it may not be able to safely stop its current activity straight away.
+ * It is also possible that Elasticsearch must complete its work on other tasks before it can process the cancellation.
+ * The get task information API will continue to list these cancelled tasks until they complete.
+ * The cancelled flag in the response indicates that the cancellation command has been processed and the task will stop as soon as possible.
+ *
+ * To troubleshoot why a cancelled task does not complete promptly, use the get task information API with the `?detailed` parameter to identify the other tasks the system is running.
+ * You can also use the node hot threads API to obtain detailed information about the work the system is doing instead of completing the cancelled task.
  * @rest_spec_name tasks.cancel
  * @availability stack since=2.3.0 stability=experimental
  * @availability serverless stability=experimental visibility=private

--- a/specification/tasks/get/GetTaskRequest.ts
+++ b/specification/tasks/get/GetTaskRequest.ts
@@ -23,7 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * Get task information.
- * Returns information about the tasks currently executing in the cluster.
+ * Get information about a task currently running in the cluster.
  * @rest_spec_name tasks.get
  * @availability stack since=5.0.0 stability=experimental
  * @availability serverless stability=experimental visibility=public

--- a/specification/tasks/list/ListTasksRequest.ts
+++ b/specification/tasks/list/ListTasksRequest.ts
@@ -23,11 +23,12 @@ import { Id, NodeIds } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * The task management API returns information about tasks currently executing on one or more nodes in the cluster.
+ * Get all tasks.
+ * Get information about the tasks currently running on one or more nodes in the cluster.
  * @rest_spec_name tasks.list
  * @availability stack since=2.3.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
- * @cluster_privileges monitor, manage
+ * @cluster_privileges monitor
  * @doc_id tasks
  */
 export interface Request extends RequestBase {
@@ -38,6 +39,7 @@ export interface Request extends RequestBase {
     actions?: string | string[]
     /**
      * If `true`, the response includes detailed information about shard recoveries.
+     * This information is useful to distinguish tasks from each other but is more costly to run.
      * @server_default false
      */
     detailed?: boolean


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3226

This PR edits the task management APIs https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-tasks based on information from https://www.elastic.co/guide/en/elasticsearch/reference/master/tasks.html