### PR TITLE
[DOCS] Edit text structure summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -33856,8 +33856,8 @@
         "tags": [
           "text_structure"
         ],
-        "summary": "Finds the structure of a text file",
-        "description": "The text file must contain data that is suitable to be ingested into Elasticsearch.",
+        "summary": "Find the structure of a text file",
+        "description": "The text file must contain data that is suitable to be ingested into Elasticsearch.\n\nThis API provides a starting point for ingesting data into Elasticsearch in a format that is suitable for subsequent use with other Elastic Stack functionality.\nUnlike other Elasticsearch endpoints, the data that is posted to this endpoint does not need to be UTF-8 encoded and in JSON format.\nIt must, however, be text; binary text formats are not currently supported.\nThe size is limited to the Elasticsearch HTTP receive buffer size, which defaults to 100 Mb.\n\nThe response from the API contains:\n\n* A couple of messages from the beginning of the text.\n* Statistics that reveal the most common values for all fields detected within the text and basic numeric statistics for numeric fields.\n* Information about the structure of the text, which is useful when you write ingest configurations to index it or similarly formatted text.\n* Appropriate mappings for an Elasticsearch index, which you could use to ingest the text.\n\nAll this information can be calculated by the structure finder with no guidance.\nHowever, you can optionally override some of the decisions about the text structure by specifying one or more query parameters.",
         "operationId": "text-structure-find-structure",
         "parameters": [
           {
@@ -33903,7 +33903,7 @@
           {
             "in": "query",
             "name": "explain",
-            "description": "If this parameter is set to true, the response includes a field named explanation, which is an array of strings that indicate how the structure finder produced its result.",
+            "description": "If this parameter is set to true, the response includes a field named explanation, which is an array of strings that indicate how the structure finder produced its result.\nIf the structure finder produces unexpected results for some text, use this query parameter to help you determine why the returned structure was chosen.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -34139,7 +34139,11 @@
         "tags": [
           "text_structure"
         ],
-        "summary": "Tests a Grok pattern on some text",
+        "summary": "Test a Grok pattern",
+        "description": "Test a Grok pattern on one or more lines of text.\nThe API indicates whether the lines match the pattern together with the offsets and lengths of the matched substrings.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/grok.html"
+        },
         "operationId": "text-structure-test-grok-pattern",
         "parameters": [
           {
@@ -34160,7 +34164,11 @@
         "tags": [
           "text_structure"
         ],
-        "summary": "Tests a Grok pattern on some text",
+        "summary": "Test a Grok pattern",
+        "description": "Test a Grok pattern on one or more lines of text.\nThe API indicates whether the lines match the pattern together with the offsets and lengths of the matched substrings.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/grok.html"
+        },
         "operationId": "text-structure-test-grok-pattern-1",
         "parameters": [
           {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -194,6 +194,7 @@ get-transform,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/g
 get-trial-status,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-trial-status.html
 graph,https://www.elastic.co/guide/en/kibana/{branch}/xpack-graph.html
 graph-explore-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/graph-explore-api.html
+grok,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/grok.html
 grok-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/grok-processor.html
 gsub-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/gsub-processor.html
 ilm-delete-lifecycle,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ilm-delete-lifecycle.html

--- a/specification/text_structure/find_structure/FindStructureRequest.ts
+++ b/specification/text_structure/find_structure/FindStructureRequest.ts
@@ -22,9 +22,27 @@ import { uint } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 /**
+ * Find the structure of a text file.
+ * The text file must contain data that is suitable to be ingested into Elasticsearch.
+ *
+ * This API provides a starting point for ingesting data into Elasticsearch in a format that is suitable for subsequent use with other Elastic Stack functionality.
+ * Unlike other Elasticsearch endpoints, the data that is posted to this endpoint does not need to be UTF-8 encoded and in JSON format.
+ * It must, however, be text; binary text formats are not currently supported.
+ * The size is limited to the Elasticsearch HTTP receive buffer size, which defaults to 100 Mb.
+ *
+ * The response from the API contains:
+ *
+ * * A couple of messages from the beginning of the text.
+ * * Statistics that reveal the most common values for all fields detected within the text and basic numeric statistics for numeric fields.
+ * * Information about the structure of the text, which is useful when you write ingest configurations to index it or similarly formatted text.
+ * * Appropriate mappings for an Elasticsearch index, which you could use to ingest the text.
+ *
+ * All this information can be calculated by the structure finder with no guidance.
+ * However, you can optionally override some of the decisions about the text structure by specifying one or more query parameters.
  * @rest_spec_name text_structure.find_structure
  * @availability stack since=7.13.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @cluster_privileges monitor_text_structure
  */
 export interface Request<TJsonDocument> {
   query_parameters: {
@@ -38,6 +56,7 @@ export interface Request<TJsonDocument> {
     ecs_compatibility?: string
     /**
      * If this parameter is set to true, the response includes a field named explanation, which is an array of strings that indicate how the structure finder produced its result.
+     * If the structure finder produces unexpected results for some text, use this query parameter to help you determine why the returned structure was chosen.
      * @server_default false
      */
     explain?: boolean

--- a/specification/text_structure/test_grok_pattern/TestGrokPatternRequest.ts
+++ b/specification/text_structure/test_grok_pattern/TestGrokPatternRequest.ts
@@ -21,9 +21,13 @@ import { RequestBase } from '@_types/Base'
 import { GrokPattern } from '@_types/common'
 
 /**
+ * Test a Grok pattern.
+ * Test a Grok pattern on one or more lines of text.
+ * The API indicates whether the lines match the pattern together with the offsets and lengths of the matched substrings.
  * @rest_spec_name text_structure.test_grok_pattern
  * @availability stack since=8.13.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @ext_doc_id grok
  */
 export interface Request extends RequestBase {
   query_parameters: {


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3226

This PR edits the text structure APIs https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-text_structure based on https://www.elastic.co/guide/en/elasticsearch/reference/master/text-structure-apis.html.

NOTE: There are two APIs in the old docs that don't exist in the specifications, so they will also need to be edited once that work is complete.