### PR TITLE
[8.x] Add allow_partial_search_results and shard_failures to EQL (#3342)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -8245,6 +8245,12 @@
             "$ref": "#/components/parameters/eql.search#allow_no_indices"
           },
           {
+            "$ref": "#/components/parameters/eql.search#allow_partial_search_results"
+          },
+          {
+            "$ref": "#/components/parameters/eql.search#allow_partial_sequence_results"
+          },
+          {
             "$ref": "#/components/parameters/eql.search#expand_wildcards"
           },
           {
@@ -8286,6 +8292,12 @@
           },
           {
             "$ref": "#/components/parameters/eql.search#allow_no_indices"
+          },
+          {
+            "$ref": "#/components/parameters/eql.search#allow_partial_search_results"
+          },
+          {
+            "$ref": "#/components/parameters/eql.search#allow_partial_sequence_results"
           },
           {
             "$ref": "#/components/parameters/eql.search#expand_wildcards"
@@ -96479,6 +96491,26 @@
         },
         "style": "form"
       },
+      "eql.search#allow_partial_search_results": {
+        "in": "query",
+        "name": "allow_partial_search_results",
+        "description": "If true, returns partial results if there are shard failures. If false, returns an error with no partial results.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
+      "eql.search#allow_partial_sequence_results": {
+        "in": "query",
+        "name": "allow_partial_sequence_results",
+        "description": "If true, sequence queries will return partial results in case of shard failures. If false, they will return no results at all.\nThis flag has effect only if allow_partial_search_results is true.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
       "eql.search#expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
@@ -104315,6 +104347,12 @@
                 },
                 "wait_for_completion_timeout": {
                   "$ref": "#/components/schemas/_types:Duration"
+                },
+                "allow_partial_search_results": {
+                  "type": "boolean"
+                },
+                "allow_partial_sequence_results": {
+                  "type": "boolean"
                 },
                 "size": {
                   "$ref": "#/components/schemas/_types:uint"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -66371,6 +66371,13 @@
           },
           "hits": {
             "$ref": "#/components/schemas/eql._types:EqlHits"
+          },
+          "shard_failures": {
+            "description": "Contains information about shard failures (if any), in case allow_partial_search_results=true",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:ShardFailure"
+            }
           }
         },
         "required": [

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -5015,6 +5015,12 @@
             "$ref": "#/components/parameters/eql.search#allow_no_indices"
           },
           {
+            "$ref": "#/components/parameters/eql.search#allow_partial_search_results"
+          },
+          {
+            "$ref": "#/components/parameters/eql.search#allow_partial_sequence_results"
+          },
+          {
             "$ref": "#/components/parameters/eql.search#expand_wildcards"
           },
           {
@@ -5056,6 +5062,12 @@
           },
           {
             "$ref": "#/components/parameters/eql.search#allow_no_indices"
+          },
+          {
+            "$ref": "#/components/parameters/eql.search#allow_partial_search_results"
+          },
+          {
+            "$ref": "#/components/parameters/eql.search#allow_partial_sequence_results"
           },
           {
             "$ref": "#/components/parameters/eql.search#expand_wildcards"
@@ -58702,6 +58714,26 @@
         },
         "style": "form"
       },
+      "eql.search#allow_partial_search_results": {
+        "in": "query",
+        "name": "allow_partial_search_results",
+        "description": "If true, returns partial results if there are shard failures. If false, returns an error with no partial results.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
+      "eql.search#allow_partial_sequence_results": {
+        "in": "query",
+        "name": "allow_partial_sequence_results",
+        "description": "If true, sequence queries will return partial results in case of shard failures. If false, they will return no results at all.\nThis flag has effect only if allow_partial_search_results is true.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
       "eql.search#expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
@@ -62852,6 +62884,12 @@
                 },
                 "wait_for_completion_timeout": {
                   "$ref": "#/components/schemas/_types:Duration"
+                },
+                "allow_partial_search_results": {
+                  "type": "boolean"
+                },
+                "allow_partial_sequence_results": {
+                  "type": "boolean"
                 },
                 "size": {
                   "$ref": "#/components/schemas/_types:uint"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -44487,6 +44487,13 @@
           },
           "hits": {
             "$ref": "#/components/schemas/eql._types:EqlHits"
+          },
+          "shard_failures": {
+            "description": "Contains information about shard failures (if any), in case allow_partial_search_results=true",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:ShardFailure"
+            }
           }
         },
         "required": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -117902,9 +117902,24 @@
               "namespace": "eql._types"
             }
           }
+        },
+        {
+          "description": "Contains information about shard failures (if any), in case allow_partial_search_results=true",
+          "name": "shard_failures",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "ShardFailure",
+                "namespace": "_types"
+              }
+            }
+          }
         }
       ],
-      "specLocation": "eql/_types/EqlSearchResponseBase.ts#L24-L49"
+      "specLocation": "eql/_types/EqlSearchResponseBase.ts#L25-L54"
     },
     {
       "generics": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -17535,6 +17535,28 @@
             }
           },
           {
+            "name": "allow_partial_search_results",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "_builtins"
+              }
+            }
+          },
+          {
+            "name": "allow_partial_sequence_results",
+            "required": false,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "boolean",
+                "namespace": "_builtins"
+              }
+            }
+          },
+          {
             "description": "For basic queries, the maximum number of matching events to return. Defaults to 10",
             "docId": "eql-basic-syntax",
             "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/eql-syntax.html#eql-basic-syntax",
@@ -17646,6 +17668,32 @@
           }
         },
         {
+          "description": "If true, returns partial results if there are shard failures. If false, returns an error with no partial results.",
+          "name": "allow_partial_search_results",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "description": "If true, sequence queries will return partial results in case of shard failures. If false, they will return no results at all.\nThis flag has effect only if allow_partial_search_results is true.",
+          "name": "allow_partial_sequence_results",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
           "name": "expand_wildcards",
           "required": false,
           "serverDefault": "open",
@@ -17709,7 +17757,7 @@
           }
         }
       ],
-      "specLocation": "eql/search/EqlSearchRequest.ts#L28-L122"
+      "specLocation": "eql/search/EqlSearchRequest.ts#L28-L135"
     },
     {
       "body": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -394,6 +394,8 @@
     "eql.search": {
       "request": [
         "Request: query parameter 'allow_no_indices' does not exist in the json spec",
+        "Request: query parameter 'allow_partial_search_results' does not exist in the json spec",
+        "Request: query parameter 'allow_partial_sequence_results' does not exist in the json spec",
         "Request: query parameter 'expand_wildcards' does not exist in the json spec",
         "Request: query parameter 'ignore_unavailable' does not exist in the json spec"
       ],

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10396,6 +10396,8 @@ export interface EqlGetStatusResponse {
 export interface EqlSearchRequest extends RequestBase {
   index: Indices
   allow_no_indices?: boolean
+  allow_partial_search_results?: boolean
+  allow_partial_sequence_results?: boolean
   expand_wildcards?: ExpandWildcards
   ignore_unavailable?: boolean
   keep_alive?: Duration
@@ -10412,6 +10414,8 @@ export interface EqlSearchRequest extends RequestBase {
     keep_alive?: Duration
     keep_on_completion?: boolean
     wait_for_completion_timeout?: Duration
+    allow_partial_search_results?: boolean
+    allow_partial_sequence_results?: boolean
     size?: uint
     fields?: QueryDslFieldAndFormat | Field | (QueryDslFieldAndFormat | Field)[]
     result_position?: EqlSearchResultPosition

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10351,6 +10351,7 @@ export interface EqlEqlSearchResponseBase<TEvent = unknown> {
   took?: DurationValue<UnitMillis>
   timed_out?: boolean
   hits: EqlEqlHits<TEvent>
+  shard_failures?: ShardFailure[]
 }
 
 export interface EqlHitsEvent<TEvent = unknown> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "elasticsearch-specification",
+  "name": "backport-8.x",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/specification/eql/_types/EqlSearchResponseBase.ts
+++ b/specification/eql/_types/EqlSearchResponseBase.ts
@@ -18,6 +18,7 @@
  */
 
 import { Id } from '@_types/common'
+import { ShardFailure } from '@_types/Errors'
 import { DurationValue, UnitMillis } from '@_types/Time'
 import { EqlHits } from './EqlHits'
 
@@ -46,4 +47,8 @@ export class EqlSearchResponseBase<TEvent> {
    * Contains matching events and sequences. Also contains related metadata.
    */
   hits: EqlHits<TEvent>
+  /**
+   * Contains information about shard failures (if any), in case allow_partial_search_results=true
+   */
+  shard_failures?: ShardFailure[]
 }

--- a/specification/eql/search/EqlSearchRequest.ts
+++ b/specification/eql/search/EqlSearchRequest.ts
@@ -44,6 +44,17 @@ export interface Request extends RequestBase {
      */
     allow_no_indices?: boolean
     /**
+     * If true, returns partial results if there are shard failures. If false, returns an error with no partial results.
+     * @server_default false
+     */
+    allow_partial_search_results?: boolean
+    /**
+     * If true, sequence queries will return partial results in case of shard failures. If false, they will return no results at all.
+     * This flag has effect only if allow_partial_search_results is true.
+     * @server_default false
+     */
+    allow_partial_sequence_results?: boolean
+    /**
      * @server_default open
      */
     expand_wildcards?: ExpandWildcards
@@ -100,6 +111,8 @@ export interface Request extends RequestBase {
     keep_alive?: Duration
     keep_on_completion?: boolean
     wait_for_completion_timeout?: Duration
+    allow_partial_search_results?: boolean
+    allow_partial_sequence_results?: boolean
     /**
      * For basic queries, the maximum number of matching events to return. Defaults to 10
      * @doc_id eql-basic-syntax


### PR DESCRIPTION
(cherry picked from commit 5987f79aed121f3657fc75769e494b26404d512b)

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
