### PR TITLE
[8.x] "local" parameter only in compatible cat requests (#3096)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -905,6 +905,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.aliases#expand_wildcards"
+          },
+          {
+            "$ref": "#/components/parameters/cat.aliases#local"
           }
         ],
         "responses": {
@@ -928,6 +931,9 @@
           },
           {
             "$ref": "#/components/parameters/cat.aliases#expand_wildcards"
+          },
+          {
+            "$ref": "#/components/parameters/cat.aliases#local"
           }
         ],
         "responses": {
@@ -93906,6 +93912,16 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:ExpandWildcards"
+        },
+        "style": "form"
+      },
+      "cat.aliases#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
         },
         "style": "form"
       },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -948,6 +948,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.allocation#bytes"
+          },
+          {
+            "$ref": "#/components/parameters/cat.allocation#local"
           }
         ],
         "responses": {
@@ -971,6 +974,9 @@
           },
           {
             "$ref": "#/components/parameters/cat.allocation#bytes"
+          },
+          {
+            "$ref": "#/components/parameters/cat.allocation#local"
           }
         ],
         "responses": {
@@ -988,6 +994,11 @@
         "summary": "Get component templates",
         "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "operationId": "cat-component-templates",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cat.component_templates#local"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/cat.component_templates#200"
@@ -1007,6 +1018,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.component_templates#name"
+          },
+          {
+            "$ref": "#/components/parameters/cat.component_templates#local"
           }
         ],
         "responses": {
@@ -1254,6 +1268,18 @@
         "summary": "Returns information about the master node, including the ID, bound IP address, and name",
         "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-master",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "local",
+            "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -1555,6 +1581,18 @@
         "summary": "Returns information about custom node attributes",
         "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-nodeattrs",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "local",
+            "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -1644,6 +1682,18 @@
         "summary": "Returns cluster-level changes that have not yet been executed",
         "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the pending cluster tasks API.",
         "operationId": "cat-pending-tasks",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "local",
+            "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -1669,6 +1719,18 @@
         "summary": "Returns a list of plugins running on each node of a cluster",
         "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-plugins",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "local",
+            "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -1778,6 +1840,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.segments#bytes"
+          },
+          {
+            "$ref": "#/components/parameters/cat.segments#local"
           }
         ],
         "responses": {
@@ -1801,6 +1866,9 @@
           },
           {
             "$ref": "#/components/parameters/cat.segments#bytes"
+          },
+          {
+            "$ref": "#/components/parameters/cat.segments#local"
           }
         ],
         "responses": {
@@ -1980,6 +2048,11 @@
         "summary": "Returns information about index templates in a cluster",
         "description": "You can use index templates to apply index settings and field mappings to new indices at creation.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index template API.",
         "operationId": "cat-templates",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cat.templates#local"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/cat.templates#200"
@@ -1999,6 +2072,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.templates#name"
+          },
+          {
+            "$ref": "#/components/parameters/cat.templates#local"
           }
         ],
         "responses": {
@@ -2020,6 +2096,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.thread_pool#time"
+          },
+          {
+            "$ref": "#/components/parameters/cat.thread_pool#local"
           }
         ],
         "responses": {
@@ -2043,6 +2122,9 @@
           },
           {
             "$ref": "#/components/parameters/cat.thread_pool#time"
+          },
+          {
+            "$ref": "#/components/parameters/cat.thread_pool#local"
           }
         ],
         "responses": {
@@ -93848,6 +93930,16 @@
         },
         "style": "form"
       },
+      "cat.allocation#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
       "cat.component_templates#name": {
         "in": "path",
         "name": "name",
@@ -93858,6 +93950,16 @@
           "type": "string"
         },
         "style": "simple"
+      },
+      "cat.component_templates#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
       },
       "cat.count#index": {
         "in": "path",
@@ -94278,6 +94380,16 @@
         },
         "style": "form"
       },
+      "cat.segments#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
       "cat.shards#index": {
         "in": "path",
         "name": "index",
@@ -94331,6 +94443,16 @@
         },
         "style": "simple"
       },
+      "cat.templates#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
+      },
       "cat.thread_pool#thread_pool_patterns": {
         "in": "path",
         "name": "thread_pool_patterns",
@@ -94349,6 +94471,16 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:TimeUnit"
+        },
+        "style": "form"
+      },
+      "cat.thread_pool#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
         },
         "style": "form"
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -683,6 +683,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.aliases#expand_wildcards"
+          },
+          {
+            "$ref": "#/components/parameters/cat.aliases#local"
           }
         ],
         "responses": {
@@ -706,6 +709,9 @@
           },
           {
             "$ref": "#/components/parameters/cat.aliases#expand_wildcards"
+          },
+          {
+            "$ref": "#/components/parameters/cat.aliases#local"
           }
         ],
         "responses": {
@@ -57837,6 +57843,16 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:ExpandWildcards"
+        },
+        "style": "form"
+      },
+      "cat.aliases#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
         },
         "style": "form"
       },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -723,6 +723,11 @@
         "summary": "Get component templates",
         "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "operationId": "cat-component-templates",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cat.component_templates#local"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/cat.component_templates#200"
@@ -742,6 +747,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.component_templates#name"
+          },
+          {
+            "$ref": "#/components/parameters/cat.component_templates#local"
           }
         ],
         "responses": {
@@ -57842,6 +57850,16 @@
           "type": "string"
         },
         "style": "simple"
+      },
+      "cat.component_templates#local": {
+        "in": "query",
+        "name": "local",
+        "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+        "deprecated": false,
+        "schema": {
+          "type": "boolean"
+        },
+        "style": "form"
       },
       "cat.count#index": {
         "in": "path",

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -3337,7 +3337,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get the status for a data stream lifecycle.\nRetrieves information about an index or data stream’s current data stream lifecycle status, such as time since index creation, time since rollover, the lifecycle configuration managing the index, or any errors encountered during lifecycle execution.",
+      "description": "Get the status for a data stream lifecycle.\nGet information about an index or data stream's current data stream lifecycle status, such as time since index creation, time since rollover, the lifecycle configuration managing the index, or any errors encountered during lifecycle execution.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams-explain-lifecycle.html",
       "name": "indices.explain_data_lifecycle",
       "request": {
@@ -3980,9 +3980,17 @@
           "stability": "stable"
         }
       },
-      "description": "Create or update an index template.\nIndex templates define settings, mappings, and aliases that can be applied automatically to new indices.",
+      "description": "Create or update an index template.\nIndex templates define settings, mappings, and aliases that can be applied automatically to new indices.\nElasticsearch applies templates to new indices based on an index pattern that matches the index name.\n\nIMPORTANT: This documentation is about legacy index templates, which are deprecated and will be replaced by the composable templates introduced in Elasticsearch 7.8.\n\nComposable templates always take precedence over legacy templates.\nIf no composable template matches a new index, matching legacy templates are applied according to their order.\n\nIndex templates are only applied during index creation.\nChanges to index templates do not affect existing indices.\nSettings and mappings specified in create index API requests override any settings or mappings specified in an index template.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-templates-v1.html",
+      "extDocId": "index-templates",
+      "extDocUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-templates.html",
       "name": "indices.put_template",
+      "privileges": {
+        "cluster": [
+          "manage_index_templates",
+          "manage"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "indices.put_template"
@@ -4448,9 +4456,14 @@
           "visibility": "public"
         }
       },
-      "description": "Create an inference endpoint",
+      "description": "Create an inference endpoint.\nWhen you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.\nAfter creating the endpoint, wait for the model deployment to complete before using it.\nTo verify the deployment status, use the get trained model statistics API.\nLook for `\"state\": \"fully_allocated\"` in the response and ensure that the `\"allocation_count\"` matches the `\"target_allocation_count\"`.\nAvoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.\n\nIMPORTANT: The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Mistral, Azure OpenAI, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face.\nFor built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models.\nHowever, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-inference-api.html",
       "name": "inference.put",
+      "privileges": {
+        "cluster": [
+          "manage_inference"
+        ]
+      },
       "request": {
         "name": "Request",
         "namespace": "inference.put"
@@ -4730,7 +4743,7 @@
           "stability": "stable"
         }
       },
-      "description": "Get license information.\nReturns information about your Elastic license, including its type, its status, when it was issued, and when it expires.\nFor more information about the different types of licenses, refer to [Elastic Stack subscriptions](https://www.elastic.co/subscriptions).",
+      "description": "Get license information.\nGet information about your Elastic license including its type, its status, when it was issued, and when it expires.\n\nNOTE: If the master node is generating a new cluster state, the get license API may return a `404 Not Found` response.\nIf you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-license.html",
       "name": "license.get",
       "request": {
@@ -4765,8 +4778,10 @@
           "stability": "stable"
         }
       },
-      "description": "Deletes a pipeline used for Logstash Central Management.",
+      "description": "Delete a Logstash pipeline.\n\nDelete a pipeline that is used for Logstash Central Management.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-delete-pipeline.html",
+      "extDocId": "logstash-centralized-pipeline-management",
+      "extDocUrl": "https://www.elastic.co/guide/en/logstash/{branch}/logstash-centralized-pipeline-management.html",
       "name": "logstash.delete_pipeline",
       "privileges": {
         "cluster": [
@@ -4805,8 +4820,10 @@
           "stability": "stable"
         }
       },
-      "description": "Retrieves pipelines used for Logstash Central Management.",
+      "description": "Get Logstash pipelines.\n\nGet pipelines that are used for Logstash Central Management.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-get-pipeline.html",
+      "extDocId": "logstash-centralized-pipeline-management",
+      "extDocUrl": "https://www.elastic.co/guide/en/logstash/{branch}/logstash-centralized-pipeline-management.html",
       "name": "logstash.get_pipeline",
       "privileges": {
         "cluster": [
@@ -4851,8 +4868,10 @@
           "stability": "stable"
         }
       },
-      "description": "Creates or updates a pipeline used for Logstash Central Management.",
+      "description": "Create or update a Logstash pipeline.\n\nCreate a pipeline that is used for Logstash Central Management.\nIf the specified pipeline exists, it is replaced.",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-put-pipeline.html",
+      "extDocId": "logstash-centralized-pipeline-management",
+      "extDocUrl": "https://www.elastic.co/guide/en/logstash/{branch}/logstash-centralized-pipeline-management.html",
       "name": "logstash.put_pipeline",
       "privileges": {
         "cluster": [
@@ -9303,7 +9322,7 @@
           "stability": "experimental"
         }
       },
-      "description": "Get task information.\nReturns information about the tasks currently executing in the cluster.",
+      "description": "Get task information.\nGet information about a task currently running in the cluster.",
       "docId": "tasks",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/tasks.html",
       "name": "tasks.get",
@@ -11344,6 +11363,19 @@
       ],
       "query": [
         {
+          "description": "If `true`, the response will include the ingest pipelines that were executed for each index or create.",
+          "name": "list_executed_pipelines",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
           "description": "ID of the pipeline to use to preprocess incoming documents.\nIf the index has a default ingest pipeline specified, then setting the value to `_none` disables the default ingest pipeline for this request.\nIf a final pipeline is configured it will always run, regardless of the value of this parameter.",
           "name": "pipeline",
           "required": false,
@@ -11454,9 +11486,22 @@
               "namespace": "_builtins"
             }
           }
+        },
+        {
+          "description": "If `true`, the request's actions must target a data stream (existing or to-be-created).",
+          "name": "require_data_stream",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
         }
       ],
-      "specLocation": "_global/bulk/BulkRequest.ts#L32-L105"
+      "specLocation": "_global/bulk/BulkRequest.ts#L32-L115"
     },
     {
       "body": {
@@ -11634,8 +11679,22 @@
           }
         }
       ],
-      "query": [],
-      "specLocation": "cat/component_templates/CatComponentTemplatesRequest.ts#L22-L39"
+      "query": [
+        {
+          "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+          "name": "local",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        }
+      ],
+      "specLocation": "cat/component_templates/CatComponentTemplatesRequest.ts#L22-L49"
     },
     {
       "body": {
@@ -21229,7 +21288,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get the status for a data stream lifecycle.\nRetrieves information about an index or data stream’s current data stream lifecycle status, such as time since index creation, time since rollover, the lifecycle configuration managing the index, or any errors encountered during lifecycle execution.",
+      "description": "Get the status for a data stream lifecycle.\nGet information about an index or data stream's current data stream lifecycle status, such as time since index creation, time since rollover, the lifecycle configuration managing the index, or any errors encountered during lifecycle execution.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -23529,7 +23588,7 @@
           }
         ]
       },
-      "description": "Create or update an index template.\nIndex templates define settings, mappings, and aliases that can be applied automatically to new indices.",
+      "description": "Create or update an index template.\nIndex templates define settings, mappings, and aliases that can be applied automatically to new indices.\nElasticsearch applies templates to new indices based on an index pattern that matches the index name.\n\nIMPORTANT: This documentation is about legacy index templates, which are deprecated and will be replaced by the composable templates introduced in Elasticsearch 7.8.\n\nComposable templates always take precedence over legacy templates.\nIf no composable template matches a new index, matching legacy templates are applied according to their order.\n\nIndex templates are only applied during index creation.\nChanges to index templates do not affect existing indices.\nSettings and mappings specified in create index API requests override any settings or mappings specified in an index template.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -23606,7 +23665,7 @@
           }
         }
       ],
-      "specLocation": "indices/put_template/IndicesPutTemplateRequest.ts#L29-L95"
+      "specLocation": "indices/put_template/IndicesPutTemplateRequest.ts#L29-L107"
     },
     {
       "body": {
@@ -25151,7 +25210,7 @@
           }
         }
       },
-      "description": "Create an inference endpoint",
+      "description": "Create an inference endpoint.\nWhen you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.\nAfter creating the endpoint, wait for the model deployment to complete before using it.\nTo verify the deployment status, use the get trained model statistics API.\nLook for `\"state\": \"fully_allocated\"` in the response and ensure that the `\"allocation_count\"` matches the `\"target_allocation_count\"`.\nAvoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.\n\nIMPORTANT: The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Mistral, Azure OpenAI, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face.\nFor built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models.\nHowever, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -25190,7 +25249,7 @@
         }
       ],
       "query": [],
-      "specLocation": "inference/put/PutRequest.ts#L25-L44"
+      "specLocation": "inference/put/PutRequest.ts#L25-L54"
     },
     {
       "body": {
@@ -25818,7 +25877,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get license information.\nReturns information about your Elastic license, including its type, its status, when it was issued, and when it expires.\nFor more information about the different types of licenses, refer to [Elastic Stack subscriptions](https://www.elastic.co/subscriptions).",
+      "description": "Get license information.\nGet information about your Elastic license including its type, its status, when it was issued, and when it expires.\n\nNOTE: If the master node is generating a new cluster state, the get license API may return a `404 Not Found` response.\nIf you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -25863,7 +25922,7 @@
           }
         }
       ],
-      "specLocation": "license/get/GetLicenseRequest.ts#L22-L45"
+      "specLocation": "license/get/GetLicenseRequest.ts#L22-L47"
     },
     {
       "body": {
@@ -25896,7 +25955,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Deletes a pipeline used for Logstash Central Management.",
+      "description": "Delete a Logstash pipeline.\n\nDelete a pipeline that is used for Logstash Central Management.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -25910,7 +25969,7 @@
       },
       "path": [
         {
-          "description": "Identifier for the pipeline.",
+          "description": "An identifier for the pipeline.",
           "name": "id",
           "required": true,
           "type": {
@@ -25923,7 +25982,7 @@
         }
       ],
       "query": [],
-      "specLocation": "logstash/delete_pipeline/LogstashDeletePipelineRequest.ts#L23-L37"
+      "specLocation": "logstash/delete_pipeline/LogstashDeletePipelineRequest.ts#L23-L40"
     },
     {
       "body": {
@@ -25943,7 +26002,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Retrieves pipelines used for Logstash Central Management.",
+      "description": "Get Logstash pipelines.\n\nGet pipelines that are used for Logstash Central Management.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -25957,7 +26016,7 @@
       },
       "path": [
         {
-          "description": "Comma-separated list of pipeline identifiers.",
+          "description": "A comma-separated list of pipeline identifiers.",
           "name": "id",
           "required": false,
           "type": {
@@ -25970,7 +26029,7 @@
         }
       ],
       "query": [],
-      "specLocation": "logstash/get_pipeline/LogstashGetPipelineRequest.ts#L23-L37"
+      "specLocation": "logstash/get_pipeline/LogstashGetPipelineRequest.ts#L23-L40"
     },
     {
       "body": {
@@ -26016,7 +26075,7 @@
           }
         }
       },
-      "description": "Creates or updates a pipeline used for Logstash Central Management.",
+      "description": "Create or update a Logstash pipeline.\n\nCreate a pipeline that is used for Logstash Central Management.\nIf the specified pipeline exists, it is replaced.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -26030,7 +26089,7 @@
       },
       "path": [
         {
-          "description": "Identifier for the pipeline.",
+          "description": "An identifier for the pipeline.",
           "name": "id",
           "required": true,
           "type": {
@@ -26043,7 +26102,7 @@
         }
       ],
       "query": [],
-      "specLocation": "logstash/put_pipeline/LogstashPutPipelineRequest.ts#L24-L39"
+      "specLocation": "logstash/put_pipeline/LogstashPutPipelineRequest.ts#L24-L44"
     },
     {
       "body": {
@@ -41911,7 +41970,7 @@
       "body": {
         "kind": "no_body"
       },
-      "description": "Get task information.\nReturns information about the tasks currently executing in the cluster.",
+      "description": "Get task information.\nGet information about a task currently running in the cluster.",
       "inherits": {
         "type": {
           "name": "RequestBase",
@@ -104935,6 +104994,7 @@
           }
         },
         {
+          "description": "Human readable text that identifies the particular request that the task is performing.\nFor example, it might identify the search request being performed by a search task.\nOther kinds of tasks have different descriptions, like `_reindex` which has the source and the destination, or `_bulk` which just has the number of requests and the destination indices.\nMany requests will have only an empty description because more detailed information about the request is not easily available or particularly helpful in identifying the request.",
           "name": "description",
           "required": false,
           "type": {
@@ -105041,7 +105101,7 @@
           }
         },
         {
-          "description": "Task status information can vary wildly from task to task.",
+          "description": "The internal status of the task, which varies from task to task.\nThe format also varies.\nWhile the goal is to keep the status for a particular task consistent from version to version, this is not always possible because sometimes the implementation changes.\nFields might be removed from the status for a particular request so any parsing you do of the status might break in minor releases.",
           "name": "status",
           "required": false,
           "type": {
@@ -105071,7 +105131,7 @@
           }
         }
       ],
-      "specLocation": "tasks/_types/TaskInfo.ts#L32-L47"
+      "specLocation": "tasks/_types/TaskInfo.ts#L32-L58"
     },
     {
       "inherits": {
@@ -105909,7 +105969,7 @@
         "name": "XPackCategory",
         "namespace": "xpack.info"
       },
-      "specLocation": "xpack/info/XPackInfoRequest.ts#L44-L48"
+      "specLocation": "xpack/info/XPackInfoRequest.ts#L49-L53"
     },
     {
       "attachedBehaviors": [
@@ -107296,19 +107356,6 @@
           }
         },
         {
-          "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
-          "name": "local",
-          "required": false,
-          "serverDefault": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "boolean",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
           "description": "Period to wait for a connection to the master node.",
           "name": "master_timeout",
           "required": false,
@@ -107347,7 +107394,7 @@
           }
         }
       ],
-      "specLocation": "_spec_utils/behaviors.ts#L86-L132"
+      "specLocation": "_spec_utils/behaviors.ts#L86-L124"
     },
     {
       "kind": "interface",
@@ -126550,7 +126597,7 @@
       },
       "properties": [
         {
-          "description": "Description of the pipeline.\nThis description is not used by Elasticsearch or Logstash.",
+          "description": "A description of the pipeline.\nThis description is not used by Elasticsearch or Logstash.",
           "name": "description",
           "required": true,
           "type": {
@@ -126562,7 +126609,7 @@
           }
         },
         {
-          "description": "Date the pipeline was last updated.\nMust be in the `yyyy-MM-dd'T'HH:mm:ss.SSSZZ` strict_date_time format.",
+          "description": "The date the pipeline was last updated.\nIt must be in the `yyyy-MM-dd'T'HH:mm:ss.SSSZZ` strict_date_time format.",
           "name": "last_modified",
           "required": true,
           "type": {
@@ -126574,33 +126621,9 @@
           }
         },
         {
-          "description": "Optional metadata about the pipeline.\nMay have any contents.\nThis metadata is not generated or used by Elasticsearch or Logstash.",
-          "name": "pipeline_metadata",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "PipelineMetadata",
-              "namespace": "logstash._types"
-            }
-          }
-        },
-        {
-          "description": "User who last updated the pipeline.",
-          "name": "username",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
-          "description": "Configuration for the pipeline.",
-          "docId": "logstash-configuration-file-structure",
-          "docUrl": "https://www.elastic.co/guide/en/logstash/{branch}/configuration-file-structure.html",
+          "description": "The configuration for the pipeline.",
+          "extDocId": "logstash-configuration-file-structure",
+          "extDocUrl": "https://www.elastic.co/guide/en/logstash/{branch}/configuration-file-structure.html",
           "name": "pipeline",
           "required": true,
           "type": {
@@ -126612,9 +126635,21 @@
           }
         },
         {
-          "description": "Settings for the pipeline.\nSupports only flat keys in dot notation.",
-          "docId": "logstash-logstash-settings-file",
-          "docUrl": "https://www.elastic.co/guide/en/logstash/{branch}/logstash-settings-file.html",
+          "description": "Optional metadata about the pipeline, which can have any contents.\nThis metadata is not generated or used by Elasticsearch or Logstash.",
+          "name": "pipeline_metadata",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "PipelineMetadata",
+              "namespace": "logstash._types"
+            }
+          }
+        },
+        {
+          "description": "Settings for the pipeline.\nIt supports only flat keys in dot notation.",
+          "extDocId": "logstash-logstash-settings-file",
+          "extDocUrl": "https://www.elastic.co/guide/en/logstash/{branch}/logstash-settings-file.html",
           "name": "pipeline_settings",
           "required": true,
           "type": {
@@ -126624,9 +126659,21 @@
               "namespace": "logstash._types"
             }
           }
+        },
+        {
+          "description": "The user who last updated the pipeline.",
+          "name": "username",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "string",
+              "namespace": "_builtins"
+            }
+          }
         }
       ],
-      "specLocation": "logstash/_types/Pipeline.ts#L60-L92"
+      "specLocation": "logstash/_types/Pipeline.ts#L60-L91"
     },
     {
       "kind": "interface",
@@ -136999,7 +137046,7 @@
         "namespace": "_spec_utils"
       },
       "properties": [],
-      "specLocation": "_spec_utils/behaviors.ts#L134-L140"
+      "specLocation": "_spec_utils/behaviors.ts#L126-L132"
     },
     {
       "attachedBehaviors": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -11620,9 +11620,22 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
+          "name": "local",
+          "required": false,
+          "serverDefault": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
         }
       ],
-      "specLocation": "cat/aliases/CatAliasesRequest.ts#L23-L43"
+      "specLocation": "cat/aliases/CatAliasesRequest.ts#L23-L51"
     },
     {
       "body": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -52,6 +52,7 @@
     "cat.aliases": {
       "request": [
         "Request: query parameter 'master_timeout' does not exist in the json spec",
+        "Request: missing json spec query parameter 'local'",
         "request definition cat.aliases:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
@@ -70,7 +71,6 @@
     },
     "cat.count": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.count:Request / body - A request with inherited properties must have a PropertyBody"
       ],
@@ -78,7 +78,6 @@
     },
     "cat.fielddata": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.fielddata:Request / body - A request with inherited properties must have a PropertyBody"
       ],
@@ -86,7 +85,6 @@
     },
     "cat.health": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.health:Request / body - A request with inherited properties must have a PropertyBody"
       ],
@@ -96,7 +94,6 @@
       "request": [
         "Request: query parameter 'format' does not exist in the json spec",
         "Request: query parameter 'h' does not exist in the json spec",
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: query parameter 'master_timeout' does not exist in the json spec",
         "Request: query parameter 'v' does not exist in the json spec",
         "request definition cat.help:Request / body - A request with inherited properties must have a PropertyBody"
@@ -105,7 +102,6 @@
     },
     "cat.indices": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "request definition cat.indices:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
@@ -118,7 +114,6 @@
     },
     "cat.ml_data_frame_analytics": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.ml_data_frame_analytics:Request / query - Property 'h' is already defined in an ancestor class",
         "request definition cat.ml_data_frame_analytics:Request / query - Property 's' is already defined in an ancestor class",
@@ -128,7 +123,6 @@
     },
     "cat.ml_datafeeds": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.ml_datafeeds:Request / query - Property 'h' is already defined in an ancestor class",
         "request definition cat.ml_datafeeds:Request / query - Property 's' is already defined in an ancestor class",
@@ -138,7 +132,6 @@
     },
     "cat.ml_jobs": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.ml_jobs:Request / query - Property 'h' is already defined in an ancestor class",
         "request definition cat.ml_jobs:Request / query - Property 's' is already defined in an ancestor class",
@@ -148,7 +141,6 @@
     },
     "cat.ml_trained_models": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: query parameter 'master_timeout' does not exist in the json spec",
         "Request: missing json spec query parameter 'time'",
         "request definition cat.ml_trained_models:Request / query - Property 'h' is already defined in an ancestor class",
@@ -165,7 +157,6 @@
     },
     "cat.nodes": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: missing json spec query parameter 'time'",
         "request definition cat.nodes:Request / body - A request with inherited properties must have a PropertyBody"
       ],
@@ -187,7 +178,6 @@
     },
     "cat.recovery": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: query parameter 'master_timeout' does not exist in the json spec",
         "Request: missing json spec query parameter 'index'",
         "Request: missing json spec query parameter 'time'",
@@ -197,6 +187,7 @@
     },
     "cat.repositories": {
       "request": [
+        "Request: missing json spec query parameter 'local'",
         "request definition cat.repositories:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
@@ -211,7 +202,6 @@
     },
     "cat.shards": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: missing json spec query parameter 'time'",
         "request definition cat.shards:Request / body - A request with inherited properties must have a PropertyBody"
       ],
@@ -219,7 +209,6 @@
     },
     "cat.snapshots": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: missing json spec query parameter 'time'",
         "request definition cat.snapshots:Request / body - A request with inherited properties must have a PropertyBody"
       ],
@@ -228,7 +217,6 @@
     "cat.tasks": {
       "request": [
         "Request: query parameter 'node_id' does not exist in the json spec",
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: query parameter 'master_timeout' does not exist in the json spec",
         "Request: missing json spec query parameter 'nodes'",
         "Request: missing json spec query parameter 'time'",
@@ -250,7 +238,6 @@
     },
     "cat.transforms": {
       "request": [
-        "Request: query parameter 'local' does not exist in the json spec",
         "Request: query parameter 'master_timeout' does not exist in the json spec",
         "request definition cat.transforms:Request / query - Property 'h' is already defined in an ancestor class",
         "request definition cat.transforms:Request / query - Property 's' is already defined in an ancestor class",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -52,7 +52,6 @@
     "cat.aliases": {
       "request": [
         "Request: query parameter 'master_timeout' does not exist in the json spec",
-        "Request: missing json spec query parameter 'local'",
         "request definition cat.aliases:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6939,6 +6939,7 @@ export interface CatAliasesAliasesRecord {
 export interface CatAliasesRequest extends CatCatRequestBase {
   name?: Names
   expand_wildcards?: ExpandWildcards
+  local?: boolean
 }
 
 export type CatAliasesResponse = CatAliasesAliasesRecord[]

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6982,6 +6982,7 @@ export interface CatAllocationAllocationRecord {
 export interface CatAllocationRequest extends CatCatRequestBase {
   node_id?: NodeIds
   bytes?: Bytes
+  local?: boolean
 }
 
 export type CatAllocationResponse = CatAllocationAllocationRecord[]
@@ -6998,6 +6999,7 @@ export interface CatComponentTemplatesComponentTemplate {
 
 export interface CatComponentTemplatesRequest extends CatCatRequestBase {
   name?: string
+  local?: boolean
 }
 
 export type CatComponentTemplatesResponse = CatComponentTemplatesComponentTemplate[]
@@ -7423,6 +7425,7 @@ export interface CatMasterMasterRecord {
 }
 
 export interface CatMasterRequest extends CatCatRequestBase {
+  local?: boolean
 }
 
 export type CatMasterResponse = CatMasterMasterRecord[]
@@ -7790,6 +7793,7 @@ export interface CatNodeattrsNodeAttributesRecord {
 }
 
 export interface CatNodeattrsRequest extends CatCatRequestBase {
+  local?: boolean
 }
 
 export type CatNodeattrsResponse = CatNodeattrsNodeAttributesRecord[]
@@ -8084,6 +8088,7 @@ export interface CatPendingTasksPendingTasksRecord {
 }
 
 export interface CatPendingTasksRequest extends CatCatRequestBase {
+  local?: boolean
 }
 
 export type CatPendingTasksResponse = CatPendingTasksPendingTasksRecord[]
@@ -8103,6 +8108,7 @@ export interface CatPluginsPluginsRecord {
 }
 
 export interface CatPluginsRequest extends CatCatRequestBase {
+  local?: boolean
 }
 
 export type CatPluginsResponse = CatPluginsPluginsRecord[]
@@ -8189,6 +8195,7 @@ export type CatRepositoriesResponse = CatRepositoriesRepositoriesRecord[]
 export interface CatSegmentsRequest extends CatCatRequestBase {
   index?: Indices
   bytes?: Bytes
+  local?: boolean
 }
 
 export type CatSegmentsResponse = CatSegmentsSegmentsRecord[]
@@ -8544,6 +8551,7 @@ export interface CatTasksTasksRecord {
 
 export interface CatTemplatesRequest extends CatCatRequestBase {
   name?: Name
+  local?: boolean
 }
 
 export type CatTemplatesResponse = CatTemplatesTemplatesRecord[]
@@ -8565,6 +8573,7 @@ export interface CatTemplatesTemplatesRecord {
 export interface CatThreadPoolRequest extends CatCatRequestBase {
   thread_pool_patterns?: Names
   time?: TimeUnit
+  local?: boolean
 }
 
 export type CatThreadPoolResponse = CatThreadPoolThreadPoolRecord[]
@@ -21276,7 +21285,6 @@ export interface SpecUtilsCommonCatQueryParameters {
   format?: string
   h?: Names
   help?: boolean
-  local?: boolean
   master_timeout?: Duration
   s?: Names
   v?: boolean

--- a/specification/_spec_utils/behaviors.ts
+++ b/specification/_spec_utils/behaviors.ts
@@ -106,14 +106,6 @@ export interface CommonCatQueryParameters {
    */
   help?: boolean
   /**
-   * If `true`, the request computes the list of selected nodes from the
-   * local cluster state. If `false` the list of selected nodes are computed
-   * from the cluster state of the master node. In both cases the coordinating
-   * node will send requests for further information to each selected node.
-   * @server_default false
-   */
-  local?: boolean
-  /**
    * Period to wait for a connection to the master node.
    * @server_default 30s
    */

--- a/specification/cat/aliases/CatAliasesRequest.ts
+++ b/specification/cat/aliases/CatAliasesRequest.ts
@@ -39,5 +39,13 @@ export interface Request extends CatRequestBase {
   }
   query_parameters: {
     expand_wildcards?: ExpandWildcards
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
   }
 }

--- a/specification/cat/allocation/CatAllocationRequest.ts
+++ b/specification/cat/allocation/CatAllocationRequest.ts
@@ -37,5 +37,13 @@ export interface Request extends CatRequestBase {
   query_parameters: {
     /** The unit used to display byte values. */
     bytes?: Bytes
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
   }
 }

--- a/specification/cat/component_templates/CatComponentTemplatesRequest.ts
+++ b/specification/cat/component_templates/CatComponentTemplatesRequest.ts
@@ -36,4 +36,14 @@ export interface Request extends CatRequestBase {
     /** The name of the component template. Accepts wildcard expressions. If omitted, all component templates are returned. */
     name?: string
   }
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
+  }
 }

--- a/specification/cat/master/CatMasterRequest.ts
+++ b/specification/cat/master/CatMasterRequest.ts
@@ -28,4 +28,15 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @doc_id cat-master
  * @cluster_privileges monitor
  */
-export interface Request extends CatRequestBase {}
+export interface Request extends CatRequestBase {
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
+  }
+}

--- a/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
+++ b/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
@@ -28,4 +28,15 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @doc_id cat-nodeattrs
  * @cluster_privileges monitor
  */
-export interface Request extends CatRequestBase {}
+export interface Request extends CatRequestBase {
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
+  }
+}

--- a/specification/cat/pending_tasks/CatPendingTasksRequest.ts
+++ b/specification/cat/pending_tasks/CatPendingTasksRequest.ts
@@ -28,4 +28,15 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @doc_id cat-pending-tasks
  * @cluster_privileges monitor
  */
-export interface Request extends CatRequestBase {}
+export interface Request extends CatRequestBase {
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
+  }
+}

--- a/specification/cat/plugins/CatPluginsRequest.ts
+++ b/specification/cat/plugins/CatPluginsRequest.ts
@@ -28,4 +28,15 @@ import { CatRequestBase } from '@cat/_types/CatBase'
  * @doc_id cat-plugins
  * @cluster_privileges monitor
  */
-export interface Request extends CatRequestBase {}
+export interface Request extends CatRequestBase {
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
+  }
+}

--- a/specification/cat/segments/CatSegmentsRequest.ts
+++ b/specification/cat/segments/CatSegmentsRequest.ts
@@ -45,5 +45,13 @@ export interface Request extends CatRequestBase {
      * The unit used to display byte values.
      */
     bytes?: Bytes
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
   }
 }

--- a/specification/cat/templates/CatTemplatesRequest.ts
+++ b/specification/cat/templates/CatTemplatesRequest.ts
@@ -38,4 +38,14 @@ export interface Request extends CatRequestBase {
      */
     name?: Name
   }
+  query_parameters: {
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
+  }
 }

--- a/specification/cat/thread_pool/CatThreadPoolRequest.ts
+++ b/specification/cat/thread_pool/CatThreadPoolRequest.ts
@@ -44,5 +44,13 @@ export interface Request extends CatRequestBase {
      * The unit used to display time values.
      */
     time?: TimeUnit
+    /**
+     * If `true`, the request computes the list of selected nodes from the
+     * local cluster state. If `false` the list of selected nodes are computed
+     * from the cluster state of the master node. In both cases the coordinating
+     * node will send requests for further information to each selected node.
+     * @server_default false
+     */
+    local?: boolean
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [&quot;local&quot; parameter only in compatible cat requests (#3096)](https://github.com/elastic/elasticsearch-specification/pull/3096)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)