### PR TITLE
Add specification for post event to an analytics collection

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -392,6 +392,16 @@ actions:
           examples:
             indicesLegacyPutTemplateRequestExample1:
               $ref: "../../specification/indices/put_template/indicesPutTemplateRequestExample1.yaml"
+## Examples for behavioral analytics
+  - target: "$.paths['/_application/analytics/{collection_name}/event/{event_type}']['post']"
+    description: "Add examples for post analytics collection event operation"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              postBehavioralAnalyticsEventRequestExample1:
+                $ref: "../../specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequestExample1.yaml"
 ## Examples for licensing
   - target: "$.paths['/_license/basic_status']['get']"
     description: "Add example for get basic status response"
@@ -461,4 +471,3 @@ actions:
                 $ref: "../../specification/search_application/render_query/SearchApplicationsRenderQueryRequestExample1.yaml"
                 renderSearchApplicationQueryResponseExample1:
                   $ref: "../../specification/search_application/render_query/SearchApplicationsRenderQueryResponseExample1.yaml"
-

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27209,15 +27209,46 @@
               "$ref": "#/components/schemas/search_application._types:EventType"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "debug",
+            "description": "Whether the response type has to include more details",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "accepted": {
+                      "type": "boolean"
+                    },
+                    "event": {
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "accepted"
+                  ]
                 }
               }
             }

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27177,6 +27177,55 @@
         "x-beta": true
       }
     },
+    "/_application/analytics/{collection_name}/event/{event_type}": {
+      "post": {
+        "tags": [
+          "analytics"
+        ],
+        "summary": "Create a behavioral analytics collection event",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/behavioral-analytics-event-reference.html"
+        },
+        "operationId": "search-application-post-behavioral-analytics-event",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "collection_name",
+            "description": "The name of the behavioral analytics collection.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Name"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "path",
+            "name": "event_type",
+            "description": "The analytics event type.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/search_application._types:EventType"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "x-state": "Technical preview"
+      }
+    },
     "/_application/search_application/{name}/_render_query": {
       "post": {
         "tags": [
@@ -83524,6 +83573,14 @@
         },
         "required": [
           "name"
+        ]
+      },
+      "search_application._types:EventType": {
+        "type": "string",
+        "enum": [
+          "page_view",
+          "search",
+          "search_click"
         ]
       },
       "search_application.put_behavioral_analytics:AnalyticsAcknowledgeResponseBase": {

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -103377,6 +103377,28 @@
       "kind": "enum",
       "members": [
         {
+          "codegenName": "PageView",
+          "name": "page_view"
+        },
+        {
+          "codegenName": "Search",
+          "name": "search"
+        },
+        {
+          "codegenName": "SearchClick",
+          "name": "search_click"
+        }
+      ],
+      "name": {
+        "name": "EventType",
+        "namespace": "search_application._types"
+      },
+      "specLocation": "search_application/_types/AnalyticsEvent.ts#L22-L26"
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
           "name": "cluster"
         },
         {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -619,7 +619,8 @@
     },
     "search_application.post_behavioral_analytics_event": {
       "request": [
-        "Missing request & response"
+        "Request: missing json spec query parameter 'debug'",
+        "Request: should have a body definition"
       ],
       "response": []
     },

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -617,13 +617,6 @@
       ],
       "response": []
     },
-    "search_application.post_behavioral_analytics_event": {
-      "request": [
-        "Request: missing json spec query parameter 'debug'",
-        "Request: should have a body definition"
-      ],
-      "response": []
-    },
     "search_mvt": {
       "request": [
         "Request: query parameter 'grid_agg' does not exist in the json spec",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17739,9 +17739,13 @@ export interface SearchApplicationListResponse {
 export interface SearchApplicationPostBehavioralAnalyticsEventRequest extends RequestBase {
   collection_name: Name
   event_type: SearchApplicationEventType
+  debug?: boolean
+  body?: any
 }
 
 export interface SearchApplicationPostBehavioralAnalyticsEventResponse {
+  accepted: boolean
+  event?: any
 }
 
 export interface SearchApplicationPutRequest extends RequestBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17684,6 +17684,8 @@ export interface SearchApplicationEventDataStream {
   name: IndexName
 }
 
+export type SearchApplicationEventType = 'page_view' | 'search' | 'search_click'
+
 export interface SearchApplicationSearchApplication extends SearchApplicationSearchApplicationParameters {
   name: Name
   updated_at_millis: EpochTime<UnitMillis>
@@ -17732,6 +17734,14 @@ export interface SearchApplicationListRequest extends RequestBase {
 export interface SearchApplicationListResponse {
   count: long
   results: SearchApplicationSearchApplication[]
+}
+
+export interface SearchApplicationPostBehavioralAnalyticsEventRequest extends RequestBase {
+  collection_name: Name
+  event_type: SearchApplicationEventType
+}
+
+export interface SearchApplicationPostBehavioralAnalyticsEventResponse {
 }
 
 export interface SearchApplicationPutRequest extends RequestBase {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -18,6 +18,7 @@ autoscaling-get-autoscaling-capacity,https://www.elastic.co/guide/en/elasticsear
 autoscaling-get-autoscaling-policy,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/autoscaling-get-autoscaling-policy.html
 autoscaling-put-autoscaling-policy,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/autoscaling-put-autoscaling-policy.html
 avoid-index-pattern-collisions,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-templates.html#avoid-index-pattern-collisions
+behavioral-analytics-collection-event,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/post-analytics-collection-event.html
 behavioral-analytics-event-reference,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/behavioral-analytics-event-reference.html
 byte-units,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/api-conventions.html#byte-units
 bytes-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/bytes-processor.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -18,6 +18,7 @@ autoscaling-get-autoscaling-capacity,https://www.elastic.co/guide/en/elasticsear
 autoscaling-get-autoscaling-policy,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/autoscaling-get-autoscaling-policy.html
 autoscaling-put-autoscaling-policy,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/autoscaling-put-autoscaling-policy.html
 avoid-index-pattern-collisions,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-templates.html#avoid-index-pattern-collisions
+behavioral-analytics-event-reference,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/behavioral-analytics-event-reference.html
 byte-units,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/api-conventions.html#byte-units
 bytes-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/bytes-processor.html
 calendar-and-fixed-intervals,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-bucket-datehistogram-aggregation.html#calendar_and_fixed_intervals

--- a/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequest.ts
+++ b/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequest.ts
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 import { EventType } from '../_types/AnalyticsEvent'
@@ -39,7 +40,6 @@ export interface Request extends RequestBase {
      */
     event_type: EventType
   }
-}
   query_parameters: {
     /**
      * Whether the response type has to include more details
@@ -48,3 +48,4 @@ export interface Request extends RequestBase {
   }
   /** @codegen_name payload */
   body: UserDefinedValue
+}

--- a/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequest.ts
+++ b/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequest.ts
@@ -25,6 +25,7 @@ import { EventType } from '../_types/AnalyticsEvent'
  * @rest_spec_name search_application.post_behavioral_analytics_event
  * @availability stack stability=experimental visibility=public
  * @doc_tag analytics
+ * @doc_id behavioral-analytics-collection-event
  * @ext_doc_id behavioral-analytics-event-reference
  */
 export interface Request extends RequestBase {

--- a/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequest.ts
+++ b/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequest.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { RequestBase } from '@_types/Base'
+import { Name } from '@_types/common'
+import { EventType } from '../_types/AnalyticsEvent'
+
+/**
+ * Create a behavioral analytics collection event.
+ * @rest_spec_name search_application.post_behavioral_analytics_event
+ * @availability stack stability=experimental visibility=public
+ * @doc_tag analytics
+ * @ext_doc_id behavioral-analytics-event-reference
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The name of the behavioral analytics collection.
+     */
+    collection_name: Name
+    /**
+     * The analytics event type.
+     */
+    event_type: EventType
+  }
+}

--- a/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequest.ts
+++ b/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequest.ts
@@ -40,3 +40,11 @@ export interface Request extends RequestBase {
     event_type: EventType
   }
 }
+  query_parameters: {
+    /**
+     * Whether the response type has to include more details
+     */
+    debug?: boolean
+  }
+  /** @codegen_name payload */
+  body: UserDefinedValue

--- a/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequestExample1.yaml
+++ b/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequestExample1.yaml
@@ -1,0 +1,13 @@
+# summary: behavioral-analytics/apis/post-analytics-collection-event.asciidoc:69
+# method_request: POST _application/analytics/my_analytics_collection/event/search_click
+description: Run `POST _application/analytics/my_analytics_collection/event/search_click` to send a `search_click` event to an analytics collection called `my_analytics_collection`.
+# type: request
+value:
+  "{\n  \"session\": {\n    \"id\": \"1797ca95-91c9-4e2e-b1bd-9c38e6f386a9\"\n\
+  \  },\n  \"user\": {\n    \"id\": \"5f26f01a-bbee-4202-9298-81261067abbd\"\n  },\n\
+  \  \"search\":{\n    \"query\": \"search term\",\n    \"results\": {\n      \"items\"\
+  : [\n        {\n          \"document\": {\n            \"id\": \"123\",\n      \
+  \      \"index\": \"products\"\n          }\n        }\n      ],\n      \"total_results\"\
+  : 10\n    },\n    \"sort\": {\n      \"name\": \"relevance\"\n    },\n    \"search_application\"\
+  : \"website\"\n  },\n  \"document\":{\n    \"id\": \"123\",\n    \"index\": \"products\"\
+  \n  }\n}"

--- a/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostResponse.ts
+++ b/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostResponse.ts
@@ -19,8 +19,8 @@
 
 export class Response {
   body: {
-      accepted: boolean
-      event?: UserDefinedValue
+    accepted: boolean
+    event?: UserDefinedValue
   }
   exceptions: [
     {

--- a/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostResponse.ts
+++ b/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostResponse.ts
@@ -18,7 +18,10 @@
  */
 
 export class Response {
-  body: {}
+  body: {
+      accepted: boolean
+      event?: UserDefinedValue
+  }
   exceptions: [
     {
       /**

--- a/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostResponse.ts
+++ b/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostResponse.ts
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class Response {
+  body: {}
+  exceptions: [
+    {
+      /**
+       * Event has been accepted and will be ingested.
+       */
+      statusCodes: [202]
+    },
+    {
+      /**
+       * Either the event type is unknown or the event payload contains invalid data.
+       */
+      statusCodes: [400]
+    },
+    {
+      /**
+       * Analytics collection does not exist.
+       */
+      statusCodes: [404]
+    }
+  ]
+}

--- a/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostResponse.ts
+++ b/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostResponse.ts
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+
 export class Response {
   body: {
     accepted: boolean


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3377, https://github.com/elastic/elasticsearch-specification/issues/2482

This PR adds a specification so that we can retire https://www.elastic.co/guide/en/elasticsearch/reference/master/post-analytics-collection-event.html