### PR TITLE
Add specification for set connector sync job stats

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -5352,15 +5352,10 @@
                     "type": "number"
                   },
                   "last_seen": {
-                    "description": "The timestamp to use in the `last_seen` property for the connector sync job.",
-                    "type": "number"
+                    "$ref": "#/components/schemas/_types:Duration"
                   },
                   "metadata": {
-                    "description": "The connector-specific metadata.",
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "object"
-                    }
+                    "$ref": "#/components/schemas/_types:Metadata"
                   },
                   "total_document_count": {
                     "description": "The total number of documents in the target index after the sync job finished.",

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -5312,6 +5312,86 @@
         "x-beta": true
       }
     },
+    "/_connector/_sync_job/{connector_sync_job_id}/_stats": {
+      "put": {
+        "tags": [
+          "connector"
+        ],
+        "summary": "Set the connector sync job stats",
+        "description": "Stats include: `deleted_document_count`, `indexed_document_count`, `indexed_document_volume`, and `total_document_count`.\nYou can also update `last_seen`.\nThis API is mainly used by the connector service for updating sync job information.\n\nTo sync data using self-managed connectors, you need to deploy the Elastic connector service on your own infrastructure.\nThis service runs automatically on Elastic Cloud for Elastic managed connectors.",
+        "operationId": "connector-sync-job-update-stats",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_sync_job_id",
+            "description": "The unique identifier of the connector sync job.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "deleted_document_count": {
+                    "description": "The number of documents the sync job deleted.",
+                    "type": "number"
+                  },
+                  "indexed_document_count": {
+                    "description": "The number of documents the sync job indexed.",
+                    "type": "number"
+                  },
+                  "indexed_document_volume": {
+                    "description": "The total size of the data (in MiB) the sync job indexed.",
+                    "type": "number"
+                  },
+                  "last_seen": {
+                    "description": "The timestamp to use in the `last_seen` property for the connector sync job.",
+                    "type": "number"
+                  },
+                  "metadata": {
+                    "description": "The connector-specific metadata.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object"
+                    }
+                  },
+                  "total_document_count": {
+                    "description": "The total number of documents in the target index after the sync job finished.",
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "deleted_document_count",
+                  "indexed_document_count",
+                  "indexed_document_volume"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "x-state": "Technical preview"
+      }
+    },
     "/_connector/{connector_id}/_filtering/_activate": {
       "put": {
         "tags": [

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -243,12 +243,6 @@
       ],
       "response": []
     },
-    "connector.sync_job_update_stats": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "enrich.delete_policy": {
       "request": [
         "Request: missing json spec query parameter 'master_timeout'"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10083,6 +10083,21 @@ export interface ConnectorSyncJobPostResponse {
   id: Id
 }
 
+export interface ConnectorSyncJobUpdateStatsRequest extends RequestBase {
+  connector_sync_job_id: Id
+  body?: {
+    deleted_document_count: integer
+    indexed_document_count: integer
+    indexed_document_volume: integer
+    last_seen?: integer
+    metadata?: Record<string, any>
+    total_document_count?: integer
+  }
+}
+
+export interface ConnectorSyncJobUpdateStatsResponse {
+}
+
 export interface ConnectorUpdateActiveFilteringRequest extends RequestBase {
   connector_id: Id
 }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10086,11 +10086,11 @@ export interface ConnectorSyncJobPostResponse {
 export interface ConnectorSyncJobUpdateStatsRequest extends RequestBase {
   connector_sync_job_id: Id
   body?: {
-    deleted_document_count: integer
-    indexed_document_count: integer
-    indexed_document_volume: integer
-    last_seen?: integer
-    metadata?: Record<string, any>
+    deleted_document_count: long
+    indexed_document_count: long
+    indexed_document_volume: long
+    last_seen?: Duration
+    metadata?: Metadata
     total_document_count?: integer
   }
 }

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -96,6 +96,7 @@ connector-sync-job-delete,https://www.elastic.co/guide/en/elasticsearch/referenc
 connector-sync-job-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-connector-sync-job-api.html
 connector-sync-job-post,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/create-connector-sync-job-api.html
 connector-sync-job-list,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/list-connector-sync-jobs-api.html
+connector-sync-job-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/set-connector-sync-job-stats-api.html
 connector-checkin,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/check-in-connector-api.html
 connector-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-connector-api.html
 connector-features,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-connector-features-api.html

--- a/specification/connector/sync_job_update_stats/SyncJobUpdateStatsRequest.ts
+++ b/specification/connector/sync_job_update_stats/SyncJobUpdateStatsRequest.ts
@@ -16,11 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Dictionary } from '@spec_utils/Dictionary'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RequestBase } from '@_types/Base'
-import { Id } from '@_types/common'
-import { integer } from '@_types/Numeric'
+import { Id, Metadata } from '@_types/common'
+import { integer, long } from '@_types/Numeric'
+import { Duration } from '@_types/Time'
 
 /**
  * Set the connector sync job stats.
@@ -48,23 +47,23 @@ export interface Request extends RequestBase {
     /**
      * The number of documents the sync job deleted.
      */
-    deleted_document_count: integer
+    deleted_document_count: long
     /**
      * The number of documents the sync job indexed.
      */
-    indexed_document_count: integer
+    indexed_document_count: long
     /**
      * The total size of the data (in MiB) the sync job indexed.
      */
-    indexed_document_volume: integer
+    indexed_document_volume: long
     /**
      * The timestamp to use in the `last_seen` property for the connector sync job.
      */
-    last_seen?: integer
+    last_seen?: Duration
     /**
      * The connector-specific metadata.
      */
-    metadata?: Dictionary<string, UserDefinedValue>
+    metadata?: Metadata
     /**
      * The total number of documents in the target index after the sync job finished.
      */

--- a/specification/connector/sync_job_update_stats/SyncJobUpdateStatsRequest.ts
+++ b/specification/connector/sync_job_update_stats/SyncJobUpdateStatsRequest.ts
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Dictionary } from '@spec_utils/Dictionary'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+import { integer } from '@_types/Numeric'
+
+/**
+ * Set the connector sync job stats.
+ * Stats include: `deleted_document_count`, `indexed_document_count`, `indexed_document_volume`, and `total_document_count`.
+ * You can also update `last_seen`.
+ * This API is mainly used by the connector service for updating sync job information.
+ *
+ * To sync data using self-managed connectors, you need to deploy the Elastic connector service on your own infrastructure.
+ * This service runs automatically on Elastic Cloud for Elastic managed connectors.
+ * @rest_spec_name connector.sync_job_update_stats
+ * @availability stack stability=experimental visibility=public
+ * @doc_id connector-sync-job-stats
+ */
+export interface Request extends RequestBase {
+  /**
+   * The sync job to be created
+   */
+  path_parts: {
+    /**
+     * The unique identifier of the connector sync job.
+     */
+    connector_sync_job_id: Id
+  }
+  body: {
+    /**
+     * The number of documents the sync job deleted.
+     */
+    deleted_document_count: integer
+    /**
+     * The number of documents the sync job indexed.
+     */
+    indexed_document_count: integer
+    /**
+     * The total size of the data (in MiB) the sync job indexed.
+     */
+    indexed_document_volume: integer
+    /**
+     * The timestamp to use in the `last_seen` property for the connector sync job.
+     */
+    last_seen?: integer
+    /**
+     * The connector-specific metadata.
+     */
+    metadata?: Dictionary<string, UserDefinedValue>
+    /**
+     * The total number of documents in the target index after the sync job finished.
+     */
+    total_document_count?: integer
+  }
+}

--- a/specification/connector/sync_job_update_stats/SyncJobUpdateStatsResponse.ts
+++ b/specification/connector/sync_job_update_stats/SyncJobUpdateStatsResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class Response {
+  body: {}
+}


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3377

This PR adds a specification to match https://www.elastic.co/guide/en/elasticsearch/reference/master/set-connector-sync-job-stats-api.html