### PR TITLE
Add min_read_only_index_version to node version information

### DIFF
--- a/specification/_global/search_shards/SearchShardsResponse.ts
+++ b/specification/_global/search_shards/SearchShardsResponse.ts
@@ -56,6 +56,7 @@ class SearchShardsNodeAttributes {
   roles: NodeRoles
   version: VersionString
   min_index_version: integer
+  min_read_only_index_version: integer
   max_index_version: integer
 }
 

--- a/specification/ml/_types/DiscoveryNode.ts
+++ b/specification/ml/_types/DiscoveryNode.ts
@@ -33,6 +33,7 @@ export class DiscoveryNodeContent {
   roles: string[]
   version: VersionString
   min_index_version: integer
+  min_read_only_index_version: integer
   max_index_version: integer
 }
 


### PR DESCRIPTION
This pull request adds the `min_read_only_index_version` to specifications.

Relates https://github.com/elastic/elasticsearch/pull/118744