### PR TITLE
Add shard_failures to EQL response spec

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -65830,6 +65830,13 @@
           },
           "hits": {
             "$ref": "#/components/schemas/eql._types:EqlHits"
+          },
+          "shard_failures": {
+            "description": "Contains information about shard failures (if any), in case allow_partial_search_results=true",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:ShardFailure"
+            }
           }
         },
         "required": [

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -44305,6 +44305,13 @@
           },
           "hits": {
             "$ref": "#/components/schemas/eql._types:EqlHits"
+          },
+          "shard_failures": {
+            "description": "Contains information about shard failures (if any), in case allow_partial_search_results=true",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:ShardFailure"
+            }
           }
         },
         "required": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -117597,9 +117597,24 @@
               "namespace": "eql._types"
             }
           }
+        },
+        {
+          "description": "Contains information about shard failures (if any), in case allow_partial_search_results=true",
+          "name": "shard_failures",
+          "required": false,
+          "type": {
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "ShardFailure",
+                "namespace": "_types"
+              }
+            }
+          }
         }
       ],
-      "specLocation": "eql/_types/EqlSearchResponseBase.ts#L24-L49"
+      "specLocation": "eql/_types/EqlSearchResponseBase.ts#L25-L54"
     },
     {
       "generics": [

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10327,6 +10327,7 @@ export interface EqlEqlSearchResponseBase<TEvent = unknown> {
   took?: DurationValue<UnitMillis>
   timed_out?: boolean
   hits: EqlEqlHits<TEvent>
+  shard_failures?: ShardFailure[]
 }
 
 export interface EqlHitsEvent<TEvent = unknown> {

--- a/specification/eql/_types/EqlSearchResponseBase.ts
+++ b/specification/eql/_types/EqlSearchResponseBase.ts
@@ -18,6 +18,7 @@
  */
 
 import { Id } from '@_types/common'
+import { ShardFailure } from '@_types/Errors'
 import { DurationValue, UnitMillis } from '@_types/Time'
 import { EqlHits } from './EqlHits'
 
@@ -46,4 +47,8 @@ export class EqlSearchResponseBase<TEvent> {
    * Contains matching events and sequences. Also contains related metadata.
    */
   hits: EqlHits<TEvent>
+  /**
+   * Contains information about shard failures (if any), in case allow_partial_search_results=true
+   */
+  shard_failures?: ShardFailure[]
 }


### PR DESCRIPTION
Adding shard_failures to the EQL response specification

Related to https://github.com/elastic/elasticsearch/pull/116388 
Follow-up to https://github.com/elastic/elasticsearch-specification/pull/3342

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
