### PR TITLE
avoiding container extension

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -70718,7 +70718,15 @@
       "ingest._types:DatabaseConfigurationFull": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/ingest._types:DatabaseConfiguration"
+            "type": "object",
+            "properties": {
+              "name": {
+                "$ref": "#/components/schemas/_types:Name"
+              }
+            },
+            "required": [
+              "name"
+            ]
           },
           {
             "type": "object",
@@ -70728,8 +70736,16 @@
               },
               "local": {
                 "$ref": "#/components/schemas/ingest._types:Local"
+              },
+              "maxmind": {
+                "$ref": "#/components/schemas/ingest._types:Maxmind"
+              },
+              "ipinfo": {
+                "$ref": "#/components/schemas/ingest._types:Ipinfo"
               }
-            }
+            },
+            "minProperties": 1,
+            "maxProperties": 1
           }
         ]
       },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12907,9 +12907,12 @@ export interface IngestDatabaseConfiguration {
   ipinfo?: IngestIpinfo
 }
 
-export interface IngestDatabaseConfigurationFull extends IngestDatabaseConfiguration {
+export interface IngestDatabaseConfigurationFull {
   web?: IngestWeb
   local?: IngestLocal
+  name: Name
+  maxmind?: IngestMaxmind
+  ipinfo?: IngestIpinfo
 }
 
 export interface IngestDateIndexNameProcessor extends IngestProcessorBase {

--- a/specification/ingest/_types/Database.ts
+++ b/specification/ingest/_types/Database.ts
@@ -36,9 +36,20 @@ export class DatabaseConfiguration {
   ipinfo?: Ipinfo
 }
 
-export class DatabaseConfigurationFull extends DatabaseConfiguration {
+/**
+ * @variants container
+ */
+export class DatabaseConfigurationFull {
   web?: Web
   local?: Local
+  /**
+   * The provider-assigned name of the IP geolocation database to download.
+   * @variant container_property
+   */
+  name: Name
+
+  maxmind?: Maxmind
+  ipinfo?: Ipinfo
 }
 
 export class Maxmind {


### PR DESCRIPTION
We merged https://github.com/elastic/elasticsearch-specification/pull/3107 which adds a class extending a container, which java doesn't support. I could add an exception in the generator, but since it's only two fields I'd prefer writing the extended class definition. 
