### PR TITLE
[Backport 8.17] Add specification for claim connector sync job (#3366)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -4935,6 +4935,65 @@
         "x-beta": true
       }
     },
+    "/_connector/_sync_job/{connector_sync_job_id}/_claim": {
+      "put": {
+        "tags": [
+          "connector"
+        ],
+        "summary": "Claim a connector sync job",
+        "description": "This action updates the job status to `in_progress` and sets the `last_seen` and `started_at` timestamps to the current time.\nAdditionally, it can set the `sync_cursor` property for the sync job.\n\nThis API is not intended for direct connector management by users.\nIt supports the implementation of services that utilize the connector protocol to communicate with Elasticsearch.\n\nTo sync data using self-managed connectors, you need to deploy the Elastic connector service on your own infrastructure.\nThis service runs automatically on Elastic Cloud for Elastic managed connectors.",
+        "operationId": "connector-sync-job-claim",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_sync_job_id",
+            "description": "The unique identifier of the connector sync job.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sync_cursor": {
+                    "description": "The cursor object from the last incremental sync job.\nThis should reference the `sync_cursor` field in the connector state for which the job runs.",
+                    "type": "object"
+                  },
+                  "worker_hostname": {
+                    "description": "The host name of the current system that will run the job.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "worker_hostname"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "x-state": "Technical preview"
+      }
+    },
     "/_connector/_sync_job/{connector_sync_job_id}": {
       "get": {
         "tags": [

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -476,12 +476,6 @@
       ],
       "response": []
     },
-    "connector.sync_job_claim": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "connector.sync_job_error": {
       "request": [
         "Missing request & response"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -9996,6 +9996,17 @@ export interface ConnectorSyncJobCancelResponse {
   result: Result
 }
 
+export interface ConnectorSyncJobClaimRequest extends RequestBase {
+  connector_sync_job_id: Id
+  body?: {
+    sync_cursor?: any
+    worker_hostname: string
+  }
+}
+
+export interface ConnectorSyncJobClaimResponse {
+}
+
 export interface ConnectorSyncJobDeleteRequest extends RequestBase {
   connector_sync_job_id: Id
 }

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -85,6 +85,8 @@ cluster,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster
 common-options,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/common-options.html
 community-id-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/community-id-processor.html
 connector-sync-job-cancel,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cancel-connector-sync-job-api.html
+connector-sync-job-checkin,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/check-in-connector-sync-job-api.html
+connector-sync-job-claim,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/claim-connector-sync-job-api.html
 collapse-search-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/collapse-search-results.html
 connector-sync-job-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-connector-sync-job-api.html
 connector-sync-job-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-connector-sync-job-api.html

--- a/specification/connector/sync_job_claim/SyncJobClaimRequest.ts
+++ b/specification/connector/sync_job_claim/SyncJobClaimRequest.ts
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+
+/**
+ * Claim a connector sync job.
+ * This action updates the job status to `in_progress` and sets the `last_seen` and `started_at` timestamps to the current time.
+ * Additionally, it can set the `sync_cursor` property for the sync job.
+ *
+ * This API is not intended for direct connector management by users.
+ * It supports the implementation of services that utilize the connector protocol to communicate with Elasticsearch.
+ *
+ * To sync data using self-managed connectors, you need to deploy the Elastic connector service on your own infrastructure.
+ * This service runs automatically on Elastic Cloud for Elastic managed connectors.
+ * @rest_spec_name connector.sync_job_claim
+ * @availability stack stability=experimental visibility=public
+ * @doc_id connector-sync-job-claim
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the connector sync job.
+     */
+    connector_sync_job_id: Id
+  }
+  body: {
+    /**
+     * The cursor object from the last incremental sync job.
+     * This should reference the `sync_cursor` field in the connector state for which the job runs.
+     */
+    sync_cursor?: UserDefinedValue
+    /**
+     * The host name of the current system that will run the job.
+     */
+    worker_hostname: string
+  }
+}

--- a/specification/connector/sync_job_claim/SyncJobClaimResponse.ts
+++ b/specification/connector/sync_job_claim/SyncJobClaimResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class Response {
+  body: {}
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Add specification for claim connector sync job (#3366)](https://github.com/elastic/elasticsearch-specification/pull/3366)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)