### PR TITLE
[Backport 8.17] Add specification for set connector sync job error (#3367)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -5004,6 +5004,61 @@
         "x-beta": true
       }
     },
+    "/_connector/_sync_job/{connector_sync_job_id}/_error": {
+      "put": {
+        "tags": [
+          "connector"
+        ],
+        "summary": "Set a connector sync job error",
+        "description": "Set the `error` field for a connector sync job and set its `status` to `error`.\n\nTo sync data using self-managed connectors, you need to deploy the Elastic connector service on your own infrastructure.\nThis service runs automatically on Elastic Cloud for Elastic managed connectors.",
+        "operationId": "connector-sync-job-error",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connector_sync_job_id",
+            "description": "The unique identifier for the connector sync job.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "error": {
+                    "description": "The error for the connector sync job error field.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "error"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "x-state": "Technical preview"
+      }
+    },
     "/_connector/_sync_job": {
       "get": {
         "tags": [

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -482,12 +482,6 @@
       ],
       "response": []
     },
-    "connector.sync_job_error": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "connector.sync_job_update_stats": {
       "request": [
         "Missing request & response"

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -476,12 +476,6 @@
       ],
       "response": []
     },
-    "connector.sync_job_error": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "connector.sync_job_update_stats": {
       "request": [
         "Missing request & response"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10002,6 +10002,16 @@ export interface ConnectorSyncJobDeleteRequest extends RequestBase {
 
 export type ConnectorSyncJobDeleteResponse = AcknowledgedResponseBase
 
+export interface ConnectorSyncJobErrorRequest extends RequestBase {
+  connector_sync_job_id: Id
+  body?: {
+    error: string
+  }
+}
+
+export interface ConnectorSyncJobErrorResponse {
+}
+
 export interface ConnectorSyncJobGetRequest extends RequestBase {
   connector_sync_job_id: Id
 }

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -85,6 +85,9 @@ cluster,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster
 common-options,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/common-options.html
 community-id-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/community-id-processor.html
 connector-sync-job-cancel,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cancel-connector-sync-job-api.html
+connector-sync-job-checkin,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/check-in-connector-sync-job-api.html
+connector-sync-job-claim,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/claim-connector-sync-job-api.html
+connector-sync-job-error,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/set-connector-sync-job-error-api.html
 collapse-search-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/collapse-search-results.html
 connector-sync-job-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-connector-sync-job-api.html
 connector-sync-job-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-connector-sync-job-api.html

--- a/specification/connector/sync_job_error/SyncJobErrorRequest.ts
+++ b/specification/connector/sync_job_error/SyncJobErrorRequest.ts
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+
+/**
+ * Set a connector sync job error.
+ * Set the `error` field for a connector sync job and set its `status` to `error`.
+ *
+ * To sync data using self-managed connectors, you need to deploy the Elastic connector service on your own infrastructure.
+ * This service runs automatically on Elastic Cloud for Elastic managed connectors.
+ * @rest_spec_name connector.sync_job_error
+ * @availability stack stability=experimental visibility=public
+ * @doc_id connector-sync-job-error
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier for the connector sync job.
+     */
+    connector_sync_job_id: Id
+  }
+  body: {
+    /**
+     * The error for the connector sync job error field.
+     */
+    error: string
+  }
+}

--- a/specification/connector/sync_job_error/SyncJobErrorResponse.ts
+++ b/specification/connector/sync_job_error/SyncJobErrorResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class Response {
+  body: {}
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Add specification for set connector sync job error (#3367)](https://github.com/elastic/elasticsearch-specification/pull/3367)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)