### PR TITLE
[DOCS] Edit ingest ip_location summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -15700,8 +15700,8 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Create or update GeoIP database configurations",
-        "description": "Create or update IP geolocation database configurations.",
+        "summary": "Create or update a GeoIP database configuration",
+        "description": "Refer to the create or update IP geolocation database configuration API.",
         "operationId": "ingest-put-geoip-database",
         "parameters": [
           {
@@ -15832,7 +15832,7 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Returns information about one or more IP location database configurations",
+        "summary": "Get IP geolocation database configurations",
         "operationId": "ingest-get-ip-location-database-1",
         "parameters": [
           {
@@ -15853,13 +15853,13 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Returns information about one or more IP location database configurations",
+        "summary": "Create or update an IP geolocation database configuration",
         "operationId": "ingest-put-ip-location-database",
         "parameters": [
           {
             "in": "path",
             "name": "id",
-            "description": "ID of the database configuration to create or update.",
+            "description": "The database configuration identifier.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -15870,7 +15870,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.\nA value of `-1` indicates that the request should never time out.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -15880,7 +15880,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a response from all relevant nodes in the cluster after updating the cluster metadata.\nIf no response is received before the timeout expires, the cluster metadata update still applies but the response indicates that it was not completely acknowledged.\nA value of `-1` indicates that the request should never time out.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -15916,13 +15916,13 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Deletes an IP location database configuration",
+        "summary": "Delete IP geolocation database configurations",
         "operationId": "ingest-delete-ip-location-database",
         "parameters": [
           {
             "in": "path",
             "name": "id",
-            "description": "A comma-separated list of IP location database configurations to delete",
+            "description": "A comma-separated list of IP location database configurations.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -15933,7 +15933,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.\nA value of `-1` indicates that the request should never time out.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -15943,7 +15943,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "Period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.\nA value of `-1` indicates that the request should never time out.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -16228,7 +16228,7 @@
         "tags": [
           "ingest"
         ],
-        "summary": "Returns information about one or more IP location database configurations",
+        "summary": "Get IP geolocation database configurations",
         "operationId": "ingest-get-ip-location-database",
         "parameters": [
           {
@@ -71204,7 +71204,7 @@
         ]
       },
       "ingest._types:DatabaseConfiguration": {
-        "description": "The configuration necessary to identify which IP geolocation provider to use to download a database, as well as any provider-specific configuration necessary for such downloading.\nAt present, the only supported providers are maxmind and ipinfo, and the maxmind provider requires that an account_id (string) is configured.\nA provider (either maxmind or ipinfo) must be specified. The web and local providers can be returned as read only configurations.",
+        "description": "The configuration necessary to identify which IP geolocation provider to use to download a database, as well as any provider-specific configuration necessary for such downloading.\nAt present, the only supported providers are `maxmind` and `ipinfo`, and the `maxmind` provider requires that an `account_id` (string) is configured.\nA provider (either `maxmind` or `ipinfo`) must be specified. The web and local providers can be returned as read only configurations.",
         "allOf": [
           {
             "type": "object",
@@ -99600,7 +99600,7 @@
       "ingest.get_ip_location_database#master_timeout": {
         "in": "query",
         "name": "master_timeout",
-        "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+        "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.\nA value of `-1` indicates that the request should never time out.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"

--- a/specification/ingest/_types/Database.ts
+++ b/specification/ingest/_types/Database.ts
@@ -21,8 +21,8 @@ import { Id, Name } from '@_types/common'
 
 /**
  * The configuration necessary to identify which IP geolocation provider to use to download a database, as well as any provider-specific configuration necessary for such downloading.
- * At present, the only supported providers are maxmind and ipinfo, and the maxmind provider requires that an account_id (string) is configured.
- * A provider (either maxmind or ipinfo) must be specified. The web and local providers can be returned as read only configurations.
+ * At present, the only supported providers are `maxmind` and `ipinfo`, and the `maxmind` provider requires that an `account_id` (string) is configured.
+ * A provider (either `maxmind` or `ipinfo`) must be specified. The web and local providers can be returned as read only configurations.
  * @variants container
  */
 export class DatabaseConfiguration {

--- a/specification/ingest/delete_ip_location_database/DeleteIpLocationDatabaseRequest.ts
+++ b/specification/ingest/delete_ip_location_database/DeleteIpLocationDatabaseRequest.ts
@@ -22,26 +22,31 @@ import { Ids } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Deletes an IP location database configuration.
+ * Delete IP geolocation database configurations.
  * @rest_spec_name ingest.delete_ip_location_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
+ * @cluster_privileges manage
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * A comma-separated list of IP location database configurations to delete
+     * A comma-separated list of IP location database configurations.
      */
     id: Ids
   }
   query_parameters: {
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
      * If no response is received before the timeout expires, the request fails and returns an error.
-     * @server_default 30s */
+     * A value of `-1` indicates that the request should never time out.
+     * @server_default 30s
+     */
     master_timeout?: Duration
     /**
-     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * Period to wait for a response.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * A value of `-1` indicates that the request should never time out.
      * @server_default 30s */
     timeout?: Duration
   }

--- a/specification/ingest/delete_ip_location_database/DeleteIpLocationDatabaseRequest.ts
+++ b/specification/ingest/delete_ip_location_database/DeleteIpLocationDatabaseRequest.ts
@@ -44,7 +44,7 @@ export interface Request extends RequestBase {
      */
     master_timeout?: Duration
     /**
-     * Period to wait for a response.
+     * The period to wait for a response.
      * If no response is received before the timeout expires, the request fails and returns an error.
      * A value of `-1` indicates that the request should never time out.
      * @server_default 30s */

--- a/specification/ingest/get_ip_location_database/GetIpLocationDatabaseRequest.ts
+++ b/specification/ingest/get_ip_location_database/GetIpLocationDatabaseRequest.ts
@@ -22,10 +22,11 @@ import { Ids } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Returns information about one or more IP location database configurations.
+ * Get IP geolocation database configurations.
  * @rest_spec_name ingest.get_ip_location_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
+ * @cluster_privileges manage
  */
 export interface Request extends RequestBase {
   path_parts: {
@@ -38,8 +39,9 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
      * If no response is received before the timeout expires, the request fails and returns an error.
+     * A value of `-1` indicates that the request should never time out.
      * @server_default 30s */
     master_timeout?: Duration
   }

--- a/specification/ingest/put_geoip_database/PutGeoipDatabaseRequest.ts
+++ b/specification/ingest/put_geoip_database/PutGeoipDatabaseRequest.ts
@@ -23,8 +23,8 @@ import { Id, Name } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Create or update GeoIP database configurations.
- * Create or update IP geolocation database configurations.
+ * Create or update a GeoIP database configuration.
+ * Refer to the create or update IP geolocation database configuration API.
  * @rest_spec_name ingest.put_geoip_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private

--- a/specification/ingest/put_ip_location_database/PutIpLocationDatabaseRequest.ts
+++ b/specification/ingest/put_ip_location_database/PutIpLocationDatabaseRequest.ts
@@ -23,26 +23,30 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Returns information about one or more IP location database configurations.
+ * Create or update an IP geolocation database configuration.
  * @rest_spec_name ingest.put_ip_location_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
+ * @cluster_privileges manage
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * ID of the database configuration to create or update.
+     * The database configuration identifier.
      */
     id: Id
   }
   query_parameters: {
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
      * If no response is received before the timeout expires, the request fails and returns an error.
+     * A value of `-1` indicates that the request should never time out.
      * @server_default 30s */
     master_timeout?: Duration
     /**
-     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * The period to wait for a response from all relevant nodes in the cluster after updating the cluster metadata.
+     * If no response is received before the timeout expires, the cluster metadata update still applies but the response indicates that it was not completely acknowledged.
+     * A value of `-1` indicates that the request should never time out.
      * @server_default 30s */
     timeout?: Duration
   }


### PR DESCRIPTION
This PR edits some summaries and descriptions in the ingest APIs based on information derived from https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-ip-location-database-api.html, https://www.elastic.co/guide/en/elasticsearch/reference/master/get-ip-location-database-api.html, and https://www.elastic.co/guide/en/elasticsearch/reference/master/put-ip-location-database-api.html.

NOTE: https://www.elastic.co/guide/en/elasticsearch/reference/master/put-geoip-database-api.html exists only in the "deleted pages" section of the Elasticsearch Guide, so I'm assuming it will eventually be deprecated and removed from the specifications but that doesn't seem to have happened yet.

