### PR TITLE
Add summary and tag to ml.validate

### DIFF
--- a/specification/ml/validate/MlValidateJobRequest.ts
+++ b/specification/ml/validate/MlValidateJobRequest.ts
@@ -25,9 +25,11 @@ import { Id, IndexName } from '@_types/common'
 import { long } from '@_types/Numeric'
 
 /**
+ * Validate an anomaly detection job.
  * @rest_spec_name ml.validate
  * @availability stack since=6.3.0 stability=stable visibility=private
  * @availability serverless stability=stable visibility=private
+ * @doc_tag ml anomaly
  */
 export interface Request extends RequestBase {
   body: {


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3300

The  `_ml/anomaly_detectors/_validate` [endpoint](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-validate) is currently appearing in the `machine learning` group instead of the `machine learning anomaly detection` group and is missing a summary.

When the referenced issue is fixed, it should not be published but until then I've fixed the doc tag and summary.