### PR TITLE
Add security.update_settings and security.get_settings

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -30962,6 +30962,143 @@
         "x-state": "Added in 7.13.0"
       }
     },
+    "/_security/settings": {
+      "get": {
+        "tags": [
+          "security"
+        ],
+        "summary": "Get security index settings",
+        "description": "Get the user-configurable settings for the security internal index (`.security` and associated indices).",
+        "operationId": "security-get-settings",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "master_timeout",
+            "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "security": {
+                      "$ref": "#/components/schemas/security.get_settings:SecuritySettings"
+                    },
+                    "security-profile": {
+                      "description": "Settings for the index used to store profile information.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "security-tokens": {
+                      "$ref": "#/components/schemas/security.get_settings:SecuritySettings"
+                    }
+                  },
+                  "required": [
+                    "security",
+                    "security-profile",
+                    "security-tokens"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "security"
+        ],
+        "summary": "Update security index settings",
+        "description": "Update the user-configurable settings for the security internal index (`.security` and associated indices). Only a subset of settings are allowed to be modified, for example `index.auto_expand_replicas` and `index.number_of_replicas`.\n\nIf a specific index is not in use on the system and settings are provided for it, the request will be rejected. This API does not yet support configuring the settings for indices before they are in use.",
+        "operationId": "security-update-settings",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "master_timeout",
+            "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "The period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "security": {
+                    "description": "Settings for the index used for most security configuration, including native realm users and roles configured with the API.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "security-profile": {
+                    "description": "Settings for the index used to store profile information.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "security-tokens": {
+                    "description": "Settings for the index used to store tokens.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "acknowledged": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "acknowledged"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/_security/oauth2/token": {
       "post": {
         "tags": [
@@ -86183,6 +86320,14 @@
         "required": [
           "nodes"
         ]
+      },
+      "security.get_settings:SecuritySettings": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "$ref": "#/components/schemas/indices._types:IndexSettings"
+          }
+        }
       },
       "security.get_token:AccessTokenGrantType": {
         "type": "string",

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -30991,17 +30991,13 @@
                   "type": "object",
                   "properties": {
                     "security": {
-                      "$ref": "#/components/schemas/security.get_settings:SecuritySettings"
+                      "$ref": "#/components/schemas/security._types:SecuritySettings"
                     },
                     "security-profile": {
-                      "description": "Settings for the index used to store profile information.",
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "string"
-                      }
+                      "$ref": "#/components/schemas/security._types:SecuritySettings"
                     },
                     "security-tokens": {
-                      "$ref": "#/components/schemas/security.get_settings:SecuritySettings"
+                      "$ref": "#/components/schemas/security._types:SecuritySettings"
                     }
                   },
                   "required": [
@@ -31051,25 +31047,13 @@
                 "type": "object",
                 "properties": {
                   "security": {
-                    "description": "Settings for the index used for most security configuration, including native realm users and roles configured with the API.",
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    }
+                    "$ref": "#/components/schemas/security._types:SecuritySettings"
                   },
                   "security-profile": {
-                    "description": "Settings for the index used to store profile information.",
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    }
+                    "$ref": "#/components/schemas/security._types:SecuritySettings"
                   },
                   "security-tokens": {
-                    "description": "Settings for the index used to store tokens.",
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    }
+                    "$ref": "#/components/schemas/security._types:SecuritySettings"
                   }
                 }
               }
@@ -86321,7 +86305,7 @@
           "nodes"
         ]
       },
-      "security.get_settings:SecuritySettings": {
+      "security._types:SecuritySettings": {
         "type": "object",
         "properties": {
           "index": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -352,12 +352,6 @@
       ],
       "response": []
     },
-    "security.get_settings": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "security.get_user_privileges": {
       "request": [
         "Request: query parameter 'application' does not exist in the json spec",
@@ -369,12 +363,6 @@
     "security.grant_api_key": {
       "request": [
         "Request: missing json spec query parameter 'refresh'"
-      ],
-      "response": []
-    },
-    "security.update_settings": {
-      "request": [
-        "Missing request & response"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -18572,6 +18572,20 @@ export interface SecurityGetServiceCredentialsResponse {
   nodes_credentials: SecurityGetServiceCredentialsNodesCredentials
 }
 
+export interface SecurityGetSettingsRequest extends RequestBase {
+  master_timeout?: Duration
+}
+
+export interface SecurityGetSettingsResponse {
+  security: SecurityGetSettingsSecuritySettings
+  'security-profile': Record<string, string>
+  'security-tokens': SecurityGetSettingsSecuritySettings
+}
+
+export interface SecurityGetSettingsSecuritySettings {
+  index?: IndicesIndexSettings
+}
+
 export type SecurityGetTokenAccessTokenGrantType = 'password' | 'client_credentials' | '_kerberos' | 'refresh_token'
 
 export interface SecurityGetTokenAuthenticatedUser extends SecurityUser {
@@ -19138,6 +19152,20 @@ export interface SecurityUpdateCrossClusterApiKeyRequest extends RequestBase {
 
 export interface SecurityUpdateCrossClusterApiKeyResponse {
   updated: boolean
+}
+
+export interface SecurityUpdateSettingsRequest extends RequestBase {
+  master_timeout?: Duration
+  timeout?: Duration
+  body?: {
+    security?: Record<string, string>
+    'security-profile'?: Record<string, string>
+    'security-tokens'?: Record<string, string>
+  }
+}
+
+export interface SecurityUpdateSettingsResponse {
+  acknowledged: boolean
 }
 
 export interface SecurityUpdateUserProfileDataRequest extends RequestBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -18100,6 +18100,10 @@ export interface SecuritySearchAccess {
   allow_restricted_indices?: boolean
 }
 
+export interface SecuritySecuritySettings {
+  index?: IndicesIndexSettings
+}
+
 export type SecurityTemplateFormat = 'string' | 'json'
 
 export interface SecurityUser {
@@ -18577,13 +18581,9 @@ export interface SecurityGetSettingsRequest extends RequestBase {
 }
 
 export interface SecurityGetSettingsResponse {
-  security: SecurityGetSettingsSecuritySettings
-  'security-profile': Record<string, string>
-  'security-tokens': SecurityGetSettingsSecuritySettings
-}
-
-export interface SecurityGetSettingsSecuritySettings {
-  index?: IndicesIndexSettings
+  security: SecuritySecuritySettings
+  'security-profile': SecuritySecuritySettings
+  'security-tokens': SecuritySecuritySettings
 }
 
 export type SecurityGetTokenAccessTokenGrantType = 'password' | 'client_credentials' | '_kerberos' | 'refresh_token'
@@ -19158,9 +19158,9 @@ export interface SecurityUpdateSettingsRequest extends RequestBase {
   master_timeout?: Duration
   timeout?: Duration
   body?: {
-    security?: Record<string, string>
-    'security-profile'?: Record<string, string>
-    'security-tokens'?: Record<string, string>
+    security?: SecuritySecuritySettings
+    'security-profile'?: SecuritySecuritySettings
+    'security-tokens'?: SecuritySecuritySettings
   }
 }
 

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -633,6 +633,7 @@ security-api-get-role-mapping,https://www.elastic.co/guide/en/elasticsearch/refe
 security-api-get-role,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-get-role.html
 security-api-get-service-accounts,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-get-service-accounts.html
 security-api-get-service-credentials,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-get-service-credentials.html
+security-api-get-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-get-settings.html
 security-api-get-token,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-get-token.html
 security-api-get-user-privileges,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-get-user-privileges.html
 security-api-get-user,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-get-user.html
@@ -658,7 +659,7 @@ security-api-saml-prepare-authentication,https://www.elastic.co/guide/en/elastic
 security-api-saml-sp-metadata,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-saml-sp-metadata.html
 security-api-ssl,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-ssl.html
 security-privileges,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-privileges.html
-security-api-get-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-get-settings.html
+security-api-update-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-update-settings.html
 service-accounts,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/service-accounts.html
 set-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/set-processor.html
 shape,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/shape.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -658,6 +658,7 @@ security-api-saml-prepare-authentication,https://www.elastic.co/guide/en/elastic
 security-api-saml-sp-metadata,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-saml-sp-metadata.html
 security-api-ssl,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-ssl.html
 security-privileges,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-privileges.html
+security-api-get-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-get-settings.html
 service-accounts,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/service-accounts.html
 set-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/set-processor.html
 shape,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/shape.html

--- a/specification/security/_types/SecuritySettings.ts
+++ b/specification/security/_types/SecuritySettings.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IndexSettings } from '@indices/_types/IndexSettings'
+
+export class SecuritySettings {
+  index?: IndexSettings
+}

--- a/specification/security/get_settings/SecurityGetSettingsRequest.ts
+++ b/specification/security/get_settings/SecurityGetSettingsRequest.ts
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Duration } from '@_types/Time'
+
+/**
+ * Get security index settings.
+ * Get the user-configurable settings for the security internal index (`.security` and associated indices).
+ * @rest_spec_name security.get_settings
+ * @availability stack stability=stable visibility=public
+ * @doc_id security-api-get-settings
+ * @cluster_privileges read_security
+ */
+export interface Request extends RequestBase {
+  query_parameters: {
+    /**
+     * Period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     */
+    master_timeout?: Duration
+  }
+}

--- a/specification/security/get_settings/SecurityGetSettingsResponse.ts
+++ b/specification/security/get_settings/SecurityGetSettingsResponse.ts
@@ -16,8 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { IndexSettings } from '@indices/_types/IndexSettings'
-import { Dictionary } from '@spec_utils/Dictionary'
+import { SecuritySettings } from '@security/_types/SecuritySettings'
 
 export class Response {
   body: {
@@ -34,8 +33,4 @@ export class Response {
      */
     'security-tokens': SecuritySettings
   }
-}
-
-export class SecuritySettings {
-  index?: IndexSettings
 }

--- a/specification/security/get_settings/SecurityGetSettingsResponse.ts
+++ b/specification/security/get_settings/SecurityGetSettingsResponse.ts
@@ -28,7 +28,7 @@ export class Response {
     /**
      * Settings for the index used to store profile information.
      */
-    'security-profile': Dictionary<string, string>
+    'security-profile': SecuritySettings
     /**
      * Settings for the index used to store tokens.
      */

--- a/specification/security/get_settings/SecurityGetSettingsResponse.ts
+++ b/specification/security/get_settings/SecurityGetSettingsResponse.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Actions } from '@security/put_privileges/types'
+import { Dictionary } from '@spec_utils/Dictionary'
+
+export class Response {
+  /** @codegen_name privileges */
+  body: Dictionary<string, Dictionary<string, Actions>>
+}

--- a/specification/security/get_settings/SecurityGetSettingsResponse.ts
+++ b/specification/security/get_settings/SecurityGetSettingsResponse.ts
@@ -16,11 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-import { Actions } from '@security/put_privileges/types'
+import { IndexSettings } from '@indices/_types/IndexSettings'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Response {
-  /** @codegen_name privileges */
-  body: Dictionary<string, Dictionary<string, Actions>>
+  body: {
+    /**
+     * Settings for the index used for most security configuration, including native realm users and roles configured with the API.
+     */
+    security: SecuritySettings
+    /**
+     * Settings for the index used to store profile information.
+     */
+    'security-profile': Dictionary<string, string>
+    /**
+     * Settings for the index used to store tokens.
+     */
+    'security-tokens': SecuritySettings
+  }
+}
+
+export class SecuritySettings {
+  index?: IndexSettings
 }

--- a/specification/security/update_settings/SecurityUpdateSettingsRequest.ts
+++ b/specification/security/update_settings/SecurityUpdateSettingsRequest.ts
@@ -48,7 +48,7 @@ export interface Request extends RequestBase {
     /**
      * Settings for the index used for most security configuration, including native realm users and roles configured with the API.
      */
-    security?: Dictionary<string, string>
+    security?: SecuritySettings
     /**
      * Settings for the index used to store profile information.
      */

--- a/specification/security/update_settings/SecurityUpdateSettingsRequest.ts
+++ b/specification/security/update_settings/SecurityUpdateSettingsRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Dictionary } from '@spec_utils/Dictionary'
+import { SecuritySettings } from '@security/_types/SecuritySettings'
 import { RequestBase } from '@_types/Base'
 import { Duration } from '@_types/Time'
 

--- a/specification/security/update_settings/SecurityUpdateSettingsRequest.ts
+++ b/specification/security/update_settings/SecurityUpdateSettingsRequest.ts
@@ -52,7 +52,7 @@ export interface Request extends RequestBase {
     /**
      * Settings for the index used to store profile information.
      */
-    'security-profile'?: Dictionary<string, string>
+    'security-profile'?: SecuritySettings
     /**
      * Settings for the index used to store tokens.
      */

--- a/specification/security/update_settings/SecurityUpdateSettingsRequest.ts
+++ b/specification/security/update_settings/SecurityUpdateSettingsRequest.ts
@@ -56,6 +56,6 @@ export interface Request extends RequestBase {
     /**
      * Settings for the index used to store tokens.
      */
-    'security-tokens'?: Dictionary<string, string>
+    'security-tokens'?: SecuritySettings
   }
 }

--- a/specification/security/update_settings/SecurityUpdateSettingsRequest.ts
+++ b/specification/security/update_settings/SecurityUpdateSettingsRequest.ts
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Dictionary } from '@spec_utils/Dictionary'
+import { RequestBase } from '@_types/Base'
+import { Duration } from '@_types/Time'
+
+/**
+ * Update security index settings.
+ * Update the user-configurable settings for the security internal index (`.security` and associated indices). Only a subset of settings are allowed to be modified, for example `index.auto_expand_replicas` and `index.number_of_replicas`.
+ *
+ * If a specific index is not in use on the system and settings are provided for it, the request will be rejected. This API does not yet support configuring the settings for indices before they are in use.
+ * @rest_spec_name security.update_settings
+ * @availability stack stability=stable visibility=public
+ * @cluster_privileges manage_security
+ * @doc_id security-api-update-settings
+ */
+export interface Request extends RequestBase {
+  query_parameters: {
+    /**
+     * The period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     */
+    master_timeout?: Duration
+    /**
+     * The period to wait for a response.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     */
+    timeout?: Duration
+  }
+  body: {
+    /**
+     * Settings for the index used for most security configuration, including native realm users and roles configured with the API.
+     */
+    security?: Dictionary<string, string>
+    /**
+     * Settings for the index used to store profile information.
+     */
+    'security-profile'?: Dictionary<string, string>
+    /**
+     * Settings for the index used to store tokens.
+     */
+    'security-tokens'?: Dictionary<string, string>
+  }
+}

--- a/specification/security/update_settings/SecurityUpdateSettingsResponse.ts
+++ b/specification/security/update_settings/SecurityUpdateSettingsResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class Response {
+  body: {
+    acknowledged: boolean
+  }
+}


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3377

This PR adds two missing specifications based on information in https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-update-settings.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-get-settings.html