### PR TITLE
Add security.bulk_update_api_keys

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -28313,6 +28313,82 @@
         "x-state": "Added in 8.15.0"
       }
     },
+    "/_security/api_key/_bulk_update": {
+      "post": {
+        "tags": [
+          "security"
+        ],
+        "summary": "Bulk update API keys",
+        "description": "Update the attributes for multiple API keys.\n\nIMPORTANT: It is not possible to use an API key as the authentication credential for this API. To update API keys, the owner user's credentials are required.\n\nThis API is similar to the update API key API but enables you to apply the same update to multiple API keys in one API call. This operation can greatly improve performance over making individual updates.\n\nIt is not possible to update expired or invalidated API keys.\n\nThis API supports updates to API key access scope, metadata and expiration.\nThe access scope of each API key is derived from the `role_descriptors` you specify in the request and a snapshot of the owner user's permissions at the time of the request.\nThe snapshot of the owner's permissions is updated automatically on every call.\n\nIMPORTANT: If you don't specify `role_descriptors` in the request, a call to this API might still change an API key's access scope. This change can occur if the owner user's permissions have changed since the API key was created or last modified.\n\nA successful request returns a JSON structure that contains the IDs of all updated API keys, the IDs of API keys that already had the requested changes and did not require an update, and error details for any failed update.",
+        "operationId": "security-bulk-update-api-keys",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "expiration": {
+                    "$ref": "#/components/schemas/_types:Duration"
+                  },
+                  "ids": {
+                    "description": "The API key identifiers.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "metadata": {
+                    "$ref": "#/components/schemas/_types:Metadata"
+                  },
+                  "role_descriptors": {
+                    "description": "The role descriptors to assign to the API keys.\nAn API key's effective permissions are an intersection of its assigned privileges and the point-in-time snapshot of permissions of the owner user.\nYou can assign new privileges by specifying them in this parameter.\nTo remove assigned privileges, supply the `role_descriptors` parameter as an empty object `{}`.\nIf an API key has no assigned privileges, it inherits the owner user's full permissions.\nThe snapshot of the owner's permissions is always updated, whether you supply the `role_descriptors` parameter.\nThe structure of a role descriptor is the same as the request for the create API keys API.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "$ref": "#/components/schemas/security._types:RoleDescriptor"
+                    }
+                  }
+                },
+                "required": [
+                  "ids"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "noops": {
+                      "type": "array",
+                      "items": {
+                        "type": "number"
+                      }
+                    },
+                    "updated": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "noops",
+                    "updated"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-state": "Added in 8.5.0"
+      }
+    },
     "/_security/user/{username}/_password": {
       "put": {
         "tags": [

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -652,12 +652,6 @@
       ],
       "response": []
     },
-    "security.bulk_update_api_keys": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "security.get_settings": {
       "request": [
         "Missing request & response"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -18129,6 +18129,20 @@ export interface SecurityBulkPutRoleResponse {
   errors?: SecurityBulkError
 }
 
+export interface SecurityBulkUpdateApiKeysRequest extends RequestBase {
+  body?: {
+    expiration?: Duration
+    ids: string[]
+    metadata?: Metadata
+    role_descriptors?: Record<string, SecurityRoleDescriptor>
+  }
+}
+
+export interface SecurityBulkUpdateApiKeysResponse {
+  noops: integer[]
+  updated: string[]
+}
+
 export interface SecurityChangePasswordRequest extends RequestBase {
   username?: Username
   refresh?: Refresh

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -560,6 +560,7 @@ searchable-snapshots-apis,https://www.elastic.co/guide/en/elasticsearch/referenc
 search-templates,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-template.html
 secure-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/secure-settings.html
 security-api-authenticate,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-authenticate.html
+security-api-bulk-update-key,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-bulk-update-api-keys.html
 security-api-change-password,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-change-password.html
 security-api-clear-api-key-cache,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-clear-api-key-cache.html
 security-api-clear-cache,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-clear-cache.html

--- a/specification/security/bulk_update_api_keys/SecurityBulkUpdateApiKeysRequest.ts
+++ b/specification/security/bulk_update_api_keys/SecurityBulkUpdateApiKeysRequest.ts
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RoleDescriptor } from '@security/_types/RoleDescriptor'
+import { Dictionary } from '@spec_utils/Dictionary'
+import { RequestBase } from '@_types/Base'
+import { Metadata } from '@_types/common'
+import { Duration } from '@_types/Time'
+
+/**
+ * Bulk update API keys.
+ * Update the attributes for multiple API keys.
+ *
+ * IMPORTANT: It is not possible to use an API key as the authentication credential for this API. To update API keys, the owner user's credentials are required.
+ *
+ * This API is similar to the update API key API but enables you to apply the same update to multiple API keys in one API call. This operation can greatly improve performance over making individual updates.
+ *
+ * It is not possible to update expired or invalidated API keys.
+ *
+ * This API supports updates to API key access scope, metadata and expiration.
+ * The access scope of each API key is derived from the `role_descriptors` you specify in the request and a snapshot of the owner user's permissions at the time of the request.
+ * The snapshot of the owner's permissions is updated automatically on every call.
+ *
+ * IMPORTANT: If you don't specify `role_descriptors` in the request, a call to this API might still change an API key's access scope. This change can occur if the owner user's permissions have changed since the API key was created or last modified.
+ *
+ * A successful request returns a JSON structure that contains the IDs of all updated API keys, the IDs of API keys that already had the requested changes and did not require an update, and error details for any failed update.
+ * @rest_spec_name security.bulk_update_api_keys
+ * @availability stack since=8.5.0 stability=stable visibility=public
+ * @doc_id security-api-bulk-update-key
+ * @cluster_privileges manage_own_api_key
+ */
+export interface Request extends RequestBase {
+  body: {
+    /**
+     * Expiration time for the API keys.
+     * By default, API keys never expire.
+     * This property can be omitted to leave the value unchanged.
+     */
+    expiration?: Duration
+    /**
+     * The API key identifiers.
+     */
+    ids: string[]
+    /**
+     * Arbitrary nested metadata to associate with the API keys.
+     * Within the `metadata` object, top-level keys beginning with an underscore (`_`) are reserved for system usage.
+     * Any information specified with this parameter fully replaces metadata previously associated with the API key.
+     */
+    metadata?: Metadata
+    /**
+     * The role descriptors to assign to the API keys.
+     * An API key's effective permissions are an intersection of its assigned privileges and the point-in-time snapshot of permissions of the owner user.
+     * You can assign new privileges by specifying them in this parameter.
+     * To remove assigned privileges, supply the `role_descriptors` parameter as an empty object `{}`.
+     * If an API key has no assigned privileges, it inherits the owner user's full permissions.
+     * The snapshot of the owner's permissions is always updated, whether you supply the `role_descriptors` parameter.
+     * The structure of a role descriptor is the same as the request for the create API keys API.
+     */
+    role_descriptors?: Dictionary<string, RoleDescriptor>
+  }
+}

--- a/specification/security/bulk_update_api_keys/SecurityBulkUpdateApiKeysResponse.ts
+++ b/specification/security/bulk_update_api_keys/SecurityBulkUpdateApiKeysResponse.ts
@@ -1,0 +1,27 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { integer } from '@_types/Numeric'
+
+export class Response {
+  body: {
+    noops: Array<integer>
+    updated: Array<string>
+  }
+}


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/3377

This PR adds a missing specification based on https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-bulk-update-api-keys.html