### PR TITLE
Add passthrough mapping type

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -60442,6 +60442,9 @@
             "$ref": "#/components/schemas/_types.mapping:ObjectProperty"
           },
           {
+            "$ref": "#/components/schemas/_types.mapping:PassthroughObjectProperty"
+          },
+          {
             "$ref": "#/components/schemas/_types.mapping:SemanticTextProperty"
           },
           {
@@ -61527,6 +61530,33 @@
                 "enum": [
                   "object"
                 ]
+              }
+            }
+          }
+        ]
+      },
+      "_types.mapping:PassthroughObjectProperty": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/_types.mapping:CorePropertyBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "passthrough"
+                ]
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "priority": {
+                "type": "number"
+              },
+              "time_series_dimension": {
+                "type": "boolean"
               }
             }
           }

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -40637,6 +40637,9 @@
             "$ref": "#/components/schemas/_types.mapping:ObjectProperty"
           },
           {
+            "$ref": "#/components/schemas/_types.mapping:PassthroughObjectProperty"
+          },
+          {
             "$ref": "#/components/schemas/_types.mapping:SemanticTextProperty"
           },
           {
@@ -41722,6 +41725,33 @@
                 "enum": [
                   "object"
                 ]
+              }
+            }
+          }
+        ]
+      },
+      "_types.mapping:PassthroughObjectProperty": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/_types.mapping:CorePropertyBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "passthrough"
+                ]
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "priority": {
+                "type": "number"
+              },
+              "time_series_dimension": {
+                "type": "boolean"
               }
             }
           }

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -52801,6 +52801,9 @@
           "name": "object"
         },
         {
+          "name": "passthrough"
+        },
+        {
           "name": "version"
         },
         {
@@ -52901,7 +52904,7 @@
         "name": "FieldType",
         "namespace": "_types.mapping"
       },
-      "specLocation": "_types/mapping/Property.ts#L166-L213"
+      "specLocation": "_types/mapping/Property.ts#L168-L216"
     },
     {
       "kind": "enum",
@@ -86553,7 +86556,7 @@
         "name": "Property",
         "namespace": "_types.mapping"
       },
-      "specLocation": "_types/mapping/Property.ts#L96-L164",
+      "specLocation": "_types/mapping/Property.ts#L97-L166",
       "type": {
         "items": [
           {
@@ -86693,6 +86696,13 @@
             "kind": "instance_of",
             "type": {
               "name": "ObjectProperty",
+              "namespace": "_types.mapping"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "PassthroughObjectProperty",
               "namespace": "_types.mapping"
             }
           },
@@ -87097,7 +87107,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/Property.ts#L84-L94"
+      "specLocation": "_types/mapping/Property.ts#L85-L95"
     },
     {
       "inherits": {
@@ -88710,7 +88720,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/complex.ts#L51-L56"
+      "specLocation": "_types/mapping/complex.ts#L59-L64"
     },
     {
       "inherits": {
@@ -88979,7 +88989,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/complex.ts#L25-L36"
+      "specLocation": "_types/mapping/complex.ts#L26-L37"
     },
     {
       "inherits": {
@@ -89036,7 +89046,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/complex.ts#L38-L43"
+      "specLocation": "_types/mapping/complex.ts#L39-L44"
     },
     {
       "inherits": {
@@ -89082,7 +89092,64 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/complex.ts#L45-L49"
+      "specLocation": "_types/mapping/complex.ts#L46-L50"
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "CorePropertyBase",
+          "namespace": "_types.mapping"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "PassthroughObjectProperty",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": false,
+          "type": {
+            "kind": "literal_value",
+            "value": "passthrough"
+          }
+        },
+        {
+          "name": "enabled",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "name": "priority",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "time_series_dimension",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        }
+      ],
+      "specLocation": "_types/mapping/complex.ts#L52-L57"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5525,7 +5525,7 @@ export interface MappingFieldNamesField {
   enabled: boolean
 }
 
-export type MappingFieldType = 'none' | 'geo_point' | 'geo_shape' | 'ip' | 'binary' | 'keyword' | 'text' | 'search_as_you_type' | 'date' | 'date_nanos' | 'boolean' | 'completion' | 'nested' | 'object' | 'version' | 'murmur3' | 'token_count' | 'percolator' | 'integer' | 'long' | 'short' | 'byte' | 'float' | 'half_float' | 'scaled_float' | 'double' | 'integer_range' | 'float_range' | 'long_range' | 'double_range' | 'date_range' | 'ip_range' | 'alias' | 'join' | 'rank_feature' | 'rank_features' | 'flattened' | 'shape' | 'histogram' | 'constant_keyword' | 'aggregate_metric_double' | 'dense_vector' | 'semantic_text' | 'sparse_vector' | 'match_only_text' | 'icu_collation_keyword'
+export type MappingFieldType = 'none' | 'geo_point' | 'geo_shape' | 'ip' | 'binary' | 'keyword' | 'text' | 'search_as_you_type' | 'date' | 'date_nanos' | 'boolean' | 'completion' | 'nested' | 'object' | 'passthrough' | 'version' | 'murmur3' | 'token_count' | 'percolator' | 'integer' | 'long' | 'short' | 'byte' | 'float' | 'half_float' | 'scaled_float' | 'double' | 'integer_range' | 'float_range' | 'long_range' | 'double_range' | 'date_range' | 'ip_range' | 'alias' | 'join' | 'rank_feature' | 'rank_features' | 'flattened' | 'shape' | 'histogram' | 'constant_keyword' | 'aggregate_metric_double' | 'dense_vector' | 'semantic_text' | 'sparse_vector' | 'match_only_text' | 'icu_collation_keyword'
 
 export interface MappingFlattenedProperty extends MappingPropertyBase {
   boost?: double
@@ -5702,6 +5702,13 @@ export interface MappingObjectProperty extends MappingCorePropertyBase {
 
 export type MappingOnScriptError = 'fail' | 'continue'
 
+export interface MappingPassthroughObjectProperty extends MappingCorePropertyBase {
+  type?: 'passthrough'
+  enabled?: boolean
+  priority?: integer
+  time_series_dimension?: boolean
+}
+
 export interface MappingPercolatorProperty extends MappingPropertyBase {
   type: 'percolator'
 }
@@ -5713,7 +5720,7 @@ export interface MappingPointProperty extends MappingDocValuesPropertyBase {
   type: 'point'
 }
 
-export type MappingProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDynamicProperty | MappingJoinProperty | MappingKeywordProperty | MappingMatchOnlyTextProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingSearchAsYouTypeProperty | MappingTextProperty | MappingVersionProperty | MappingWildcardProperty | MappingDateNanosProperty | MappingDateProperty | MappingAggregateMetricDoubleProperty | MappingDenseVectorProperty | MappingFlattenedProperty | MappingNestedProperty | MappingObjectProperty | MappingSemanticTextProperty | MappingSparseVectorProperty | MappingCompletionProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingTokenCountProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingPointProperty | MappingShapeProperty | MappingByteNumberProperty | MappingDoubleNumberProperty | MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingScaledFloatNumberProperty | MappingShortNumberProperty | MappingUnsignedLongNumberProperty | MappingDateRangeProperty | MappingDoubleRangeProperty | MappingFloatRangeProperty | MappingIntegerRangeProperty | MappingIpRangeProperty | MappingLongRangeProperty | MappingIcuCollationProperty
+export type MappingProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDynamicProperty | MappingJoinProperty | MappingKeywordProperty | MappingMatchOnlyTextProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingSearchAsYouTypeProperty | MappingTextProperty | MappingVersionProperty | MappingWildcardProperty | MappingDateNanosProperty | MappingDateProperty | MappingAggregateMetricDoubleProperty | MappingDenseVectorProperty | MappingFlattenedProperty | MappingNestedProperty | MappingObjectProperty | MappingPassthroughObjectProperty | MappingSemanticTextProperty | MappingSparseVectorProperty | MappingCompletionProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingTokenCountProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingPointProperty | MappingShapeProperty | MappingByteNumberProperty | MappingDoubleNumberProperty | MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingScaledFloatNumberProperty | MappingShortNumberProperty | MappingUnsignedLongNumberProperty | MappingDateRangeProperty | MappingDoubleRangeProperty | MappingFloatRangeProperty | MappingIntegerRangeProperty | MappingIpRangeProperty | MappingLongRangeProperty | MappingIcuCollationProperty
 
 export interface MappingPropertyBase {
   meta?: Record<string, string>

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -38,7 +38,8 @@ import {
   AggregateMetricDoubleProperty,
   FlattenedProperty,
   NestedProperty,
-  ObjectProperty
+  ObjectProperty,
+  PassthroughObjectProperty
 } from './complex'
 import {
   BinaryProperty,
@@ -123,6 +124,7 @@ export type Property =
   | FlattenedProperty
   | NestedProperty
   | ObjectProperty
+  | PassthroughObjectProperty
   | SemanticTextProperty
   | SparseVectorProperty
 
@@ -178,6 +180,7 @@ export enum FieldType {
   completion,
   nested,
   object,
+  passthrough,
   version,
   murmur3,
   token_count,

--- a/specification/_types/mapping/complex.ts
+++ b/specification/_types/mapping/complex.ts
@@ -48,6 +48,13 @@ export class ObjectProperty extends CorePropertyBase {
   type?: 'object'
 }
 
+export class PassthroughObjectProperty extends CorePropertyBase {
+  type?: 'passthrough'
+  enabled?: boolean
+  priority?: integer
+  time_series_dimension?: boolean
+}
+
 export class AggregateMetricDoubleProperty extends PropertyBase {
   type: 'aggregate_metric_double'
   default_metric: string


### PR DESCRIPTION
It was added in 8.13, and made visible in our tests by an unrelated `get_document_template` YAML test: https://github.com/elastic/elasticsearch/compare/c662aecac3bbef1abcfb801a6a0b8326c3dfba0d...43e6fad99cfa6010f620ad2c39db93ea724a18f6. (Which means this can be tested with `make api=cluster.get_component_template branch=main`.)