### PR TITLE
[8.x] Add passthrough mapping type (#3404)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -60472,6 +60472,9 @@
             "$ref": "#/components/schemas/_types.mapping:ObjectProperty"
           },
           {
+            "$ref": "#/components/schemas/_types.mapping:PassthroughObjectProperty"
+          },
+          {
             "$ref": "#/components/schemas/_types.mapping:SemanticTextProperty"
           },
           {
@@ -61385,20 +61388,22 @@
                   "dense_vector"
                 ]
               },
-              "element_type": {
-                "type": "string"
-              },
               "dims": {
+                "description": "Number of vector dimensions. Can't exceed `4096`. If `dims` is not specified, it will be set to the length of\nthe first vector added to the field.",
                 "type": "number"
               },
-              "similarity": {
-                "type": "string"
+              "element_type": {
+                "$ref": "#/components/schemas/_types.mapping:DenseVectorElementType"
               },
               "index": {
+                "description": "If `true`, you can search this field using the kNN search API.",
                 "type": "boolean"
               },
               "index_options": {
                 "$ref": "#/components/schemas/_types.mapping:DenseVectorIndexOptions"
+              },
+              "similarity": {
+                "$ref": "#/components/schemas/_types.mapping:DenseVectorSimilarity"
               }
             },
             "required": [
@@ -61407,24 +61412,55 @@
           }
         ]
       },
+      "_types.mapping:DenseVectorElementType": {
+        "type": "string",
+        "enum": [
+          "bit",
+          "byte",
+          "float"
+        ]
+      },
       "_types.mapping:DenseVectorIndexOptions": {
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string"
-          },
-          "m": {
+          "confidence_interval": {
+            "description": "The confidence interval to use when quantizing the vectors. Can be any value between and including `0.90` and\n`1.0` or exactly `0`. When the value is `0`, this indicates that dynamic quantiles should be calculated for\noptimized quantization. When between `0.90` and `1.0`, this value restricts the values used when calculating\nthe quantization thresholds.\n\nFor example, a value of `0.95` will only use the middle `95%` of the values when calculating the quantization\nthresholds (e.g. the highest and lowest `2.5%` of values will be ignored).\n\nDefaults to `1/(dims + 1)` for `int8` quantized vectors and `0` for `int4` for dynamic quantile calculation.\n\nOnly applicable to `int8_hnsw`, `int4_hnsw`, `int8_flat`, and `int4_flat` index types.",
             "type": "number"
           },
           "ef_construction": {
+            "description": "The number of candidates to track while assembling the list of nearest neighbors for each new node.\n\nOnly applicable to `hnsw`, `int8_hnsw`, and `int4_hnsw` index types.",
             "type": "number"
           },
-          "confidence_interval": {
+          "m": {
+            "description": "The number of neighbors each node will be connected to in the HNSW graph.\n\nOnly applicable to `hnsw`, `int8_hnsw`, and `int4_hnsw` index types.",
             "type": "number"
+          },
+          "type": {
+            "$ref": "#/components/schemas/_types.mapping:DenseVectorIndexOptionsType"
           }
         },
         "required": [
           "type"
+        ]
+      },
+      "_types.mapping:DenseVectorIndexOptionsType": {
+        "type": "string",
+        "enum": [
+          "flat",
+          "hnsw",
+          "int4_flat",
+          "int4_hnsw",
+          "int8_flat",
+          "int8_hnsw"
+        ]
+      },
+      "_types.mapping:DenseVectorSimilarity": {
+        "type": "string",
+        "enum": [
+          "cosine",
+          "dot_product",
+          "l2_norm",
+          "max_inner_product"
         ]
       },
       "_types.mapping:FlattenedProperty": {
@@ -61524,6 +61560,33 @@
                 "enum": [
                   "object"
                 ]
+              }
+            }
+          }
+        ]
+      },
+      "_types.mapping:PassthroughObjectProperty": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/_types.mapping:CorePropertyBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "passthrough"
+                ]
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "priority": {
+                "type": "number"
+              },
+              "time_series_dimension": {
+                "type": "boolean"
               }
             }
           }

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -40717,6 +40717,9 @@
             "$ref": "#/components/schemas/_types.mapping:ObjectProperty"
           },
           {
+            "$ref": "#/components/schemas/_types.mapping:PassthroughObjectProperty"
+          },
+          {
             "$ref": "#/components/schemas/_types.mapping:SemanticTextProperty"
           },
           {
@@ -41630,20 +41633,22 @@
                   "dense_vector"
                 ]
               },
-              "element_type": {
-                "type": "string"
-              },
               "dims": {
+                "description": "Number of vector dimensions. Can't exceed `4096`. If `dims` is not specified, it will be set to the length of\nthe first vector added to the field.",
                 "type": "number"
               },
-              "similarity": {
-                "type": "string"
+              "element_type": {
+                "$ref": "#/components/schemas/_types.mapping:DenseVectorElementType"
               },
               "index": {
+                "description": "If `true`, you can search this field using the kNN search API.",
                 "type": "boolean"
               },
               "index_options": {
                 "$ref": "#/components/schemas/_types.mapping:DenseVectorIndexOptions"
+              },
+              "similarity": {
+                "$ref": "#/components/schemas/_types.mapping:DenseVectorSimilarity"
               }
             },
             "required": [
@@ -41652,24 +41657,55 @@
           }
         ]
       },
+      "_types.mapping:DenseVectorElementType": {
+        "type": "string",
+        "enum": [
+          "bit",
+          "byte",
+          "float"
+        ]
+      },
       "_types.mapping:DenseVectorIndexOptions": {
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string"
-          },
-          "m": {
+          "confidence_interval": {
+            "description": "The confidence interval to use when quantizing the vectors. Can be any value between and including `0.90` and\n`1.0` or exactly `0`. When the value is `0`, this indicates that dynamic quantiles should be calculated for\noptimized quantization. When between `0.90` and `1.0`, this value restricts the values used when calculating\nthe quantization thresholds.\n\nFor example, a value of `0.95` will only use the middle `95%` of the values when calculating the quantization\nthresholds (e.g. the highest and lowest `2.5%` of values will be ignored).\n\nDefaults to `1/(dims + 1)` for `int8` quantized vectors and `0` for `int4` for dynamic quantile calculation.\n\nOnly applicable to `int8_hnsw`, `int4_hnsw`, `int8_flat`, and `int4_flat` index types.",
             "type": "number"
           },
           "ef_construction": {
+            "description": "The number of candidates to track while assembling the list of nearest neighbors for each new node.\n\nOnly applicable to `hnsw`, `int8_hnsw`, and `int4_hnsw` index types.",
             "type": "number"
           },
-          "confidence_interval": {
+          "m": {
+            "description": "The number of neighbors each node will be connected to in the HNSW graph.\n\nOnly applicable to `hnsw`, `int8_hnsw`, and `int4_hnsw` index types.",
             "type": "number"
+          },
+          "type": {
+            "$ref": "#/components/schemas/_types.mapping:DenseVectorIndexOptionsType"
           }
         },
         "required": [
           "type"
+        ]
+      },
+      "_types.mapping:DenseVectorIndexOptionsType": {
+        "type": "string",
+        "enum": [
+          "flat",
+          "hnsw",
+          "int4_flat",
+          "int4_hnsw",
+          "int8_flat",
+          "int8_hnsw"
+        ]
+      },
+      "_types.mapping:DenseVectorSimilarity": {
+        "type": "string",
+        "enum": [
+          "cosine",
+          "dot_product",
+          "l2_norm",
+          "max_inner_product"
         ]
       },
       "_types.mapping:FlattenedProperty": {
@@ -41769,6 +41805,33 @@
                 "enum": [
                   "object"
                 ]
+              }
+            }
+          }
+        ]
+      },
+      "_types.mapping:PassthroughObjectProperty": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/_types.mapping:CorePropertyBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "passthrough"
+                ]
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "priority": {
+                "type": "number"
+              },
+              "time_series_dimension": {
+                "type": "boolean"
               }
             }
           }

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -3149,6 +3149,7 @@
         }
       },
       "description": "Delete data streams.\nDeletes one or more data streams and their backing indices.",
+      "docTag": "data stream",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
       "name": "indices.delete_data_stream",
       "privileges": {
@@ -3338,6 +3339,7 @@
         }
       },
       "description": "Get the status for a data stream lifecycle.\nGet information about an index or data stream's current data stream lifecycle status, such as time since index creation, time since rollover, the lifecycle configuration managing the index, or any errors encountered during lifecycle execution.",
+      "docTag": "data stream",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams-explain-lifecycle.html",
       "name": "indices.explain_data_lifecycle",
       "request": {
@@ -3819,6 +3821,7 @@
         }
       },
       "description": "Update data stream lifecycles.\nUpdate the data stream lifecycle of the specified data streams.",
+      "docTag": "data stream",
       "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams-put-lifecycle.html",
       "name": "indices.put_data_lifecycle",
       "request": {
@@ -20970,7 +20973,7 @@
           }
         }
       ],
-      "specLocation": "indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts#L24-L51"
+      "specLocation": "indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts#L24-L52"
     },
     {
       "body": {
@@ -21433,7 +21436,7 @@
           }
         }
       ],
-      "specLocation": "indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts#L24-L39"
+      "specLocation": "indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts#L24-L40"
     },
     {
       "body": {
@@ -22858,7 +22861,7 @@
           }
         }
       ],
-      "specLocation": "indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts#L25-L76"
+      "specLocation": "indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts#L25-L77"
     },
     {
       "body": {
@@ -52982,6 +52985,9 @@
           "name": "object"
         },
         {
+          "name": "passthrough"
+        },
+        {
           "name": "version"
         },
         {
@@ -53082,7 +53088,7 @@
         "name": "FieldType",
         "namespace": "_types.mapping"
       },
-      "specLocation": "_types/mapping/Property.ts#L166-L213"
+      "specLocation": "_types/mapping/Property.ts#L168-L216"
     },
     {
       "kind": "enum",
@@ -86528,6 +86534,88 @@
       "specLocation": "_types/analysis/nori-plugin.ts#L28-L34"
     },
     {
+      "kind": "enum",
+      "members": [
+        {
+          "description": "Indexes a single bit per dimension. Useful for very high-dimensional vectors or models that specifically support\nbit vectors.\n\nNOTE: when using `bit`, the number of dimensions must be a multiple of `8` and must represent the number of bits.",
+          "name": "bit"
+        },
+        {
+          "description": "Indexes a 1-byte integer value per dimension.",
+          "name": "byte"
+        },
+        {
+          "description": "Indexes a 4-byte floating-point value per dimension.",
+          "name": "float"
+        }
+      ],
+      "name": {
+        "name": "DenseVectorElementType",
+        "namespace": "_types.mapping"
+      },
+      "specLocation": "_types/mapping/DenseVectorProperty.ts#L64-L80"
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "description": "This utilizes a brute-force search algorithm for exact kNN search. This supports all `element_type` values.",
+          "name": "flat"
+        },
+        {
+          "description": "This utilizes the HNSW algorithm for scalable approximate kNN search. This supports all `element_type` values.",
+          "name": "hnsw"
+        },
+        {
+          "description": "This utilizes a brute-force search algorithm in addition to automatically half-byte scalar quantization.\nOnly supports `element_type` of `float`.",
+          "name": "int4_flat"
+        },
+        {
+          "description": "This utilizes the HNSW algorithm in addition to automatically scalar quantization for scalable approximate kNN\nsearch with `element_type` of `float`.\n\nThis can reduce the memory footprint by 8x at the cost of some accuracy.",
+          "name": "int4_hnsw"
+        },
+        {
+          "description": "This utilizes a brute-force search algorithm in addition to automatically scalar quantization. Only supports\n`element_type` of `float`.",
+          "name": "int8_flat"
+        },
+        {
+          "description": "The default index type for `float` vectors. This utilizes the HNSW algorithm in addition to automatically scalar\nquantization for scalable approximate kNN search with `element_type` of `float`.\n\nThis can reduce the memory footprint by 4x at the cost of some accuracy.",
+          "name": "int8_hnsw"
+        }
+      ],
+      "name": {
+        "name": "DenseVectorIndexOptionsType",
+        "namespace": "_types.mapping"
+      },
+      "specLocation": "_types/mapping/DenseVectorProperty.ts#L164-L197"
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "description": "Computes the cosine similarity. During indexing Elasticsearch automatically normalizes vectors with `cosine`\nsimilarity to unit length. This allows to internally use `dot_product` for computing similarity, which is more\nefficient. Original un-normalized vectors can be still accessed through scripts.\n\nThe document `_score` is computed as `(1 + cosine(query, vector)) / 2`.\n\nThe `cosine` similarity does not allow vectors with zero magnitude, since cosine is not defined in this case.",
+          "name": "cosine"
+        },
+        {
+          "description": "Computes the dot product of two unit vectors. This option provides an optimized way to perform cosine similarity.\nThe constraints and computed score are defined by `element_type`.\n\nWhen `element_type` is `float`, all vectors must be unit length, including both document and query vectors.\n\nThe document `_score` is computed as `(1 + dot_product(query, vector)) / 2`.\n\nWhen `element_type` is `byte`, all vectors must have the same length including both document and query vectors or\nresults will be inaccurate.\n\nThe document `_score` is computed as `0.5 + (dot_product(query, vector) / (32768 * dims))` where `dims` is the\nnumber of dimensions per vector.",
+          "name": "dot_product"
+        },
+        {
+          "description": "Computes similarity based on the `L2` distance (also known as Euclidean distance) between the vectors.\n\nThe document `_score` is computed as `1 / (1 + l2_norm(query, vector)^2)`.\n\nFor `bit` vectors, instead of using `l2_norm`, the `hamming` distance between the vectors is used.\n\nThe `_score` transformation is `(numBits - hamming(a, b)) / numBits`.",
+          "name": "l2_norm"
+        },
+        {
+          "description": "Computes the maximum inner product of two vectors. This is similar to `dot_product`, but doesn't require vectors\nto be normalized. This means that each vector’s magnitude can significantly effect the score.\n\nThe document `_score` is adjusted to prevent negative values. For `max_inner_product` values `< 0`, the `_score`\nis `1 / (1 + -1 * max_inner_product(query, vector))`. For non-negative `max_inner_product` results the `_score`\nis calculated `max_inner_product(query, vector) + 1`.",
+          "name": "max_inner_product"
+        }
+      ],
+      "name": {
+        "name": "DenseVectorSimilarity",
+        "namespace": "_types.mapping"
+      },
+      "specLocation": "_types/mapping/DenseVectorProperty.ts#L82-L127"
+    },
+    {
       "esQuirk": "This is a boolean that evolved into an enum. Boolean values should be accepted on reading, and\ntrue and false must be serialized as JSON booleans, or it may break Kibana (see elasticsearch-java#139)",
       "kind": "enum",
       "members": [
@@ -86652,7 +86740,7 @@
         "name": "Property",
         "namespace": "_types.mapping"
       },
-      "specLocation": "_types/mapping/Property.ts#L96-L164",
+      "specLocation": "_types/mapping/Property.ts#L97-L166",
       "type": {
         "items": [
           {
@@ -86792,6 +86880,13 @@
             "kind": "instance_of",
             "type": {
               "name": "ObjectProperty",
+              "namespace": "_types.mapping"
+            }
+          },
+          {
+            "kind": "instance_of",
+            "type": {
+              "name": "PassthroughObjectProperty",
               "namespace": "_types.mapping"
             }
           },
@@ -87196,7 +87291,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/Property.ts#L84-L94"
+      "specLocation": "_types/mapping/Property.ts#L85-L95"
     },
     {
       "inherits": {
@@ -88809,7 +88904,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/complex.ts#L61-L66"
+      "specLocation": "_types/mapping/complex.ts#L58-L63"
     },
     {
       "inherits": {
@@ -88833,17 +88928,7 @@
           }
         },
         {
-          "name": "element_type",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
+          "description": "Number of vector dimensions. Can't exceed `4096`. If `dims` is not specified, it will be set to the length of\nthe first vector added to the field.",
           "name": "dims",
           "required": false,
           "type": {
@@ -88855,19 +88940,23 @@
           }
         },
         {
-          "name": "similarity",
+          "description": "The data type used to encode vectors. The supported data types are `float` (default), `byte`, and `bit`.",
+          "name": "element_type",
           "required": false,
+          "serverDefault": "float",
           "type": {
             "kind": "instance_of",
             "type": {
-              "name": "string",
-              "namespace": "_builtins"
+              "name": "DenseVectorElementType",
+              "namespace": "_types.mapping"
             }
           }
         },
         {
+          "description": "If `true`, you can search this field using the kNN search API.",
           "name": "index",
           "required": false,
+          "serverDefault": true,
           "type": {
             "kind": "instance_of",
             "type": {
@@ -88877,6 +88966,7 @@
           }
         },
         {
+          "description": "An optional section that configures the kNN indexing algorithm. The HNSW algorithm has two internal parameters\nthat influence how the data structure is built. These can be adjusted to improve the accuracy of results, at the\nexpense of slower indexing speed.\n\nThis parameter can only be specified when `index` is `true`.",
           "name": "index_options",
           "required": false,
           "type": {
@@ -88886,9 +88976,21 @@
               "namespace": "_types.mapping"
             }
           }
+        },
+        {
+          "description": "The vector similarity metric to use in kNN search.\n\nDocuments are ranked by their vector field's similarity to the query vector. The `_score` of each document will\nbe derived from the similarity, in a way that ensures scores are positive and that a larger score corresponds\nto a higher ranking.\n\nDefaults to `l2_norm` when `element_type` is `bit` otherwise defaults to `cosine`.\n\n`bit` vectors only support `l2_norm` as their similarity metric.\n\nThis parameter can only be specified when `index` is `true`.",
+          "name": "similarity",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DenseVectorSimilarity",
+              "namespace": "_types.mapping"
+            }
+          }
         }
       ],
-      "specLocation": "_types/mapping/complex.ts#L52-L59"
+      "specLocation": "_types/mapping/DenseVectorProperty.ts#L23-L62"
     },
     {
       "kind": "interface",
@@ -88898,39 +89000,7 @@
       },
       "properties": [
         {
-          "name": "type",
-          "required": true,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "string",
-              "namespace": "_builtins"
-            }
-          }
-        },
-        {
-          "name": "m",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
-          "name": "ef_construction",
-          "required": false,
-          "type": {
-            "kind": "instance_of",
-            "type": {
-              "name": "integer",
-              "namespace": "_types"
-            }
-          }
-        },
-        {
+          "description": "The confidence interval to use when quantizing the vectors. Can be any value between and including `0.90` and\n`1.0` or exactly `0`. When the value is `0`, this indicates that dynamic quantiles should be calculated for\noptimized quantization. When between `0.90` and `1.0`, this value restricts the values used when calculating\nthe quantization thresholds.\n\nFor example, a value of `0.95` will only use the middle `95%` of the values when calculating the quantization\nthresholds (e.g. the highest and lowest `2.5%` of values will be ignored).\n\nDefaults to `1/(dims + 1)` for `int8` quantized vectors and `0` for `int4` for dynamic quantile calculation.\n\nOnly applicable to `int8_hnsw`, `int4_hnsw`, `int8_flat`, and `int4_flat` index types.",
           "name": "confidence_interval",
           "required": false,
           "type": {
@@ -88940,9 +89010,47 @@
               "namespace": "_types"
             }
           }
+        },
+        {
+          "description": "The number of candidates to track while assembling the list of nearest neighbors for each new node.\n\nOnly applicable to `hnsw`, `int8_hnsw`, and `int4_hnsw` index types.",
+          "name": "ef_construction",
+          "required": false,
+          "serverDefault": 100,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The number of neighbors each node will be connected to in the HNSW graph.\n\nOnly applicable to `hnsw`, `int8_hnsw`, and `int4_hnsw` index types.",
+          "name": "m",
+          "required": false,
+          "serverDefault": 16,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "description": "The type of kNN algorithm to use.",
+          "name": "type",
+          "required": true,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "DenseVectorIndexOptionsType",
+              "namespace": "_types.mapping"
+            }
+          }
         }
       ],
-      "specLocation": "_types/mapping/DenseVectorIndexOptions.ts#L22-L27"
+      "specLocation": "_types/mapping/DenseVectorProperty.ts#L129-L162"
     },
     {
       "inherits": {
@@ -89065,7 +89173,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/complex.ts#L26-L37"
+      "specLocation": "_types/mapping/complex.ts#L25-L36"
     },
     {
       "inherits": {
@@ -89122,7 +89230,7 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/complex.ts#L39-L44"
+      "specLocation": "_types/mapping/complex.ts#L38-L43"
     },
     {
       "inherits": {
@@ -89168,7 +89276,64 @@
           }
         }
       ],
-      "specLocation": "_types/mapping/complex.ts#L46-L50"
+      "specLocation": "_types/mapping/complex.ts#L45-L49"
+    },
+    {
+      "inherits": {
+        "type": {
+          "name": "CorePropertyBase",
+          "namespace": "_types.mapping"
+        }
+      },
+      "kind": "interface",
+      "name": {
+        "name": "PassthroughObjectProperty",
+        "namespace": "_types.mapping"
+      },
+      "properties": [
+        {
+          "name": "type",
+          "required": false,
+          "type": {
+            "kind": "literal_value",
+            "value": "passthrough"
+          }
+        },
+        {
+          "name": "enabled",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        },
+        {
+          "name": "priority",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "integer",
+              "namespace": "_types"
+            }
+          }
+        },
+        {
+          "name": "time_series_dimension",
+          "required": false,
+          "type": {
+            "kind": "instance_of",
+            "type": {
+              "name": "boolean",
+              "namespace": "_builtins"
+            }
+          }
+        }
+      ],
+      "specLocation": "_types/mapping/complex.ts#L51-L56"
     },
     {
       "kind": "interface",
@@ -105260,6 +105425,44 @@
       "kind": "enum",
       "members": [
         {
+          "name": "disabled"
+        },
+        {
+          "name": "v1"
+        }
+      ],
+      "name": {
+        "name": "EcsCompatibilityType",
+        "namespace": "text_structure._types"
+      },
+      "specLocation": "text_structure/_types/Structure.ts#L40-L43"
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
+          "name": "delimited"
+        },
+        {
+          "name": "ndjson"
+        },
+        {
+          "name": "semi_structured_text"
+        },
+        {
+          "name": "xml"
+        }
+      ],
+      "name": {
+        "name": "FormatType",
+        "namespace": "text_structure._types"
+      },
+      "specLocation": "text_structure/_types/Structure.ts#L45-L50"
+    },
+    {
+      "kind": "enum",
+      "members": [
+        {
           "name": "awaits_successful_execution"
         },
         {
@@ -116416,7 +116619,7 @@
           }
         }
       ],
-      "specLocation": "connector/_types/Connector.ts#L237-L268"
+      "specLocation": "connector/_types/Connector.ts#L252-L283"
     },
     {
       "kind": "interface",
@@ -116426,6 +116629,7 @@
       },
       "properties": [
         {
+          "description": "Indicates whether document-level security is enabled.",
           "name": "document_level_security",
           "required": false,
           "type": {
@@ -116437,6 +116641,7 @@
           }
         },
         {
+          "description": "Indicates whether incremental syncs are enabled.",
           "name": "incremental_sync",
           "required": false,
           "type": {
@@ -116448,6 +116653,7 @@
           }
         },
         {
+          "description": "Indicates whether managed connector API keys are enabled.",
           "name": "native_connector_api_keys",
           "required": false,
           "type": {
@@ -116470,7 +116676,7 @@
           }
         }
       ],
-      "specLocation": "connector/_types/Connector.ts#L224-L229"
+      "specLocation": "connector/_types/Connector.ts#L230-L244"
     },
     {
       "kind": "interface",
@@ -116501,6 +116707,7 @@
       },
       "properties": [
         {
+          "description": "Indicates whether advanced sync rules are enabled.",
           "name": "advanced",
           "required": false,
           "type": {
@@ -116512,6 +116719,7 @@
           }
         },
         {
+          "description": "Indicates whether basic sync rules are enabled.",
           "name": "basic",
           "required": false,
           "type": {
@@ -116523,7 +116731,7 @@
           }
         }
       ],
-      "specLocation": "connector/_types/Connector.ts#L219-L222"
+      "specLocation": "connector/_types/Connector.ts#L219-L228"
     },
     {
       "kind": "interface",
@@ -116919,7 +117127,7 @@
           }
         }
       ],
-      "specLocation": "connector/_types/Connector.ts#L231-L235"
+      "specLocation": "connector/_types/Connector.ts#L246-L250"
     },
     {
       "kind": "interface",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5516,7 +5516,7 @@ export interface MappingFieldNamesField {
   enabled: boolean
 }
 
-export type MappingFieldType = 'none' | 'geo_point' | 'geo_shape' | 'ip' | 'binary' | 'keyword' | 'text' | 'search_as_you_type' | 'date' | 'date_nanos' | 'boolean' | 'completion' | 'nested' | 'object' | 'version' | 'murmur3' | 'token_count' | 'percolator' | 'integer' | 'long' | 'short' | 'byte' | 'float' | 'half_float' | 'scaled_float' | 'double' | 'integer_range' | 'float_range' | 'long_range' | 'double_range' | 'date_range' | 'ip_range' | 'alias' | 'join' | 'rank_feature' | 'rank_features' | 'flattened' | 'shape' | 'histogram' | 'constant_keyword' | 'aggregate_metric_double' | 'dense_vector' | 'semantic_text' | 'sparse_vector' | 'match_only_text' | 'icu_collation_keyword'
+export type MappingFieldType = 'none' | 'geo_point' | 'geo_shape' | 'ip' | 'binary' | 'keyword' | 'text' | 'search_as_you_type' | 'date' | 'date_nanos' | 'boolean' | 'completion' | 'nested' | 'object' | 'passthrough' | 'version' | 'murmur3' | 'token_count' | 'percolator' | 'integer' | 'long' | 'short' | 'byte' | 'float' | 'half_float' | 'scaled_float' | 'double' | 'integer_range' | 'float_range' | 'long_range' | 'double_range' | 'date_range' | 'ip_range' | 'alias' | 'join' | 'rank_feature' | 'rank_features' | 'flattened' | 'shape' | 'histogram' | 'constant_keyword' | 'aggregate_metric_double' | 'dense_vector' | 'semantic_text' | 'sparse_vector' | 'match_only_text' | 'icu_collation_keyword'
 
 export interface MappingFlattenedProperty extends MappingPropertyBase {
   boost?: double
@@ -5693,6 +5693,13 @@ export interface MappingObjectProperty extends MappingCorePropertyBase {
 
 export type MappingOnScriptError = 'fail' | 'continue'
 
+export interface MappingPassthroughObjectProperty extends MappingCorePropertyBase {
+  type?: 'passthrough'
+  enabled?: boolean
+  priority?: integer
+  time_series_dimension?: boolean
+}
+
 export interface MappingPercolatorProperty extends MappingPropertyBase {
   type: 'percolator'
 }
@@ -5704,7 +5711,7 @@ export interface MappingPointProperty extends MappingDocValuesPropertyBase {
   type: 'point'
 }
 
-export type MappingProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDynamicProperty | MappingJoinProperty | MappingKeywordProperty | MappingMatchOnlyTextProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingSearchAsYouTypeProperty | MappingTextProperty | MappingVersionProperty | MappingWildcardProperty | MappingDateNanosProperty | MappingDateProperty | MappingAggregateMetricDoubleProperty | MappingDenseVectorProperty | MappingFlattenedProperty | MappingNestedProperty | MappingObjectProperty | MappingSemanticTextProperty | MappingSparseVectorProperty | MappingCompletionProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingTokenCountProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingPointProperty | MappingShapeProperty | MappingByteNumberProperty | MappingDoubleNumberProperty | MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingScaledFloatNumberProperty | MappingShortNumberProperty | MappingUnsignedLongNumberProperty | MappingDateRangeProperty | MappingDoubleRangeProperty | MappingFloatRangeProperty | MappingIntegerRangeProperty | MappingIpRangeProperty | MappingLongRangeProperty | MappingIcuCollationProperty
+export type MappingProperty = MappingBinaryProperty | MappingBooleanProperty | MappingDynamicProperty | MappingJoinProperty | MappingKeywordProperty | MappingMatchOnlyTextProperty | MappingPercolatorProperty | MappingRankFeatureProperty | MappingRankFeaturesProperty | MappingSearchAsYouTypeProperty | MappingTextProperty | MappingVersionProperty | MappingWildcardProperty | MappingDateNanosProperty | MappingDateProperty | MappingAggregateMetricDoubleProperty | MappingDenseVectorProperty | MappingFlattenedProperty | MappingNestedProperty | MappingObjectProperty | MappingPassthroughObjectProperty | MappingSemanticTextProperty | MappingSparseVectorProperty | MappingCompletionProperty | MappingConstantKeywordProperty | MappingFieldAliasProperty | MappingHistogramProperty | MappingIpProperty | MappingMurmur3HashProperty | MappingTokenCountProperty | MappingGeoPointProperty | MappingGeoShapeProperty | MappingPointProperty | MappingShapeProperty | MappingByteNumberProperty | MappingDoubleNumberProperty | MappingFloatNumberProperty | MappingHalfFloatNumberProperty | MappingIntegerNumberProperty | MappingLongNumberProperty | MappingScaledFloatNumberProperty | MappingShortNumberProperty | MappingUnsignedLongNumberProperty | MappingDateRangeProperty | MappingDoubleRangeProperty | MappingFloatRangeProperty | MappingIntegerRangeProperty | MappingIpRangeProperty | MappingLongRangeProperty | MappingIcuCollationProperty
 
 export interface MappingPropertyBase {
   meta?: Record<string, string>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "backport-8.x",
+  "name": "elasticsearch-specification",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -38,7 +38,8 @@ import {
   AggregateMetricDoubleProperty,
   FlattenedProperty,
   NestedProperty,
-  ObjectProperty
+  ObjectProperty,
+  PassthroughObjectProperty
 } from './complex'
 import {
   BinaryProperty,
@@ -123,6 +124,7 @@ export type Property =
   | FlattenedProperty
   | NestedProperty
   | ObjectProperty
+  | PassthroughObjectProperty
   | SemanticTextProperty
   | SparseVectorProperty
 
@@ -178,6 +180,7 @@ export enum FieldType {
   completion,
   nested,
   object,
+  passthrough,
   version,
   murmur3,
   token_count,

--- a/specification/_types/mapping/complex.ts
+++ b/specification/_types/mapping/complex.ts
@@ -48,6 +48,13 @@ export class ObjectProperty extends CorePropertyBase {
   type?: 'object'
 }
 
+export class PassthroughObjectProperty extends CorePropertyBase {
+  type?: 'passthrough'
+  enabled?: boolean
+  priority?: integer
+  time_series_dimension?: boolean
+}
+
 export class AggregateMetricDoubleProperty extends PropertyBase {
   type: 'aggregate_metric_double'
   default_metric: string


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add passthrough mapping type (#3404)](https://github.com/elastic/elasticsearch-specification/pull/3404)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)

Closes https://github.com/elastic/elasticsearch-specification/pull/3408