### PR TITLE
[8.x] Change `Indices` -> `IndexName[]` (#3016)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -29992,23 +29992,19 @@
                     "cluster": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/security._types:ClusterPrivilege"
+                        "type": "string"
                       }
                     },
                     "index": {
-                      "$ref": "#/components/schemas/_types:Indices"
-                    },
-                    "remote_cluster": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/security._types:RemoteClusterPrivilege"
+                        "$ref": "#/components/schemas/_types:IndexName"
                       }
                     }
                   },
                   "required": [
                     "cluster",
-                    "index",
-                    "remote_cluster"
+                    "index"
                   ]
                 }
               }
@@ -83847,17 +83843,10 @@
           },
           "names": {
             "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/_types:IndexName"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/_types:IndexName"
-                }
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:IndexName"
+            }
           },
           "privileges": {
             "description": "The index level privileges that owners of the role have on the specified indices.",
@@ -83994,17 +83983,10 @@
           },
           "names": {
             "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/_types:IndexName"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/_types:IndexName"
-                }
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:IndexName"
+            }
           },
           "privileges": {
             "description": "The index level privileges that owners of the role have on the specified indices.",
@@ -84814,17 +84796,10 @@
           },
           "names": {
             "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/_types:IndexName"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/_types:IndexName"
-                }
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:IndexName"
+            }
           },
           "privileges": {
             "description": "The index level privileges that owners of the role have on the specified indices.",
@@ -104446,6 +104421,10 @@
                 },
                 "runtime_mappings": {
                   "$ref": "#/components/schemas/_types.mapping:RuntimeFields"
+                },
+                "max_samples_per_key": {
+                  "description": "By default, the response of a sample query contains up to `10` samples, with one sample per unique set of join keys. Use the `size`\nparameter to get a smaller or larger set of samples. To retrieve more than one sample per set of join keys, use the\n`max_samples_per_key` parameter. Pipes are not supported for sample queries.",
+                  "type": "number"
                 }
               },
               "required": [

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -29992,7 +29992,7 @@
                     "cluster": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/security._types:ClusterPrivilege"
                       }
                     },
                     "index": {
@@ -30000,11 +30000,18 @@
                       "items": {
                         "$ref": "#/components/schemas/_types:IndexName"
                       }
+                    },
+                    "remote_cluster": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/security._types:RemoteClusterPrivilege"
+                      }
                     }
                   },
                   "required": [
                     "cluster",
-                    "index"
+                    "index",
+                    "remote_cluster"
                   ]
                 }
               }

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -54385,17 +54385,10 @@
           },
           "names": {
             "description": "A list of indices (or index name patterns) to which the permissions in this entry apply.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/_types:IndexName"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/_types:IndexName"
-                }
-              }
-            ]
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:IndexName"
+            }
           },
           "privileges": {
             "description": "The index level privileges that owners of the role have on the specified indices.",
@@ -62983,6 +62976,10 @@
                 },
                 "runtime_mappings": {
                   "$ref": "#/components/schemas/_types.mapping:RuntimeFields"
+                },
+                "max_samples_per_key": {
+                  "description": "By default, the response of a sample query contains up to `10` samples, with one sample per unique set of join keys. Use the `size`\nparameter to get a smaller or larger set of samples. To retrieve more than one sample per set of join keys, use the\n`max_samples_per_key` parameter. Pipes are not supported for sample queries.",
+                  "type": "number"
                 }
               },
               "required": [

--- a/output/schema/schema-serverless.json
+++ b/output/schema/schema-serverless.json
@@ -17628,6 +17628,19 @@
                 "namespace": "_types.mapping"
               }
             }
+          },
+          {
+            "description": "By default, the response of a sample query contains up to `10` samples, with one sample per unique set of join keys. Use the `size`\nparameter to get a smaller or larger set of samples. To retrieve more than one sample per set of join keys, use the\n`max_samples_per_key` parameter. Pipes are not supported for sample queries.",
+            "name": "max_samples_per_key",
+            "required": false,
+            "serverDefault": 1,
+            "type": {
+              "kind": "instance_of",
+              "type": {
+                "name": "integer",
+                "namespace": "_types"
+              }
+            }
           }
         ]
       },
@@ -17760,7 +17773,7 @@
           }
         }
       ],
-      "specLocation": "eql/search/EqlSearchRequest.ts#L28-L135"
+      "specLocation": "eql/search/EqlSearchRequest.ts#L28-L142"
     },
     {
       "body": {
@@ -141273,26 +141286,14 @@
           "name": "names",
           "required": true,
           "type": {
-            "items": [
-              {
-                "kind": "instance_of",
-                "type": {
-                  "name": "IndexName",
-                  "namespace": "_types"
-                }
-              },
-              {
-                "kind": "array_of",
-                "value": {
-                  "kind": "instance_of",
-                  "type": {
-                    "name": "IndexName",
-                    "namespace": "_types"
-                  }
-                }
+            "kind": "array_of",
+            "value": {
+              "kind": "instance_of",
+              "type": {
+                "name": "IndexName",
+                "namespace": "_types"
               }
-            ],
-            "kind": "union_of"
+            }
           }
         },
         {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10434,6 +10434,7 @@ export interface EqlSearchRequest extends RequestBase {
     fields?: QueryDslFieldAndFormat | Field | (QueryDslFieldAndFormat | Field)[]
     result_position?: EqlSearchResultPosition
     runtime_mappings?: MappingRuntimeFields
+    max_samples_per_key?: integer
   }
 }
 
@@ -17904,7 +17905,7 @@ export type SecurityIndexPrivilege = 'all' | 'auto_configure' | 'create' | 'crea
 
 export interface SecurityIndicesPrivileges {
   field_security?: SecurityFieldSecurity
-  names: IndexName | IndexName[]
+  names: IndexName[]
   privileges: SecurityIndexPrivilege[]
   query?: SecurityIndicesPrivilegesQuery
   allow_restricted_indices?: boolean
@@ -17931,7 +17932,7 @@ export interface SecurityRemoteClusterPrivileges {
 export interface SecurityRemoteIndicesPrivileges {
   clusters: Names
   field_security?: SecurityFieldSecurity
-  names: IndexName | IndexName[]
+  names: IndexName[]
   privileges: SecurityIndexPrivilege[]
   query?: SecurityIndicesPrivilegesQuery
   allow_restricted_indices?: boolean
@@ -18033,7 +18034,7 @@ export interface SecurityUser {
 
 export interface SecurityUserIndicesPrivileges {
   field_security?: SecurityFieldSecurity[]
-  names: IndexName | IndexName[]
+  names: IndexName[]
   privileges: SecurityIndexPrivilege[]
   query?: SecurityIndicesPrivilegesQuery[]
   allow_restricted_indices: boolean
@@ -18374,9 +18375,8 @@ export interface SecurityGetBuiltinPrivilegesRequest extends RequestBase {
 }
 
 export interface SecurityGetBuiltinPrivilegesResponse {
-  cluster: SecurityClusterPrivilege[]
-  index: Indices
-  remote_cluster: SecurityRemoteClusterPrivilege[]
+  cluster: string[]
+  index: IndexName[]
 }
 
 export interface SecurityGetPrivilegesRequest extends RequestBase {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -18375,8 +18375,9 @@ export interface SecurityGetBuiltinPrivilegesRequest extends RequestBase {
 }
 
 export interface SecurityGetBuiltinPrivilegesResponse {
-  cluster: string[]
+  cluster: SecurityClusterPrivilege[]
   index: IndexName[]
+  remote_cluster: SecurityRemoteClusterPrivilege[]
 }
 
 export interface SecurityGetPrivilegesRequest extends RequestBase {

--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -225,7 +225,7 @@ export class IndicesPrivileges {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: IndexName | IndexName[]
+  names: IndexName[]
   /**
    * The index level privileges that owners of the role have on the specified indices.
    */
@@ -259,7 +259,7 @@ export class RemoteIndicesPrivileges {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: IndexName | IndexName[]
+  names: IndexName[]
   /**
    * The index level privileges that owners of the role have on the specified indices.
    */
@@ -299,7 +299,7 @@ export class UserIndicesPrivileges {
   /**
    * A list of indices (or index name patterns) to which the permissions in this entry apply.
    */
-  names: IndexName | IndexName[]
+  names: IndexName[]
   /**
    * The index level privileges that owners of the role have on the specified indices.
    */

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
@@ -17,8 +17,16 @@
  * under the License.
  */
 
+import {
+  ClusterPrivilege,
+  RemoteClusterPrivilege
+} from '@security/_types/Privileges'
 import { IndexName } from '@_types/common'
 
 export class Response {
-  body: { cluster: string[]; index: IndexName[] }
+  body: {
+    cluster: ClusterPrivilege[]
+    index: IndexName[]
+    remote_cluster: RemoteClusterPrivilege[]
+  }
 }

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
@@ -17,16 +17,8 @@
  * under the License.
  */
 
-import {
-  ClusterPrivilege,
-  RemoteClusterPrivilege
-} from '@security/_types/Privileges'
-import { Indices } from '@_types/common'
+import { IndexName } from '@_types/common'
 
 export class Response {
-  body: {
-    cluster: ClusterPrivilege[]
-    index: Indices
-    remote_cluster: RemoteClusterPrivilege[]
-  }
+  body: { cluster: string[]; index: IndexName[] }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Change &#x60;Indices&#x60; -&gt; &#x60;IndexName[]&#x60; (#3016)](https://github.com/elastic/elasticsearch-specification/pull/3016)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)