### PR TITLE
[8.x] Fix `RemoteClusterPrivilege` availability (#3145)

### DIFF
--- a/specification/security/_types/Privileges.ts
+++ b/specification/security/_types/Privileges.ts
@@ -200,7 +200,6 @@ export enum ClusterPrivilege {
 
 /**
  * The subset of cluster level privileges that can be defined for remote clusters.
- * @availability stack
  */
 export enum RemoteClusterPrivilege {
   /**

--- a/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
+++ b/specification/security/get_builtin_privileges/SecurityGetBuiltinPrivilegesResponse.ts
@@ -27,6 +27,9 @@ export class Response {
   body: {
     cluster: ClusterPrivilege[]
     index: IndexName[]
+    /**
+     * @availability stack since=8.15.0
+     */
     remote_cluster: RemoteClusterPrivilege[]
   }
 }

--- a/specification/security/put_role/SecurityPutRoleRequest.ts
+++ b/specification/security/put_role/SecurityPutRoleRequest.ts
@@ -78,7 +78,6 @@ export interface Request extends RequestBase {
     /**
      * A list of remote cluster permissions entries.
      * @availability stack since=8.15.0
-     *
      */
     remote_cluster?: RemoteClusterPrivileges[]
     /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Fix &#x60;RemoteClusterPrivilege&#x60; availability (#3145)](https://github.com/elastic/elasticsearch-specification/pull/3145)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)