### PR TITLE
[8.x] Add missing fields to `CreateFollowIndexRequest` (#3042)

### DIFF
--- a/specification/ccr/follow/CreateFollowIndexRequest.ts
+++ b/specification/ccr/follow/CreateFollowIndexRequest.ts
@@ -17,9 +17,10 @@
  * under the License.
  */
 
+import { IndexSettings } from '@indices/_types/IndexSettings'
 import { RequestBase } from '@_types/Base'
-import { IndexName, WaitForActiveShards } from '@_types/common'
-import { long } from '@_types/Numeric'
+import { ByteSize, IndexName, WaitForActiveShards } from '@_types/common'
+import { integer, long } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 /**
@@ -32,23 +33,81 @@ import { Duration } from '@_types/Time'
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * The name of the follower index.
+     */
     index: IndexName
   }
   query_parameters: {
+    /**
+     * Specifies the number of shards to wait on being active before responding. This defaults to waiting on none of the shards to be
+     * active.
+     * A shard must be restored from the leader index before being active. Restoring a follower shard requires transferring all the
+     * remote Lucene segment files to the follower index.
+     */
     wait_for_active_shards?: WaitForActiveShards
   }
   body: {
-    leader_index?: IndexName
+    /**
+     * If the leader index is part of a data stream, the name to which the local data stream for the followed index should be renamed.
+     */
+    data_stream_name?: string
+    /**
+     * The name of the index in the leader cluster to follow.
+     */
+    leader_index: IndexName
+    /**
+     * The maximum number of outstanding reads requests from the remote cluster.
+     */
     max_outstanding_read_requests?: long
-    max_outstanding_write_requests?: long
-    max_read_request_operation_count?: long
-    max_read_request_size?: string
+    /**
+     * The maximum number of outstanding write requests on the follower.
+     */
+    max_outstanding_write_requests?: integer
+    /**
+     * The maximum number of operations to pull per read from the remote cluster.
+     */
+    max_read_request_operation_count?: integer
+    /**
+     * The maximum size in bytes of per read of a batch of operations pulled from the remote cluster.
+     */
+    max_read_request_size?: ByteSize
+    /**
+     * The maximum time to wait before retrying an operation that failed exceptionally. An exponential backoff strategy is employed when
+     * retrying.
+     */
     max_retry_delay?: Duration
-    max_write_buffer_count?: long
-    max_write_buffer_size?: string
-    max_write_request_operation_count?: long
-    max_write_request_size?: string
+    /**
+     * The maximum number of operations that can be queued for writing. When this limit is reached, reads from the remote cluster will be
+     * deferred until the number of queued operations goes below the limit.
+     */
+    max_write_buffer_count?: integer
+    /**
+     * The maximum total bytes of operations that can be queued for writing. When this limit is reached, reads from the remote cluster will
+     * be deferred until the total bytes of queued operations goes below the limit.
+     */
+    max_write_buffer_size?: ByteSize
+    /**
+     * The maximum number of operations per bulk write request executed on the follower.
+     */
+    max_write_request_operation_count?: integer
+    /**
+     * The maximum total bytes of operations per bulk write request executed on the follower.
+     */
+    max_write_request_size?: ByteSize
+    /**
+     * The maximum time to wait for new operations on the remote cluster when the follower index is synchronized with the leader index.
+     * When the timeout has elapsed, the poll for operations will return to the follower so that it can update some statistics.
+     * Then the follower will immediately attempt to read from the leader again.
+     */
     read_poll_timeout?: Duration
-    remote_cluster?: string
+    /**
+     * The remote cluster containing the leader index.
+     */
+    remote_cluster: string
+    /**
+     * Settings to override from the leader index.
+     */
+    settings?: IndexSettings
   }
 }

--- a/specification/ccr/follow_info/types.ts
+++ b/specification/ccr/follow_info/types.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { IndexName, Name } from '@_types/common'
-import { integer } from '@_types/Numeric'
+import { ByteSize, IndexName, Name } from '@_types/common'
+import { integer, long } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 export class FollowerIndex {
@@ -35,14 +35,49 @@ export enum FollowerIndexStatus {
 }
 
 export class FollowerIndexParameters {
-  max_outstanding_read_requests: integer
-  max_outstanding_write_requests: integer
-  max_read_request_operation_count: integer
-  max_read_request_size: string
-  max_retry_delay: Duration
-  max_write_buffer_count: integer
-  max_write_buffer_size: string
-  max_write_request_operation_count: integer
-  max_write_request_size: string
-  read_poll_timeout: Duration
+  /**
+   * The maximum number of outstanding reads requests from the remote cluster.
+   */
+  max_outstanding_read_requests?: long
+  /**
+   * The maximum number of outstanding write requests on the follower.
+   */
+  max_outstanding_write_requests?: integer
+  /**
+   * The maximum number of operations to pull per read from the remote cluster.
+   */
+  max_read_request_operation_count?: integer
+  /**
+   * The maximum size in bytes of per read of a batch of operations pulled from the remote cluster.
+   */
+  max_read_request_size?: ByteSize
+  /**
+   * The maximum time to wait before retrying an operation that failed exceptionally. An exponential backoff strategy is employed when
+   * retrying.
+   */
+  max_retry_delay?: Duration
+  /**
+   * The maximum number of operations that can be queued for writing. When this limit is reached, reads from the remote cluster will be
+   * deferred until the number of queued operations goes below the limit.
+   */
+  max_write_buffer_count?: integer
+  /**
+   * The maximum total bytes of operations that can be queued for writing. When this limit is reached, reads from the remote cluster will
+   * be deferred until the total bytes of queued operations goes below the limit.
+   */
+  max_write_buffer_size?: ByteSize
+  /**
+   * The maximum number of operations per bulk write request executed on the follower.
+   */
+  max_write_request_operation_count?: integer
+  /**
+   * The maximum total bytes of operations per bulk write request executed on the follower.
+   */
+  max_write_request_size?: ByteSize
+  /**
+   * The maximum time to wait for new operations on the remote cluster when the follower index is synchronized with the leader index.
+   * When the timeout has elapsed, the poll for operations will return to the follower so that it can update some statistics.
+   * Then the follower will immediately attempt to read from the leader again.
+   */
+  read_poll_timeout?: Duration
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add missing fields to &#x60;CreateFollowIndexRequest&#x60; (#3042)](https://github.com/elastic/elasticsearch-specification/pull/3042)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)