### PR TITLE
[8.x] Add search_application.render_query (#3401)

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -392,3 +392,20 @@ actions:
           examples:
             indicesLegacyPutTemplateRequestExample1:
               $ref: "../../specification/indices/put_template/indicesPutTemplateRequestExample1.yaml"
+## Examples for search applications
+  - target: "$.paths['/_application/search_application/{name}/_render_query']['post']"
+    description: "Add examples for render search application query operation"
+    update:
+      requestBody: 
+        content: 
+          application/json: 
+            examples:
+              renderSearchApplicationQueryRequestExample1: 
+                $ref: "../../specification/search_application/render_query/SearchApplicationsRenderQueryRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                renderSearchApplicationQueryResponseExample1:
+                  $ref: "../../specification/search_application/render_query/SearchApplicationsRenderQueryResponseExample1.yaml"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -27202,6 +27202,59 @@
         "x-beta": true
       }
     },
+    "/_application/search_application/{name}/_render_query": {
+      "post": {
+        "tags": [
+          "search_application"
+        ],
+        "summary": "Render a search application query",
+        "description": "Generate an Elasticsearch query using the specified query parameters and the search template associated with the search application or a default template if none is specified.\nIf a parameter used in the search template is not specified in `params`, the parameter's default value will be used.\nThe API returns the specific Elasticsearch query that would be generated and run by calling the search application search API.\n\nYou must have `read` privileges on the backing alias of the search application.",
+        "operationId": "search-application-render-query",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "description": "The name of the search application to render teh query for.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Name"
+            },
+            "style": "simple"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "params": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "x-state": "Technical preview"
+      }
+    },
     "/_application/search_application/{name}/_search": {
       "get": {
         "tags": [

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -735,12 +735,6 @@
       ],
       "response": []
     },
-    "search_application.render_query": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "search_mvt": {
       "request": [
         "Request: query parameter 'grid_agg' does not exist in the json spec",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -17752,6 +17752,16 @@ export interface SearchApplicationPutBehavioralAnalyticsRequest extends RequestB
 
 export type SearchApplicationPutBehavioralAnalyticsResponse = SearchApplicationPutBehavioralAnalyticsAnalyticsAcknowledgeResponseBase
 
+export interface SearchApplicationRenderQueryRequest extends RequestBase {
+  name: Name
+  body?: {
+    params?: Record<string, any>
+  }
+}
+
+export interface SearchApplicationRenderQueryResponse {
+}
+
 export interface SearchApplicationSearchRequest extends RequestBase {
   name: Name
   typed_keys?: boolean

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -541,6 +541,7 @@ search-aggregations-metrics-valuecount-aggregation,https://www.elastic.co/guide/
 search-aggregations-metrics-weight-avg-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-metrics-weight-avg-aggregation.html
 search-aggregations-bucket-variablewidthhistogram-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-bucket-variablewidthhistogram-aggregation.html
 search-analyzer,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-analyzer.html
+search-render-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-application-render-query.html
 search-count,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-count.html
 search-explain,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-explain.html
 search-field-caps,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-field-caps.html

--- a/specification/search_application/render_query/SearchApplicationsRenderQueryRequest.ts
+++ b/specification/search_application/render_query/SearchApplicationsRenderQueryRequest.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Dictionary } from '@spec_utils/Dictionary'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { RequestBase } from '@_types/Base'
+import { Name } from '@_types/common'
+
+/**
+ * Render a search application query.
+ * Generate an Elasticsearch query using the specified query parameters and the search template associated with the search application or a default template if none is specified.
+ * If a parameter used in the search template is not specified in `params`, the parameter's default value will be used.
+ * The API returns the specific Elasticsearch query that would be generated and run by calling the search application search API.
+ *
+ * You must have `read` privileges on the backing alias of the search application.
+ * @rest_spec_name search_application.render_query
+ * @availability stack since=8.9.0 stability=experimental visibility=public
+ * @doc_id search-render-query
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The name of the search application to render teh query for.
+     */
+    name: Name
+  }
+  /**
+   * Contains parameters for a search application.
+   */
+  body: {
+    params?: Dictionary<string, UserDefinedValue>
+  }
+}

--- a/specification/search_application/render_query/SearchApplicationsRenderQueryRequestExample1.yaml
+++ b/specification/search_application/render_query/SearchApplicationsRenderQueryRequestExample1.yaml
@@ -1,0 +1,12 @@
+# summary:
+# method_request: POST _application/search_application/my-app/_render_query
+description: Run `POST _application/search_application/my-app/_render_query` to generate a query for a search application called `my-app` that uses the search template.
+# type: request
+value:
+  params:
+    query_string: my first query
+    text_fields:
+      - name: title
+        boost: 5
+      - name: description
+        boost: 1

--- a/specification/search_application/render_query/SearchApplicationsRenderQueryResponse.ts
+++ b/specification/search_application/render_query/SearchApplicationsRenderQueryResponse.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class Response {
+  body: {}
+}

--- a/specification/search_application/render_query/SearchApplicationsRenderQueryResponseExample1.yaml
+++ b/specification/search_application/render_query/SearchApplicationsRenderQueryResponseExample1.yaml
@@ -1,0 +1,14 @@
+# summary: ''
+description: A successful response for generating a query for a search application. The `from`, `size`, and `explain` parameters were not specified in the request, so the default values specified in the search template are used.
+# type: response
+# response_code: 200
+value:
+  from: 0
+  size: 10
+  query:
+    multi_match:
+      query: my first query
+      fields:
+        - 'description^1.0'
+        - 'title^5.0'
+  explain: false


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add search_application.render_query (#3401)](https://github.com/elastic/elasticsearch-specification/pull/3401)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)