### PR TITLE
[8.x] Add examples to licensing APIs (#3420)

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -392,6 +392,63 @@ actions:
           examples:
             indicesLegacyPutTemplateRequestExample1:
               $ref: "../../specification/indices/put_template/indicesPutTemplateRequestExample1.yaml"
+## Examples for licensing
+  - target: "$.paths['/_license/basic_status']['get']"
+    description: "Add example for get basic status response"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                getBasicStatusResponseExample1:
+                  $ref: "../../specification/license/get_basic_status/GetBasicLicenseStatusResponseExample1.yaml"
+  - target: "$.paths['/_license/trial_status']['get']"
+    description: "Add example for get trial status response"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                getLicenseResponseExample1:
+                  $ref: "../../specification/license/get_trial_status/GetTrialLicenseStatusResponseExample1.yaml"
+  - target: "$.paths['/_license/start_basic']['post']"
+    description: "Add example for start basic response"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                startBasicLicenseResponseExample1:
+                  $ref: "../../specification/license/post_start_basic/StartBasicLicenseResponseExample1.yaml"
+  - target: "$.paths['/_license/start_trial']['post']"
+    description: "Add example for start trial response"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                startTrialLicenseResponseExample1:
+                  $ref: "../../specification/license/post_start_trial/StartTrialLicenseResponseExample1.yaml"
+  - target: "$.components['requestBodies']['license.post']"
+    description: "Add examples for update license request"
+    update: 
+      content: 
+        application/json: 
+          examples: 
+            updateLicenseRequestExample1: 
+              $ref: "../../specification/license/post/PostLicenseRequestExample1.yaml"
+  - target: "$.components['responses']['license.post#200']"
+    description: "Add examples for update license response"
+    update: 
+      content:
+        application/json:
+          examples:
+            clusterHealthResponseExample1:
+              $ref: "../../specification/license/post/PostLicenseResponseExample1.yaml"
 ## Examples for search applications
   - target: "$.paths['/_application/search_application/{name}/_render_query']['post']"
     description: "Add examples for render search application query operation"
@@ -402,10 +459,5 @@ actions:
             examples:
               renderSearchApplicationQueryRequestExample1: 
                 $ref: "../../specification/search_application/render_query/SearchApplicationsRenderQueryRequestExample1.yaml"
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
                 renderSearchApplicationQueryResponseExample1:
                   $ref: "../../specification/search_application/render_query/SearchApplicationsRenderQueryResponseExample1.yaml"

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -1351,3 +1351,14 @@ actions:
           examples:
             indicesRolloverResponseExample1:
               $ref: "../../specification/indices/rollover/indicesRolloverResponseExample1.yaml"
+## Examples for licensing
+  - target: "$.paths['/_license']['get']"
+    description: "Add example for get license response"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                getLicenseResponseExample1:
+                  $ref: "../../specification/license/get/GetLicenseResponseExample1.yaml"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -2602,7 +2602,7 @@
           {
             "in": "path",
             "name": "index",
-            "description": "The name of the follower index",
+            "description": "The name of the follower index.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -2613,7 +2613,7 @@
           {
             "in": "query",
             "name": "wait_for_active_shards",
-            "description": "Sets the number of shard copies that must be active before returning. Defaults to 0. Set to `all` for all shard copies, otherwise set to any non-negative value less than or equal to the total number of copies for the shard (number of replicas + 1)",
+            "description": "Specifies the number of shards to wait on being active before responding. This defaults to waiting on none of the shards to be\nactive.\nA shard must be restored from the leader index before being active. Restoring a follower shard requires transferring all the\nremote Lucene segment files to the follower index.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:WaitForActiveShards"
@@ -2627,43 +2627,60 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "data_stream_name": {
+                    "description": "If the leader index is part of a data stream, the name to which the local data stream for the followed index should be renamed.",
+                    "type": "string"
+                  },
                   "leader_index": {
                     "$ref": "#/components/schemas/_types:IndexName"
                   },
                   "max_outstanding_read_requests": {
+                    "description": "The maximum number of outstanding reads requests from the remote cluster.",
                     "type": "number"
                   },
                   "max_outstanding_write_requests": {
+                    "description": "The maximum number of outstanding write requests on the follower.",
                     "type": "number"
                   },
                   "max_read_request_operation_count": {
+                    "description": "The maximum number of operations to pull per read from the remote cluster.",
                     "type": "number"
                   },
                   "max_read_request_size": {
-                    "type": "string"
+                    "$ref": "#/components/schemas/_types:ByteSize"
                   },
                   "max_retry_delay": {
                     "$ref": "#/components/schemas/_types:Duration"
                   },
                   "max_write_buffer_count": {
+                    "description": "The maximum number of operations that can be queued for writing. When this limit is reached, reads from the remote cluster will be\ndeferred until the number of queued operations goes below the limit.",
                     "type": "number"
                   },
                   "max_write_buffer_size": {
-                    "type": "string"
+                    "$ref": "#/components/schemas/_types:ByteSize"
                   },
                   "max_write_request_operation_count": {
+                    "description": "The maximum number of operations per bulk write request executed on the follower.",
                     "type": "number"
                   },
                   "max_write_request_size": {
-                    "type": "string"
+                    "$ref": "#/components/schemas/_types:ByteSize"
                   },
                   "read_poll_timeout": {
                     "$ref": "#/components/schemas/_types:Duration"
                   },
                   "remote_cluster": {
+                    "description": "The remote cluster containing the leader index.",
                     "type": "string"
+                  },
+                  "settings": {
+                    "$ref": "#/components/schemas/indices._types:IndexSettings"
                   }
-                }
+                },
+                "required": [
+                  "leader_index",
+                  "remote_cluster"
+                ]
               }
             }
           },
@@ -12016,18 +12033,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "data_retention": {
-                    "$ref": "#/components/schemas/_types:Duration"
-                  },
-                  "downsampling": {
-                    "$ref": "#/components/schemas/indices._types:DataStreamLifecycleDownsampling"
-                  }
-                }
+                "$ref": "#/components/schemas/indices._types:DataStreamLifecycle"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -26968,7 +26978,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/search_application._types:SearchApplication"
+                "$ref": "#/components/schemas/search_application._types:SearchApplicationParameters"
               }
             }
           },
@@ -27186,7 +27196,7 @@
                     "results": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/search_application.list:SearchApplicationListItem"
+                        "$ref": "#/components/schemas/search_application._types:SearchApplication"
                       }
                     }
                   },
@@ -54326,809 +54336,6 @@
           }
         }
       },
-      "ccr.follow_info:FollowerIndex": {
-        "type": "object",
-        "properties": {
-          "follower_index": {
-            "$ref": "#/components/schemas/_types:IndexName"
-          },
-          "leader_index": {
-            "$ref": "#/components/schemas/_types:IndexName"
-          },
-          "parameters": {
-            "$ref": "#/components/schemas/ccr.follow_info:FollowerIndexParameters"
-          },
-          "remote_cluster": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "status": {
-            "$ref": "#/components/schemas/ccr.follow_info:FollowerIndexStatus"
-          }
-        },
-        "required": [
-          "follower_index",
-          "leader_index",
-          "remote_cluster",
-          "status"
-        ]
-      },
-      "ccr.follow_info:FollowerIndexParameters": {
-        "type": "object",
-        "properties": {
-          "max_outstanding_read_requests": {
-            "type": "number"
-          },
-          "max_outstanding_write_requests": {
-            "type": "number"
-          },
-          "max_read_request_operation_count": {
-            "type": "number"
-          },
-          "max_read_request_size": {
-            "type": "string"
-          },
-          "max_retry_delay": {
-            "$ref": "#/components/schemas/_types:Duration"
-          },
-          "max_write_buffer_count": {
-            "type": "number"
-          },
-          "max_write_buffer_size": {
-            "type": "string"
-          },
-          "max_write_request_operation_count": {
-            "type": "number"
-          },
-          "max_write_request_size": {
-            "type": "string"
-          },
-          "read_poll_timeout": {
-            "$ref": "#/components/schemas/_types:Duration"
-          }
-        },
-        "required": [
-          "max_outstanding_read_requests",
-          "max_outstanding_write_requests",
-          "max_read_request_operation_count",
-          "max_read_request_size",
-          "max_retry_delay",
-          "max_write_buffer_count",
-          "max_write_buffer_size",
-          "max_write_request_operation_count",
-          "max_write_request_size",
-          "read_poll_timeout"
-        ]
-      },
-      "ccr.follow_info:FollowerIndexStatus": {
-        "type": "string",
-        "enum": [
-          "active",
-          "paused"
-        ]
-      },
-      "ccr._types:FollowIndexStats": {
-        "type": "object",
-        "properties": {
-          "index": {
-            "$ref": "#/components/schemas/_types:IndexName"
-          },
-          "shards": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ccr._types:ShardStats"
-            }
-          }
-        },
-        "required": [
-          "index",
-          "shards"
-        ]
-      },
-      "ccr._types:ShardStats": {
-        "type": "object",
-        "properties": {
-          "bytes_read": {
-            "type": "number"
-          },
-          "failed_read_requests": {
-            "type": "number"
-          },
-          "failed_write_requests": {
-            "type": "number"
-          },
-          "fatal_exception": {
-            "$ref": "#/components/schemas/_types:ErrorCause"
-          },
-          "follower_aliases_version": {
-            "$ref": "#/components/schemas/_types:VersionNumber"
-          },
-          "follower_global_checkpoint": {
-            "type": "number"
-          },
-          "follower_index": {
-            "type": "string"
-          },
-          "follower_mapping_version": {
-            "$ref": "#/components/schemas/_types:VersionNumber"
-          },
-          "follower_max_seq_no": {
-            "$ref": "#/components/schemas/_types:SequenceNumber"
-          },
-          "follower_settings_version": {
-            "$ref": "#/components/schemas/_types:VersionNumber"
-          },
-          "last_requested_seq_no": {
-            "$ref": "#/components/schemas/_types:SequenceNumber"
-          },
-          "leader_global_checkpoint": {
-            "type": "number"
-          },
-          "leader_index": {
-            "type": "string"
-          },
-          "leader_max_seq_no": {
-            "$ref": "#/components/schemas/_types:SequenceNumber"
-          },
-          "operations_read": {
-            "type": "number"
-          },
-          "operations_written": {
-            "type": "number"
-          },
-          "outstanding_read_requests": {
-            "type": "number"
-          },
-          "outstanding_write_requests": {
-            "type": "number"
-          },
-          "read_exceptions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ccr._types:ReadException"
-            }
-          },
-          "remote_cluster": {
-            "type": "string"
-          },
-          "shard_id": {
-            "type": "number"
-          },
-          "successful_read_requests": {
-            "type": "number"
-          },
-          "successful_write_requests": {
-            "type": "number"
-          },
-          "time_since_last_read": {
-            "$ref": "#/components/schemas/_types:Duration"
-          },
-          "time_since_last_read_millis": {
-            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
-          },
-          "total_read_remote_exec_time": {
-            "$ref": "#/components/schemas/_types:Duration"
-          },
-          "total_read_remote_exec_time_millis": {
-            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
-          },
-          "total_read_time": {
-            "$ref": "#/components/schemas/_types:Duration"
-          },
-          "total_read_time_millis": {
-            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
-          },
-          "total_write_time": {
-            "$ref": "#/components/schemas/_types:Duration"
-          },
-          "total_write_time_millis": {
-            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
-          },
-          "write_buffer_operation_count": {
-            "type": "number"
-          },
-          "write_buffer_size_in_bytes": {
-            "$ref": "#/components/schemas/_types:ByteSize"
-          }
-        },
-        "required": [
-          "bytes_read",
-          "failed_read_requests",
-          "failed_write_requests",
-          "follower_aliases_version",
-          "follower_global_checkpoint",
-          "follower_index",
-          "follower_mapping_version",
-          "follower_max_seq_no",
-          "follower_settings_version",
-          "last_requested_seq_no",
-          "leader_global_checkpoint",
-          "leader_index",
-          "leader_max_seq_no",
-          "operations_read",
-          "operations_written",
-          "outstanding_read_requests",
-          "outstanding_write_requests",
-          "read_exceptions",
-          "remote_cluster",
-          "shard_id",
-          "successful_read_requests",
-          "successful_write_requests",
-          "time_since_last_read_millis",
-          "total_read_remote_exec_time_millis",
-          "total_read_time_millis",
-          "total_write_time_millis",
-          "write_buffer_operation_count",
-          "write_buffer_size_in_bytes"
-        ]
-      },
-      "ccr._types:ReadException": {
-        "type": "object",
-        "properties": {
-          "exception": {
-            "$ref": "#/components/schemas/_types:ErrorCause"
-          },
-          "from_seq_no": {
-            "$ref": "#/components/schemas/_types:SequenceNumber"
-          },
-          "retries": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "exception",
-          "from_seq_no",
-          "retries"
-        ]
-      },
-      "_types:Uuid": {
-        "type": "string"
-      },
-      "ccr.get_auto_follow_pattern:AutoFollowPattern": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "pattern": {
-            "$ref": "#/components/schemas/ccr.get_auto_follow_pattern:AutoFollowPatternSummary"
-          }
-        },
-        "required": [
-          "name",
-          "pattern"
-        ]
-      },
-      "ccr.get_auto_follow_pattern:AutoFollowPatternSummary": {
-        "type": "object",
-        "properties": {
-          "active": {
-            "type": "boolean"
-          },
-          "remote_cluster": {
-            "description": "The remote cluster containing the leader indices to match against.",
-            "type": "string"
-          },
-          "follow_index_pattern": {
-            "$ref": "#/components/schemas/_types:IndexPattern"
-          },
-          "leader_index_patterns": {
-            "$ref": "#/components/schemas/_types:IndexPatterns"
-          },
-          "leader_index_exclusion_patterns": {
-            "$ref": "#/components/schemas/_types:IndexPatterns"
-          },
-          "max_outstanding_read_requests": {
-            "description": "The maximum number of outstanding reads requests from the remote cluster.",
-            "type": "number"
-          }
-        },
-        "required": [
-          "active",
-          "remote_cluster",
-          "leader_index_patterns",
-          "leader_index_exclusion_patterns",
-          "max_outstanding_read_requests"
-        ]
-      },
-      "_types:IndexPattern": {
-        "type": "string"
-      },
-      "_types:IndexPatterns": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/_types:IndexPattern"
-        }
-      },
-      "ccr.stats:AutoFollowStats": {
-        "type": "object",
-        "properties": {
-          "auto_followed_clusters": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ccr.stats:AutoFollowedCluster"
-            }
-          },
-          "number_of_failed_follow_indices": {
-            "type": "number"
-          },
-          "number_of_failed_remote_cluster_state_requests": {
-            "type": "number"
-          },
-          "number_of_successful_follow_indices": {
-            "type": "number"
-          },
-          "recent_auto_follow_errors": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/_types:ErrorCause"
-            }
-          }
-        },
-        "required": [
-          "auto_followed_clusters",
-          "number_of_failed_follow_indices",
-          "number_of_failed_remote_cluster_state_requests",
-          "number_of_successful_follow_indices",
-          "recent_auto_follow_errors"
-        ]
-      },
-      "ccr.stats:AutoFollowedCluster": {
-        "type": "object",
-        "properties": {
-          "cluster_name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "last_seen_metadata_version": {
-            "$ref": "#/components/schemas/_types:VersionNumber"
-          },
-          "time_since_last_check_millis": {
-            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
-          }
-        },
-        "required": [
-          "cluster_name",
-          "last_seen_metadata_version",
-          "time_since_last_check_millis"
-        ]
-      },
-      "ccr.stats:FollowStats": {
-        "type": "object",
-        "properties": {
-          "indices": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ccr._types:FollowIndexStats"
-            }
-          }
-        },
-        "required": [
-          "indices"
-        ]
-      },
-      "_types:ScrollIds": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/_types:ScrollId"
-          },
-          {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/_types:ScrollId"
-            }
-          }
-        ]
-      },
-      "cluster.allocation_explain:Decision": {
-        "type": "string",
-        "enum": [
-          "yes",
-          "no",
-          "worse_balance",
-          "throttled",
-          "awaiting_info",
-          "allocation_delayed",
-          "no_valid_shard_copy",
-          "no_attempt"
-        ]
-      },
-      "cluster.allocation_explain:AllocationDecision": {
-        "type": "object",
-        "properties": {
-          "decider": {
-            "type": "string"
-          },
-          "decision": {
-            "$ref": "#/components/schemas/cluster.allocation_explain:AllocationExplainDecision"
-          },
-          "explanation": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "decider",
-          "decision",
-          "explanation"
-        ]
-      },
-      "cluster.allocation_explain:AllocationExplainDecision": {
-        "type": "string",
-        "enum": [
-          "NO",
-          "YES",
-          "THROTTLE",
-          "ALWAYS"
-        ]
-      },
-      "cluster.allocation_explain:ClusterInfo": {
-        "type": "object",
-        "properties": {
-          "nodes": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/cluster.allocation_explain:NodeDiskUsage"
-            }
-          },
-          "shard_sizes": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "number"
-            }
-          },
-          "shard_data_set_sizes": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "shard_paths": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "reserved_sizes": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/cluster.allocation_explain:ReservedSize"
-            }
-          }
-        },
-        "required": [
-          "nodes",
-          "shard_sizes",
-          "shard_paths",
-          "reserved_sizes"
-        ]
-      },
-      "cluster.allocation_explain:NodeDiskUsage": {
-        "type": "object",
-        "properties": {
-          "node_name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "least_available": {
-            "$ref": "#/components/schemas/cluster.allocation_explain:DiskUsage"
-          },
-          "most_available": {
-            "$ref": "#/components/schemas/cluster.allocation_explain:DiskUsage"
-          }
-        },
-        "required": [
-          "node_name",
-          "least_available",
-          "most_available"
-        ]
-      },
-      "cluster.allocation_explain:DiskUsage": {
-        "type": "object",
-        "properties": {
-          "path": {
-            "type": "string"
-          },
-          "total_bytes": {
-            "type": "number"
-          },
-          "used_bytes": {
-            "type": "number"
-          },
-          "free_bytes": {
-            "type": "number"
-          },
-          "free_disk_percent": {
-            "type": "number"
-          },
-          "used_disk_percent": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "path",
-          "total_bytes",
-          "used_bytes",
-          "free_bytes",
-          "free_disk_percent",
-          "used_disk_percent"
-        ]
-      },
-      "cluster.allocation_explain:ReservedSize": {
-        "type": "object",
-        "properties": {
-          "node_id": {
-            "$ref": "#/components/schemas/_types:Id"
-          },
-          "path": {
-            "type": "string"
-          },
-          "total": {
-            "type": "number"
-          },
-          "shards": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        },
-        "required": [
-          "node_id",
-          "path",
-          "total",
-          "shards"
-        ]
-      },
-      "cluster.allocation_explain:CurrentNode": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/_types:Id"
-          },
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "roles": {
-            "$ref": "#/components/schemas/_types:NodeRoles"
-          },
-          "attributes": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "transport_address": {
-            "$ref": "#/components/schemas/_types:TransportAddress"
-          },
-          "weight_ranking": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "roles",
-          "attributes",
-          "transport_address",
-          "weight_ranking"
-        ]
-      },
-      "_types:NodeRoles": {
-        "description": "* @doc_id node-roles",
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/_types:NodeRole"
-        }
-      },
-      "_types:NodeRole": {
-        "type": "string",
-        "enum": [
-          "master",
-          "data",
-          "data_cold",
-          "data_content",
-          "data_frozen",
-          "data_hot",
-          "data_warm",
-          "client",
-          "ingest",
-          "ml",
-          "voting_only",
-          "transform",
-          "remote_cluster_client",
-          "coordinating_only"
-        ]
-      },
-      "_types:TransportAddress": {
-        "type": "string"
-      },
-      "cluster.allocation_explain:NodeAllocationExplanation": {
-        "type": "object",
-        "properties": {
-          "deciders": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/cluster.allocation_explain:AllocationDecision"
-            }
-          },
-          "node_attributes": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "node_decision": {
-            "$ref": "#/components/schemas/cluster.allocation_explain:Decision"
-          },
-          "node_id": {
-            "$ref": "#/components/schemas/_types:Id"
-          },
-          "node_name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "roles": {
-            "$ref": "#/components/schemas/_types:NodeRoles"
-          },
-          "store": {
-            "$ref": "#/components/schemas/cluster.allocation_explain:AllocationStore"
-          },
-          "transport_address": {
-            "$ref": "#/components/schemas/_types:TransportAddress"
-          },
-          "weight_ranking": {
-            "type": "number"
-          }
-        },
-        "required": [
-          "deciders",
-          "node_attributes",
-          "node_decision",
-          "node_id",
-          "node_name",
-          "roles",
-          "transport_address",
-          "weight_ranking"
-        ]
-      },
-      "cluster.allocation_explain:AllocationStore": {
-        "type": "object",
-        "properties": {
-          "allocation_id": {
-            "type": "string"
-          },
-          "found": {
-            "type": "boolean"
-          },
-          "in_sync": {
-            "type": "boolean"
-          },
-          "matching_size_in_bytes": {
-            "type": "number"
-          },
-          "matching_sync_id": {
-            "type": "boolean"
-          },
-          "store_exception": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "allocation_id",
-          "found",
-          "in_sync",
-          "matching_size_in_bytes",
-          "matching_sync_id",
-          "store_exception"
-        ]
-      },
-      "cluster.allocation_explain:UnassignedInformation": {
-        "type": "object",
-        "properties": {
-          "at": {
-            "$ref": "#/components/schemas/_types:DateTime"
-          },
-          "last_allocation_status": {
-            "type": "string"
-          },
-          "reason": {
-            "$ref": "#/components/schemas/cluster.allocation_explain:UnassignedInformationReason"
-          },
-          "details": {
-            "type": "string"
-          },
-          "failed_allocation_attempts": {
-            "type": "number"
-          },
-          "delayed": {
-            "type": "boolean"
-          },
-          "allocation_status": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "at",
-          "reason"
-        ]
-      },
-      "cluster.allocation_explain:UnassignedInformationReason": {
-        "type": "string",
-        "enum": [
-          "INDEX_CREATED",
-          "CLUSTER_RECOVERED",
-          "INDEX_REOPENED",
-          "DANGLING_INDEX_IMPORTED",
-          "NEW_INDEX_RESTORED",
-          "EXISTING_INDEX_RESTORED",
-          "REPLICA_ADDED",
-          "ALLOCATION_FAILED",
-          "NODE_LEFT",
-          "REROUTE_CANCELLED",
-          "REINITIALIZED",
-          "REALLOCATED_REPLICA",
-          "PRIMARY_FAILED",
-          "FORCED_EMPTY_PRIMARY",
-          "MANUAL_ALLOCATION"
-        ]
-      },
-      "cluster._types:ComponentTemplate": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "component_template": {
-            "$ref": "#/components/schemas/cluster._types:ComponentTemplateNode"
-          }
-        },
-        "required": [
-          "name",
-          "component_template"
-        ]
-      },
-      "cluster._types:ComponentTemplateNode": {
-        "type": "object",
-        "properties": {
-          "template": {
-            "$ref": "#/components/schemas/cluster._types:ComponentTemplateSummary"
-          },
-          "version": {
-            "$ref": "#/components/schemas/_types:VersionNumber"
-          },
-          "_meta": {
-            "$ref": "#/components/schemas/_types:Metadata"
-          }
-        },
-        "required": [
-          "template"
-        ]
-      },
-      "cluster._types:ComponentTemplateSummary": {
-        "type": "object",
-        "properties": {
-          "_meta": {
-            "$ref": "#/components/schemas/_types:Metadata"
-          },
-          "version": {
-            "$ref": "#/components/schemas/_types:VersionNumber"
-          },
-          "settings": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/indices._types:IndexSettings"
-            }
-          },
-          "mappings": {
-            "$ref": "#/components/schemas/_types.mapping:TypeMapping"
-          },
-          "aliases": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/indices._types:AliasDefinition"
-            }
-          },
-          "lifecycle": {
-            "$ref": "#/components/schemas/indices._types:DataStreamLifecycleWithRollover"
-          }
-        }
-      },
       "indices._types:IndexSettings": {
         "type": "object",
         "properties": {
@@ -55740,6 +54947,9 @@
             "type": "string"
           }
         ]
+      },
+      "_types:Uuid": {
+        "type": "string"
       },
       "indices._types:IndexVersioning": {
         "type": "object",
@@ -60440,6 +59650,799 @@
           }
         ]
       },
+      "ccr.follow_info:FollowerIndex": {
+        "type": "object",
+        "properties": {
+          "follower_index": {
+            "$ref": "#/components/schemas/_types:IndexName"
+          },
+          "leader_index": {
+            "$ref": "#/components/schemas/_types:IndexName"
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/ccr.follow_info:FollowerIndexParameters"
+          },
+          "remote_cluster": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ccr.follow_info:FollowerIndexStatus"
+          }
+        },
+        "required": [
+          "follower_index",
+          "leader_index",
+          "remote_cluster",
+          "status"
+        ]
+      },
+      "ccr.follow_info:FollowerIndexParameters": {
+        "type": "object",
+        "properties": {
+          "max_outstanding_read_requests": {
+            "description": "The maximum number of outstanding reads requests from the remote cluster.",
+            "type": "number"
+          },
+          "max_outstanding_write_requests": {
+            "description": "The maximum number of outstanding write requests on the follower.",
+            "type": "number"
+          },
+          "max_read_request_operation_count": {
+            "description": "The maximum number of operations to pull per read from the remote cluster.",
+            "type": "number"
+          },
+          "max_read_request_size": {
+            "$ref": "#/components/schemas/_types:ByteSize"
+          },
+          "max_retry_delay": {
+            "$ref": "#/components/schemas/_types:Duration"
+          },
+          "max_write_buffer_count": {
+            "description": "The maximum number of operations that can be queued for writing. When this limit is reached, reads from the remote cluster will be\ndeferred until the number of queued operations goes below the limit.",
+            "type": "number"
+          },
+          "max_write_buffer_size": {
+            "$ref": "#/components/schemas/_types:ByteSize"
+          },
+          "max_write_request_operation_count": {
+            "description": "The maximum number of operations per bulk write request executed on the follower.",
+            "type": "number"
+          },
+          "max_write_request_size": {
+            "$ref": "#/components/schemas/_types:ByteSize"
+          },
+          "read_poll_timeout": {
+            "$ref": "#/components/schemas/_types:Duration"
+          }
+        }
+      },
+      "ccr.follow_info:FollowerIndexStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "paused"
+        ]
+      },
+      "ccr._types:FollowIndexStats": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "$ref": "#/components/schemas/_types:IndexName"
+          },
+          "shards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ccr._types:ShardStats"
+            }
+          }
+        },
+        "required": [
+          "index",
+          "shards"
+        ]
+      },
+      "ccr._types:ShardStats": {
+        "type": "object",
+        "properties": {
+          "bytes_read": {
+            "type": "number"
+          },
+          "failed_read_requests": {
+            "type": "number"
+          },
+          "failed_write_requests": {
+            "type": "number"
+          },
+          "fatal_exception": {
+            "$ref": "#/components/schemas/_types:ErrorCause"
+          },
+          "follower_aliases_version": {
+            "$ref": "#/components/schemas/_types:VersionNumber"
+          },
+          "follower_global_checkpoint": {
+            "type": "number"
+          },
+          "follower_index": {
+            "type": "string"
+          },
+          "follower_mapping_version": {
+            "$ref": "#/components/schemas/_types:VersionNumber"
+          },
+          "follower_max_seq_no": {
+            "$ref": "#/components/schemas/_types:SequenceNumber"
+          },
+          "follower_settings_version": {
+            "$ref": "#/components/schemas/_types:VersionNumber"
+          },
+          "last_requested_seq_no": {
+            "$ref": "#/components/schemas/_types:SequenceNumber"
+          },
+          "leader_global_checkpoint": {
+            "type": "number"
+          },
+          "leader_index": {
+            "type": "string"
+          },
+          "leader_max_seq_no": {
+            "$ref": "#/components/schemas/_types:SequenceNumber"
+          },
+          "operations_read": {
+            "type": "number"
+          },
+          "operations_written": {
+            "type": "number"
+          },
+          "outstanding_read_requests": {
+            "type": "number"
+          },
+          "outstanding_write_requests": {
+            "type": "number"
+          },
+          "read_exceptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ccr._types:ReadException"
+            }
+          },
+          "remote_cluster": {
+            "type": "string"
+          },
+          "shard_id": {
+            "type": "number"
+          },
+          "successful_read_requests": {
+            "type": "number"
+          },
+          "successful_write_requests": {
+            "type": "number"
+          },
+          "time_since_last_read": {
+            "$ref": "#/components/schemas/_types:Duration"
+          },
+          "time_since_last_read_millis": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
+          },
+          "total_read_remote_exec_time": {
+            "$ref": "#/components/schemas/_types:Duration"
+          },
+          "total_read_remote_exec_time_millis": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
+          },
+          "total_read_time": {
+            "$ref": "#/components/schemas/_types:Duration"
+          },
+          "total_read_time_millis": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
+          },
+          "total_write_time": {
+            "$ref": "#/components/schemas/_types:Duration"
+          },
+          "total_write_time_millis": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
+          },
+          "write_buffer_operation_count": {
+            "type": "number"
+          },
+          "write_buffer_size_in_bytes": {
+            "$ref": "#/components/schemas/_types:ByteSize"
+          }
+        },
+        "required": [
+          "bytes_read",
+          "failed_read_requests",
+          "failed_write_requests",
+          "follower_aliases_version",
+          "follower_global_checkpoint",
+          "follower_index",
+          "follower_mapping_version",
+          "follower_max_seq_no",
+          "follower_settings_version",
+          "last_requested_seq_no",
+          "leader_global_checkpoint",
+          "leader_index",
+          "leader_max_seq_no",
+          "operations_read",
+          "operations_written",
+          "outstanding_read_requests",
+          "outstanding_write_requests",
+          "read_exceptions",
+          "remote_cluster",
+          "shard_id",
+          "successful_read_requests",
+          "successful_write_requests",
+          "time_since_last_read_millis",
+          "total_read_remote_exec_time_millis",
+          "total_read_time_millis",
+          "total_write_time_millis",
+          "write_buffer_operation_count",
+          "write_buffer_size_in_bytes"
+        ]
+      },
+      "ccr._types:ReadException": {
+        "type": "object",
+        "properties": {
+          "exception": {
+            "$ref": "#/components/schemas/_types:ErrorCause"
+          },
+          "from_seq_no": {
+            "$ref": "#/components/schemas/_types:SequenceNumber"
+          },
+          "retries": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "exception",
+          "from_seq_no",
+          "retries"
+        ]
+      },
+      "ccr.get_auto_follow_pattern:AutoFollowPattern": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "pattern": {
+            "$ref": "#/components/schemas/ccr.get_auto_follow_pattern:AutoFollowPatternSummary"
+          }
+        },
+        "required": [
+          "name",
+          "pattern"
+        ]
+      },
+      "ccr.get_auto_follow_pattern:AutoFollowPatternSummary": {
+        "type": "object",
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "remote_cluster": {
+            "description": "The remote cluster containing the leader indices to match against.",
+            "type": "string"
+          },
+          "follow_index_pattern": {
+            "$ref": "#/components/schemas/_types:IndexPattern"
+          },
+          "leader_index_patterns": {
+            "$ref": "#/components/schemas/_types:IndexPatterns"
+          },
+          "leader_index_exclusion_patterns": {
+            "$ref": "#/components/schemas/_types:IndexPatterns"
+          },
+          "max_outstanding_read_requests": {
+            "description": "The maximum number of outstanding reads requests from the remote cluster.",
+            "type": "number"
+          }
+        },
+        "required": [
+          "active",
+          "remote_cluster",
+          "leader_index_patterns",
+          "leader_index_exclusion_patterns",
+          "max_outstanding_read_requests"
+        ]
+      },
+      "_types:IndexPattern": {
+        "type": "string"
+      },
+      "_types:IndexPatterns": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/_types:IndexPattern"
+        }
+      },
+      "ccr.stats:AutoFollowStats": {
+        "type": "object",
+        "properties": {
+          "auto_followed_clusters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ccr.stats:AutoFollowedCluster"
+            }
+          },
+          "number_of_failed_follow_indices": {
+            "type": "number"
+          },
+          "number_of_failed_remote_cluster_state_requests": {
+            "type": "number"
+          },
+          "number_of_successful_follow_indices": {
+            "type": "number"
+          },
+          "recent_auto_follow_errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:ErrorCause"
+            }
+          }
+        },
+        "required": [
+          "auto_followed_clusters",
+          "number_of_failed_follow_indices",
+          "number_of_failed_remote_cluster_state_requests",
+          "number_of_successful_follow_indices",
+          "recent_auto_follow_errors"
+        ]
+      },
+      "ccr.stats:AutoFollowedCluster": {
+        "type": "object",
+        "properties": {
+          "cluster_name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "last_seen_metadata_version": {
+            "$ref": "#/components/schemas/_types:VersionNumber"
+          },
+          "time_since_last_check_millis": {
+            "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
+          }
+        },
+        "required": [
+          "cluster_name",
+          "last_seen_metadata_version",
+          "time_since_last_check_millis"
+        ]
+      },
+      "ccr.stats:FollowStats": {
+        "type": "object",
+        "properties": {
+          "indices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ccr._types:FollowIndexStats"
+            }
+          }
+        },
+        "required": [
+          "indices"
+        ]
+      },
+      "_types:ScrollIds": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/_types:ScrollId"
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/_types:ScrollId"
+            }
+          }
+        ]
+      },
+      "cluster.allocation_explain:Decision": {
+        "type": "string",
+        "enum": [
+          "yes",
+          "no",
+          "worse_balance",
+          "throttled",
+          "awaiting_info",
+          "allocation_delayed",
+          "no_valid_shard_copy",
+          "no_attempt"
+        ]
+      },
+      "cluster.allocation_explain:AllocationDecision": {
+        "type": "object",
+        "properties": {
+          "decider": {
+            "type": "string"
+          },
+          "decision": {
+            "$ref": "#/components/schemas/cluster.allocation_explain:AllocationExplainDecision"
+          },
+          "explanation": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "decider",
+          "decision",
+          "explanation"
+        ]
+      },
+      "cluster.allocation_explain:AllocationExplainDecision": {
+        "type": "string",
+        "enum": [
+          "NO",
+          "YES",
+          "THROTTLE",
+          "ALWAYS"
+        ]
+      },
+      "cluster.allocation_explain:ClusterInfo": {
+        "type": "object",
+        "properties": {
+          "nodes": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/cluster.allocation_explain:NodeDiskUsage"
+            }
+          },
+          "shard_sizes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "shard_data_set_sizes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "shard_paths": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "reserved_sizes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/cluster.allocation_explain:ReservedSize"
+            }
+          }
+        },
+        "required": [
+          "nodes",
+          "shard_sizes",
+          "shard_paths",
+          "reserved_sizes"
+        ]
+      },
+      "cluster.allocation_explain:NodeDiskUsage": {
+        "type": "object",
+        "properties": {
+          "node_name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "least_available": {
+            "$ref": "#/components/schemas/cluster.allocation_explain:DiskUsage"
+          },
+          "most_available": {
+            "$ref": "#/components/schemas/cluster.allocation_explain:DiskUsage"
+          }
+        },
+        "required": [
+          "node_name",
+          "least_available",
+          "most_available"
+        ]
+      },
+      "cluster.allocation_explain:DiskUsage": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "total_bytes": {
+            "type": "number"
+          },
+          "used_bytes": {
+            "type": "number"
+          },
+          "free_bytes": {
+            "type": "number"
+          },
+          "free_disk_percent": {
+            "type": "number"
+          },
+          "used_disk_percent": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "path",
+          "total_bytes",
+          "used_bytes",
+          "free_bytes",
+          "free_disk_percent",
+          "used_disk_percent"
+        ]
+      },
+      "cluster.allocation_explain:ReservedSize": {
+        "type": "object",
+        "properties": {
+          "node_id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "path": {
+            "type": "string"
+          },
+          "total": {
+            "type": "number"
+          },
+          "shards": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "node_id",
+          "path",
+          "total",
+          "shards"
+        ]
+      },
+      "cluster.allocation_explain:CurrentNode": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "roles": {
+            "$ref": "#/components/schemas/_types:NodeRoles"
+          },
+          "attributes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "transport_address": {
+            "$ref": "#/components/schemas/_types:TransportAddress"
+          },
+          "weight_ranking": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "roles",
+          "attributes",
+          "transport_address",
+          "weight_ranking"
+        ]
+      },
+      "_types:NodeRoles": {
+        "description": "* @doc_id node-roles",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/_types:NodeRole"
+        }
+      },
+      "_types:NodeRole": {
+        "type": "string",
+        "enum": [
+          "master",
+          "data",
+          "data_cold",
+          "data_content",
+          "data_frozen",
+          "data_hot",
+          "data_warm",
+          "client",
+          "ingest",
+          "ml",
+          "voting_only",
+          "transform",
+          "remote_cluster_client",
+          "coordinating_only"
+        ]
+      },
+      "_types:TransportAddress": {
+        "type": "string"
+      },
+      "cluster.allocation_explain:NodeAllocationExplanation": {
+        "type": "object",
+        "properties": {
+          "deciders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/cluster.allocation_explain:AllocationDecision"
+            }
+          },
+          "node_attributes": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "node_decision": {
+            "$ref": "#/components/schemas/cluster.allocation_explain:Decision"
+          },
+          "node_id": {
+            "$ref": "#/components/schemas/_types:Id"
+          },
+          "node_name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "roles": {
+            "$ref": "#/components/schemas/_types:NodeRoles"
+          },
+          "store": {
+            "$ref": "#/components/schemas/cluster.allocation_explain:AllocationStore"
+          },
+          "transport_address": {
+            "$ref": "#/components/schemas/_types:TransportAddress"
+          },
+          "weight_ranking": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "deciders",
+          "node_attributes",
+          "node_decision",
+          "node_id",
+          "node_name",
+          "roles",
+          "transport_address",
+          "weight_ranking"
+        ]
+      },
+      "cluster.allocation_explain:AllocationStore": {
+        "type": "object",
+        "properties": {
+          "allocation_id": {
+            "type": "string"
+          },
+          "found": {
+            "type": "boolean"
+          },
+          "in_sync": {
+            "type": "boolean"
+          },
+          "matching_size_in_bytes": {
+            "type": "number"
+          },
+          "matching_sync_id": {
+            "type": "boolean"
+          },
+          "store_exception": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "allocation_id",
+          "found",
+          "in_sync",
+          "matching_size_in_bytes",
+          "matching_sync_id",
+          "store_exception"
+        ]
+      },
+      "cluster.allocation_explain:UnassignedInformation": {
+        "type": "object",
+        "properties": {
+          "at": {
+            "$ref": "#/components/schemas/_types:DateTime"
+          },
+          "last_allocation_status": {
+            "type": "string"
+          },
+          "reason": {
+            "$ref": "#/components/schemas/cluster.allocation_explain:UnassignedInformationReason"
+          },
+          "details": {
+            "type": "string"
+          },
+          "failed_allocation_attempts": {
+            "type": "number"
+          },
+          "delayed": {
+            "type": "boolean"
+          },
+          "allocation_status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "at",
+          "reason"
+        ]
+      },
+      "cluster.allocation_explain:UnassignedInformationReason": {
+        "type": "string",
+        "enum": [
+          "INDEX_CREATED",
+          "CLUSTER_RECOVERED",
+          "INDEX_REOPENED",
+          "DANGLING_INDEX_IMPORTED",
+          "NEW_INDEX_RESTORED",
+          "EXISTING_INDEX_RESTORED",
+          "REPLICA_ADDED",
+          "ALLOCATION_FAILED",
+          "NODE_LEFT",
+          "REROUTE_CANCELLED",
+          "REINITIALIZED",
+          "REALLOCATED_REPLICA",
+          "PRIMARY_FAILED",
+          "FORCED_EMPTY_PRIMARY",
+          "MANUAL_ALLOCATION"
+        ]
+      },
+      "cluster._types:ComponentTemplate": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/_types:Name"
+          },
+          "component_template": {
+            "$ref": "#/components/schemas/cluster._types:ComponentTemplateNode"
+          }
+        },
+        "required": [
+          "name",
+          "component_template"
+        ]
+      },
+      "cluster._types:ComponentTemplateNode": {
+        "type": "object",
+        "properties": {
+          "template": {
+            "$ref": "#/components/schemas/cluster._types:ComponentTemplateSummary"
+          },
+          "version": {
+            "$ref": "#/components/schemas/_types:VersionNumber"
+          },
+          "_meta": {
+            "$ref": "#/components/schemas/_types:Metadata"
+          }
+        },
+        "required": [
+          "template"
+        ]
+      },
+      "cluster._types:ComponentTemplateSummary": {
+        "type": "object",
+        "properties": {
+          "_meta": {
+            "$ref": "#/components/schemas/_types:Metadata"
+          },
+          "version": {
+            "$ref": "#/components/schemas/_types:VersionNumber"
+          },
+          "settings": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/indices._types:IndexSettings"
+            }
+          },
+          "mappings": {
+            "$ref": "#/components/schemas/_types.mapping:TypeMapping"
+          },
+          "aliases": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/indices._types:AliasDefinition"
+            }
+          },
+          "lifecycle": {
+            "$ref": "#/components/schemas/indices._types:DataStreamLifecycleWithRollover"
+          }
+        }
+      },
       "_types.mapping:TypeMapping": {
         "type": "object",
         "properties": {
@@ -62917,6 +62920,56 @@
         }
       },
       "indices._types:DataStreamLifecycleWithRollover": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/indices._types:DataStreamLifecycle"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "rollover": {
+                "$ref": "#/components/schemas/indices._types:DataStreamLifecycleRolloverConditions"
+              }
+            }
+          }
+        ]
+      },
+      "indices._types:DataStreamLifecycleRolloverConditions": {
+        "type": "object",
+        "properties": {
+          "min_age": {
+            "$ref": "#/components/schemas/_types:Duration"
+          },
+          "max_age": {
+            "type": "string"
+          },
+          "min_docs": {
+            "type": "number"
+          },
+          "max_docs": {
+            "type": "number"
+          },
+          "min_size": {
+            "$ref": "#/components/schemas/_types:ByteSize"
+          },
+          "max_size": {
+            "$ref": "#/components/schemas/_types:ByteSize"
+          },
+          "min_primary_shard_size": {
+            "$ref": "#/components/schemas/_types:ByteSize"
+          },
+          "max_primary_shard_size": {
+            "$ref": "#/components/schemas/_types:ByteSize"
+          },
+          "min_primary_shard_docs": {
+            "type": "number"
+          },
+          "max_primary_shard_docs": {
+            "type": "number"
+          }
+        }
+      },
+      "indices._types:DataStreamLifecycle": {
         "type": "object",
         "properties": {
           "data_retention": {
@@ -62925,8 +62978,9 @@
           "downsampling": {
             "$ref": "#/components/schemas/indices._types:DataStreamLifecycleDownsampling"
           },
-          "rollover": {
-            "$ref": "#/components/schemas/indices._types:DataStreamLifecycleRolloverConditions"
+          "enabled": {
+            "description": "If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle\nthat's disabled (enabled: `false`) will have no effect on the data stream.",
+            "type": "boolean"
           }
         }
       },
@@ -62970,41 +63024,6 @@
         "required": [
           "fixed_interval"
         ]
-      },
-      "indices._types:DataStreamLifecycleRolloverConditions": {
-        "type": "object",
-        "properties": {
-          "min_age": {
-            "$ref": "#/components/schemas/_types:Duration"
-          },
-          "max_age": {
-            "type": "string"
-          },
-          "min_docs": {
-            "type": "number"
-          },
-          "max_docs": {
-            "type": "number"
-          },
-          "min_size": {
-            "$ref": "#/components/schemas/_types:ByteSize"
-          },
-          "max_size": {
-            "$ref": "#/components/schemas/_types:ByteSize"
-          },
-          "min_primary_shard_size": {
-            "$ref": "#/components/schemas/_types:ByteSize"
-          },
-          "max_primary_shard_size": {
-            "$ref": "#/components/schemas/_types:ByteSize"
-          },
-          "min_primary_shard_docs": {
-            "type": "number"
-          },
-          "max_primary_shard_docs": {
-            "type": "number"
-          }
-        }
       },
       "_types:Level": {
         "type": "string",
@@ -63688,17 +63707,6 @@
       },
       "_types:DataStreamName": {
         "type": "string"
-      },
-      "indices._types:DataStreamLifecycle": {
-        "type": "object",
-        "properties": {
-          "data_retention": {
-            "$ref": "#/components/schemas/_types:Duration"
-          },
-          "downsampling": {
-            "$ref": "#/components/schemas/indices._types:DataStreamLifecycleDownsampling"
-          }
-        }
       },
       "cluster.remote_info:ClusterRemoteInfo": {
         "discriminator": {
@@ -69030,7 +69038,7 @@
             "$ref": "#/components/schemas/_types:DataStreamName"
           },
           "lifecycle": {
-            "$ref": "#/components/schemas/indices._types:DataStreamLifecycle"
+            "$ref": "#/components/schemas/indices._types:DataStreamLifecycleWithRollover"
           }
         },
         "required": [
@@ -83433,20 +83441,36 @@
         ]
       },
       "search_application._types:SearchApplication": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/search_application._types:SearchApplicationParameters"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "$ref": "#/components/schemas/_types:Name"
+              },
+              "updated_at_millis": {
+                "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+              }
+            },
+            "required": [
+              "name",
+              "updated_at_millis"
+            ]
+          }
+        ]
+      },
+      "search_application._types:SearchApplicationParameters": {
         "type": "object",
         "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
           "indices": {
             "description": "Indices that are part of the Search Application.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/_types:IndexName"
             }
-          },
-          "updated_at_millis": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
           "analytics_collection_name": {
             "$ref": "#/components/schemas/_types:Name"
@@ -83456,9 +83480,7 @@
           }
         },
         "required": [
-          "name",
-          "indices",
-          "updated_at_millis"
+          "indices"
         ]
       },
       "search_application._types:SearchApplicationTemplate": {
@@ -83492,32 +83514,6 @@
         },
         "required": [
           "name"
-        ]
-      },
-      "search_application.list:SearchApplicationListItem": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "indices": {
-            "description": "Indices that are part of the Search Application",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/_types:IndexName"
-            }
-          },
-          "updated_at_millis": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
-          },
-          "analytics_collection_name": {
-            "$ref": "#/components/schemas/_types:Name"
-          }
-        },
-        "required": [
-          "name",
-          "indices",
-          "updated_at_millis"
         ]
       },
       "search_application.put_behavioral_analytics:AnalyticsAcknowledgeResponseBase": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -7048,18 +7048,11 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "data_retention": {
-                    "$ref": "#/components/schemas/_types:Duration"
-                  },
-                  "downsampling": {
-                    "$ref": "#/components/schemas/indices._types:DataStreamLifecycleDownsampling"
-                  }
-                }
+                "$ref": "#/components/schemas/indices._types:DataStreamLifecycle"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -16469,7 +16462,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/search_application._types:SearchApplication"
+                "$ref": "#/components/schemas/search_application._types:SearchApplicationParameters"
               }
             }
           },
@@ -16687,7 +16680,7 @@
                     "results": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/search_application.list:SearchApplicationListItem"
+                        "$ref": "#/components/schemas/search_application._types:SearchApplication"
                       }
                     }
                   },
@@ -42898,6 +42891,56 @@
         }
       },
       "indices._types:DataStreamLifecycleWithRollover": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/indices._types:DataStreamLifecycle"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "rollover": {
+                "$ref": "#/components/schemas/indices._types:DataStreamLifecycleRolloverConditions"
+              }
+            }
+          }
+        ]
+      },
+      "indices._types:DataStreamLifecycleRolloverConditions": {
+        "type": "object",
+        "properties": {
+          "min_age": {
+            "$ref": "#/components/schemas/_types:Duration"
+          },
+          "max_age": {
+            "type": "string"
+          },
+          "min_docs": {
+            "type": "number"
+          },
+          "max_docs": {
+            "type": "number"
+          },
+          "min_size": {
+            "$ref": "#/components/schemas/_types:ByteSize"
+          },
+          "max_size": {
+            "$ref": "#/components/schemas/_types:ByteSize"
+          },
+          "min_primary_shard_size": {
+            "$ref": "#/components/schemas/_types:ByteSize"
+          },
+          "max_primary_shard_size": {
+            "$ref": "#/components/schemas/_types:ByteSize"
+          },
+          "min_primary_shard_docs": {
+            "type": "number"
+          },
+          "max_primary_shard_docs": {
+            "type": "number"
+          }
+        }
+      },
+      "indices._types:DataStreamLifecycle": {
         "type": "object",
         "properties": {
           "data_retention": {
@@ -42906,8 +42949,9 @@
           "downsampling": {
             "$ref": "#/components/schemas/indices._types:DataStreamLifecycleDownsampling"
           },
-          "rollover": {
-            "$ref": "#/components/schemas/indices._types:DataStreamLifecycleRolloverConditions"
+          "enabled": {
+            "description": "If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle\nthat's disabled (enabled: `false`) will have no effect on the data stream.",
+            "type": "boolean"
           }
         }
       },
@@ -42951,41 +42995,6 @@
         "required": [
           "fixed_interval"
         ]
-      },
-      "indices._types:DataStreamLifecycleRolloverConditions": {
-        "type": "object",
-        "properties": {
-          "min_age": {
-            "$ref": "#/components/schemas/_types:Duration"
-          },
-          "max_age": {
-            "type": "string"
-          },
-          "min_docs": {
-            "type": "number"
-          },
-          "max_docs": {
-            "type": "number"
-          },
-          "min_size": {
-            "$ref": "#/components/schemas/_types:ByteSize"
-          },
-          "max_size": {
-            "$ref": "#/components/schemas/_types:ByteSize"
-          },
-          "min_primary_shard_size": {
-            "$ref": "#/components/schemas/_types:ByteSize"
-          },
-          "max_primary_shard_size": {
-            "$ref": "#/components/schemas/_types:ByteSize"
-          },
-          "min_primary_shard_docs": {
-            "type": "number"
-          },
-          "max_primary_shard_docs": {
-            "type": "number"
-          }
-        }
       },
       "_types:ClusterInfoTargets": {
         "oneOf": [
@@ -43329,17 +43338,6 @@
       },
       "_types:DataStreamName": {
         "type": "string"
-      },
-      "indices._types:DataStreamLifecycle": {
-        "type": "object",
-        "properties": {
-          "data_retention": {
-            "$ref": "#/components/schemas/_types:Duration"
-          },
-          "downsampling": {
-            "$ref": "#/components/schemas/indices._types:DataStreamLifecycleDownsampling"
-          }
-        }
       },
       "_types:Result": {
         "type": "string",
@@ -45394,7 +45392,7 @@
             "$ref": "#/components/schemas/_types:DataStreamName"
           },
           "lifecycle": {
-            "$ref": "#/components/schemas/indices._types:DataStreamLifecycle"
+            "$ref": "#/components/schemas/indices._types:DataStreamLifecycleWithRollover"
           }
         },
         "required": [
@@ -54117,20 +54115,36 @@
         ]
       },
       "search_application._types:SearchApplication": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/search_application._types:SearchApplicationParameters"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "$ref": "#/components/schemas/_types:Name"
+              },
+              "updated_at_millis": {
+                "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
+              }
+            },
+            "required": [
+              "name",
+              "updated_at_millis"
+            ]
+          }
+        ]
+      },
+      "search_application._types:SearchApplicationParameters": {
         "type": "object",
         "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
           "indices": {
             "description": "Indices that are part of the Search Application.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/_types:IndexName"
             }
-          },
-          "updated_at_millis": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
           },
           "analytics_collection_name": {
             "$ref": "#/components/schemas/_types:Name"
@@ -54140,9 +54154,7 @@
           }
         },
         "required": [
-          "name",
-          "indices",
-          "updated_at_millis"
+          "indices"
         ]
       },
       "search_application._types:SearchApplicationTemplate": {
@@ -54176,32 +54188,6 @@
         },
         "required": [
           "name"
-        ]
-      },
-      "search_application.list:SearchApplicationListItem": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$ref": "#/components/schemas/_types:Name"
-          },
-          "indices": {
-            "description": "Indices that are part of the Search Application",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/_types:IndexName"
-            }
-          },
-          "updated_at_millis": {
-            "$ref": "#/components/schemas/_types:EpochTimeUnitMillis"
-          },
-          "analytics_collection_name": {
-            "$ref": "#/components/schemas/_types:Name"
-          }
-        },
-        "required": [
-          "name",
-          "indices",
-          "updated_at_millis"
         ]
       },
       "search_application.put_behavioral_analytics:AnalyticsAcknowledgeResponseBase": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -8802,18 +8802,20 @@ export interface CcrFollowRequest extends RequestBase {
   index: IndexName
   wait_for_active_shards?: WaitForActiveShards
   body?: {
-    leader_index?: IndexName
+    data_stream_name?: string
+    leader_index: IndexName
     max_outstanding_read_requests?: long
-    max_outstanding_write_requests?: long
-    max_read_request_operation_count?: long
-    max_read_request_size?: string
+    max_outstanding_write_requests?: integer
+    max_read_request_operation_count?: integer
+    max_read_request_size?: ByteSize
     max_retry_delay?: Duration
-    max_write_buffer_count?: long
-    max_write_buffer_size?: string
-    max_write_request_operation_count?: long
-    max_write_request_size?: string
+    max_write_buffer_count?: integer
+    max_write_buffer_size?: ByteSize
+    max_write_request_operation_count?: integer
+    max_write_request_size?: ByteSize
     read_poll_timeout?: Duration
-    remote_cluster?: string
+    remote_cluster: string
+    settings?: IndicesIndexSettings
   }
 }
 
@@ -8832,16 +8834,16 @@ export interface CcrFollowInfoFollowerIndex {
 }
 
 export interface CcrFollowInfoFollowerIndexParameters {
-  max_outstanding_read_requests: integer
-  max_outstanding_write_requests: integer
-  max_read_request_operation_count: integer
-  max_read_request_size: string
-  max_retry_delay: Duration
-  max_write_buffer_count: integer
-  max_write_buffer_size: string
-  max_write_request_operation_count: integer
-  max_write_request_size: string
-  read_poll_timeout: Duration
+  max_outstanding_read_requests?: long
+  max_outstanding_write_requests?: integer
+  max_read_request_operation_count?: integer
+  max_read_request_size?: ByteSize
+  max_retry_delay?: Duration
+  max_write_buffer_count?: integer
+  max_write_buffer_size?: ByteSize
+  max_write_request_operation_count?: integer
+  max_write_request_size?: ByteSize
+  read_poll_timeout?: Duration
 }
 
 export type CcrFollowInfoFollowerIndexStatus = 'active' | 'paused'
@@ -10996,6 +10998,7 @@ export interface IndicesDataStreamIndex {
 export interface IndicesDataStreamLifecycle {
   data_retention?: Duration
   downsampling?: IndicesDataStreamLifecycleDownsampling
+  enabled?: boolean
 }
 
 export interface IndicesDataStreamLifecycleDownsampling {
@@ -11015,9 +11018,7 @@ export interface IndicesDataStreamLifecycleRolloverConditions {
   max_primary_shard_docs?: long
 }
 
-export interface IndicesDataStreamLifecycleWithRollover {
-  data_retention?: Duration
-  downsampling?: IndicesDataStreamLifecycleDownsampling
+export interface IndicesDataStreamLifecycleWithRollover extends IndicesDataStreamLifecycle {
   rollover?: IndicesDataStreamLifecycleRolloverConditions
 }
 
@@ -11883,7 +11884,7 @@ export type IndicesGetAliasResponse = Record<IndexName, IndicesGetAliasIndexAlia
 
 export interface IndicesGetDataLifecycleDataStreamWithLifecycle {
   name: DataStreamName
-  lifecycle?: IndicesDataStreamLifecycle
+  lifecycle?: IndicesDataStreamLifecycleWithRollover
 }
 
 export interface IndicesGetDataLifecycleRequest extends RequestBase {
@@ -12050,10 +12051,7 @@ export interface IndicesPutDataLifecycleRequest extends RequestBase {
   expand_wildcards?: ExpandWildcards
   master_timeout?: Duration
   timeout?: Duration
-  body?: {
-    data_retention?: Duration
-    downsampling?: IndicesDataStreamLifecycleDownsampling
-  }
+  body?: IndicesDataStreamLifecycle
 }
 
 export type IndicesPutDataLifecycleResponse = AcknowledgedResponseBase
@@ -17678,10 +17676,13 @@ export interface SearchApplicationEventDataStream {
   name: IndexName
 }
 
-export interface SearchApplicationSearchApplication {
+export interface SearchApplicationSearchApplication extends SearchApplicationSearchApplicationParameters {
   name: Name
-  indices: IndexName[]
   updated_at_millis: EpochTime<UnitMillis>
+}
+
+export interface SearchApplicationSearchApplicationParameters {
+  indices: IndexName[]
   analytics_collection_name?: Name
   template?: SearchApplicationSearchApplicationTemplate
 }
@@ -17722,20 +17723,13 @@ export interface SearchApplicationListRequest extends RequestBase {
 
 export interface SearchApplicationListResponse {
   count: long
-  results: SearchApplicationListSearchApplicationListItem[]
-}
-
-export interface SearchApplicationListSearchApplicationListItem {
-  name: Name
-  indices: IndexName[]
-  updated_at_millis: EpochTime<UnitMillis>
-  analytics_collection_name?: Name
+  results: SearchApplicationSearchApplication[]
 }
 
 export interface SearchApplicationPutRequest extends RequestBase {
   name: Name
   create?: boolean
-  body?: SearchApplicationSearchApplication
+  body?: SearchApplicationSearchApplicationParameters
 }
 
 export interface SearchApplicationPutResponse {

--- a/specification/license/get/GetLicenseResponseExample1.yaml
+++ b/specification/license/get/GetLicenseResponseExample1.yaml
@@ -1,0 +1,11 @@
+# summary: licensing/get-license.asciidoc:61
+description: A successful response from `GET /_license`.
+# type: response
+# response_code: ''
+value:
+  "{\n  \"license\" : {\n    \"status\" : \"active\",\n    \"uid\" : \"cbff45e7-c553-41f7-ae4f-9205eabd80xx\"\
+  ,\n    \"type\" : \"trial\",\n    \"issue_date\" : \"2018-10-20T22:05:12.332Z\"\
+  ,\n    \"issue_date_in_millis\" : 1540073112332,\n    \"expiry_date\" : \"2018-11-19T22:05:12.332Z\"\
+  ,\n    \"expiry_date_in_millis\" : 1542665112332,\n    \"max_nodes\" : 1000,\n \
+  \   \"max_resource_units\" : null,\n    \"issued_to\" : \"test\",\n    \"issuer\"\
+  \ : \"elasticsearch\",\n    \"start_date_in_millis\" : -1\n  }\n}"

--- a/specification/license/get_basic_status/GetBasicLicenseStatusResponseExample1.yaml
+++ b/specification/license/get_basic_status/GetBasicLicenseStatusResponseExample1.yaml
@@ -1,0 +1,6 @@
+# summary: licensing/get-basic-status.asciidoc:42
+description: A successful response from `GET /_license/basic_status`.
+# type: response
+# response_code: 200
+value:
+  eligible_to_start_basic: true

--- a/specification/license/get_trial_status/GetTrialLicenseStatusResponseExample1.yaml
+++ b/specification/license/get_trial_status/GetTrialLicenseStatusResponseExample1.yaml
@@ -1,0 +1,6 @@
+# summary: licensing/get-trial-status.asciidoc:47
+description: A successful response from `GET /_license/trial_status`.
+# type: response
+# response_code: 200
+value:
+  eligible_to_start_trial: true

--- a/specification/license/post/PostLicenseRequestExample1.yaml
+++ b/specification/license/post/PostLicenseRequestExample1.yaml
@@ -1,0 +1,11 @@
+# summary: licensing/update-license.asciidoc:63
+# method_request: PUT _license
+description: >
+  Run `PUT _license` to update to a basic license. NOTE: These values are invalid; you must substitute the appropriate contents from your license file.
+# type: request
+value:
+  "{\n  \"licenses\": [\n    {\n      \"uid\":\"893361dc-9749-4997-93cb-802e3d7fa4xx\"\
+  ,\n      \"type\":\"basic\",\n      \"issue_date_in_millis\":1411948800000,\n  \
+  \    \"expiry_date_in_millis\":1914278399999,\n      \"max_nodes\":1,\n      \"\
+  issued_to\":\"issuedTo\",\n      \"issuer\":\"issuer\",\n      \"signature\":\"\
+  xx\"\n    }\n    ]\n}"

--- a/specification/license/post/PostLicenseResponseExample1.yaml
+++ b/specification/license/post/PostLicenseResponseExample1.yaml
@@ -1,0 +1,15 @@
+# summary: licensing/get-trial-status.asciidoc:47
+description: If you update to a basic license and you previously had a license with more features, you receive this type of response. You must re-submit the API request and set the `acknowledge` parameter to `true`.
+# type: response
+# response_code: 200
+value:
+  acknowledged: false
+  license_status: valid
+  acknowledge:
+    message: '"""This license update requires acknowledgement. To acknowledge the license, please read the following messages and update the license again, this time with the "acknowledge=true" parameter:"""'
+    watcher:
+      - Watcher will be disabled
+    logstash:
+      - Logstash will no longer poll for centrally-managed pipelines
+    security:
+      - The following X-Pack security functionality will be disabled ...

--- a/specification/license/post_start_basic/StartBasicLicenseResponseExample1.yaml
+++ b/specification/license/post_start_basic/StartBasicLicenseResponseExample1.yaml
@@ -1,0 +1,7 @@
+# summary:
+description: A successful response from `POST /_license/start_basic?acknowledge=true`. If you currently have a license with more features than a basic license and you start a basic license, you must pass the acknowledge parameter.
+# type: response
+# response_code: 200
+value:
+  basic_was_started: true
+  acknowledged: true

--- a/specification/license/post_start_trial/StartTrialLicenseRequest.ts
+++ b/specification/license/post_start_trial/StartTrialLicenseRequest.ts
@@ -30,6 +30,7 @@ import { RequestBase } from '@_types/Base'
  * @rest_spec_name license.post_start_trial
  * @availability stack since=6.1.0 stability=stable
  * @cluster_privileges manage
+ * @doc_id start-trial
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/license/post_start_trial/StartTrialLicenseResponseExample1.yaml
+++ b/specification/license/post_start_trial/StartTrialLicenseResponseExample1.yaml
@@ -1,0 +1,7 @@
+# summary:
+description: A successful response from `POST /_license/start_trial?acknowledge=true`.
+# type: response
+# response_code: 200
+value:
+  trial_was_started: true
+  acknowledged: true


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add examples to licensing APIs (#3420)](https://github.com/elastic/elasticsearch-specification/pull/3420)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)