### PR TITLE
Add connector API examples

### DIFF
--- a/specification/connector/last_sync/ConnectorUpdateLastSyncRequestExample1.yaml
+++ b/specification/connector/last_sync/ConnectorUpdateLastSyncRequestExample1.yaml
@@ -1,0 +1,12 @@
+# summary: connector/apis/update-connector-last-sync-api.asciidoc:115
+# method_request: PUT _connector/my-connector/_last_sync
+# description: ''
+# type: request
+value: "{\n    \"last_access_control_sync_error\": \"Houston, we have a problem!\"\
+  ,\n    \"last_access_control_sync_scheduled_at\": \"2023-11-09T15:13:08.231Z\",\n\
+  \    \"last_access_control_sync_status\": \"pending\",\n    \"last_deleted_document_count\"\
+  : 42,\n    \"last_incremental_sync_scheduled_at\": \"2023-11-09T15:13:08.231Z\"\
+  ,\n    \"last_indexed_document_count\": 42,\n    \"last_sync_error\": \"Houston,\
+  \ we have a problem!\",\n    \"last_sync_scheduled_at\": \"2024-11-09T15:13:08.231Z\"\
+  ,\n    \"last_sync_status\": \"completed\",\n    \"last_synced\": \"2024-11-09T15:13:08.231Z\"\
+  \n}"

--- a/specification/connector/put/ConnectorPutRequestExample1.yaml
+++ b/specification/connector/put/ConnectorPutRequestExample1.yaml
@@ -1,0 +1,6 @@
+# summary: connector/apis/create-connector-api.asciidoc:20
+# method_request: PUT _connector/my-connector
+# description: ''
+# type: request
+value: "{\n  \"index_name\": \"search-google-drive\",\n  \"name\": \"My Connector\"\
+  ,\n  \"service_type\": \"google_drive\"\n}"

--- a/specification/connector/put/ConnectorPutRequestExample2.yaml
+++ b/specification/connector/put/ConnectorPutRequestExample2.yaml
@@ -1,0 +1,7 @@
+# summary: connector/apis/create-connector-api.asciidoc:111
+# method_request: PUT _connector/my-connector
+# description: ''
+# type: request
+value: "{\n  \"index_name\": \"search-google-drive\",\n  \"name\": \"My Connector\"\
+  ,\n  \"description\": \"My Connector to sync data to Elastic index from Google Drive\"\
+  ,\n  \"service_type\": \"google_drive\",\n  \"language\": \"english\"\n}"

--- a/specification/connector/sync_job_error/SyncJobErrorRequestExample1.yaml
+++ b/specification/connector/sync_job_error/SyncJobErrorRequestExample1.yaml
@@ -1,0 +1,5 @@
+# summary: connector/apis/set-connector-sync-job-error-api.asciidoc:56
+# method_request: PUT _connector/_sync_job/my-connector-sync-job/_error
+# description: ''
+# type: request
+value: "{\n    \"error\": \"some-error\"\n}"

--- a/specification/connector/sync_job_post/SyncJobPostRequestExample1.yaml
+++ b/specification/connector/sync_job_post/SyncJobPostRequestExample1.yaml
@@ -1,0 +1,6 @@
+# summary: connector/apis/create-connector-sync-job-api.asciidoc:15
+# method_request: POST _connector/_sync_job
+# description: ''
+# type: request
+value: "{\n  \"id\": \"connector-id\",\n  \"job_type\": \"full\",\n  \"trigger_method\"\
+  : \"on_demand\"\n}"

--- a/specification/connector/update_api_key_id/ConnectorUpdateApiKeyIdExample1.yaml
+++ b/specification/connector/update_api_key_id/ConnectorUpdateApiKeyIdExample1.yaml
@@ -1,0 +1,6 @@
+# summary: connector/apis/update-connector-api-key-id-api.asciidoc:86
+# method_request: PUT _connector/my-connector/_api_key_id
+# description: ''
+# type: request
+value: "{\n    \"api_key_id\": \"my-api-key-id\",\n    \"api_key_secret_id\": \"my-connector-secret-id\"\
+  \n}"

--- a/specification/connector/update_configuration/ConnectorUpdateConfigurationRequestExample1.yaml
+++ b/specification/connector/update_configuration/ConnectorUpdateConfigurationRequestExample1.yaml
@@ -1,0 +1,7 @@
+# summary: connector/apis/update-connector-configuration-api.asciidoc:308
+# method_request: PUT _connector/my-spo-connector/_configuration
+# description: ''
+# type: request
+value: "{\n    \"values\": {\n        \"tenant_id\": \"my-tenant-id\",\n        \"\
+  tenant_name\": \"my-sharepoint-site\",\n        \"client_id\": \"foo\",\n      \
+  \  \"secret_value\": \"bar\",\n        \"site_collections\": \"*\"\n    }\n}"

--- a/specification/connector/update_configuration/ConnectorUpdateConfigurationRequestExample2.yaml
+++ b/specification/connector/update_configuration/ConnectorUpdateConfigurationRequestExample2.yaml
@@ -1,0 +1,5 @@
+# summary: connector/apis/update-connector-configuration-api.asciidoc:335
+# method_request: PUT _connector/my-spo-connector/_configuration
+# description: ''
+# type: request
+value: "{\n    \"values\": {\n        \"secret_value\": \"foo-bar\"\n    }\n}"

--- a/specification/connector/update_error/ConnectorUpdateErrorRequestExample1.yaml
+++ b/specification/connector/update_error/ConnectorUpdateErrorRequestExample1.yaml
@@ -1,0 +1,5 @@
+# summary: connector/apis/update-connector-error-api.asciidoc:75
+# method_request: PUT _connector/my-connector/_error
+# description: ''
+# type: request
+value: "{\n    \"error\": \"Houston, we have a problem!\"\n}"

--- a/specification/connector/update_features/ConnectorUpdateFeaturesRequestExample1.yaml
+++ b/specification/connector/update_features/ConnectorUpdateFeaturesRequestExample1.yaml
@@ -1,0 +1,8 @@
+# summary: connector/apis/update-connector-features-api.asciidoc:90
+# method_request: PUT _connector/my-connector/_features
+# description: ''
+# type: request
+value: "{\n  \"features\": {\n    \"document_level_security\": {\n      \"enabled\"\
+  : true\n    },\n    \"incremental_sync\": {\n      \"enabled\": true\n    },\n \
+  \   \"sync_rules\": {\n      \"advanced\": {\n        \"enabled\": false\n     \
+  \ },\n      \"basic\": {\n        \"enabled\": true\n      }\n    }\n  }\n}"

--- a/specification/connector/update_features/ConnectorUpdateFeaturesRequestExample2.yaml
+++ b/specification/connector/update_features/ConnectorUpdateFeaturesRequestExample2.yaml
@@ -1,0 +1,6 @@
+# summary: connector/apis/update-connector-features-api.asciidoc:122
+# method_request: PUT _connector/my-connector/_features
+# description: ''
+# type: request
+value: "{\n  \"features\": {\n    \"document_level_security\": {\n      \"enabled\"\
+  : true\n    }\n  }\n}"

--- a/specification/connector/update_filtering/ConnectorUpdateFilteringRequestExample1.yaml
+++ b/specification/connector/update_filtering/ConnectorUpdateFilteringRequestExample1.yaml
@@ -1,0 +1,11 @@
+# summary: connector/apis/update-connector-filtering-api.asciidoc:115
+# method_request: PUT _connector/my-g-drive-connector/_filtering
+# description: ''
+# type: request
+value: "{\n    \"rules\": [\n         {\n            \"field\": \"file_extension\"\
+  ,\n            \"id\": \"exclude-txt-files\",\n            \"order\": 0,\n     \
+  \       \"policy\": \"exclude\",\n            \"rule\": \"equals\",\n          \
+  \  \"value\": \"txt\"\n        },\n        {\n            \"field\": \"_\",\n  \
+  \          \"id\": \"DEFAULT\",\n            \"order\": 1,\n            \"policy\"\
+  : \"include\",\n            \"rule\": \"regex\",\n            \"value\": \".*\"\n\
+  \        }\n    ]\n}"

--- a/specification/connector/update_filtering/ConnectorUpdateFilteringRequestExample2.yaml
+++ b/specification/connector/update_filtering/ConnectorUpdateFilteringRequestExample2.yaml
@@ -1,0 +1,8 @@
+# summary: connector/apis/update-connector-filtering-api.asciidoc:149
+# method_request: PUT _connector/my-sql-connector/_filtering
+# description: ''
+# type: request
+value: "{\n    \"advanced_snippet\": {\n        \"value\": [{\n            \"tables\"\
+  : [\n                \"users\",\n                \"orders\"\n            ],\n  \
+  \          \"query\": \"SELECT users.id AS id, orders.order_id AS order_id FROM\
+  \ users JOIN orders ON users.id = orders.user_id\"\n        }]\n    }\n}"

--- a/specification/connector/update_index_name/ConnectorUpdateIndexNameRequestExample1.yaml
+++ b/specification/connector/update_index_name/ConnectorUpdateIndexNameRequestExample1.yaml
@@ -1,0 +1,5 @@
+# summary: connector/apis/update-connector-index-name-api.asciidoc:75
+# method_request: PUT _connector/my-connector/_index_name
+# description: ''
+# type: request
+value: "{\n    \"index_name\": \"data-from-my-google-drive\"\n}"

--- a/specification/connector/update_name/ConnectorUpdateNameRequestExample1.yaml
+++ b/specification/connector/update_name/ConnectorUpdateNameRequestExample1.yaml
@@ -1,0 +1,6 @@
+# summary: connector/apis/update-connector-name-description-api.asciidoc:79
+# method_request: PUT _connector/my-connector/_name
+# description: ''
+# type: request
+value: "{\n    \"name\": \"Custom connector\",\n    \"description\": \"This is my\
+  \ customized connector\"\n}"

--- a/specification/connector/update_pipeline/ConnectorUpdatePipelineRequestExample1.yaml
+++ b/specification/connector/update_pipeline/ConnectorUpdatePipelineRequestExample1.yaml
@@ -1,0 +1,7 @@
+# summary: connector/apis/update-connector-pipeline-api.asciidoc:87
+# method_request: PUT _connector/my-connector/_pipeline
+# description: ''
+# type: request
+value: "{\n    \"pipeline\": {\n        \"extract_binary_content\": true,\n      \
+  \  \"name\": \"my-connector-pipeline\",\n        \"reduce_whitespace\": true,\n\
+  \        \"run_ml_inference\": true\n    }\n}"

--- a/specification/connector/update_scheduling/ConnectorUpdateSchedulingRequestExample1.yaml
+++ b/specification/connector/update_scheduling/ConnectorUpdateSchedulingRequestExample1.yaml
@@ -1,0 +1,9 @@
+# summary: connector/apis/update-connector-scheduling-api.asciidoc:89
+# method_request: PUT _connector/my-connector/_scheduling
+# description: ''
+# type: request
+value: "{\n    \"scheduling\": {\n        \"access_control\": {\n            \"enabled\"\
+  : true,\n            \"interval\": \"0 10 0 * * ?\"\n        },\n        \"full\"\
+  : {\n            \"enabled\": true,\n            \"interval\": \"0 20 0 * * ?\"\n\
+  \        },\n        \"incremental\": {\n            \"enabled\": false,\n     \
+  \       \"interval\": \"0 30 0 * * ?\"\n        }\n    }\n}"

--- a/specification/connector/update_scheduling/ConnectorUpdateSchedulingRequestExample2.yaml
+++ b/specification/connector/update_scheduling/ConnectorUpdateSchedulingRequestExample2.yaml
@@ -1,0 +1,6 @@
+# summary: connector/apis/update-connector-scheduling-api.asciidoc:119
+# method_request: PUT _connector/my-connector/_scheduling
+# description: ''
+# type: request
+value: "{\n    \"scheduling\": {\n        \"full\": {\n            \"enabled\": true,\n\
+  \            \"interval\": \"0 10 0 * * ?\"\n        }\n    }\n}"

--- a/specification/connector/update_service_type/ConnectorUpdateServiceTypeRequestExample1.yaml
+++ b/specification/connector/update_service_type/ConnectorUpdateServiceTypeRequestExample1.yaml
@@ -1,0 +1,5 @@
+# summary: connector/apis/update-connector-service-type-api.asciidoc:77
+# method_request: PUT _connector/my-connector/_service_type
+# description: ''
+# type: request
+value: "{\n    \"service_type\": \"sharepoint_online\"\n}"

--- a/specification/connector/update_status/ConnectorUpdateStatusRequestExample1.yaml
+++ b/specification/connector/update_status/ConnectorUpdateStatusRequestExample1.yaml
@@ -1,0 +1,5 @@
+# summary: connector/apis/update-connector-status-api.asciidoc:75
+# method_request: PUT _connector/my-connector/_status
+# description: ''
+# type: request
+value: "{\n    \"status\": \"needs_configuration\"\n}"


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR adds the connector API example files.
It does not add overlays to hook these examples into the OpenAPI documents. That task will occur after all the examples are ported to avoid merge conflicts.