### PR TITLE
Add datastream API examples

### DIFF
--- a/specification/indices/downsample/RequestExample1.yaml
+++ b/specification/indices/downsample/RequestExample1.yaml
@@ -1,0 +1,6 @@
+# summary:
+# method_request: POST /my-time-series-index/_downsample/my-downsampled-time-series-index
+# description: ''
+# type: request
+value:
+  fixed_interval: 1d

--- a/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleResponseExample1.yaml
+++ b/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleResponseExample1.yaml
@@ -1,5 +1,6 @@
-# summary: ''
-description: A successful response for retrieving data stream lifecycle status for a data stream backing index.
+summary: Successful response
+description: >
+  A successful response from `GET .ds-metrics-2023.03.22-000001/_lifecycle/explain`, which retrieves  the lifecycle status for a data stream backing index. If the index is managed by a data stream lifecycle, the API will show the `managed_by_lifecycle` field set to `true` and the rest of the response will contain information about the lifecycle execution status for this index.
 # type: response
 # response_code: 200
 value:

--- a/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleResponseExample2.yaml
+++ b/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleResponseExample2.yaml
@@ -1,0 +1,12 @@
+summary: Successful response with error messages
+description: The API reports any errors related to the lifecycle execution for the target index.
+# type: response
+# response_code: ''
+value:
+  "{\n  \"indices\": {\n    \".ds-metrics-2023.03.22-000001\": {\n      \"index\"\
+  \ : \".ds-metrics-2023.03.22-000001\",\n      \"managed_by_lifecycle\" : true,\n\
+  \      \"index_creation_date_millis\" : 1679475563571,\n      \"time_since_index_creation\"\
+  \ : \"843ms\",\n      \"lifecycle\" : {\n        \"enabled\": true\n      },\n \
+  \     \"error\": \"{\\\"type\\\":\\\"validation_exception\\\",\\\"reason\\\":\\\"\
+  Validation Failed: 1: this action would add [2] shards, but this cluster\ncurrently\
+  \ has [4]/[3] maximum normal shards open;\\\"}\"\n  }\n}"

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleResponseExample1.yaml
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleResponseExample1.yaml
@@ -1,5 +1,5 @@
 # summary:
-description: A successful response of getting the lifecycle of a set of data streams.
+description: A successful response from `GET _lifecycle/stats?human&pretty`.
 # type: response
 # response_code: 200
 value:


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR copies examples from https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-apis.html