### PR TITLE
Add migration API examples

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -17086,7 +17086,7 @@
           "migration"
         ],
         "summary": "Get deprecation information",
-        "description": "Get information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.\n\nTIP: This APIs is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.",
+        "description": "Get information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.\n\nTIP: This APIs is designed for indirect use by the Upgrade Assistant.\nYou are strongly recommended to use the Upgrade Assistant.",
         "operationId": "migration-deprecations",
         "responses": {
           "200": {
@@ -17102,7 +17102,7 @@
           "migration"
         ],
         "summary": "Get deprecation information",
-        "description": "Get information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.\n\nTIP: This APIs is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.",
+        "description": "Get information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.\n\nTIP: This APIs is designed for indirect use by the Upgrade Assistant.\nYou are strongly recommended to use the Upgrade Assistant.",
         "operationId": "migration-deprecations-1",
         "parameters": [
           {
@@ -17123,7 +17123,7 @@
           "migration"
         ],
         "summary": "Get feature migration information",
-        "description": "Version upgrades sometimes require changes to how features store configuration information and data in system indices.\nCheck which features need to be migrated and the status of any migrations that are in progress.\n\nTIP: This API is designed for indirect use by the Upgrade Assistant.\nWe strongly recommend you use the Upgrade Assistant.",
+        "description": "Version upgrades sometimes require changes to how features store configuration information and data in system indices.\nCheck which features need to be migrated and the status of any migrations that are in progress.\n\nTIP: This API is designed for indirect use by the Upgrade Assistant.\nYou are strongly recommended to use the Upgrade Assistant.",
         "operationId": "migration-get-feature-upgrade-status",
         "responses": {
           "200": {
@@ -73995,15 +73995,18 @@
         "type": "object",
         "properties": {
           "details": {
+            "description": "Optional details about the deprecation warning.",
             "type": "string"
           },
           "level": {
             "$ref": "#/components/schemas/migration.deprecations:DeprecationLevel"
           },
           "message": {
+            "description": "Descriptive information about the deprecation warning.",
             "type": "string"
           },
           "url": {
+            "description": "A link to the breaking change documentation, where you can find more information about this change.",
             "type": "string"
           },
           "resolve_during_rolling_upgrade": {
@@ -92749,12 +92752,14 @@
               "type": "object",
               "properties": {
                 "cluster_settings": {
+                  "description": "Cluster-level deprecation warnings.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/migration.deprecations:Deprecation"
                   }
                 },
                 "index_settings": {
+                  "description": "Index warnings are sectioned off per index and can be filtered using an index-pattern in the query.\nThis section includes warnings for the backing indices of data streams specified in the request path.",
                   "type": "object",
                   "additionalProperties": {
                     "type": "array",
@@ -92773,12 +92778,14 @@
                   }
                 },
                 "node_settings": {
+                  "description": "Node-level deprecation warnings.\nSince only a subset of your nodes might incorporate these settings, it is important to read the details section for more information about which nodes are affected.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/migration.deprecations:Deprecation"
                   }
                 },
                 "ml_settings": {
+                  "description": "Machine learning-related deprecation warnings.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/migration.deprecations:Deprecation"

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -290,7 +290,7 @@ mapping,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping
 mean-reciprocal,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#_mean_reciprocal_rank
 migrate-index-allocation-filters,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/migrate-index-allocation-filters.html
 migration-api-deprecation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/migration-api-deprecation.html
-migration-api-feature-upgrade,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/migration-api-feature-upgrade.html
+migration-api-feature-upgrade,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/feature-migration-api.html
 ml-apis,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-apis.html
 ml-classification,https://www.elastic.co/guide/en/machine-learning/{branch}/ml-dfa-classification.html
 ml-close-job,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-close-job.html

--- a/specification/migration/deprecations/DeprecationInfoRequest.ts
+++ b/specification/migration/deprecations/DeprecationInfoRequest.ts
@@ -24,10 +24,12 @@ import { IndexName } from '@_types/common'
  * Get deprecation information.
  * Get information about different cluster, node, and index level settings that use deprecated features that will be removed or changed in the next major version.
  *
- * TIP: This APIs is designed for indirect use by the Upgrade Assistant. We strongly recommend you use the Upgrade Assistant.
+ * TIP: This APIs is designed for indirect use by the Upgrade Assistant.
+ * You are strongly recommended to use the Upgrade Assistant.
  * @rest_spec_name migration.deprecations
  * @availability stack since=6.1.0 stability=stable
  * @cluster_privileges manage
+ * @doc_id migration-api-deprecation
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/migration/deprecations/DeprecationInfoResponse.ts
+++ b/specification/migration/deprecations/DeprecationInfoResponse.ts
@@ -22,10 +22,24 @@ import { Deprecation } from './types'
 
 export class Response {
   body: {
+    /**
+     * Cluster-level deprecation warnings.
+     */
     cluster_settings: Deprecation[]
+    /**
+     * Index warnings are sectioned off per index and can be filtered using an index-pattern in the query.
+     * This section includes warnings for the backing indices of data streams specified in the request path.
+     */
     index_settings: Dictionary<string, Deprecation[]>
     data_streams: Dictionary<string, Deprecation[]>
+    /**
+     * Node-level deprecation warnings.
+     * Since only a subset of your nodes might incorporate these settings, it is important to read the details section for more information about which nodes are affected.
+     */
     node_settings: Deprecation[]
+    /**
+     * Machine learning-related deprecation warnings.
+     */
     ml_settings: Deprecation[]
   }
 }

--- a/specification/migration/deprecations/DeprecationInfoResponseExample1.yaml
+++ b/specification/migration/deprecations/DeprecationInfoResponseExample1.yaml
@@ -1,0 +1,19 @@
+# summary:
+description: >
+  An abbreviated response from `GET /_migration/deprecations`.
+# type: "response"
+# response_code: 200
+value:
+  cluster_settings:
+    - level: critical
+      message: "Cluster name cannot contain ':'"
+      url: 'https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#_literal_literal_is_no_longer_allowed_in_cluster_name'
+      details: "This cluster is named [mycompany:logging], which contains the illegal character ':'."
+  node_settings: []
+  index_settings:
+    'logs:apache':
+      - level: warning
+        message: "Index name cannot contain ':'"
+        url: 'https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#_literal_literal_is_no_longer_allowed_in_index_name'
+        details: "This index is named [logs:apache], which contains the illegal character ':'."
+  ml_settings: []

--- a/specification/migration/deprecations/types.ts
+++ b/specification/migration/deprecations/types.ts
@@ -30,10 +30,17 @@ export enum DeprecationLevel {
 }
 
 export class Deprecation {
+  /**
+   * Optional details about the deprecation warning.
+   */
   details?: string
   /** The level property describes the significance of the issue. */
   level: DeprecationLevel
+  /** Descriptive information about the deprecation warning. */
   message: string
+  /**
+   * A link to the breaking change documentation, where you can find more information about this change.
+   */
   url: string
   resolve_during_rolling_upgrade: boolean
   _meta?: Dictionary<string, UserDefinedValue>

--- a/specification/migration/get_feature_upgrade_status/GetFeatureUpgradeStatusRequest.ts
+++ b/specification/migration/get_feature_upgrade_status/GetFeatureUpgradeStatusRequest.ts
@@ -25,10 +25,11 @@ import { RequestBase } from '@_types/Base'
  * Check which features need to be migrated and the status of any migrations that are in progress.
  *
  * TIP: This API is designed for indirect use by the Upgrade Assistant.
- * We strongly recommend you use the Upgrade Assistant.
+ * You are strongly recommended to use the Upgrade Assistant.
  * @rest_spec_name migration.get_feature_upgrade_status
  * @availability stack since=7.16.0 stability=stable
  * @index_privileges manage
  * @cluster_privileges manage
+ * @doc_id migration-api-feature-upgrade
  */
 export interface Request extends RequestBase {}

--- a/specification/migration/get_feature_upgrade_status/GetFeatureUpgradeStatusResponseExample1.yaml
+++ b/specification/migration/get_feature_upgrade_status/GetFeatureUpgradeStatusResponseExample1.yaml
@@ -1,0 +1,36 @@
+# summary:
+description: A successful response from `GET /_migration/system_features`.
+# type: response
+# response_code: ''
+value:
+  "{\n  \"features\" : [\n    {\n      \"feature_name\" : \"async_search\",\n\
+  \      \"minimum_index_version\" : \"8100099\",\n      \"migration_status\" : \"\
+  NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n    },\n    {\n      \"feature_name\"\
+  \ : \"enrich\",\n      \"minimum_index_version\" : \"8100099\",\n      \"migration_status\"\
+  \ : \"NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n    },\n    {\n      \"feature_name\"\
+  \ : \"ent_search\",\n      \"minimum_index_version\" : \"8100099\",\n      \"migration_status\"\
+  \ : \"NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n    },\n    {\n      \"feature_name\"\
+  \ : \"fleet\",\n      \"minimum_index_version\" : \"8100099\",\n      \"migration_status\"\
+  \ : \"NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n    },\n    {\n      \"feature_name\"\
+  \ : \"geoip\",\n      \"minimum_index_version\" : \"8100099\",\n      \"migration_status\"\
+  \ : \"NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n    },\n    {\n      \"feature_name\"\
+  \ : \"kibana\",\n      \"minimum_index_version\" : \"8100099\",\n      \"migration_status\"\
+  \ : \"NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n    },\n    {\n      \"feature_name\"\
+  \ : \"logstash_management\",\n      \"minimum_index_version\" : \"8100099\",\n \
+  \     \"migration_status\" : \"NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n\
+  \    },\n    {\n      \"feature_name\" : \"machine_learning\",\n      \"minimum_index_version\"\
+  \ : \"8100099\",\n      \"migration_status\" : \"NO_MIGRATION_NEEDED\",\n      \"\
+  indices\" : [ ]\n    },\n    {\n      \"feature_name\" : \"searchable_snapshots\"\
+  ,\n      \"minimum_index_version\" : \"8100099\",\n      \"migration_status\" :\
+  \ \"NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n    },\n    {\n      \"feature_name\"\
+  \ : \"security\",\n      \"minimum_index_version\" : \"8100099\",\n      \"migration_status\"\
+  \ : \"NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n    },\n    {\n      \"feature_name\"\
+  \ : \"synonyms\",\n      \"minimum_index_version\" : \"8100099\",\n      \"migration_status\"\
+  \ : \"NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n    },\n    {\n      \"feature_name\"\
+  \ : \"tasks\",\n      \"minimum_index_version\" : \"8100099\",\n      \"migration_status\"\
+  \ : \"NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n    },\n    {\n      \"feature_name\"\
+  \ : \"transform\",\n      \"minimum_index_version\" : \"8100099\",\n      \"migration_status\"\
+  \ : \"NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n    },\n    {\n      \"feature_name\"\
+  \ : \"watcher\",\n      \"minimum_index_version\" : \"8100099\",\n      \"migration_status\"\
+  \ : \"NO_MIGRATION_NEEDED\",\n      \"indices\" : [ ]\n    }\n  ],\n  \"migration_status\"\
+  \ : \"NO_MIGRATION_NEEDED\"\n}"

--- a/specification/migration/post_feature_upgrade/PostFeatureUpgradeRequest.ts
+++ b/specification/migration/post_feature_upgrade/PostFeatureUpgradeRequest.ts
@@ -31,5 +31,6 @@ import { RequestBase } from '@_types/Base'
  * @availability stack since=7.16.0 stability=stable
  * @index_privileges manage
  * @cluster_privileges manage
+ * @doc_id migration-api-feature-upgrade
  */
 export interface Request extends RequestBase {}

--- a/specification/migration/post_feature_upgrade/PostFeatureUpgradeResponseExample1.yaml
+++ b/specification/migration/post_feature_upgrade/PostFeatureUpgradeResponseExample1.yaml
@@ -1,0 +1,8 @@
+# summary:
+description: >
+  When you run `POST /_migration/system_features` to start the migration process, the response lists the features that will be migrated.
+# type: response
+# response_code: ''
+value:
+  "{\n  \"accepted\" : true,\n  \"features\" : [\n    {\n      \"feature_name\"\
+  \ : \"security\"\n    }\n  ]\n}"


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR copies examples from https://www.elastic.co/guide/en/elasticsearch/reference/master/migration-api-deprecation.html