### PR TITLE
Add query rule API examples

### DIFF
--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -668,7 +668,7 @@ export function hoistRequestAnnotations (
       const privileges = [
         'all', 'cancel_task', 'create_snapshot', 'grant_api_key', 'manage', 'manage_api_key', 'manage_ccr',
         'manage_enrich', 'manage_ilm', 'manage_index_templates', 'manage_inference', 'manage_ingest_pipelines', 'manage_logstash_pipelines',
-        'manage_ml', 'manage_oidc', 'manage_own_api_key', 'manage_pipeline', 'manage_rollup', 'manage_saml', 'manage_search_application',
+        'manage_ml', 'manage_oidc', 'manage_own_api_key', 'manage_pipeline', 'manage_rollup', 'manage_saml', 'manage_search_application', 'manage_search_query_rules',
         'manage_security', 'manage_service_account', 'manage_slm', 'manage_token', 'manage_transform', 'manage_user_profile',
         'manage_watcher', 'monitor', 'monitor_ml', 'monitor_rollup', 'monitor_snapshot', 'monitor_text_structure',
         'monitor_transform', 'monitor_watcher', 'read_ccr', 'read_ilm', 'read_pipeline', 'read_security', 'read_slm', 'transport_client'

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -24950,13 +24950,13 @@
           "query_rules"
         ],
         "summary": "Create or update a query rule",
-        "description": "Create or update a query rule within a query ruleset.",
+        "description": "Create or update a query rule within a query ruleset.\n\nIMPORTANT: Due to limitations within pinned queries, you can only pin documents using ids or docs, but cannot use both in single rule.\nIt is advised to use one or the other in query rulesets, to avoid errors.\nAdditionally, pinned queries have a maximum limit of 100 pinned hits.\nIf multiple matching rules pin more than 100 documents, only the first 100 documents are pinned in the order they are specified in the ruleset.",
         "operationId": "query-rules-put-rule",
         "parameters": [
           {
             "in": "path",
             "name": "ruleset_id",
-            "description": "The unique identifier of the query ruleset containing the rule to be created or updated",
+            "description": "The unique identifier of the query ruleset containing the rule to be created or updated.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -24967,7 +24967,7 @@
           {
             "in": "path",
             "name": "rule_id",
-            "description": "The unique identifier of the query rule within the specified ruleset to be created or updated",
+            "description": "The unique identifier of the query rule within the specified ruleset to be created or updated.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -24986,6 +24986,7 @@
                     "$ref": "#/components/schemas/query_rules._types:QueryRuleType"
                   },
                   "criteria": {
+                    "description": "The criteria that must be met for the rule to be applied.\nIf multiple criteria are specified for a rule, all criteria must be met for the rule to be applied.",
                     "oneOf": [
                       {
                         "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
@@ -25042,7 +25043,7 @@
           "query_rules"
         ],
         "summary": "Delete a query rule",
-        "description": "Delete a query rule within a query ruleset.",
+        "description": "Delete a query rule within a query ruleset.\nThis is a destructive action that is only recoverable by re-adding the same rule with the create or update query rule API.",
         "operationId": "query-rules-delete-rule",
         "parameters": [
           {
@@ -25123,6 +25124,7 @@
           "query_rules"
         ],
         "summary": "Create or update a query ruleset",
+        "description": "There is a limit of 100 rules per ruleset.\nThis limit can be increased by using the `xpack.applications.rules.max_rules_per_ruleset` cluster setting.\n\nIMPORTANT: Due to limitations within pinned queries, you can only select documents using `ids` or `docs`, but cannot use both in single rule.\nIt is advised to use one or the other in query rulesets, to avoid errors.\nAdditionally, pinned queries have a maximum limit of 100 pinned hits.\nIf multiple matching rules pin more than 100 documents, only the first 100 documents are pinned in the order they are specified in the ruleset.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-using-query-rules.html"
         },
@@ -25131,7 +25133,7 @@
           {
             "in": "path",
             "name": "ruleset_id",
-            "description": "The unique identifier of the query ruleset to be created or updated",
+            "description": "The unique identifier of the query ruleset to be created or updated.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -25195,6 +25197,7 @@
           "query_rules"
         ],
         "summary": "Delete a query ruleset",
+        "description": "Remove a query ruleset and its associated data.\nThis is a destructive action that is not recoverable.",
         "operationId": "query-rules-delete-ruleset",
         "parameters": [
           {
@@ -25236,7 +25239,7 @@
           {
             "in": "query",
             "name": "from",
-            "description": "Starting offset (default: 0)",
+            "description": "The offset from the first result to fetch.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -25246,7 +25249,7 @@
           {
             "in": "query",
             "name": "size",
-            "description": "specifies a max number of results to get",
+            "description": "The maximum number of results to retrieve.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -25312,6 +25315,7 @@
                 "type": "object",
                 "properties": {
                   "match_criteria": {
+                    "description": "The match criteria to apply to rules in the given query ruleset.\nMatch criteria should match the keys defined in the `criteria.metadata` field of the rule.",
                     "type": "object",
                     "additionalProperties": {
                       "type": "object"
@@ -82216,6 +82220,7 @@
             "$ref": "#/components/schemas/query_rules._types:QueryRuleType"
           },
           "criteria": {
+            "description": "The criteria that must be met for the rule to be applied.\nIf multiple criteria are specified for a rule, all criteria must be met for the rule to be applied.",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
@@ -82256,9 +82261,11 @@
             "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteriaType"
           },
           "metadata": {
+            "description": "The metadata field to match against.\nThis metadata will be used to match against `match_criteria` sent in the rule.\nIt is required for all criteria types except `always`.",
             "type": "string"
           },
           "values": {
+            "description": "The values to match against the `metadata` field.\nOnly one value must match for the criteria to be met.\nIt is required for all criteria types except `always`.",
             "type": "array",
             "items": {
               "type": "object"
@@ -82290,12 +82297,14 @@
         "type": "object",
         "properties": {
           "ids": {
+            "description": "The unique document IDs of the documents to apply the rule to.\nOnly one of `ids` or `docs` may be specified and at least one must be specified.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/_types:Id"
             }
           },
           "docs": {
+            "description": "The documents to apply the rule to.\nOnly one of `ids` or `docs` may be specified and at least one must be specified.\nThere is a maximum value of 100 documents in a rule.\nYou can specify the following attributes for each document:\n\n* `_index`: The index of the document to pin.\n* `_id`: The unique document ID.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/_types.query_dsl:PinnedDoc"
@@ -82310,7 +82319,7 @@
             "$ref": "#/components/schemas/_types:Id"
           },
           "rules": {
-            "description": "Rules associated with the query ruleset",
+            "description": "Rules associated with the query ruleset.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/query_rules._types:QueryRule"
@@ -82329,18 +82338,18 @@
             "$ref": "#/components/schemas/_types:Id"
           },
           "rule_total_count": {
-            "description": "The number of rules associated with this ruleset",
+            "description": "The number of rules associated with the ruleset.",
             "type": "number"
           },
           "rule_criteria_types_counts": {
-            "description": "A map of criteria type (e.g. exact) to the number of rules of that type",
+            "description": "A map of criteria type (for example, `exact`) to the number of rules of that type.\n\nNOTE: The counts in `rule_criteria_types_counts` may be larger than the value of `rule_total_count` because a rule may have multiple criteria.",
             "type": "object",
             "additionalProperties": {
               "type": "number"
             }
           },
           "rule_type_counts": {
-            "description": "A map of rule type (e.g. pinned) to the number of rules of that type",
+            "description": "A map of rule type (for example, `pinned`) to the number of rules of that type.",
             "type": "object",
             "additionalProperties": {
               "type": "number"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -14693,13 +14693,13 @@
           "query_rules"
         ],
         "summary": "Create or update a query rule",
-        "description": "Create or update a query rule within a query ruleset.",
+        "description": "Create or update a query rule within a query ruleset.\n\nIMPORTANT: Due to limitations within pinned queries, you can only pin documents using ids or docs, but cannot use both in single rule.\nIt is advised to use one or the other in query rulesets, to avoid errors.\nAdditionally, pinned queries have a maximum limit of 100 pinned hits.\nIf multiple matching rules pin more than 100 documents, only the first 100 documents are pinned in the order they are specified in the ruleset.",
         "operationId": "query-rules-put-rule",
         "parameters": [
           {
             "in": "path",
             "name": "ruleset_id",
-            "description": "The unique identifier of the query ruleset containing the rule to be created or updated",
+            "description": "The unique identifier of the query ruleset containing the rule to be created or updated.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -14710,7 +14710,7 @@
           {
             "in": "path",
             "name": "rule_id",
-            "description": "The unique identifier of the query rule within the specified ruleset to be created or updated",
+            "description": "The unique identifier of the query rule within the specified ruleset to be created or updated.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -14729,6 +14729,7 @@
                     "$ref": "#/components/schemas/query_rules._types:QueryRuleType"
                   },
                   "criteria": {
+                    "description": "The criteria that must be met for the rule to be applied.\nIf multiple criteria are specified for a rule, all criteria must be met for the rule to be applied.",
                     "oneOf": [
                       {
                         "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
@@ -14785,7 +14786,7 @@
           "query_rules"
         ],
         "summary": "Delete a query rule",
-        "description": "Delete a query rule within a query ruleset.",
+        "description": "Delete a query rule within a query ruleset.\nThis is a destructive action that is only recoverable by re-adding the same rule with the create or update query rule API.",
         "operationId": "query-rules-delete-rule",
         "parameters": [
           {
@@ -14866,6 +14867,7 @@
           "query_rules"
         ],
         "summary": "Create or update a query ruleset",
+        "description": "There is a limit of 100 rules per ruleset.\nThis limit can be increased by using the `xpack.applications.rules.max_rules_per_ruleset` cluster setting.\n\nIMPORTANT: Due to limitations within pinned queries, you can only select documents using `ids` or `docs`, but cannot use both in single rule.\nIt is advised to use one or the other in query rulesets, to avoid errors.\nAdditionally, pinned queries have a maximum limit of 100 pinned hits.\nIf multiple matching rules pin more than 100 documents, only the first 100 documents are pinned in the order they are specified in the ruleset.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-using-query-rules.html"
         },
@@ -14874,7 +14876,7 @@
           {
             "in": "path",
             "name": "ruleset_id",
-            "description": "The unique identifier of the query ruleset to be created or updated",
+            "description": "The unique identifier of the query ruleset to be created or updated.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -14938,6 +14940,7 @@
           "query_rules"
         ],
         "summary": "Delete a query ruleset",
+        "description": "Remove a query ruleset and its associated data.\nThis is a destructive action that is not recoverable.",
         "operationId": "query-rules-delete-ruleset",
         "parameters": [
           {
@@ -14979,7 +14982,7 @@
           {
             "in": "query",
             "name": "from",
-            "description": "Starting offset (default: 0)",
+            "description": "The offset from the first result to fetch.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -14989,7 +14992,7 @@
           {
             "in": "query",
             "name": "size",
-            "description": "specifies a max number of results to get",
+            "description": "The maximum number of results to retrieve.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -15055,6 +15058,7 @@
                 "type": "object",
                 "properties": {
                   "match_criteria": {
+                    "description": "The match criteria to apply to rules in the given query ruleset.\nMatch criteria should match the keys defined in the `criteria.metadata` field of the rule.",
                     "type": "object",
                     "additionalProperties": {
                       "type": "object"
@@ -53130,6 +53134,7 @@
             "$ref": "#/components/schemas/query_rules._types:QueryRuleType"
           },
           "criteria": {
+            "description": "The criteria that must be met for the rule to be applied.\nIf multiple criteria are specified for a rule, all criteria must be met for the rule to be applied.",
             "oneOf": [
               {
                 "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteria"
@@ -53170,9 +53175,11 @@
             "$ref": "#/components/schemas/query_rules._types:QueryRuleCriteriaType"
           },
           "metadata": {
+            "description": "The metadata field to match against.\nThis metadata will be used to match against `match_criteria` sent in the rule.\nIt is required for all criteria types except `always`.",
             "type": "string"
           },
           "values": {
+            "description": "The values to match against the `metadata` field.\nOnly one value must match for the criteria to be met.\nIt is required for all criteria types except `always`.",
             "type": "array",
             "items": {
               "type": "object"
@@ -53204,12 +53211,14 @@
         "type": "object",
         "properties": {
           "ids": {
+            "description": "The unique document IDs of the documents to apply the rule to.\nOnly one of `ids` or `docs` may be specified and at least one must be specified.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/_types:Id"
             }
           },
           "docs": {
+            "description": "The documents to apply the rule to.\nOnly one of `ids` or `docs` may be specified and at least one must be specified.\nThere is a maximum value of 100 documents in a rule.\nYou can specify the following attributes for each document:\n\n* `_index`: The index of the document to pin.\n* `_id`: The unique document ID.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/_types.query_dsl:PinnedDoc"
@@ -53224,7 +53233,7 @@
             "$ref": "#/components/schemas/_types:Id"
           },
           "rules": {
-            "description": "Rules associated with the query ruleset",
+            "description": "Rules associated with the query ruleset.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/query_rules._types:QueryRule"
@@ -53243,18 +53252,18 @@
             "$ref": "#/components/schemas/_types:Id"
           },
           "rule_total_count": {
-            "description": "The number of rules associated with this ruleset",
+            "description": "The number of rules associated with the ruleset.",
             "type": "number"
           },
           "rule_criteria_types_counts": {
-            "description": "A map of criteria type (e.g. exact) to the number of rules of that type",
+            "description": "A map of criteria type (for example, `exact`) to the number of rules of that type.\n\nNOTE: The counts in `rule_criteria_types_counts` may be larger than the value of `rule_total_count` because a rule may have multiple criteria.",
             "type": "object",
             "additionalProperties": {
               "type": "number"
             }
           },
           "rule_type_counts": {
-            "description": "A map of rule type (e.g. pinned) to the number of rules of that type",
+            "description": "A map of rule type (for example, `pinned`) to the number of rules of that type.",
             "type": "object",
             "additionalProperties": {
               "type": "number"

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -436,6 +436,14 @@ query-dsl-wildcard-query,https://www.elastic.co/guide/en/elasticsearch/reference
 query-dsl-wrapper-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-wrapper-query.html
 query-dsl,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl.html
 query-rule,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-using-query-rules.html
+query-rule-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-query-rule.html
+query-rule-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-query-rule.html
+query-rule-put,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-query-rule.html
+query-ruleset-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-query-ruleset.html
+query-ruleset-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-query-ruleset.html
+query-ruleset-list,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/list-query-rulesets.html
+query-ruleset-put,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-query-ruleset.html
+query-ruleset-test,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/test-query-ruleset.html
 realtime,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-get.html#realtime
 redact-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/redact-processor.html
 regexp-syntax,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/regexp-syntax.html

--- a/specification/query_rules/_types/QueryRuleset.ts
+++ b/specification/query_rules/_types/QueryRuleset.ts
@@ -24,19 +24,35 @@ import { PinnedDoc } from '../../_types/query_dsl/specialized'
 
 export class QueryRuleset {
   /**
-   * Query Ruleset unique identifier
+   * A unique identifier for the ruleset.
    */
   ruleset_id: Id
   /**
-   * Rules associated with the query ruleset
+   * Rules associated with the query ruleset.
    */
   rules: QueryRule[]
 }
 
 export class QueryRule {
+  /**
+   * A unique identifier for the rule.
+   */
   rule_id: Id
+  /**
+   * The type of rule.
+   * `pinned` will identify and pin specific documents to the top of search results.
+   * `exclude` will exclude specific documents from search results.
+   */
   type: QueryRuleType
+  /**
+   * The criteria that must be met for the rule to be applied.
+   * If multiple criteria are specified for a rule, all criteria must be met for the rule to be applied.
+   */
   criteria: QueryRuleCriteria | QueryRuleCriteria[]
+  /**
+   * The actions to take when the rule is matched.
+   * The format of this action depends on the rule type.
+   */
   actions: QueryRuleActions
   priority?: integer
 }
@@ -47,8 +63,32 @@ export enum QueryRuleType {
 }
 
 export class QueryRuleCriteria {
+  /**
+   * The type of criteria. The following criteria types are supported:
+   *
+   * * `always`: Matches all queries, regardless of input.
+   * * `contains`: Matches that contain this value anywhere in the field meet the criteria defined by the rule. Only applicable for string values.
+   * * `exact`: Only exact matches meet the criteria defined by the rule. Applicable for string or numerical values.
+   * * `fuzzy`: Exact matches or matches within the allowed Levenshtein Edit Distance meet the criteria defined by the rule. Only applicable for string values.
+   * * `gt`: Matches with a value greater than this value meet the criteria defined by the rule. Only applicable for numerical values.
+   * * `gte`: Matches with a value greater than or equal to this value meet the criteria defined by the rule. Only applicable for numerical values.
+   * * `lt`: Matches with a value less than this value meet the criteria defined by the rule. Only applicable for numerical values.
+   * * `lte`: Matches with a value less than or equal to this value meet the criteria defined by the rule. Only applicable for numerical values.
+   * * `prefix`: Matches that start with this value meet the criteria defined by the rule. Only applicable for string values.
+   * * `suffix`: Matches that end with this value meet the criteria defined by the rule. Only applicable for string values.
+   */
   type: QueryRuleCriteriaType
+  /**
+   * The metadata field to match against.
+   * This metadata will be used to match against `match_criteria` sent in the rule.
+   * It is required for all criteria types except `always`.
+   */
   metadata?: string
+  /**
+   * The values to match against the `metadata` field.
+   * Only one value must match for the criteria to be met.
+   * It is required for all criteria types except `always`.
+   */
   values?: UserDefinedValue[]
 }
 
@@ -68,6 +108,19 @@ export enum QueryRuleCriteriaType {
 }
 
 export class QueryRuleActions {
+  /**
+   * The unique document IDs of the documents to apply the rule to.
+   * Only one of `ids` or `docs` may be specified and at least one must be specified.
+   */
   ids?: Id[]
+  /**
+   * The documents to apply the rule to.
+   * Only one of `ids` or `docs` may be specified and at least one must be specified.
+   * There is a maximum value of 100 documents in a rule.
+   * You can specify the following attributes for each document:
+   *
+   * * `_index`: The index of the document to pin.
+   * * `_id`: The unique document ID.
+   */
   docs?: PinnedDoc[]
 }

--- a/specification/query_rules/delete_rule/QueryRuleDeleteRequest.ts
+++ b/specification/query_rules/delete_rule/QueryRuleDeleteRequest.ts
@@ -22,9 +22,12 @@ import { Id } from '@_types/common'
 /**
  * Delete a query rule.
  * Delete a query rule within a query ruleset.
+ * This is a destructive action that is only recoverable by re-adding the same rule with the create or update query rule API.
  * @rest_spec_name query_rules.delete_rule
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_query_rules
+ * @doc_id query-rule-delete
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/query_rules/delete_ruleset/QueryRulesetDeleteRequest.ts
+++ b/specification/query_rules/delete_ruleset/QueryRulesetDeleteRequest.ts
@@ -21,9 +21,13 @@ import { Id } from '@_types/common'
 
 /**
  * Delete a query ruleset.
+ * Remove a query ruleset and its associated data.
+ * This is a destructive action that is not recoverable.
  * @rest_spec_name query_rules.delete_ruleset
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_query_rules
+ * @doc_id query-ruleset-delete
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/query_rules/get_rule/QueryRuleGetRequest.ts
+++ b/specification/query_rules/get_rule/QueryRuleGetRequest.ts
@@ -25,6 +25,8 @@ import { Id } from '@_types/common'
  * @rest_spec_name query_rules.get_rule
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_query_rules
+ * @doc_id query-rule-get
  * @ext_doc_id query-rule
  */
 export interface Request extends RequestBase {

--- a/specification/query_rules/get_rule/QueryRuleGetResponseExample1.yaml
+++ b/specification/query_rules/get_rule/QueryRuleGetResponseExample1.yaml
@@ -1,0 +1,17 @@
+# summary:
+description: A successful response from `GET _query_rules/my-ruleset/_rule/my-rule1`.
+# type: response
+# response_code: ''
+value:
+  rule_id: my-rule1
+  type: pinned
+  criteria:
+    - type: contains
+      metadata: query_string
+      values:
+        - pugs
+        - puggles
+  actions:
+    ids:
+      - id1
+      - id2

--- a/specification/query_rules/get_ruleset/QueryRulesetGetRequest.ts
+++ b/specification/query_rules/get_ruleset/QueryRulesetGetRequest.ts
@@ -25,6 +25,8 @@ import { Id } from '@_types/common'
  * @rest_spec_name query_rules.get_ruleset
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_query_rules
+ * @doc_id query-ruleset-get
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/query_rules/get_ruleset/QueryRulesetGetResponseExample1.yaml
+++ b/specification/query_rules/get_ruleset/QueryRulesetGetResponseExample1.yaml
@@ -1,0 +1,21 @@
+# summary:
+description: A successful response from `GET _query_rules/my-ruleset/`.
+# type: response
+# response_code: ''
+value:
+  "{\n    \"ruleset_id\": \"my-ruleset\",\n    \"rules\": [\n        {\n    \
+  \        \"rule_id\": \"my-rule1\",\n            \"type\": \"pinned\",\n       \
+  \     \"criteria\": [\n                {\n                    \"type\": \"contains\"\
+  ,\n                    \"metadata\": \"query_string\",\n                    \"values\"\
+  : [ \"pugs\", \"puggles\" ]\n                }\n            ],\n            \"actions\"\
+  : {\n                \"ids\": [\n                    \"id1\",\n                \
+  \    \"id2\"\n                ]\n            }\n        },\n        {\n        \
+  \    \"rule_id\": \"my-rule2\",\n            \"type\": \"pinned\",\n           \
+  \ \"criteria\": [\n                {\n                    \"type\": \"fuzzy\",\n\
+  \                    \"metadata\": \"query_string\",\n                    \"values\"\
+  : [ \"rescue dogs\" ]\n                }\n            ],\n            \"actions\"\
+  : {\n                \"docs\": [\n                    {\n                      \
+  \  \"_index\": \"index1\",\n                        \"_id\": \"id3\"\n         \
+  \           },\n                    {\n                        \"_index\": \"index2\"\
+  ,\n                        \"_id\": \"id4\"\n                    }\n           \
+  \     ]\n            }\n        }\n    ]\n}"

--- a/specification/query_rules/list_rulesets/QueryRulesetListRequest.ts
+++ b/specification/query_rules/list_rulesets/QueryRulesetListRequest.ts
@@ -25,15 +25,18 @@ import { integer } from '@_types/Numeric'
  * @rest_spec_name query_rules.list_rulesets
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_query_rules
+ * @doc_id query-ruleset-list
  */
 export interface Request extends RequestBase {
   query_parameters: {
     /**
-     * Starting offset (default: 0)
+     * The offset from the first result to fetch.
+     * @server_default 0
      */
     from?: integer
     /**
-     * specifies a max number of results to get
+     * The maximum number of results to retrieve.
      */
     size?: integer
   }

--- a/specification/query_rules/list_rulesets/QueryRulesetListResponseExample1.yaml
+++ b/specification/query_rules/list_rulesets/QueryRulesetListResponseExample1.yaml
@@ -1,0 +1,14 @@
+# summary:
+description: A successful response from `GET _query_rules/?from=0&size=3`.
+# type: response
+# response_code: ''
+value:
+  "{\n    \"count\": 3,\n    \"results\": [\n        {\n            \"ruleset_id\"\
+  : \"ruleset-1\",\n            \"rule_total_count\": 1,\n            \"rule_criteria_types_counts\"\
+  : {\n                \"exact\": 1\n            }\n        },\n        {\n      \
+  \      \"ruleset_id\": \"ruleset-2\",\n            \"rule_total_count\": 2,\n  \
+  \          \"rule_criteria_types_counts\": {\n                \"exact\": 1,\n  \
+  \              \"fuzzy\": 1\n            }\n        },\n        {\n            \"\
+  ruleset_id\": \"ruleset-3\",\n            \"rule_total_count\": 3,\n           \
+  \ \"rule_criteria_types_counts\": {\n                \"exact\": 1,\n           \
+  \     \"fuzzy\": 2\n            }\n        }\n    ]\n}"

--- a/specification/query_rules/list_rulesets/types.ts
+++ b/specification/query_rules/list_rulesets/types.ts
@@ -22,21 +22,23 @@ import { integer } from '@_types/Numeric'
 
 export class QueryRulesetListItem {
   /**
-   * Ruleset unique identifier
+   * A unique identifier for the ruleset.
    */
   ruleset_id: Id
   /**
-   * The number of rules associated with this ruleset
+   * The number of rules associated with the ruleset.
    */
   rule_total_count: integer
 
   /**
-   * A map of criteria type (e.g. exact) to the number of rules of that type
+   * A map of criteria type (for example, `exact`) to the number of rules of that type.
+   *
+   * NOTE: The counts in `rule_criteria_types_counts` may be larger than the value of `rule_total_count` because a rule may have multiple criteria.
    */
   rule_criteria_types_counts: Dictionary<string, integer>
 
   /**
-   * A map of rule type (e.g. pinned) to the number of rules of that type
+   * A map of rule type (for example, `pinned`) to the number of rules of that type.
    */
   rule_type_counts: Dictionary<string, integer>
 }

--- a/specification/query_rules/put_rule/QueryRulePutRequest.ts
+++ b/specification/query_rules/put_rule/QueryRulePutRequest.ts
@@ -28,29 +28,45 @@ import {
 /**
  * Create or update a query rule.
  * Create or update a query rule within a query ruleset.
+ *
+ * IMPORTANT: Due to limitations within pinned queries, you can only pin documents using ids or docs, but cannot use both in single rule.
+ * It is advised to use one or the other in query rulesets, to avoid errors.
+ * Additionally, pinned queries have a maximum limit of 100 pinned hits.
+ * If multiple matching rules pin more than 100 documents, only the first 100 documents are pinned in the order they are specified in the ruleset.
  * @rest_spec_name query_rules.put_rule
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_query_rules
+ * @doc_id query-rule-put
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * The unique identifier of the query ruleset containing the rule to be created or updated
+     * The unique identifier of the query ruleset containing the rule to be created or updated.
      */
     ruleset_id: Id
 
     /**
-     * The unique identifier of the query rule within the specified ruleset to be created or updated
+     * The unique identifier of the query rule within the specified ruleset to be created or updated.
      */
     rule_id: Id
   }
   /**
-   * The query rule information
+   * The query rule information.
    */
   /** @codegen_name query_rule */
   body: {
+    /** The type of rule. */
     type: QueryRuleType
+    /**
+     * The criteria that must be met for the rule to be applied.
+     * If multiple criteria are specified for a rule, all criteria must be met for the rule to be applied.
+     */
     criteria: QueryRuleCriteria | QueryRuleCriteria[]
+    /**
+     * The actions to take when the rule is matched.
+     * The format of this action depends on the rule type.
+     */
     actions: QueryRuleActions
     priority?: integer
   }

--- a/specification/query_rules/put_rule/QueryRulePutRequestExample1.yaml
+++ b/specification/query_rules/put_rule/QueryRulePutRequestExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+# method_request: POST _query_rules/my-ruleset/_test
+description: >
+  Run `POST _query_rules/my-ruleset/_test` to test a ruleset.
+  Provide the match criteria that you want to test against.
+# type: request
+value:
+  match_criteria:
+    query_string: puggles

--- a/specification/query_rules/put_ruleset/QueryRulesetPutRequest.ts
+++ b/specification/query_rules/put_ruleset/QueryRulesetPutRequest.ts
@@ -22,15 +22,24 @@ import { QueryRule } from '../_types/QueryRuleset'
 
 /**
  * Create or update a query ruleset.
+ * There is a limit of 100 rules per ruleset.
+ * This limit can be increased by using the `xpack.applications.rules.max_rules_per_ruleset` cluster setting.
+ *
+ * IMPORTANT: Due to limitations within pinned queries, you can only select documents using `ids` or `docs`, but cannot use both in single rule.
+ * It is advised to use one or the other in query rulesets, to avoid errors.
+ * Additionally, pinned queries have a maximum limit of 100 pinned hits.
+ * If multiple matching rules pin more than 100 documents, only the first 100 documents are pinned in the order they are specified in the ruleset.
  * @rest_spec_name query_rules.put_ruleset
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_query_rules
+ * @doc_id query-ruleset-put
  * @ext_doc_id query-rule
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * The unique identifier of the query ruleset to be created or updated
+     * The unique identifier of the query ruleset to be created or updated.
      */
     ruleset_id: Id
   }

--- a/specification/query_rules/put_ruleset/QueryRulesetPutRequestExample1.yaml
+++ b/specification/query_rules/put_ruleset/QueryRulesetPutRequestExample1.yaml
@@ -1,0 +1,27 @@
+# summary:
+# method_request: PUT _query_rules/my-ruleset
+description: >
+  Run `PUT _query_rules/my-ruleset` to create a new query ruleset.
+  Two rules are associated with `my-ruleset`.
+  `my-rule1` will pin documents with IDs `id1` and `id2` when `user_query` contains `pugs` or `puggles` and `user_country` exactly matches `us`.
+  `my-rule2` will exclude documents from different specified indices with IDs `id3` and `id4` when the `query_string` fuzzily matches `rescue dogs`.
+# type: request
+value:
+  "{\n    \"rules\": [\n        {\n            \"rule_id\": \"my-rule1\",\n \
+  \           \"type\": \"pinned\",\n            \"criteria\": [\n               \
+  \ {\n                    \"type\": \"contains\",\n                    \"metadata\"\
+  : \"user_query\",\n                    \"values\": [ \"pugs\", \"puggles\" ]\n \
+  \               },\n                {\n                    \"type\": \"exact\",\n\
+  \                    \"metadata\": \"user_country\",\n                    \"values\"\
+  : [ \"us\" ]\n                }\n            ],\n            \"actions\": {\n  \
+  \              \"ids\": [\n                    \"id1\",\n                    \"\
+  id2\"\n                ]\n            }\n        },\n        {\n            \"rule_id\"\
+  : \"my-rule2\",\n            \"type\": \"pinned\",\n            \"criteria\": [\n\
+  \                {\n                    \"type\": \"fuzzy\",\n                 \
+  \   \"metadata\": \"user_query\",\n                    \"values\": [ \"rescue dogs\"\
+  \ ]\n                }\n            ],\n            \"actions\": {\n           \
+  \     \"docs\": [\n                    {\n                        \"_index\": \"\
+  index1\",\n                        \"_id\": \"id3\"\n                    },\n  \
+  \                  {\n                        \"_index\": \"index2\",\n        \
+  \                \"_id\": \"id4\"\n                    }\n                ]\n  \
+  \          }\n        }\n    ]\n}"

--- a/specification/query_rules/test/QueryRulesetTestRequest.ts
+++ b/specification/query_rules/test/QueryRulesetTestRequest.ts
@@ -27,6 +27,8 @@ import { Id } from '@_types/common'
  * @rest_spec_name query_rules.test
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_query_rules
+ * @doc_id query-ruleset-test
  */
 export interface Request extends RequestBase {
   path_parts: {
@@ -40,6 +42,10 @@ export interface Request extends RequestBase {
    */
   /** @codegen_name match_criteria */
   body: {
+    /**
+     * The match criteria to apply to rules in the given query ruleset.
+     * Match criteria should match the keys defined in the `criteria.metadata` field of the rule.
+     */
     match_criteria: Dictionary<string, UserDefinedValue>
   }
 }

--- a/specification/query_rules/test/QueryRulesetTestRequestExample1.yaml
+++ b/specification/query_rules/test/QueryRulesetTestRequestExample1.yaml
@@ -1,0 +1,27 @@
+# summary:
+# method_request: PUT _query_rules/my-ruleset
+description: >
+  Run `PUT _query_rules/my-ruleset` to create a new query ruleset.
+  Two rules are associated with `my-ruleset`.
+  `my-rule1` will pin documents with IDs `id1` and `id2` when `user_query` contains `pugs` or `puggles` and `user_country` exactly matches `us`.
+  `my-rule2` will exclude documents from different specified indices with IDs `id3` and `id4` when the `query_string` fuzzily matches `rescue dogs`.
+# type: request
+value:
+  "{\n    \"rules\": [\n        {\n            \"rule_id\": \"my-rule1\",\n \
+  \           \"type\": \"pinned\",\n            \"criteria\": [\n               \
+  \ {\n                    \"type\": \"contains\",\n                    \"metadata\"\
+  : \"user_query\",\n                    \"values\": [ \"pugs\", \"puggles\" ]\n \
+  \               },\n                {\n                    \"type\": \"exact\",\n\
+  \                    \"metadata\": \"user_country\",\n                    \"values\"\
+  : [ \"us\" ]\n                }\n            ],\n            \"actions\": {\n  \
+  \              \"ids\": [\n                    \"id1\",\n                    \"\
+  id2\"\n                ]\n            }\n        },\n        {\n            \"rule_id\"\
+  : \"my-rule2\",\n            \"type\": \"pinned\",\n            \"criteria\": [\n\
+  \                {\n                    \"type\": \"fuzzy\",\n                 \
+  \   \"metadata\": \"user_query\",\n                    \"values\": [ \"rescue dogs\"\
+  \ ]\n                }\n            ],\n            \"actions\": {\n           \
+  \     \"docs\": [\n                    {\n                        \"_index\": \"\
+  index1\",\n                        \"_id\": \"id3\"\n                    },\n  \
+  \                  {\n                        \"_index\": \"index2\",\n        \
+  \                \"_id\": \"id4\"\n                    }\n                ]\n  \
+  \          }\n        }\n    ]\n}"

--- a/specification/query_rules/test/QueryRulesetTestResponseExample1.yaml
+++ b/specification/query_rules/test/QueryRulesetTestResponseExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+description: A successful response from `POST _query_rules/my-ruleset/_test`.
+# type: response
+# response_code: ''
+value:
+  total_matched_rules: 1
+  matched_rules:
+    - ruleset_id: my-ruleset
+      rule_id: my-rule1


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR copies examples from https://www.elastic.co/guide/en/elasticsearch/reference/master/query-rules-apis.html