### PR TITLE
[8.x] Add missing default ML query descriptions (#2917)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -17834,7 +17834,7 @@
           "ml data frame"
         ],
         "summary": "Create a data frame analytics job",
-        "description": "This API creates a data frame analytics job that performs an analysis on the\nsource indices and stores the outcome in a destination index.",
+        "description": "This API creates a data frame analytics job that performs an analysis on the\nsource indices and stores the outcome in a destination index.\nBy default, the query used in the source configuration is `{\"match_all\": {}}`.\n\nIf the destination index does not exist, it is created automatically when you start the job.\n\nIf you supply only a subset of the regression or classification parameters, hyperparameter optimization occurs. It determines a value for each of the undefined parameters.",
         "operationId": "ml-put-data-frame-analytics",
         "parameters": [
           {
@@ -18054,7 +18054,7 @@
           "ml anomaly"
         ],
         "summary": "Create a datafeed",
-        "description": "Datafeeds retrieve data from Elasticsearch for analysis by an anomaly detection job.\nYou can associate only one datafeed with each anomaly detection job.\nThe datafeed contains a query that runs at a defined interval (`frequency`).\nIf you are concerned about delayed data, you can add a delay (`query_delay') at each interval.\nWhen Elasticsearch security features are enabled, your datafeed remembers which roles the user who created it had\nat the time of creation and runs the query using those same roles. If you provide secondary authorization headers,\nthose credentials are used instead.\nYou must use Kibana, this API, or the create anomaly detection jobs API to create a datafeed. Do not add a datafeed\ndirectly to the `.ml-config` index. Do not give users `write` privileges on the `.ml-config` index.",
+        "description": "Datafeeds retrieve data from Elasticsearch for analysis by an anomaly detection job.\nYou can associate only one datafeed with each anomaly detection job.\nThe datafeed contains a query that runs at a defined interval (`frequency`).\nIf you are concerned about delayed data, you can add a delay (`query_delay') at each interval.\nBy default, the datafeed uses the following query: `{\"match_all\": {\"boost\": 1}}`.\n\nWhen Elasticsearch security features are enabled, your datafeed remembers which roles the user who created it had\nat the time of creation and runs the query using those same roles. If you provide secondary authorization headers,\nthose credentials are used instead.\nYou must use Kibana, this API, or the create anomaly detection jobs API to create a datafeed. Do not add a datafeed\ndirectly to the `.ml-config` index. Do not give users `write` privileges on the `.ml-config` index.",
         "operationId": "ml-put-datafeed",
         "parameters": [
           {
@@ -18675,7 +18675,7 @@
           "ml anomaly"
         ],
         "summary": "Create an anomaly detection job",
-        "description": "If you include a `datafeed_config`, you must have read index privileges on the source index.",
+        "description": "If you include a `datafeed_config`, you must have read index privileges on the source index.\nIf you include a `datafeed_config` but do not provide a query, the datafeed uses `{\"match_all\": {\"boost\": 1}}`.",
         "operationId": "ml-put-job",
         "parameters": [
           {
@@ -43780,6 +43780,7 @@
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html"
         },
+        "description": "An Elasticsearch Query DSL (Domain Specific Language) object that defines a query.",
         "type": "object",
         "properties": {
           "bool": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -10297,7 +10297,7 @@
           "ml data frame"
         ],
         "summary": "Create a data frame analytics job",
-        "description": "This API creates a data frame analytics job that performs an analysis on the\nsource indices and stores the outcome in a destination index.",
+        "description": "This API creates a data frame analytics job that performs an analysis on the\nsource indices and stores the outcome in a destination index.\nBy default, the query used in the source configuration is `{\"match_all\": {}}`.\n\nIf the destination index does not exist, it is created automatically when you start the job.\n\nIf you supply only a subset of the regression or classification parameters, hyperparameter optimization occurs. It determines a value for each of the undefined parameters.",
         "operationId": "ml-put-data-frame-analytics",
         "parameters": [
           {
@@ -10517,7 +10517,7 @@
           "ml anomaly"
         ],
         "summary": "Create a datafeed",
-        "description": "Datafeeds retrieve data from Elasticsearch for analysis by an anomaly detection job.\nYou can associate only one datafeed with each anomaly detection job.\nThe datafeed contains a query that runs at a defined interval (`frequency`).\nIf you are concerned about delayed data, you can add a delay (`query_delay') at each interval.\nWhen Elasticsearch security features are enabled, your datafeed remembers which roles the user who created it had\nat the time of creation and runs the query using those same roles. If you provide secondary authorization headers,\nthose credentials are used instead.\nYou must use Kibana, this API, or the create anomaly detection jobs API to create a datafeed. Do not add a datafeed\ndirectly to the `.ml-config` index. Do not give users `write` privileges on the `.ml-config` index.",
+        "description": "Datafeeds retrieve data from Elasticsearch for analysis by an anomaly detection job.\nYou can associate only one datafeed with each anomaly detection job.\nThe datafeed contains a query that runs at a defined interval (`frequency`).\nIf you are concerned about delayed data, you can add a delay (`query_delay') at each interval.\nBy default, the datafeed uses the following query: `{\"match_all\": {\"boost\": 1}}`.\n\nWhen Elasticsearch security features are enabled, your datafeed remembers which roles the user who created it had\nat the time of creation and runs the query using those same roles. If you provide secondary authorization headers,\nthose credentials are used instead.\nYou must use Kibana, this API, or the create anomaly detection jobs API to create a datafeed. Do not add a datafeed\ndirectly to the `.ml-config` index. Do not give users `write` privileges on the `.ml-config` index.",
         "operationId": "ml-put-datafeed",
         "parameters": [
           {
@@ -10927,7 +10927,7 @@
           "ml anomaly"
         ],
         "summary": "Create an anomaly detection job",
-        "description": "If you include a `datafeed_config`, you must have read index privileges on the source index.",
+        "description": "If you include a `datafeed_config`, you must have read index privileges on the source index.\nIf you include a `datafeed_config` but do not provide a query, the datafeed uses `{\"match_all\": {\"boost\": 1}}`.",
         "operationId": "ml-put-job",
         "parameters": [
           {
@@ -25708,6 +25708,7 @@
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html"
         },
+        "description": "An Elasticsearch Query DSL (Domain Specific Language) object that defines a query.",
         "type": "object",
         "properties": {
           "bool": {

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -100,6 +100,7 @@ import { TextExpansionQuery } from './TextExpansionQuery'
 import { WeightedTokensQuery } from './WeightedTokensQuery'
 
 /**
+ * An Elasticsearch Query DSL (Domain Specific Language) object that defines a query.
  * @variants container
  * @non_exhaustive
  * @ext_doc_id query-dsl

--- a/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
+++ b/specification/ml/put_data_frame_analytics/MlPutDataFrameAnalyticsRequest.ts
@@ -31,6 +31,11 @@ import { integer } from '@_types/Numeric'
  * Create a data frame analytics job.
  * This API creates a data frame analytics job that performs an analysis on the
  * source indices and stores the outcome in a destination index.
+ * By default, the query used in the source configuration is `{"match_all": {}}`.
+ *
+ * If the destination index does not exist, it is created automatically when you start the job.
+ *
+ * If you supply only a subset of the regression or classification parameters, hyperparameter optimization occurs. It determines a value for each of the undefined parameters.
  * @rest_spec_name ml.put_data_frame_analytics
  * @availability stack since=7.3.0 stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
@@ -40,6 +40,8 @@ import { Duration } from '@_types/Time'
  * You can associate only one datafeed with each anomaly detection job.
  * The datafeed contains a query that runs at a defined interval (`frequency`).
  * If you are concerned about delayed data, you can add a delay (`query_delay') at each interval.
+ * By default, the datafeed uses the following query: `{"match_all": {"boost": 1}}`.
+ *
  * When Elasticsearch security features are enabled, your datafeed remembers which roles the user who created it had
  * at the time of creation and runs the query using those same roles. If you provide secondary authorization headers,
  * those credentials are used instead.

--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -30,6 +30,7 @@ import { Duration } from '@_types/Time'
 /**
  * Create an anomaly detection job.
  * If you include a `datafeed_config`, you must have read index privileges on the source index.
+ * If you include a `datafeed_config` but do not provide a query, the datafeed uses `{"match_all": {"boost": 1}}`.
  * @rest_spec_name ml.put_job
  * @availability stack since=5.4.0 stability=stable
  * @availability serverless stability=stable visibility=public


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add missing default ML query descriptions (#2917)](https://github.com/elastic/elasticsearch-specification/pull/2917)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)