### PR TITLE
Add synonym API examples

### DIFF
--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -668,7 +668,7 @@ export function hoistRequestAnnotations (
       const privileges = [
         'all', 'cancel_task', 'create_snapshot', 'grant_api_key', 'manage', 'manage_api_key', 'manage_ccr',
         'manage_enrich', 'manage_ilm', 'manage_index_templates', 'manage_inference', 'manage_ingest_pipelines', 'manage_logstash_pipelines',
-        'manage_ml', 'manage_oidc', 'manage_own_api_key', 'manage_pipeline', 'manage_rollup', 'manage_saml', 'manage_search_application', 'manage_search_query_rules',
+        'manage_ml', 'manage_oidc', 'manage_own_api_key', 'manage_pipeline', 'manage_rollup', 'manage_saml', 'manage_search_application', 'manage_search_query_rules', 'manage_search_synonyms',
         'manage_security', 'manage_service_account', 'manage_slm', 'manage_token', 'manage_transform', 'manage_user_profile',
         'manage_watcher', 'monitor', 'monitor_ml', 'monitor_rollup', 'monitor_snapshot', 'monitor_text_structure',
         'monitor_transform', 'monitor_watcher', 'read_ccr', 'read_ilm', 'read_pipeline', 'read_security', 'read_slm', 'transport_client'

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -34741,7 +34741,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "\"The id of the synonyms set to be retrieved",
+            "description": "The synonyms set identifier to retrieve.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -34752,7 +34752,7 @@
           {
             "in": "query",
             "name": "from",
-            "description": "Starting offset for query rules to be retrieved",
+            "description": "The starting offset for query rules to retrieve.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -34762,7 +34762,7 @@
           {
             "in": "query",
             "name": "size",
-            "description": "specifies a max number of query rules to retrieve",
+            "description": "The max number of query rules to retrieve.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -34779,9 +34779,11 @@
                   "type": "object",
                   "properties": {
                     "count": {
+                      "description": "The total number of synonyms rules that the synonyms set contains.",
                       "type": "number"
                     },
                     "synonyms_set": {
+                      "description": "Synonym rule details.",
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/synonyms._types:SynonymRuleRead"
@@ -34804,13 +34806,13 @@
           "synonyms"
         ],
         "summary": "Create or update a synonym set",
-        "description": "Synonyms sets are limited to a maximum of 10,000 synonym rules per set.\nIf you need to manage more synonym rules, you can create multiple synonym sets.",
+        "description": "Synonyms sets are limited to a maximum of 10,000 synonym rules per set.\nIf you need to manage more synonym rules, you can create multiple synonym sets.\n\nWhen an existing synonyms set is updated, the search analyzers that use the synonyms set are reloaded automatically for all indices.\nThis is equivalent to invoking the reload search analyzers API for all indices that use the synonyms set.",
         "operationId": "synonyms-put-synonym",
         "parameters": [
           {
             "in": "path",
             "name": "id",
-            "description": "The id of the synonyms set to be created or updated",
+            "description": "The ID of the synonyms set to be created or updated.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -34826,7 +34828,7 @@
                 "type": "object",
                 "properties": {
                   "synonyms_set": {
-                    "description": "The synonym set information to update",
+                    "description": "The synonym rules definitions for the synonyms set.",
                     "oneOf": [
                       {
                         "$ref": "#/components/schemas/synonyms._types:SynonymRule"
@@ -34879,12 +34881,13 @@
           "synonyms"
         ],
         "summary": "Delete a synonym set",
+        "description": "You can only delete a synonyms set that is not in use by any index analyzer.\n\nSynonyms sets can be used in synonym graph token filters and synonym token filters.\nThese synonym filters can be used as part of search analyzers.\n\nAnalyzers need to be loaded when an index is restored (such as when a node starts, or the index becomes open).\nEven if the analyzer is not used on any field mapping, it still needs to be loaded on the index recovery phase.\n\nIf any analyzers cannot be loaded, the index becomes unavailable and the cluster status becomes red or yellow as index shards are not available.\nTo prevent that, synonyms sets that are used in analyzers can't be deleted.\nA delete request in this case will return a 400 response code.\n\nTo remove a synonyms set, you must first remove all indices that contain analyzers using it.\nYou can migrate an index by creating a new index that does not contain the token filter with the synonyms set, and use the reindex API in order to copy over the index data.\nOnce finished, you can delete the index.\nWhen the synonyms set is not used in analyzers, you will be able to delete it.",
         "operationId": "synonyms-delete-synonym",
         "parameters": [
           {
             "in": "path",
             "name": "id",
-            "description": "The id of the synonyms set to be deleted",
+            "description": "The synonyms set identifier to delete.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -34920,7 +34923,7 @@
           {
             "in": "path",
             "name": "set_id",
-            "description": "The id of the synonym set to retrieve the synonym rule from",
+            "description": "The ID of the synonym set to retrieve the synonym rule from.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -34931,7 +34934,7 @@
           {
             "in": "path",
             "name": "rule_id",
-            "description": "The id of the synonym rule to retrieve",
+            "description": "The ID of the synonym rule to retrieve.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -34959,13 +34962,13 @@
           "synonyms"
         ],
         "summary": "Create or update a synonym rule",
-        "description": "Create or update a synonym rule in a synonym set.",
+        "description": "Create or update a synonym rule in a synonym set.\n\nIf any of the synonym rules included is invalid, the API returns an error.\n\nWhen you update a synonym rule, all analyzers using the synonyms set will be reloaded automatically to reflect the new rule.",
         "operationId": "synonyms-put-synonym-rule",
         "parameters": [
           {
             "in": "path",
             "name": "set_id",
-            "description": "The id of the synonym set to be updated with the synonym rule",
+            "description": "The ID of the synonym set.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -34976,7 +34979,7 @@
           {
             "in": "path",
             "name": "rule_id",
-            "description": "The id of the synonym rule to be updated or created",
+            "description": "The ID of the synonym rule to be updated or created.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -35028,7 +35031,7 @@
           {
             "in": "path",
             "name": "set_id",
-            "description": "The id of the synonym set to be updated",
+            "description": "The ID of the synonym set to update.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -35039,7 +35042,7 @@
           {
             "in": "path",
             "name": "rule_id",
-            "description": "The id of the synonym rule to be deleted",
+            "description": "The ID of the synonym rule to delete.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -35075,7 +35078,7 @@
           {
             "in": "query",
             "name": "from",
-            "description": "Starting offset",
+            "description": "The starting offset for synonyms sets to retrieve.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -35085,7 +35088,7 @@
           {
             "in": "query",
             "name": "size",
-            "description": "specifies a max number of results to get",
+            "description": "The maximum number of synonyms sets to retrieve.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -35102,9 +35105,11 @@
                   "type": "object",
                   "properties": {
                     "count": {
+                      "description": "The total number of synonyms sets defined.",
                       "type": "number"
                     },
                     "results": {
+                      "description": "The identifier and total number of defined synonym rules for each synonyms set.",
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/synonyms.get_synonyms_sets:SynonymsSetItem"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -18023,7 +18023,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "\"The id of the synonyms set to be retrieved",
+            "description": "The synonyms set identifier to retrieve.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -18034,7 +18034,7 @@
           {
             "in": "query",
             "name": "from",
-            "description": "Starting offset for query rules to be retrieved",
+            "description": "The starting offset for query rules to retrieve.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -18044,7 +18044,7 @@
           {
             "in": "query",
             "name": "size",
-            "description": "specifies a max number of query rules to retrieve",
+            "description": "The max number of query rules to retrieve.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -18061,9 +18061,11 @@
                   "type": "object",
                   "properties": {
                     "count": {
+                      "description": "The total number of synonyms rules that the synonyms set contains.",
                       "type": "number"
                     },
                     "synonyms_set": {
+                      "description": "Synonym rule details.",
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/synonyms._types:SynonymRuleRead"
@@ -18086,13 +18088,13 @@
           "synonyms"
         ],
         "summary": "Create or update a synonym set",
-        "description": "Synonyms sets are limited to a maximum of 10,000 synonym rules per set.\nIf you need to manage more synonym rules, you can create multiple synonym sets.",
+        "description": "Synonyms sets are limited to a maximum of 10,000 synonym rules per set.\nIf you need to manage more synonym rules, you can create multiple synonym sets.\n\nWhen an existing synonyms set is updated, the search analyzers that use the synonyms set are reloaded automatically for all indices.\nThis is equivalent to invoking the reload search analyzers API for all indices that use the synonyms set.",
         "operationId": "synonyms-put-synonym",
         "parameters": [
           {
             "in": "path",
             "name": "id",
-            "description": "The id of the synonyms set to be created or updated",
+            "description": "The ID of the synonyms set to be created or updated.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -18108,7 +18110,7 @@
                 "type": "object",
                 "properties": {
                   "synonyms_set": {
-                    "description": "The synonym set information to update",
+                    "description": "The synonym rules definitions for the synonyms set.",
                     "oneOf": [
                       {
                         "$ref": "#/components/schemas/synonyms._types:SynonymRule"
@@ -18161,12 +18163,13 @@
           "synonyms"
         ],
         "summary": "Delete a synonym set",
+        "description": "You can only delete a synonyms set that is not in use by any index analyzer.\n\nSynonyms sets can be used in synonym graph token filters and synonym token filters.\nThese synonym filters can be used as part of search analyzers.\n\nAnalyzers need to be loaded when an index is restored (such as when a node starts, or the index becomes open).\nEven if the analyzer is not used on any field mapping, it still needs to be loaded on the index recovery phase.\n\nIf any analyzers cannot be loaded, the index becomes unavailable and the cluster status becomes red or yellow as index shards are not available.\nTo prevent that, synonyms sets that are used in analyzers can't be deleted.\nA delete request in this case will return a 400 response code.\n\nTo remove a synonyms set, you must first remove all indices that contain analyzers using it.\nYou can migrate an index by creating a new index that does not contain the token filter with the synonyms set, and use the reindex API in order to copy over the index data.\nOnce finished, you can delete the index.\nWhen the synonyms set is not used in analyzers, you will be able to delete it.",
         "operationId": "synonyms-delete-synonym",
         "parameters": [
           {
             "in": "path",
             "name": "id",
-            "description": "The id of the synonyms set to be deleted",
+            "description": "The synonyms set identifier to delete.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -18202,7 +18205,7 @@
           {
             "in": "path",
             "name": "set_id",
-            "description": "The id of the synonym set to retrieve the synonym rule from",
+            "description": "The ID of the synonym set to retrieve the synonym rule from.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -18213,7 +18216,7 @@
           {
             "in": "path",
             "name": "rule_id",
-            "description": "The id of the synonym rule to retrieve",
+            "description": "The ID of the synonym rule to retrieve.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -18241,13 +18244,13 @@
           "synonyms"
         ],
         "summary": "Create or update a synonym rule",
-        "description": "Create or update a synonym rule in a synonym set.",
+        "description": "Create or update a synonym rule in a synonym set.\n\nIf any of the synonym rules included is invalid, the API returns an error.\n\nWhen you update a synonym rule, all analyzers using the synonyms set will be reloaded automatically to reflect the new rule.",
         "operationId": "synonyms-put-synonym-rule",
         "parameters": [
           {
             "in": "path",
             "name": "set_id",
-            "description": "The id of the synonym set to be updated with the synonym rule",
+            "description": "The ID of the synonym set.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -18258,7 +18261,7 @@
           {
             "in": "path",
             "name": "rule_id",
-            "description": "The id of the synonym rule to be updated or created",
+            "description": "The ID of the synonym rule to be updated or created.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -18310,7 +18313,7 @@
           {
             "in": "path",
             "name": "set_id",
-            "description": "The id of the synonym set to be updated",
+            "description": "The ID of the synonym set to update.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -18321,7 +18324,7 @@
           {
             "in": "path",
             "name": "rule_id",
-            "description": "The id of the synonym rule to be deleted",
+            "description": "The ID of the synonym rule to delete.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -18357,7 +18360,7 @@
           {
             "in": "query",
             "name": "from",
-            "description": "Starting offset",
+            "description": "The starting offset for synonyms sets to retrieve.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -18367,7 +18370,7 @@
           {
             "in": "query",
             "name": "size",
-            "description": "specifies a max number of results to get",
+            "description": "The maximum number of synonyms sets to retrieve.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -18384,9 +18387,11 @@
                   "type": "object",
                   "properties": {
                     "count": {
+                      "description": "The total number of synonyms sets defined.",
                       "type": "number"
                     },
                     "results": {
+                      "description": "The identifier and total number of defined synonym rules for each synonyms set.",
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/synonyms.get_synonyms_sets:SynonymsSetItem"

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -268,7 +268,7 @@ indices-rollover-index,https://www.elastic.co/guide/en/elasticsearch/reference/{
 indices-segments,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-segments.html
 indices-shards-stores,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-shards-stores.html
 indices-shrink-index,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-shrink-index.html
-indices-simulate,https://www.elastic.co/guide/en/elasticsearch/reference/{master}/indices-simulate-index.html
+indices-simulate,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-simulate-index.html
 indices-simulate-template,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-simulate-template.html
 indices-split-index,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-split-index.html
 indices-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-stats.html
@@ -705,6 +705,13 @@ start-trial,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/sta
 stop-dfanalytics,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/stop-dfanalytics.html
 stop-trained-model-deployment,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/stop-trained-model-deployment.html
 stop-transform,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/stop-transform.html
+synonym-rule-create,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-synonym-rule.html
+synonym-rule-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-synonym-rule.html
+synonym-rule-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-synonym-rule.html
+synonym-set-create,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-synonyms-set.html
+synonym-set-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-synonyms-set.html
+synonym-set-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-synonyms-set.html
+synonym-set-list,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-synonyms-set.html
 supported-flags,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-simple-query-string-query.html#supported-flags
 tasks,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/tasks.html
 templating-role-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/field-and-document-access-control.html#templating-role-query

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -709,6 +709,7 @@ synonym-rule-create,https://www.elastic.co/guide/en/elasticsearch/reference/{bra
 synonym-rule-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-synonym-rule.html
 synonym-rule-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-synonym-rule.html
 synonym-set-create,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-synonyms-set.html
+synonym-set-define,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/analysis-synonym-graph-tokenfilter.html#analysis-synonym-graph-define-synonyms
 synonym-set-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-synonyms-set.html
 synonym-set-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-synonyms-set.html
 synonym-set-list,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-synonyms-set.html

--- a/specification/synonyms/_types/SynonymRule.ts
+++ b/specification/synonyms/_types/SynonymRule.ts
@@ -25,11 +25,13 @@ export type SynonymString = string
 // Synonym Rule with optional ID, used for PUT method
 export class SynonymRule {
   /**
-   * Synonym Rule identifier
+   * The identifier for the synonym rule.
+   * If you do not specify a synonym rule ID when you create a rule, an identifier is created automatically by Elasticsearch.
    */
   id?: Id
   /**
-   * Synonyms, in Solr format, that conform the synonym rule. See https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-synonym-graph-tokenfilter.html#_solr_synonyms_2
+   * The synonyms that conform the synonym rule in Solr format.
+   * @ext_doc_id synonym-set-define
    */
   synonyms: SynonymString
 }

--- a/specification/synonyms/_types/SynonymsUpdateResult.ts
+++ b/specification/synonyms/_types/SynonymsUpdateResult.ts
@@ -22,13 +22,13 @@ import { Result } from '@_types/Result'
 
 export class SynonymsUpdateResult {
   /**
-   * Update operation result
+   * The update operation result.
    */
   result: Result
 
   /**
    * Updating synonyms in a synonym set reloads the associated analyzers.
-   * This is the analyzers reloading result
+   * This information is the analyzers reloading result.
    */
   reload_analyzers_details: ReloadResult
 }

--- a/specification/synonyms/delete_synonym/SynonymsDeleteRequest.ts
+++ b/specification/synonyms/delete_synonym/SynonymsDeleteRequest.ts
@@ -24,6 +24,7 @@ import { Id } from '@_types/common'
  * @rest_spec_name synonyms.delete_synonym
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id synonym-set-delete
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/synonyms/delete_synonym/SynonymsDeleteRequest.ts
+++ b/specification/synonyms/delete_synonym/SynonymsDeleteRequest.ts
@@ -21,15 +21,33 @@ import { Id } from '@_types/common'
 
 /**
  * Delete a synonym set.
+ *
+ * You can only delete a synonyms set that is not in use by any index analyzer.
+ *
+ * Synonyms sets can be used in synonym graph token filters and synonym token filters.
+ * These synonym filters can be used as part of search analyzers.
+ *
+ * Analyzers need to be loaded when an index is restored (such as when a node starts, or the index becomes open).
+ * Even if the analyzer is not used on any field mapping, it still needs to be loaded on the index recovery phase.
+ *
+ * If any analyzers cannot be loaded, the index becomes unavailable and the cluster status becomes red or yellow as index shards are not available.
+ * To prevent that, synonyms sets that are used in analyzers can't be deleted.
+ * A delete request in this case will return a 400 response code.
+ *
+ * To remove a synonyms set, you must first remove all indices that contain analyzers using it.
+ * You can migrate an index by creating a new index that does not contain the token filter with the synonyms set, and use the reindex API in order to copy over the index data.
+ * Once finished, you can delete the index.
+ * When the synonyms set is not used in analyzers, you will be able to delete it.
  * @rest_spec_name synonyms.delete_synonym
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_synonyms
  * @doc_id synonym-set-delete
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * The id of the synonyms set to be deleted
+     * The synonyms set identifier to delete.
      */
     id: Id
   }

--- a/specification/synonyms/delete_synonym_rule/SynonymRuleDeleteRequest.ts
+++ b/specification/synonyms/delete_synonym_rule/SynonymRuleDeleteRequest.ts
@@ -25,17 +25,17 @@ import { Id } from '@_types/common'
  * @rest_spec_name synonyms.delete_synonym_rule
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_synonyms
  * @doc_id synonym-rule-delete
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * The id of the synonym set to be updated
+     * The ID of the synonym set to update.
      */
     set_id: Id
-
     /**
-     * The id of the synonym rule to be deleted
+     * The ID of the synonym rule to delete.
      */
     rule_id: Id
   }

--- a/specification/synonyms/delete_synonym_rule/SynonymRuleDeleteRequest.ts
+++ b/specification/synonyms/delete_synonym_rule/SynonymRuleDeleteRequest.ts
@@ -25,6 +25,7 @@ import { Id } from '@_types/common'
  * @rest_spec_name synonyms.delete_synonym_rule
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id synonym-rule-delete
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/synonyms/delete_synonym_rule/examples/response/SynonymRuleDeleteResponseExample1.yaml
+++ b/specification/synonyms/delete_synonym_rule/examples/response/SynonymRuleDeleteResponseExample1.yaml
@@ -1,0 +1,28 @@
+# summary:
+description: >
+  A successful response from `DELETE _synonyms/my-synonyms-set/test-1`.
+  All analyzers using this synonyms set will be reloaded automatically to reflect the rule being deleted.
+# type: response
+# response_code: ''
+value: |-
+  {
+    "result": "deleted",
+    "reload_analyzers_details": {
+      "_shards": {
+        "total": 2,
+        "successful": 1,
+        "failed": 0
+      },
+      "reload_details": [
+        {
+          "index": "test-index",
+          "reloaded_analyzers": [
+            "my_search_analyzer"
+          ],
+          "reloaded_node_ids": [
+            "1wYFZzq8Sxeu_Jvt9mlbkg"
+          ]
+        }
+      ]
+    }
+  }

--- a/specification/synonyms/get_synonym/SynonymsGetRequest.ts
+++ b/specification/synonyms/get_synonym/SynonymsGetRequest.ts
@@ -25,23 +25,24 @@ import { integer } from '@_types/Numeric'
  * @rest_spec_name synonyms.get_synonym
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_synonyms
  * @doc_id synonym-set-get
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * "The id of the synonyms set to be retrieved
+     * The synonyms set identifier to retrieve.
      */
     id: Id
   }
   query_parameters: {
     /**
-     * Starting offset for query rules to be retrieved
+     * The starting offset for query rules to retrieve.
      * @server_default 0
      */
     from?: integer
     /**
-     * specifies a max number of query rules to retrieve
+     * The max number of query rules to retrieve.
      * @server_default 10
      */
     size?: integer

--- a/specification/synonyms/get_synonym/SynonymsGetRequest.ts
+++ b/specification/synonyms/get_synonym/SynonymsGetRequest.ts
@@ -25,6 +25,7 @@ import { integer } from '@_types/Numeric'
  * @rest_spec_name synonyms.get_synonym
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id synonym-set-get
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/synonyms/get_synonym/SynonymsGetResponse.ts
+++ b/specification/synonyms/get_synonym/SynonymsGetResponse.ts
@@ -22,7 +22,13 @@ import { SynonymRuleRead } from '../_types/SynonymRule'
 
 export class Response {
   body: {
+    /**
+     * The total number of synonyms rules that the synonyms set contains.
+     */
     count: integer
+    /**
+     * Synonym rule details.
+     */
     synonyms_set: SynonymRuleRead[]
   }
 }

--- a/specification/synonyms/get_synonym/examples/response/SynonymsGetResponseExample1.yaml
+++ b/specification/synonyms/get_synonym/examples/response/SynonymsGetResponseExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+description: A successful response from `GET _synonyms/my-synonyms-set`.
+# type: response
+# response_code: ''
+value:
+  "{\n  \"count\": 3,\n  \"synonyms_set\": [\n    {\n      \"id\": \"test-1\"\
+  ,\n      \"synonyms\": \"hello, hi\"\n    },\n    {\n      \"id\": \"test-2\",\n\
+  \      \"synonyms\": \"bye, goodbye\"\n    },\n    {\n      \"id\": \"test-3\",\n\
+  \      \"synonyms\": \"test => check\"\n    }\n  ]\n}"

--- a/specification/synonyms/get_synonym_rule/SynonymRuleGetRequest.ts
+++ b/specification/synonyms/get_synonym_rule/SynonymRuleGetRequest.ts
@@ -25,6 +25,7 @@ import { Id } from '@_types/common'
  * @rest_spec_name synonyms.get_synonym_rule
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id synonym-rule-get
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/synonyms/get_synonym_rule/SynonymRuleGetRequest.ts
+++ b/specification/synonyms/get_synonym_rule/SynonymRuleGetRequest.ts
@@ -25,17 +25,17 @@ import { Id } from '@_types/common'
  * @rest_spec_name synonyms.get_synonym_rule
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_synonyms
  * @doc_id synonym-rule-get
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * The id of the synonym set to retrieve the synonym rule from
+     * The ID of the synonym set to retrieve the synonym rule from.
      */
     set_id: Id
-
     /**
-     * The id of the synonym rule to retrieve
+     * The ID of the synonym rule to retrieve.
      */
     rule_id: Id
   }

--- a/specification/synonyms/get_synonym_rule/examples/response/SynonymRuleGetResponseExample1.yaml
+++ b/specification/synonyms/get_synonym_rule/examples/response/SynonymRuleGetResponseExample1.yaml
@@ -1,0 +1,5 @@
+# summary:
+description: A successful response from `GET _synonyms/my-synonyms-set/test-1`.
+# type: response
+# response_code: ''
+value: "{\n  \"id\": \"test-1\",\n  \"synonyms\": \"hello, hi\"\n}"

--- a/specification/synonyms/get_synonyms_sets/SynonymsSetsGetRequest.ts
+++ b/specification/synonyms/get_synonyms_sets/SynonymsSetsGetRequest.ts
@@ -25,17 +25,18 @@ import { integer } from '@_types/Numeric'
  * @rest_spec_name synonyms.get_synonyms_sets
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_synonyms
  * @doc_id synonym-set-list
  */
 export interface Request extends RequestBase {
   query_parameters: {
     /**
-     * Starting offset
+     * The starting offset for synonyms sets to retrieve.
      * @server_default 0
      */
     from?: integer
     /**
-     * specifies a max number of results to get
+     * The maximum number of synonyms sets to retrieve.
      * @server_default 10
      */
     size?: integer

--- a/specification/synonyms/get_synonyms_sets/SynonymsSetsGetRequest.ts
+++ b/specification/synonyms/get_synonyms_sets/SynonymsSetsGetRequest.ts
@@ -25,6 +25,7 @@ import { integer } from '@_types/Numeric'
  * @rest_spec_name synonyms.get_synonyms_sets
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id synonym-set-list
  */
 export interface Request extends RequestBase {
   query_parameters: {

--- a/specification/synonyms/get_synonyms_sets/SynonymsSetsGetResponse.ts
+++ b/specification/synonyms/get_synonyms_sets/SynonymsSetsGetResponse.ts
@@ -22,7 +22,13 @@ import { integer } from '@_types/Numeric'
 
 export class Response {
   body: {
+    /**
+     * The total number of synonyms sets defined.
+     */
     count: integer
+    /**
+     * The identifier and total number of defined synonym rules for each synonyms set.
+     */
     results: SynonymsSetItem[]
   }
 }

--- a/specification/synonyms/get_synonyms_sets/examples/response/SynonymsSetsGetResponseExample1.yaml
+++ b/specification/synonyms/get_synonyms_sets/examples/response/SynonymsSetsGetResponseExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+description: A successful response from `GET _synonyms`.
+# type: response
+# response_code: ''
+value:
+  "{\n  \"count\": 3,\n  \"results\": [\n    {\n      \"synonyms_set\": \"ecommerce-synonyms\"\
+  ,\n      \"count\": 2\n    },\n    {\n      \"synonyms_set\": \"my-synonyms-set\"\
+  ,\n      \"count\": 3\n    },\n    {\n      \"synonyms_set\": \"new-ecommerce-synonyms\"\
+  ,\n      \"count\": 1\n    }\n  ]\n}"

--- a/specification/synonyms/put_synonym/SynonymsPutRequest.ts
+++ b/specification/synonyms/put_synonym/SynonymsPutRequest.ts
@@ -27,6 +27,7 @@ import { SynonymRule } from '../_types/SynonymRule'
  * @rest_spec_name synonyms.put_synonym
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id synonym-set-create
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/synonyms/put_synonym/SynonymsPutRequest.ts
+++ b/specification/synonyms/put_synonym/SynonymsPutRequest.ts
@@ -24,21 +24,25 @@ import { SynonymRule } from '../_types/SynonymRule'
  * Create or update a synonym set.
  * Synonyms sets are limited to a maximum of 10,000 synonym rules per set.
  * If you need to manage more synonym rules, you can create multiple synonym sets.
+ *
+ * When an existing synonyms set is updated, the search analyzers that use the synonyms set are reloaded automatically for all indices.
+ * This is equivalent to invoking the reload search analyzers API for all indices that use the synonyms set.
  * @rest_spec_name synonyms.put_synonym
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_synonyms
  * @doc_id synonym-set-create
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * The id of the synonyms set to be created or updated
+     * The ID of the synonyms set to be created or updated.
      */
     id: Id
   }
   body: {
     /**
-     * The synonym set information to update
+     * The synonym rules definitions for the synonyms set.
      */
     synonyms_set: SynonymRule | SynonymRule[]
   }

--- a/specification/synonyms/put_synonym/examples/400_response/SynonymsPutRequestExample1.yaml
+++ b/specification/synonyms/put_synonym/examples/400_response/SynonymsPutRequestExample1.yaml
@@ -1,0 +1,11 @@
+# summary:
+# method_request: PUT _synonyms/my-synonyms-set
+description: >
+  Run `PUT _synonyms/my-synonyms-set` to create a new synonyms set.
+  If any of the synonym rules included is not valid, the API will return an error.
+# type: request
+value:
+  "{\n  \"synonyms_set\": [\n    {\n      \"id\": \"test-1\",\n      \"synonyms\"\
+  : \"hello, hi\"\n    },\n    {\n      \"synonyms\": \"bye, goodbye\"\n    },\n \
+  \   {\n      \"id\": \"test-2\",\n      \"synonyms\": \"test => check\"\n    }\n\
+  \  ]\n}"

--- a/specification/synonyms/put_synonym/examples/400_response/SynonymsPutResponseExample1.yaml
+++ b/specification/synonyms/put_synonym/examples/400_response/SynonymsPutResponseExample1.yaml
@@ -1,0 +1,14 @@
+# summary:
+description: >
+  An abbreviated response from `PUT _synonyms/my-synonyms-set`.
+  If any of the synonym rules included is not valid, the API returns an error.
+# type: response
+# response_code: 400
+value:
+  "{\n  \"error\": {\n    \"root_cause\": [\n      {\n        \"type\": \"action_request_validation_exception\"\
+  ,\n        \"reason\": \"Validation Failed: 1: More than one explicit mapping specified\
+  \ in the same synonyms rule: [hello => hi => howdy];\",\n        \"stack_trace\"\
+  : ...\n      }\n    ],\n    \"type\": \"action_request_validation_exception\",\n\
+  \    \"reason\": \"Validation Failed: 1: More than one explicit mapping specified\
+  \ in the same synonyms rule: [hello => hi => howdy];\",\n    \"stack_trace\": ...\n\
+  \  },\n  \"status\": 400\n}"

--- a/specification/synonyms/put_synonym_rule/SynonymRulePutRequest.ts
+++ b/specification/synonyms/put_synonym_rule/SynonymRulePutRequest.ts
@@ -23,27 +23,32 @@ import { SynonymString } from '../_types/SynonymRule'
 /**
  * Create or update a synonym rule.
  * Create or update a synonym rule in a synonym set.
+ *
+ * If any of the synonym rules included is invalid, the API returns an error.
+ *
+ * When you update a synonym rule, all analyzers using the synonyms set will be reloaded automatically to reflect the new rule.
  * @rest_spec_name synonyms.put_synonym_rule
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage_search_synonyms
  * @doc_id synonym-rule-create
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * The id of the synonym set to be updated with the synonym rule
+     * The ID of the synonym set.
      */
     set_id: Id
-
     /**
-     * The id of the synonym rule to be updated or created
+     * The ID of the synonym rule to be updated or created.
      */
     rule_id: Id
   }
-  /**
-   * The synonym rule information to update
-   */
   body: {
+    /**
+     * The synonym rule information definition, which must be in Solr format.
+     * @ext_doc_id synonym-set-define
+     */
     synonyms: SynonymString
   }
 }

--- a/specification/synonyms/put_synonym_rule/SynonymRulePutRequest.ts
+++ b/specification/synonyms/put_synonym_rule/SynonymRulePutRequest.ts
@@ -26,6 +26,7 @@ import { SynonymString } from '../_types/SynonymRule'
  * @rest_spec_name synonyms.put_synonym_rule
  * @availability stack since=8.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id synonym-rule-create
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/synonyms/put_synonym_rule/examples/request/SynonymRulePutRequestExample1.yaml
+++ b/specification/synonyms/put_synonym_rule/examples/request/SynonymRulePutRequestExample1.yaml
@@ -1,0 +1,5 @@
+summary: synonyms/apis/put-synonym-rule.asciidoc:107
+method_request: PUT _synonyms/my-synonyms-set/test-1
+description: ''
+type: request
+value: "{\n  \"synonyms\": \"hello, hi, howdy\"\n}"

--- a/specification/synonyms/put_synonym_rule/examples/response/SynonymRuleResponseExample1.yaml
+++ b/specification/synonyms/put_synonym_rule/examples/response/SynonymRuleResponseExample1.yaml
@@ -1,0 +1,13 @@
+# summary:
+description: >
+  A successful response from `PUT _synonyms/my-synonyms-set/test-1`.
+
+# type: response
+# response_code: ''
+value:
+  "{\n  \"result\": \"updated\",\n  \"reload_analyzers_details\": {\n    \"_shards\"\
+  : {\n      \"total\": 2,\n      \"successful\": 1,\n      \"failed\": 0\n    },\n\
+  \    \"reload_details\": [\n      {\n        \"index\": \"test-index\",\n      \
+  \  \"reloaded_analyzers\": [\n          \"my_search_analyzer\"\n        ],\n   \
+  \     \"reloaded_node_ids\": [\n          \"1wYFZzq8Sxeu_Jvt9mlbkg\"\n        ]\n\
+  \      }\n    ]\n  }\n}"


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR copies the examples from https://www.elastic.co/guide/en/elasticsearch/reference/master/synonyms-apis.html
It also adds the missing `doc_id` values and edits some descriptions.