### PR TITLE
Add text structure API examples

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -35643,7 +35643,7 @@
           "text_structure"
         ],
         "summary": "Find the structure of a text field",
-        "description": "Find the structure of a text field in an Elasticsearch index.",
+        "description": "Find the structure of a text field in an Elasticsearch index.\n\nThis API provides a starting point for extracting further information from log messages already ingested into Elasticsearch.\nFor example, if you have ingested data into a very simple index that has just `@timestamp` and message fields, you can use this API to see what common structure exists in the message field.\n\nThe response from the API contains:\n\n* Sample messages.\n* Statistics that reveal the most common values for all fields detected within the text and basic numeric statistics for numeric fields.\n* Information about the structure of the text, which is useful when you write ingest configurations to index it or similarly formatted text.\n* Appropriate mappings for an Elasticsearch index, which you could use to ingest the text.\n\nAll this information can be calculated by the structure finder with no guidance.\nHowever, you can optionally override some of the decisions about the text structure by specifying one or more query parameters.\n\nIf the structure finder produces unexpected results, specify the `explain` query parameter and an explanation will appear in the response.\nIt helps determine why the returned structure was chosen.",
         "operationId": "text-structure-find-field-structure",
         "parameters": [
           {
@@ -35689,7 +35689,7 @@
           {
             "in": "query",
             "name": "explain",
-            "description": "If true, the response includes a field named `explanation`, which is an array of strings that indicate how the structure finder produced its result.",
+            "description": "If `true`, the response includes a field named `explanation`, which is an array of strings that indicate how the structure finder produced its result.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -35751,7 +35751,7 @@
           {
             "in": "query",
             "name": "should_trim_fields",
-            "description": "If the format is `delimited`, you can specify whether values between delimiters should have whitespace trimmed from them.\nIf this parameter is not specified and the delimiter is pipe (`|`), the default value is true.\nOtherwise, the default value is false.",
+            "description": "If the format is `delimited`, you can specify whether values between delimiters should have whitespace trimmed from them.\nIf this parameter is not specified and the delimiter is pipe (`|`), the default value is true.\nOtherwise, the default value is `false`.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -35876,7 +35876,7 @@
           "text_structure"
         ],
         "summary": "Find the structure of text messages",
-        "description": "Find the structure of a list of text messages.\nThe messages must contain data that is suitable to be ingested into Elasticsearch.\n\nThis API provides a starting point for ingesting data into Elasticsearch in a format that is suitable for subsequent use with other Elastic Stack functionality.\nUse this API rather than the find text structure API if your input text has already been split up into separate messages by some other process.\nThe response from the API contains:\n\n* Sample messages.\n* Statistics that reveal the most common values for all fields detected within the text and basic numeric statistics for numeric fields.\n* Information about the structure of the text, which is useful when you write ingest configurations to index it or similarly formatted text.\nAppropriate mappings for an Elasticsearch index, which you could use to ingest the text.\n\nAll this information can be calculated by the structure finder with no guidance.\nHowever, you can optionally override some of the decisions about the text structure by specifying one or more query parameters.",
+        "description": "Find the structure of a list of text messages.\nThe messages must contain data that is suitable to be ingested into Elasticsearch.\n\nThis API provides a starting point for ingesting data into Elasticsearch in a format that is suitable for subsequent use with other Elastic Stack functionality.\nUse this API rather than the find text structure API if your input text has already been split up into separate messages by some other process.\n\nThe response from the API contains:\n\n* Sample messages.\n* Statistics that reveal the most common values for all fields detected within the text and basic numeric statistics for numeric fields.\n* Information about the structure of the text, which is useful when you write ingest configurations to index it or similarly formatted text.\nAppropriate mappings for an Elasticsearch index, which you could use to ingest the text.\n\nAll this information can be calculated by the structure finder with no guidance.\nHowever, you can optionally override some of the decisions about the text structure by specifying one or more query parameters.\n\nIf the structure finder produces unexpected results, specify the `explain` query parameter and an explanation will appear in the response.\nIt helps determine why the returned structure was chosen.",
         "operationId": "text-structure-find-message-structure",
         "parameters": [
           {
@@ -35927,7 +35927,7 @@
           "text_structure"
         ],
         "summary": "Find the structure of text messages",
-        "description": "Find the structure of a list of text messages.\nThe messages must contain data that is suitable to be ingested into Elasticsearch.\n\nThis API provides a starting point for ingesting data into Elasticsearch in a format that is suitable for subsequent use with other Elastic Stack functionality.\nUse this API rather than the find text structure API if your input text has already been split up into separate messages by some other process.\nThe response from the API contains:\n\n* Sample messages.\n* Statistics that reveal the most common values for all fields detected within the text and basic numeric statistics for numeric fields.\n* Information about the structure of the text, which is useful when you write ingest configurations to index it or similarly formatted text.\nAppropriate mappings for an Elasticsearch index, which you could use to ingest the text.\n\nAll this information can be calculated by the structure finder with no guidance.\nHowever, you can optionally override some of the decisions about the text structure by specifying one or more query parameters.",
+        "description": "Find the structure of a list of text messages.\nThe messages must contain data that is suitable to be ingested into Elasticsearch.\n\nThis API provides a starting point for ingesting data into Elasticsearch in a format that is suitable for subsequent use with other Elastic Stack functionality.\nUse this API rather than the find text structure API if your input text has already been split up into separate messages by some other process.\n\nThe response from the API contains:\n\n* Sample messages.\n* Statistics that reveal the most common values for all fields detected within the text and basic numeric statistics for numeric fields.\n* Information about the structure of the text, which is useful when you write ingest configurations to index it or similarly formatted text.\nAppropriate mappings for an Elasticsearch index, which you could use to ingest the text.\n\nAll this information can be calculated by the structure finder with no guidance.\nHowever, you can optionally override some of the decisions about the text structure by specifying one or more query parameters.\n\nIf the structure finder produces unexpected results, specify the `explain` query parameter and an explanation will appear in the response.\nIt helps determine why the returned structure was chosen.",
         "operationId": "text-structure-find-message-structure-1",
         "parameters": [
           {
@@ -35986,7 +35986,7 @@
           {
             "in": "query",
             "name": "charset",
-            "description": "The text’s character set. It must be a character set that is supported by the JVM that Elasticsearch uses. For example, UTF-8, UTF-16LE, windows-1252, or EUC-JP. If this parameter is not specified, the structure finder chooses an appropriate character set.",
+            "description": "The text's character set.\nIt must be a character set that is supported by the JVM that Elasticsearch uses.\nFor example, `UTF-8`, `UTF-16LE`, `windows-1252`, or `EUC-JP`.\nIf this parameter is not specified, the structure finder chooses an appropriate character set.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -35996,7 +35996,7 @@
           {
             "in": "query",
             "name": "column_names",
-            "description": "If you have set format to delimited, you can specify the column names in a comma-separated list. If this parameter is not specified, the structure finder uses the column names from the header row of the text. If the text does not have a header role, columns are named \"column1\", \"column2\", \"column3\", for example.",
+            "description": "If you have set format to `delimited`, you can specify the column names in a comma-separated list.\nIf this parameter is not specified, the structure finder uses the column names from the header row of the text.\nIf the text does not have a header role, columns are named \"column1\", \"column2\", \"column3\", for example.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -36006,7 +36006,7 @@
           {
             "in": "query",
             "name": "delimiter",
-            "description": "If you have set format to delimited, you can specify the character used to delimit the values in each row. Only a single character is supported; the delimiter cannot have multiple characters. By default, the API considers the following possibilities: comma, tab, semi-colon, and pipe (|). In this default scenario, all rows must have the same number of fields for the delimited format to be detected. If you specify a delimiter, up to 10% of the rows can have a different number of columns than the first row.",
+            "description": "If you have set `format` to `delimited`, you can specify the character used to delimit the values in each row.\nOnly a single character is supported; the delimiter cannot have multiple characters.\nBy default, the API considers the following possibilities: comma, tab, semi-colon, and pipe (`|`).\nIn this default scenario, all rows must have the same number of fields for the delimited format to be detected.\nIf you specify a delimiter, up to 10% of the rows can have a different number of columns than the first row.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -36016,7 +36016,7 @@
           {
             "in": "query",
             "name": "ecs_compatibility",
-            "description": "The mode of compatibility with ECS compliant Grok patterns (disabled or v1, default: disabled).",
+            "description": "The mode of compatibility with ECS compliant Grok patterns.\nUse this parameter to specify whether to use ECS Grok patterns instead of legacy ones when the structure finder creates a Grok pattern.\nValid values are `disabled` and `v1`.\nThis setting primarily has an impact when a whole message Grok pattern such as `%{CATALINALOG}` matches the input.\nIf the structure finder identifies a common structure but has no idea of meaning then generic field names such as `path`, `ipaddress`, `field1`, and `field2` are used in the `grok_pattern` output, with the intention that a user who knows the meanings rename these fields before using it.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -36026,7 +36026,7 @@
           {
             "in": "query",
             "name": "explain",
-            "description": "If this parameter is set to true, the response includes a field named explanation, which is an array of strings that indicate how the structure finder produced its result.\nIf the structure finder produces unexpected results for some text, use this query parameter to help you determine why the returned structure was chosen.",
+            "description": "If this parameter is set to `true`, the response includes a field named explanation, which is an array of strings that indicate how the structure finder produced its result.\nIf the structure finder produces unexpected results for some text, use this query parameter to help you determine why the returned structure was chosen.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -36036,7 +36036,7 @@
           {
             "in": "query",
             "name": "format",
-            "description": "The high level structure of the text. Valid values are ndjson, xml, delimited, and semi_structured_text. By default, the API chooses the format. In this default scenario, all rows must have the same number of fields for a delimited format to be detected. If the format is set to delimited and the delimiter is not set, however, the API tolerates up to 5% of rows that have a different number of columns than the first row.",
+            "description": "The high level structure of the text.\nValid values are `ndjson`, `xml`, `delimited`, and `semi_structured_text`.\nBy default, the API chooses the format.\nIn this default scenario, all rows must have the same number of fields for a delimited format to be detected.\nIf the format is set to `delimited` and the delimiter is not set, however, the API tolerates up to 5% of rows that have a different number of columns than the first row.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -36046,7 +36046,7 @@
           {
             "in": "query",
             "name": "grok_pattern",
-            "description": "If you have set format to semi_structured_text, you can specify a Grok pattern that is used to extract fields from every message in the text. The name of the timestamp field in the Grok pattern must match what is specified in the timestamp_field parameter. If that parameter is not specified, the name of the timestamp field in the Grok pattern must match \"timestamp\". If grok_pattern is not specified, the structure finder creates a Grok pattern.",
+            "description": "If you have set `format` to `semi_structured_text`, you can specify a Grok pattern that is used to extract fields from every message in the text.\nThe name of the timestamp field in the Grok pattern must match what is specified in the `timestamp_field` parameter.\nIf that parameter is not specified, the name of the timestamp field in the Grok pattern must match \"timestamp\".\nIf `grok_pattern` is not specified, the structure finder creates a Grok pattern.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:GrokPattern"
@@ -36056,7 +36056,7 @@
           {
             "in": "query",
             "name": "has_header_row",
-            "description": "If you have set format to delimited, you can use this parameter to indicate whether the column names are in the first row of the text. If this parameter is not specified, the structure finder guesses based on the similarity of the first row of the text to other rows.",
+            "description": "If you have set `format` to `delimited`, you can use this parameter to indicate whether the column names are in the first row of the text.\nIf this parameter is not specified, the structure finder guesses based on the similarity of the first row of the text to other rows.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -36066,7 +36066,7 @@
           {
             "in": "query",
             "name": "line_merge_size_limit",
-            "description": "The maximum number of characters in a message when lines are merged to form messages while analyzing semi-structured text. If you have extremely long messages you may need to increase this, but be aware that this may lead to very long processing times if the way to group lines into messages is misdetected.",
+            "description": "The maximum number of characters in a message when lines are merged to form messages while analyzing semi-structured text.\nIf you have extremely long messages you may need to increase this, but be aware that this may lead to very long processing times if the way to group lines into messages is misdetected.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:uint"
@@ -36076,7 +36076,7 @@
           {
             "in": "query",
             "name": "lines_to_sample",
-            "description": "The number of lines to include in the structural analysis, starting from the beginning of the text. The minimum is 2; If the value of this parameter is greater than the number of lines in the text, the analysis proceeds (as long as there are at least two lines in the text) for all of the lines.",
+            "description": "The number of lines to include in the structural analysis, starting from the beginning of the text.\nThe minimum is 2.\nIf the value of this parameter is greater than the number of lines in the text, the analysis proceeds (as long as there are at least two lines in the text) for all of the lines.\n\nNOTE: The number of lines and the variation of the lines affects the speed of the analysis.\nFor example, if you upload text where the first 1000 lines are all variations on the same message, the analysis will find more commonality than would be seen with a bigger sample.\nIf possible, however, it is more efficient to upload sample text with more variety in the first 1000 lines than to request analysis of 100000 lines to achieve some variety.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:uint"
@@ -36086,7 +36086,7 @@
           {
             "in": "query",
             "name": "quote",
-            "description": "If you have set format to delimited, you can specify the character used to quote the values in each row if they contain newlines or the delimiter character. Only a single character is supported. If this parameter is not specified, the default value is a double quote (\"). If your delimited text format does not use quoting, a workaround is to set this argument to a character that does not appear anywhere in the sample.",
+            "description": "If you have set `format` to `delimited`, you can specify the character used to quote the values in each row if they contain newlines or the delimiter character.\nOnly a single character is supported.\nIf this parameter is not specified, the default value is a double quote (`\"`).\nIf your delimited text format does not use quoting, a workaround is to set this argument to a character that does not appear anywhere in the sample.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -36096,7 +36096,7 @@
           {
             "in": "query",
             "name": "should_trim_fields",
-            "description": "If you have set format to delimited, you can specify whether values between delimiters should have whitespace trimmed from them. If this parameter is not specified and the delimiter is pipe (|), the default value is true. Otherwise, the default value is false.",
+            "description": "If you have set `format` to `delimited`, you can specify whether values between delimiters should have whitespace trimmed from them.\nIf this parameter is not specified and the delimiter is pipe (`|`), the default value is `true`.\nOtherwise, the default value is `false`.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -36106,7 +36106,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Sets the maximum amount of time that the structure analysis can take. If the analysis is still running when the timeout expires then it will be stopped.",
+            "description": "The maximum amount of time that the structure analysis can take.\nIf the analysis is still running when the timeout expires then it will be stopped.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -36116,7 +36116,7 @@
           {
             "in": "query",
             "name": "timestamp_field",
-            "description": "Optional parameter to specify the timestamp field in the file",
+            "description": "The name of the field that contains the primary timestamp of each record in the text.\nIn particular, if the text were ingested into an index, this is the field that would be used to populate the `@timestamp` field.\n\nIf the `format` is `semi_structured_text`, this field must match the name of the appropriate extraction in the `grok_pattern`.\nTherefore, for semi-structured text, it is best not to specify this parameter unless `grok_pattern` is also specified.\n\nFor structured text, if you specify this parameter, the field must exist within the text.\n\nIf this parameter is not specified, the structure finder makes a decision about which field (if any) is the primary timestamp field.\nFor structured text, it is not compulsory to have a timestamp in the text.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Field"
@@ -36126,7 +36126,7 @@
           {
             "in": "query",
             "name": "timestamp_format",
-            "description": "The Java time format of the timestamp field in the text.",
+            "description": "The Java time format of the timestamp field in the text.\n\nOnly a subset of Java time format letter groups are supported:\n\n* `a`\n* `d`\n* `dd`\n* `EEE`\n* `EEEE`\n* `H`\n* `HH`\n* `h`\n* `M`\n* `MM`\n* `MMM`\n* `MMMM`\n* `mm`\n* `ss`\n* `XX`\n* `XXX`\n* `yy`\n* `yyyy`\n* `zzz`\n\nAdditionally `S` letter groups (fractional seconds) of length one to nine are supported providing they occur after `ss` and separated from the `ss` by a `.`, `,` or `:`.\nSpacing and punctuation is also permitted with the exception of `?`, newline and carriage return, together with literal text enclosed in single quotes.\nFor example, `MM/dd HH.mm.ss,SSSSSS 'in' yyyy` is a valid override format.\n\nOne valuable use case for this parameter is when the format is semi-structured text, there are multiple timestamp formats in the text, and you know which format corresponds to the primary timestamp, but you do not want to specify the full `grok_pattern`.\nAnother is when the timestamp format is one that the structure finder does not consider by default.\n\nIf this parameter is not specified, the structure finder chooses the best format from a built-in set.\n\nIf the special value `null` is specified the structure finder will not look for a primary timestamp in the text.\nWhen the format is semi-structured text this will result in the structure finder treating the text as single-line messages.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -36156,27 +36156,33 @@
                   "type": "object",
                   "properties": {
                     "charset": {
+                      "description": "The character encoding used to parse the text.",
                       "type": "string"
                     },
                     "has_header_row": {
                       "type": "boolean"
                     },
                     "has_byte_order_marker": {
+                      "description": "For UTF character encodings, it indicates whether the text begins with a byte order marker.",
                       "type": "boolean"
                     },
                     "format": {
+                      "description": "Valid values include `ndjson`, `xml`, `delimited`, and `semi_structured_text`.",
                       "type": "string"
                     },
                     "field_stats": {
+                      "description": "The most common values of each field, plus basic numeric statistics for the numeric `page_count` field.\nThis information may provide clues that the data needs to be cleaned or transformed prior to use by other Elastic Stack functionality.",
                       "type": "object",
                       "additionalProperties": {
                         "$ref": "#/components/schemas/text_structure._types:FieldStat"
                       }
                     },
                     "sample_start": {
+                      "description": "The first two messages in the text verbatim.\nThis may help diagnose parse errors or accidental uploads of the wrong text.",
                       "type": "string"
                     },
                     "num_messages_analyzed": {
+                      "description": "The number of distinct messages the lines contained.\nFor NDJSON, this value is the same as `num_lines_analyzed`.\nFor other text formats, messages can span several lines.",
                       "type": "number"
                     },
                     "mappings": {
@@ -36189,12 +36195,15 @@
                       "type": "string"
                     },
                     "need_client_timezone": {
+                      "description": "If a timestamp format is detected that does not include a timezone, `need_client_timezone` is `true`.\nThe server that parses the text must therefore be told the correct timezone by the client.",
                       "type": "boolean"
                     },
                     "num_lines_analyzed": {
+                      "description": "The number of lines of the text that were analyzed.",
                       "type": "number"
                     },
                     "column_names": {
+                      "description": "If `format` is `delimited`, the `column_names` field lists the column names in the order they appear in the sample.",
                       "type": "array",
                       "items": {
                         "type": "string"
@@ -36216,12 +36225,14 @@
                       "type": "string"
                     },
                     "java_timestamp_formats": {
+                      "description": "The Java time formats recognized in the time fields.\nElasticsearch mappings and ingest pipelines use this format.",
                       "type": "array",
                       "items": {
                         "type": "string"
                       }
                     },
                     "joda_timestamp_formats": {
+                      "description": "Information that is used to tell Logstash how to parse timestamps.",
                       "type": "array",
                       "items": {
                         "type": "string"
@@ -105254,7 +105265,7 @@
       "text_structure.find_message_structure#should_trim_fields": {
         "in": "query",
         "name": "should_trim_fields",
-        "description": "If the format is `delimited`, you can specify whether values between delimiters should have whitespace trimmed from them.\nIf this parameter is not specified and the delimiter is pipe (`|`), the default value is true.\nOtherwise, the default value is false.",
+        "description": "If the format is `delimited`, you can specify whether values between delimiters should have whitespace trimmed from them.\nIf this parameter is not specified and the delimiter is pipe (`|`), the default value is true.\nOtherwise, the default value is `false`.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -105294,7 +105305,7 @@
       "text_structure.test_grok_pattern#ecs_compatibility": {
         "in": "query",
         "name": "ecs_compatibility",
-        "description": "The mode of compatibility with ECS compliant Grok patterns (disabled or v1, default: disabled).",
+        "description": "The mode of compatibility with ECS compliant Grok patterns.\nUse this parameter to specify whether to use ECS Grok patterns instead of legacy ones when the structure finder creates a Grok pattern.\nValid values are `disabled` and `v1`.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -108328,7 +108339,7 @@
                   "$ref": "#/components/schemas/_types:GrokPattern"
                 },
                 "text": {
-                  "description": "Lines of text to run the Grok pattern on.",
+                  "description": "The lines of text to run the Grok pattern on.",
                   "type": "array",
                   "items": {
                     "type": "string"

--- a/specification/text_structure/find_field_structure/FindFieldStructureRequest.ts
+++ b/specification/text_structure/find_field_structure/FindFieldStructureRequest.ts
@@ -26,6 +26,22 @@ import { EcsCompatibilityType, FormatType } from '../_types/Structure'
 /**
  * Find the structure of a text field.
  * Find the structure of a text field in an Elasticsearch index.
+ *
+ * This API provides a starting point for extracting further information from log messages already ingested into Elasticsearch.
+ * For example, if you have ingested data into a very simple index that has just `@timestamp` and message fields, you can use this API to see what common structure exists in the message field.
+ *
+ * The response from the API contains:
+ *
+ * * Sample messages.
+ * * Statistics that reveal the most common values for all fields detected within the text and basic numeric statistics for numeric fields.
+ * * Information about the structure of the text, which is useful when you write ingest configurations to index it or similarly formatted text.
+ * * Appropriate mappings for an Elasticsearch index, which you could use to ingest the text.
+ *
+ * All this information can be calculated by the structure finder with no guidance.
+ * However, you can optionally override some of the decisions about the text structure by specifying one or more query parameters.
+ *
+ * If the structure finder produces unexpected results, specify the `explain` query parameter and an explanation will appear in the response.
+ * It helps determine why the returned structure was chosen.
  * @rest_spec_name text_structure.find_field_structure
  * @availability stack stability=stable visibility=public
  * @cluster_privileges monitor_text_structure
@@ -63,7 +79,7 @@ interface Request extends RequestBase {
      */
     ecs_compatibility?: EcsCompatibilityType
     /**
-     * If true, the response includes a field named `explanation`, which is an array of strings that indicate how the structure finder produced its result.
+     * If `true`, the response includes a field named `explanation`, which is an array of strings that indicate how the structure finder produced its result.
      * @server_default false
      */
     explain?: boolean
@@ -99,7 +115,7 @@ interface Request extends RequestBase {
     /**
      * If the format is `delimited`, you can specify whether values between delimiters should have whitespace trimmed from them.
      * If this parameter is not specified and the delimiter is pipe (`|`), the default value is true.
-     * Otherwise, the default value is false.
+     * Otherwise, the default value is `false`.
      */
     should_trim_fields?: boolean
     /**

--- a/specification/text_structure/find_field_structure/examples/response/FindFieldStructureResponseExample1.yaml
+++ b/specification/text_structure/find_field_structure/examples/response/FindFieldStructureResponseExample1.yaml
@@ -1,0 +1,65 @@
+# summary:
+description: A successful response from `GET _text_structure/find_field_structure?index=test-logs&field=message`.
+# type: response
+# response_code: ''
+value:
+  "{\n  \"num_lines_analyzed\" : 22,\n  \"num_messages_analyzed\" : 22,\n  \"\
+  sample_start\" : \"[2024-03-05T10:52:36,256][INFO ][o.a.l.u.VectorUtilPanamaProvider]\
+  \ [laptop] Java vector incubator API enabled; uses preferredBitSize=128\\n[2024-03-05T10:52:41,038][INFO\
+  \ ][o.e.p.PluginsService     ] [laptop] loaded module [repository-url]\\n\",\n \
+  \ \"charset\" : \"UTF-8\",\n  \"format\" : \"semi_structured_text\",\n  \"multiline_start_pattern\"\
+  \ : \"^\\\\[\\\\b\\\\d{4}-\\\\d{2}-\\\\d{2}[T ]\\\\d{2}:\\\\d{2}\",\n  \"grok_pattern\"\
+  \ : \"\\\\[%{TIMESTAMP_ISO8601:timestamp}\\\\]\\\\[%{LOGLEVEL:loglevel} \\\\]\\\\\
+  [.*\",\n  \"ecs_compatibility\" : \"disabled\",\n  \"timestamp_field\" : \"timestamp\"\
+  ,\n  \"joda_timestamp_formats\" : [\n    \"ISO8601\"\n  ],\n  \"java_timestamp_formats\"\
+  \ : [\n    \"ISO8601\"\n  ],\n  \"need_client_timezone\" : true,\n  \"mappings\"\
+  \ : {\n    \"properties\" : {\n      \"@timestamp\" : {\n        \"type\" : \"date\"\
+  \n      },\n      \"loglevel\" : {\n        \"type\" : \"keyword\"\n      },\n \
+  \     \"message\" : {\n        \"type\" : \"text\"\n      }\n    }\n  },\n  \"ingest_pipeline\"\
+  \ : {\n    \"description\" : \"Ingest pipeline created by text structure finder\"\
+  ,\n    \"processors\" : [\n      {\n        \"grok\" : {\n          \"field\" :\
+  \ \"message\",\n          \"patterns\" : [\n            \"\\\\[%{TIMESTAMP_ISO8601:timestamp}\\\
+  \\]\\\\[%{LOGLEVEL:loglevel} \\\\]\\\\[.*\"\n          ],\n          \"ecs_compatibility\"\
+  \ : \"disabled\"\n        }\n      },\n      {\n        \"date\" : {\n         \
+  \ \"field\" : \"timestamp\",\n          \"timezone\" : \"{{ event.timezone }}\"\
+  ,\n          \"formats\" : [\n            \"ISO8601\"\n          ]\n        }\n\
+  \      },\n      {\n        \"remove\" : {\n          \"field\" : \"timestamp\"\n\
+  \        }\n      }\n    ]\n  },\n  \"field_stats\" : {\n    \"loglevel\" : {\n\
+  \      \"count\" : 22,\n      \"cardinality\" : 1,\n      \"top_hits\" : [\n   \
+  \     {\n          \"value\" : \"INFO\",\n          \"count\" : 22\n        }\n\
+  \      ]\n    },\n    \"message\" : {\n      \"count\" : 22,\n      \"cardinality\"\
+  \ : 22,\n      \"top_hits\" : [\n        {\n          \"value\" : \"[2024-03-05T10:52:36,256][INFO\
+  \ ][o.a.l.u.VectorUtilPanamaProvider] [laptop] Java vector incubator API enabled;\
+  \ uses preferredBitSize=128\",\n          \"count\" : 1\n        },\n        {\n\
+  \          \"value\" : \"[2024-03-05T10:52:41,038][INFO ][o.e.p.PluginsService \
+  \    ] [laptop] loaded module [repository-url]\",\n          \"count\" : 1\n   \
+  \     },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,042][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [rest-root]\",\n          \"count\" : 1\n       \
+  \ },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [ingest-user-agent]\",\n          \"count\" : 1\n\
+  \        },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [x-pack-core]\",\n          \"count\" : 1\n     \
+  \   },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [x-pack-redact]\",\n          \"count\" : 1\n   \
+  \     },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [lang-painless]]\",\n          \"count\" : 1\n  \
+  \      },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [repository-s3]\",\n          \"count\" : 1\n   \
+  \     },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [x-pack-analytics]\",\n          \"count\" : 1\n\
+  \        },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [x-pack-autoscaling]\",\n          \"count\" : 1\n\
+  \        }\n      ]\n    },\n    \"timestamp\" : {\n      \"count\" : 22,\n    \
+  \  \"cardinality\" : 14,\n      \"earliest\" : \"2024-03-05T10:52:36,256\",\n  \
+  \    \"latest\" : \"2024-03-05T10:52:49,199\",\n      \"top_hits\" : [\n       \
+  \ {\n          \"value\" : \"2024-03-05T10:52:41,044\",\n          \"count\" : 6\n\
+  \        },\n        {\n          \"value\" : \"2024-03-05T10:52:41,043\",\n   \
+  \       \"count\" : 3\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:41,059\"\
+  ,\n          \"count\" : 2\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:36,256\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:41,038\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:41,042\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:43,291\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:46,098\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:47,227\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:47,259\"\
+  ,\n          \"count\" : 1\n        }\n      ]\n    }\n  }\n}"

--- a/specification/text_structure/find_message_structure/FindMessageStructureRequest.ts
+++ b/specification/text_structure/find_message_structure/FindMessageStructureRequest.ts
@@ -29,6 +29,7 @@ import { EcsCompatibilityType, FormatType } from '../_types/Structure'
  *
  * This API provides a starting point for ingesting data into Elasticsearch in a format that is suitable for subsequent use with other Elastic Stack functionality.
  * Use this API rather than the find text structure API if your input text has already been split up into separate messages by some other process.
+ *
  * The response from the API contains:
  *
  * * Sample messages.
@@ -38,6 +39,9 @@ import { EcsCompatibilityType, FormatType } from '../_types/Structure'
  *
  * All this information can be calculated by the structure finder with no guidance.
  * However, you can optionally override some of the decisions about the text structure by specifying one or more query parameters.
+ *
+ * If the structure finder produces unexpected results, specify the `explain` query parameter and an explanation will appear in the response.
+ * It helps determine why the returned structure was chosen.
  * @rest_spec_name text_structure.find_message_structure
  * @availability stack stability=stable visibility=public
  * @cluster_privileges monitor_text_structure
@@ -71,7 +75,8 @@ interface Request extends RequestBase {
      * @server_default false
      */
     explain?: boolean
-    /** The high level structure of the text.
+    /**
+     * The high level structure of the text.
      * By default, the API chooses the format.
      * In this default scenario, all rows must have the same number of fields for a delimited format to be detected.
      * If the format is `delimited` and the delimiter is not set, however, the API tolerates up to 5% of rows that have a different number of columns than the first row.
@@ -94,7 +99,7 @@ interface Request extends RequestBase {
     /**
      * If the format is `delimited`, you can specify whether values between delimiters should have whitespace trimmed from them.
      * If this parameter is not specified and the delimiter is pipe (`|`), the default value is true.
-     * Otherwise, the default value is false.
+     * Otherwise, the default value is `false`.
      */
     should_trim_fields?: boolean
     /**

--- a/specification/text_structure/find_message_structure/examples/request/FindMessageStructureRequestExample1.yaml
+++ b/specification/text_structure/find_message_structure/examples/request/FindMessageStructureRequestExample1.yaml
@@ -1,0 +1,36 @@
+# summary:
+# method_request: POST _text_structure/find_message_structure
+description: >
+  Run `POST _text_structure/find_message_structure` to analyze Elasticsearch log files.
+# type: request
+value:
+  "{\n  \"messages\": [\n    \"[2024-03-05T10:52:36,256][INFO ][o.a.l.u.VectorUtilPanamaProvider]\
+  \ [laptop] Java vector incubator API enabled; uses preferredBitSize=128\",\n   \
+  \ \"[2024-03-05T10:52:41,038][INFO ][o.e.p.PluginsService     ] [laptop] loaded\
+  \ module [repository-url]\",\n    \"[2024-03-05T10:52:41,042][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [rest-root]\",\n    \"[2024-03-05T10:52:41,043][INFO\
+  \ ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-core]\",\n    \"[2024-03-05T10:52:41,043][INFO\
+  \ ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-redact]\",\n    \"\
+  [2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module\
+  \ [ingest-user-agent]\",\n    \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [x-pack-monitoring]\",\n    \"[2024-03-05T10:52:41,044][INFO\
+  \ ][o.e.p.PluginsService     ] [laptop] loaded module [repository-s3]\",\n    \"\
+  [2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module\
+  \ [x-pack-analytics]\",\n    \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [x-pack-ent-search]\",\n    \"[2024-03-05T10:52:41,044][INFO\
+  \ ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-autoscaling]\",\n\
+  \    \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded\
+  \ module [lang-painless]]\",\n    \"[2024-03-05T10:52:41,059][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [lang-expression]\",\n    \"[2024-03-05T10:52:41,059][INFO\
+  \ ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-eql]\",\n    \"[2024-03-05T10:52:43,291][INFO\
+  \ ][o.e.e.NodeEnvironment    ] [laptop] heap size [16gb], compressed ordinary object\
+  \ pointers [true]\",\n    \"[2024-03-05T10:52:46,098][INFO ][o.e.x.s.Security  \
+  \       ] [laptop] Security is enabled\",\n    \"[2024-03-05T10:52:47,227][INFO\
+  \ ][o.e.x.p.ProfilingPlugin  ] [laptop] Profiling is enabled\",\n    \"[2024-03-05T10:52:47,259][INFO\
+  \ ][o.e.x.p.ProfilingPlugin  ] [laptop] profiling index templates will not be installed\
+  \ or reinstalled\",\n    \"[2024-03-05T10:52:47,755][INFO ][o.e.i.r.RecoverySettings\
+  \ ] [laptop] using rate limit [40mb] with [default=40mb, read=0b, write=0b, max=0b]\"\
+  ,\n    \"[2024-03-05T10:52:47,787][INFO ][o.e.d.DiscoveryModule    ] [laptop] using\
+  \ discovery type [multi-node] and seed hosts providers [settings]\",\n    \"[2024-03-05T10:52:49,188][INFO\
+  \ ][o.e.n.Node               ] [laptop] initialized\",\n    \"[2024-03-05T10:52:49,199][INFO\
+  \ ][o.e.n.Node               ] [laptop] starting ...\"\n  ]\n}"

--- a/specification/text_structure/find_message_structure/examples/response/FindMessageStructureResponseExample1.yaml
+++ b/specification/text_structure/find_message_structure/examples/response/FindMessageStructureResponseExample1.yaml
@@ -1,0 +1,65 @@
+# summary:
+description: A successful response from `POST _text_structure/find_message_structure`.
+# type: response
+# response_code: ''
+value:
+  "{\n  \"num_lines_analyzed\" : 22,\n  \"num_messages_analyzed\" : 22,\n  \"\
+  sample_start\" : \"[2024-03-05T10:52:36,256][INFO ][o.a.l.u.VectorUtilPanamaProvider]\
+  \ [laptop] Java vector incubator API enabled; uses preferredBitSize=128\\n[2024-03-05T10:52:41,038][INFO\
+  \ ][o.e.p.PluginsService     ] [laptop] loaded module [repository-url]\\n\",\n \
+  \ \"charset\" : \"UTF-8\",\n  \"format\" : \"semi_structured_text\",\n  \"multiline_start_pattern\"\
+  \ : \"^\\\\[\\\\b\\\\d{4}-\\\\d{2}-\\\\d{2}[T ]\\\\d{2}:\\\\d{2}\",\n  \"grok_pattern\"\
+  \ : \"\\\\[%{TIMESTAMP_ISO8601:timestamp}\\\\]\\\\[%{LOGLEVEL:loglevel} \\\\]\\\\\
+  [.*\",\n  \"ecs_compatibility\" : \"disabled\",\n  \"timestamp_field\" : \"timestamp\"\
+  ,\n  \"joda_timestamp_formats\" : [\n    \"ISO8601\"\n  ],\n  \"java_timestamp_formats\"\
+  \ : [\n    \"ISO8601\"\n  ],\n  \"need_client_timezone\" : true,\n  \"mappings\"\
+  \ : {\n    \"properties\" : {\n      \"@timestamp\" : {\n        \"type\" : \"date\"\
+  \n      },\n      \"loglevel\" : {\n        \"type\" : \"keyword\"\n      },\n \
+  \     \"message\" : {\n        \"type\" : \"text\"\n      }\n    }\n  },\n  \"ingest_pipeline\"\
+  \ : {\n    \"description\" : \"Ingest pipeline created by text structure finder\"\
+  ,\n    \"processors\" : [\n      {\n        \"grok\" : {\n          \"field\" :\
+  \ \"message\",\n          \"patterns\" : [\n            \"\\\\[%{TIMESTAMP_ISO8601:timestamp}\\\
+  \\]\\\\[%{LOGLEVEL:loglevel} \\\\]\\\\[.*\"\n          ],\n          \"ecs_compatibility\"\
+  \ : \"disabled\"\n        }\n      },\n      {\n        \"date\" : {\n         \
+  \ \"field\" : \"timestamp\",\n          \"timezone\" : \"{{ event.timezone }}\"\
+  ,\n          \"formats\" : [\n            \"ISO8601\"\n          ]\n        }\n\
+  \      },\n      {\n        \"remove\" : {\n          \"field\" : \"timestamp\"\n\
+  \        }\n      }\n    ]\n  },\n  \"field_stats\" : {\n    \"loglevel\" : {\n\
+  \      \"count\" : 22,\n      \"cardinality\" : 1,\n      \"top_hits\" : [\n   \
+  \     {\n          \"value\" : \"INFO\",\n          \"count\" : 22\n        }\n\
+  \      ]\n    },\n    \"message\" : {\n      \"count\" : 22,\n      \"cardinality\"\
+  \ : 22,\n      \"top_hits\" : [\n        {\n          \"value\" : \"[2024-03-05T10:52:36,256][INFO\
+  \ ][o.a.l.u.VectorUtilPanamaProvider] [laptop] Java vector incubator API enabled;\
+  \ uses preferredBitSize=128\",\n          \"count\" : 1\n        },\n        {\n\
+  \          \"value\" : \"[2024-03-05T10:52:41,038][INFO ][o.e.p.PluginsService \
+  \    ] [laptop] loaded module [repository-url]\",\n          \"count\" : 1\n   \
+  \     },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,042][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [rest-root]\",\n          \"count\" : 1\n       \
+  \ },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [ingest-user-agent]\",\n          \"count\" : 1\n\
+  \        },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [x-pack-core]\",\n          \"count\" : 1\n     \
+  \   },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [x-pack-redact]\",\n          \"count\" : 1\n   \
+  \     },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [lang-painless]]\",\n          \"count\" : 1\n  \
+  \      },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [repository-s3]\",\n          \"count\" : 1\n   \
+  \     },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [x-pack-analytics]\",\n          \"count\" : 1\n\
+  \        },\n        {\n          \"value\" : \"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService\
+  \     ] [laptop] loaded module [x-pack-autoscaling]\",\n          \"count\" : 1\n\
+  \        }\n      ]\n    },\n    \"timestamp\" : {\n      \"count\" : 22,\n    \
+  \  \"cardinality\" : 14,\n      \"earliest\" : \"2024-03-05T10:52:36,256\",\n  \
+  \    \"latest\" : \"2024-03-05T10:52:49,199\",\n      \"top_hits\" : [\n       \
+  \ {\n          \"value\" : \"2024-03-05T10:52:41,044\",\n          \"count\" : 6\n\
+  \        },\n        {\n          \"value\" : \"2024-03-05T10:52:41,043\",\n   \
+  \       \"count\" : 3\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:41,059\"\
+  ,\n          \"count\" : 2\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:36,256\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:41,038\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:41,042\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:43,291\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:46,098\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:47,227\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"2024-03-05T10:52:47,259\"\
+  ,\n          \"count\" : 1\n        }\n      ]\n    }\n  }\n}"

--- a/specification/text_structure/find_structure/FindStructureRequest.ts
+++ b/specification/text_structure/find_structure/FindStructureRequest.ts
@@ -43,52 +43,159 @@ import { Duration } from '@_types/Time'
  * @availability stack since=7.13.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_text_structure
+ * @doc_id find-structure
  */
 export interface Request<TJsonDocument> {
   query_parameters: {
-    /** The text’s character set. It must be a character set that is supported by the JVM that Elasticsearch uses. For example, UTF-8, UTF-16LE, windows-1252, or EUC-JP. If this parameter is not specified, the structure finder chooses an appropriate character set. */
+    /**
+     * The text's character set.
+     * It must be a character set that is supported by the JVM that Elasticsearch uses.
+     * For example, `UTF-8`, `UTF-16LE`, `windows-1252`, or `EUC-JP`.
+     * If this parameter is not specified, the structure finder chooses an appropriate character set.
+     */
     charset?: string
-    /** If you have set format to delimited, you can specify the column names in a comma-separated list. If this parameter is not specified, the structure finder uses the column names from the header row of the text. If the text does not have a header role, columns are named "column1", "column2", "column3", for example. */
+    /**
+     * If you have set format to `delimited`, you can specify the column names in a comma-separated list.
+     * If this parameter is not specified, the structure finder uses the column names from the header row of the text.
+     * If the text does not have a header role, columns are named "column1", "column2", "column3", for example.
+     */
     column_names?: string
-    /** If you have set format to delimited, you can specify the character used to delimit the values in each row. Only a single character is supported; the delimiter cannot have multiple characters. By default, the API considers the following possibilities: comma, tab, semi-colon, and pipe (|). In this default scenario, all rows must have the same number of fields for the delimited format to be detected. If you specify a delimiter, up to 10% of the rows can have a different number of columns than the first row. */
+    /**
+     * If you have set `format` to `delimited`, you can specify the character used to delimit the values in each row.
+     * Only a single character is supported; the delimiter cannot have multiple characters.
+     * By default, the API considers the following possibilities: comma, tab, semi-colon, and pipe (`|`).
+     * In this default scenario, all rows must have the same number of fields for the delimited format to be detected.
+     * If you specify a delimiter, up to 10% of the rows can have a different number of columns than the first row.
+     */
     delimiter?: string
-    /** The mode of compatibility with ECS compliant Grok patterns (disabled or v1, default: disabled). */
+    /**
+     * The mode of compatibility with ECS compliant Grok patterns.
+     * Use this parameter to specify whether to use ECS Grok patterns instead of legacy ones when the structure finder creates a Grok pattern.
+     * Valid values are `disabled` and `v1`.
+     * This setting primarily has an impact when a whole message Grok pattern such as `%{CATALINALOG}` matches the input.
+     * If the structure finder identifies a common structure but has no idea of meaning then generic field names such as `path`, `ipaddress`, `field1`, and `field2` are used in the `grok_pattern` output, with the intention that a user who knows the meanings rename these fields before using it.
+     * @server_default disabled
+     */
     ecs_compatibility?: string
     /**
-     * If this parameter is set to true, the response includes a field named explanation, which is an array of strings that indicate how the structure finder produced its result.
+     * If this parameter is set to `true`, the response includes a field named explanation, which is an array of strings that indicate how the structure finder produced its result.
      * If the structure finder produces unexpected results for some text, use this query parameter to help you determine why the returned structure was chosen.
      * @server_default false
      */
     explain?: boolean
-    /** The high level structure of the text. Valid values are ndjson, xml, delimited, and semi_structured_text. By default, the API chooses the format. In this default scenario, all rows must have the same number of fields for a delimited format to be detected. If the format is set to delimited and the delimiter is not set, however, the API tolerates up to 5% of rows that have a different number of columns than the first row. */
+    /**
+     * The high level structure of the text.
+     * Valid values are `ndjson`, `xml`, `delimited`, and `semi_structured_text`.
+     * By default, the API chooses the format.
+     * In this default scenario, all rows must have the same number of fields for a delimited format to be detected.
+     * If the format is set to `delimited` and the delimiter is not set, however, the API tolerates up to 5% of rows that have a different number of columns than the first row.
+     */
     format?: string
-    /** If you have set format to semi_structured_text, you can specify a Grok pattern that is used to extract fields from every message in the text. The name of the timestamp field in the Grok pattern must match what is specified in the timestamp_field parameter. If that parameter is not specified, the name of the timestamp field in the Grok pattern must match "timestamp". If grok_pattern is not specified, the structure finder creates a Grok pattern. */
+    /**
+     * If you have set `format` to `semi_structured_text`, you can specify a Grok pattern that is used to extract fields from every message in the text.
+     * The name of the timestamp field in the Grok pattern must match what is specified in the `timestamp_field` parameter.
+     * If that parameter is not specified, the name of the timestamp field in the Grok pattern must match "timestamp".
+     * If `grok_pattern` is not specified, the structure finder creates a Grok pattern.
+     */
     grok_pattern?: GrokPattern
-    /** If you have set format to delimited, you can use this parameter to indicate whether the column names are in the first row of the text. If this parameter is not specified, the structure finder guesses based on the similarity of the first row of the text to other rows. */
+    /**
+     * If you have set `format` to `delimited`, you can use this parameter to indicate whether the column names are in the first row of the text.
+     * If this parameter is not specified, the structure finder guesses based on the similarity of the first row of the text to other rows.
+     */
     has_header_row?: boolean
     /**
-     * The maximum number of characters in a message when lines are merged to form messages while analyzing semi-structured text. If you have extremely long messages you may need to increase this, but be aware that this may lead to very long processing times if the way to group lines into messages is misdetected.
+     * The maximum number of characters in a message when lines are merged to form messages while analyzing semi-structured text.
+     * If you have extremely long messages you may need to increase this, but be aware that this may lead to very long processing times if the way to group lines into messages is misdetected.
      * @server_default 10000
      */
     line_merge_size_limit?: uint
     /**
-     * The number of lines to include in the structural analysis, starting from the beginning of the text. The minimum is 2; If the value of this parameter is greater than the number of lines in the text, the analysis proceeds (as long as there are at least two lines in the text) for all of the lines.
+     * The number of lines to include in the structural analysis, starting from the beginning of the text.
+     * The minimum is 2.
+     * If the value of this parameter is greater than the number of lines in the text, the analysis proceeds (as long as there are at least two lines in the text) for all of the lines.
+     *
+     * NOTE: The number of lines and the variation of the lines affects the speed of the analysis.
+     * For example, if you upload text where the first 1000 lines are all variations on the same message, the analysis will find more commonality than would be seen with a bigger sample.
+     * If possible, however, it is more efficient to upload sample text with more variety in the first 1000 lines than to request analysis of 100000 lines to achieve some variety.
      * @server_default 1000
      */
     lines_to_sample?: uint
-    /** If you have set format to delimited, you can specify the character used to quote the values in each row if they contain newlines or the delimiter character. Only a single character is supported. If this parameter is not specified, the default value is a double quote ("). If your delimited text format does not use quoting, a workaround is to set this argument to a character that does not appear anywhere in the sample. */
+    /**
+     * If you have set `format` to `delimited`, you can specify the character used to quote the values in each row if they contain newlines or the delimiter character.
+     * Only a single character is supported.
+     * If this parameter is not specified, the default value is a double quote (`"`).
+     * If your delimited text format does not use quoting, a workaround is to set this argument to a character that does not appear anywhere in the sample.
+     */
     quote?: string
-    /** If you have set format to delimited, you can specify whether values between delimiters should have whitespace trimmed from them. If this parameter is not specified and the delimiter is pipe (|), the default value is true. Otherwise, the default value is false. */
+    /**
+     * If you have set `format` to `delimited`, you can specify whether values between delimiters should have whitespace trimmed from them.
+     * If this parameter is not specified and the delimiter is pipe (`|`), the default value is `true`.
+     * Otherwise, the default value is `false`.
+     */
     should_trim_fields?: boolean
     /**
-     * Sets the maximum amount of time that the structure analysis can take. If the analysis is still running when the timeout expires then it will be stopped.
+     * The maximum amount of time that the structure analysis can take.
+     * If the analysis is still running when the timeout expires then it will be stopped.
      * @server_default 25s
      */
     timeout?: Duration
+    /**
+     * The name of the field that contains the primary timestamp of each record in the text.
+     * In particular, if the text were ingested into an index, this is the field that would be used to populate the `@timestamp` field.
+     *
+     * If the `format` is `semi_structured_text`, this field must match the name of the appropriate extraction in the `grok_pattern`.
+     * Therefore, for semi-structured text, it is best not to specify this parameter unless `grok_pattern` is also specified.
+     *
+     * For structured text, if you specify this parameter, the field must exist within the text.
+     *
+     * If this parameter is not specified, the structure finder makes a decision about which field (if any) is the primary timestamp field.
+     * For structured text, it is not compulsory to have a timestamp in the text.
+     */
     timestamp_field?: Field
-    /** The Java time format of the timestamp field in the text. */
+    /**
+     * The Java time format of the timestamp field in the text.
+     *
+     * Only a subset of Java time format letter groups are supported:
+     *
+     * * `a`
+     * * `d`
+     * * `dd`
+     * * `EEE`
+     * * `EEEE`
+     * * `H`
+     * * `HH`
+     * * `h`
+     * * `M`
+     * * `MM`
+     * * `MMM`
+     * * `MMMM`
+     * * `mm`
+     * * `ss`
+     * * `XX`
+     * * `XXX`
+     * * `yy`
+     * * `yyyy`
+     * * `zzz`
+     *
+     * Additionally `S` letter groups (fractional seconds) of length one to nine are supported providing they occur after `ss` and separated from the `ss` by a `.`, `,` or `:`.
+     * Spacing and punctuation is also permitted with the exception of `?`, newline and carriage return, together with literal text enclosed in single quotes.
+     * For example, `MM/dd HH.mm.ss,SSSSSS 'in' yyyy` is a valid override format.
+     *
+     * One valuable use case for this parameter is when the format is semi-structured text, there are multiple timestamp formats in the text, and you know which format corresponds to the primary timestamp, but you do not want to specify the full `grok_pattern`.
+     * Another is when the timestamp format is one that the structure finder does not consider by default.
+     *
+     * If this parameter is not specified, the structure finder chooses the best format from a built-in set.
+     *
+     * If the special value `null` is specified the structure finder will not look for a primary timestamp in the text.
+     * When the format is semi-structured text this will result in the structure finder treating the text as single-line messages.
+     */
     timestamp_format?: string
   }
-  /** @codegen_name text_files */
+  /**
+   * The text that you want to analyze.
+   * It must contain data that is suitable to be ingested into Elasticsearch.
+   * It does not need to be in JSON format and it does not need to be UTF-8 encoded.
+   * The size is limited to the Elasticsearch HTTP receive buffer size, which defaults to 100 Mb.
+   * @codegen_name text_files */
   body: Array<TJsonDocument>
 }

--- a/specification/text_structure/find_structure/FindStructureResponse.ts
+++ b/specification/text_structure/find_structure/FindStructureResponse.ts
@@ -26,25 +26,70 @@ import { FieldStat } from '../_types/Structure'
 
 export class Response {
   body: {
+    /**
+     * The character encoding used to parse the text.
+     */
     charset: string
     has_header_row?: boolean
+    /**
+     * For UTF character encodings, it indicates whether the text begins with a byte order marker.
+     */
     has_byte_order_marker: boolean
+    /**
+     * Valid values include `ndjson`, `xml`, `delimited`, and `semi_structured_text`.
+     */
     format: string
+    /**
+     * The most common values of each field, plus basic numeric statistics for the numeric `page_count` field.
+     * This information may provide clues that the data needs to be cleaned or transformed prior to use by other Elastic Stack functionality.
+     */
     field_stats: Dictionary<Field, FieldStat>
+    /**
+     * The first two messages in the text verbatim.
+     * This may help diagnose parse errors or accidental uploads of the wrong text.
+     */
     sample_start: string
+    /**
+     * The number of distinct messages the lines contained.
+     * For NDJSON, this value is the same as `num_lines_analyzed`.
+     * For other text formats, messages can span several lines.
+     */
     num_messages_analyzed: integer
+    /**
+     * Some suitable mappings for an index into which the data could be ingested.
+     */
     mappings: TypeMapping
     quote?: string
     delimiter?: string
+    /**
+     * If a timestamp format is detected that does not include a timezone, `need_client_timezone` is `true`.
+     * The server that parses the text must therefore be told the correct timezone by the client.
+     */
     need_client_timezone: boolean
+    /**
+     * The number of lines of the text that were analyzed.
+     */
     num_lines_analyzed: integer
+    /**
+     * If `format` is `delimited`, the `column_names` field lists the column names in the order they appear in the sample.
+     */
     column_names?: string[]
     explanation?: string[]
     grok_pattern?: GrokPattern
     multiline_start_pattern?: string
     exclude_lines_pattern?: string
+    /**
+     * The Java time formats recognized in the time fields.
+     * Elasticsearch mappings and ingest pipelines use this format.
+     */
     java_timestamp_formats?: string[]
+    /**
+     * Information that is used to tell Logstash how to parse timestamps.
+     */
     joda_timestamp_formats?: string[]
+    /**
+     * The field considered most likely to be the primary timestamp of each document.
+     */
     timestamp_field?: Field
     should_trim_fields?: boolean
     ingest_pipeline: PipelineConfig

--- a/specification/text_structure/find_structure/examples/request/FindStructureRequestExample1.yaml
+++ b/specification/text_structure/find_structure/examples/request/FindStructureRequestExample1.yaml
@@ -1,0 +1,76 @@
+# summary:
+# method_request: POST _text_structure/find_structure
+description: Run `POST _text_structure/find_structure` to analyze newline-delimited JSON text.
+# type: request
+value:
+  '{"name": "Leviathan Wakes", "author": "James S.A. Corey", "release_date":
+  "2011-06-02", "page_count": 561}
+
+  {"name": "Hyperion", "author": "Dan Simmons", "release_date": "1989-05-26", "page_count":
+  482}
+
+  {"name": "Dune", "author": "Frank Herbert", "release_date": "1965-06-01", "page_count":
+  604}
+
+  {"name": "Dune Messiah", "author": "Frank Herbert", "release_date": "1969-10-15",
+  "page_count": 331}
+
+  {"name": "Children of Dune", "author": "Frank Herbert", "release_date": "1976-04-21",
+  "page_count": 408}
+
+  {"name": "God Emperor of Dune", "author": "Frank Herbert", "release_date": "1981-05-28",
+  "page_count": 454}
+
+  {"name": "Consider Phlebas", "author": "Iain M. Banks", "release_date": "1987-04-23",
+  "page_count": 471}
+
+  {"name": "Pandora''s Star", "author": "Peter F. Hamilton", "release_date": "2004-03-02",
+  "page_count": 768}
+
+  {"name": "Revelation Space", "author": "Alastair Reynolds", "release_date": "2000-03-15",
+  "page_count": 585}
+
+  {"name": "A Fire Upon the Deep", "author": "Vernor Vinge", "release_date": "1992-06-01",
+  "page_count": 613}
+
+  {"name": "Ender''s Game", "author": "Orson Scott Card", "release_date": "1985-06-01",
+  "page_count": 324}
+
+  {"name": "1984", "author": "George Orwell", "release_date": "1985-06-01", "page_count":
+  328}
+
+  {"name": "Fahrenheit 451", "author": "Ray Bradbury", "release_date": "1953-10-15",
+  "page_count": 227}
+
+  {"name": "Brave New World", "author": "Aldous Huxley", "release_date": "1932-06-01",
+  "page_count": 268}
+
+  {"name": "Foundation", "author": "Isaac Asimov", "release_date": "1951-06-01", "page_count":
+  224}
+
+  {"name": "The Giver", "author": "Lois Lowry", "release_date": "1993-04-26", "page_count":
+  208}
+
+  {"name": "Slaughterhouse-Five", "author": "Kurt Vonnegut", "release_date": "1969-06-01",
+  "page_count": 275}
+
+  {"name": "The Hitchhiker''s Guide to the Galaxy", "author": "Douglas Adams", "release_date":
+  "1979-10-12", "page_count": 180}
+
+  {"name": "Snow Crash", "author": "Neal Stephenson", "release_date": "1992-06-01",
+  "page_count": 470}
+
+  {"name": "Neuromancer", "author": "William Gibson", "release_date": "1984-07-01",
+  "page_count": 271}
+
+  {"name": "The Handmaid''s Tale", "author": "Margaret Atwood", "release_date": "1985-06-01",
+  "page_count": 311}
+
+  {"name": "Starship Troopers", "author": "Robert A. Heinlein", "release_date": "1959-12-01",
+  "page_count": 335}
+
+  {"name": "The Left Hand of Darkness", "author": "Ursula K. Le Guin", "release_date":
+  "1969-06-01", "page_count": 304}
+
+  {"name": "The Moon is a Harsh Mistress", "author": "Robert A. Heinlein", "release_date":
+  "1966-04-01", "page_count": 288}'

--- a/specification/text_structure/find_structure/examples/response/FindStructureResponseExample1.yaml
+++ b/specification/text_structure/find_structure/examples/response/FindStructureResponseExample1.yaml
@@ -1,0 +1,75 @@
+# summary:
+description: A successful response from `POST _text_structure/find_structure`.
+# type: response
+# response_code: ''
+value:
+  "{\n  \"num_lines_analyzed\" : 24,\n  \"num_messages_analyzed\" : 24,\n  \"\
+  sample_start\" : \"{\\\"name\\\": \\\"Leviathan Wakes\\\", \\\"author\\\": \\\"\
+  James S.A. Corey\\\", \\\"release_date\\\": \\\"2011-06-02\\\", \\\"page_count\\\
+  \": 561}\\n{\\\"name\\\": \\\"Hyperion\\\", \\\"author\\\": \\\"Dan Simmons\\\"\
+  , \\\"release_date\\\": \\\"1989-05-26\\\", \\\"page_count\\\": 482}\\n\",\n  \"\
+  charset\" : \"UTF-8\",\n  \"has_byte_order_marker\" : false,\n  \"format\" : \"\
+  ndjson\",\n  \"ecs_compatibility\" : \"disabled\",\n  \"timestamp_field\" : \"release_date\"\
+  ,\n  \"joda_timestamp_formats\" : [\n    \"ISO8601\"\n  ],\n  \"java_timestamp_formats\"\
+  \ : [\n    \"ISO8601\"\n  ],\n  \"need_client_timezone\" : true,\n  \"mappings\"\
+  \ : {\n    \"properties\" : {\n      \"@timestamp\" : {\n        \"type\" : \"date\"\
+  \n      },\n      \"author\" : {\n        \"type\" : \"keyword\"\n      },\n   \
+  \   \"name\" : {\n        \"type\" : \"keyword\"\n      },\n      \"page_count\"\
+  \ : {\n        \"type\" : \"long\"\n      },\n      \"release_date\" : {\n     \
+  \   \"type\" : \"date\",\n        \"format\" : \"iso8601\"\n      }\n    }\n  },\n\
+  \  \"ingest_pipeline\" : {\n    \"description\" : \"Ingest pipeline created by text\
+  \ structure finder\",\n    \"processors\" : [\n      {\n        \"date\" : {\n \
+  \         \"field\" : \"release_date\",\n          \"timezone\" : \"{{ event.timezone\
+  \ }}\",\n          \"formats\" : [\n            \"ISO8601\"\n          ]\n     \
+  \   }\n      }\n    ]\n  },\n  \"field_stats\" : {\n    \"author\" : {\n      \"\
+  count\" : 24,\n      \"cardinality\" : 20,\n      \"top_hits\" : [\n        {\n\
+  \          \"value\" : \"Frank Herbert\",\n          \"count\" : 4\n        },\n\
+  \        {\n          \"value\" : \"Robert A. Heinlein\",\n          \"count\" :\
+  \ 2\n        },\n        {\n          \"value\" : \"Alastair Reynolds\",\n     \
+  \     \"count\" : 1\n        },\n        {\n          \"value\" : \"Aldous Huxley\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"Dan Simmons\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"Douglas\
+  \ Adams\",\n          \"count\" : 1\n        },\n        {\n          \"value\"\
+  \ : \"George Orwell\",\n          \"count\" : 1\n        },\n        {\n       \
+  \   \"value\" : \"Iain M. Banks\",\n          \"count\" : 1\n        },\n      \
+  \  {\n          \"value\" : \"Isaac Asimov\",\n          \"count\" : 1\n       \
+  \ },\n        {\n          \"value\" : \"James S.A. Corey\",\n          \"count\"\
+  \ : 1\n        }\n      ]\n    },\n    \"name\" : {\n      \"count\" : 24,\n   \
+  \   \"cardinality\" : 24,\n      \"top_hits\" : [\n        {\n          \"value\"\
+  \ : \"1984\",\n          \"count\" : 1\n        },\n        {\n          \"value\"\
+  \ : \"A Fire Upon the Deep\",\n          \"count\" : 1\n        },\n        {\n\
+  \          \"value\" : \"Brave New World\",\n          \"count\" : 1\n        },\n\
+  \        {\n          \"value\" : \"Children of Dune\",\n          \"count\" : 1\n\
+  \        },\n        {\n          \"value\" : \"Consider Phlebas\",\n          \"\
+  count\" : 1\n        },\n        {\n          \"value\" : \"Dune\",\n          \"\
+  count\" : 1\n        },\n        {\n          \"value\" : \"Dune Messiah\",\n  \
+  \        \"count\" : 1\n        },\n        {\n          \"value\" : \"Ender's Game\"\
+  ,\n          \"count\" : 1\n        },\n        {\n          \"value\" : \"Fahrenheit\
+  \ 451\",\n          \"count\" : 1\n        },\n        {\n          \"value\" :\
+  \ \"Foundation\",\n          \"count\" : 1\n        }\n      ]\n    },\n    \"page_count\"\
+  \ : {\n      \"count\" : 24,\n      \"cardinality\" : 24,\n      \"min_value\" :\
+  \ 180,\n      \"max_value\" : 768,\n      \"mean_value\" : 387.0833333333333,\n\
+  \      \"median_value\" : 329.5,\n      \"top_hits\" : [\n        {\n          \"\
+  value\" : 180,\n          \"count\" : 1\n        },\n        {\n          \"value\"\
+  \ : 208,\n          \"count\" : 1\n        },\n        {\n          \"value\" :\
+  \ 224,\n          \"count\" : 1\n        },\n        {\n          \"value\" : 227,\n\
+  \          \"count\" : 1\n        },\n        {\n          \"value\" : 268,\n  \
+  \        \"count\" : 1\n        },\n        {\n          \"value\" : 271,\n    \
+  \      \"count\" : 1\n        },\n        {\n          \"value\" : 275,\n      \
+  \    \"count\" : 1\n        },\n        {\n          \"value\" : 288,\n        \
+  \  \"count\" : 1\n        },\n        {\n          \"value\" : 304,\n          \"\
+  count\" : 1\n        },\n        {\n          \"value\" : 311,\n          \"count\"\
+  \ : 1\n        }\n      ]\n    },\n    \"release_date\" : {\n      \"count\" : 24,\n\
+  \      \"cardinality\" : 20,\n      \"earliest\" : \"1932-06-01\",\n      \"latest\"\
+  \ : \"2011-06-02\",\n      \"top_hits\" : [\n        {\n          \"value\" : \"\
+  1985-06-01\",\n          \"count\" : 3\n        },\n        {\n          \"value\"\
+  \ : \"1969-06-01\",\n          \"count\" : 2\n        },\n        {\n          \"\
+  value\" : \"1992-06-01\",\n          \"count\" : 2\n        },\n        {\n    \
+  \      \"value\" : \"1932-06-01\",\n          \"count\" : 1\n        },\n      \
+  \  {\n          \"value\" : \"1951-06-01\",\n          \"count\" : 1\n        },\n\
+  \        {\n          \"value\" : \"1953-10-15\",\n          \"count\" : 1\n   \
+  \     },\n        {\n          \"value\" : \"1959-12-01\",\n          \"count\"\
+  \ : 1\n        },\n        {\n          \"value\" : \"1965-06-01\",\n          \"\
+  count\" : 1\n        },\n        {\n          \"value\" : \"1966-04-01\",\n    \
+  \      \"count\" : 1\n        },\n        {\n          \"value\" : \"1969-10-15\"\
+  ,\n          \"count\" : 1\n        }\n      ]\n    }\n  }\n}"

--- a/specification/text_structure/test_grok_pattern/TestGrokPatternRequest.ts
+++ b/specification/text_structure/test_grok_pattern/TestGrokPatternRequest.ts
@@ -31,17 +31,21 @@ import { GrokPattern } from '@_types/common'
  */
 export interface Request extends RequestBase {
   query_parameters: {
-    /** The mode of compatibility with ECS compliant Grok patterns (disabled or v1, default: disabled). */
+    /**
+     * The mode of compatibility with ECS compliant Grok patterns.
+     * Use this parameter to specify whether to use ECS Grok patterns instead of legacy ones when the structure finder creates a Grok pattern.
+     * Valid values are `disabled` and `v1`.
+     * @server_default disabled
+     */
     ecs_compatibility?: string
   }
   body: {
     /**
-     * Grok pattern to run on the text.
+     * The Grok pattern to run on the text.
      */
     grok_pattern: GrokPattern
-
     /**
-     * Lines of text to run the Grok pattern on.
+     * The lines of text to run the Grok pattern on.
      */
     text: string[]
   }

--- a/specification/text_structure/test_grok_pattern/examples/request/TestGrokPatternRequestExample1.yaml
+++ b/specification/text_structure/test_grok_pattern/examples/request/TestGrokPatternRequestExample1.yaml
@@ -1,0 +1,7 @@
+# summary:
+# method_request: GET _text_structure/test_grok_pattern
+description: Run `GET _text_structure/test_grok_pattern` to test a Grok pattern.
+# type: request
+value:
+  "{\n  \"grok_pattern\": \"Hello %{WORD:first_name} %{WORD:last_name}\",\n \
+  \ \"text\": [\n    \"Hello John Doe\",\n    \"this does not match\"\n  ]\n}"

--- a/specification/text_structure/test_grok_pattern/examples/response/TestGrokPatternResponseExample1.yaml
+++ b/specification/text_structure/test_grok_pattern/examples/response/TestGrokPatternResponseExample1.yaml
@@ -1,0 +1,11 @@
+# summary:
+description: A successful response from `GET _text_structure/test_grok_pattern`.
+# type: response
+# response_code: ''
+value:
+  "{\n  \"matches\": [\n    {\n      \"matched\": true,\n      \"fields\": {\n\
+  \        \"first_name\": [\n          {\n            \"match\": \"John\",\n    \
+  \        \"offset\": 6,\n            \"length\": 4\n          }\n        ],\n  \
+  \      \"last_name\": [\n          {\n            \"match\": \"Doe\",\n        \
+  \    \"offset\": 11,\n            \"length\": 3\n          }\n        ]\n      }\n\
+  \    },\n    {\n      \"matched\": false\n    }\n  ]\n}"


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR copies examples from https://www.elastic.co/guide/en/elasticsearch/reference/master/text-structure-apis.html
It also edits some descriptions and adds missing `doc_id` values.