### PR TITLE
Add info and usage API examples

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -38488,7 +38488,7 @@
           {
             "in": "query",
             "name": "categories",
-            "description": "A comma-separated list of the information categories to include in the response. For example, `build,license,features`.",
+            "description": "A comma-separated list of the information categories to include in the response.\nFor example, `build,license,features`.",
             "deprecated": false,
             "schema": {
               "type": "array",
@@ -38511,7 +38511,7 @@
           {
             "in": "query",
             "name": "human",
-            "description": "Defines whether additional human-readable information is included in the response. In particular, it adds descriptions and a tag line.",
+            "description": "Defines whether additional human-readable information is included in the response.\nIn particular, it adds descriptions and a tag line.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -38565,7 +38565,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.\nTo indicate that the request should never timeout, set it to `-1`.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"

--- a/specification/xpack/info/XPackInfoRequest.ts
+++ b/specification/xpack/info/XPackInfoRequest.ts
@@ -30,16 +30,19 @@ import { RequestBase } from '@_types/Base'
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor
+ * @doc_id info-api
  */
 export interface Request extends RequestBase {
   query_parameters: {
     /**
-     * A comma-separated list of the information categories to include in the response. For example, `build,license,features`.
+     * A comma-separated list of the information categories to include in the response.
+     * For example, `build,license,features`.
      */
     categories?: XPackCategory[]
     accept_enterprise?: boolean
     /**
-     * Defines whether additional human-readable information is included in the response. In particular, it adds descriptions and a tag line.
+     * Defines whether additional human-readable information is included in the response.
+     * In particular, it adds descriptions and a tag line.
      * @server_default true
      */
     human?: boolean

--- a/specification/xpack/info/examples/response/XPackInfoResponseExample1.yaml
+++ b/specification/xpack/info/examples/response/XPackInfoResponseExample1.yaml
@@ -1,0 +1,129 @@
+# summary:
+description: A successful response from `GET /_xpack`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "build" : {
+        "hash" : "2798b1a3ce779b3611bb53a0082d4d741e4d3168",
+        "date" : "2015-04-07T13:34:42Z"
+    },
+    "license" : {
+        "uid" : "893361dc-9749-4997-93cb-xxx",
+        "type" : "trial",
+        "mode" : "trial",
+        "status" : "active",
+        "expiry_date_in_millis" : 1542665112332
+    },
+    "features" : {
+        "ccr" : {
+          "available" : true,
+          "enabled" : true
+        },
+      "aggregate_metric" : {
+            "available" : true,
+            "enabled" : true
+        },
+        "analytics" : {
+            "available" : true,
+            "enabled" : true
+        },
+        "archive" : {
+            "available" : true,
+            "enabled" : true
+        },
+        "enrich" : {
+            "available" : true,
+            "enabled" : true
+        },
+        "frozen_indices" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "graph" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "ilm" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "logstash" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "ml" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "esql" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "monitoring" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "rollup": {
+          "available": true,
+          "enabled": true
+        },
+        "searchable_snapshots" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "security" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "slm" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "spatial" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "eql" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "sql" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "transform" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "voting_only" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "watcher" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "data_streams" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "data_tiers" : {
+          "available" : true,
+          "enabled" : true
+        },
+        "enterprise_search": {
+          "available": true,
+          "enabled": true
+        },
+        "universal_profiling": {
+          "available": true,
+          "enabled": true
+        },
+        "logsdb": {
+          "available": true,
+          "enabled": false
+        }
+    },
+    "tagline" : "You know, for X"
+  }

--- a/specification/xpack/usage/XPackUsageRequest.ts
+++ b/specification/xpack/usage/XPackUsageRequest.ts
@@ -28,11 +28,14 @@ import { Duration } from '@_types/Time'
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor
+ * @doc_id usage-api
  */
 export interface Request extends RequestBase {
   query_parameters: {
     /**
-     * Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
+     * The period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     * To indicate that the request should never timeout, set it to `-1`.
      * @server_default 30s
      */
     master_timeout?: Duration

--- a/specification/xpack/usage/examples/response/XPackUsageResponseExample1.yaml
+++ b/specification/xpack/usage/examples/response/XPackUsageResponseExample1.yaml
@@ -1,0 +1,471 @@
+# summary:
+description: An abbreviated response from `GET /_xpack/usage`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "security" : {
+      "available" : true,
+      "enabled" : true
+    },
+    "monitoring" : {
+      "available" : true,
+      "enabled" : true,
+      "collection_enabled" : false,
+      "enabled_exporters" : {
+        "local" : 1
+      }
+    },
+    "watcher" : {
+        "available" : true,
+        "enabled" : true,
+        "execution" : {
+          "actions" : {
+            "_all" : {
+              "total" : 0,
+              "total_time_in_ms" : 0
+            }
+          }
+        },
+      "watch" : {
+        "input" : {
+          "_all" : {
+            "total" : 0,
+            "active" : 0
+          }
+        },
+        "trigger" : {
+          "_all" : {
+            "total" : 0,
+            "active" : 0
+          }
+        }
+      },
+      "count" : {
+        "total" : 0,
+        "active" : 0
+      }
+    },
+    "graph" : {
+      "available" : true,
+      "enabled" : true
+    },
+    "ml" : {
+      "available" : true,
+      "enabled" : true,
+      "jobs" : {
+        "_all" : {
+          "count" : 0,
+          "detectors" : { },
+          "created_by" : { },
+          "model_size" : { },
+          "forecasts" : {
+            "total" : 0,
+            "forecasted_jobs" : 0
+          }
+        }
+      },
+      "datafeeds" : {
+        "_all" : {
+          "count" : 0
+        }
+      },
+      "data_frame_analytics_jobs" : {
+        "_all" : {
+          "count" : 0
+        },
+        "analysis_counts": { },
+        "memory_usage": {
+          "peak_usage_bytes": {
+            "min": 0.0,
+            "max": 0.0,
+            "avg": 0.0,
+            "total": 0.0
+          }
+        }
+      },
+      "inference" : {
+        "ingest_processors" : {
+          "_all" : {
+            "num_docs_processed" : {
+              "max" : 0,
+              "sum" : 0,
+              "min" : 0
+            },
+            "pipelines" : {
+              "count" : 0
+            },
+            "num_failures" : {
+              "max" : 0,
+              "sum" : 0,
+              "min" : 0
+            },
+            "time_ms" : {
+              "max" : 0,
+              "sum" : 0,
+              "min" : 0
+            }
+          }
+        },
+        "trained_models" : {
+          "_all" : {
+            "count": 1
+          },
+          "count": {
+            "total": 1,
+            "prepackaged": 1,
+            "other": 0
+          },
+          "model_size_bytes": {
+            "min": 0.0,
+            "max": 0.0,
+            "avg": 0.0,
+            "total": 0.0
+          },
+          "estimated_operations": {
+            "min": 0.0,
+            "max": 0.0,
+            "avg": 0.0,
+            "total": 0.0
+          }
+        },
+        "deployments": {
+          "count": 0,
+          "inference_counts": {
+            "total": 0.0,
+            "min": 0.0,
+            "avg": 0.0,
+            "max": 0.0
+          },
+          "stats_by_model": [],
+          "model_sizes_bytes": {
+            "total": 0.0,
+            "min": 0.0,
+            "avg": 0.0,
+            "max": 0.0
+          },
+          "time_ms": {
+            "avg": 0.0
+          }
+        }
+      },
+      "node_count" : 1,
+      "memory": {
+        anomaly_detectors_memory_bytes: 0,
+        data_frame_analytics_memory_bytes: 0,
+        pytorch_inference_memory_bytes: 0,
+        total_used_memory_bytes: 0
+      }
+    },
+    "inference": {
+      "available" : true,
+      "enabled" : true,
+      "models" : [ ]
+    },
+    "logstash" : {
+      "available" : true,
+      "enabled" : true
+    },
+    "eql" : {
+      "available" : true,
+      "enabled" : true
+    },
+    "esql" : {
+      "available" : true,
+      "enabled" : true,
+      "features" : {
+        "eval" : 0,
+        "stats" : 0,
+        "dissect": 0,
+        "grok" : 0,
+        "limit" : 0,
+        "where" : 0,
+        "sort" : 0,
+        "drop" : 0,
+        "show" : 0,
+        "rename" : 0,
+        "mv_expand" : 0,
+        "keep" : 0,
+        "enrich" : 0,
+        "from" : 0,
+        "row" : 0
+      },
+      "queries" : {
+        "rest" : {
+          "total" : 0,
+          "failed" : 0
+        },
+        "kibana" : {
+          "total" : 0,
+          "failed" : 0
+        },
+        "_all" : {
+          "total" : 0,
+          "failed" : 0
+      }
+    }
+    },
+    "sql" : {
+      "available" : true,
+      "enabled" : true,
+      "features" : {
+        "having" : 0,
+        "subselect" : 0,
+        "limit" : 0,
+        "orderby" : 0,
+        "where" : 0,
+        "join" : 0,
+        "groupby" : 0,
+        "command" : 0,
+        "local" : 0
+      },
+      "queries" : {
+        "rest" : {
+          "total" : 0,
+          "paging" : 0,
+          "failed" : 0
+        },
+        "cli" : {
+          "total" : 0,
+          "paging" : 0,
+          "failed" : 0
+        },
+        "canvas" : {
+          "total" : 0,
+          "paging" : 0,
+          "failed" : 0
+        },
+        "odbc" : {
+          "total" : 0,
+          "paging" : 0,
+          "failed" : 0
+        },
+        "jdbc" : {
+          "total" : 0,
+          "paging" : 0,
+          "failed" : 0
+        },
+        "odbc32" : {
+          "total" : 0,
+          "paging" : 0,
+          "failed" : 0
+        },
+        "odbc64" : {
+          "total" : 0,
+          "paging" : 0,
+          "failed" : 0
+        },
+        "_all" : {
+          "total" : 0,
+          "paging" : 0,
+          "failed" : 0
+        },
+        "translate" : {
+          "count" : 0
+        }
+      }
+    },
+    "rollup" : {
+      "available" : true,
+      "enabled" : true
+    },
+    "ilm" : {
+      "policy_count" : 3,
+      "policy_stats" : [ ]
+    },
+    "slm" : {
+      "available" : true,
+      "enabled" : true
+    },
+    "ccr" : {
+      "available" : true,
+      "enabled" : true,
+      "follower_indices_count" : 0,
+      "auto_follow_patterns_count" : 0
+    },
+    "transform" : {
+      "available" : true,
+      "enabled" : true
+    },
+    "voting_only" : {
+      "available" : true,
+      "enabled" : true
+    },
+    "searchable_snapshots" : {
+      "available" : true,
+      "enabled" : true,
+      "indices_count" : 0,
+      "full_copy_indices_count" : 0,
+      "shared_cache_indices_count" : 0
+    },
+    "frozen_indices" : {
+      "available" : true,
+      "enabled" : true,
+      "indices_count" : 0
+    },
+    "spatial" : {
+      "available" : true,
+      "enabled" : true
+    },
+    "analytics" : {
+      "available" : true,
+      "enabled" : true,
+      "stats": {
+        "boxplot_usage" : 0,
+        "top_metrics_usage" : 0,
+        "normalize_usage" : 0,
+        "cumulative_cardinality_usage" : 0,
+        "t_test_usage" : 0,
+        "rate_usage" : 0,
+        "string_stats_usage" : 0,
+        "moving_percentiles_usage" : 0,
+        "multi_terms_usage" : 0
+      }
+    },
+    "data_streams" : {
+      "available" : true,
+      "enabled" : true,
+      "data_streams" : 0,
+      "indices_count" : 0
+    },
+    "data_lifecycle" : {
+      "available": true,
+      "enabled": true,
+      "count": 0,
+      "default_rollover_used": true,
+      "data_retention": {
+        "configured_data_streams": 0
+      },
+      "effective_retention": {
+        "retained_data_streams": 0
+      },
+      "global_retention": {
+        "default": {
+          "defined": false
+        },
+        "max": {
+          "defined": false
+        }
+      }
+    },
+    "data_tiers" : {
+      "available" : true,
+      "enabled" : true,
+      "data_warm" : {
+        "node_count" : 0,
+        "index_count" : 0,
+        "total_shard_count" : 0,
+        "primary_shard_count" : 0,
+        "doc_count" : 0,
+        "total_size_bytes" : 0,
+        "primary_size_bytes" : 0,
+        "primary_shard_size_avg_bytes" : 0,
+        "primary_shard_size_median_bytes" : 0,
+        "primary_shard_size_mad_bytes" : 0
+      },
+      "data_frozen" : {
+        "node_count" : 1,
+        "index_count" : 0,
+        "total_shard_count" : 0,
+        "primary_shard_count" : 0,
+        "doc_count" : 0,
+        "total_size_bytes" : 0,
+        "primary_size_bytes" : 0,
+        "primary_shard_size_avg_bytes" : 0,
+        "primary_shard_size_median_bytes" : 0,
+        "primary_shard_size_mad_bytes" : 0
+      },
+      "data_cold" : {
+        "node_count" : 0,
+        "index_count" : 0,
+        "total_shard_count" : 0,
+        "primary_shard_count" : 0,
+        "doc_count" : 0,
+        "total_size_bytes" : 0,
+        "primary_size_bytes" : 0,
+        "primary_shard_size_avg_bytes" : 0,
+        "primary_shard_size_median_bytes" : 0,
+        "primary_shard_size_mad_bytes" : 0
+      },
+      "data_content" : {
+        "node_count" : 0,
+        "index_count" : 0,
+        "total_shard_count" : 0,
+        "primary_shard_count" : 0,
+        "doc_count" : 0,
+        "total_size_bytes" : 0,
+        "primary_size_bytes" : 0,
+        "primary_shard_size_avg_bytes" : 0,
+        "primary_shard_size_median_bytes" : 0,
+        "primary_shard_size_mad_bytes" : 0
+      },
+      "data_hot" : {
+        "node_count" : 0,
+        "index_count" : 0,
+        "total_shard_count" : 0,
+        "primary_shard_count" : 0,
+        "doc_count" : 0,
+        "total_size_bytes" : 0,
+        "primary_size_bytes" : 0,
+        "primary_shard_size_avg_bytes" : 0,
+        "primary_shard_size_median_bytes" : 0,
+        "primary_shard_size_mad_bytes" : 0
+      }
+    },
+    "aggregate_metric" : {
+      "available" : true,
+      "enabled" : true
+    },
+    "archive" : {
+      "available" : true,
+      "enabled" : true,
+      "indices_count" : 0
+    },
+    "health_api" : {
+      "available" : true,
+      "enabled" : true,
+      "invocations": {
+        "total": 0
+      }
+    },
+    "remote_clusters": {
+      "size": 0,
+      "mode": {
+        "proxy": 0,
+        "sniff": 0
+      },
+      "security": {
+        "cert": 0,
+        "api_key": 0
+      }
+    },
+    "enterprise_search" : {
+      "available": true,
+      "enabled": true,
+      "search_applications" : {
+        "count": 0
+      },
+      "analytics_collections": {
+        "count": 0
+      },
+      "query_rulesets": {
+        "total_rule_count": 0,
+        "total_count": 0,
+        "min_rule_count": 0,
+        "max_rule_count": 0
+      }
+    },
+    "universal_profiling" : {
+      "available" : true,
+      "enabled" : true
+    },
+    "logsdb": {
+      "available": true,
+      "enabled": false,
+      "indices_count": 0,
+      "indices_with_synthetic_source": 0,
+      "num_docs": 0,
+      "size_in_bytes": 0,
+      "has_custom_cutoff_date": false
+    }
+  }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR copies examples from https://www.elastic.co/guide/en/elasticsearch/reference/master/usage-api.html and https://www.elastic.co/guide/en/elasticsearch/reference/master/info-api.html
It also adds missing `doc_id` and edits some descriptions. 