### PR TITLE
[8.x] Add Watcher API examples (#3489)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -37674,7 +37674,7 @@
           "watcher"
         ],
         "summary": "Acknowledge a watch",
-        "description": "Acknowledging a watch enables you to manually throttle the execution of the watch's actions.\n\nThe acknowledgement state of an action is stored in the `status.actions.<id>.ack.state` structure.\n\nIMPORTANT: If the specified watch is currently being executed, this API will return an error\nThe reason for this behavior is to prevent overwriting the watch status from a watch execution.",
+        "description": "Acknowledging a watch enables you to manually throttle the execution of the watch's actions.\n\nThe acknowledgement state of an action is stored in the `status.actions.<id>.ack.state` structure.\n\nIMPORTANT: If the specified watch is currently being executed, this API will return an error\nThe reason for this behavior is to prevent overwriting the watch status from a watch execution.\n\nAcknowledging an action throttles further executions of that action until its `ack.state` is reset to `awaits_successful_execution`.\nThis happens when the condition of the watch is not met (the condition evaluates to false).",
         "operationId": "watcher-ack-watch",
         "parameters": [
           {
@@ -37692,7 +37692,7 @@
           "watcher"
         ],
         "summary": "Acknowledge a watch",
-        "description": "Acknowledging a watch enables you to manually throttle the execution of the watch's actions.\n\nThe acknowledgement state of an action is stored in the `status.actions.<id>.ack.state` structure.\n\nIMPORTANT: If the specified watch is currently being executed, this API will return an error\nThe reason for this behavior is to prevent overwriting the watch status from a watch execution.",
+        "description": "Acknowledging a watch enables you to manually throttle the execution of the watch's actions.\n\nThe acknowledgement state of an action is stored in the `status.actions.<id>.ack.state` structure.\n\nIMPORTANT: If the specified watch is currently being executed, this API will return an error\nThe reason for this behavior is to prevent overwriting the watch status from a watch execution.\n\nAcknowledging an action throttles further executions of that action until its `ack.state` is reset to `awaits_successful_execution`.\nThis happens when the condition of the watch is not met (the condition evaluates to false).",
         "operationId": "watcher-ack-watch-1",
         "parameters": [
           {
@@ -37712,7 +37712,7 @@
           "watcher"
         ],
         "summary": "Acknowledge a watch",
-        "description": "Acknowledging a watch enables you to manually throttle the execution of the watch's actions.\n\nThe acknowledgement state of an action is stored in the `status.actions.<id>.ack.state` structure.\n\nIMPORTANT: If the specified watch is currently being executed, this API will return an error\nThe reason for this behavior is to prevent overwriting the watch status from a watch execution.",
+        "description": "Acknowledging a watch enables you to manually throttle the execution of the watch's actions.\n\nThe acknowledgement state of an action is stored in the `status.actions.<id>.ack.state` structure.\n\nIMPORTANT: If the specified watch is currently being executed, this API will return an error\nThe reason for this behavior is to prevent overwriting the watch status from a watch execution.\n\nAcknowledging an action throttles further executions of that action until its `ack.state` is reset to `awaits_successful_execution`.\nThis happens when the condition of the watch is not met (the condition evaluates to false).",
         "operationId": "watcher-ack-watch-2",
         "parameters": [
           {
@@ -37733,7 +37733,7 @@
           "watcher"
         ],
         "summary": "Acknowledge a watch",
-        "description": "Acknowledging a watch enables you to manually throttle the execution of the watch's actions.\n\nThe acknowledgement state of an action is stored in the `status.actions.<id>.ack.state` structure.\n\nIMPORTANT: If the specified watch is currently being executed, this API will return an error\nThe reason for this behavior is to prevent overwriting the watch status from a watch execution.",
+        "description": "Acknowledging a watch enables you to manually throttle the execution of the watch's actions.\n\nThe acknowledgement state of an action is stored in the `status.actions.<id>.ack.state` structure.\n\nIMPORTANT: If the specified watch is currently being executed, this API will return an error\nThe reason for this behavior is to prevent overwriting the watch status from a watch execution.\n\nAcknowledging an action throttles further executions of that action until its `ack.state` is reset to `awaits_successful_execution`.\nThis happens when the condition of the watch is not met (the condition evaluates to false).",
         "operationId": "watcher-ack-watch-3",
         "parameters": [
           {
@@ -37849,7 +37849,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "Watch ID",
+            "description": "The watch identifier.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -37976,7 +37976,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "Watch ID",
+            "description": "The watch identifier.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -38021,7 +38021,7 @@
           "watcher"
         ],
         "summary": "Run a watch",
-        "description": "This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes.\n\nFor testing and debugging purposes, you also have fine-grained control on how the watch runs.\nYou can run the watch without running all of its actions or alternatively by simulating them.\nYou can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after it runs.\n\nYou can use the run watch API to run watches that are not yet registered by specifying the watch definition inline.\nThis serves as great tool for testing and debugging your watches prior to adding them to Watcher.",
+        "description": "This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes.\n\nFor testing and debugging purposes, you also have fine-grained control on how the watch runs.\nYou can run the watch without running all of its actions or alternatively by simulating them.\nYou can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after it runs.\n\nYou can use the run watch API to run watches that are not yet registered by specifying the watch definition inline.\nThis serves as great tool for testing and debugging your watches prior to adding them to Watcher.\n\nWhen Elasticsearch security features are enabled on your cluster, watches are run with the privileges of the user that stored the watches.\nIf your user is allowed to read index `a`, but not index `b`, then the exact same set of rules will apply during execution of a watch.\n\nWhen using the run watch API, the authorization data of the user that called the API will be used as a base, instead of the information who stored the watch.",
         "operationId": "watcher-execute-watch",
         "parameters": [
           {
@@ -38045,7 +38045,7 @@
           "watcher"
         ],
         "summary": "Run a watch",
-        "description": "This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes.\n\nFor testing and debugging purposes, you also have fine-grained control on how the watch runs.\nYou can run the watch without running all of its actions or alternatively by simulating them.\nYou can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after it runs.\n\nYou can use the run watch API to run watches that are not yet registered by specifying the watch definition inline.\nThis serves as great tool for testing and debugging your watches prior to adding them to Watcher.",
+        "description": "This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes.\n\nFor testing and debugging purposes, you also have fine-grained control on how the watch runs.\nYou can run the watch without running all of its actions or alternatively by simulating them.\nYou can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after it runs.\n\nYou can use the run watch API to run watches that are not yet registered by specifying the watch definition inline.\nThis serves as great tool for testing and debugging your watches prior to adding them to Watcher.\n\nWhen Elasticsearch security features are enabled on your cluster, watches are run with the privileges of the user that stored the watches.\nIf your user is allowed to read index `a`, but not index `b`, then the exact same set of rules will apply during execution of a watch.\n\nWhen using the run watch API, the authorization data of the user that called the API will be used as a base, instead of the information who stored the watch.",
         "operationId": "watcher-execute-watch-1",
         "parameters": [
           {
@@ -38071,7 +38071,7 @@
           "watcher"
         ],
         "summary": "Run a watch",
-        "description": "This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes.\n\nFor testing and debugging purposes, you also have fine-grained control on how the watch runs.\nYou can run the watch without running all of its actions or alternatively by simulating them.\nYou can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after it runs.\n\nYou can use the run watch API to run watches that are not yet registered by specifying the watch definition inline.\nThis serves as great tool for testing and debugging your watches prior to adding them to Watcher.",
+        "description": "This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes.\n\nFor testing and debugging purposes, you also have fine-grained control on how the watch runs.\nYou can run the watch without running all of its actions or alternatively by simulating them.\nYou can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after it runs.\n\nYou can use the run watch API to run watches that are not yet registered by specifying the watch definition inline.\nThis serves as great tool for testing and debugging your watches prior to adding them to Watcher.\n\nWhen Elasticsearch security features are enabled on your cluster, watches are run with the privileges of the user that stored the watches.\nIf your user is allowed to read index `a`, but not index `b`, then the exact same set of rules will apply during execution of a watch.\n\nWhen using the run watch API, the authorization data of the user that called the API will be used as a base, instead of the information who stored the watch.",
         "operationId": "watcher-execute-watch-2",
         "parameters": [
           {
@@ -38092,7 +38092,7 @@
           "watcher"
         ],
         "summary": "Run a watch",
-        "description": "This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes.\n\nFor testing and debugging purposes, you also have fine-grained control on how the watch runs.\nYou can run the watch without running all of its actions or alternatively by simulating them.\nYou can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after it runs.\n\nYou can use the run watch API to run watches that are not yet registered by specifying the watch definition inline.\nThis serves as great tool for testing and debugging your watches prior to adding them to Watcher.",
+        "description": "This API can be used to force execution of the watch outside of its triggering logic or to simulate the watch execution for debugging purposes.\n\nFor testing and debugging purposes, you also have fine-grained control on how the watch runs.\nYou can run the watch without running all of its actions or alternatively by simulating them.\nYou can also force execution by ignoring the watch condition and control whether a watch record would be written to the watch history after it runs.\n\nYou can use the run watch API to run watches that are not yet registered by specifying the watch definition inline.\nThis serves as great tool for testing and debugging your watches prior to adding them to Watcher.\n\nWhen Elasticsearch security features are enabled on your cluster, watches are run with the privileges of the user that stored the watches.\nIf your user is allowed to read index `a`, but not index `b`, then the exact same set of rules will apply during execution of a watch.\n\nWhen using the run watch API, the authorization data of the user that called the API will be used as a base, instead of the information who stored the watch.",
         "operationId": "watcher-execute-watch-3",
         "parameters": [
           {
@@ -38115,7 +38115,7 @@
           "watcher"
         ],
         "summary": "Query watches",
-        "description": "Get all registered watches in a paginated manner and optionally filter watches by a query.",
+        "description": "Get all registered watches in a paginated manner and optionally filter watches by a query.\n\nNote that only the `_id` and `metadata.*` fields are queryable or sortable.",
         "operationId": "watcher-query-watches",
         "requestBody": {
           "$ref": "#/components/requestBodies/watcher.query_watches"
@@ -38132,7 +38132,7 @@
           "watcher"
         ],
         "summary": "Query watches",
-        "description": "Get all registered watches in a paginated manner and optionally filter watches by a query.",
+        "description": "Get all registered watches in a paginated manner and optionally filter watches by a query.\n\nNote that only the `_id` and `metadata.*` fields are queryable or sortable.",
         "operationId": "watcher-query-watches-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/watcher.query_watches"
@@ -38173,6 +38173,7 @@
           "watcher"
         ],
         "summary": "Get Watcher statistics",
+        "description": "This API always returns basic metrics.\nYou retrieve more metrics by using the metric parameter.",
         "operationId": "watcher-stats",
         "parameters": [
           {
@@ -38196,6 +38197,7 @@
           "watcher"
         ],
         "summary": "Get Watcher statistics",
+        "description": "This API always returns basic metrics.\nYou retrieve more metrics by using the metric parameter.",
         "operationId": "watcher-stats-1",
         "parameters": [
           {
@@ -38224,6 +38226,18 @@
         "summary": "Stop the watch service",
         "description": "Stop the Watcher service if it is running.",
         "operationId": "watcher-stop",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "master_timeout",
+            "description": "The period to wait for the master node.\nIf the master node is not available before the timeout expires, the request fails and returns an error.\nTo indicate that the request should never timeout, set it to `-1`.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -90096,6 +90110,7 @@
         "type": "object",
         "properties": {
           "current_watches": {
+            "description": "The current executing watches metric gives insight into the watches that are currently being executed by Watcher.\nAdditional information is shared per watch that is currently executing.\nThis information includes the `watch_id`, the time its execution started and its current execution phase.\nTo include this metric, the `metric` option should be set to `current_watches` or `_all`.\nIn addition you can also specify the `emit_stacktraces=true` parameter, which adds stack traces for each watch that is being run.\nThese stack traces can give you more insight into an execution of a watch.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/watcher.stats:WatchRecordStats"
@@ -90105,12 +90120,14 @@
             "$ref": "#/components/schemas/watcher._types:ExecutionThreadPool"
           },
           "queued_watches": {
+            "description": "Watcher moderates the execution of watches such that their execution won't put too much pressure on the node and its resources.\nIf too many watches trigger concurrently and there isn't enough capacity to run them all, some of the watches are queued, waiting for the current running watches to finish.s\nThe queued watches metric gives insight on these queued watches.\n\nTo include this metric, the `metric` option should include `queued_watches` or `_all`.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/watcher.stats:WatchRecordQueuedStats"
             }
           },
           "watch_count": {
+            "description": "The number of watches currently registered.",
             "type": "number"
           },
           "watcher_state": {
@@ -90191,9 +90208,11 @@
         "type": "object",
         "properties": {
           "max_size": {
+            "description": "The largest size of the execution thread pool, which indicates the largest number of concurrent running watches.",
             "type": "number"
           },
           "queue_size": {
+            "description": "The number of watches that were triggered and are currently queued.",
             "type": "number"
           }
         },
@@ -95552,9 +95571,11 @@
               "type": "object",
               "properties": {
                 "count": {
+                  "description": "The total number of watches found.",
                   "type": "number"
                 },
                 "watches": {
+                  "description": "A list of watches based on the `from`, `size`, or `search_after` request body parameters.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/watcher._types:QueryWatch"
@@ -105028,7 +105049,7 @@
       "watcher.ack_watch#watch_id": {
         "in": "path",
         "name": "watch_id",
-        "description": "Watch ID",
+        "description": "The watch identifier.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -105039,7 +105060,7 @@
       "watcher.ack_watch#action_id": {
         "in": "path",
         "name": "action_id",
-        "description": "A comma-separated list of the action ids to be acked",
+        "description": "A comma-separated list of the action identifiers to acknowledge.\nIf you omit this parameter, all of the actions of the watch are acknowledged.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -105050,7 +105071,7 @@
       "watcher.activate_watch#watch_id": {
         "in": "path",
         "name": "watch_id",
-        "description": "Watch ID",
+        "description": "The watch identifier.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -105061,7 +105082,7 @@
       "watcher.deactivate_watch#watch_id": {
         "in": "path",
         "name": "watch_id",
-        "description": "Watch ID",
+        "description": "The watch identifier.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -105072,7 +105093,7 @@
       "watcher.execute_watch#id": {
         "in": "path",
         "name": "id",
-        "description": "Identifier for the watch.",
+        "description": "The watch identifier.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -105093,7 +105114,7 @@
       "watcher.put_watch#id": {
         "in": "path",
         "name": "id",
-        "description": "Watch ID",
+        "description": "The identifier for the watch.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -105104,7 +105125,7 @@
       "watcher.put_watch#active": {
         "in": "query",
         "name": "active",
-        "description": "Specify whether the watch is in/active by default",
+        "description": "The initial state of the watch.\nThe default value is `true`, which means the watch is active by default.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -108054,7 +108075,7 @@
                   "type": "boolean"
                 },
                 "record_execution": {
-                  "description": "When set to `true`, the watch record representing the watch execution result is persisted to the `.watcher-history` index for the current time. In addition, the status of the watch is updated, possibly throttling subsequent executions. This can also be specified as an HTTP parameter.",
+                  "description": "When set to `true`, the watch record representing the watch execution result is persisted to the `.watcher-history` index for the current time.\nIn addition, the status of the watch is updated, possibly throttling subsequent runs.\nThis can also be specified as an HTTP parameter.",
                   "type": "boolean"
                 },
                 "simulated_actions": {
@@ -108078,6 +108099,7 @@
               "type": "object",
               "properties": {
                 "actions": {
+                  "description": "The list of actions that will be run if the condition matches.",
                   "type": "object",
                   "additionalProperties": {
                     "$ref": "#/components/schemas/watcher._types:Action"
@@ -108093,7 +108115,10 @@
                   "$ref": "#/components/schemas/_types:Metadata"
                 },
                 "throttle_period": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/_types:Duration"
+                },
+                "throttle_period_in_millis": {
+                  "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
                 },
                 "transform": {
                   "$ref": "#/components/schemas/_types:TransformContainer"
@@ -108113,11 +108138,11 @@
               "type": "object",
               "properties": {
                 "from": {
-                  "description": "The offset from the first result to fetch. Needs to be non-negative.",
+                  "description": "The offset from the first result to fetch.\nIt must be non-negative.",
                   "type": "number"
                 },
                 "size": {
-                  "description": "The number of hits to return. Needs to be non-negative.",
+                  "description": "The number of hits to return.\nIt must be non-negative.",
                   "type": "number"
                 },
                 "query": {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -789,12 +789,6 @@
       ],
       "response": []
     },
-    "watcher.stop": {
-      "request": [
-        "Request: missing json spec query parameter 'master_timeout'"
-      ],
-      "response": []
-    },
     "watcher.update_settings": {
       "request": [
         "Missing request & response"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -21068,7 +21068,8 @@ export interface WatcherPutWatchRequest extends RequestBase {
     condition?: WatcherConditionContainer
     input?: WatcherInputContainer
     metadata?: Metadata
-    throttle_period?: string
+    throttle_period?: Duration
+    throttle_period_in_millis?: DurationValue<UnitMillis>
     transform?: TransformContainer
     trigger?: WatcherTriggerContainer
   }
@@ -21140,6 +21141,7 @@ export interface WatcherStatsWatcherNodeStats {
 export type WatcherStatsWatcherState = 'stopped' | 'starting' | 'started' | 'stopping'
 
 export interface WatcherStopRequest extends RequestBase {
+  master_timeout?: Duration
 }
 
 export type WatcherStopResponse = AcknowledgedResponseBase

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -493,6 +493,7 @@ run-as-privilege,https://www.elastic.co/guide/en/elasticsearch/reference/{branch
 runtime-search-request,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/runtime-search-request.html
 script-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/script-processor.html
 scroll-search-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html#scroll-search-results
+search-after,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html#search-after
 search-aggregations,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations.html
 search-aggregations-bucket-adjacency-matrix-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-bucket-adjacency-matrix-aggregation.html
 search-aggregations-bucket-autodatehistogram-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-bucket-autodatehistogram-aggregation.html

--- a/specification/ccr/put_auto_follow_pattern/examples/response/PutAutoFollowPatternResponseExample1.yaml
+++ b/specification/ccr/put_auto_follow_pattern/examples/response/PutAutoFollowPatternResponseExample1.yaml
@@ -3,4 +3,4 @@ description: A successful response for creating an auto-follow pattern.
 # type: response
 # response_code: 200
 value:
-  acknowledged": true
+  acknowledged: true

--- a/specification/watcher/_types/Execution.ts
+++ b/specification/watcher/_types/Execution.ts
@@ -92,6 +92,12 @@ export class ExecutionResultInput {
 }
 
 export class ExecutionThreadPool {
+  /**
+   * The largest size of the execution thread pool, which indicates the largest number of concurrent running watches.
+   */
   max_size: long
+  /**
+   * The number of watches that were triggered and are currently queued.
+   */
   queue_size: long
 }

--- a/specification/watcher/ack_watch/WatcherAckWatchRequest.ts
+++ b/specification/watcher/ack_watch/WatcherAckWatchRequest.ts
@@ -28,13 +28,24 @@ import { Name, Names } from '@_types/common'
  *
  * IMPORTANT: If the specified watch is currently being executed, this API will return an error
  * The reason for this behavior is to prevent overwriting the watch status from a watch execution.
+ *
+ * Acknowledging an action throttles further executions of that action until its `ack.state` is reset to `awaits_successful_execution`.
+ * This happens when the condition of the watch is not met (the condition evaluates to false).
  * @rest_spec_name watcher.ack_watch
  * @availability stack stability=stable
  * @cluster_privileges manage_watcher
+ * @doc_id watcher-api-ack-watch
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * The watch identifier.
+     */
     watch_id: Name
+    /**
+     * A comma-separated list of the action identifiers to acknowledge.
+     * If you omit this parameter, all of the actions of the watch are acknowledged.
+     */
     action_id?: Names
   }
 }

--- a/specification/watcher/ack_watch/examples/response/WatcherAckWatchResponseExample1.yaml
+++ b/specification/watcher/ack_watch/examples/response/WatcherAckWatchResponseExample1.yaml
@@ -1,0 +1,33 @@
+# summary:
+description: A successful response from `POST _watcher/watch/my_watch/_ack`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "status": {
+      "state": {
+        "active": true,
+        "timestamp": "2015-05-26T18:04:27.723Z"
+      },
+      "last_checked": "2015-05-26T18:04:27.753Z",
+      "last_met_condition": "2015-05-26T18:04:27.763Z",
+      "actions": {
+        "test_index": {
+          "ack" : {
+            "timestamp": "2015-05-26T18:04:27.713Z",
+            "state": "acked"
+          },
+          "last_execution" : {
+            "timestamp": "2015-05-25T18:04:27.733Z",
+            "successful": true
+          },
+          "last_successful_execution" : {
+            "timestamp": "2015-05-25T18:04:27.773Z",
+            "successful": true
+          }
+        }
+      },
+      "execution_state": "executed",
+      "version": 2
+    }
+  }

--- a/specification/watcher/activate_watch/WatcherActivateWatchRequest.ts
+++ b/specification/watcher/activate_watch/WatcherActivateWatchRequest.ts
@@ -26,10 +26,14 @@ import { Name } from '@_types/common'
  * @rest_spec_name watcher.activate_watch
  * @availability stack stability=stable
  * @cluster_privileges manage_watcher
+ * @doc_id watcher-api-activate-watch
  * @ext_doc_id watcher-works
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * The watch identifier.
+     */
     watch_id: Name
   }
 }

--- a/specification/watcher/deactivate_watch/DeactivateWatchRequest.ts
+++ b/specification/watcher/deactivate_watch/DeactivateWatchRequest.ts
@@ -26,10 +26,14 @@ import { Name } from '@_types/common'
  * @rest_spec_name watcher.deactivate_watch
  * @availability stack stability=stable
  * @cluster_privileges manage_watcher
+ * @doc_id watcher-api-deactivate-watch
  * @ext_doc_id watcher-works
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * The watch identifier.
+     */
     watch_id: Name
   }
 }

--- a/specification/watcher/delete_watch/DeleteWatchRequest.ts
+++ b/specification/watcher/delete_watch/DeleteWatchRequest.ts
@@ -32,9 +32,13 @@ import { Name } from '@_types/common'
  * @rest_spec_name watcher.delete_watch
  * @availability stack stability=stable
  * @cluster_privileges manage_watcher
+ * @doc_id watcher-api-delete-watch
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * The watch identifier.
+     */
     id: Name
   }
 }

--- a/specification/watcher/delete_watch/examples/response/DeleteWatchResponseExample1.yaml
+++ b/specification/watcher/delete_watch/examples/response/DeleteWatchResponseExample1.yaml
@@ -1,0 +1,10 @@
+# summary:
+description: A successful response from `DELETE _watcher/watch/my_watch`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "found": true,
+    "_id": "my_watch",
+    "_version": 2
+  }

--- a/specification/watcher/execute_watch/WatcherExecuteWatchRequest.ts
+++ b/specification/watcher/execute_watch/WatcherExecuteWatchRequest.ts
@@ -35,14 +35,20 @@ import { Id } from '@_types/common'
  *
  * You can use the run watch API to run watches that are not yet registered by specifying the watch definition inline.
  * This serves as great tool for testing and debugging your watches prior to adding them to Watcher.
+ *
+ * When Elasticsearch security features are enabled on your cluster, watches are run with the privileges of the user that stored the watches.
+ * If your user is allowed to read index `a`, but not index `b`, then the exact same set of rules will apply during execution of a watch.
+ *
+ * When using the run watch API, the authorization data of the user that called the API will be used as a base, instead of the information who stored the watch.
  * @rest_spec_name watcher.execute_watch
  * @availability stack stability=stable
  * @cluster_privileges manage_watcher
+ * @doc_id watcher-api-execute-watch
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * Identifier for the watch.
+     * The watch identifier.
      */
     id?: Id
   }
@@ -68,17 +74,20 @@ export interface Request extends RequestBase {
      */
     ignore_condition?: boolean
     /**
-     * When set to `true`, the watch record representing the watch execution result is persisted to the `.watcher-history` index for the current time. In addition, the status of the watch is updated, possibly throttling subsequent executions. This can also be specified as an HTTP parameter.
+     * When set to `true`, the watch record representing the watch execution result is persisted to the `.watcher-history` index for the current time.
+     * In addition, the status of the watch is updated, possibly throttling subsequent runs.
+     * This can also be specified as an HTTP parameter.
      * @server_default false
      */
     record_execution?: boolean
     simulated_actions?: SimulatedActions
     /**
-     * This structure is parsed as the data of the trigger event that will be used during the watch execution
+     * This structure is parsed as the data of the trigger event that will be used during the watch execution.
      */
     trigger_data?: ScheduleTriggerEvent
     /**
-     * When present, this watch is used instead of the one specified in the request. This watch is not persisted to the index and record_execution cannot be set.
+     * When present, this watch is used instead of the one specified in the request.
+     * This watch is not persisted to the index and `record_execution` cannot be set.
      * @server_default null
      */
     watch?: Watch

--- a/specification/watcher/execute_watch/WatcherExecuteWatchResponse.ts
+++ b/specification/watcher/execute_watch/WatcherExecuteWatchResponse.ts
@@ -21,5 +21,14 @@ import { Id } from '@_types/common'
 import { WatchRecord } from './types'
 
 export class Response {
-  body: { _id: Id; watch_record: WatchRecord }
+  body: {
+    /**
+     * The watch record identifier as it would be stored in the `.watcher-history` index.
+     */
+    _id: Id
+    /**
+     * The watch record document as it would be stored in the `.watcher-history` index.
+     */
+    watch_record: WatchRecord
+  }
 }

--- a/specification/watcher/execute_watch/examples/request/WatcherExecuteRequestExample1.yaml
+++ b/specification/watcher/execute_watch/examples/request/WatcherExecuteRequestExample1.yaml
@@ -1,0 +1,24 @@
+summary: Run a watch
+# method_request: POST _watcher/watch/my_watch/_execute
+description: >
+  Run `POST _watcher/watch/my_watch/_execute` to run a watch.
+  The input defined in the watch is ignored and the `alternative_input` is used as the payload.
+  The condition as defined by the watch is ignored and is assumed to evaluate to true.
+  The `force_simulate` action forces the simulation of `my-action`.
+  Forcing the simulation means that throttling is ignored and the watch is simulated by Watcher instead of being run normally.
+# type: request
+value: |-
+  {
+    "trigger_data" : { 
+      "triggered_time" : "now",
+      "scheduled_time" : "now"
+    },
+    "alternative_input" : { 
+      "foo" : "bar"
+    },
+    "ignore_condition" : true, 
+    "action_modes" : {
+      "my-action" : "force_simulate" 
+    },
+    "record_execution" : true 
+  }

--- a/specification/watcher/execute_watch/examples/request/WatcherExecuteRequestExample2.yaml
+++ b/specification/watcher/execute_watch/examples/request/WatcherExecuteRequestExample2.yaml
@@ -1,0 +1,12 @@
+summary: Run a watch with multiple action modes
+# method_request: POST _watcher/watch/my_watch/_execute
+description: >
+  Run `POST _watcher/watch/my_watch/_execute` and set a different mode for each action.
+# type: request
+value: |-
+  {
+    "action_modes" : {
+      "action1" : "force_simulate",
+      "action2" : "skip"
+    }
+  }

--- a/specification/watcher/execute_watch/examples/request/WatcherExecuteRequestExample3.yaml
+++ b/specification/watcher/execute_watch/examples/request/WatcherExecuteRequestExample3.yaml
@@ -1,0 +1,35 @@
+summary: Run a watch inline
+# method_request: POST _watcher/watch/_execute
+description: >
+  Run `POST _watcher/watch/_execute` to run a watch inline.
+  All other settings for this API still apply when inlining a watch.
+  In this example, while the inline watch defines a compare condition, during the execution this condition will be ignored.
+# type: request
+value: |-
+  {
+    "watch" : {
+      "trigger" : { "schedule" : { "interval" : "10s" } },
+      "input" : {
+        "search" : {
+          "request" : {
+            "indices" : [ "logs" ],
+            "body" : {
+              "query" : {
+                "match" : { "message": "error" }
+              }
+            }
+          }
+        }
+      },
+      "condition" : {
+        "compare" : { "ctx.payload.hits.total" : { "gt" : 0 }}
+      },
+      "actions" : {
+        "log_error" : {
+          "logging" : {
+            "text" : "Found {{ctx.payload.hits.total}} errors in the logs"
+          }
+        }
+      }
+    }
+  }

--- a/specification/watcher/execute_watch/examples/response/WatcherExecuteWatchResponseExample1.yaml
+++ b/specification/watcher/execute_watch/examples/response/WatcherExecuteWatchResponseExample1.yaml
@@ -1,0 +1,94 @@
+# summary:
+description: >
+  A successful response from `POST _watcher/watch/my_watch/_execute`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "_id": "my_watch_0-2015-06-02T23:17:55.124Z", 
+    "watch_record": { 
+      "@timestamp": "2015-06-02T23:17:55.124Z",
+      "watch_id": "my_watch",
+      "node": "my_node",
+      "messages": [],
+      "trigger_event": {
+        "type": "manual",
+        "triggered_time": "2015-06-02T23:17:55.124Z",
+        "manual": {
+          "schedule": {
+            "scheduled_time": "2015-06-02T23:17:55.124Z"
+          }
+        }
+      },
+      "state": "executed",
+      "status": {
+        "version": 1,
+        "execution_state": "executed",
+        "state": {
+          "active": true,
+          "timestamp": "2015-06-02T23:17:55.111Z"
+        },
+        "last_checked": "2015-06-02T23:17:55.124Z",
+        "last_met_condition": "2015-06-02T23:17:55.124Z",
+        "actions": {
+          "test_index": {
+            "ack": {
+              "timestamp": "2015-06-02T23:17:55.124Z",
+              "state": "ackable"
+            },
+            "last_execution": {
+              "timestamp": "2015-06-02T23:17:55.124Z",
+              "successful": true
+            },
+            "last_successful_execution": {
+              "timestamp": "2015-06-02T23:17:55.124Z",
+              "successful": true
+            }
+          }
+        }
+      },
+      "input": {
+        "simple": {
+          "payload": {
+            "send": "yes"
+          }
+        }
+      },
+      "condition": {
+        "always": {}
+      },
+      "result": { 
+        "execution_time": "2015-06-02T23:17:55.124Z",
+        "execution_duration": 12608,
+        "input": {
+          "type": "simple",
+          "payload": {
+            "foo": "bar"
+          },
+          "status": "success"
+        },
+        "condition": {
+          "type": "always",
+          "met": true,
+          "status": "success"
+        },
+        "actions": [
+          {
+            "id": "test_index",
+            "index": {
+              "response": {
+                "index": "test",
+                "version": 1,
+                "created": true,
+                "result": "created",
+                "id": "AVSHKzPa9zx62AzUzFXY"
+              }
+            },
+            "status": "success",
+            "type": "index"
+          }
+        ]
+      },
+      "user": "test_admin" 
+    }
+  }

--- a/specification/watcher/get_watch/GetWatchRequest.ts
+++ b/specification/watcher/get_watch/GetWatchRequest.ts
@@ -25,9 +25,13 @@ import { Name } from '@_types/common'
  * @rest_spec_name watcher.get_watch
  * @availability stack since=5.6.0 stability=stable
  * @cluster_privileges monitor_watcher
+ * @doc_id watcher-api-get-watch
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * The watch identifier.
+     */
     id: Name
   }
 }

--- a/specification/watcher/get_watch/examples/response/GetWatchResponseExample1.yaml
+++ b/specification/watcher/get_watch/examples/response/GetWatchResponseExample1.yaml
@@ -1,0 +1,53 @@
+# summary:
+description: A successful response from `GET _watcher/watch/my_watch`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "found": true,
+    "_id": "my_watch",
+    "_seq_no": 0,
+    "_primary_term": 1,
+    "_version": 1,
+    "status": { 
+      "version": 1,
+      "state": {
+        "active": true,
+        "timestamp": "2015-05-26T18:21:08.630Z"
+      },
+      "actions": {
+        "test_index": {
+          "ack": {
+            "timestamp": "2015-05-26T18:21:08.630Z",
+            "state": "awaits_successful_execution"
+          }
+        }
+      }
+    },
+    "watch": {
+      "input": {
+        "simple": {
+          "payload": {
+            "send": "yes"
+          }
+        }
+      },
+      "condition": {
+        "always": {}
+      },
+      "trigger": {
+        "schedule": {
+          "hourly": {
+            "minute": [0, 5]
+          }
+        }
+      },
+      "actions": {
+        "test_index": {
+          "index": {
+            "index": "test"
+          }
+        }
+      }
+    }
+  }

--- a/specification/watcher/put_watch/WatcherPutWatchRequest.ts
+++ b/specification/watcher/put_watch/WatcherPutWatchRequest.ts
@@ -25,6 +25,7 @@ import { TriggerContainer } from '@watcher/_types/Trigger'
 import { RequestBase } from '@_types/Base'
 import { Id, Metadata, SequenceNumber, VersionNumber } from '@_types/common'
 import { long } from '@_types/Numeric'
+import { Duration, DurationValue, UnitMillis } from '@_types/Time'
 import { TransformContainer } from '@_types/Transform'
 
 /**
@@ -43,24 +44,61 @@ import { TransformContainer } from '@_types/Transform'
  * @rest_spec_name watcher.put_watch
  * @availability stack stability=stable
  * @cluster_privileges manage_watcher
+ * @doc_id watcher-api-put-watch
  */
 export interface Request extends RequestBase {
   path_parts: {
+    /**
+     * The identifier for the watch.
+     */
     id: Id
   }
   query_parameters: {
+    /**
+     * The initial state of the watch.
+     * The default value is `true`, which means the watch is active by default.
+     * @server_default true
+     */
     active?: boolean
     if_primary_term?: long
     if_seq_no?: SequenceNumber
     version?: VersionNumber
   }
   body: {
+    /**
+     * The list of actions that will be run if the condition matches.
+     */
     actions?: Dictionary<string, Action>
+    /**
+     * The condition that defines if the actions should be run.
+     */
     condition?: ConditionContainer
+    /**
+     * The input that defines the input that loads the data for the watch.
+     */
     input?: InputContainer
+    /**
+     * Metadata JSON that will be copied into the history entries.
+     */
     metadata?: Metadata
-    throttle_period?: string
+    /**
+     * The minimum time between actions being run.
+     * The default is 5 seconds.
+     * This default can be changed in the config file with the setting `xpack.watcher.throttle.period.default_period`.
+     * If both this value and the `throttle_period_in_millis` parameter are specified, Watcher uses the last parameter included in the request.
+     */
+    throttle_period?: Duration
+    /**
+     * Minimum time in milliseconds between actions being run. Defaults to 5000. If both this value and the throttle_period parameter are specified, Watcher uses the last parameter included in the request.
+     */
+    throttle_period_in_millis?: DurationValue<UnitMillis>
+    /**
+     * The transform that processes the watch payload to prepare it for the watch actions.
+     */
     transform?: TransformContainer
+    /**
+     * The trigger that defines when the watch should run.
+     */
     trigger?: TriggerContainer
   }
 }

--- a/specification/watcher/put_watch/examples/request/WatcherPutWatchRequestExample1.yaml
+++ b/specification/watcher/put_watch/examples/request/WatcherPutWatchRequestExample1.yaml
@@ -1,0 +1,54 @@
+# summary:
+# method_request: PUT _watcher/watch/my-watch
+description: >
+  Run `PUT _watcher/watch/my-watch` add a watch.
+  The watch schedule triggers every minute.
+  The watch search input looks for any 404 HTTP responses that occurred in the last five minutes.
+  The watch condition checks if any search hits where found.
+  When found, the watch action sends an email to an administrator.
+# type: request
+value: |-
+  {
+    "trigger" : {
+      "schedule" : { "cron" : "0 0/1 * * * ?" }
+    },
+    "input" : {
+      "search" : {
+        "request" : {
+          "indices" : [
+            "logstash*"
+          ],
+          "body" : {
+            "query" : {
+              "bool" : {
+                "must" : {
+                  "match": {
+                    "response": 404
+                  }
+                },
+                "filter" : {
+                  "range": {
+                    "@timestamp": {
+                      "from": "{{ctx.trigger.scheduled_time}}||-5m",
+                      "to": "{{ctx.trigger.triggered_time}}"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "condition" : {
+      "compare" : { "ctx.payload.hits.total" : { "gt" : 0 }}
+    },
+    "actions" : {
+      "email_admin" : {
+        "email" : {
+          "to" : "admin@domain.host.com",
+          "subject" : "404 recently encountered"
+        }
+      }
+    }
+  }

--- a/specification/watcher/query_watches/WatcherQueryWatchesRequest.ts
+++ b/specification/watcher/query_watches/WatcherQueryWatchesRequest.ts
@@ -25,27 +25,40 @@ import { Sort, SortResults } from '@_types/sort'
 /**
  * Query watches.
  * Get all registered watches in a paginated manner and optionally filter watches by a query.
+ *
+ * Note that only the `_id` and `metadata.*` fields are queryable or sortable.
  * @rest_spec_name watcher.query_watches
  * @availability stack since=7.11.0 stability=stable
  * @cluster_privileges monitor_watcher
+ * @doc_id watcher-api-query-watches
  */
 export interface Request extends RequestBase {
   body: {
     /**
-     * The offset from the first result to fetch. Needs to be non-negative.
+     * The offset from the first result to fetch.
+     * It must be non-negative.
      * @server_default 0
      */
     from?: integer
     /**
-     * The number of hits to return. Needs to be non-negative.
+     * The number of hits to return.
+     * It must be non-negative.
      * @server_default 10
      */
     size?: integer
-    /** Optional, query filter watches to be returned. */
+    /**
+     * A query that filters the watches to be returned.
+     */
     query?: QueryContainer
-    /** Optional sort definition. */
+    /**
+     * One or more fields used to sort the search results.
+     * @ext_doc_id sort-search-results
+     */
     sort?: Sort
-    /** Optional search After to do pagination using last hit’s sort values. */
+    /**
+     * Retrieve the next page of hits using a set of sort values from the previous page.
+     * @ext_doc_id search-after
+     */
     search_after?: SortResults
   }
 }

--- a/specification/watcher/query_watches/WatcherQueryWatchesResponse.ts
+++ b/specification/watcher/query_watches/WatcherQueryWatchesResponse.ts
@@ -22,7 +22,13 @@ import { QueryWatch } from '../_types/Watch'
 
 export class Response {
   body: {
+    /**
+     * The total number of watches found.
+     */
     count: integer
+    /**
+     * A list of watches based on the `from`, `size`, or `search_after` request body parameters.
+     */
     watches: QueryWatch[]
   }
 }

--- a/specification/watcher/query_watches/examples/response/WatcherQueryWatchesResponseExample1.yaml
+++ b/specification/watcher/query_watches/examples/response/WatcherQueryWatchesResponseExample1.yaml
@@ -1,0 +1,59 @@
+# summary: ''
+description: A successful response from `GET /_watcher/_query/watches`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "count": 1,
+    "watches": [
+        {
+            "_id": "my_watch",
+            "watch": {
+                "trigger": {
+                    "schedule": {
+                        "hourly": {
+                            "minute": [
+                                0,
+                                5
+                            ]
+                        }
+                    }
+                },
+                "input": {
+                    "simple": {
+                        "payload": {
+                            "send": "yes"
+                        }
+                    }
+                },
+                "condition": {
+                    "always": {}
+                },
+                "actions": {
+                    "test_index": {
+                        "index": {
+                            "index": "test"
+                        }
+                    }
+                }
+            },
+            "status": {
+                "state": {
+                    "active": true,
+                    "timestamp": "2015-05-26T18:21:08.630Z"
+                },
+                "actions": {
+                    "test_index": {
+                        "ack": {
+                            "timestamp": "2015-05-26T18:21:08.630Z",
+                            "state": "awaits_successful_execution"
+                        }
+                    }
+                },
+                "version": -1
+            },
+            "_seq_no": 0,
+            "_primary_term": 1
+        }
+    ]
+  }

--- a/specification/watcher/start/WatcherStartRequest.ts
+++ b/specification/watcher/start/WatcherStartRequest.ts
@@ -25,5 +25,6 @@ import { RequestBase } from '@_types/Base'
  * @rest_spec_name watcher.start
  * @availability stack stability=stable
  * @cluster_privileges manage_watcher
+ * @doc_id watcher-api-start
  */
 export interface Request extends RequestBase {}

--- a/specification/watcher/start/examples/response/WatcherStartResponseExample1.yaml
+++ b/specification/watcher/start/examples/response/WatcherStartResponseExample1.yaml
@@ -1,0 +1,6 @@
+# summary: ''
+description: A successful response from `POST _watcher/_start`.
+# type: response
+# response_code: 200
+value:
+  acknowledged: true

--- a/specification/watcher/stats/WatcherStatsRequest.ts
+++ b/specification/watcher/stats/WatcherStatsRequest.ts
@@ -22,9 +22,12 @@ import { WatcherMetric } from './types'
 
 /**
  * Get Watcher statistics.
+ * This API always returns basic metrics.
+ * You retrieve more metrics by using the metric parameter.
  * @rest_spec_name watcher.stats
  * @availability stack since=5.5.0 stability=stable
  * @cluster_privileges monitor_watcher
+ * @doc_id watcher-api-stats
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/watcher/stats/examples/response/WatcherStatsResponseExample1.yaml
+++ b/specification/watcher/stats/examples/response/WatcherStatsResponseExample1.yaml
@@ -1,0 +1,13 @@
+summary: Basic metrics
+description: A successful response from `GET _watcher/stats`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "watcher_state": "started",  
+    "watch_count": 1, 
+    "execution_thread_pool": {
+      "size": 1000, 
+      "max_size": 1 
+    }
+  }

--- a/specification/watcher/stats/examples/response/WatcherStatsResponseExample2.yaml
+++ b/specification/watcher/stats/examples/response/WatcherStatsResponseExample2.yaml
@@ -1,0 +1,22 @@
+summary: Current watch metrics
+description: A successful response from `GET _watcher/stats?metric=current_watches`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "watcher_state": "started",
+    "watch_count": 2,
+    "execution_thread_pool": {
+        "queue_size": 1000,
+        "max_size": 20
+    },
+    "current_watches": [ 
+        {
+          "watch_id": "slow_condition", 
+          "watch_record_id": "slow_condition_3-2015-05-13T07:42:32.179Z", 
+          "triggered_time": "2015-05-12T11:53:51.800Z", 
+          "execution_time": "2015-05-13T07:42:32.179Z", 
+          "execution_phase": "condition" 
+        }
+    ]
+  }

--- a/specification/watcher/stats/examples/response/WatcherStatsResponseExample3.yaml
+++ b/specification/watcher/stats/examples/response/WatcherStatsResponseExample3.yaml
@@ -1,0 +1,21 @@
+summary: Queued watch metrics
+description: An abbreviated response from `GET _watcher/stats/queued_watches`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "watcher_state": "started",
+    "watch_count": 10,
+    "execution_thread_pool": {
+        "queue_size": 1000,
+        "max_size": 20
+    },
+    "queued_watches": [ 
+          {
+              "watch_id": "slow_condition4", 
+              "watch_record_id": "slow_condition4_223-2015-05-21T11:59:59.811Z", 
+              "triggered_time": "2015-05-21T11:59:59.811Z", 
+              "execution_time": "2015-05-21T11:59:59.811Z" 
+          }
+    ]
+  }

--- a/specification/watcher/stats/types.ts
+++ b/specification/watcher/stats/types.ts
@@ -31,10 +31,31 @@ export enum WatcherState {
 }
 
 export class WatcherNodeStats {
+  /**
+   * The current executing watches metric gives insight into the watches that are currently being executed by Watcher.
+   * Additional information is shared per watch that is currently executing.
+   * This information includes the `watch_id`, the time its execution started and its current execution phase.
+   * To include this metric, the `metric` option should be set to `current_watches` or `_all`.
+   * In addition you can also specify the `emit_stacktraces=true` parameter, which adds stack traces for each watch that is being run.
+   * These stack traces can give you more insight into an execution of a watch.
+   */
   current_watches?: WatchRecordStats[]
   execution_thread_pool: ExecutionThreadPool
+  /**
+   * Watcher moderates the execution of watches such that their execution won't put too much pressure on the node and its resources.
+   * If too many watches trigger concurrently and there isn't enough capacity to run them all, some of the watches are queued, waiting for the current running watches to finish.s
+   * The queued watches metric gives insight on these queued watches.
+   *
+   * To include this metric, the `metric` option should include `queued_watches` or `_all`.
+   */
   queued_watches?: WatchRecordQueuedStats[]
+  /**
+   * The number of watches currently registered.
+   */
   watch_count: long
+  /**
+   * The current state of Watcher.
+   */
   watcher_state: WatcherState
   node_id: Id
 }
@@ -48,13 +69,26 @@ export enum WatcherMetric {
 }
 
 export class WatchRecordQueuedStats {
+  /**
+   * The time the watch was run.
+   * This is just before the input is being run.
+   */
   execution_time: DateTime
 }
 
 export class WatchRecordStats extends WatchRecordQueuedStats {
+  /**
+   * The current watch execution phase.
+   */
   execution_phase: ExecutionPhase
+  /**
+   * The time the watch was triggered by the trigger engine.
+   */
   triggered_time: DateTime
   executed_actions?: Array<string>
   watch_id: Id
+  /**
+   * The watch record identifier.
+   */
   watch_record_id: Id
 }

--- a/specification/watcher/stop/WatcherStopRequest.ts
+++ b/specification/watcher/stop/WatcherStopRequest.ts
@@ -18,6 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
+import { Duration } from '@_types/Time'
 
 /**
  * Stop the watch service.
@@ -25,5 +26,16 @@ import { RequestBase } from '@_types/Base'
  * @rest_spec_name watcher.stop
  * @availability stack stability=stable
  * @cluster_privileges manage_watcher
+ * @doc_id watcher-api-stop
  */
-export interface Request extends RequestBase {}
+export interface Request extends RequestBase {
+  query_parameters: {
+    /**
+     * The period to wait for the master node.
+     * If the master node is not available before the timeout expires, the request fails and returns an error.
+     * To indicate that the request should never timeout, set it to `-1`.
+     * @server_default 30s
+     */
+    master_timeout?: Duration
+  }
+}

--- a/specification/watcher/stop/examples/response/WatcherStopResponseExample1.yaml
+++ b/specification/watcher/stop/examples/response/WatcherStopResponseExample1.yaml
@@ -1,0 +1,6 @@
+# summary: ''
+description: A successful response from `POST _watcher/_stop`.
+# type: response
+# response_code: 200
+value:
+  acknowledged: true


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add Watcher API examples (#3489)](https://github.com/elastic/elasticsearch-specification/pull/3489)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)