### PR TITLE
[8.17] Add watcher.get_settings and watcher.update_settings (#3397)

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -520,3 +520,24 @@ actions:
               examples:
                 delegatePkiResponseExample1:
                   $ref: "../../specification/security/delegate_pki/examples/200_response/SecurityDelegatePkiResponseExample1.yaml"
+## Examples for watcher
+  - target: "$.paths['/_watcher/settings']['put']"
+    description: "Add request example for update watcher settings"
+    update:
+      requestBody: 
+        content: 
+          application/json: 
+            examples:
+              updateWatcherSettingsRequestExample1: 
+                $ref: "../../specification/watcher/update_settings/examples/request/WatcherUpdateSettingsRequestExample1.yaml"
+  - target: "$.paths['/_watcher/settings']['get']"
+    description: "Add response example for get watcher settings"
+    update:
+      responses:
+        200:
+          content: 
+            application/json: 
+              examples:
+                updateWatcherSettingsRequestExample1: 
+                  $ref: "../../specification/watcher/get_settings/examples/200_response/WatcherGetSettingsResponseExample1.yaml"
+              

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -37988,6 +37988,116 @@
         }
       }
     },
+    "/_watcher/settings": {
+      "get": {
+        "tags": [
+          "watcher"
+        ],
+        "summary": "Get Watcher index settings",
+        "description": "Get settings for the Watcher internal index (`.watches`).\nOnly a subset of settings are shown, for example `index.auto_expand_replicas` and `index.number_of_replicas`.",
+        "operationId": "watcher-get-settings",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "master_timeout",
+            "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "index": {
+                      "$ref": "#/components/schemas/indices._types:IndexSettings"
+                    }
+                  },
+                  "required": [
+                    "index"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "watcher"
+        ],
+        "summary": "Update Watcher index settings",
+        "description": "Update settings for the Watcher internal index (`.watches`).\nOnly a subset of settings can be modified.\nThis includes `index.auto_expand_replicas` and `index.number_of_replicas`.",
+        "operationId": "watcher-update-settings",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "master_timeout",
+            "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "The period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Duration"
+            },
+            "style": "form"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "index.auto_expand_replicas": {
+                    "type": "string"
+                  },
+                  "index.number_of_replicas": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "acknowledged": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "acknowledged"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/_watcher/_query/watches": {
       "get": {
         "tags": [

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -964,12 +964,6 @@
         "interface definition watcher._types:TriggerEventContainer - Property schedule is a single-variant and must be required"
       ]
     },
-    "watcher.get_settings": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "watcher.start": {
       "request": [
         "Request: missing json spec query parameter 'master_timeout'"
@@ -979,12 +973,6 @@
     "watcher.stop": {
       "request": [
         "Request: missing json spec query parameter 'master_timeout'"
-      ],
-      "response": []
-    },
-    "watcher.update_settings": {
-      "request": [
-        "Missing request & response"
       ],
       "response": []
     },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -21013,6 +21013,14 @@ export interface WatcherExecuteWatchWatchRecord {
   status?: WatcherWatchStatus
 }
 
+export interface WatcherGetSettingsRequest extends RequestBase {
+  master_timeout?: Duration
+}
+
+export interface WatcherGetSettingsResponse {
+  index: IndicesIndexSettings
+}
+
 export interface WatcherGetWatchRequest extends RequestBase {
   id: Name
 }
@@ -21113,6 +21121,19 @@ export interface WatcherStopRequest extends RequestBase {
 }
 
 export type WatcherStopResponse = AcknowledgedResponseBase
+
+export interface WatcherUpdateSettingsRequest extends RequestBase {
+  master_timeout?: Duration
+  timeout?: Duration
+  body?: {
+    'index.auto_expand_replicas'?: string
+    'index.number_of_replicas'?: integer
+  }
+}
+
+export interface WatcherUpdateSettingsResponse {
+  acknowledged: boolean
+}
 
 export interface XpackInfoBuildInformation {
   date: DateTime

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -718,10 +718,12 @@ watcher-api-activate-watch,https://www.elastic.co/guide/en/elasticsearch/referen
 watcher-api-deactivate-watch,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-deactivate-watch.html
 watcher-api-delete-watch,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-delete-watch.html
 watcher-api-execute-watch,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-execute-watch.html
+watcher-api-get-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-get-settings.html
 watcher-api-get-watch,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-get-watch.html
 watcher-api-put-watch,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-put-watch.html
 watcher-api-query-watches,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-query-watches.html
 watcher-api-start,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-start.html
 watcher-api-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-stats.html
 watcher-api-stop,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-stop.html
+watcher-api-update-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/watcher-api-update-settings.html
 xpack-rollup,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/xpack-rollup.html

--- a/specification/watcher/get_settings/WatcherGetSettingsRequest.ts
+++ b/specification/watcher/get_settings/WatcherGetSettingsRequest.ts
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Duration } from '@_types/Time'
+
+/**
+ * Get Watcher index settings.
+ * Get settings for the Watcher internal index (`.watches`).
+ * Only a subset of settings are shown, for example `index.auto_expand_replicas` and `index.number_of_replicas`.
+ * @rest_spec_name watcher.get_settings
+ * @availability stack stability=stable visibility=public
+ * @doc_id watcher-api-get-settings
+ */
+export interface Request extends RequestBase {
+  query_parameters: {
+    /**
+     * The period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     */
+    master_timeout?: Duration
+  }
+}

--- a/specification/watcher/get_settings/WatcherGetSettingsResponse.ts
+++ b/specification/watcher/get_settings/WatcherGetSettingsResponse.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IndexSettings } from '@indices/_types/IndexSettings'
+
+export class Response {
+  body: {
+    index: IndexSettings
+  }
+}

--- a/specification/watcher/get_settings/examples/200_response/WatcherGetSettingsResponseExample1.yaml
+++ b/specification/watcher/get_settings/examples/200_response/WatcherGetSettingsResponseExample1.yaml
@@ -1,0 +1,8 @@
+# summary:
+description: A successful response with two index settings.
+# type: response
+# response_code: 200
+value:
+  index:
+    auto_expand_replicas: 0-4
+    number_of_replicas: 0

--- a/specification/watcher/update_settings/WatcherUpdateSettingsRequest.ts
+++ b/specification/watcher/update_settings/WatcherUpdateSettingsRequest.ts
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { integer } from '@_types/Numeric'
+import { Duration } from '@_types/Time'
+
+/**
+ * Update Watcher index settings.
+ * Update settings for the Watcher internal index (`.watches`).
+ * Only a subset of settings can be modified.
+ * This includes `index.auto_expand_replicas` and `index.number_of_replicas`.
+ * @rest_spec_name watcher.update_settings
+ * @availability stack stability=stable visibility=public
+ * @cluster_privileges manage_watcher
+ * @doc_id watcher-api-update-settings
+ */
+export interface Request extends RequestBase {
+  query_parameters: {
+    /**
+     * The period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     */
+    master_timeout?: Duration
+    /**
+     * The period to wait for a response.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     */
+    timeout?: Duration
+  }
+  /** @codegen_name watcher_index_settings */
+  body: {
+    'index.auto_expand_replicas'?: string
+    'index.number_of_replicas'?: integer
+  }
+}

--- a/specification/watcher/update_settings/WatcherUpdateSettingsResponse.ts
+++ b/specification/watcher/update_settings/WatcherUpdateSettingsResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class Response {
+  body: {
+    acknowledged: boolean
+  }
+}

--- a/specification/watcher/update_settings/examples/request/WatcherUpdateSettingsRequestExample1.yaml
+++ b/specification/watcher/update_settings/examples/request/WatcherUpdateSettingsRequestExample1.yaml
@@ -1,0 +1,6 @@
+# summary:
+# description:
+# type: request
+# method_request: PUT /_watcher/settings
+value:
+  index.auto_expand_replicas: 0-4


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Add watcher.get_settings and watcher.update_settings (#3397)](https://github.com/elastic/elasticsearch-specification/pull/3397)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)