### PR TITLE
Adding new reindex data stream apis

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -17565,6 +17565,161 @@
         "x-state": "Added in 1.3.0"
       }
     },
+    "/_migration/reindex/{index}/_cancel": {
+      "post": {
+        "tags": [
+          "cancel_reindex"
+        ],
+        "summary": "This API cancels a migration reindex attempt for a data stream or index",
+        "operationId": "migrate-cancel-reindex",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "index",
+            "description": "The index or data stream name",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Indices"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_types:AcknowledgedResponseBase"
+                }
+              }
+            }
+          }
+        },
+        "x-state": "Technical preview"
+      }
+    },
+    "/_create_from/{source}/{dest}": {
+      "put": {
+        "tags": [
+          "create_from"
+        ],
+        "summary": "This API creates a destination from a source index",
+        "description": "It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.",
+        "operationId": "migrate-create-from",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/migrate.create_from#source"
+          },
+          {
+            "$ref": "#/components/parameters/migrate.create_from#dest"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/migrate.create_from"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/migrate.create_from#200"
+          }
+        },
+        "x-state": "Technical preview"
+      },
+      "post": {
+        "tags": [
+          "create_from"
+        ],
+        "summary": "This API creates a destination from a source index",
+        "description": "It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.",
+        "operationId": "migrate-create-from-1",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/migrate.create_from#source"
+          },
+          {
+            "$ref": "#/components/parameters/migrate.create_from#dest"
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/migrate.create_from"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/migrate.create_from#200"
+          }
+        },
+        "x-state": "Technical preview"
+      }
+    },
+    "/_migration/reindex/{index}/_status": {
+      "get": {
+        "tags": [
+          "get_reindex_status"
+        ],
+        "summary": "This API returns the status of a migration reindex attempt for a data stream or index",
+        "operationId": "migrate-get-reindex-status",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "index",
+            "description": "The index or data stream name",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Indices"
+            },
+            "style": "simple"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_types:AcknowledgedResponseBase"
+                }
+              }
+            }
+          }
+        },
+        "x-state": "Technical preview"
+      }
+    },
+    "/_migration/reindex": {
+      "post": {
+        "tags": [
+          "reindex"
+        ],
+        "summary": "\"This API reindexes all legacy backing indices for a data stream",
+        "description": "It does this in a persistent task. The persistent task id is returned immediately, and the reindexing work is completed in that task",
+        "operationId": "migrate-reindex",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/migrate._types:MigrateReindex"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/_types:AcknowledgedResponseBase"
+                }
+              }
+            }
+          }
+        },
+        "x-state": "Technical preview"
+      }
+    },
     "/_migration/deprecations": {
       "get": {
         "tags": [
@@ -75382,6 +75537,33 @@
           "_index"
         ]
       },
+      "migrate._types:MigrateReindex": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "description": "Reindex mode. Currently only 'upgrade' is supported.",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/migrate._types:Index"
+          }
+        },
+        "required": [
+          "mode",
+          "source"
+        ]
+      },
+      "migrate._types:Index": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "$ref": "#/components/schemas/_types:Indices"
+          }
+        },
+        "required": [
+          "index"
+        ]
+      },
       "migration.deprecations:Deprecation": {
         "type": "object",
         "properties": {
@@ -94366,6 +94548,16 @@
           }
         }
       },
+      "migrate.create_from#200": {
+        "description": "",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/_types:AcknowledgedResponseBase"
+            }
+          }
+        }
+      },
       "migration.deprecations#200": {
         "description": "",
         "content": {
@@ -101906,6 +102098,28 @@
         },
         "style": "form"
       },
+      "migrate.create_from#source": {
+        "in": "path",
+        "name": "source",
+        "description": "The source index or data stream name",
+        "required": true,
+        "deprecated": false,
+        "schema": {
+          "type": "string"
+        },
+        "style": "simple"
+      },
+      "migrate.create_from#dest": {
+        "in": "path",
+        "name": "dest",
+        "description": "The destination index or data stream name",
+        "required": true,
+        "deprecated": false,
+        "schema": {
+          "type": "string"
+        },
+        "style": "simple"
+      },
       "migration.deprecations#index": {
         "in": "path",
         "name": "index",
@@ -107356,6 +107570,16 @@
                   "$ref": "#/components/schemas/_types:Ids"
                 }
               }
+            }
+          }
+        },
+        "required": true
+      },
+      "migrate.create_from": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/migrate._types:MigrateReindex"
             }
           }
         },

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -75537,6 +75537,17 @@
           "_index"
         ]
       },
+      "migrate._types:CreateFrom": {
+        "type": "object",
+        "properties": {
+          "mappings_override": {
+            "$ref": "#/components/schemas/_types.mapping:TypeMapping"
+          },
+          "settings_override": {
+            "$ref": "#/components/schemas/indices._types:IndexSettings"
+          }
+        }
+      },
       "migrate._types:MigrateReindex": {
         "type": "object",
         "properties": {
@@ -94553,7 +94564,23 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/_types:AcknowledgedResponseBase"
+              "type": "object",
+              "properties": {
+                "acknowledged": {
+                  "type": "boolean"
+                },
+                "index": {
+                  "$ref": "#/components/schemas/_types:IndexName"
+                },
+                "shards_acknowledged": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "acknowledged",
+                "index",
+                "shards_acknowledged"
+              ]
             }
           }
         }
@@ -107579,7 +107606,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/migrate._types:MigrateReindex"
+              "$ref": "#/components/schemas/migrate._types:CreateFrom"
             }
           }
         },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13826,6 +13826,41 @@ export interface LogstashPutPipelineRequest extends RequestBase {
 
 export type LogstashPutPipelineResponse = boolean
 
+export interface MigrateIndex {
+  index: Indices
+}
+
+export interface MigrateMigrateReindex {
+  mode: string
+  source: MigrateIndex
+}
+
+export interface MigrateCancelReindexRequest extends RequestBase {
+  index: Indices
+}
+
+export type MigrateCancelReindexResponse = AcknowledgedResponseBase
+
+export interface MigrateCreateFromRequest extends RequestBase {
+  source: string
+  dest: string
+  body?: MigrateMigrateReindex
+}
+
+export type MigrateCreateFromResponse = AcknowledgedResponseBase
+
+export interface MigrateGetReindexStatusRequest extends RequestBase {
+  index: Indices
+}
+
+export type MigrateGetReindexStatusResponse = AcknowledgedResponseBase
+
+export interface MigrateReindexRequest extends RequestBase {
+  body?: MigrateMigrateReindex
+}
+
+export type MigrateReindexResponse = AcknowledgedResponseBase
+
 export interface MigrationDeprecationsDeprecation {
   details?: string
   level: MigrationDeprecationsDeprecationLevel

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13826,6 +13826,11 @@ export interface LogstashPutPipelineRequest extends RequestBase {
 
 export type LogstashPutPipelineResponse = boolean
 
+export interface MigrateCreateFrom {
+  mappings_override?: MappingTypeMapping
+  settings_override?: IndicesIndexSettings
+}
+
 export interface MigrateIndex {
   index: Indices
 }
@@ -13844,10 +13849,14 @@ export type MigrateCancelReindexResponse = AcknowledgedResponseBase
 export interface MigrateCreateFromRequest extends RequestBase {
   source: string
   dest: string
-  body?: MigrateMigrateReindex
+  body?: MigrateCreateFrom
 }
 
-export type MigrateCreateFromResponse = AcknowledgedResponseBase
+export interface MigrateCreateFromResponse {
+  acknowledged: boolean
+  index: IndexName
+  shards_acknowledged: boolean
+}
 
 export interface MigrateGetReindexStatusRequest extends RequestBase {
   index: Indices

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -302,6 +302,7 @@ mapping-source-field,https://www.elastic.co/guide/en/elasticsearch/reference/{br
 mapping,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping.html
 mapping,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping.html
 mean-reciprocal,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#_mean_reciprocal_rank
+migrate,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/migrate-data-stream.html
 migrate-index-allocation-filters,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/migrate-index-allocation-filters.html
 migration-api-deprecation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/migration-api-deprecation.html
 migration-api-feature-upgrade,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/feature-migration-api.html

--- a/specification/_json_spec/migrate.cancel_reindex.json
+++ b/specification/_json_spec/migrate.cancel_reindex.json
@@ -1,0 +1,28 @@
+{
+  "migrate.cancel_reindex": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-reindex.html",
+      "description": "This API cancels migration reindex attempt for a data stream or index"
+    },
+    "stability": "experimental",
+    "visibility": "private",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_migration/reindex/{index}/_cancel",
+          "methods": ["POST"],
+          "parts": {
+            "index": {
+              "type": "string",
+              "description": "The index or data stream name"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/specification/_json_spec/migrate.create_from.json
+++ b/specification/_json_spec/migrate.create_from.json
@@ -1,0 +1,36 @@
+{
+  "migrate.create_from": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-reindex.html",
+      "description": "This API creates a destination from a source index. It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values."
+    },
+    "stability": "experimental",
+    "visibility": "private",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_create_from/{source}/{dest}",
+          "methods": ["PUT", "POST"],
+          "parts": {
+            "source": {
+              "type": "string",
+              "description": "The source index name"
+            },
+            "dest": {
+              "type": "string",
+              "description": "The destination index name"
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "The body contains the fields `mappings_override` and `settings_override`.",
+      "required": false
+    }
+  }
+}

--- a/specification/_json_spec/migrate.get_reindex_status.json
+++ b/specification/_json_spec/migrate.get_reindex_status.json
@@ -1,0 +1,28 @@
+{
+  "migrate.get_reindex_status": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-reindex.html",
+      "description": "This API returns the status of a migration reindex attempt for a data stream or index"
+    },
+    "stability": "experimental",
+    "visibility": "private",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_migration/reindex/{index}/_status",
+          "methods": ["GET"],
+          "parts": {
+            "index": {
+              "type": "string",
+              "description": "The index or data stream name"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/specification/_json_spec/migrate.reindex.json
+++ b/specification/_json_spec/migrate.reindex.json
@@ -1,0 +1,26 @@
+{
+  "migrate.reindex": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-stream-reindex.html",
+      "description": "This API reindexes all legacy backing indices for a data stream. It does this in a persistent task. The persistent task id is returned immediately, and the reindexing work is completed in that task"
+    },
+    "stability": "experimental",
+    "visibility": "private",
+    "headers": {
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_migration/reindex",
+          "methods": ["POST"]
+        }
+      ]
+    },
+    "body": {
+      "description": "The body contains the fields `mode` and `source.index`, where the only mode currently supported is `upgrade`, and the `source.index` must be a data stream name",
+      "required": true
+    }
+  }
+}

--- a/specification/migrate/_types/CreateFrom.ts
+++ b/specification/migrate/_types/CreateFrom.ts
@@ -21,12 +21,12 @@ import { Indices } from '@_types/common'
 
 export class CreateFrom {
   /**
-   * Reindex mode. Currently only 'upgrade' is supported.
+   * Mappings overrides to be applied to the destination index (optional)
    */
   mappings_override: string
   /**
-   * The source index or data stream (only data streams are currently supported).
+   * Settings overrides to be applied to the destination index (optional)
    */
-  settings_ovveride: string
+  settings_override: string
 }
 

--- a/specification/migrate/_types/CreateFrom.ts
+++ b/specification/migrate/_types/CreateFrom.ts
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-import { Indices } from '@_types/common'
 import { IndexSettings } from '@indices/_types/IndexSettings'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 
@@ -31,4 +30,3 @@ export class CreateFrom {
    */
   settings_override?: IndexSettings
 }
-

--- a/specification/migrate/_types/CreateFrom.ts
+++ b/specification/migrate/_types/CreateFrom.ts
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Indices } from '@_types/common'
+
+export class CreateFrom {
+  /**
+   * Reindex mode. Currently only 'upgrade' is supported.
+   */
+  mappings_override: string
+  /**
+   * The source index or data stream (only data streams are currently supported).
+   */
+  settings_ovveride: string
+}
+

--- a/specification/migrate/_types/CreateFrom.ts
+++ b/specification/migrate/_types/CreateFrom.ts
@@ -18,15 +18,17 @@
  */
 
 import { Indices } from '@_types/common'
+import { IndexSettings } from '@indices/_types/IndexSettings'
+import { TypeMapping } from '@_types/mapping/TypeMapping'
 
 export class CreateFrom {
   /**
    * Mappings overrides to be applied to the destination index (optional)
    */
-  mappings_override: string
+  mappings_override?: TypeMapping
   /**
    * Settings overrides to be applied to the destination index (optional)
    */
-  settings_override: string
+  settings_override?: IndexSettings
 }
 

--- a/specification/migrate/_types/MigrateReindex.ts
+++ b/specification/migrate/_types/MigrateReindex.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Indices } from '@_types/common'
+
+export class MigrateReindex {
+  /**
+   * Reindex mode. Currently only 'upgrade' is supported.
+   */
+  mode: string
+  /**
+   * The source index or data stream (only data streams are currently supported).
+   */
+  source: Index
+}
+
+export class Index {
+  index: Indices
+}

--- a/specification/migrate/cancel_reindex/MigrateCancelReindexRequest.ts
+++ b/specification/migrate/cancel_reindex/MigrateCancelReindexRequest.ts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Indices } from '@_types/common'
+
+/**
+ * This API cancels a migration reindex attempt for a data stream or index
+ *
+ * @rest_spec_name migrate.cancel_reindex
+ * @availability stack since=8.18.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
+ * @doc_id migrate
+ * @doc_tag cancel_reindex
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /** The index or data stream name */
+    index: Indices
+  }
+}

--- a/specification/migrate/cancel_reindex/MigrateCancelReindexResponse.ts
+++ b/specification/migrate/cancel_reindex/MigrateCancelReindexResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  body: AcknowledgedResponseBase
+}

--- a/specification/migrate/create_from/MigrateCreateFromRequest.ts
+++ b/specification/migrate/create_from/MigrateCreateFromRequest.ts
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { MigrateReindex } from '../_types/MigrateReindex'
+import { RequestBase } from '@_types/Base'
+import { Indices } from '@_types/common'
+
+/**
+ * This API creates a destination from a source index. It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.
+ *
+ * @rest_spec_name migrate.create_from
+ * @availability stack since=8.18.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
+ * @doc_id migrate
+ * @doc_tag create_from
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /** The source index or data stream name */
+    source: string,
+    /** The destination index or data stream name */
+    dest: string
+  },
+  /** @codegen_name create_from */
+  body: MigrateReindex
+}

--- a/specification/migrate/create_from/MigrateCreateFromRequest.ts
+++ b/specification/migrate/create_from/MigrateCreateFromRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { RequestBase } from '@_types/Base'
-import { MigrateReindex } from '../_types/MigrateReindex'
+import { CreateFrom } from '../_types/CreateFrom'
 
 /**
  * This API creates a destination from a source index. It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.
@@ -37,5 +37,5 @@ export interface Request extends RequestBase {
     dest: string
   }
   /** @codegen_name create_from */
-  body: MigrateReindex
+  body: CreateFrom
 }

--- a/specification/migrate/create_from/MigrateCreateFromRequest.ts
+++ b/specification/migrate/create_from/MigrateCreateFromRequest.ts
@@ -17,9 +17,8 @@
  * under the License.
  */
 
-import { MigrateReindex } from '../_types/MigrateReindex'
 import { RequestBase } from '@_types/Base'
-import { Indices } from '@_types/common'
+import { MigrateReindex } from '../_types/MigrateReindex'
 
 /**
  * This API creates a destination from a source index. It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.
@@ -33,10 +32,10 @@ import { Indices } from '@_types/common'
 export interface Request extends RequestBase {
   path_parts: {
     /** The source index or data stream name */
-    source: string,
+    source: string
     /** The destination index or data stream name */
     dest: string
-  },
+  }
   /** @codegen_name create_from */
   body: MigrateReindex
 }

--- a/specification/migrate/create_from/MigrateCreateFromResponse.ts
+++ b/specification/migrate/create_from/MigrateCreateFromResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  body: AcknowledgedResponseBase
+}

--- a/specification/migrate/create_from/MigrateCreateFromResponse.ts
+++ b/specification/migrate/create_from/MigrateCreateFromResponse.ts
@@ -17,8 +17,12 @@
  * under the License.
  */
 
-import { AcknowledgedResponseBase } from '@_types/Base'
+import { IndexName } from '@_types/common'
 
 export class Response {
-  body: AcknowledgedResponseBase
+  body: {
+    acknowledged: boolean
+    index: IndexName
+    shards_acknowledged: boolean
+  }
 }

--- a/specification/migrate/get_reindex_status/MigrateGetReindexStatusRequest.ts
+++ b/specification/migrate/get_reindex_status/MigrateGetReindexStatusRequest.ts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Indices } from '@_types/common'
+
+/**
+ * This API returns the status of a migration reindex attempt for a data stream or index
+ *
+ * @rest_spec_name migrate.get_reindex_status
+ * @availability stack since=8.18.0 stability=experimental
+ * @availability serverless stability=experimental visibility=private
+ * @doc_id migrate
+ * @doc_tag get_reindex_status
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /** The index or data stream name */
+    index: Indices
+  }
+}

--- a/specification/migrate/get_reindex_status/MigrateGetReindexStatusResponse.ts
+++ b/specification/migrate/get_reindex_status/MigrateGetReindexStatusResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  body: AcknowledgedResponseBase
+}

--- a/specification/migrate/reindex/MigrateReindexRequest.ts
+++ b/specification/migrate/reindex/MigrateReindexRequest.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { MigrateReindex } from '../_types/MigrateReindex'
+import { RequestBase } from '@_types/Base'
+import { Indices } from '@_types/common'
+
+/**
+ * "This API reindexes all legacy backing indices for a data stream. It does this in a persistent task. The persistent task id is returned immediately, and the reindexing work is completed in that task
+ *
+ * @rest_spec_name migrate.reindex
+ * @availability stack since=8.18.0 stability=experimental
+ * @doc_id migrate
+ * @doc_tag reindex
+ */
+export interface Request extends RequestBase {
+  /** @codegen_name reindex */
+  body: MigrateReindex
+}

--- a/specification/migrate/reindex/MigrateReindexRequest.ts
+++ b/specification/migrate/reindex/MigrateReindexRequest.ts
@@ -17,9 +17,8 @@
  * under the License.
  */
 
-import { MigrateReindex } from '../_types/MigrateReindex'
 import { RequestBase } from '@_types/Base'
-import { Indices } from '@_types/common'
+import { MigrateReindex } from '../_types/MigrateReindex'
 
 /**
  * "This API reindexes all legacy backing indices for a data stream. It does this in a persistent task. The persistent task id is returned immediately, and the reindexing work is completed in that task

--- a/specification/migrate/reindex/MigrateReindexResponse.ts
+++ b/specification/migrate/reindex/MigrateReindexResponse.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  body: AcknowledgedResponseBase
+}


### PR DESCRIPTION
This adds elasticsearch-specification code for the new data stream reindex API. Specifically:

- `/_migration/reindex`
- `/_migration/reindex/{index}/_status`
- `/_migration/reindex/{index}/_cancel`
- `/_create_from/{source}/{dest}`