### PR TITLE
Fix Markdown header syntax

### DIFF
--- a/specification/_global/create/CreateRequest.ts
+++ b/specification/_global/create/CreateRequest.ts
@@ -75,7 +75,7 @@ import { Duration } from '@_types/Time'
  *
  * NOTE: Data streams do not support custom routing unless they were created with the `allow_custom_routing` setting enabled in the template.
  *
- * ** Distributed**
+ * **Distributed**
  *
  * The index operation is directed to the primary shard based on its route and performed on the actual node containing this shard.
  * After the primary shard completes the operation, if needed, the update is distributed to applicable replicas.

--- a/specification/_global/index/IndexRequest.ts
+++ b/specification/_global/index/IndexRequest.ts
@@ -87,7 +87,7 @@ import { Duration } from '@_types/Time'
  *
  * NOTE: Data streams do not support custom routing unless they were created with the `allow_custom_routing` setting enabled in the template.
  *
- *  * ** Distributed**
+ * **Distributed**
  *
  * The index operation is directed to the primary shard based on its route and performed on the actual node containing this shard.
  * After the primary shard completes the operation, if needed, the update is distributed to applicable replicas.

--- a/specification/_global/reindex/ReindexRequest.ts
+++ b/specification/_global/reindex/ReindexRequest.ts
@@ -96,7 +96,7 @@ import { Destination, Source } from './types'
  * done
  * ```
  *
- * ** Throttling**
+ * **Throttling**
  *
  * Set `requests_per_second` to any positive decimal number (`1.4`, `6`, `1000`, for example) to throttle the rate at which reindex issues batches of index operations.
  * Requests are throttled by padding each batch with a wait time.


### PR DESCRIPTION
I noticed that when finally implementing Markdown in my client.