### PR TITLE
Add rescore_vector to knn query, knn section and knn retriever

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2510,6 +2510,7 @@ export interface KnnRetriever extends RetrieverBase {
   k: integer
   num_candidates: integer
   similarity?: float
+  rescore_vector?: RescoreVector
 }
 
 export interface KnnSearch {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2500,6 +2500,7 @@ export interface KnnQuery extends QueryDslQueryBase {
   k?: integer
   filter?: QueryDslQueryContainer | QueryDslQueryContainer[]
   similarity?: float
+  rescore_vector?: RescoreVector
 }
 
 export interface KnnRetriever extends RetrieverBase {
@@ -2521,6 +2522,7 @@ export interface KnnSearch {
   filter?: QueryDslQueryContainer | QueryDslQueryContainer[]
   similarity?: float
   inner_hits?: SearchInnerHits
+  rescore_vector?: RescoreVector
 }
 
 export interface LatLonGeoLocation {
@@ -2699,6 +2701,10 @@ export interface RequestCacheStats {
   memory_size?: string
   memory_size_in_bytes: long
   miss_count: long
+}
+
+export interface RescoreVector {
+  oversample: float
 }
 
 export type Result = 'created' | 'updated' | 'deleted' | 'not_found' | 'noop'

--- a/specification/_types/Knn.ts
+++ b/specification/_types/Knn.ts
@@ -27,6 +27,11 @@ export type QueryVector = float[]
 /* KnnSearch (used in kNN search) and KnnQuery (ued in kNN queries) are close
  * but different enough to require different classes */
 
+export interface RescoreVector {
+  /** Applies the specified oversample factor to k on the approximate kNN search */
+  oversample: float
+}
+
 export interface KnnSearch {
   /** The name of the vector field to search against */
   field: Field
@@ -49,6 +54,8 @@ export interface KnnSearch {
    * @doc_id knn-inner-hits
    */
   inner_hits?: InnerHits
+  /** Apply oversampling and rescoring to quantized vectors */
+  rescore_vector?: RescoreVector
 }
 
 /**
@@ -69,6 +76,8 @@ export interface KnnQuery extends QueryBase {
   filter?: QueryContainer | QueryContainer[]
   /** The minimum similarity for a vector to be considered a match */
   similarity?: float
+  /** Apply oversampling and rescoring to quantized vectors */
+  rescore_vector?: RescoreVector
 }
 
 /** @variants container */

--- a/specification/_types/Retriever.ts
+++ b/specification/_types/Retriever.ts
@@ -19,7 +19,7 @@
 
 import { FieldCollapse } from '@global/search/_types/FieldCollapse'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { QueryVector, QueryVectorBuilder } from '@_types/Knn'
+import {QueryVector, QueryVectorBuilder, RescoreVector} from '@_types/Knn'
 import { float, integer } from '@_types/Numeric'
 import { Sort, SortResults } from '@_types/sort'
 import { Id } from './common'
@@ -74,6 +74,8 @@ export class KnnRetriever extends RetrieverBase {
   num_candidates: integer
   /** The minimum similarity required for a document to be considered a match.  */
   similarity?: float
+  /** Apply oversampling and rescoring to quantized vectors */
+  rescore_vector?: RescoreVector
 }
 
 export class RRFRetriever extends RetrieverBase {


### PR DESCRIPTION
Adds `rescore_vector` to knn query, knn search and knn query, introduced in  https://github.com/elastic/elasticsearch/pull/119835
