### PR TITLE
[8.x] Add rescore_vector to knn query, knn section and knn retriever (#3553)

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2491,6 +2491,7 @@ export interface KnnQuery extends QueryDslQueryBase {
   k?: integer
   filter?: QueryDslQueryContainer | QueryDslQueryContainer[]
   similarity?: float
+  rescore_vector?: RescoreVector
 }
 
 export interface KnnRetriever extends RetrieverBase {
@@ -2500,6 +2501,7 @@ export interface KnnRetriever extends RetrieverBase {
   k: integer
   num_candidates: integer
   similarity?: float
+  rescore_vector?: RescoreVector
 }
 
 export interface KnnSearch {
@@ -2512,6 +2514,7 @@ export interface KnnSearch {
   filter?: QueryDslQueryContainer | QueryDslQueryContainer[]
   similarity?: float
   inner_hits?: SearchInnerHits
+  rescore_vector?: RescoreVector
 }
 
 export interface LatLonGeoLocation {
@@ -2690,6 +2693,10 @@ export interface RequestCacheStats {
   memory_size?: string
   memory_size_in_bytes: long
   miss_count: long
+}
+
+export interface RescoreVector {
+  oversample: float
 }
 
 export type Result = 'created' | 'updated' | 'deleted' | 'not_found' | 'noop'

--- a/specification/_types/Knn.ts
+++ b/specification/_types/Knn.ts
@@ -27,6 +27,11 @@ export type QueryVector = float[]
 /* KnnSearch (used in kNN search) and KnnQuery (ued in kNN queries) are close
  * but different enough to require different classes */
 
+export interface RescoreVector {
+  /** Applies the specified oversample factor to k on the approximate kNN search */
+  oversample: float
+}
+
 export interface KnnSearch {
   /** The name of the vector field to search against */
   field: Field
@@ -49,6 +54,8 @@ export interface KnnSearch {
    * @doc_id knn-inner-hits
    */
   inner_hits?: InnerHits
+  /** Apply oversampling and rescoring to quantized vectors */
+  rescore_vector?: RescoreVector
 }
 
 /**
@@ -69,6 +76,8 @@ export interface KnnQuery extends QueryBase {
   filter?: QueryContainer | QueryContainer[]
   /** The minimum similarity for a vector to be considered a match */
   similarity?: float
+  /** Apply oversampling and rescoring to quantized vectors */
+  rescore_vector?: RescoreVector
 }
 
 /** @variants container */

--- a/specification/_types/Retriever.ts
+++ b/specification/_types/Retriever.ts
@@ -19,7 +19,7 @@
 
 import { FieldCollapse } from '@global/search/_types/FieldCollapse'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
-import { QueryVector, QueryVectorBuilder } from '@_types/Knn'
+import { QueryVector, QueryVectorBuilder, RescoreVector } from '@_types/Knn'
 import { float, integer } from '@_types/Numeric'
 import { Sort, SortResults } from '@_types/sort'
 import { Id } from './common'
@@ -74,6 +74,8 @@ export class KnnRetriever extends RetrieverBase {
   num_candidates: integer
   /** The minimum similarity required for a document to be considered a match.  */
   similarity?: float
+  /** Apply oversampling and rescoring to quantized vectors */
+  rescore_vector?: RescoreVector
 }
 
 export class RRFRetriever extends RetrieverBase {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add rescore_vector to knn query, knn section and knn retriever (#3553)](https://github.com/elastic/elasticsearch-specification/pull/3553)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)