### PR TITLE
[8.17] Add cat response examples (#3419)

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -1360,6 +1360,293 @@ actions:
           examples:
             getBehavioralAnalyticsCollectionsResponseExample1:
               $ref: "../../specification/search_application/get_behavioral_analytics/examples/200_response/BehavioralAnalyticsGetResponseExample1.yaml"
+## Examples for cat
+  - target: "$.components['responses']['cat.aliases#200']"
+    description: "Add example for cat aliases response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catAliasesResponseExample1:
+              $ref: "../../specification/cat/aliases/examples/200_response/CatAliasesResponseExample1.yaml"
+  - target: "$.components['responses']['cat.allocation#200']"
+    description: "Add example for cat allocation response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catAllocationResponseExample1:
+              $ref: "../../specification/cat/allocation/examples/200_response/CatAllocationResponseExample1.yaml"
+  - target: "$.components['responses']['cat.component_templates#200']"
+    description: "Add example for cat component templates response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catComponentTemplatesResponseExample1:
+              $ref: "../../specification/cat/component_templates/examples/200_response/CatComponentTemplatesResponseExample1.yaml"
+  - target: "$.components['responses']['cat.count#200']"
+    description: "Add example for cat count response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catCountResponseExample1:
+              $ref: "../../specification/cat/count/examples/200_response/CatCountResponseExample1.yaml"
+            catCountResponseExample2:
+              $ref: "../../specification/cat/count/examples/200_response/CatCountResponseExample2.yaml" 
+  - target: "$.components['responses']['cat.fielddata#200']"
+    description: "Add example for cat fielddata response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catFieldDataResponseExample1:
+              $ref: "../../specification/cat/fielddata/examples/200_response/CatFielddataResponseExample1.yaml"
+            catFieldDataResponseExample2:
+              $ref: "../../specification/cat/fielddata/examples/200_response/CatFielddataResponseExample2.yaml" 
+  - target: "$.components['responses']['cat.indices#200']"
+    description: "Add example for cat indices response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catIndicesResponseExample1:
+              $ref: "../../specification/cat/indices/examples/200_response/CatIndicesResponseExample1.yaml" 
+  - target: "$.components['responses']['cat.ml_datafeeds#200']"
+    description: "Add example for cat datafeeds response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catDatafeedsResponseExample1:
+              $ref: "../../specification/cat/ml_datafeeds/examples/200_response/CatDatafeedsResponseExample1.yaml"
+  - target: "$.components['responses']['cat.ml_data_frame_analytics#200']"
+    description: "Add example for cat data frame analytics response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catDataFrameAnalyticsResponseExample1:
+              $ref: "../../specification/cat/ml_data_frame_analytics/examples/200_response/CatDataFrameAnalyticsResponseExample1.yaml" 
+  - target: "$.components['responses']['cat.ml_jobs#200']"
+    description: "Add example for cat anomaly detectors response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catAnomalyDetectorsResponseExample1:
+              $ref: "../../specification/cat/ml_jobs/examples/200_response/CatJobsResponseExample1.yaml"
+  - target: "$.components['responses']['cat.ml_trained_models#200']"
+    description: "Add example for cat trained models response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catTrainedModelsResponseExample1:
+              $ref: "../../specification/cat/ml_trained_models/examples/200_response/CatTrainedModelsResponseExample1.yaml"
+  - target: "$.components['responses']['cat.recovery#200']"
+    description: "Add example for cat recovery response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catRecoveryResponseExample1:
+              $ref: "../../specification/cat/recovery/examples/200_response/CatRecoveryResponseExample1.yaml"
+            catRecoveryResponseExample2:
+              $ref: "../../specification/cat/recovery/examples/200_response/CatRecoveryResponseExample2.yaml"
+            catRecoveryResponseExample3:
+              $ref: "../../specification/cat/recovery/examples/200_response/CatRecoveryResponseExample3.yaml"
+  - target: "$.components['responses']['cat.segments#200']"
+    description: "Add example for cat segments response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catSegmentsResponseExample1:
+              $ref: "../../specification/cat/segments/examples/200_response/CatSegmentsResponseExample1.yaml"
+  - target: "$.components['responses']['cat.shards#200']"
+    description: "Add example for cat shards response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catShardsResponseExample1:
+              $ref: "../../specification/cat/shards/examples/200_response/CatShardsResponseExample1.yaml"
+            catShardsResponseExample2:
+              $ref: "../../specification/cat/shards/examples/200_response/CatShardsResponseExample2.yaml"
+            catShardsResponseExample3:
+              $ref: "../../specification/cat/shards/examples/200_response/CatShardsResponseExample3.yaml"
+            catShardsResponseExample4:
+              $ref: "../../specification/cat/shards/examples/200_response/CatShardsResponseExample4.yaml"
+            catShardsResponseExample5:
+              $ref: "../../specification/cat/shards/examples/200_response/CatShardsResponseExample5.yaml"
+  - target: "$.components['responses']['cat.snapshots#200']"
+    description: "Add example for cat snapshot response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catSnapshotsResponseExample1:
+              $ref: "../../specification/cat/snapshots/examples/200_response/CatSnapshotsResponseExample1.yaml"
+  - target: "$.components['responses']['cat.templates#200']"
+    description: "Add example for cat templates response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catTemplatesResponseExample1:
+              $ref: "../../specification/cat/templates/examples/200_response/CatTemplatesResponseExample1.yaml"
+  - target: "$.components['responses']['cat.thread_pool#200']"
+    description: "Add example for cat thread pool response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catThreadPoolResponseExample1:
+              $ref: "../../specification/cat/thread_pool/examples/200_response/CatThreadPoolResponseExample1.yaml"
+            catThreadPoolResponseExample2:
+              $ref: "../../specification/cat/thread_pool/examples/200_response/CatThreadPoolResponseExample2.yaml"
+  - target: "$.components['responses']['cat.transforms#200']"
+    description: "Add example for cat transforms response"
+    update: 
+      content:
+        application/json:
+          examples:
+            catTransformsResponseExample1:
+              $ref: "../../specification/cat/transforms/examples/200_response/CatTransformsResponseExample1.yaml"
+  - target: "$.paths['/_cat/health']['get']"
+    description: "Add examples for cat health operation"
+    update: 
+      responses:
+        200: 
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                catMasterResponseExample1: 
+                  $ref: "../../specification/cat/health/examples/200_response/CatHealthResponseExample1.yaml"
+  - target: "$.paths['/_cat/master']['get']"
+    description: "Add examples for cat master operation"
+    update: 
+      responses:
+        200: 
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                catMasterResponseExample1: 
+                  $ref: "../../specification/cat/master/examples/200_response/CatMasterResponseExample1.yaml"
+  - target: "$.paths['/_cat/nodeattrs']['get']"
+    description: "Add examples for cat node attributes operation"
+    update: 
+      responses:
+        200: 
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                catNodeAttributesResponseExample1: 
+                  $ref: "../../specification/cat/nodeattrs/examples/200_response/CatNodeAttributesResponseExample1.yaml"
+                catNodeAttributesResponseExample2: 
+                  $ref: "../../specification/cat/nodeattrs/examples/200_response/CatNodeAttributesResponseExample2.yaml"
+  - target: "$.paths['/_cat/nodes']['get']"
+    description: "Add examples for cat nodes operation"
+    update: 
+      responses:
+        200: 
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                catNodesResponseExample1: 
+                  $ref: "../../specification/cat/nodes/examples/200_response/CatNodesResponseExample1.yaml"
+                catNodesResponseExample2: 
+                  $ref: "../../specification/cat/nodes/examples/200_response/CatNodesResponseExample2.yaml"
+  - target: "$.paths['/_cat/pending_tasks']['get']"
+    description: "Add examples for cat pending tasks operation"
+    update: 
+      responses:
+        200: 
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                catPendingTasksResponseExample1: 
+                  $ref: "../../specification/cat/pending_tasks/examples/200_response/CatPendingTasksResponseExample1.yaml"
+  - target: "$.paths['/_cat/plugins']['get']"
+    description: "Add examples for cat plugins operation"
+    update: 
+      responses:
+        200: 
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                catPluginsResponseExample1: 
+                  $ref: "../../specification/cat/plugins/examples/200_response/CatPluginsResponseExample1.yaml"
+  - target: "$.paths['/_cat/repositories']['get']"
+    description: "Add examples for cat repositories operation"
+    update: 
+      responses:
+        200: 
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                catRepositoriesResponseExample1: 
+                  $ref: "../../specification/cat/repositories/examples/200_response/CatRepositoriesResponseExample1.yaml"
+  - target: "$.paths['/_cat/tasks']['get']"
+    description: "Add examples for cat tasks operation"
+    update: 
+      responses:
+        200: 
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                catTasksResponseExample1: 
+                  $ref: "../../specification/cat/tasks/examples/200_response/CatTasksResponseExample1.yaml"
 ## Examples for licensing
   - target: "$.paths['/_license']['get']"
     description: "Add example for get license response"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -900,7 +900,7 @@
           "cat"
         ],
         "summary": "Get aliases",
-        "description": "Retrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
+        "description": "Get the cluster's index aliases, including filter and routing information.\nThis API does not return data stream aliases.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
         "operationId": "cat-aliases",
         "parameters": [
           {
@@ -926,7 +926,7 @@
           "cat"
         ],
         "summary": "Get aliases",
-        "description": "Retrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
+        "description": "Get the cluster's index aliases, including filter and routing information.\nThis API does not return data stream aliases.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
         "operationId": "cat-aliases-1",
         "parameters": [
           {
@@ -954,8 +954,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Provides a snapshot of the number of shards allocated to each data node and their disk space",
-        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.",
+        "summary": "Get shard allocation information",
+        "description": "Get a snapshot of the number of shards allocated to each data node and their disk space.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.",
         "operationId": "cat-allocation",
         "parameters": [
           {
@@ -980,8 +980,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Provides a snapshot of the number of shards allocated to each data node and their disk space",
-        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.",
+        "summary": "Get shard allocation information",
+        "description": "Get a snapshot of the number of shards allocated to each data node and their disk space.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.",
         "operationId": "cat-allocation-1",
         "parameters": [
           {
@@ -1010,7 +1010,7 @@
           "cat"
         ],
         "summary": "Get component templates",
-        "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
+        "description": "Get information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "operationId": "cat-component-templates",
         "parameters": [
           {
@@ -1034,7 +1034,7 @@
           "cat"
         ],
         "summary": "Get component templates",
-        "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
+        "description": "Get information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "operationId": "cat-component-templates-1",
         "parameters": [
           {
@@ -1061,7 +1061,7 @@
           "cat"
         ],
         "summary": "Get a document count",
-        "description": "Provides quick access to a document count for a data stream, an index, or an entire cluster.\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
+        "description": "Get quick access to a document count for a data stream, an index, or an entire cluster.\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
         "operationId": "cat-count",
         "responses": {
           "200": {
@@ -1076,7 +1076,7 @@
           "cat"
         ],
         "summary": "Get a document count",
-        "description": "Provides quick access to a document count for a data stream, an index, or an entire cluster.\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
+        "description": "Get quick access to a document count for a data stream, an index, or an entire cluster.\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
         "operationId": "cat-count-1",
         "parameters": [
           {
@@ -1095,8 +1095,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns the amount of heap memory currently used by the field data cache on every data node in the cluster",
-        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the nodes stats API.",
+        "summary": "Get field data cache information",
+        "description": "Get the amount of heap memory currently used by the field data cache on every data node in the cluster.\n\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the nodes stats API.",
         "operationId": "cat-fielddata",
         "parameters": [
           {
@@ -1118,8 +1118,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns the amount of heap memory currently used by the field data cache on every data node in the cluster",
-        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the nodes stats API.",
+        "summary": "Get field data cache information",
+        "description": "Get the amount of heap memory currently used by the field data cache on every data node in the cluster.\n\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the nodes stats API.",
         "operationId": "cat-fielddata-1",
         "parameters": [
           {
@@ -1144,8 +1144,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns the health status of a cluster, similar to the cluster health API",
-        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the cluster health API.\nThis API is often used to check malfunctioning clusters.\nTo help you track cluster health alongside log files and alerting systems, the API returns timestamps in two formats:\n`HH:MM:SS`, which is human-readable but includes no date information;\n`Unix epoch time`, which is machine-sortable and includes date information.\nThe latter format is useful for cluster recoveries that take multiple days.\nYou can use the cat health API to verify cluster health across multiple nodes.\nYou also can use the API to track the recovery of a large cluster over a longer period of time.",
+        "summary": "Get the cluster health status",
+        "description": "IMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the cluster health API.\nThis API is often used to check malfunctioning clusters.\nTo help you track cluster health alongside log files and alerting systems, the API returns timestamps in two formats:\n`HH:MM:SS`, which is human-readable but includes no date information;\n`Unix epoch time`, which is machine-sortable and includes date information.\nThe latter format is useful for cluster recoveries that take multiple days.\nYou can use the cat health API to verify cluster health across multiple nodes.\nYou also can use the API to track the recovery of a large cluster over a longer period of time.",
         "operationId": "cat-health",
         "parameters": [
           {
@@ -1192,7 +1192,7 @@
           "cat"
         ],
         "summary": "Get CAT help",
-        "description": "Returns help for the CAT APIs.",
+        "description": "Get help for the CAT APIs.",
         "operationId": "cat-help",
         "responses": {
           "200": {
@@ -1214,7 +1214,7 @@
           "cat"
         ],
         "summary": "Get index information",
-        "description": "Returns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
+        "description": "Get high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
         "operationId": "cat-indices",
         "parameters": [
           {
@@ -1252,7 +1252,7 @@
           "cat"
         ],
         "summary": "Get index information",
-        "description": "Returns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
+        "description": "Get high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
         "operationId": "cat-indices-1",
         "parameters": [
           {
@@ -1292,8 +1292,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns information about the master node, including the ID, bound IP address, and name",
-        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
+        "summary": "Get master node information",
+        "description": "Get information about the master node, including the ID, bound IP address, and name.\n\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-master",
         "parameters": [
           {
@@ -1340,7 +1340,7 @@
           "cat"
         ],
         "summary": "Get data frame analytics jobs",
-        "description": "Returns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
+        "description": "Get configuration and usage information about data frame analytics jobs.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
         "operationId": "cat-ml-data-frame-analytics",
         "parameters": [
           {
@@ -1373,7 +1373,7 @@
           "cat"
         ],
         "summary": "Get data frame analytics jobs",
-        "description": "Returns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
+        "description": "Get configuration and usage information about data frame analytics jobs.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
         "operationId": "cat-ml-data-frame-analytics-1",
         "parameters": [
           {
@@ -1409,7 +1409,7 @@
           "cat"
         ],
         "summary": "Get datafeeds",
-        "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
+        "description": "Get configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
         "operationId": "cat-ml-datafeeds",
         "parameters": [
           {
@@ -1439,7 +1439,7 @@
           "cat"
         ],
         "summary": "Get datafeeds",
-        "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
+        "description": "Get configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
         "operationId": "cat-ml-datafeeds-1",
         "parameters": [
           {
@@ -1472,7 +1472,7 @@
           "cat"
         ],
         "summary": "Get anomaly detection jobs",
-        "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
+        "description": "Get configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
         "operationId": "cat-ml-jobs",
         "parameters": [
           {
@@ -1505,7 +1505,7 @@
           "cat"
         ],
         "summary": "Get anomaly detection jobs",
-        "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
+        "description": "Get configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
         "operationId": "cat-ml-jobs-1",
         "parameters": [
           {
@@ -1541,7 +1541,7 @@
           "cat"
         ],
         "summary": "Get trained models",
-        "description": "Returns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
+        "description": "Get configuration and usage information about inference trained models.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
         "operationId": "cat-ml-trained-models",
         "parameters": [
           {
@@ -1580,7 +1580,7 @@
           "cat"
         ],
         "summary": "Get trained models",
-        "description": "Returns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
+        "description": "Get configuration and usage information about inference trained models.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
         "operationId": "cat-ml-trained-models-1",
         "parameters": [
           {
@@ -1621,8 +1621,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns information about custom node attributes",
-        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
+        "summary": "Get node attribute information",
+        "description": "Get information about custom node attributes.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-nodeattrs",
         "parameters": [
           {
@@ -1668,8 +1668,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns information about the nodes in a cluster",
-        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
+        "summary": "Get node information",
+        "description": "Get information about the nodes in a cluster.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-nodes",
         "parameters": [
           {
@@ -1752,8 +1752,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns cluster-level changes that have not yet been executed",
-        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the pending cluster tasks API.",
+        "summary": "Get pending task information",
+        "description": "Get information about cluster-level changes that have not yet taken effect.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the pending cluster tasks API.",
         "operationId": "cat-pending-tasks",
         "parameters": [
           {
@@ -1809,8 +1809,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns a list of plugins running on each node of a cluster",
-        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
+        "summary": "Get plugin information",
+        "description": "Get a list of plugins running on each node of a cluster.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-plugins",
         "parameters": [
           {
@@ -1866,8 +1866,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns information about ongoing and completed shard recoveries",
-        "description": "Shard recovery is the process of initializing a shard copy, such as restoring a primary shard from a snapshot or syncing a replica shard from a primary shard. When a shard recovery completes, the recovered shard is available for search and indexing.\nFor data streams, the API returns information about the stream’s backing indices.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index recovery API.",
+        "summary": "Get shard recovery information",
+        "description": "Get information about ongoing and completed shard recoveries.\nShard recovery is the process of initializing a shard copy, such as restoring a primary shard from a snapshot or syncing a replica shard from a primary shard. When a shard recovery completes, the recovered shard is available for search and indexing.\nFor data streams, the API returns information about the stream’s backing indices.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index recovery API.",
         "operationId": "cat-recovery",
         "parameters": [
           {
@@ -1895,8 +1895,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns information about ongoing and completed shard recoveries",
-        "description": "Shard recovery is the process of initializing a shard copy, such as restoring a primary shard from a snapshot or syncing a replica shard from a primary shard. When a shard recovery completes, the recovered shard is available for search and indexing.\nFor data streams, the API returns information about the stream’s backing indices.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index recovery API.",
+        "summary": "Get shard recovery information",
+        "description": "Get information about ongoing and completed shard recoveries.\nShard recovery is the process of initializing a shard copy, such as restoring a primary shard from a snapshot or syncing a replica shard from a primary shard. When a shard recovery completes, the recovered shard is available for search and indexing.\nFor data streams, the API returns information about the stream’s backing indices.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index recovery API.",
         "operationId": "cat-recovery-1",
         "parameters": [
           {
@@ -1927,8 +1927,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns the snapshot repositories for a cluster",
-        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot repository API.",
+        "summary": "Get snapshot repository information",
+        "description": "Get a list of snapshot repositories for a cluster.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot repository API.",
         "operationId": "cat-repositories",
         "parameters": [
           {
@@ -1975,8 +1975,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns low-level information about the Lucene segments in index shards",
-        "description": "For data streams, the API returns information about the backing indices.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index segments API.",
+        "summary": "Get segment information",
+        "description": "Get low-level information about the Lucene segments in index shards.\nFor data streams, the API returns information about the backing indices.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index segments API.",
         "operationId": "cat-segments",
         "parameters": [
           {
@@ -2001,8 +2001,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns low-level information about the Lucene segments in index shards",
-        "description": "For data streams, the API returns information about the backing indices.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index segments API.",
+        "summary": "Get segment information",
+        "description": "Get low-level information about the Lucene segments in index shards.\nFor data streams, the API returns information about the backing indices.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index segments API.",
         "operationId": "cat-segments-1",
         "parameters": [
           {
@@ -2030,8 +2030,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns information about the shards in a cluster",
-        "description": "For data streams, the API returns information about the backing indices.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.",
+        "summary": "Get shard information",
+        "description": "Get information about the shards in a cluster.\nFor data streams, the API returns information about the backing indices.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.",
         "operationId": "cat-shards",
         "parameters": [
           {
@@ -2056,8 +2056,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns information about the shards in a cluster",
-        "description": "For data streams, the API returns information about the backing indices.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.",
+        "summary": "Get shard information",
+        "description": "Get information about the shards in a cluster.\nFor data streams, the API returns information about the backing indices.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.",
         "operationId": "cat-shards-1",
         "parameters": [
           {
@@ -2085,8 +2085,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns information about the snapshots stored in one or more repositories",
-        "description": "A snapshot is a backup of an index or running Elasticsearch cluster.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot API.",
+        "summary": "Get snapshot information",
+        "description": "Get information about the snapshots stored in one or more repositories.\nA snapshot is a backup of an index or running Elasticsearch cluster.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot API.",
         "operationId": "cat-snapshots",
         "parameters": [
           {
@@ -2112,8 +2112,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns information about the snapshots stored in one or more repositories",
-        "description": "A snapshot is a backup of an index or running Elasticsearch cluster.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot API.",
+        "summary": "Get snapshot information",
+        "description": "Get information about the snapshots stored in one or more repositories.\nA snapshot is a backup of an index or running Elasticsearch cluster.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot API.",
         "operationId": "cat-snapshots-1",
         "parameters": [
           {
@@ -2142,8 +2142,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns information about tasks currently executing in the cluster",
-        "description": "IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the task management API.",
+        "summary": "Get task information",
+        "description": "Get information about tasks currently running in the cluster.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the task management API.",
         "operationId": "cat-tasks",
         "parameters": [
           {
@@ -2246,8 +2246,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns information about index templates in a cluster",
-        "description": "You can use index templates to apply index settings and field mappings to new indices at creation.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index template API.",
+        "summary": "Get index template information",
+        "description": "Get information about the index templates in a cluster.\nYou can use index templates to apply index settings and field mappings to new indices at creation.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index template API.",
         "operationId": "cat-templates",
         "parameters": [
           {
@@ -2270,8 +2270,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns information about index templates in a cluster",
-        "description": "You can use index templates to apply index settings and field mappings to new indices at creation.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index template API.",
+        "summary": "Get index template information",
+        "description": "Get information about the index templates in a cluster.\nYou can use index templates to apply index settings and field mappings to new indices at creation.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index template API.",
         "operationId": "cat-templates-1",
         "parameters": [
           {
@@ -2297,8 +2297,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns thread pool statistics for each node in a cluster",
-        "description": "Returned information includes all built-in thread pools and custom thread pools.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
+        "summary": "Get thread pool statistics",
+        "description": "Get thread pool statistics for each node in a cluster.\nReturned information includes all built-in thread pools and custom thread pools.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-thread-pool",
         "parameters": [
           {
@@ -2323,8 +2323,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Returns thread pool statistics for each node in a cluster",
-        "description": "Returned information includes all built-in thread pools and custom thread pools.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
+        "summary": "Get thread pool statistics",
+        "description": "Get thread pool statistics for each node in a cluster.\nReturned information includes all built-in thread pools and custom thread pools.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-thread-pool-1",
         "parameters": [
           {
@@ -2352,8 +2352,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Get transforms",
-        "description": "Returns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
+        "summary": "Get transform information",
+        "description": "Get configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
         "operationId": "cat-transforms",
         "parameters": [
           {
@@ -2388,8 +2388,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Get transforms",
-        "description": "Returns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
+        "summary": "Get transform information",
+        "description": "Get configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
         "operationId": "cat-transforms-1",
         "parameters": [
           {
@@ -97402,7 +97402,7 @@
       "cat.aliases#expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
-        "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
+        "description": "The type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nIt supports comma-separated values, such as `open,hidden`.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -97422,7 +97422,7 @@
       "cat.aliases#master_timeout": {
         "in": "query",
         "name": "master_timeout",
-        "description": "Period to wait for a connection to the master node.",
+        "description": "The period to wait for a connection to the master node.\nIf the master node is not available before the timeout expires, the request fails and returns an error.\nTo indicated that the request should never timeout, you can set it to `-1`.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -97432,7 +97432,7 @@
       "cat.allocation#node_id": {
         "in": "path",
         "name": "node_id",
-        "description": "Comma-separated list of node identifiers or names used to limit the returned information.",
+        "description": "A comma-separated list of node identifiers or names used to limit the returned information.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -97473,7 +97473,7 @@
       "cat.component_templates#name": {
         "in": "path",
         "name": "name",
-        "description": "The name of the component template. Accepts wildcard expressions. If omitted, all component templates are returned.",
+        "description": "The name of the component template.\nIt accepts wildcard expressions.\nIf it is omitted, all component templates are returned.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -97494,7 +97494,7 @@
       "cat.component_templates#master_timeout": {
         "in": "query",
         "name": "master_timeout",
-        "description": "Period to wait for a connection to the master node.",
+        "description": "The period to wait for a connection to the master node.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -97504,7 +97504,7 @@
       "cat.count#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices, and aliases used to limit the request.\nSupports wildcards (`*`). To target all data streams and indices, omit this parameter or use `*` or `_all`.",
+        "description": "A comma-separated list of data streams, indices, and aliases used to limit the request.\nIt supports wildcards (`*`).\nTo target all data streams and indices, omit this parameter or use `*` or `_all`.",
         "required": true,
         "deprecated": false,
         "schema": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -678,7 +678,7 @@
           "cat"
         ],
         "summary": "Get aliases",
-        "description": "Retrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
+        "description": "Get the cluster's index aliases, including filter and routing information.\nThis API does not return data stream aliases.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
         "operationId": "cat-aliases",
         "parameters": [
           {
@@ -704,7 +704,7 @@
           "cat"
         ],
         "summary": "Get aliases",
-        "description": "Retrieves the cluster’s index aliases, including filter and routing information.\nThe API does not return data stream aliases.\n\nCAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
+        "description": "Get the cluster's index aliases, including filter and routing information.\nThis API does not return data stream aliases.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.",
         "operationId": "cat-aliases-1",
         "parameters": [
           {
@@ -733,7 +733,7 @@
           "cat"
         ],
         "summary": "Get component templates",
-        "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
+        "description": "Get information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "operationId": "cat-component-templates",
         "parameters": [
           {
@@ -757,7 +757,7 @@
           "cat"
         ],
         "summary": "Get component templates",
-        "description": "Returns information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
+        "description": "Get information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "operationId": "cat-component-templates-1",
         "parameters": [
           {
@@ -784,7 +784,7 @@
           "cat"
         ],
         "summary": "Get a document count",
-        "description": "Provides quick access to a document count for a data stream, an index, or an entire cluster.\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
+        "description": "Get quick access to a document count for a data stream, an index, or an entire cluster.\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
         "operationId": "cat-count",
         "responses": {
           "200": {
@@ -799,7 +799,7 @@
           "cat"
         ],
         "summary": "Get a document count",
-        "description": "Provides quick access to a document count for a data stream, an index, or an entire cluster.\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
+        "description": "Get quick access to a document count for a data stream, an index, or an entire cluster.\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
         "operationId": "cat-count-1",
         "parameters": [
           {
@@ -819,7 +819,7 @@
           "cat"
         ],
         "summary": "Get CAT help",
-        "description": "Returns help for the CAT APIs.",
+        "description": "Get help for the CAT APIs.",
         "operationId": "cat-help",
         "responses": {
           "200": {
@@ -841,7 +841,7 @@
           "cat"
         ],
         "summary": "Get index information",
-        "description": "Returns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
+        "description": "Get high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
         "operationId": "cat-indices",
         "parameters": [
           {
@@ -879,7 +879,7 @@
           "cat"
         ],
         "summary": "Get index information",
-        "description": "Returns high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
+        "description": "Get high-level information about indices in a cluster, including backing indices for data streams.\n\nUse this request to get the following information for each index in a cluster:\n- shard count\n- document count\n- deleted document count\n- primary store size\n- total store size of all shards, including shard replicas\n\nThese metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.\nTo get an accurate count of Elasticsearch documents, use the cat count or count APIs.\n\nCAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use an index endpoint.",
         "operationId": "cat-indices-1",
         "parameters": [
           {
@@ -920,7 +920,7 @@
           "cat"
         ],
         "summary": "Get data frame analytics jobs",
-        "description": "Returns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
+        "description": "Get configuration and usage information about data frame analytics jobs.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
         "operationId": "cat-ml-data-frame-analytics",
         "parameters": [
           {
@@ -953,7 +953,7 @@
           "cat"
         ],
         "summary": "Get data frame analytics jobs",
-        "description": "Returns configuration and usage information about data frame analytics jobs.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
+        "description": "Get configuration and usage information about data frame analytics jobs.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get data frame analytics jobs statistics API.",
         "operationId": "cat-ml-data-frame-analytics-1",
         "parameters": [
           {
@@ -989,7 +989,7 @@
           "cat"
         ],
         "summary": "Get datafeeds",
-        "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
+        "description": "Get configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
         "operationId": "cat-ml-datafeeds",
         "parameters": [
           {
@@ -1019,7 +1019,7 @@
           "cat"
         ],
         "summary": "Get datafeeds",
-        "description": "Returns configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
+        "description": "Get configuration and usage information about datafeeds.\nThis API returns a maximum of 10,000 datafeeds.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`\ncluster privileges to use this API.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get datafeed statistics API.",
         "operationId": "cat-ml-datafeeds-1",
         "parameters": [
           {
@@ -1052,7 +1052,7 @@
           "cat"
         ],
         "summary": "Get anomaly detection jobs",
-        "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
+        "description": "Get configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
         "operationId": "cat-ml-jobs",
         "parameters": [
           {
@@ -1085,7 +1085,7 @@
           "cat"
         ],
         "summary": "Get anomaly detection jobs",
-        "description": "Returns configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
+        "description": "Get configuration and usage information for anomaly detection jobs.\nThis API returns a maximum of 10,000 jobs.\nIf the Elasticsearch security features are enabled, you must have `monitor_ml`,\n`monitor`, `manage_ml`, or `manage` cluster privileges to use this API.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get anomaly detection job statistics API.",
         "operationId": "cat-ml-jobs-1",
         "parameters": [
           {
@@ -1121,7 +1121,7 @@
           "cat"
         ],
         "summary": "Get trained models",
-        "description": "Returns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
+        "description": "Get configuration and usage information about inference trained models.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
         "operationId": "cat-ml-trained-models",
         "parameters": [
           {
@@ -1160,7 +1160,7 @@
           "cat"
         ],
         "summary": "Get trained models",
-        "description": "Returns configuration and usage information about inference trained models.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
+        "description": "Get configuration and usage information about inference trained models.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get trained models statistics API.",
         "operationId": "cat-ml-trained-models-1",
         "parameters": [
           {
@@ -1201,8 +1201,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Get transforms",
-        "description": "Returns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
+        "summary": "Get transform information",
+        "description": "Get configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
         "operationId": "cat-transforms",
         "parameters": [
           {
@@ -1237,8 +1237,8 @@
         "tags": [
           "cat"
         ],
-        "summary": "Get transforms",
-        "description": "Returns configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
+        "summary": "Get transform information",
+        "description": "Get configuration and usage information about transforms.\n\nCAT APIs are only intended for human consumption using the Kibana\nconsole or command line. They are not intended for use by applications. For\napplication consumption, use the get transform statistics API.",
         "operationId": "cat-transforms-1",
         "parameters": [
           {
@@ -57956,7 +57956,7 @@
       "cat.aliases#expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
-        "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
+        "description": "The type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nIt supports comma-separated values, such as `open,hidden`.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -57976,7 +57976,7 @@
       "cat.aliases#master_timeout": {
         "in": "query",
         "name": "master_timeout",
-        "description": "Period to wait for a connection to the master node.",
+        "description": "The period to wait for a connection to the master node.\nIf the master node is not available before the timeout expires, the request fails and returns an error.\nTo indicated that the request should never timeout, you can set it to `-1`.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -57986,7 +57986,7 @@
       "cat.component_templates#name": {
         "in": "path",
         "name": "name",
-        "description": "The name of the component template. Accepts wildcard expressions. If omitted, all component templates are returned.",
+        "description": "The name of the component template.\nIt accepts wildcard expressions.\nIf it is omitted, all component templates are returned.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -58007,7 +58007,7 @@
       "cat.component_templates#master_timeout": {
         "in": "query",
         "name": "master_timeout",
-        "description": "Period to wait for a connection to the master node.",
+        "description": "The period to wait for a connection to the master node.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -58017,7 +58017,7 @@
       "cat.count#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices, and aliases used to limit the request.\nSupports wildcards (`*`). To target all data streams and indices, omit this parameter or use `*` or `_all`.",
+        "description": "A comma-separated list of data streams, indices, and aliases used to limit the request.\nIt supports wildcards (`*`).\nTo target all data streams and indices, omit this parameter or use `*` or `_all`.",
         "required": true,
         "deprecated": false,
         "schema": {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -28,6 +28,7 @@ calendar-and-fixed-intervals,https://www.elastic.co/guide/en/elasticsearch/refer
 cat-alias,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-alias.html
 cat-allocation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-allocation.html
 cat-anomaly-detectors,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-anomaly-detectors.html
+cat-component-templates,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-component-templates.html
 cat-count,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-count.html
 cat-datafeeds,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-datafeeds.html
 cat-dfanalytics,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-dfanalytics.html

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -212,7 +212,7 @@ export enum ExpandWildcard {
   open,
   /** Match closed, non-hidden indices. Also matches any non-hidden data stream. Data streams cannot be closed. */
   closed,
-  /** Match hidden data streams and hidden indices. Must be combined with open, closed, or both. */
+  /** Match hidden data streams and hidden indices. Must be combined with `open`, `closed`, or `both`. */
   hidden,
   /** Wildcard expressions are not accepted. */
   none

--- a/specification/cat/aliases/CatAliasesRequest.ts
+++ b/specification/cat/aliases/CatAliasesRequest.ts
@@ -23,10 +23,11 @@ import { Duration } from '@_types/Time'
 
 /**
  * Get aliases.
- * Retrieves the cluster’s index aliases, including filter and routing information.
- * The API does not return data stream aliases.
  *
- * CAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.
+ * Get the cluster's index aliases, including filter and routing information.
+ * This API does not return data stream aliases.
+ *
+ * IMPORTANT: CAT APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.
  * @rest_spec_name cat.aliases
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
@@ -39,6 +40,11 @@ export interface Request extends CatRequestBase {
     name?: Names
   }
   query_parameters: {
+    /**
+     * The type of index that wildcard patterns can match.
+     * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
+     * It supports comma-separated values, such as `open,hidden`.
+     */
     expand_wildcards?: ExpandWildcards
     /**
      * If `true`, the request computes the list of selected nodes from the
@@ -49,7 +55,9 @@ export interface Request extends CatRequestBase {
      */
     local?: boolean
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
+     * If the master node is not available before the timeout expires, the request fails and returns an error.
+     * To indicated that the request should never timeout, you can set it to `-1`.
      * @server_default 30s
      */
     master_timeout?: Duration

--- a/specification/cat/aliases/examples/200_response/CatAliasesResponseExample1.yaml
+++ b/specification/cat/aliases/examples/200_response/CatAliasesResponseExample1.yaml
@@ -1,0 +1,12 @@
+# summary:
+description: >
+  A successful response from `GET _cat/aliases?v=true`.
+  This response shows that `alias2` has configured a filter and `alias3` and `alias4` have routing configurations.
+# type: response
+# response_code: 200
+value: |-
+  alias  index filter routing.index routing.search is_write_index
+  alias1 test1 -      -            -              -
+  alias2 test1 *      -            -              -
+  alias3 test1 -      1            1              -
+  alias4 test1 -      2            1,2            -

--- a/specification/cat/allocation/CatAllocationRequest.ts
+++ b/specification/cat/allocation/CatAllocationRequest.ts
@@ -22,8 +22,11 @@ import { Bytes, NodeIds } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Provides a snapshot of the number of shards allocated to each data node and their disk space.
- * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.
+ * Get shard allocation information.
+ *
+ * Get a snapshot of the number of shards allocated to each data node and their disk space.
+ *
+ * IMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.
  * @rest_spec_name cat.allocation
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=private
@@ -32,7 +35,7 @@ import { Duration } from '@_types/Time'
  */
 export interface Request extends CatRequestBase {
   path_parts: {
-    /** Comma-separated list of node identifiers or names used to limit the returned information. */
+    /** A comma-separated list of node identifiers or names used to limit the returned information. */
     node_id?: NodeIds
   }
   query_parameters: {

--- a/specification/cat/allocation/examples/200_response/CatAllocationResponseExample1.yaml
+++ b/specification/cat/allocation/examples/200_response/CatAllocationResponseExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+description: >
+  A successful response from `GET /_cat/allocation?v=true`.
+  It shows a single shard is allocated to the one node available.
+# type: response
+# response_code: 200
+value: |-
+  shards shards.undesired write_load.forecast disk.indices.forecast disk.indices disk.used disk.avail disk.total disk.percent host      ip        node    node.role
+       1                0                 0.0                  260b         260b    47.3gb     43.4gb    100.7gb           46 127.0.0.1 127.0.0.1 CSUXak2 himrst

--- a/specification/cat/component_templates/CatComponentTemplatesRequest.ts
+++ b/specification/cat/component_templates/CatComponentTemplatesRequest.ts
@@ -22,19 +22,24 @@ import { Duration } from '@_types/Time'
 
 /**
  * Get component templates.
- * Returns information about component templates in a cluster.
+ *
+ * Get information about component templates in a cluster.
  * Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.
  *
- * CAT APIs are only intended for human consumption using the command line or Kibana console.
+ * IMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.
  * They are not intended for use by applications. For application consumption, use the get component template API.
  * @rest_spec_name cat.component_templates
  * @availability stack since=5.1.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor
+ * @doc_id cat-component-templates
  */
 export interface Request extends CatRequestBase {
   path_parts: {
-    /** The name of the component template. Accepts wildcard expressions. If omitted, all component templates are returned. */
+    /**
+     * The name of the component template.
+     * It accepts wildcard expressions.
+     * If it is omitted, all component templates are returned. */
     name?: string
   }
   query_parameters: {
@@ -47,7 +52,7 @@ export interface Request extends CatRequestBase {
      */
     local?: boolean
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
      * @server_default 30s
      */
     master_timeout?: Duration

--- a/specification/cat/component_templates/examples/200_response/CatComponentTemplatesResponseExample1.yaml
+++ b/specification/cat/component_templates/examples/200_response/CatComponentTemplatesResponseExample1.yaml
@@ -1,0 +1,12 @@
+# summary:
+description: >
+  A successful response from `GET _cat/aliases?v=true`.
+  This response shows that `alias2` has configured a filter and `alias3` and `alias4` have routing configurations.
+# type: response
+# response_code: 200
+value: |-
+  alias  index filter routing.index routing.search is_write_index
+  alias1 test1 -      -            -              -
+  alias2 test1 *      -            -              -
+  alias3 test1 -      1            1              -
+  alias4 test1 -      2            1,2            -

--- a/specification/cat/count/CatCountRequest.ts
+++ b/specification/cat/count/CatCountRequest.ts
@@ -22,10 +22,11 @@ import { Indices } from '@_types/common'
 
 /**
  * Get a document count.
- * Provides quick access to a document count for a data stream, an index, or an entire cluster.
+ *
+ * Get quick access to a document count for a data stream, an index, or an entire cluster.
  * The document count only includes live documents, not deleted documents which have not yet been removed by the merge process.
  *
- * CAT APIs are only intended for human consumption using the command line or Kibana console.
+ * IMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.
  * They are not intended for use by applications. For application consumption, use the count API.
  * @rest_spec_name cat.count
  * @availability stack stability=stable
@@ -36,8 +37,9 @@ import { Indices } from '@_types/common'
 export interface Request extends CatRequestBase {
   path_parts: {
     /**
-     * Comma-separated list of data streams, indices, and aliases used to limit the request.
-     * Supports wildcards (`*`). To target all data streams and indices, omit this parameter or use `*` or `_all`.
+     * A comma-separated list of data streams, indices, and aliases used to limit the request.
+     * It supports wildcards (`*`).
+     * To target all data streams and indices, omit this parameter or use `*` or `_all`.
      */
     index?: Indices
   }

--- a/specification/cat/count/examples/200_response/CatCountResponseExample1.yaml
+++ b/specification/cat/count/examples/200_response/CatCountResponseExample1.yaml
@@ -1,0 +1,9 @@
+summary: Single data stream or index count
+description: >
+  A successful response from `GET /_cat/count/my-index-000001?v=true`.
+  It retrieves the document count for the `my-index-000001` data stream or index.
+# type: response
+# response_code: 200
+value: |-
+  epoch      timestamp count
+  1475868259 15:24:20  120

--- a/specification/cat/count/examples/200_response/CatCountResponseExample2.yaml
+++ b/specification/cat/count/examples/200_response/CatCountResponseExample2.yaml
@@ -1,0 +1,9 @@
+summary: All data streams and indices count
+description: >
+  A successful response from `GET /_cat/count?v=true`.
+  It retrieves the document count for all data streams and indices in the cluster.
+# type: response
+# response_code: 200
+value: |-
+  epoch      timestamp count
+  1475868259 15:24:20  121

--- a/specification/cat/fielddata/CatFielddataRequest.ts
+++ b/specification/cat/fielddata/CatFielddataRequest.ts
@@ -21,7 +21,10 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { Bytes, Fields } from '@_types/common'
 
 /**
- * Returns the amount of heap memory currently used by the field data cache on every data node in the cluster.
+ * Get field data cache information.
+ *
+ * Get the amount of heap memory currently used by the field data cache on every data node in the cluster.
+ *
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console.
  * They are not intended for use by applications. For application consumption, use the nodes stats API.
  * @rest_spec_name cat.fielddata

--- a/specification/cat/fielddata/examples/200_response/CatFielddataResponseExample1.yaml
+++ b/specification/cat/fielddata/examples/200_response/CatFielddataResponseExample1.yaml
@@ -1,0 +1,10 @@
+summary: Single field data
+description: >
+  A successful response from `GET /_cat/fielddata?v=true&fields=body`.
+  You can specify an individual field in the request body or URL path.
+  This example retrieves heap memory size information for the `body` field.
+# type: response
+# response_code:
+value: |-
+  id                     host      ip        node    field   size
+  Nqk-6inXQq-OxUfOUI8jNQ 127.0.0.1 127.0.0.1 Nqk-6in body    544b

--- a/specification/cat/fielddata/examples/200_response/CatFielddataResponseExample2.yaml
+++ b/specification/cat/fielddata/examples/200_response/CatFielddataResponseExample2.yaml
@@ -1,0 +1,12 @@
+summary: Multiple fields data
+description: >
+  A successful response from `GET /_cat/fielddata/body,soul?v=true`.
+  You can specify a comma-separated list of fields in the request body or URL path.
+  This example retrieves heap memory size information for the `body` and `soul` fields.
+  To get information for all fields, run `GET /_cat/fielddata?v=true`.
+# type: response
+# response_code:
+value: |-
+  id                     host      ip        node    field   size
+  Nqk-6inXQq-OxUfOUI8jNQ 127.0.0.1 127.0.0.1 Nqk-6in body    544b
+  Nqk-6inXQq-OxUfOUI8jNQ 127.0.0.1 127.0.0.1 Nqk-6in soul    480b

--- a/specification/cat/health/CatHealthRequest.ts
+++ b/specification/cat/health/CatHealthRequest.ts
@@ -21,8 +21,9 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { TimeUnit } from '@_types/Time'
 
 /**
- * Returns the health status of a cluster, similar to the cluster health API.
- * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console.
+ * Get the cluster health status.
+ *
+ * IMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.
  * They are not intended for use by applications. For application consumption, use the cluster health API.
  * This API is often used to check malfunctioning clusters.
  * To help you track cluster health alongside log files and alerting systems, the API returns timestamps in two formats:

--- a/specification/cat/health/examples/200_response/CatHealthResponseExample1.yaml
+++ b/specification/cat/health/examples/200_response/CatHealthResponseExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+description: >
+  A successful response from `GET /_cat/health?v=true`.
+  By default, it returns `HH:MM:SS` and Unix epoch timestamps.
+# type: response
+# response_code: 200
+value: |-
+  epoch      timestamp cluster       status node.total node.data shards pri relo init unassign unassign.pri pending_tasks max_task_wait_time active_shards_percent
+  1475871424 16:17:04  elasticsearch green           1         1      1   1    0    0        0            0             0                  -                100.0%

--- a/specification/cat/help/CatHelpRequest.ts
+++ b/specification/cat/help/CatHelpRequest.ts
@@ -19,7 +19,8 @@
 
 /**
  * Get CAT help.
- * Returns help for the CAT APIs.
+ *
+ * Get help for the CAT APIs.
  * @rest_spec_name cat.help
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/cat/indices/CatIndicesRequest.ts
+++ b/specification/cat/indices/CatIndicesRequest.ts
@@ -23,7 +23,8 @@ import { Duration, TimeUnit } from '@_types/Time'
 
 /**
  * Get index information.
- * Returns high-level information about indices in a cluster, including backing indices for data streams.
+ *
+ * Get high-level information about indices in a cluster, including backing indices for data streams.
  *
  * Use this request to get the following information for each index in a cluster:
  * - shard count

--- a/specification/cat/indices/examples/200_response/CatIndicesResponseExample1.yaml
+++ b/specification/cat/indices/examples/200_response/CatIndicesResponseExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+description: >
+  A successful response from `GET /_cat/indices/my-index-*?v=true&s=index`.
+# type: response
+# response_code:
+value: |-
+  health status index            uuid                   pri rep docs.count docs.deleted store.size pri.store.size dataset.size
+  yellow open   my-index-000001  u8FNjxh8Rfy_awN11oDKYQ   1   1       1200            0     88.1kb         88.1kb       88.1kb
+  green  open   my-index-000002  nYFWZEO7TUiOjLQXBaYJpA   1   0          0            0       260b           260b         260b

--- a/specification/cat/master/CatMasterRequest.ts
+++ b/specification/cat/master/CatMasterRequest.ts
@@ -21,7 +21,10 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { Duration } from '@_types/Time'
 
 /**
- * Returns information about the master node, including the ID, bound IP address, and name.
+ * Get master node information.
+ *
+ * Get information about the master node, including the ID, bound IP address, and name.
+ *
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.
  * @rest_spec_name cat.master
  * @availability stack stability=stable

--- a/specification/cat/master/examples/200_response/CatMasterResponseExample1.yaml
+++ b/specification/cat/master/examples/200_response/CatMasterResponseExample1.yaml
@@ -1,0 +1,8 @@
+# summary:
+description: >
+  A successful response from `GET /_cat/master?v=true`.
+# type: response
+# response_code:
+value: |-
+  id                     host      ip        node
+  YzWoH_2BT-6UjVGDyPdqYg 127.0.0.1 127.0.0.1 YzWoH_2

--- a/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
+++ b/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
@@ -23,9 +23,10 @@ import { TimeUnit } from '@_types/Time'
 
 /**
  * Get data frame analytics jobs.
- * Returns configuration and usage information about data frame analytics jobs.
  *
- * CAT APIs are only intended for human consumption using the Kibana
+ * Get configuration and usage information about data frame analytics jobs.
+ *
+ * IMPORTANT: CAT APIs are only intended for human consumption using the Kibana
  * console or command line. They are not intended for use by applications. For
  * application consumption, use the get data frame analytics jobs statistics API.
  *

--- a/specification/cat/ml_data_frame_analytics/examples/200_response/CatDataframeanalyticsResponseExample1.yaml
+++ b/specification/cat/ml_data_frame_analytics/examples/200_response/CatDataframeanalyticsResponseExample1.yaml
@@ -1,0 +1,11 @@
+# summary:
+description: A successful response from `GET _cat/ml/data_frame/analytics?v=true`.
+# type: response
+# response_code: 200
+value: |-
+  id               create_time              type             state
+  classifier_job_1 2020-02-12T11:49:09.594Z classification stopped
+  classifier_job_2 2020-02-12T11:49:14.479Z classification stopped
+  classifier_job_3 2020-02-12T11:49:16.928Z classification stopped
+  classifier_job_4 2020-02-12T11:49:19.127Z classification stopped
+  classifier_job_5 2020-02-12T11:49:21.349Z classification stopped

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -23,12 +23,13 @@ import { TimeUnit } from '@_types/Time'
 
 /**
  * Get datafeeds.
- * Returns configuration and usage information about datafeeds.
+ *
+ * Get configuration and usage information about datafeeds.
  * This API returns a maximum of 10,000 datafeeds.
  * If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`
  * cluster privileges to use this API.
  *
- * CAT APIs are only intended for human consumption using the Kibana
+ * IMPORTANT: CAT APIs are only intended for human consumption using the Kibana
  * console or command line. They are not intended for use by applications. For
  * application consumption, use the get datafeed statistics API.
  *

--- a/specification/cat/ml_datafeeds/examples/200_response/CatDatafeedsResponseExample1.yaml
+++ b/specification/cat/ml_datafeeds/examples/200_response/CatDatafeedsResponseExample1.yaml
@@ -1,0 +1,10 @@
+# summary:
+description: A successful response from `GET _cat/ml/datafeeds?v=true`.
+# type: response
+# response_code:
+value: |-
+  id                              state buckets.count search.count
+  datafeed-high_sum_total_sales stopped 743          7
+  datafeed-low_request_rate     stopped 1457         3
+  datafeed-response_code_rates  stopped 1460         18
+  datafeed-url_scanning         stopped 1460         18

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -23,12 +23,13 @@ import { TimeUnit } from '@_types/Time'
 
 /**
  * Get anomaly detection jobs.
- * Returns configuration and usage information for anomaly detection jobs.
+ *
+ * Get configuration and usage information for anomaly detection jobs.
  * This API returns a maximum of 10,000 jobs.
  * If the Elasticsearch security features are enabled, you must have `monitor_ml`,
  * `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.
  *
- * CAT APIs are only intended for human consumption using the Kibana
+ * IMPORTANT: CAT APIs are only intended for human consumption using the Kibana
  * console or command line. They are not intended for use by applications. For
  * application consumption, use the get anomaly detection job statistics API.
  *

--- a/specification/cat/ml_jobs/examples/200_response/CatJobsResponseExample1.yaml
+++ b/specification/cat/ml_jobs/examples/200_response/CatJobsResponseExample1.yaml
@@ -1,0 +1,8 @@
+# summary:
+description: A succesful response from `GET _cat/component_templates/my-template-*?v=true&s=name`.
+# type: response
+# response_code: ''
+value: |-
+  name          version alias_count mapping_count settings_count metadata_count included_in
+  my-template-1         0           0             1              0              [my-index-template]
+  my-template-2         0           3             0              0              [my-index-template]

--- a/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
+++ b/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
@@ -24,9 +24,10 @@ import { TimeUnit } from '@_types/Time'
 
 /**
  * Get trained models.
- * Returns configuration and usage information about inference trained models.
  *
- * CAT APIs are only intended for human consumption using the Kibana
+ * Get configuration and usage information about inference trained models.
+ *
+ * IMPORTANT: CAT APIs are only intended for human consumption using the Kibana
  * console or command line. They are not intended for use by applications. For
  * application consumption, use the get trained models statistics API.
  *

--- a/specification/cat/ml_trained_models/examples/200_response/CatTrainedModelsResponseExample1.yaml
+++ b/specification/cat/ml_trained_models/examples/200_response/CatTrainedModelsResponseExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+description: A successful response from `GET _cat/ml/trained_models?h=c,o,l,ct,v&v=true`.
+# type: response
+# response_code: ''
+value: |-
+  id                           created_by operations license  create_time              version
+  ddddd-1580216177138              _xpack 196        PLATINUM 2020-01-28T12:56:17.138Z 8.0.0
+  flight-regress-1580215685537     _xpack 102        PLATINUM 2020-01-28T12:48:05.537Z 8.0.0
+  lang_ident_model_1               _xpack 39629      BASIC    2019-12-05T12:28:34.594Z 7.6.0

--- a/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
+++ b/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
@@ -21,7 +21,9 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { Duration } from '@_types/Time'
 
 /**
- * Returns information about custom node attributes.
+ * Get node attribute information.
+ *
+ * Get information about custom node attributes.
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.
  * @rest_spec_name cat.nodeattrs
  * @availability stack stability=stable

--- a/specification/cat/nodeattrs/examples/200_response/CatNodeAttributesResponseExample1.yaml
+++ b/specification/cat/nodeattrs/examples/200_response/CatNodeAttributesResponseExample1.yaml
@@ -1,0 +1,10 @@
+summary: Default columns
+description: >
+  A successful response from `GET /_cat/nodeattrs?v=true`.
+  The `node`, `host`, and `ip` columns provide basic information about each node.
+  The `attr` and `value` columns return custom node attributes, one per line.
+# type: response
+# response_code: 200
+value: |-
+  node    host      ip        attr     value
+  node-0 127.0.0.1 127.0.0.1 testattr test

--- a/specification/cat/nodeattrs/examples/200_response/CatNodeAttributesResponseExample2.yaml
+++ b/specification/cat/nodeattrs/examples/200_response/CatNodeAttributesResponseExample2.yaml
@@ -1,0 +1,9 @@
+summary: Explicit columns
+description: >
+  A successful response from `GET /_cat/nodeattrs?v=true&h=name,pid,attr,value`.
+  It returns the `name`, `pid`, `attr`, and `value` columns.
+# type: response
+# response_code: 200
+value: |-
+  name    pid   attr     value
+  node-0 19566 testattr test

--- a/specification/cat/nodes/CatNodesRequest.ts
+++ b/specification/cat/nodes/CatNodesRequest.ts
@@ -22,7 +22,9 @@ import { Bytes } from '@_types/common'
 import { Duration, TimeUnit } from '@_types/Time'
 
 /**
- * Returns information about the nodes in a cluster.
+ * Get node information.
+ *
+ * Get information about the nodes in a cluster.
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.
  * @rest_spec_name cat.nodes
  * @availability stack stability=stable

--- a/specification/cat/nodes/examples/200_response/CatNodesResponseExample1.yaml
+++ b/specification/cat/nodes/examples/200_response/CatNodesResponseExample1.yaml
@@ -1,0 +1,10 @@
+summary: Default columns
+description: >
+  A successful response from `GET /_cat/nodes?v=true`.
+  The `ip`, `heap.percent`, `ram.percent`, `cpu`, and `load_*` columns provide the IP addresses and performance information of each node.
+  The `node.role`, `master`, and `name` columns provide information useful for monitoring an entire cluster, particularly large ones.
+# type: response
+# response_code: 200
+value: |-
+  ip        heap.percent ram.percent cpu load_1m load_5m load_15m node.role master name
+  127.0.0.1           65          99  42    3.07                  dim       *      mJw06l1

--- a/specification/cat/nodes/examples/200_response/CatNodesResponseExample2.yaml
+++ b/specification/cat/nodes/examples/200_response/CatNodesResponseExample2.yaml
@@ -1,0 +1,9 @@
+summary: Explicit columns
+description: >
+  A successful response from `GET /_cat/nodes?v=true&h=id,ip,port,v,m`.
+  It returns the `id`, `ip`, `port`, `v` (version), and `m` (master) columns.
+# type: response
+# response_code:
+value: |-
+  id   ip        port  v         m
+  veJR 127.0.0.1 59938 8.17.0 *

--- a/specification/cat/pending_tasks/CatPendingTasksRequest.ts
+++ b/specification/cat/pending_tasks/CatPendingTasksRequest.ts
@@ -21,7 +21,9 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { Duration, TimeUnit } from '@_types/Time'
 
 /**
- * Returns cluster-level changes that have not yet been executed.
+ * Get pending task information.
+ *
+ * Get information about cluster-level changes that have not yet taken effect.
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the pending cluster tasks API.
  * @rest_spec_name cat.pending_tasks
  * @availability stack stability=stable

--- a/specification/cat/pending_tasks/examples/200_response/CatPendingTasksResponseExample1.yaml
+++ b/specification/cat/pending_tasks/examples/200_response/CatPendingTasksResponseExample1.yaml
@@ -1,0 +1,14 @@
+# summary:
+description: >
+  A successful response from `GET /_cat/pending_tasks?v=true`.
+# type: response
+# response_code: 200
+value: |-
+  insertOrder timeInQueue priority source
+        1685       855ms HIGH     update-mapping [foo][t]
+        1686       843ms HIGH     update-mapping [foo][t]
+        1693       753ms HIGH     refresh-mapping [foo][[t]]
+        1688       816ms HIGH     update-mapping [foo][t]
+        1689       802ms HIGH     update-mapping [foo][t]
+        1690       787ms HIGH     update-mapping [foo][t]
+        1691       773ms HIGH     update-mapping [foo][t]

--- a/specification/cat/plugins/CatPluginsRequest.ts
+++ b/specification/cat/plugins/CatPluginsRequest.ts
@@ -21,7 +21,9 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { Duration } from '@_types/Time'
 
 /**
- * Returns a list of plugins running on each node of a cluster.
+ * Get plugin information.
+ *
+ * Get a list of plugins running on each node of a cluster.
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.
  * @rest_spec_name cat.plugins
  * @availability stack stability=stable

--- a/specification/cat/plugins/examples/200_response/CatPluginsResponseExample1.yaml
+++ b/specification/cat/plugins/examples/200_response/CatPluginsResponseExample1.yaml
@@ -1,0 +1,21 @@
+# summary:
+description: >
+  A successful response from `GET /_cat/plugins?v=true&s=component&h=name,component,version,description`.
+# type: response
+# response_code:
+value: |-
+  name    component               version   description
+  U7321H6 analysis-icu            8.17.0 The ICU Analysis plugin integrates the Lucene ICU module into Elasticsearch, adding ICU-related analysis components.
+  U7321H6 analysis-kuromoji       8.17.0 The Japanese (kuromoji) Analysis plugin integrates Lucene kuromoji analysis module into elasticsearch.
+  U7321H6 analysis-nori           8.17.0 The Korean (nori) Analysis plugin integrates Lucene nori analysis module into elasticsearch.
+  U7321H6 analysis-phonetic       8.17.0 The Phonetic Analysis plugin integrates phonetic token filter analysis with elasticsearch.
+  U7321H6 analysis-smartcn        8.17.0 Smart Chinese Analysis plugin integrates Lucene Smart Chinese analysis module into elasticsearch.
+  U7321H6 analysis-stempel        8.17.0 The Stempel (Polish) Analysis plugin integrates Lucene stempel (polish) analysis module into elasticsearch.
+  U7321H6 analysis-ukrainian      8.17.0 The Ukrainian Analysis plugin integrates the Lucene UkrainianMorfologikAnalyzer into elasticsearch.
+  U7321H6 discovery-azure-classic 8.17.0 The Azure Classic Discovery plugin allows to use Azure Classic API for the unicast discovery mechanism
+  U7321H6 discovery-ec2           8.17.0 The EC2 discovery plugin allows to use AWS API for the unicast discovery mechanism.
+  U7321H6 discovery-gce           8.17.0 The Google Compute Engine (GCE) Discovery plugin allows to use GCE API for the unicast discovery mechanism.
+  U7321H6 mapper-annotated-text   8.17.0 The Mapper Annotated_text plugin adds support for text fields with markup used to inject annotation tokens into the index.
+  U7321H6 mapper-murmur3          8.17.0 The Mapper Murmur3 plugin allows to compute hashes of a field's values at index-time and to store them in the index.
+  U7321H6 mapper-size             8.17.0 The Mapper Size plugin allows document to record their uncompressed size at index time.
+  U7321H6 store-smb               8.17.0 The Store SMB plugin adds support for SMB stores.

--- a/specification/cat/recovery/CatRecoveryRequest.ts
+++ b/specification/cat/recovery/CatRecoveryRequest.ts
@@ -22,7 +22,9 @@ import { Bytes, Indices } from '@_types/common'
 import { TimeUnit } from '@_types/Time'
 
 /**
- * Returns information about ongoing and completed shard recoveries.
+ * Get shard recovery information.
+ *
+ * Get information about ongoing and completed shard recoveries.
  * Shard recovery is the process of initializing a shard copy, such as restoring a primary shard from a snapshot or syncing a replica shard from a primary shard. When a shard recovery completes, the recovered shard is available for search and indexing.
  * For data streams, the API returns information about the stream’s backing indices.
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index recovery API.

--- a/specification/cat/recovery/examples/200_response/CatRecoveryResponseExample1.yaml
+++ b/specification/cat/recovery/examples/200_response/CatRecoveryResponseExample1.yaml
@@ -1,0 +1,9 @@
+summary: No ongoing recoveries
+description: >
+  A successful response from `GET _cat/recovery?v=true`.
+  In this example, the source and target nodes are the same because the recovery type is `store`, meaning they were read from local storage on node start.
+# type: response
+# response_code: 200
+value: |-
+  index             shard time type  stage source_host source_node target_host target_node repository snapshot files files_recovered files_percent files_total bytes bytes_recovered bytes_percent bytes_total translog_ops translog_ops_recovered translog_ops_percent
+  my-index-000001   0     13ms store done  n/a         n/a         127.0.0.1   node-0      n/a        n/a      0     0               100%          13          0b    0b              100%          9928b       0            0                      100.0%

--- a/specification/cat/recovery/examples/200_response/CatRecoveryResponseExample2.yaml
+++ b/specification/cat/recovery/examples/200_response/CatRecoveryResponseExample2.yaml
@@ -1,0 +1,11 @@
+summary: A live shard recovery
+description: >
+  A successful response from `GET _cat/recovery?v=true&h=i,s,t,ty,st,shost,thost,f,fp,b,bp`.
+  You can retrieve information about an ongoing recovery for example when you increase the replica count of an index and bring another node online to host the replicas.
+  In this example, the recovery type is `peer`, meaning the shard recovered from another node.
+  The `files` and `bytes` are real-time measurements.
+# type: response
+# response_code: 200
+value: |-
+  i               s t      ty   st    shost       thost       f     fp      b  bp
+  my-index-000001 0 1252ms peer done  192.168.1.1 192.168.1.2 0     100.0%  0b 100.0%

--- a/specification/cat/recovery/examples/200_response/CatRecoveryResponseExample3.yaml
+++ b/specification/cat/recovery/examples/200_response/CatRecoveryResponseExample3.yaml
@@ -1,0 +1,10 @@
+summary: A snapshot recovery
+description: >
+  A successful response from `GET _cat/recovery?v=true&h=i,s,t,ty,st,rep,snap,f,fp,b,bp`.
+  You can restore backups of an index using the snapshot and restore API.
+  You can use the cat recovery API to get information about a snapshot recovery.
+# type: response
+# response_code: 200
+value: |-
+  i               s t      ty       st    rep     snap   f  fp   b     bp
+  my-index-000001 0 1978ms snapshot done  my-repo snap-1 79 8.0% 12086 9.0%

--- a/specification/cat/repositories/CatRepositoriesRequest.ts
+++ b/specification/cat/repositories/CatRepositoriesRequest.ts
@@ -21,7 +21,9 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { Duration } from '@_types/Time'
 
 /**
- * Returns the snapshot repositories for a cluster.
+ * Get snapshot repository information.
+ *
+ * Get a list of snapshot repositories for a cluster.
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot repository API.
  * @rest_spec_name cat.repositories
  * @availability stack since=2.1.0 stability=stable

--- a/specification/cat/repositories/examples/200_response/CatRepositoriesResponseExample1.yaml
+++ b/specification/cat/repositories/examples/200_response/CatRepositoriesResponseExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+description: >
+  A successful response from `GET /_cat/repositories?v=true`.
+# type: response
+# response_code: 200
+value: |-
+  id    type
+  repo1   fs
+  repo2   s3

--- a/specification/cat/segments/CatSegmentsRequest.ts
+++ b/specification/cat/segments/CatSegmentsRequest.ts
@@ -22,7 +22,9 @@ import { Bytes, Indices } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Returns low-level information about the Lucene segments in index shards.
+ * Get segment information.
+ *
+ * Get low-level information about the Lucene segments in index shards.
  * For data streams, the API returns information about the backing indices.
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the index segments API.
  * @rest_spec_name cat.segments

--- a/specification/cat/segments/examples/200_response/CatSegmentsResponseExample1.yaml
+++ b/specification/cat/segments/examples/200_response/CatSegmentsResponseExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+description: >
+  A successful response from `GET /_cat/segments?v=true`.
+# type: response
+# response_code: 200
+value: |-
+  index shard prirep ip        segment generation docs.count docs.deleted size size.memory committed searchable version compound
+  test  0     p      127.0.0.1 _0               0          1            0  3kb           0 false     true       9.12.0   true
+  test1 0     p      127.0.0.1 _0               0          1            0  3kb           0 false     true       9.12.0   true

--- a/specification/cat/shards/CatShardsRequest.ts
+++ b/specification/cat/shards/CatShardsRequest.ts
@@ -22,7 +22,9 @@ import { Bytes, Indices } from '@_types/common'
 import { Duration, TimeUnit } from '@_types/Time'
 
 /**
- * Returns information about the shards in a cluster.
+ * Get shard information.
+ *
+ * Get information about the shards in a cluster.
  * For data streams, the API returns information about the backing indices.
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications.
  * @rest_spec_name cat.shards

--- a/specification/cat/shards/examples/200_response/CatShardsResponseExample1.yaml
+++ b/specification/cat/shards/examples/200_response/CatShardsResponseExample1.yaml
@@ -1,0 +1,7 @@
+summary: A single data stream or index
+description: >
+  A successful response from `GET _cat/shards`.
+# type: response
+# response_code: 200
+value: |-
+  my-index-000001 0 p STARTED 3014 31.1mb 192.168.56.10 H5dfFeA

--- a/specification/cat/shards/examples/200_response/CatShardsResponseExample2.yaml
+++ b/specification/cat/shards/examples/200_response/CatShardsResponseExample2.yaml
@@ -1,0 +1,8 @@
+summary: A wildcard pattern
+description: >
+  A successful response from `GET _cat/shards/my-index-*`.
+  It returns information for any data streams or indices beginning with `my-index-`.
+# type: response
+# response_code: 200
+value: |-
+  my-index-000001 0 p STARTED 3014 31.1mb 192.168.56.10 H5dfFeA

--- a/specification/cat/shards/examples/200_response/CatShardsResponseExample3.yaml
+++ b/specification/cat/shards/examples/200_response/CatShardsResponseExample3.yaml
@@ -1,0 +1,8 @@
+summary: A relocating shard
+description: >
+  A successful response from `GET _cat/shards`.
+  The `RELOCATING` value in the `state` column indicates the index shard is relocating.
+# type: response
+# response_code: 200
+value: |-
+  my-index-000001 0 p RELOCATING 3014 31.1mb 192.168.56.10 H5dfFeA -> -> 192.168.56.30 bGG90GE

--- a/specification/cat/shards/examples/200_response/CatShardsResponseExample4.yaml
+++ b/specification/cat/shards/examples/200_response/CatShardsResponseExample4.yaml
@@ -1,0 +1,10 @@
+summary: Shard states
+description: >
+  A successful response from `GET _cat/shards`.
+  Before a shard is available for use, it goes through an `INITIALIZING` state.
+  You can use the cat shards API to see which shards are initializing.
+# type: response
+# response_code: 200
+value: |-
+  my-index-000001 0 p STARTED      3014 31.1mb 192.168.56.10 H5dfFeA
+  my-index-000001 0 r INITIALIZING    0 14.3mb 192.168.56.30 bGG90GE

--- a/specification/cat/shards/examples/200_response/CatShardsResponseExample5.yaml
+++ b/specification/cat/shards/examples/200_response/CatShardsResponseExample5.yaml
@@ -1,0 +1,11 @@
+summary: Reasons for unassigned shards
+description: >
+  A successful response from `GET _cat/shards?h=index,shard,prirep,state,unassigned.reason`.
+  It includes the `unassigned.reason` column, which indicates why a shard is unassigned.
+# type: response
+# response_code: 200
+value: |-
+  my-index-000001 0 p STARTED    3014 31.1mb 192.168.56.10 H5dfFeA
+  my-index-000001 0 r STARTED    3014 31.1mb 192.168.56.30 bGG90GE
+  my-index-000001 0 r STARTED    3014 31.1mb 192.168.56.20 I8hydUG
+  my-index-000001 0 r UNASSIGNED ALLOCATION_FAILED

--- a/specification/cat/snapshots/CatSnapshotsRequest.ts
+++ b/specification/cat/snapshots/CatSnapshotsRequest.ts
@@ -22,7 +22,9 @@ import { Names } from '@_types/common'
 import { Duration, TimeUnit } from '@_types/Time'
 
 /**
- * Returns information about the snapshots stored in one or more repositories.
+ * Get snapshot information.
+ *
+ * Get information about the snapshots stored in one or more repositories.
  * A snapshot is a backup of an index or running Elasticsearch cluster.
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot API.
  * @rest_spec_name cat.snapshots

--- a/specification/cat/snapshots/examples/200_response/CatSnapshotsResponseExample1.yaml
+++ b/specification/cat/snapshots/examples/200_response/CatSnapshotsResponseExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+description: >
+  A successful response from `GET /_cat/snapshots/repo1?v=true&s=id`.
+# type: response
+# response_code: 200
+value: |-
+  id     repository status start_epoch start_time end_epoch  end_time duration indices successful_shards failed_shards total_shards
+  snap1  repo1      FAILED 1445616705  18:11:45   1445616978 18:16:18     4.6m       1                 4             1            5
+  snap2  repo1      SUCCESS 1445634298  23:04:58   1445634672 23:11:12     6.2m       2                10             0           10

--- a/specification/cat/tasks/CatTasksRequest.ts
+++ b/specification/cat/tasks/CatTasksRequest.ts
@@ -21,7 +21,9 @@ import { CatRequestBase } from '@cat/_types/CatBase'
 import { Duration, TimeUnit } from '@_types/Time'
 
 /**
- * Returns information about tasks currently executing in the cluster.
+ * Get task information.
+ *
+ * Get information about tasks currently running in the cluster.
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the task management API.
  * @rest_spec_name cat.tasks
  * @availability stack since=5.0.0 stability=experimental

--- a/specification/cat/tasks/examples/200_response/CatTasksResponseExample1.yaml
+++ b/specification/cat/tasks/examples/200_response/CatTasksResponseExample1.yaml
@@ -1,0 +1,8 @@
+# summary:
+description: A successful response from `GET _cat/tasks?v=true`.
+# type: response
+# response_code: 200
+value: |-
+  action                         task_id                    parent_task_id             type      start_time    timestamp running_time ip             node
+  cluster:monitor/tasks/lists[n] oTUltX4IQMOUUVeiohTt8A:124 oTUltX4IQMOUUVeiohTt8A:123 direct    1458585884904 01:48:24  44.1micros   127.0.0.1:9300 oTUltX4IQMOUUVeiohTt8A
+  cluster:monitor/tasks/lists    oTUltX4IQMOUUVeiohTt8A:123 -                          transport 1458585884904 01:48:24  186.2micros  127.0.0.1:9300 oTUltX4IQMOUUVeiohTt8A

--- a/specification/cat/templates/CatTemplatesRequest.ts
+++ b/specification/cat/templates/CatTemplatesRequest.ts
@@ -22,7 +22,9 @@ import { Name } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Returns information about index templates in a cluster.
+ * Get index template information.
+ *
+ * Get information about the index templates in a cluster.
  * You can use index templates to apply index settings and field mappings to new indices at creation.
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get index template API.
  * @rest_spec_name cat.templates

--- a/specification/cat/templates/examples/200_response/CatTemplatesResponseExample1.yaml
+++ b/specification/cat/templates/examples/200_response/CatTemplatesResponseExample1.yaml
@@ -1,0 +1,10 @@
+# summary:
+description: >
+  A successful response from `GET _cat/templates/my-template-*?v=true&s=name`.
+# type: response
+# response_code: 200
+value: |-
+  name          index_patterns order version composed_of
+  my-template-0 [te*]          500           []
+  my-template-1 [tea*]         501           []
+  my-template-2 [teak*]        502   7       []

--- a/specification/cat/thread_pool/CatThreadPoolRequest.ts
+++ b/specification/cat/thread_pool/CatThreadPoolRequest.ts
@@ -22,7 +22,9 @@ import { Names } from '@_types/common'
 import { Duration, TimeUnit } from '@_types/Time'
 
 /**
- * Returns thread pool statistics for each node in a cluster.
+ * Get thread pool statistics.
+ *
+ * Get thread pool statistics for each node in a cluster.
  * Returned information includes all built-in thread pools and custom thread pools.
  * IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.
  * @rest_spec_name cat.thread_pool

--- a/specification/cat/thread_pool/examples/200_response/CatThreadPoolResponseExample1.yaml
+++ b/specification/cat/thread_pool/examples/200_response/CatThreadPoolResponseExample1.yaml
@@ -1,0 +1,11 @@
+summary: Default columns
+description: >
+  A successful response from `GET /_cat/thread_pool`.
+# type: response
+# response_code: 200
+value: |-
+  node-0 analyze             0 0 0
+  node-0 fetch_shard_started 0 0 0
+  node-0 fetch_shard_store   0 0 0
+  node-0 flush               0 0 0
+  node-0 write               0 0 0

--- a/specification/cat/thread_pool/examples/200_response/CatThreadPoolResponseExample2.yaml
+++ b/specification/cat/thread_pool/examples/200_response/CatThreadPoolResponseExample2.yaml
@@ -1,0 +1,10 @@
+summary: Explicit columns
+description: >
+  A successful response from `GET /_cat/thread_pool/generic?v=true&h=id,name,active,rejected,completed`.
+  It returns the `id`, `name`, `active`, `rejected`, and `completed` columns.
+  It also limits returned information to the generic thread pool.
+# type: response
+# response_code: 200
+value: |-
+  id                     name    active rejected completed
+  0EWUhXeBQtaVGlexUeVwMg generic      0        0        70

--- a/specification/cat/transforms/CatTransformsRequest.ts
+++ b/specification/cat/transforms/CatTransformsRequest.ts
@@ -23,8 +23,9 @@ import { integer } from '@_types/Numeric'
 import { TimeUnit } from '@_types/Time'
 
 /**
- * Get transforms.
- * Returns configuration and usage information about transforms.
+ * Get transform information.
+ *
+ * Get configuration and usage information about transforms.
  *
  * CAT APIs are only intended for human consumption using the Kibana
  * console or command line. They are not intended for use by applications. For

--- a/specification/cat/transforms/examples/200_response/CatTransformsResponseExample1.yaml
+++ b/specification/cat/transforms/examples/200_response/CatTransformsResponseExample1.yaml
@@ -1,0 +1,15 @@
+# summary:
+description: A successful response from `GET /_cat/transforms?v=true&format=json`.
+# type: response
+# response_code: 200
+value: |-
+  [
+    {
+      "id" : "ecommerce_transform",
+      "state" : "started",
+      "checkpoint" : "1",
+      "documents_processed" : "705",
+      "checkpoint_progress" : "100.00",
+      "changes_last_detection_time" : null
+    }
+  ]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Add cat response examples (#3419)](https://github.com/elastic/elasticsearch-specification/pull/3419)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)