### PR TITLE
Add examples to search and open PIT APIs

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -25668,7 +25668,7 @@
           "search"
         ],
         "summary": "Open a point in time",
-        "description": "A search request by default runs against the most recent visible data of the target indices,\nwhich is called point in time. Elasticsearch pit (point in time) is a lightweight view into the\nstate of the data as it existed when initiated. In some cases, it’s preferred to perform multiple\nsearch requests using the same point in time. For example, if refreshes happen between\n`search_after` requests, then the results of those requests might not be consistent as changes happening\nbetween searches are only visible to the more recent point in time.\n\nA point in time must be opened explicitly before being used in search requests.\nThe `keep_alive` parameter tells Elasticsearch how long it should persist.",
+        "description": "A search request by default runs against the most recent visible data of the target indices,\nwhich is called point in time. Elasticsearch pit (point in time) is a lightweight view into the\nstate of the data as it existed when initiated. In some cases, it’s preferred to perform multiple\nsearch requests using the same point in time. For example, if refreshes happen between\n`search_after` requests, then the results of those requests might not be consistent as changes happening\nbetween searches are only visible to the more recent point in time.\n\nA point in time must be opened explicitly before being used in search requests.\n\nA subsequent search request with the `pit` parameter must not specify `index`, `routing`, or `preference` values as these parameters are copied from the point in time.\n\nJust like regular searches, you can use `from` and `size` to page through point in time search results, up to the first 10,000 hits.\nIf you want to retrieve more hits, use PIT with `search_after`.\n\nIMPORTANT: The open point in time request and each subsequent search request can return different identifiers; always use the most recently received ID for the next search request.\n\nWhen a PIT that contains shard failures is used in a search request, the missing are always reported in the search response as a `NoShardAvailableActionException` exception.\nTo get rid of these exceptions, a new PIT needs to be created so that shards missing from the previous PIT can be handled, assuming they become available in the meantime.\n\n**Keeping point in time alive**\n\nThe `keep_alive` parameter, which is passed to a open point in time request and search request, extends the time to live of the corresponding point in time.\nThe value does not need to be long enough to process all data — it just needs to be long enough for the next request.\n\nNormally, the background merge process optimizes the index by merging together smaller segments to create new, bigger segments.\nOnce the smaller segments are no longer needed they are deleted.\nHowever, open point-in-times prevent the old segments from being deleted since they are still in use.\n\nTIP: Keeping older segments alive means that more disk space and file handles are needed.\nEnsure that you have configured your nodes to have ample free file handles.\n\nAdditionally, if a segment contains deleted or updated documents then the point in time must keep track of whether each document in the segment was live at the time of the initial search request.\nEnsure that your nodes have sufficient heap space if you have many open point-in-times on an index that is subject to ongoing deletes or updates.\nNote that a point-in-time doesn't prevent its associated indices from being deleted.\nYou can check how many point-in-times (that is, search contexts) are open with the nodes stats API.",
         "operationId": "open-point-in-time",
         "parameters": [
           {
@@ -25685,7 +25685,7 @@
           {
             "in": "query",
             "name": "keep_alive",
-            "description": "Extends the time to live of the corresponding point in time.",
+            "description": "Extend the length of time that the point in time persists.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -25706,7 +25706,7 @@
           {
             "in": "query",
             "name": "preference",
-            "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+            "description": "The node or shard the operation should be performed on.\nBy default, it is random.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -25716,7 +25716,7 @@
           {
             "in": "query",
             "name": "routing",
-            "description": "Custom value used to route operations to a specific shard.",
+            "description": "A custom value that is used to route operations to a specific shard.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Routing"
@@ -25726,7 +25726,7 @@
           {
             "in": "query",
             "name": "expand_wildcards",
-            "description": "Type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nSupports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.",
+            "description": "The type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nIt supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -25736,7 +25736,7 @@
           {
             "in": "query",
             "name": "allow_partial_search_results",
-            "description": "If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception.\nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
+            "description": "Indicates whether the point in time tolerates unavailable shards or shard failures when initially creating the PIT.\nIf `false`, creating a point in time request when a shard is missing or unavailable will throw an exception.\nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -27247,7 +27247,10 @@
           "search"
         ],
         "summary": "Run a search",
-        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.\n\nIf the Elasticsearch security features are enabled, you must have the read index privilege for the target data stream, index, or alias. For cross-cluster search, refer to the documentation about configuring CCS privileges.\nTo search a point in time (PIT) for an alias, you must have the `read` index privilege for the alias's data streams or indices.\n\n**Search slicing**\n\nWhen paging through a large number of documents, it can be helpful to split the search into multiple slices to consume them independently with the `slice` and `pit` properties.\nBy default the splitting is done first on the shards, then locally on each shard.\nThe local splitting partitions the shard into contiguous ranges based on Lucene document IDs.\n\nFor instance if the number of shards is equal to 2 and you request 4 slices, the slices 0 and 2 are assigned to the first shard and the slices 1 and 3 are assigned to the second shard.\n\nIMPORTANT: The same point-in-time ID should be used for all slices.\nIf different PIT IDs are used, slices can overlap and miss documents.\nThis situation can occur because the splitting criterion is based on Lucene document IDs, which are not stable across changes to the index.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/remote-clusters-cert.html#remote-clusters-privileges-ccs"
+        },
         "operationId": "search",
         "parameters": [
           {
@@ -27397,7 +27400,10 @@
           "search"
         ],
         "summary": "Run a search",
-        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.\n\nIf the Elasticsearch security features are enabled, you must have the read index privilege for the target data stream, index, or alias. For cross-cluster search, refer to the documentation about configuring CCS privileges.\nTo search a point in time (PIT) for an alias, you must have the `read` index privilege for the alias's data streams or indices.\n\n**Search slicing**\n\nWhen paging through a large number of documents, it can be helpful to split the search into multiple slices to consume them independently with the `slice` and `pit` properties.\nBy default the splitting is done first on the shards, then locally on each shard.\nThe local splitting partitions the shard into contiguous ranges based on Lucene document IDs.\n\nFor instance if the number of shards is equal to 2 and you request 4 slices, the slices 0 and 2 are assigned to the first shard and the slices 1 and 3 are assigned to the second shard.\n\nIMPORTANT: The same point-in-time ID should be used for all slices.\nIf different PIT IDs are used, slices can overlap and miss documents.\nThis situation can occur because the splitting criterion is based on Lucene document IDs, which are not stable across changes to the index.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/remote-clusters-cert.html#remote-clusters-privileges-ccs"
+        },
         "operationId": "search-1",
         "parameters": [
           {
@@ -27549,7 +27555,10 @@
           "search"
         ],
         "summary": "Run a search",
-        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.\n\nIf the Elasticsearch security features are enabled, you must have the read index privilege for the target data stream, index, or alias. For cross-cluster search, refer to the documentation about configuring CCS privileges.\nTo search a point in time (PIT) for an alias, you must have the `read` index privilege for the alias's data streams or indices.\n\n**Search slicing**\n\nWhen paging through a large number of documents, it can be helpful to split the search into multiple slices to consume them independently with the `slice` and `pit` properties.\nBy default the splitting is done first on the shards, then locally on each shard.\nThe local splitting partitions the shard into contiguous ranges based on Lucene document IDs.\n\nFor instance if the number of shards is equal to 2 and you request 4 slices, the slices 0 and 2 are assigned to the first shard and the slices 1 and 3 are assigned to the second shard.\n\nIMPORTANT: The same point-in-time ID should be used for all slices.\nIf different PIT IDs are used, slices can overlap and miss documents.\nThis situation can occur because the splitting criterion is based on Lucene document IDs, which are not stable across changes to the index.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/remote-clusters-cert.html#remote-clusters-privileges-ccs"
+        },
         "operationId": "search-2",
         "parameters": [
           {
@@ -27702,7 +27711,10 @@
           "search"
         ],
         "summary": "Run a search",
-        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.\n\nIf the Elasticsearch security features are enabled, you must have the read index privilege for the target data stream, index, or alias. For cross-cluster search, refer to the documentation about configuring CCS privileges.\nTo search a point in time (PIT) for an alias, you must have the `read` index privilege for the alias's data streams or indices.\n\n**Search slicing**\n\nWhen paging through a large number of documents, it can be helpful to split the search into multiple slices to consume them independently with the `slice` and `pit` properties.\nBy default the splitting is done first on the shards, then locally on each shard.\nThe local splitting partitions the shard into contiguous ranges based on Lucene document IDs.\n\nFor instance if the number of shards is equal to 2 and you request 4 slices, the slices 0 and 2 are assigned to the first shard and the slices 1 and 3 are assigned to the second shard.\n\nIMPORTANT: The same point-in-time ID should be used for all slices.\nIf different PIT IDs are used, slices can overlap and miss documents.\nThis situation can occur because the splitting criterion is based on Lucene document IDs, which are not stable across changes to the index.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/remote-clusters-cert.html#remote-clusters-privileges-ccs"
+        },
         "operationId": "search-3",
         "parameters": [
           {
@@ -46686,7 +46698,7 @@
             "$ref": "#/components/schemas/_types:Field"
           },
           "format": {
-            "description": "Format in which the values are returned.",
+            "description": "The format in which the values are returned.",
             "type": "string"
           },
           "include_unmapped": {
@@ -69363,9 +69375,11 @@
         "type": "object",
         "properties": {
           "took": {
+            "description": "The number of milliseconds it took Elasticsearch to run the request.\nThis value is calculated by measuring the time elapsed between receipt of a request on the coordinating node and the time at which the coordinating node is ready to send the response.\nIt includes:\n\n* Communication time between the coordinating node and data nodes\n* Time the request spends in the search thread pool, queued for execution\n* Actual run time\n\nIt does not include:\n\n* Time needed to send the request to Elasticsearch\n* Time needed to serialize the JSON response\n* Time needed to send the response to a client",
             "type": "number"
           },
           "timed_out": {
+            "description": "If `true`, the request timed out before completion; returned results may be partial or empty.",
             "type": "boolean"
           },
           "_shards": {
@@ -105246,7 +105260,7 @@
       "search#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices, and aliases to search.\nSupports wildcards (`*`).\nTo search all data streams and indices, omit this parameter or use `*` or `_all`.",
+        "description": "A comma-separated list of data streams, indices, and aliases to search.\nIt supports wildcards (`*`).\nTo search all data streams and indices, omit this parameter or use `*` or `_all`.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -105267,7 +105281,7 @@
       "search#allow_partial_search_results": {
         "in": "query",
         "name": "allow_partial_search_results",
-        "description": "If true, returns partial results if there are shard request timeouts or shard failures. If false, returns an error with no partial results.",
+        "description": "If `true` and there are shard request timeouts or shard failures, the request returns partial results.\nIf `false`, it returns an error with no partial results.\n\nTo override the default behavior, you can set the `search.default_allow_partial_results` cluster setting to `false`.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -105277,7 +105291,7 @@
       "search#analyzer": {
         "in": "query",
         "name": "analyzer",
-        "description": "Analyzer to use for the query string.\nThis parameter can only be used when the q query string parameter is specified.",
+        "description": "The analyzer to use for the query string.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -105287,7 +105301,7 @@
       "search#analyze_wildcard": {
         "in": "query",
         "name": "analyze_wildcard",
-        "description": "If true, wildcard and prefix queries are analyzed.\nThis parameter can only be used when the q query string parameter is specified.",
+        "description": "If `true`, wildcard and prefix queries are analyzed.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -105297,7 +105311,7 @@
       "search#batched_reduce_size": {
         "in": "query",
         "name": "batched_reduce_size",
-        "description": "The number of shard results that should be reduced at once on the coordinating node.\nThis value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.",
+        "description": "The number of shard results that should be reduced at once on the coordinating node.\nIf the potential number of shards in the request can be large, this value should be used as a protection mechanism to reduce the memory overhead per search request.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -105307,7 +105321,7 @@
       "search#ccs_minimize_roundtrips": {
         "in": "query",
         "name": "ccs_minimize_roundtrips",
-        "description": "If true, network round-trips between the coordinating node and the remote clusters are minimized when executing cross-cluster search (CCS) requests.",
+        "description": "If `true`, network round-trips between the coordinating node and the remote clusters are minimized when running cross-cluster search (CCS) requests.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -105317,7 +105331,7 @@
       "search#default_operator": {
         "in": "query",
         "name": "default_operator",
-        "description": "The default operator for query string query: AND or OR.\nThis parameter can only be used when the `q` query string parameter is specified.",
+        "description": "The default operator for the query string query: `AND` or `OR`.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types.query_dsl:Operator"
@@ -105327,7 +105341,7 @@
       "search#df": {
         "in": "query",
         "name": "df",
-        "description": "Field to use as default where no field prefix is given in the query string.\nThis parameter can only be used when the q query string parameter is specified.",
+        "description": "The field to use as a default when no field prefix is given in the query string.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -105337,7 +105351,7 @@
       "search#docvalue_fields": {
         "in": "query",
         "name": "docvalue_fields",
-        "description": "A comma-separated list of fields to return as the docvalue representation for each hit.",
+        "description": "A comma-separated list of fields to return as the docvalue representation of a field for each hit.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
@@ -105347,7 +105361,7 @@
       "search#expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
-        "description": "Type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nSupports comma-separated values, such as `open,hidden`.",
+        "description": "The type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nIt supports comma-separated values such as `open,hidden`.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -105357,7 +105371,7 @@
       "search#explain": {
         "in": "query",
         "name": "explain",
-        "description": "If `true`, returns detailed information about score computation as part of a hit.",
+        "description": "If `true`, the request returns detailed information about score computation as part of a hit.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -105368,7 +105382,7 @@
         "in": "query",
         "name": "ignore_throttled",
         "description": "If `true`, concrete, expanded or aliased indices will be ignored when frozen.",
-        "deprecated": false,
+        "deprecated": true,
         "schema": {
           "type": "boolean"
         },
@@ -105387,7 +105401,7 @@
       "search#include_named_queries_score": {
         "in": "query",
         "name": "include_named_queries_score",
-        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)\nThis functionality reruns each named query on every hit in a search response.\nTypically, this adds a small overhead to a request.\nHowever, using computationally expensive named queries on a large number of hits may add significant overhead.",
+        "description": "If `true`, the response includes the score contribution from any named queries.\n\nThis functionality reruns each named query on every hit in a search response.\nTypically, this adds a small overhead to a request.\nHowever, using computationally expensive named queries on a large number of hits may add significant overhead.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -105397,7 +105411,7 @@
       "search#lenient": {
         "in": "query",
         "name": "lenient",
-        "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.\nThis parameter can only be used when the `q` query string parameter is specified.",
+        "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -105407,7 +105421,7 @@
       "search#max_concurrent_shard_requests": {
         "in": "query",
         "name": "max_concurrent_shard_requests",
-        "description": "Defines the number of concurrent shard requests per node this search executes concurrently.\nThis value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests.",
+        "description": "The number of concurrent shard requests per node that the search runs concurrently.\nThis value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -105417,7 +105431,7 @@
       "search#preference": {
         "in": "query",
         "name": "preference",
-        "description": "Nodes and shards used for the search.\nBy default, Elasticsearch selects from eligible nodes and shards using adaptive replica selection, accounting for allocation awareness. Valid values are:\n`_only_local` to run the search only on shards on the local node;\n`_local` to, if possible, run the search on shards on the local node, or if not, select shards using the default method;\n`_only_nodes:<node-id>,<node-id>` to run the search on only the specified nodes IDs, where, if suitable shards exist on more than one selected node, use shards on those nodes using the default method, or if none of the specified nodes are available, select shards from any available node using the default method;\n`_prefer_nodes:<node-id>,<node-id>` to if possible, run the search on the specified nodes IDs, or if not, select shards using the default method;\n`_shards:<shard>,<shard>` to run the search only on the specified shards;\n`<custom-string>` (any string that does not start with `_`) to route searches with the same `<custom-string>` to the same shards in the same order.",
+        "description": "The nodes and shards used for the search.\nBy default, Elasticsearch selects from eligible nodes and shards using adaptive replica selection, accounting for allocation awareness.\nValid values are:\n\n* `_only_local` to run the search only on shards on the local node.\n* `_local` to, if possible, run the search on shards on the local node, or if not, select shards using the default method.\n* `_only_nodes:<node-id>,<node-id>` to run the search on only the specified nodes IDs. If suitable shards exist on more than one selected node, use shards on those nodes using the default method. If none of the specified nodes are available, select shards from any available node using the default method.\n* `_prefer_nodes:<node-id>,<node-id>` to if possible, run the search on the specified nodes IDs. If not, select shards using the default method.\n`_shards:<shard>,<shard>` to run the search only on the specified shards. You can combine this value with other `preference` values. However, the `_shards` value must come first. For example: `_shards:2,3|_local`.\n`<custom-string>` (any string that does not start with `_`) to route searches with the same `<custom-string>` to the same shards in the same order.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -105427,7 +105441,7 @@
       "search#pre_filter_shard_size": {
         "in": "query",
         "name": "pre_filter_shard_size",
-        "description": "Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold.\nThis filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method (if date filters are mandatory to match but the shard bounds and the query are disjoint).\nWhen unspecified, the pre-filter phase is executed if any of these conditions is met:\nthe request targets more than 128 shards;\nthe request targets one or more read-only index;\nthe primary sort of the query targets an indexed field.",
+        "description": "A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold.\nThis filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method (if date filters are mandatory to match but the shard bounds and the query are disjoint).\nWhen unspecified, the pre-filter phase is executed if any of these conditions is met:\n\n* The request targets more than 128 shards.\n* The request targets one or more read-only index.\n* The primary sort of the query targets an indexed field.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -105437,7 +105451,7 @@
       "search#request_cache": {
         "in": "query",
         "name": "request_cache",
-        "description": "If `true`, the caching of search results is enabled for requests where `size` is `0`.\nDefaults to index level settings.",
+        "description": "If `true`, the caching of search results is enabled for requests where `size` is `0`.\nIt defaults to index level settings.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -105447,7 +105461,7 @@
       "search#routing": {
         "in": "query",
         "name": "routing",
-        "description": "Custom value used to route operations to a specific shard.",
+        "description": "A custom value that is used to route operations to a specific shard.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
@@ -105457,7 +105471,7 @@
       "search#scroll": {
         "in": "query",
         "name": "scroll",
-        "description": "Period to retain the search context for scrolling. See Scroll search results.\nBy default, this value cannot exceed `1d` (24 hours).\nYou can change this limit using the `search.max_keep_alive` cluster-level setting.",
+        "description": "The period to retain the search context for scrolling.\nBy default, this value cannot exceed `1d` (24 hours).\nYou can change this limit by using the `search.max_keep_alive` cluster-level setting.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -105467,7 +105481,7 @@
       "search#search_type": {
         "in": "query",
         "name": "search_type",
-        "description": "How distributed term frequencies are calculated for relevance scoring.",
+        "description": "Indicates how distributed term frequencies are calculated for relevance scoring.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:SearchType"
@@ -105500,7 +105514,7 @@
       "search#suggest_field": {
         "in": "query",
         "name": "suggest_field",
-        "description": "Specifies which field to use for suggestions.",
+        "description": "The field to use for suggestions.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Field"
@@ -105510,7 +105524,7 @@
       "search#suggest_mode": {
         "in": "query",
         "name": "suggest_mode",
-        "description": "Specifies the suggest mode.\nThis parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.",
+        "description": "The suggest mode.\nThis parameter can be used only when the `suggest_field` and `suggest_text` query string parameters are specified.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:SuggestMode"
@@ -105520,7 +105534,7 @@
       "search#suggest_size": {
         "in": "query",
         "name": "suggest_size",
-        "description": "Number of suggestions to return.\nThis parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.",
+        "description": "The number of suggestions to return.\nThis parameter can be used only when the `suggest_field` and `suggest_text` query string parameters are specified.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -105530,7 +105544,7 @@
       "search#suggest_text": {
         "in": "query",
         "name": "suggest_text",
-        "description": "The source text for which the suggestions should be returned.\nThis parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.",
+        "description": "The source text for which the suggestions should be returned.\nThis parameter can be used only when the `suggest_field` and `suggest_text` query string parameters are specified.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -105540,7 +105554,7 @@
       "search#terminate_after": {
         "in": "query",
         "name": "terminate_after",
-        "description": "Maximum number of documents to collect for each shard.\nIf a query reaches this limit, Elasticsearch terminates the query early.\nElasticsearch collects documents before sorting.\nUse with caution.\nElasticsearch applies this parameter to each shard handling the request.\nWhen possible, let Elasticsearch perform early termination automatically.\nAvoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.\nIf set to `0` (default), the query does not terminate early.",
+        "description": "The maximum number of documents to collect for each shard.\nIf a query reaches this limit, Elasticsearch terminates the query early.\nElasticsearch collects documents before sorting.\n\nIMPORTANT: Use with caution.\nElasticsearch applies this parameter to each shard handling the request.\nWhen possible, let Elasticsearch perform early termination automatically.\nAvoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.\nIf set to `0` (default), the query does not terminate early.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -105550,7 +105564,7 @@
       "search#timeout": {
         "in": "query",
         "name": "timeout",
-        "description": "Specifies the period of time to wait for a response from each shard.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+        "description": "The period of time to wait for a response from each shard.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt defaults to no timeout.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -105560,7 +105574,7 @@
       "search#track_total_hits": {
         "in": "query",
         "name": "track_total_hits",
-        "description": "Number of hits matching the query to count accurately.\nIf `true`, the exact number of hits is returned at the cost of some performance.\nIf `false`, the response does not include the total number of hits matching the query.",
+        "description": "The number of hits matching the query to count accurately.\nIf `true`, the exact number of hits is returned at the cost of some performance.\nIf `false`, the response does not include the total number of hits matching the query.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_global.search._types:TrackHits"
@@ -105570,7 +105584,7 @@
       "search#track_scores": {
         "in": "query",
         "name": "track_scores",
-        "description": "If `true`, calculate and return document scores, even if the scores are not used for sorting.",
+        "description": "If `true`, the request calculates and returns document scores, even if the scores are not used for sorting.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -105600,7 +105614,7 @@
       "search#version": {
         "in": "query",
         "name": "version",
-        "description": "If `true`, returns document version as part of a hit.",
+        "description": "If `true`, the request returns the document version as part of a hit.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -105610,7 +105624,7 @@
       "search#_source": {
         "in": "query",
         "name": "_source",
-        "description": "Indicates which source fields are returned for matching documents.\nThese fields are returned in the `hits._source` property of the search response.\nValid values are:\n`true` to return the entire document source;\n`false` to not return the document source;\n`<string>` to return the source fields that are specified as a comma-separated list (supports wildcard (`*`) patterns).",
+        "description": "The source fields that are returned for matching documents.\nThese fields are returned in the `hits._source` property of the search response.\nValid values are:\n\n* `true` to return the entire document source.\n* `false` to not return the document source.\n* `<string>` to return the source fields that are specified as a comma-separated list that supports wildcard (`*`) patterns.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_global.search._types:SourceConfigParam"
@@ -105640,7 +105654,7 @@
       "search#seq_no_primary_term": {
         "in": "query",
         "name": "seq_no_primary_term",
-        "description": "If `true`, returns sequence number and primary term of the last modification of each hit.",
+        "description": "If `true`, the request returns the sequence number and primary term of the last modification of each hit.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -105650,7 +105664,7 @@
       "search#q": {
         "in": "query",
         "name": "q",
-        "description": "Query in the Lucene query string syntax using query parameter search.\nQuery parameter searches do not support the full Elasticsearch Query DSL but are handy for testing.",
+        "description": "A query in the Lucene query string syntax.\nQuery parameter searches do not support the full Elasticsearch Query DSL but are handy for testing.\n\nIMPORTANT: This parameter overrides the query parameter in the request body.\nIf both parameters are specified, documents matching the query request body parameter are not returned.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -105660,7 +105674,7 @@
       "search#size": {
         "in": "query",
         "name": "size",
-        "description": "Defines the number of hits to return.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
+        "description": "The number of hits to return.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -105670,7 +105684,7 @@
       "search#from": {
         "in": "query",
         "name": "from",
-        "description": "Starting document offset.\nNeeds to be non-negative.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
+        "description": "The starting document offset, which must be non-negative.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -105680,7 +105694,7 @@
       "search#sort": {
         "in": "query",
         "name": "sort",
-        "description": "A comma-separated list of <field>:<direction> pairs.",
+        "description": "A comma-separated list of `<field>:<direction>` pairs.",
         "deprecated": false,
         "schema": {
           "oneOf": [
@@ -109296,7 +109310,7 @@
                   "$ref": "#/components/schemas/_global.search._types:FieldCollapse"
                 },
                 "explain": {
-                  "description": "If true, returns detailed information about score computation as part of a hit.",
+                  "description": "If `true`, the request returns detailed information about score computation as part of a hit.",
                   "type": "boolean"
                 },
                 "ext": {
@@ -109307,7 +109321,7 @@
                   }
                 },
                 "from": {
-                  "description": "Starting document offset.\nNeeds to be non-negative.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
+                  "description": "The starting document offset, which must be non-negative.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
                   "type": "number"
                 },
                 "highlight": {
@@ -109317,7 +109331,10 @@
                   "$ref": "#/components/schemas/_global.search._types:TrackHits"
                 },
                 "indices_boost": {
-                  "description": "Boosts the _score of documents from specified indices.",
+                  "externalDocs": {
+                    "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores"
+                  },
+                  "description": "Boost the `_score` of documents from specified indices.\nThe boost value is the factor by which scores are multiplied.\nA boost value greater than `1.0` increases the score.\nA boost value between `0` and `1.0` decreases the score.",
                   "type": "array",
                   "items": {
                     "type": "object",
@@ -109327,14 +109344,20 @@
                   }
                 },
                 "docvalue_fields": {
-                  "description": "Array of wildcard (`*`) patterns.\nThe request returns doc values for field names matching these patterns in the `hits.fields` property of the response.",
+                  "externalDocs": {
+                    "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#docvalue-fields"
+                  },
+                  "description": "An array of wildcard (`*`) field patterns.\nThe request returns doc values for field names matching these patterns in the `hits.fields` property of the response.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
                   }
                 },
                 "knn": {
-                  "description": "Defines the approximate kNN search to run.",
+                  "externalDocs": {
+                    "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html#approximate-knn"
+                  },
+                  "description": "The approximate kNN search to run.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/_types:KnnSearch"
@@ -109351,7 +109374,7 @@
                   "$ref": "#/components/schemas/_types:RankContainer"
                 },
                 "min_score": {
-                  "description": "Minimum `_score` for matching documents.\nDocuments with a lower `_score` are not included in the search results.",
+                  "description": "The minimum `_score` for matching documents.\nDocuments with a lower `_score` are not included in the search results.",
                   "type": "number"
                 },
                 "post_filter": {
@@ -109392,7 +109415,7 @@
                   "$ref": "#/components/schemas/_types:SortResults"
                 },
                 "size": {
-                  "description": "The number of hits to return.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
+                  "description": "The number of hits to return, which must not be negative.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` property.",
                   "type": "number"
                 },
                 "slice": {
@@ -109405,7 +109428,7 @@
                   "$ref": "#/components/schemas/_global.search._types:SourceConfig"
                 },
                 "fields": {
-                  "description": "Array of wildcard (`*`) patterns.\nThe request returns values for field names matching these patterns in the `hits.fields` property of the response.",
+                  "description": "An array of wildcard (`*`) field patterns.\nThe request returns values for field names matching these patterns in the `hits.fields` property of the response.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
@@ -109415,23 +109438,26 @@
                   "$ref": "#/components/schemas/_global.search._types:Suggester"
                 },
                 "terminate_after": {
-                  "description": "Maximum number of documents to collect for each shard.\nIf a query reaches this limit, Elasticsearch terminates the query early.\nElasticsearch collects documents before sorting.\nUse with caution.\nElasticsearch applies this parameter to each shard handling the request.\nWhen possible, let Elasticsearch perform early termination automatically.\nAvoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.\nIf set to `0` (default), the query does not terminate early.",
+                  "description": "The maximum number of documents to collect for each shard.\nIf a query reaches this limit, Elasticsearch terminates the query early.\nElasticsearch collects documents before sorting.\n\nIMPORTANT: Use with caution.\nElasticsearch applies this property to each shard handling the request.\nWhen possible, let Elasticsearch perform early termination automatically.\nAvoid specifying this property for requests that target data streams with backing indices across multiple data tiers.\n\nIf set to `0` (default), the query does not terminate early.",
                   "type": "number"
                 },
                 "timeout": {
-                  "description": "Specifies the period of time to wait for a response from each shard.\nIf no response is received before the timeout expires, the request fails and returns an error.\nDefaults to no timeout.",
+                  "description": "The period of time to wait for a response from each shard.\nIf no response is received before the timeout expires, the request fails and returns an error.\nDefaults to no timeout.",
                   "type": "string"
                 },
                 "track_scores": {
-                  "description": "If true, calculate and return document scores, even if the scores are not used for sorting.",
+                  "description": "If `true`, calculate and return document scores, even if the scores are not used for sorting.",
                   "type": "boolean"
                 },
                 "version": {
-                  "description": "If true, returns document version as part of a hit.",
+                  "description": "If `true`, the request returns the document version as part of a hit.",
                   "type": "boolean"
                 },
                 "seq_no_primary_term": {
-                  "description": "If `true`, returns sequence number and primary term of the last modification of each hit.",
+                  "externalDocs": {
+                    "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html"
+                  },
+                  "description": "If `true`, the request returns sequence number and primary term of the last modification of each hit.",
                   "type": "boolean"
                 },
                 "stored_fields": {
@@ -109444,7 +109470,7 @@
                   "$ref": "#/components/schemas/_types.mapping:RuntimeFields"
                 },
                 "stats": {
-                  "description": "Stats groups to associate with the search.\nEach group maintains a statistics aggregation for its associated searches.\nYou can retrieve these stats using the indices stats API.",
+                  "description": "The stats groups to associate with the search.\nEach group maintains a statistics aggregation for its associated searches.\nYou can retrieve these stats using the indices stats API.",
                   "type": "array",
                   "items": {
                     "type": "string"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -14617,7 +14617,7 @@
           "search"
         ],
         "summary": "Open a point in time",
-        "description": "A search request by default runs against the most recent visible data of the target indices,\nwhich is called point in time. Elasticsearch pit (point in time) is a lightweight view into the\nstate of the data as it existed when initiated. In some cases, it’s preferred to perform multiple\nsearch requests using the same point in time. For example, if refreshes happen between\n`search_after` requests, then the results of those requests might not be consistent as changes happening\nbetween searches are only visible to the more recent point in time.\n\nA point in time must be opened explicitly before being used in search requests.\nThe `keep_alive` parameter tells Elasticsearch how long it should persist.",
+        "description": "A search request by default runs against the most recent visible data of the target indices,\nwhich is called point in time. Elasticsearch pit (point in time) is a lightweight view into the\nstate of the data as it existed when initiated. In some cases, it’s preferred to perform multiple\nsearch requests using the same point in time. For example, if refreshes happen between\n`search_after` requests, then the results of those requests might not be consistent as changes happening\nbetween searches are only visible to the more recent point in time.\n\nA point in time must be opened explicitly before being used in search requests.\n\nA subsequent search request with the `pit` parameter must not specify `index`, `routing`, or `preference` values as these parameters are copied from the point in time.\n\nJust like regular searches, you can use `from` and `size` to page through point in time search results, up to the first 10,000 hits.\nIf you want to retrieve more hits, use PIT with `search_after`.\n\nIMPORTANT: The open point in time request and each subsequent search request can return different identifiers; always use the most recently received ID for the next search request.\n\nWhen a PIT that contains shard failures is used in a search request, the missing are always reported in the search response as a `NoShardAvailableActionException` exception.\nTo get rid of these exceptions, a new PIT needs to be created so that shards missing from the previous PIT can be handled, assuming they become available in the meantime.\n\n**Keeping point in time alive**\n\nThe `keep_alive` parameter, which is passed to a open point in time request and search request, extends the time to live of the corresponding point in time.\nThe value does not need to be long enough to process all data — it just needs to be long enough for the next request.\n\nNormally, the background merge process optimizes the index by merging together smaller segments to create new, bigger segments.\nOnce the smaller segments are no longer needed they are deleted.\nHowever, open point-in-times prevent the old segments from being deleted since they are still in use.\n\nTIP: Keeping older segments alive means that more disk space and file handles are needed.\nEnsure that you have configured your nodes to have ample free file handles.\n\nAdditionally, if a segment contains deleted or updated documents then the point in time must keep track of whether each document in the segment was live at the time of the initial search request.\nEnsure that your nodes have sufficient heap space if you have many open point-in-times on an index that is subject to ongoing deletes or updates.\nNote that a point-in-time doesn't prevent its associated indices from being deleted.\nYou can check how many point-in-times (that is, search contexts) are open with the nodes stats API.",
         "operationId": "open-point-in-time",
         "parameters": [
           {
@@ -14634,7 +14634,7 @@
           {
             "in": "query",
             "name": "keep_alive",
-            "description": "Extends the time to live of the corresponding point in time.",
+            "description": "Extend the length of time that the point in time persists.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -14655,7 +14655,7 @@
           {
             "in": "query",
             "name": "preference",
-            "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+            "description": "The node or shard the operation should be performed on.\nBy default, it is random.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -14665,7 +14665,7 @@
           {
             "in": "query",
             "name": "routing",
-            "description": "Custom value used to route operations to a specific shard.",
+            "description": "A custom value that is used to route operations to a specific shard.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Routing"
@@ -14675,7 +14675,7 @@
           {
             "in": "query",
             "name": "expand_wildcards",
-            "description": "Type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nSupports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.",
+            "description": "The type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nIt supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -14685,7 +14685,7 @@
           {
             "in": "query",
             "name": "allow_partial_search_results",
-            "description": "If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception.\nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
+            "description": "Indicates whether the point in time tolerates unavailable shards or shard failures when initially creating the PIT.\nIf `false`, creating a point in time request when a shard is missing or unavailable will throw an exception.\nIf `true`, the point in time will contain all the shards that are available at the time of the request.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -15717,7 +15717,10 @@
           "search"
         ],
         "summary": "Run a search",
-        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.\n\nIf the Elasticsearch security features are enabled, you must have the read index privilege for the target data stream, index, or alias. For cross-cluster search, refer to the documentation about configuring CCS privileges.\nTo search a point in time (PIT) for an alias, you must have the `read` index privilege for the alias's data streams or indices.\n\n**Search slicing**\n\nWhen paging through a large number of documents, it can be helpful to split the search into multiple slices to consume them independently with the `slice` and `pit` properties.\nBy default the splitting is done first on the shards, then locally on each shard.\nThe local splitting partitions the shard into contiguous ranges based on Lucene document IDs.\n\nFor instance if the number of shards is equal to 2 and you request 4 slices, the slices 0 and 2 are assigned to the first shard and the slices 1 and 3 are assigned to the second shard.\n\nIMPORTANT: The same point-in-time ID should be used for all slices.\nIf different PIT IDs are used, slices can overlap and miss documents.\nThis situation can occur because the splitting criterion is based on Lucene document IDs, which are not stable across changes to the index.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/remote-clusters-cert.html#remote-clusters-privileges-ccs"
+        },
         "operationId": "search",
         "parameters": [
           {
@@ -15864,7 +15867,10 @@
           "search"
         ],
         "summary": "Run a search",
-        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.\n\nIf the Elasticsearch security features are enabled, you must have the read index privilege for the target data stream, index, or alias. For cross-cluster search, refer to the documentation about configuring CCS privileges.\nTo search a point in time (PIT) for an alias, you must have the `read` index privilege for the alias's data streams or indices.\n\n**Search slicing**\n\nWhen paging through a large number of documents, it can be helpful to split the search into multiple slices to consume them independently with the `slice` and `pit` properties.\nBy default the splitting is done first on the shards, then locally on each shard.\nThe local splitting partitions the shard into contiguous ranges based on Lucene document IDs.\n\nFor instance if the number of shards is equal to 2 and you request 4 slices, the slices 0 and 2 are assigned to the first shard and the slices 1 and 3 are assigned to the second shard.\n\nIMPORTANT: The same point-in-time ID should be used for all slices.\nIf different PIT IDs are used, slices can overlap and miss documents.\nThis situation can occur because the splitting criterion is based on Lucene document IDs, which are not stable across changes to the index.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/remote-clusters-cert.html#remote-clusters-privileges-ccs"
+        },
         "operationId": "search-1",
         "parameters": [
           {
@@ -16013,7 +16019,10 @@
           "search"
         ],
         "summary": "Run a search",
-        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.\n\nIf the Elasticsearch security features are enabled, you must have the read index privilege for the target data stream, index, or alias. For cross-cluster search, refer to the documentation about configuring CCS privileges.\nTo search a point in time (PIT) for an alias, you must have the `read` index privilege for the alias's data streams or indices.\n\n**Search slicing**\n\nWhen paging through a large number of documents, it can be helpful to split the search into multiple slices to consume them independently with the `slice` and `pit` properties.\nBy default the splitting is done first on the shards, then locally on each shard.\nThe local splitting partitions the shard into contiguous ranges based on Lucene document IDs.\n\nFor instance if the number of shards is equal to 2 and you request 4 slices, the slices 0 and 2 are assigned to the first shard and the slices 1 and 3 are assigned to the second shard.\n\nIMPORTANT: The same point-in-time ID should be used for all slices.\nIf different PIT IDs are used, slices can overlap and miss documents.\nThis situation can occur because the splitting criterion is based on Lucene document IDs, which are not stable across changes to the index.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/remote-clusters-cert.html#remote-clusters-privileges-ccs"
+        },
         "operationId": "search-2",
         "parameters": [
           {
@@ -16163,7 +16172,10 @@
           "search"
         ],
         "summary": "Run a search",
-        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.",
+        "description": "Get search hits that match the query defined in the request.\nYou can provide search queries using the `q` query string parameter or the request body.\nIf both are specified, only the query parameter is used.\n\nIf the Elasticsearch security features are enabled, you must have the read index privilege for the target data stream, index, or alias. For cross-cluster search, refer to the documentation about configuring CCS privileges.\nTo search a point in time (PIT) for an alias, you must have the `read` index privilege for the alias's data streams or indices.\n\n**Search slicing**\n\nWhen paging through a large number of documents, it can be helpful to split the search into multiple slices to consume them independently with the `slice` and `pit` properties.\nBy default the splitting is done first on the shards, then locally on each shard.\nThe local splitting partitions the shard into contiguous ranges based on Lucene document IDs.\n\nFor instance if the number of shards is equal to 2 and you request 4 slices, the slices 0 and 2 are assigned to the first shard and the slices 1 and 3 are assigned to the second shard.\n\nIMPORTANT: The same point-in-time ID should be used for all slices.\nIf different PIT IDs are used, slices can overlap and miss documents.\nThis situation can occur because the splitting criterion is based on Lucene document IDs, which are not stable across changes to the index.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/remote-clusters-cert.html#remote-clusters-privileges-ccs"
+        },
         "operationId": "search-3",
         "parameters": [
           {
@@ -27185,7 +27197,7 @@
             "$ref": "#/components/schemas/_types:Field"
           },
           "format": {
-            "description": "Format in which the values are returned.",
+            "description": "The format in which the values are returned.",
             "type": "string"
           },
           "include_unmapped": {
@@ -53259,9 +53271,11 @@
         "type": "object",
         "properties": {
           "took": {
+            "description": "The number of milliseconds it took Elasticsearch to run the request.\nThis value is calculated by measuring the time elapsed between receipt of a request on the coordinating node and the time at which the coordinating node is ready to send the response.\nIt includes:\n\n* Communication time between the coordinating node and data nodes\n* Time the request spends in the search thread pool, queued for execution\n* Actual run time\n\nIt does not include:\n\n* Time needed to send the request to Elasticsearch\n* Time needed to serialize the JSON response\n* Time needed to send the response to a client",
             "type": "number"
           },
           "timed_out": {
+            "description": "If `true`, the request timed out before completion; returned results may be partial or empty.",
             "type": "boolean"
           },
           "_shards": {
@@ -62026,7 +62040,7 @@
       "search#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices, and aliases to search.\nSupports wildcards (`*`).\nTo search all data streams and indices, omit this parameter or use `*` or `_all`.",
+        "description": "A comma-separated list of data streams, indices, and aliases to search.\nIt supports wildcards (`*`).\nTo search all data streams and indices, omit this parameter or use `*` or `_all`.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -62047,7 +62061,7 @@
       "search#allow_partial_search_results": {
         "in": "query",
         "name": "allow_partial_search_results",
-        "description": "If true, returns partial results if there are shard request timeouts or shard failures. If false, returns an error with no partial results.",
+        "description": "If `true` and there are shard request timeouts or shard failures, the request returns partial results.\nIf `false`, it returns an error with no partial results.\n\nTo override the default behavior, you can set the `search.default_allow_partial_results` cluster setting to `false`.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -62057,7 +62071,7 @@
       "search#analyzer": {
         "in": "query",
         "name": "analyzer",
-        "description": "Analyzer to use for the query string.\nThis parameter can only be used when the q query string parameter is specified.",
+        "description": "The analyzer to use for the query string.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -62067,7 +62081,7 @@
       "search#analyze_wildcard": {
         "in": "query",
         "name": "analyze_wildcard",
-        "description": "If true, wildcard and prefix queries are analyzed.\nThis parameter can only be used when the q query string parameter is specified.",
+        "description": "If `true`, wildcard and prefix queries are analyzed.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -62077,7 +62091,7 @@
       "search#batched_reduce_size": {
         "in": "query",
         "name": "batched_reduce_size",
-        "description": "The number of shard results that should be reduced at once on the coordinating node.\nThis value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.",
+        "description": "The number of shard results that should be reduced at once on the coordinating node.\nIf the potential number of shards in the request can be large, this value should be used as a protection mechanism to reduce the memory overhead per search request.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -62087,7 +62101,7 @@
       "search#ccs_minimize_roundtrips": {
         "in": "query",
         "name": "ccs_minimize_roundtrips",
-        "description": "If true, network round-trips between the coordinating node and the remote clusters are minimized when executing cross-cluster search (CCS) requests.",
+        "description": "If `true`, network round-trips between the coordinating node and the remote clusters are minimized when running cross-cluster search (CCS) requests.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -62097,7 +62111,7 @@
       "search#default_operator": {
         "in": "query",
         "name": "default_operator",
-        "description": "The default operator for query string query: AND or OR.\nThis parameter can only be used when the `q` query string parameter is specified.",
+        "description": "The default operator for the query string query: `AND` or `OR`.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types.query_dsl:Operator"
@@ -62107,7 +62121,7 @@
       "search#df": {
         "in": "query",
         "name": "df",
-        "description": "Field to use as default where no field prefix is given in the query string.\nThis parameter can only be used when the q query string parameter is specified.",
+        "description": "The field to use as a default when no field prefix is given in the query string.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -62117,7 +62131,7 @@
       "search#docvalue_fields": {
         "in": "query",
         "name": "docvalue_fields",
-        "description": "A comma-separated list of fields to return as the docvalue representation for each hit.",
+        "description": "A comma-separated list of fields to return as the docvalue representation of a field for each hit.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
@@ -62127,7 +62141,7 @@
       "search#expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
-        "description": "Type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nSupports comma-separated values, such as `open,hidden`.",
+        "description": "The type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nIt supports comma-separated values such as `open,hidden`.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -62137,7 +62151,7 @@
       "search#explain": {
         "in": "query",
         "name": "explain",
-        "description": "If `true`, returns detailed information about score computation as part of a hit.",
+        "description": "If `true`, the request returns detailed information about score computation as part of a hit.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -62148,7 +62162,7 @@
         "in": "query",
         "name": "ignore_throttled",
         "description": "If `true`, concrete, expanded or aliased indices will be ignored when frozen.",
-        "deprecated": false,
+        "deprecated": true,
         "schema": {
           "type": "boolean"
         },
@@ -62167,7 +62181,7 @@
       "search#include_named_queries_score": {
         "in": "query",
         "name": "include_named_queries_score",
-        "description": "Indicates whether hit.matched_queries should be rendered as a map that includes\nthe name of the matched query associated with its score (true)\nor as an array containing the name of the matched queries (false)\nThis functionality reruns each named query on every hit in a search response.\nTypically, this adds a small overhead to a request.\nHowever, using computationally expensive named queries on a large number of hits may add significant overhead.",
+        "description": "If `true`, the response includes the score contribution from any named queries.\n\nThis functionality reruns each named query on every hit in a search response.\nTypically, this adds a small overhead to a request.\nHowever, using computationally expensive named queries on a large number of hits may add significant overhead.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -62177,7 +62191,7 @@
       "search#lenient": {
         "in": "query",
         "name": "lenient",
-        "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.\nThis parameter can only be used when the `q` query string parameter is specified.",
+        "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -62187,7 +62201,7 @@
       "search#max_concurrent_shard_requests": {
         "in": "query",
         "name": "max_concurrent_shard_requests",
-        "description": "Defines the number of concurrent shard requests per node this search executes concurrently.\nThis value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests.",
+        "description": "The number of concurrent shard requests per node that the search runs concurrently.\nThis value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -62197,7 +62211,7 @@
       "search#preference": {
         "in": "query",
         "name": "preference",
-        "description": "Nodes and shards used for the search.\nBy default, Elasticsearch selects from eligible nodes and shards using adaptive replica selection, accounting for allocation awareness. Valid values are:\n`_only_local` to run the search only on shards on the local node;\n`_local` to, if possible, run the search on shards on the local node, or if not, select shards using the default method;\n`_only_nodes:<node-id>,<node-id>` to run the search on only the specified nodes IDs, where, if suitable shards exist on more than one selected node, use shards on those nodes using the default method, or if none of the specified nodes are available, select shards from any available node using the default method;\n`_prefer_nodes:<node-id>,<node-id>` to if possible, run the search on the specified nodes IDs, or if not, select shards using the default method;\n`_shards:<shard>,<shard>` to run the search only on the specified shards;\n`<custom-string>` (any string that does not start with `_`) to route searches with the same `<custom-string>` to the same shards in the same order.",
+        "description": "The nodes and shards used for the search.\nBy default, Elasticsearch selects from eligible nodes and shards using adaptive replica selection, accounting for allocation awareness.\nValid values are:\n\n* `_only_local` to run the search only on shards on the local node.\n* `_local` to, if possible, run the search on shards on the local node, or if not, select shards using the default method.\n* `_only_nodes:<node-id>,<node-id>` to run the search on only the specified nodes IDs. If suitable shards exist on more than one selected node, use shards on those nodes using the default method. If none of the specified nodes are available, select shards from any available node using the default method.\n* `_prefer_nodes:<node-id>,<node-id>` to if possible, run the search on the specified nodes IDs. If not, select shards using the default method.\n`_shards:<shard>,<shard>` to run the search only on the specified shards. You can combine this value with other `preference` values. However, the `_shards` value must come first. For example: `_shards:2,3|_local`.\n`<custom-string>` (any string that does not start with `_`) to route searches with the same `<custom-string>` to the same shards in the same order.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -62207,7 +62221,7 @@
       "search#pre_filter_shard_size": {
         "in": "query",
         "name": "pre_filter_shard_size",
-        "description": "Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold.\nThis filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method (if date filters are mandatory to match but the shard bounds and the query are disjoint).\nWhen unspecified, the pre-filter phase is executed if any of these conditions is met:\nthe request targets more than 128 shards;\nthe request targets one or more read-only index;\nthe primary sort of the query targets an indexed field.",
+        "description": "A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold.\nThis filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method (if date filters are mandatory to match but the shard bounds and the query are disjoint).\nWhen unspecified, the pre-filter phase is executed if any of these conditions is met:\n\n* The request targets more than 128 shards.\n* The request targets one or more read-only index.\n* The primary sort of the query targets an indexed field.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -62217,7 +62231,7 @@
       "search#request_cache": {
         "in": "query",
         "name": "request_cache",
-        "description": "If `true`, the caching of search results is enabled for requests where `size` is `0`.\nDefaults to index level settings.",
+        "description": "If `true`, the caching of search results is enabled for requests where `size` is `0`.\nIt defaults to index level settings.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -62227,7 +62241,7 @@
       "search#routing": {
         "in": "query",
         "name": "routing",
-        "description": "Custom value used to route operations to a specific shard.",
+        "description": "A custom value that is used to route operations to a specific shard.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
@@ -62237,7 +62251,7 @@
       "search#scroll": {
         "in": "query",
         "name": "scroll",
-        "description": "Period to retain the search context for scrolling. See Scroll search results.\nBy default, this value cannot exceed `1d` (24 hours).\nYou can change this limit using the `search.max_keep_alive` cluster-level setting.",
+        "description": "The period to retain the search context for scrolling.\nBy default, this value cannot exceed `1d` (24 hours).\nYou can change this limit by using the `search.max_keep_alive` cluster-level setting.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -62247,7 +62261,7 @@
       "search#search_type": {
         "in": "query",
         "name": "search_type",
-        "description": "How distributed term frequencies are calculated for relevance scoring.",
+        "description": "Indicates how distributed term frequencies are calculated for relevance scoring.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:SearchType"
@@ -62280,7 +62294,7 @@
       "search#suggest_field": {
         "in": "query",
         "name": "suggest_field",
-        "description": "Specifies which field to use for suggestions.",
+        "description": "The field to use for suggestions.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Field"
@@ -62290,7 +62304,7 @@
       "search#suggest_mode": {
         "in": "query",
         "name": "suggest_mode",
-        "description": "Specifies the suggest mode.\nThis parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.",
+        "description": "The suggest mode.\nThis parameter can be used only when the `suggest_field` and `suggest_text` query string parameters are specified.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:SuggestMode"
@@ -62300,7 +62314,7 @@
       "search#suggest_size": {
         "in": "query",
         "name": "suggest_size",
-        "description": "Number of suggestions to return.\nThis parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.",
+        "description": "The number of suggestions to return.\nThis parameter can be used only when the `suggest_field` and `suggest_text` query string parameters are specified.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -62310,7 +62324,7 @@
       "search#suggest_text": {
         "in": "query",
         "name": "suggest_text",
-        "description": "The source text for which the suggestions should be returned.\nThis parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.",
+        "description": "The source text for which the suggestions should be returned.\nThis parameter can be used only when the `suggest_field` and `suggest_text` query string parameters are specified.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -62320,7 +62334,7 @@
       "search#terminate_after": {
         "in": "query",
         "name": "terminate_after",
-        "description": "Maximum number of documents to collect for each shard.\nIf a query reaches this limit, Elasticsearch terminates the query early.\nElasticsearch collects documents before sorting.\nUse with caution.\nElasticsearch applies this parameter to each shard handling the request.\nWhen possible, let Elasticsearch perform early termination automatically.\nAvoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.\nIf set to `0` (default), the query does not terminate early.",
+        "description": "The maximum number of documents to collect for each shard.\nIf a query reaches this limit, Elasticsearch terminates the query early.\nElasticsearch collects documents before sorting.\n\nIMPORTANT: Use with caution.\nElasticsearch applies this parameter to each shard handling the request.\nWhen possible, let Elasticsearch perform early termination automatically.\nAvoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.\nIf set to `0` (default), the query does not terminate early.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -62330,7 +62344,7 @@
       "search#timeout": {
         "in": "query",
         "name": "timeout",
-        "description": "Specifies the period of time to wait for a response from each shard.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+        "description": "The period of time to wait for a response from each shard.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt defaults to no timeout.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -62340,7 +62354,7 @@
       "search#track_total_hits": {
         "in": "query",
         "name": "track_total_hits",
-        "description": "Number of hits matching the query to count accurately.\nIf `true`, the exact number of hits is returned at the cost of some performance.\nIf `false`, the response does not include the total number of hits matching the query.",
+        "description": "The number of hits matching the query to count accurately.\nIf `true`, the exact number of hits is returned at the cost of some performance.\nIf `false`, the response does not include the total number of hits matching the query.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_global.search._types:TrackHits"
@@ -62350,7 +62364,7 @@
       "search#track_scores": {
         "in": "query",
         "name": "track_scores",
-        "description": "If `true`, calculate and return document scores, even if the scores are not used for sorting.",
+        "description": "If `true`, the request calculates and returns document scores, even if the scores are not used for sorting.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -62380,7 +62394,7 @@
       "search#version": {
         "in": "query",
         "name": "version",
-        "description": "If `true`, returns document version as part of a hit.",
+        "description": "If `true`, the request returns the document version as part of a hit.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -62390,7 +62404,7 @@
       "search#_source": {
         "in": "query",
         "name": "_source",
-        "description": "Indicates which source fields are returned for matching documents.\nThese fields are returned in the `hits._source` property of the search response.\nValid values are:\n`true` to return the entire document source;\n`false` to not return the document source;\n`<string>` to return the source fields that are specified as a comma-separated list (supports wildcard (`*`) patterns).",
+        "description": "The source fields that are returned for matching documents.\nThese fields are returned in the `hits._source` property of the search response.\nValid values are:\n\n* `true` to return the entire document source.\n* `false` to not return the document source.\n* `<string>` to return the source fields that are specified as a comma-separated list that supports wildcard (`*`) patterns.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_global.search._types:SourceConfigParam"
@@ -62420,7 +62434,7 @@
       "search#seq_no_primary_term": {
         "in": "query",
         "name": "seq_no_primary_term",
-        "description": "If `true`, returns sequence number and primary term of the last modification of each hit.",
+        "description": "If `true`, the request returns the sequence number and primary term of the last modification of each hit.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -62430,7 +62444,7 @@
       "search#q": {
         "in": "query",
         "name": "q",
-        "description": "Query in the Lucene query string syntax using query parameter search.\nQuery parameter searches do not support the full Elasticsearch Query DSL but are handy for testing.",
+        "description": "A query in the Lucene query string syntax.\nQuery parameter searches do not support the full Elasticsearch Query DSL but are handy for testing.\n\nIMPORTANT: This parameter overrides the query parameter in the request body.\nIf both parameters are specified, documents matching the query request body parameter are not returned.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -62440,7 +62454,7 @@
       "search#size": {
         "in": "query",
         "name": "size",
-        "description": "Defines the number of hits to return.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
+        "description": "The number of hits to return.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -62450,7 +62464,7 @@
       "search#from": {
         "in": "query",
         "name": "from",
-        "description": "Starting document offset.\nNeeds to be non-negative.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
+        "description": "The starting document offset, which must be non-negative.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -62460,7 +62474,7 @@
       "search#sort": {
         "in": "query",
         "name": "sort",
-        "description": "A comma-separated list of <field>:<direction> pairs.",
+        "description": "A comma-separated list of `<field>:<direction>` pairs.",
         "deprecated": false,
         "schema": {
           "oneOf": [
@@ -64285,7 +64299,7 @@
                   "$ref": "#/components/schemas/_global.search._types:FieldCollapse"
                 },
                 "explain": {
-                  "description": "If true, returns detailed information about score computation as part of a hit.",
+                  "description": "If `true`, the request returns detailed information about score computation as part of a hit.",
                   "type": "boolean"
                 },
                 "ext": {
@@ -64296,7 +64310,7 @@
                   }
                 },
                 "from": {
-                  "description": "Starting document offset.\nNeeds to be non-negative.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
+                  "description": "The starting document offset, which must be non-negative.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
                   "type": "number"
                 },
                 "highlight": {
@@ -64306,7 +64320,10 @@
                   "$ref": "#/components/schemas/_global.search._types:TrackHits"
                 },
                 "indices_boost": {
-                  "description": "Boosts the _score of documents from specified indices.",
+                  "externalDocs": {
+                    "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores"
+                  },
+                  "description": "Boost the `_score` of documents from specified indices.\nThe boost value is the factor by which scores are multiplied.\nA boost value greater than `1.0` increases the score.\nA boost value between `0` and `1.0` decreases the score.",
                   "type": "array",
                   "items": {
                     "type": "object",
@@ -64316,14 +64333,20 @@
                   }
                 },
                 "docvalue_fields": {
-                  "description": "Array of wildcard (`*`) patterns.\nThe request returns doc values for field names matching these patterns in the `hits.fields` property of the response.",
+                  "externalDocs": {
+                    "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#docvalue-fields"
+                  },
+                  "description": "An array of wildcard (`*`) field patterns.\nThe request returns doc values for field names matching these patterns in the `hits.fields` property of the response.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
                   }
                 },
                 "knn": {
-                  "description": "Defines the approximate kNN search to run.",
+                  "externalDocs": {
+                    "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html#approximate-knn"
+                  },
+                  "description": "The approximate kNN search to run.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/_types:KnnSearch"
@@ -64337,7 +64360,7 @@
                   ]
                 },
                 "min_score": {
-                  "description": "Minimum `_score` for matching documents.\nDocuments with a lower `_score` are not included in the search results.",
+                  "description": "The minimum `_score` for matching documents.\nDocuments with a lower `_score` are not included in the search results.",
                   "type": "number"
                 },
                 "post_filter": {
@@ -64378,7 +64401,7 @@
                   "$ref": "#/components/schemas/_types:SortResults"
                 },
                 "size": {
-                  "description": "The number of hits to return.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` parameter.",
+                  "description": "The number of hits to return, which must not be negative.\nBy default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.\nTo page through more hits, use the `search_after` property.",
                   "type": "number"
                 },
                 "slice": {
@@ -64391,7 +64414,7 @@
                   "$ref": "#/components/schemas/_global.search._types:SourceConfig"
                 },
                 "fields": {
-                  "description": "Array of wildcard (`*`) patterns.\nThe request returns values for field names matching these patterns in the `hits.fields` property of the response.",
+                  "description": "An array of wildcard (`*`) field patterns.\nThe request returns values for field names matching these patterns in the `hits.fields` property of the response.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
@@ -64401,23 +64424,26 @@
                   "$ref": "#/components/schemas/_global.search._types:Suggester"
                 },
                 "terminate_after": {
-                  "description": "Maximum number of documents to collect for each shard.\nIf a query reaches this limit, Elasticsearch terminates the query early.\nElasticsearch collects documents before sorting.\nUse with caution.\nElasticsearch applies this parameter to each shard handling the request.\nWhen possible, let Elasticsearch perform early termination automatically.\nAvoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.\nIf set to `0` (default), the query does not terminate early.",
+                  "description": "The maximum number of documents to collect for each shard.\nIf a query reaches this limit, Elasticsearch terminates the query early.\nElasticsearch collects documents before sorting.\n\nIMPORTANT: Use with caution.\nElasticsearch applies this property to each shard handling the request.\nWhen possible, let Elasticsearch perform early termination automatically.\nAvoid specifying this property for requests that target data streams with backing indices across multiple data tiers.\n\nIf set to `0` (default), the query does not terminate early.",
                   "type": "number"
                 },
                 "timeout": {
-                  "description": "Specifies the period of time to wait for a response from each shard.\nIf no response is received before the timeout expires, the request fails and returns an error.\nDefaults to no timeout.",
+                  "description": "The period of time to wait for a response from each shard.\nIf no response is received before the timeout expires, the request fails and returns an error.\nDefaults to no timeout.",
                   "type": "string"
                 },
                 "track_scores": {
-                  "description": "If true, calculate and return document scores, even if the scores are not used for sorting.",
+                  "description": "If `true`, calculate and return document scores, even if the scores are not used for sorting.",
                   "type": "boolean"
                 },
                 "version": {
-                  "description": "If true, returns document version as part of a hit.",
+                  "description": "If `true`, the request returns the document version as part of a hit.",
                   "type": "boolean"
                 },
                 "seq_no_primary_term": {
-                  "description": "If `true`, returns sequence number and primary term of the last modification of each hit.",
+                  "externalDocs": {
+                    "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/optimistic-concurrency-control.html"
+                  },
+                  "description": "If `true`, the request returns sequence number and primary term of the last modification of each hit.",
                   "type": "boolean"
                 },
                 "stored_fields": {
@@ -64430,7 +64456,7 @@
                   "$ref": "#/components/schemas/_types.mapping:RuntimeFields"
                 },
                 "stats": {
-                  "description": "Stats groups to associate with the search.\nEach group maintains a statistics aggregation for its associated searches.\nYou can retrieve these stats using the indices stats API.",
+                  "description": "The stats groups to associate with the search.\nEach group maintains a statistics aggregation for its associated searches.\nYou can retrieve these stats using the indices stats API.",
                   "type": "array",
                   "items": {
                     "type": "string"

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -66,6 +66,7 @@ ccr-put-auto-follow-pattern,https://www.elastic.co/guide/en/elasticsearch/refere
 ccr-put-follow,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ccr-put-follow.html
 ccr-resume-auto-follow-pattern,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ccr-resume-auto-follow-pattern.html
 ccs-network-delays,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/modules-cross-cluster-search.html#ccs-network-delays
+ccs-privileges,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/remote-clusters-cert.html#remote-clusters-privileges-ccs
 clean-up-snapshot-repo,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/snapshots-register-repository.html#snapshots-repository-cleanup
 clear-repositories-metering-archive-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/clear-repositories-metering-archive-api.html
 clear-scroll-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/clear-scroll-api.html
@@ -151,6 +152,7 @@ docs-termvectors,https://www.elastic.co/guide/en/elasticsearch/reference/{branch
 docs-update-by-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-update-by-query.html
 docs-update,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-update.html
 document-input-parameters,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-mlt-query.html#_document_input_parameters
+docvalue-fields,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-fields.html#docvalue-fields
 dot-expand-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/dot-expand-processor.html
 drop-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/drop-processor.html
 enrich-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/enrich-processor.html
@@ -286,6 +288,7 @@ json-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/
 k-precision,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#k-precision
 k-recall,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#k-recall
 kv-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/kv-processor.html
+knn-approximate,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/knn-search.html#approximate-knn
 knn-inner-hits,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/knn-search.html#nested-knn-search-inner-hits
 license-management,https://www.elastic.co/guide/en/kibana/{branch}/managing-licenses.html
 logstash-api-delete-pipeline,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/logstash-api-delete-pipeline.html
@@ -450,6 +453,7 @@ query-dsl-span-not-query,https://www.elastic.co/guide/en/elasticsearch/reference
 query-dsl-span-or-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-span-or-query.html
 query-dsl-span-term-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-span-term-query.html
 query-dsl-span-within-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-span-within-query.html
+query-dsl-sparse-vector-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-sparse-vector-query.html
 query-dsl-term-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-term-query.html
 query-dsl-terms-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-terms-query.html
 query-dsl-terms-set-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-terms-set-query.html
@@ -472,6 +476,7 @@ redact-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch
 regexp-syntax,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/regexp-syntax.html
 register-repository,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/snapshots-register-repository.html
 registered-domain-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/registered-domain-processor.html
+relevance-scores,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-filter-context.html#relevance-scores
 remove-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/remove-processor.html
 remote-clusters-api-key,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/remote-clusters-api-key.html
 rename-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/rename-processor.html
@@ -686,6 +691,7 @@ security-user-cache,https://www.elastic.co/guide/en/elasticsearch/reference/{bra
 service-accounts,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/service-accounts.html
 set-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/set-processor.html
 shape,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/shape.html
+shard-request-cache,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/shard-request-cache.html
 simulate-ingest-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/simulate-ingest-api.html
 simulate-pipeline-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/simulate-pipeline-api.html
 slice-scroll,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html#slice-scroll
@@ -716,7 +722,7 @@ snapshot-restore-feature-state,https://www.elastic.co/guide/en/elasticsearch/ref
 sort-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/sort-processor.html
 sort-search-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/sort-search-results.html
 sort-tiebreaker,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/eql.html#eql-search-specify-a-sort-tiebreaker
-query-dsl-sparse-vector-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/query-dsl-sparse-vector-query.html
+source-filtering,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-fields.html#source-filtering
 split-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/split-processor.html
 sql-async-search-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-async-sql-search-api.html
 sql-async-status-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-async-sql-search-status-api.html
@@ -736,6 +742,7 @@ start-trial,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/sta
 stop-dfanalytics,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/stop-dfanalytics.html
 stop-trained-model-deployment,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/stop-trained-model-deployment.html
 stop-transform,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/stop-transform.html
+stored-fields,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-fields.html#stored-fields
 synonym-rule-create,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-synonym-rule.html
 synonym-rule-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-synonym-rule.html
 synonym-rule-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-synonym-rule.html

--- a/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
+++ b/specification/_global/open_point_in_time/OpenPointInTimeRequest.ts
@@ -33,13 +33,40 @@ import { Duration } from '@_types/Time'
  * between searches are only visible to the more recent point in time.
  *
  * A point in time must be opened explicitly before being used in search requests.
- * The `keep_alive` parameter tells Elasticsearch how long it should persist.
+ *
+ * A subsequent search request with the `pit` parameter must not specify `index`, `routing`, or `preference` values as these parameters are copied from the point in time.
+ *
+ * Just like regular searches, you can use `from` and `size` to page through point in time search results, up to the first 10,000 hits.
+ * If you want to retrieve more hits, use PIT with `search_after`.
+ *
+ * IMPORTANT: The open point in time request and each subsequent search request can return different identifiers; always use the most recently received ID for the next search request.
+ *
+ * When a PIT that contains shard failures is used in a search request, the missing are always reported in the search response as a `NoShardAvailableActionException` exception.
+ * To get rid of these exceptions, a new PIT needs to be created so that shards missing from the previous PIT can be handled, assuming they become available in the meantime.
+ *
+ * **Keeping point in time alive**
+ *
+ * The `keep_alive` parameter, which is passed to a open point in time request and search request, extends the time to live of the corresponding point in time.
+ * The value does not need to be long enough to process all data — it just needs to be long enough for the next request.
+ *
+ * Normally, the background merge process optimizes the index by merging together smaller segments to create new, bigger segments.
+ * Once the smaller segments are no longer needed they are deleted.
+ * However, open point-in-times prevent the old segments from being deleted since they are still in use.
+ *
+ * TIP: Keeping older segments alive means that more disk space and file handles are needed.
+ * Ensure that you have configured your nodes to have ample free file handles.
+ *
+ * Additionally, if a segment contains deleted or updated documents then the point in time must keep track of whether each document in the segment was live at the time of the initial search request.
+ * Ensure that your nodes have sufficient heap space if you have many open point-in-times on an index that is subject to ongoing deletes or updates.
+ * Note that a point-in-time doesn't prevent its associated indices from being deleted.
+ * You can check how many point-in-times (that is, search contexts) are open with the nodes stats API.
  * @rest_spec_name open_point_in_time
  * @availability stack since=7.10.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_id point-in-time-api
  * @index_privileges read
  * @doc_tag search
+ * @doc_id point-in-time-api
  */
 export interface Request extends RequestBase {
   urls: [
@@ -53,7 +80,7 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
-     * Extends the time to live of the corresponding point in time.
+     * Extend the length of time that the point in time persists.
      */
     keep_alive: Duration
     /**
@@ -62,22 +89,23 @@ export interface Request extends RequestBase {
      */
     ignore_unavailable?: boolean
     /**
-     * Specifies the node or shard the operation should be performed on.
-     * Random by default.
+     * The node or shard the operation should be performed on.
+     * By default, it is random.
      */
     preference?: string
     /**
-     * Custom value used to route operations to a specific shard.
+     * A custom value that is used to route operations to a specific shard.
      */
     routing?: Routing
     /**
-     * Type of index that wildcard patterns can match.
+     * The type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-     * Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * It supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
      * @server_default open
      */
     expand_wildcards?: ExpandWildcards
     /**
+     * Indicates whether the point in time tolerates unavailable shards or shard failures when initially creating the PIT.
      * If `false`, creating a point in time request when a shard is missing or unavailable will throw an exception.
      * If `true`, the point in time will contain all the shards that are available at the time of the request.
      * @server_default false
@@ -86,7 +114,7 @@ export interface Request extends RequestBase {
   }
   body: {
     /**
-     * Allows to filter indices if the provided query rewrites to `match_none` on every shard.
+     * Filter indices if the provided query rewrites to `match_none` on every shard.
      */
     index_filter?: QueryContainer
   }

--- a/specification/_global/open_point_in_time/examples/response/OpenPointInTimeResponseExample1.yaml
+++ b/specification/_global/open_point_in_time/examples/response/OpenPointInTimeResponseExample1.yaml
@@ -1,0 +1,16 @@
+# summary:
+description: >
+  A successful response from `POST /my-index-000001/_pit?keep_alive=1m&allow_partial_search_results=true`.
+  It includes a summary of the total number of shards, as well as the number of successful shards when creating the PIT.
+# type: response
+# response_code: ''
+value: |-
+  {
+    "id": "46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA=",
+    "_shards": {
+      "total": 10,
+      "successful": 10,
+      "skipped": 0,
+      "failed": 0
+    }
+  }

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -56,10 +56,26 @@ import { Suggester } from './_types/suggester'
  * Get search hits that match the query defined in the request.
  * You can provide search queries using the `q` query string parameter or the request body.
  * If both are specified, only the query parameter is used.
+ *
+ * If the Elasticsearch security features are enabled, you must have the read index privilege for the target data stream, index, or alias. For cross-cluster search, refer to the documentation about configuring CCS privileges.
+ * To search a point in time (PIT) for an alias, you must have the `read` index privilege for the alias's data streams or indices.
+ *
+ * **Search slicing**
+ *
+ * When paging through a large number of documents, it can be helpful to split the search into multiple slices to consume them independently with the `slice` and `pit` properties.
+ * By default the splitting is done first on the shards, then locally on each shard.
+ * The local splitting partitions the shard into contiguous ranges based on Lucene document IDs.
+ *
+ * For instance if the number of shards is equal to 2 and you request 4 slices, the slices 0 and 2 are assigned to the first shard and the slices 1 and 3 are assigned to the second shard.
+ *
+ * IMPORTANT: The same point-in-time ID should be used for all slices.
+ * If different PIT IDs are used, slices can overlap and miss documents.
+ * This situation can occur because the splitting criterion is based on Lucene document IDs, which are not stable across changes to the index.
  * @rest_spec_name search
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
  * @index_privileges read
+ * @ext_doc_id ccs-privileges
  */
 export interface Request extends RequestBase {
   urls: [
@@ -74,8 +90,8 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Comma-separated list of data streams, indices, and aliases to search.
-     * Supports wildcards (`*`).
+     * A comma-separated list of data streams, indices, and aliases to search.
+     * It supports wildcards (`*`).
      * To search all data streams and indices, omit this parameter or use `*` or `_all`.
      */
     index?: Indices
@@ -89,62 +105,68 @@ export interface Request extends RequestBase {
      */
     allow_no_indices?: boolean
     /**
-     * If true, returns partial results if there are shard request timeouts or shard failures. If false, returns an error with no partial results.
+     * If `true` and there are shard request timeouts or shard failures, the request returns partial results.
+     * If `false`, it returns an error with no partial results.
+     *
+     * To override the default behavior, you can set the `search.default_allow_partial_results` cluster setting to `false`.
      * @server_default true
      */
     allow_partial_search_results?: boolean
     /**
-     * Analyzer to use for the query string.
-     * This parameter can only be used when the q query string parameter is specified.
+     * The analyzer to use for the query string.
+     * This parameter can be used only when the `q` query string parameter is specified.
      */
     analyzer?: string
     /**
-     *  If true, wildcard and prefix queries are analyzed.
-     * This parameter can only be used when the q query string parameter is specified.
+     * If `true`, wildcard and prefix queries are analyzed.
+     * This parameter can be used only when the `q` query string parameter is specified.
      * @server_default false
      */
     analyze_wildcard?: boolean
     /**
      * The number of shard results that should be reduced at once on the coordinating node.
-     * This value should be used as a protection mechanism to reduce the memory overhead per search request if the potential number of shards in the request can be large.
+     * If the potential number of shards in the request can be large, this value should be used as a protection mechanism to reduce the memory overhead per search request.
      * @server_default 512
      */
     batched_reduce_size?: long
     /**
-     * If true, network round-trips between the coordinating node and the remote clusters are minimized when executing cross-cluster search (CCS) requests.
-     * @doc_id ccs-network-delays
+     * If `true`, network round-trips between the coordinating node and the remote clusters are minimized when running cross-cluster search (CCS) requests.
+     * @ext_doc_id ccs-network-delays
      * @server_default true
      */
     ccs_minimize_roundtrips?: boolean
     /**
-     * The default operator for query string query: AND or OR.
-     * This parameter can only be used when the `q` query string parameter is specified.
+     * The default operator for the query string query: `AND` or `OR`.
+     * This parameter can be used only when the `q` query string parameter is specified.
      * @server_default OR
      */
     default_operator?: Operator
     /**
-     * Field to use as default where no field prefix is given in the query string.
-     * This parameter can only be used when the q query string parameter is specified.
+     * The field to use as a default when no field prefix is given in the query string.
+     * This parameter can be used only when the `q` query string parameter is specified.
      */
     df?: string
     /**
-     * A comma-separated list of fields to return as the docvalue representation for each hit.
+     * A comma-separated list of fields to return as the docvalue representation of a field for each hit.
+     * @ext_doc_id docvalue-fields
      */
     docvalue_fields?: Fields
     /**
-     * Type of index that wildcard patterns can match.
+     * The type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-     * Supports comma-separated values, such as `open,hidden`.
+     * It supports comma-separated values such as `open,hidden`.
+     * @server_default open
      */
     expand_wildcards?: ExpandWildcards
     /**
-     * If `true`, returns detailed information about score computation as part of a hit.
+     * If `true`, the request returns detailed information about score computation as part of a hit.
      * @server_default false
      */
     explain?: boolean
     /**
      * If `true`, concrete, expanded or aliased indices will be ignored when frozen.
      * @server_default true
+     * @deprecated 7.16.0
      */
     ignore_throttled?: boolean
     /**
@@ -153,9 +175,8 @@ export interface Request extends RequestBase {
      */
     ignore_unavailable?: boolean
     /**
-     * Indicates whether hit.matched_queries should be rendered as a map that includes
-     * the name of the matched query associated with its score (true)
-     * or as an array containing the name of the matched queries (false)
+     * If `true`, the response includes the score contribution from any named queries.
+     *
      * This functionality reruns each named query on every hit in a search response.
      * Typically, this adds a small overhead to a request.
      * However, using computationally expensive named queries on a large number of hits may add significant overhead.
@@ -164,54 +185,59 @@ export interface Request extends RequestBase {
     include_named_queries_score?: boolean
     /**
      *  If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
-     * This parameter can only be used when the `q` query string parameter is specified.
+     * This parameter can be used only when the `q` query string parameter is specified.
      * @server_default false
      */
     lenient?: boolean
     /**
-     * Defines the number of concurrent shard requests per node this search executes concurrently.
+     * The number of concurrent shard requests per node that the search runs concurrently.
      * This value should be used to limit the impact of the search on the cluster in order to limit the number of concurrent shard requests.
      * @server_default 5
      */
     max_concurrent_shard_requests?: long
     /**
-     * Nodes and shards used for the search.
-     * By default, Elasticsearch selects from eligible nodes and shards using adaptive replica selection, accounting for allocation awareness. Valid values are:
-     * `_only_local` to run the search only on shards on the local node;
-     * `_local` to, if possible, run the search on shards on the local node, or if not, select shards using the default method;
-     * `_only_nodes:<node-id>,<node-id>` to run the search on only the specified nodes IDs, where, if suitable shards exist on more than one selected node, use shards on those nodes using the default method, or if none of the specified nodes are available, select shards from any available node using the default method;
-     * `_prefer_nodes:<node-id>,<node-id>` to if possible, run the search on the specified nodes IDs, or if not, select shards using the default method;
-     * `_shards:<shard>,<shard>` to run the search only on the specified shards;
+     * The nodes and shards used for the search.
+     * By default, Elasticsearch selects from eligible nodes and shards using adaptive replica selection, accounting for allocation awareness.
+     * Valid values are:
+     *
+     * * `_only_local` to run the search only on shards on the local node.
+     * * `_local` to, if possible, run the search on shards on the local node, or if not, select shards using the default method.
+     * * `_only_nodes:<node-id>,<node-id>` to run the search on only the specified nodes IDs. If suitable shards exist on more than one selected node, use shards on those nodes using the default method. If none of the specified nodes are available, select shards from any available node using the default method.
+     * * `_prefer_nodes:<node-id>,<node-id>` to if possible, run the search on the specified nodes IDs. If not, select shards using the default method.
+     * `_shards:<shard>,<shard>` to run the search only on the specified shards. You can combine this value with other `preference` values. However, the `_shards` value must come first. For example: `_shards:2,3|_local`.
      * `<custom-string>` (any string that does not start with `_`) to route searches with the same `<custom-string>` to the same shards in the same order.
      */
     preference?: string
     /**
-     * Defines a threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold.
+     * A threshold that enforces a pre-filter roundtrip to prefilter search shards based on query rewriting if the number of shards the search request expands to exceeds the threshold.
      * This filter roundtrip can limit the number of shards significantly if for instance a shard can not match any documents based on its rewrite method (if date filters are mandatory to match but the shard bounds and the query are disjoint).
      * When unspecified, the pre-filter phase is executed if any of these conditions is met:
-     * the request targets more than 128 shards;
-     * the request targets one or more read-only index;
-     * the primary sort of the query targets an indexed field.
+     *
+     * * The request targets more than 128 shards.
+     * * The request targets one or more read-only index.
+     * * The primary sort of the query targets an indexed field.
      */
     pre_filter_shard_size?: long
     /**
      * If `true`, the caching of search results is enabled for requests where `size` is `0`.
-     * Defaults to index level settings.
+     * It defaults to index level settings.
+     * @ext_doc_id shard-request-cache
      */
     request_cache?: boolean
     /**
-     * Custom value used to route operations to a specific shard.
+     * A custom value that is used to route operations to a specific shard.
      */
     routing?: Routing
     /**
-     * Period to retain the search context for scrolling. See Scroll search results.
+     * The period to retain the search context for scrolling.
      * By default, this value cannot exceed `1d` (24 hours).
-     * You can change this limit using the `search.max_keep_alive` cluster-level setting.
-     * @doc_id scroll-search-results
+     * You can change this limit by using the `search.max_keep_alive` cluster-level setting.
+     * @ext_doc_id scroll-search-results
      */
     scroll?: Duration
     /**
-     * How distributed term frequencies are calculated for relevance scoring.
+     * Indicates how distributed term frequencies are calculated for relevance scoring.
+     * @ext_doc_id relevance-scores
      */
     search_type?: SearchType
     /**
@@ -223,33 +249,35 @@ export interface Request extends RequestBase {
      * If no fields are specified, no stored fields are included in the response.
      * If this field is specified, the `_source` parameter defaults to `false`.
      * You can pass `_source: true` to return both source fields and stored fields in the search response.
+     * @ext_doc_id stored-fields
      */
     stored_fields?: Fields
     /**
-     * Specifies which field to use for suggestions.
+     * The field to use for suggestions.
      */
     suggest_field?: Field
     /**
-     * Specifies the suggest mode.
-     * This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
+     * The suggest mode.
+     * This parameter can be used only when the `suggest_field` and `suggest_text` query string parameters are specified.
      * @server_default missing
      */
     suggest_mode?: SuggestMode
     /**
-     * Number of suggestions to return.
-     * This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
+     * The number of suggestions to return.
+     * This parameter can be used only when the `suggest_field` and `suggest_text` query string parameters are specified.
      */
     suggest_size?: long
     /**
      * The source text for which the suggestions should be returned.
-     * This parameter can only be used when the `suggest_field` and `suggest_text` query string parameters are specified.
+     * This parameter can be used only when the `suggest_field` and `suggest_text` query string parameters are specified.
      */
     suggest_text?: string
     /**
-     * Maximum number of documents to collect for each shard.
+     * The maximum number of documents to collect for each shard.
      * If a query reaches this limit, Elasticsearch terminates the query early.
      * Elasticsearch collects documents before sorting.
-     * Use with caution.
+     *
+     * IMPORTANT: Use with caution.
      * Elasticsearch applies this parameter to each shard handling the request.
      * When possible, let Elasticsearch perform early termination automatically.
      * Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
@@ -258,25 +286,26 @@ export interface Request extends RequestBase {
      */
     terminate_after?: long
     /**
-     * Specifies the period of time to wait for a response from each shard.
+     * The period of time to wait for a response from each shard.
      * If no response is received before the timeout expires, the request fails and returns an error.
+     * It defaults to no timeout.
      */
     timeout?: Duration
     /**
-     * Number of hits matching the query to count accurately.
+     * The number of hits matching the query to count accurately.
      * If `true`, the exact number of hits is returned at the cost of some performance.
      * If `false`, the response does not include the total number of hits matching the query.
      * @server_default 10000
      */
     track_total_hits?: TrackHits
     /**
-     * If `true`, calculate and return document scores, even if the scores are not used for sorting.
+     * If `true`, the request calculates and returns document scores, even if the scores are not used for sorting.
      * @server_default false
      */
     track_scores?: boolean
     /**
      * If `true`, aggregation and suggester names are be prefixed by their respective types in the response.
-     * @server_default true
+     * @server_default false
      */
     typed_keys?: boolean
     /**
@@ -285,17 +314,18 @@ export interface Request extends RequestBase {
      */
     rest_total_hits_as_int?: boolean
     /**
-     * If `true`, returns document version as part of a hit.
+     * If `true`, the request returns the document version as part of a hit.
      * @server_default false
      */
     version?: boolean
     /**
-     * Indicates which source fields are returned for matching documents.
+     * The source fields that are returned for matching documents.
      * These fields are returned in the `hits._source` property of the search response.
      * Valid values are:
-     * `true` to return the entire document source;
-     * `false` to not return the document source;
-     * `<string>` to return the source fields that are specified as a comma-separated list (supports wildcard (`*`) patterns).
+     *
+     * * `true` to return the entire document source.
+     * * `false` to not return the document source.
+     * * `<string>` to return the source fields that are specified as a comma-separated list that supports wildcard (`*`) patterns.
      * @server_default true
      */
     _source?: SourceConfigParam
@@ -313,32 +343,35 @@ export interface Request extends RequestBase {
      */
     _source_includes?: Fields
     /**
-     * If `true`, returns sequence number and primary term of the last modification of each hit.
+     * If `true`, the request returns the sequence number and primary term of the last modification of each hit.
+     * @ext_doc_id optimistic-concurrency
      */
     seq_no_primary_term?: boolean
     /**
-     * Query in the Lucene query string syntax using query parameter search.
+     * A query in the Lucene query string syntax.
      * Query parameter searches do not support the full Elasticsearch Query DSL but are handy for testing.
+     *
+     * IMPORTANT: This parameter overrides the query parameter in the request body.
+     * If both parameters are specified, documents matching the query request body parameter are not returned.
      */
     q?: string
     /**
-     * Defines the number of hits to return.
+     * The number of hits to return.
      * By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.
      * To page through more hits, use the `search_after` parameter.
      * @server_default 10
      */
     size?: integer
     /**
-     * Starting document offset.
-     * Needs to be non-negative.
+     * The starting document offset, which must be non-negative.
      * By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.
      * To page through more hits, use the `search_after` parameter.
      * @server_default 0
      */
     from?: integer
     /**
-     * A comma-separated list of <field>:<direction> pairs.
-     * @doc_id sort-search-results
+     * A comma-separated list of `<field>:<direction>` pairs.
+     * @ext_doc_id sort-search-results
      */
     sort?: string | string[]
     /**
@@ -360,7 +393,7 @@ export interface Request extends RequestBase {
      */
     collapse?: FieldCollapse
     /**
-     * If true, returns detailed information about score computation as part of a hit.
+     * If `true`, the request returns detailed information about score computation as part of a hit.
      * @server_default false
      */
     explain?: boolean
@@ -369,8 +402,7 @@ export interface Request extends RequestBase {
      */
     ext?: Dictionary<string, UserDefinedValue>
     /**
-     * Starting document offset.
-     * Needs to be non-negative.
+     * The starting document offset, which must be non-negative.
      * By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.
      * To page through more hits, use the `search_after` parameter.
      * @server_default 0
@@ -388,27 +420,33 @@ export interface Request extends RequestBase {
      */
     track_total_hits?: TrackHits
     /**
-     * Boosts the _score of documents from specified indices.
+     * Boost the `_score` of documents from specified indices.
+     * The boost value is the factor by which scores are multiplied.
+     * A boost value greater than `1.0` increases the score.
+     * A boost value between `0` and `1.0` decreases the score.
+     * @ext_doc_id relevance-scores
      */
     indices_boost?: Array<Dictionary<IndexName, double>>
     /**
-     * Array of wildcard (`*`) patterns.
+     * An array of wildcard (`*`) field patterns.
      * The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.
+     * @ext_doc_id docvalue-fields
      */
     docvalue_fields?: FieldAndFormat[]
     /**
-     * Defines the approximate kNN search to run.
+     * The approximate kNN search to run.
      * @availability stack since=8.4.0
      * @availability serverless
+     * @ext_doc_id knn-approximate
      */
     knn?: KnnSearch | KnnSearch[]
     /**
-     * Defines the Reciprocal Rank Fusion (RRF) to use.
+     * The Reciprocal Rank Fusion (RRF) to use.
      * @availability stack since=8.8.0
      */
     rank?: RankContainer
     /**
-     * Minimum `_score` for matching documents.
+     * The minimum `_score` for matching documents.
      * Documents with a lower `_score` are not included in the search results.
      */
     min_score?: double
@@ -425,7 +463,8 @@ export interface Request extends RequestBase {
      */
     profile?: boolean
     /**
-     * Defines the search definition using the Query DSL.
+     * The search definition using the Query DSL.
+     * @ext_doc_id query-dsl
      */
     query?: QueryContainer
     /**
@@ -433,7 +472,8 @@ export interface Request extends RequestBase {
      */
     rescore?: Rescore | Rescore[]
     /**
-     * A retriever is a specification to describe top documents returned from a search. A retriever replaces other elements of the search API that also return top documents such as query and knn.
+     * A retriever is a specification to describe top documents returned from a search.
+     * A retriever replaces other elements of the search API that also return top documents such as `query` and `knn`.
      * @availability stack since=8.14.0 stability=stable
      * @availability serverless stability=stable
      */
@@ -447,28 +487,31 @@ export interface Request extends RequestBase {
      */
     search_after?: SortResults
     /**
-     * The number of hits to return.
+     * The number of hits to return, which must not be negative.
      * By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters.
-     * To page through more hits, use the `search_after` parameter.
+     * To page through more hits, use the `search_after` property.
      * @server_default 10
      */
     size?: integer
     /**
-     * Can be used to split a scrolled search into multiple slices that can be consumed independently.
+     * Split a scrolled search into multiple slices that can be consumed independently.
      */
     slice?: SlicedScroll
     /**
      * A comma-separated list of <field>:<direction> pairs.
-     * @doc_id sort-search-results
+     * @ext_doc_id sort-search-results
      */
     sort?: Sort
     /**
-     * Indicates which source fields are returned for matching documents.
-     * These fields are returned in the hits._source property of the search response.
+     * The source fields that are returned for matching documents.
+     * These fields are returned in the `hits._source` property of the search response.
+     * If the `stored_fields` property is specified, the `_source` property defaults to `false`.
+     * Otherwise, it defaults to `true`.
+     * @ext_doc_id source-filtering
      */
     _source?: SourceConfig
     /**
-     * Array of wildcard (`*`) patterns.
+     * An array of wildcard (`*`) field patterns.
      * The request returns values for field names matching these patterns in the `hits.fields` property of the response.
      */
     fields?: Array<FieldAndFormat>
@@ -477,56 +520,61 @@ export interface Request extends RequestBase {
      */
     suggest?: Suggester
     /**
-     * Maximum number of documents to collect for each shard.
+     * The maximum number of documents to collect for each shard.
      * If a query reaches this limit, Elasticsearch terminates the query early.
      * Elasticsearch collects documents before sorting.
-     * Use with caution.
-     * Elasticsearch applies this parameter to each shard handling the request.
+     *
+     * IMPORTANT: Use with caution.
+     * Elasticsearch applies this property to each shard handling the request.
      * When possible, let Elasticsearch perform early termination automatically.
-     * Avoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.
+     * Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers.
+     *
      * If set to `0` (default), the query does not terminate early.
      * @server_default 0
      */
     terminate_after?: long
     /**
-     * Specifies the period of time to wait for a response from each shard.
+     * The period of time to wait for a response from each shard.
      * If no response is received before the timeout expires, the request fails and returns an error.
      * Defaults to no timeout.
      */
     timeout?: string
     /**
-     * If true, calculate and return document scores, even if the scores are not used for sorting.
+     * If `true`, calculate and return document scores, even if the scores are not used for sorting.
      * @server_default false
      */
     track_scores?: boolean
     /**
-     * If true, returns document version as part of a hit.
+     * If `true`, the request returns the document version as part of a hit.
      * @server_default false
      */
     version?: boolean
     /**
-     * If `true`, returns sequence number and primary term of the last modification of each hit.
+     * If `true`, the request returns sequence number and primary term of the last modification of each hit.
+     * @ext_doc_id optimistic-concurrency
      */
     seq_no_primary_term?: boolean
     /**
-     * List of stored fields to return as part of a hit.
+     * A comma-separated list of stored fields to return as part of a hit.
      * If no fields are specified, no stored fields are included in the response.
-     * If this field is specified, the `_source` parameter defaults to `false`.
+     * If this field is specified, the `_source` property defaults to `false`.
      * You can pass `_source: true` to return both source fields and stored fields in the search response.
+     * @ext_doc_id stored-fields
      */
     stored_fields?: Fields
     /**
-     * Limits the search to a point in time (PIT).
+     * Limit the search to a point in time (PIT).
      * If you provide a PIT, you cannot specify an `<index>` in the request path.
      */
     pit?: PointInTimeReference
     /**
-     * Defines one or more runtime fields in the search request.
+     * One or more runtime fields in the search request.
      * These fields take precedence over mapped fields with the same name.
+     * @ext_doc_id runtime-search-request
      */
     runtime_mappings?: RuntimeFields
     /**
-     * Stats groups to associate with the search.
+     * The stats groups to associate with the search.
      * Each group maintains a statistics aggregation for its associated searches.
      * You can retrieve these stats using the indices stats API.
      */

--- a/specification/_global/search/SearchResponse.ts
+++ b/specification/_global/search/SearchResponse.ts
@@ -37,9 +37,33 @@ export class Response<TDocument> {
 
 export class ResponseBody<TDocument> {
   // Has to be kept in sync with SearchTemplateResponse
+  /**
+   * The number of milliseconds it took Elasticsearch to run the request.
+   * This value is calculated by measuring the time elapsed between receipt of a request on the coordinating node and the time at which the coordinating node is ready to send the response.
+   * It includes:
+   *
+   * * Communication time between the coordinating node and data nodes
+   * * Time the request spends in the search thread pool, queued for execution
+   * * Actual run time
+   *
+   * It does not include:
+   *
+   * * Time needed to send the request to Elasticsearch
+   * * Time needed to serialize the JSON response
+   * * Time needed to send the response to a client
+   */
   took: long
+  /**
+   * If `true`, the request timed out before completion; returned results may be partial or empty.
+   */
   timed_out: boolean
+  /**
+   * A count of shards used for the request.
+   */
   _shards: ShardStatistics
+  /**
+   * The returned documents and metadata.
+   */
   hits: HitsMetadata<TDocument>
   aggregations?: Dictionary<AggregateName, Aggregate>
   _clusters?: ClusterStatistics
@@ -48,6 +72,12 @@ export class ResponseBody<TDocument> {
   num_reduce_phases?: long
   profile?: Profile
   pit_id?: Id
+  /**
+   * The identifier for the search and its search context.
+   * You can use this scroll ID with the scroll API to retrieve the next batch of search results for the request.
+   * This property is returned only if the `scroll` query parameter is specified in the request.
+   * @ext_doc_id scroll-search-results
+   */
   _scroll_id?: ScrollId
   suggest?: Dictionary<SuggestionName, Suggest<TDocument>[]>
   terminated_early?: boolean

--- a/specification/_global/search/examples/200_response/SearchResponseExample1.yaml
+++ b/specification/_global/search/examples/200_response/SearchResponseExample1.yaml
@@ -1,0 +1,50 @@
+# summary:
+description: >
+  An abbreviated response from `GET /my-index-000001/_search?from=40&size=20` with a simple term query.
+# type: response
+# response_code: ''
+value: |-
+  {
+    "took": 5,
+    "timed_out": false,
+    "_shards": {
+      "total": 1,
+      "successful": 1,
+      "skipped": 0,
+      "failed": 0
+    },
+    "hits": {
+      "total": {
+        "value": 20,
+        "relation": "eq"
+      },
+      "max_score": 1.3862942,
+      "hits": [
+        {
+          "_index": "my-index-000001",
+          "_id": "0",
+          "_score": 1.3862942,
+          "_source": {
+            "@timestamp": "2099-11-15T14:12:12",
+            "http": {
+              "request": {
+                "method": "get"
+              },
+              "response": {
+                "status_code": 200,
+                "bytes": 1070000
+              },
+              "version": "1.1"
+            },
+            "source": {
+              "ip": "127.0.0.1"
+            },
+            "message": "GET /search HTTP/1.1 200 1070000",
+            "user": {
+              "id": "kimchy"
+            }
+          }
+        }
+      ]
+    }
+  }

--- a/specification/_global/search/examples/request/SearchRequestExample1.yaml
+++ b/specification/_global/search/examples/request/SearchRequestExample1.yaml
@@ -1,0 +1,13 @@
+summary: A simple term search
+# method_request: GET /my-index-000001/_search?from=40&size=20
+description: >
+  Run `GET /my-index-000001/_search?from=40&size=20` to run a search.
+# type: request
+value: |-
+  {
+    "query": {
+      "term": {
+        "user.id": "kimchy"
+      }
+    }
+  }

--- a/specification/_global/search/examples/request/SearchRequestExample2.yaml
+++ b/specification/_global/search/examples/request/SearchRequestExample2.yaml
@@ -1,0 +1,20 @@
+summary: A point in time search
+# method_request: POST /_search
+description: >
+  Run `POST /_search` to run a point in time search.
+  The `id` parameter tells Elasticsearch to run the request using contexts from this open point in time.
+  The `keep_alive` parameter tells Elasticsearch how long it should extend the time to live of the point in time.
+# type: request
+value: |-
+  {
+      "size": 100,  
+      "query": {
+          "match" : {
+              "title" : "elasticsearch"
+          }
+      },
+      "pit": {
+        "id":  "46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==", 
+        "keep_alive": "1m"  
+      }
+  }

--- a/specification/_global/search/examples/request/SearchRequestExample3.yaml
+++ b/specification/_global/search/examples/request/SearchRequestExample3.yaml
@@ -1,0 +1,23 @@
+summary: Search slicing
+# method_request: GET /_search
+description: >
+  When paging through a large number of documents, it can be helpful to split the search into multiple slices to consume them independently.
+  The result from running the first `GET /_search` request returns documents belonging to the first slice (`id: 0`).
+  If you run a second request with `id` set to `1', it returns documents in the second slice.
+  Since the maximum number of slices is set to `2`, the union of the results is equivalent to the results of a point-in-time search without slicing.
+# type: request
+value: |-
+  {
+    "slice": {
+      "id": 0,                      
+      "max": 2                      
+    },
+    "query": {
+      "match": {
+        "message": "foo"
+      }
+    },
+    "pit": {
+      "id": "46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA=="
+    }
+  }

--- a/specification/_types/query_dsl/abstractions.ts
+++ b/specification/_types/query_dsl/abstractions.ts
@@ -532,11 +532,11 @@ export enum CombinedFieldsZeroTerms {
  */
 export class FieldAndFormat {
   /**
-   * Wildcard pattern. The request returns values for field names matching this pattern.
+   * A wildcard pattern. The request returns values for field names matching this pattern.
    */
   field: Field
   /**
-   * Format in which the values are returned.
+   * The format in which the values are returned.
    */
   format?: string
   include_unmapped?: boolean


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR adds descriptions and examples from https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html and https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html