### PR TITLE
Fix typo in overlays

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -519,8 +519,6 @@ actions:
             examples:
               renderSearchApplicationQueryRequestExample1: 
                 $ref: "../../specification/search_application/render_query/examples/request/SearchApplicationsRenderQueryRequestExample1.yaml"
-                renderSearchApplicationQueryResponseExample1:
-                  $ref: "../../specification/search_application/render_query/examples/request/SearchApplicationsRenderQueryResponseExample1.yaml"
 # Examples for security
   - target: "$.paths['/_security/api_key/_bulk_update']['post']"
     description: "Add examples for bulk update API keys operation"


### PR DESCRIPTION
There was a redundant line in one of the overlay files, likely caused by a merge conflict.
It was caught by our linter, so this is just a quick fix.