### PR TITLE
Update doc tag for migration APIs

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -17863,7 +17863,7 @@
     "/_migration/reindex/{index}/_cancel": {
       "post": {
         "tags": [
-          "cancel_reindex"
+          "migration"
         ],
         "summary": "This API cancels a migration reindex attempt for a data stream or index",
         "operationId": "migrate-cancel-reindex",
@@ -17898,7 +17898,7 @@
     "/_create_from/{source}/{dest}": {
       "put": {
         "tags": [
-          "create_from"
+          "migration"
         ],
         "summary": "This API creates a destination from a source index",
         "description": "It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.",
@@ -17923,7 +17923,7 @@
       },
       "post": {
         "tags": [
-          "create_from"
+          "migration"
         ],
         "summary": "This API creates a destination from a source index",
         "description": "It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.",
@@ -17950,7 +17950,7 @@
     "/_migration/reindex/{index}/_status": {
       "get": {
         "tags": [
-          "get_reindex_status"
+          "migration"
         ],
         "summary": "This API returns the status of a migration reindex attempt for a data stream or index",
         "operationId": "migrate-get-reindex-status",
@@ -18033,7 +18033,7 @@
     "/_migration/reindex": {
       "post": {
         "tags": [
-          "reindex"
+          "migration"
         ],
         "summary": "\"This API reindexes all legacy backing indices for a data stream",
         "description": "It does this in a persistent task. The persistent task id is returned immediately, and the reindexing work is completed in that task",

--- a/specification/migrate/cancel_reindex/MigrateCancelReindexRequest.ts
+++ b/specification/migrate/cancel_reindex/MigrateCancelReindexRequest.ts
@@ -27,7 +27,7 @@ import { Indices } from '@_types/common'
  * @availability stack since=8.18.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
  * @doc_id migrate
- * @doc_tag cancel_reindex
+ * @doc_tag migration
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/migrate/create_from/MigrateCreateFromRequest.ts
+++ b/specification/migrate/create_from/MigrateCreateFromRequest.ts
@@ -29,7 +29,7 @@ import { TypeMapping } from '@_types/mapping/TypeMapping'
  * @availability stack since=8.18.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
  * @doc_id migrate
- * @doc_tag create_from
+ * @doc_tag migration
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/migrate/get_reindex_status/MigrateGetReindexStatusRequest.ts
+++ b/specification/migrate/get_reindex_status/MigrateGetReindexStatusRequest.ts
@@ -27,7 +27,7 @@ import { Indices } from '@_types/common'
  * @availability stack since=8.18.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
  * @doc_id migrate
- * @doc_tag get_reindex_status
+ * @doc_tag migration
  */
 export interface Request extends RequestBase {
   path_parts: {

--- a/specification/migrate/reindex/MigrateReindexRequest.ts
+++ b/specification/migrate/reindex/MigrateReindexRequest.ts
@@ -26,7 +26,7 @@ import { IndexName } from '@_types/common'
  * @rest_spec_name migrate.reindex
  * @availability stack since=8.18.0 stability=experimental
  * @doc_id migrate
- * @doc_tag reindex
+ * @doc_tag migration
  */
 export interface Request extends RequestBase {
   /** @codegen_name reindex */


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/pull/3518, https://github.com/elastic/elasticsearch/pull/118291

This PR addresses the following errors returned from `make lint-docs-errs`:
 ```
 18464:11  error  operation-tag-defined  Operation tags must be defined in global tags.                            paths./_migration/reindex/{index}/_cancel.post.tags[0]
 18499:11  error  operation-tag-defined  Operation tags must be defined in global tags.                            paths./_create_from/{source}/{dest}.put.tags[0]
 18524:11  error  operation-tag-defined  Operation tags must be defined in global tags.                            paths./_create_from/{source}/{dest}.post.tags[0]
 18551:11  error  operation-tag-defined  Operation tags must be defined in global tags.                            paths./_migration/reindex/{index}/_status.get.tags[0]
 18634:11  error  operation-tag-defined  Operation tags must be defined in global tags.                            paths./_migration/reindex.post.tags[0]
```

These errors were occurring because the APIs had tags that didn't exist in the global list of tags. I am assuming these APIs ought to appear in the "Migration" section (https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-migration) and so am updating the tag accordingly. If they ought to be added to a different existing or new tag group, that's acceptable too.