### PR TITLE
Add remove_index_blocks param to _create_from

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -76306,6 +76306,10 @@
           },
           "settings_override": {
             "$ref": "#/components/schemas/indices._types:IndexSettings"
+          },
+          "remove_index_blocks": {
+            "description": "If index blocks should be removed when creating destination index (optional)",
+            "type": "boolean"
           }
         }
       },

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13891,6 +13891,7 @@ export type MigrateCancelReindexResponse = AcknowledgedResponseBase
 export interface MigrateCreateFromCreateFrom {
   mappings_override?: MappingTypeMapping
   settings_override?: IndicesIndexSettings
+  remove_index_blocks?: boolean
 }
 
 export interface MigrateCreateFromRequest extends RequestBase {

--- a/specification/migrate/create_from/MigrateCreateFromRequest.ts
+++ b/specification/migrate/create_from/MigrateCreateFromRequest.ts
@@ -53,6 +53,7 @@ export class CreateFrom {
   settings_override?: IndexSettings
   /**
    * If index blocks should be removed when creating destination index (optional)
+   * @server_default false
    */
   remove_index_blocks?: boolean
 }

--- a/specification/migrate/create_from/MigrateCreateFromRequest.ts
+++ b/specification/migrate/create_from/MigrateCreateFromRequest.ts
@@ -51,4 +51,8 @@ export class CreateFrom {
    * Settings overrides to be applied to the destination index (optional)
    */
   settings_override?: IndexSettings
+  /**
+   * If index blocks should be removed when creating destination index (optional)
+   */
+  remove_index_blocks?: boolean
 }


### PR DESCRIPTION
Add a new parameter to the request body for `_create_from/{source}/{dest}` api.
Parameter is an optional boolean called `remove_index_blocks`.

Add to ES in https://github.com/elastic/elasticsearch/pull/120548/files