### PR TITLE
Edit migration reindexing summaries

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -11470,7 +11470,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "This API cancels a migration reindex attempt for a data stream or index",
+        "summary": "Cancel a reindex operation",
+        "description": "Cancel a migration reindex attempt for a data stream or index.",
         "operationId": "indices-cancel-migrate-reindex",
         "parameters": [
           {
@@ -12302,8 +12303,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "This API creates a destination from a source index",
-        "description": "It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.",
+        "summary": "Create a destination from a source index",
+        "description": "This API copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.",
         "operationId": "indices-create-from",
         "parameters": [
           {
@@ -12327,8 +12328,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "This API creates a destination from a source index",
-        "description": "It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.",
+        "summary": "Create a destination from a source index",
+        "description": "This API copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.",
         "operationId": "indices-create-from-1",
         "parameters": [
           {
@@ -14230,13 +14231,14 @@
         "tags": [
           "migration"
         ],
-        "summary": "This API returns the status of a migration reindex attempt for a data stream or index",
+        "summary": "Get the reindexing status",
+        "description": "Get the status of a migration reindex attempt for a data stream or index.",
         "operationId": "indices-get-migrate-reindex-status",
         "parameters": [
           {
             "in": "path",
             "name": "index",
-            "description": "The index or data stream name",
+            "description": "The index or data stream name.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -14593,8 +14595,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "\"This API reindexes all legacy backing indices for a data stream",
-        "description": "It does this in a persistent task. The persistent task id is returned immediately, and the reindexing work is completed in that task",
+        "summary": "Reindex legacy backing indices",
+        "description": "Reindex all legacy backing indices for a data stream.\nThis operation occurs in a persistent task.\nThe persistent task ID is returned immediately and the reindexing work is completed in that task.",
         "operationId": "indices-migrate-reindex",
         "requestBody": {
           "content": {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -11470,7 +11470,7 @@
         "tags": [
           "migration"
         ],
-        "summary": "Cancel a reindex operation",
+        "summary": "Cancel a migration reindex operation",
         "description": "Cancel a migration reindex attempt for a data stream or index.",
         "operationId": "indices-cancel-migrate-reindex",
         "parameters": [
@@ -12303,8 +12303,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "Create a destination from a source index",
-        "description": "This API copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.",
+        "summary": "Create an index from a source index",
+        "description": "Copy the mappings and settings from the source index to a destination index while allowing request settings and mappings to override the source values.",
         "operationId": "indices-create-from",
         "parameters": [
           {
@@ -12328,8 +12328,8 @@
         "tags": [
           "migration"
         ],
-        "summary": "Create a destination from a source index",
-        "description": "This API copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.",
+        "summary": "Create an index from a source index",
+        "description": "Copy the mappings and settings from the source index to a destination index while allowing request settings and mappings to override the source values.",
         "operationId": "indices-create-from-1",
         "parameters": [
           {
@@ -14231,7 +14231,7 @@
         "tags": [
           "migration"
         ],
-        "summary": "Get the reindexing status",
+        "summary": "Get the migration reindexing status",
         "description": "Get the status of a migration reindex attempt for a data stream or index.",
         "operationId": "indices-get-migrate-reindex-status",
         "parameters": [

--- a/specification/indices/cancel_migrate_reindex/MigrateCancelReindexRequest.ts
+++ b/specification/indices/cancel_migrate_reindex/MigrateCancelReindexRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Indices } from '@_types/common'
 
 /**
- * Cancel a reindex operation.
+ * Cancel a migration reindex operation.
  *
  * Cancel a migration reindex attempt for a data stream or index.
  * @rest_spec_name indices.cancel_migrate_reindex

--- a/specification/indices/cancel_migrate_reindex/MigrateCancelReindexRequest.ts
+++ b/specification/indices/cancel_migrate_reindex/MigrateCancelReindexRequest.ts
@@ -21,8 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { Indices } from '@_types/common'
 
 /**
- * This API cancels a migration reindex attempt for a data stream or index
+ * Cancel a reindex operation.
  *
+ * Cancel a migration reindex attempt for a data stream or index.
  * @rest_spec_name indices.cancel_migrate_reindex
  * @availability stack since=8.18.0 stability=experimental
  * @availability serverless stability=experimental visibility=private

--- a/specification/indices/create_from/MigrateCreateFromRequest.ts
+++ b/specification/indices/create_from/MigrateCreateFromRequest.ts
@@ -23,9 +23,9 @@ import { IndexName } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 
 /**
- * Create a destination from a source index.
+ * Create an index from a source index.
  *
- * This API copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.
+ * Copy the mappings and settings from the source index to a destination index while allowing request settings and mappings to override the source values.
  * @rest_spec_name indices.create_from
  * @availability stack since=8.18.0 stability=experimental
  * @availability serverless stability=experimental visibility=private

--- a/specification/indices/create_from/MigrateCreateFromRequest.ts
+++ b/specification/indices/create_from/MigrateCreateFromRequest.ts
@@ -23,8 +23,9 @@ import { IndexName } from '@_types/common'
 import { TypeMapping } from '@_types/mapping/TypeMapping'
 
 /**
- * This API creates a destination from a source index. It copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.
+ * Create a destination from a source index.
  *
+ * This API copies the mappings and settings from the source index while allowing request settings and mappings to override the source values.
  * @rest_spec_name indices.create_from
  * @availability stack since=8.18.0 stability=experimental
  * @availability serverless stability=experimental visibility=private

--- a/specification/indices/get_migrate_reindex_status/MigrateGetReindexStatusRequest.ts
+++ b/specification/indices/get_migrate_reindex_status/MigrateGetReindexStatusRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Indices } from '@_types/common'
 
 /**
- * Get the reindexing status.
+ * Get the migration reindexing status.
  *
  * Get the status of a migration reindex attempt for a data stream or index.
  * @rest_spec_name indices.get_migrate_reindex_status

--- a/specification/indices/get_migrate_reindex_status/MigrateGetReindexStatusRequest.ts
+++ b/specification/indices/get_migrate_reindex_status/MigrateGetReindexStatusRequest.ts
@@ -21,8 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { Indices } from '@_types/common'
 
 /**
- * This API returns the status of a migration reindex attempt for a data stream or index
+ * Get the reindexing status.
  *
+ * Get the status of a migration reindex attempt for a data stream or index.
  * @rest_spec_name indices.get_migrate_reindex_status
  * @availability stack since=8.18.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
@@ -31,7 +32,7 @@ import { Indices } from '@_types/common'
  */
 export interface Request extends RequestBase {
   path_parts: {
-    /** The index or data stream name */
+    /** The index or data stream name. */
     index: Indices
   }
 }

--- a/specification/indices/migrate_reindex/MigrateReindexRequest.ts
+++ b/specification/indices/migrate_reindex/MigrateReindexRequest.ts
@@ -21,8 +21,11 @@ import { RequestBase } from '@_types/Base'
 import { IndexName } from '@_types/common'
 
 /**
- * "This API reindexes all legacy backing indices for a data stream. It does this in a persistent task. The persistent task id is returned immediately, and the reindexing work is completed in that task
+ * Reindex legacy backing indices.
  *
+ * Reindex all legacy backing indices for a data stream.
+ * This operation occurs in a persistent task.
+ * The persistent task ID is returned immediately and the reindexing work is completed in that task.
  * @rest_spec_name indices.migrate_reindex
  * @availability stack since=8.18.0 stability=experimental
  * @doc_id migrate


### PR DESCRIPTION
This PR edits the operation summaries for the new APIs that appear in https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-migration

That first line needs to be short and sweet and start with a verb to align with all the other titles that appear in the left-hand navigation. There's some more guidance in https://github.com/elastic/elasticsearch-specification/blob/main/docs/doc-comments-guide.md with more to come soon.

NOTE: I have not drafted descriptions for all the request body and response body properties, but those should eventually be added for clarity and completeness too.