### PR TITLE
[DOCS] Add examples for delete by query API

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -7524,13 +7524,13 @@
           "document"
         ],
         "summary": "Delete documents",
-        "description": "Deletes documents that match the specified query.",
+        "description": "Deletes documents that match the specified query.\n\nIf the Elasticsearch security features are enabled, you must have the following index privileges for the target data stream, index, or alias:\n\n* `read`\n* `delete` or `write`\n\nYou can specify the query criteria in the request URI or the request body using the same syntax as the search API.\nWhen you submit a delete by query request, Elasticsearch gets a snapshot of the data stream or index when it begins processing the request and deletes matching documents using internal versioning.\nIf a document changes between the time that the snapshot is taken and the delete operation is processed, it results in a version conflict and the delete operation fails.\n\nNOTE: Documents with a version equal to 0 cannot be deleted using delete by query because internal versioning does not support 0 as a valid version number.\n\nWhile processing a delete by query request, Elasticsearch performs multiple search requests sequentially to find all of the matching documents to delete.\nA bulk delete request is performed for each batch of matching documents.\nIf a search or bulk request is rejected, the requests are retried up to 10 times, with exponential back off.\nIf the maximum retry limit is reached, processing halts and all failed requests are returned in the response.\nAny delete requests that completed successfully still stick, they are not rolled back.\n\nYou can opt to count version conflicts instead of halting and returning by setting `conflicts` to `proceed`.\nNote that if you opt to count version conflicts the operation could attempt to delete more documents from the source than `max_docs` until it has successfully deleted `max_docs documents`, or it has gone through every document in the source query.\n\n**Throttling delete requests**\n\nTo control the rate at which delete by query issues batches of delete operations, you can set `requests_per_second` to any positive decimal number.\nThis pads each batch with a wait time to throttle the rate.\nSet `requests_per_second` to `-1` to disable throttling.\n\nThrottling uses a wait time between batches so that the internal scroll requests can be given a timeout that takes the request padding into account.\nThe padding time is the difference between the batch size divided by the `requests_per_second` and the time spent writing.\nBy default the batch size is `1000`, so if `requests_per_second` is set to `500`:\n\n```\ntarget_time = 1000 / 500 per second = 2 seconds\nwait_time = target_time - write_time = 2 seconds - .5 seconds = 1.5 seconds\n```\n\nSince the batch is issued as a single `_bulk` request, large batch sizes cause Elasticsearch to create many requests and wait before starting the next set.\nThis is \"bursty\" instead of \"smooth\".\n\n**Slicing**\n\nDelete by query supports sliced scroll to parallelize the delete process.\nThis can improve efficiency and provide a convenient way to break the request down into smaller parts.\n\nSetting `slices` to `auto` lets Elasticsearch choose the number of slices to use.\nThis setting will use one slice per shard, up to a certain limit.\nIf there are multiple source data streams or indices, it will choose the number of slices based on the index or backing index with the smallest number of shards.\nAdding slices to the delete by query operation creates sub-requests which means it has some quirks:\n\n* You can see these requests in the tasks APIs. These sub-requests are \"child\" tasks of the task for the request with slices.\n* Fetching the status of the task for the request with slices only contains the status of completed slices.\n* These sub-requests are individually addressable for things like cancellation and rethrottling.\n* Rethrottling the request with `slices` will rethrottle the unfinished sub-request proportionally.\n* Canceling the request with `slices` will cancel each sub-request.\n* Due to the nature of `slices` each sub-request won't get a perfectly even portion of the documents. All documents will be addressed, but some slices may be larger than others. Expect larger slices to have a more even distribution.\n* Parameters like `requests_per_second` and `max_docs` on a request with `slices` are distributed proportionally to each sub-request. Combine that with the earlier point about distribution being uneven and you should conclude that using `max_docs` with `slices` might not result in exactly `max_docs` documents being deleted.\n* Each sub-request gets a slightly different snapshot of the source data stream or index though these are all taken at approximately the same time.\n\nIf you're slicing manually or otherwise tuning automatic slicing, keep in mind that:\n\n* Query performance is most efficient when the number of slices is equal to the number of shards in the index or backing index. If that number is large (for example, 500), choose a lower number as too many `slices` hurts performance. Setting `slices` higher than the number of shards generally does not improve efficiency and adds overhead.\n* Delete performance scales linearly across available resources with the number of slices.\n\nWhether query or delete performance dominates the runtime depends on the documents being reindexed and cluster resources.\n\n**Cancel a delete by query operation**\n\nAny delete by query can be canceled using the task cancel API. For example:\n\n```\nPOST _tasks/r1A2WoRbTwKZ516z6NEs5A:36619/_cancel\n```\n\nThe task ID can be found by using the get tasks API.\n\nCancellation should happen quickly but might take a few seconds.\nThe get task status API will continue to list the delete by query task until this task checks that it has been cancelled and terminates itself.",
         "operationId": "delete-by-query",
         "parameters": [
           {
             "in": "path",
             "name": "index",
-            "description": "Comma-separated list of data streams, indices, and aliases to search.\nSupports wildcards (`*`).\nTo search all data streams or indices, omit this parameter or use `*` or `_all`.",
+            "description": "A comma-separated list of data streams, indices, and aliases to search.\nIt supports wildcards (`*`).\nTo search all data streams or indices, omit this parameter or use `*` or `_all`.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -7551,7 +7551,7 @@
           {
             "in": "query",
             "name": "analyzer",
-            "description": "Analyzer to use for the query string.",
+            "description": "Analyzer to use for the query string.\nThis parameter can be used only when the `q` query string parameter is specified.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -7561,7 +7561,7 @@
           {
             "in": "query",
             "name": "analyze_wildcard",
-            "description": "If `true`, wildcard and prefix queries are analyzed.",
+            "description": "If `true`, wildcard and prefix queries are analyzed.\nThis parameter can be used only when the `q` query string parameter is specified.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -7581,7 +7581,7 @@
           {
             "in": "query",
             "name": "default_operator",
-            "description": "The default operator for query string query: `AND` or `OR`.",
+            "description": "The default operator for query string query: `AND` or `OR`.\nThis parameter can be used only when the `q` query string parameter is specified.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types.query_dsl:Operator"
@@ -7591,7 +7591,7 @@
           {
             "in": "query",
             "name": "df",
-            "description": "Field to use as default where no field prefix is given in the query string.",
+            "description": "The field to use as default where no field prefix is given in the query string.\nThis parameter can be used only when the `q` query string parameter is specified.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -7601,7 +7601,7 @@
           {
             "in": "query",
             "name": "expand_wildcards",
-            "description": "Type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nSupports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.",
+            "description": "The type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nIt supports comma-separated values, such as `open,hidden`.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -7631,7 +7631,7 @@
           {
             "in": "query",
             "name": "lenient",
-            "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.",
+            "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.\nThis parameter can be used only when the `q` query string parameter is specified.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -7641,7 +7641,7 @@
           {
             "in": "query",
             "name": "max_docs",
-            "description": "Maximum number of documents to process.\nDefaults to all documents.",
+            "description": "The maximum number of documents to process.\nDefaults to all documents.\nWhen set to a value less then or equal to `scroll_size`, a scroll will not be used to retrieve the results for the operation.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -7651,7 +7651,7 @@
           {
             "in": "query",
             "name": "preference",
-            "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+            "description": "The node or shard the operation should be performed on.\nIt is random by default.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -7661,7 +7661,7 @@
           {
             "in": "query",
             "name": "refresh",
-            "description": "If `true`, Elasticsearch refreshes all shards involved in the delete by query after the request completes.",
+            "description": "If `true`, Elasticsearch refreshes all shards involved in the delete by query after the request completes.\nThis is different than the delete API's `refresh` parameter, which causes just the shard that received the delete request to be refreshed.\nUnlike the delete API, it does not support `wait_for`.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -7691,7 +7691,7 @@
           {
             "in": "query",
             "name": "routing",
-            "description": "Custom value used to route operations to a specific shard.",
+            "description": "A custom value used to route operations to a specific shard.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Routing"
@@ -7701,7 +7701,7 @@
           {
             "in": "query",
             "name": "q",
-            "description": "Query in the Lucene query string syntax.",
+            "description": "A query in the Lucene query string syntax.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -7711,7 +7711,7 @@
           {
             "in": "query",
             "name": "scroll",
-            "description": "Period to retain the search context for scrolling.",
+            "description": "The period to retain the search context for scrolling.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -7721,7 +7721,7 @@
           {
             "in": "query",
             "name": "scroll_size",
-            "description": "Size of the scroll request that powers the operation.",
+            "description": "The size of the scroll request that powers the operation.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -7731,7 +7731,7 @@
           {
             "in": "query",
             "name": "search_timeout",
-            "description": "Explicit timeout for each search request.\nDefaults to no timeout.",
+            "description": "The explicit timeout for each search request.\nIt defaults to no timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -7741,7 +7741,7 @@
           {
             "in": "query",
             "name": "search_type",
-            "description": "The type of the search operation.\nAvailable options: `query_then_fetch`, `dfs_query_then_fetch`.",
+            "description": "The type of the search operation.\nAvailable options include `query_then_fetch` and `dfs_query_then_fetch`.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:SearchType"
@@ -7761,7 +7761,7 @@
           {
             "in": "query",
             "name": "sort",
-            "description": "A comma-separated list of <field>:<direction> pairs.",
+            "description": "A comma-separated list of `<field>:<direction>` pairs.",
             "deprecated": false,
             "schema": {
               "type": "array",
@@ -7774,7 +7774,7 @@
           {
             "in": "query",
             "name": "stats",
-            "description": "Specific `tag` of the request for logging and statistical purposes.",
+            "description": "The specific `tag` of the request for logging and statistical purposes.",
             "deprecated": false,
             "schema": {
               "type": "array",
@@ -7787,7 +7787,7 @@
           {
             "in": "query",
             "name": "terminate_after",
-            "description": "Maximum number of documents to collect for each shard.\nIf a query reaches this limit, Elasticsearch terminates the query early.\nElasticsearch collects documents before sorting.\nUse with caution.\nElasticsearch applies this parameter to each shard handling the request.\nWhen possible, let Elasticsearch perform early termination automatically.\nAvoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.",
+            "description": "The maximum number of documents to collect for each shard.\nIf a query reaches this limit, Elasticsearch terminates the query early.\nElasticsearch collects documents before sorting.\n\nUse with caution.\nElasticsearch applies this parameter to each shard handling the request.\nWhen possible, let Elasticsearch perform early termination automatically.\nAvoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -7797,7 +7797,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Period each deletion request waits for active shards.",
+            "description": "The period each deletion request waits for active shards.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -7817,7 +7817,7 @@
           {
             "in": "query",
             "name": "wait_for_active_shards",
-            "description": "The number of shard copies that must be active before proceeding with the operation.\nSet to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).",
+            "description": "The number of shard copies that must be active before proceeding with the operation.\nSet to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).\nThe `timeout` value controls how long each write request waits for unavailable shards to become available.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:WaitForActiveShards"
@@ -7827,7 +7827,7 @@
           {
             "in": "query",
             "name": "wait_for_completion",
-            "description": "If `true`, the request blocks until the operation is complete.",
+            "description": "If `true`, the request blocks until the operation is complete.\nIf `false`, Elasticsearch performs some preflight checks, launches the request, and returns a task you can use to cancel or get the status of the task. Elasticsearch creates a record of this task as a document at `.tasks/task/${taskId}`. When you are done with a task, you should delete the task document so Elasticsearch can reclaim the space.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -7866,21 +7866,26 @@
                   "type": "object",
                   "properties": {
                     "batches": {
+                      "description": "The number of scroll responses pulled back by the delete by query.",
                       "type": "number"
                     },
                     "deleted": {
+                      "description": "The number of documents that were successfully deleted.",
                       "type": "number"
                     },
                     "failures": {
+                      "description": "An array of failures if there were any unrecoverable errors during the process.\nIf this array is not empty, the request ended abnormally because of those failures.\nDelete by query is implemented using batches and any failures cause the entire process to end but all failures in the current batch are collected into the array.\nYou can use the `conflicts` option to prevent reindex from ending on version conflicts.",
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/_types:BulkIndexByScrollFailure"
                       }
                     },
                     "noops": {
+                      "description": "This field is always equal to zero for delete by query.\nIt exists only so that delete by query, update by query, and reindex APIs return responses with the same structure.",
                       "type": "number"
                     },
                     "requests_per_second": {
+                      "description": "The number of requests per second effectively run during the delete by query.",
                       "type": "number"
                     },
                     "retries": {
@@ -7905,15 +7910,18 @@
                       "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
                     },
                     "timed_out": {
+                      "description": "If `true`, some requests run during the delete by query operation timed out.",
                       "type": "boolean"
                     },
                     "took": {
                       "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
                     },
                     "total": {
+                      "description": "The number of documents that were successfully processed.",
                       "type": "number"
                     },
                     "version_conflicts": {
+                      "description": "The number of version conflicts that the delete by query hit.",
                       "type": "number"
                     }
                   }
@@ -7948,7 +7956,7 @@
           {
             "in": "query",
             "name": "requests_per_second",
-            "description": "The throttle for this request in sub-requests per second.",
+            "description": "The throttle for this request in sub-requests per second.\nTo disable throttling, set it to `-1`.",
             "deprecated": false,
             "schema": {
               "type": "number"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -4082,13 +4082,13 @@
           "document"
         ],
         "summary": "Delete documents",
-        "description": "Deletes documents that match the specified query.",
+        "description": "Deletes documents that match the specified query.\n\nIf the Elasticsearch security features are enabled, you must have the following index privileges for the target data stream, index, or alias:\n\n* `read`\n* `delete` or `write`\n\nYou can specify the query criteria in the request URI or the request body using the same syntax as the search API.\nWhen you submit a delete by query request, Elasticsearch gets a snapshot of the data stream or index when it begins processing the request and deletes matching documents using internal versioning.\nIf a document changes between the time that the snapshot is taken and the delete operation is processed, it results in a version conflict and the delete operation fails.\n\nNOTE: Documents with a version equal to 0 cannot be deleted using delete by query because internal versioning does not support 0 as a valid version number.\n\nWhile processing a delete by query request, Elasticsearch performs multiple search requests sequentially to find all of the matching documents to delete.\nA bulk delete request is performed for each batch of matching documents.\nIf a search or bulk request is rejected, the requests are retried up to 10 times, with exponential back off.\nIf the maximum retry limit is reached, processing halts and all failed requests are returned in the response.\nAny delete requests that completed successfully still stick, they are not rolled back.\n\nYou can opt to count version conflicts instead of halting and returning by setting `conflicts` to `proceed`.\nNote that if you opt to count version conflicts the operation could attempt to delete more documents from the source than `max_docs` until it has successfully deleted `max_docs documents`, or it has gone through every document in the source query.\n\n**Throttling delete requests**\n\nTo control the rate at which delete by query issues batches of delete operations, you can set `requests_per_second` to any positive decimal number.\nThis pads each batch with a wait time to throttle the rate.\nSet `requests_per_second` to `-1` to disable throttling.\n\nThrottling uses a wait time between batches so that the internal scroll requests can be given a timeout that takes the request padding into account.\nThe padding time is the difference between the batch size divided by the `requests_per_second` and the time spent writing.\nBy default the batch size is `1000`, so if `requests_per_second` is set to `500`:\n\n```\ntarget_time = 1000 / 500 per second = 2 seconds\nwait_time = target_time - write_time = 2 seconds - .5 seconds = 1.5 seconds\n```\n\nSince the batch is issued as a single `_bulk` request, large batch sizes cause Elasticsearch to create many requests and wait before starting the next set.\nThis is \"bursty\" instead of \"smooth\".\n\n**Slicing**\n\nDelete by query supports sliced scroll to parallelize the delete process.\nThis can improve efficiency and provide a convenient way to break the request down into smaller parts.\n\nSetting `slices` to `auto` lets Elasticsearch choose the number of slices to use.\nThis setting will use one slice per shard, up to a certain limit.\nIf there are multiple source data streams or indices, it will choose the number of slices based on the index or backing index with the smallest number of shards.\nAdding slices to the delete by query operation creates sub-requests which means it has some quirks:\n\n* You can see these requests in the tasks APIs. These sub-requests are \"child\" tasks of the task for the request with slices.\n* Fetching the status of the task for the request with slices only contains the status of completed slices.\n* These sub-requests are individually addressable for things like cancellation and rethrottling.\n* Rethrottling the request with `slices` will rethrottle the unfinished sub-request proportionally.\n* Canceling the request with `slices` will cancel each sub-request.\n* Due to the nature of `slices` each sub-request won't get a perfectly even portion of the documents. All documents will be addressed, but some slices may be larger than others. Expect larger slices to have a more even distribution.\n* Parameters like `requests_per_second` and `max_docs` on a request with `slices` are distributed proportionally to each sub-request. Combine that with the earlier point about distribution being uneven and you should conclude that using `max_docs` with `slices` might not result in exactly `max_docs` documents being deleted.\n* Each sub-request gets a slightly different snapshot of the source data stream or index though these are all taken at approximately the same time.\n\nIf you're slicing manually or otherwise tuning automatic slicing, keep in mind that:\n\n* Query performance is most efficient when the number of slices is equal to the number of shards in the index or backing index. If that number is large (for example, 500), choose a lower number as too many `slices` hurts performance. Setting `slices` higher than the number of shards generally does not improve efficiency and adds overhead.\n* Delete performance scales linearly across available resources with the number of slices.\n\nWhether query or delete performance dominates the runtime depends on the documents being reindexed and cluster resources.\n\n**Cancel a delete by query operation**\n\nAny delete by query can be canceled using the task cancel API. For example:\n\n```\nPOST _tasks/r1A2WoRbTwKZ516z6NEs5A:36619/_cancel\n```\n\nThe task ID can be found by using the get tasks API.\n\nCancellation should happen quickly but might take a few seconds.\nThe get task status API will continue to list the delete by query task until this task checks that it has been cancelled and terminates itself.",
         "operationId": "delete-by-query",
         "parameters": [
           {
             "in": "path",
             "name": "index",
-            "description": "Comma-separated list of data streams, indices, and aliases to search.\nSupports wildcards (`*`).\nTo search all data streams or indices, omit this parameter or use `*` or `_all`.",
+            "description": "A comma-separated list of data streams, indices, and aliases to search.\nIt supports wildcards (`*`).\nTo search all data streams or indices, omit this parameter or use `*` or `_all`.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -4109,7 +4109,7 @@
           {
             "in": "query",
             "name": "analyzer",
-            "description": "Analyzer to use for the query string.",
+            "description": "Analyzer to use for the query string.\nThis parameter can be used only when the `q` query string parameter is specified.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -4119,7 +4119,7 @@
           {
             "in": "query",
             "name": "analyze_wildcard",
-            "description": "If `true`, wildcard and prefix queries are analyzed.",
+            "description": "If `true`, wildcard and prefix queries are analyzed.\nThis parameter can be used only when the `q` query string parameter is specified.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -4139,7 +4139,7 @@
           {
             "in": "query",
             "name": "default_operator",
-            "description": "The default operator for query string query: `AND` or `OR`.",
+            "description": "The default operator for query string query: `AND` or `OR`.\nThis parameter can be used only when the `q` query string parameter is specified.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types.query_dsl:Operator"
@@ -4149,7 +4149,7 @@
           {
             "in": "query",
             "name": "df",
-            "description": "Field to use as default where no field prefix is given in the query string.",
+            "description": "The field to use as default where no field prefix is given in the query string.\nThis parameter can be used only when the `q` query string parameter is specified.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -4159,7 +4159,7 @@
           {
             "in": "query",
             "name": "expand_wildcards",
-            "description": "Type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nSupports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.",
+            "description": "The type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nIt supports comma-separated values, such as `open,hidden`.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -4189,7 +4189,7 @@
           {
             "in": "query",
             "name": "lenient",
-            "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.",
+            "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.\nThis parameter can be used only when the `q` query string parameter is specified.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -4199,7 +4199,7 @@
           {
             "in": "query",
             "name": "max_docs",
-            "description": "Maximum number of documents to process.\nDefaults to all documents.",
+            "description": "The maximum number of documents to process.\nDefaults to all documents.\nWhen set to a value less then or equal to `scroll_size`, a scroll will not be used to retrieve the results for the operation.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -4209,7 +4209,7 @@
           {
             "in": "query",
             "name": "preference",
-            "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+            "description": "The node or shard the operation should be performed on.\nIt is random by default.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -4219,7 +4219,7 @@
           {
             "in": "query",
             "name": "refresh",
-            "description": "If `true`, Elasticsearch refreshes all shards involved in the delete by query after the request completes.",
+            "description": "If `true`, Elasticsearch refreshes all shards involved in the delete by query after the request completes.\nThis is different than the delete API's `refresh` parameter, which causes just the shard that received the delete request to be refreshed.\nUnlike the delete API, it does not support `wait_for`.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -4249,7 +4249,7 @@
           {
             "in": "query",
             "name": "routing",
-            "description": "Custom value used to route operations to a specific shard.",
+            "description": "A custom value used to route operations to a specific shard.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Routing"
@@ -4259,7 +4259,7 @@
           {
             "in": "query",
             "name": "q",
-            "description": "Query in the Lucene query string syntax.",
+            "description": "A query in the Lucene query string syntax.",
             "deprecated": false,
             "schema": {
               "type": "string"
@@ -4269,7 +4269,7 @@
           {
             "in": "query",
             "name": "scroll",
-            "description": "Period to retain the search context for scrolling.",
+            "description": "The period to retain the search context for scrolling.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -4279,7 +4279,7 @@
           {
             "in": "query",
             "name": "scroll_size",
-            "description": "Size of the scroll request that powers the operation.",
+            "description": "The size of the scroll request that powers the operation.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -4289,7 +4289,7 @@
           {
             "in": "query",
             "name": "search_timeout",
-            "description": "Explicit timeout for each search request.\nDefaults to no timeout.",
+            "description": "The explicit timeout for each search request.\nIt defaults to no timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -4299,7 +4299,7 @@
           {
             "in": "query",
             "name": "search_type",
-            "description": "The type of the search operation.\nAvailable options: `query_then_fetch`, `dfs_query_then_fetch`.",
+            "description": "The type of the search operation.\nAvailable options include `query_then_fetch` and `dfs_query_then_fetch`.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:SearchType"
@@ -4319,7 +4319,7 @@
           {
             "in": "query",
             "name": "sort",
-            "description": "A comma-separated list of <field>:<direction> pairs.",
+            "description": "A comma-separated list of `<field>:<direction>` pairs.",
             "deprecated": false,
             "schema": {
               "type": "array",
@@ -4332,7 +4332,7 @@
           {
             "in": "query",
             "name": "stats",
-            "description": "Specific `tag` of the request for logging and statistical purposes.",
+            "description": "The specific `tag` of the request for logging and statistical purposes.",
             "deprecated": false,
             "schema": {
               "type": "array",
@@ -4345,7 +4345,7 @@
           {
             "in": "query",
             "name": "terminate_after",
-            "description": "Maximum number of documents to collect for each shard.\nIf a query reaches this limit, Elasticsearch terminates the query early.\nElasticsearch collects documents before sorting.\nUse with caution.\nElasticsearch applies this parameter to each shard handling the request.\nWhen possible, let Elasticsearch perform early termination automatically.\nAvoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.",
+            "description": "The maximum number of documents to collect for each shard.\nIf a query reaches this limit, Elasticsearch terminates the query early.\nElasticsearch collects documents before sorting.\n\nUse with caution.\nElasticsearch applies this parameter to each shard handling the request.\nWhen possible, let Elasticsearch perform early termination automatically.\nAvoid specifying this parameter for requests that target data streams with backing indices across multiple data tiers.",
             "deprecated": false,
             "schema": {
               "type": "number"
@@ -4355,7 +4355,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Period each deletion request waits for active shards.",
+            "description": "The period each deletion request waits for active shards.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -4375,7 +4375,7 @@
           {
             "in": "query",
             "name": "wait_for_active_shards",
-            "description": "The number of shard copies that must be active before proceeding with the operation.\nSet to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).",
+            "description": "The number of shard copies that must be active before proceeding with the operation.\nSet to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).\nThe `timeout` value controls how long each write request waits for unavailable shards to become available.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:WaitForActiveShards"
@@ -4385,7 +4385,7 @@
           {
             "in": "query",
             "name": "wait_for_completion",
-            "description": "If `true`, the request blocks until the operation is complete.",
+            "description": "If `true`, the request blocks until the operation is complete.\nIf `false`, Elasticsearch performs some preflight checks, launches the request, and returns a task you can use to cancel or get the status of the task. Elasticsearch creates a record of this task as a document at `.tasks/task/${taskId}`. When you are done with a task, you should delete the task document so Elasticsearch can reclaim the space.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -4424,21 +4424,26 @@
                   "type": "object",
                   "properties": {
                     "batches": {
+                      "description": "The number of scroll responses pulled back by the delete by query.",
                       "type": "number"
                     },
                     "deleted": {
+                      "description": "The number of documents that were successfully deleted.",
                       "type": "number"
                     },
                     "failures": {
+                      "description": "An array of failures if there were any unrecoverable errors during the process.\nIf this array is not empty, the request ended abnormally because of those failures.\nDelete by query is implemented using batches and any failures cause the entire process to end but all failures in the current batch are collected into the array.\nYou can use the `conflicts` option to prevent reindex from ending on version conflicts.",
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/_types:BulkIndexByScrollFailure"
                       }
                     },
                     "noops": {
+                      "description": "This field is always equal to zero for delete by query.\nIt exists only so that delete by query, update by query, and reindex APIs return responses with the same structure.",
                       "type": "number"
                     },
                     "requests_per_second": {
+                      "description": "The number of requests per second effectively run during the delete by query.",
                       "type": "number"
                     },
                     "retries": {
@@ -4463,15 +4468,18 @@
                       "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
                     },
                     "timed_out": {
+                      "description": "If `true`, some requests run during the delete by query operation timed out.",
                       "type": "boolean"
                     },
                     "took": {
                       "$ref": "#/components/schemas/_types:DurationValueUnitMillis"
                     },
                     "total": {
+                      "description": "The number of documents that were successfully processed.",
                       "type": "number"
                     },
                     "version_conflicts": {
+                      "description": "The number of version conflicts that the delete by query hit.",
                       "type": "number"
                     }
                   }

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -142,6 +142,7 @@ dissect-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branc
 distance-units,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/api-conventions.html#distance-units
 docs-bulk,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-bulk.html
 docs-delete-by-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-delete-by-query.html
+docs-delete-by-query-rethrottle,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-delete-by-query.html#docs-delete-by-query-rethrottle
 docs-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-delete.html
 docs-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-get.html
 docs-index,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-index_.html

--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -35,11 +35,91 @@ import { Duration } from '@_types/Time'
 
 /**
  * Delete documents.
+ *
  * Deletes documents that match the specified query.
+ *
+ * If the Elasticsearch security features are enabled, you must have the following index privileges for the target data stream, index, or alias:
+ *
+ * * `read`
+ * * `delete` or `write`
+ *
+ * You can specify the query criteria in the request URI or the request body using the same syntax as the search API.
+ * When you submit a delete by query request, Elasticsearch gets a snapshot of the data stream or index when it begins processing the request and deletes matching documents using internal versioning.
+ * If a document changes between the time that the snapshot is taken and the delete operation is processed, it results in a version conflict and the delete operation fails.
+ *
+ * NOTE: Documents with a version equal to 0 cannot be deleted using delete by query because internal versioning does not support 0 as a valid version number.
+ *
+ * While processing a delete by query request, Elasticsearch performs multiple search requests sequentially to find all of the matching documents to delete.
+ * A bulk delete request is performed for each batch of matching documents.
+ * If a search or bulk request is rejected, the requests are retried up to 10 times, with exponential back off.
+ * If the maximum retry limit is reached, processing halts and all failed requests are returned in the response.
+ * Any delete requests that completed successfully still stick, they are not rolled back.
+ *
+ * You can opt to count version conflicts instead of halting and returning by setting `conflicts` to `proceed`.
+ * Note that if you opt to count version conflicts the operation could attempt to delete more documents from the source than `max_docs` until it has successfully deleted `max_docs documents`, or it has gone through every document in the source query.
+ *
+ * **Throttling delete requests**
+ *
+ * To control the rate at which delete by query issues batches of delete operations, you can set `requests_per_second` to any positive decimal number.
+ * This pads each batch with a wait time to throttle the rate.
+ * Set `requests_per_second` to `-1` to disable throttling.
+ *
+ * Throttling uses a wait time between batches so that the internal scroll requests can be given a timeout that takes the request padding into account.
+ * The padding time is the difference between the batch size divided by the `requests_per_second` and the time spent writing.
+ * By default the batch size is `1000`, so if `requests_per_second` is set to `500`:
+ *
+ * ```
+ * target_time = 1000 / 500 per second = 2 seconds
+ * wait_time = target_time - write_time = 2 seconds - .5 seconds = 1.5 seconds
+ * ```
+ *
+ * Since the batch is issued as a single `_bulk` request, large batch sizes cause Elasticsearch to create many requests and wait before starting the next set.
+ * This is "bursty" instead of "smooth".
+ *
+ * **Slicing**
+ *
+ * Delete by query supports sliced scroll to parallelize the delete process.
+ * This can improve efficiency and provide a convenient way to break the request down into smaller parts.
+ *
+ * Setting `slices` to `auto` lets Elasticsearch choose the number of slices to use.
+ * This setting will use one slice per shard, up to a certain limit.
+ * If there are multiple source data streams or indices, it will choose the number of slices based on the index or backing index with the smallest number of shards.
+ * Adding slices to the delete by query operation creates sub-requests which means it has some quirks:
+ *
+ * * You can see these requests in the tasks APIs. These sub-requests are "child" tasks of the task for the request with slices.
+ * * Fetching the status of the task for the request with slices only contains the status of completed slices.
+ * * These sub-requests are individually addressable for things like cancellation and rethrottling.
+ * * Rethrottling the request with `slices` will rethrottle the unfinished sub-request proportionally.
+ * * Canceling the request with `slices` will cancel each sub-request.
+ * * Due to the nature of `slices` each sub-request won't get a perfectly even portion of the documents. All documents will be addressed, but some slices may be larger than others. Expect larger slices to have a more even distribution.
+ * * Parameters like `requests_per_second` and `max_docs` on a request with `slices` are distributed proportionally to each sub-request. Combine that with the earlier point about distribution being uneven and you should conclude that using `max_docs` with `slices` might not result in exactly `max_docs` documents being deleted.
+ * * Each sub-request gets a slightly different snapshot of the source data stream or index though these are all taken at approximately the same time.
+ *
+ * If you're slicing manually or otherwise tuning automatic slicing, keep in mind that:
+ *
+ * * Query performance is most efficient when the number of slices is equal to the number of shards in the index or backing index. If that number is large (for example, 500), choose a lower number as too many `slices` hurts performance. Setting `slices` higher than the number of shards generally does not improve efficiency and adds overhead.
+ * * Delete performance scales linearly across available resources with the number of slices.
+ *
+ * Whether query or delete performance dominates the runtime depends on the documents being reindexed and cluster resources.
+ *
+ * **Cancel a delete by query operation**
+ *
+ * Any delete by query can be canceled using the task cancel API. For example:
+ *
+ * ```
+ * POST _tasks/r1A2WoRbTwKZ516z6NEs5A:36619/_cancel
+ * ```
+ *
+ * The task ID can be found by using the get tasks API.
+ *
+ * Cancellation should happen quickly but might take a few seconds.
+ * The get task status API will continue to list the delete by query task until this task checks that it has been cancelled and terminates itself.
  * @rest_spec_name delete_by_query
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges read,delete
  * @doc_tag document
+ * @doc_id docs-delete-by-query
  */
 export interface Request extends RequestBase {
   urls: [
@@ -50,8 +130,8 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Comma-separated list of data streams, indices, and aliases to search.
-     * Supports wildcards (`*`).
+     * A comma-separated list of data streams, indices, and aliases to search.
+     * It supports wildcards (`*`).
      * To search all data streams or indices, omit this parameter or use `*` or `_all`.
      */
     index: Indices
@@ -66,10 +146,12 @@ export interface Request extends RequestBase {
     allow_no_indices?: boolean
     /**
      * Analyzer to use for the query string.
+     * This parameter can be used only when the `q` query string parameter is specified.
      */
     analyzer?: string
     /**
      * If `true`, wildcard and prefix queries are analyzed.
+     * This parameter can be used only when the `q` query string parameter is specified.
      * @server_default false
      */
     analyze_wildcard?: boolean
@@ -80,17 +162,19 @@ export interface Request extends RequestBase {
     conflicts?: Conflicts
     /**
      * The default operator for query string query: `AND` or `OR`.
+     * This parameter can be used only when the `q` query string parameter is specified.
      * @server_default OR
      */
     default_operator?: Operator
     /**
-     * Field to use as default where no field prefix is given in the query string.
+     * The field to use as default where no field prefix is given in the query string.
+     * This parameter can be used only when the `q` query string parameter is specified.
      */
     df?: string
     /**
-     * Type of index that wildcard patterns can match.
+     * The type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
-     * Supports comma-separated values, such as `open,hidden`. Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
+     * It supports comma-separated values, such as `open,hidden`.
      * @server_default open
      */
     expand_wildcards?: ExpandWildcards
@@ -102,21 +186,25 @@ export interface Request extends RequestBase {
     ignore_unavailable?: boolean
     /**
      * If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
+     * This parameter can be used only when the `q` query string parameter is specified.
      * @server_default false
      */
     lenient?: boolean
     /**
-     * Maximum number of documents to process.
+     * The maximum number of documents to process.
      * Defaults to all documents.
+     * When set to a value less then or equal to `scroll_size`, a scroll will not be used to retrieve the results for the operation.
      */
     max_docs?: long
     /**
-     * Specifies the node or shard the operation should be performed on.
-     * Random by default.
+     * The node or shard the operation should be performed on.
+     * It is random by default.
      */
     preference?: string
     /**
      * If `true`, Elasticsearch refreshes all shards involved in the delete by query after the request completes.
+     * This is different than the delete API's `refresh` parameter, which causes just the shard that received the delete request to be refreshed.
+     * Unlike the delete API, it does not support `wait_for`.
      * @server_default false
      */
     refresh?: boolean
@@ -127,33 +215,35 @@ export interface Request extends RequestBase {
     request_cache?: boolean
     /**
      * The throttle for this request in sub-requests per second.
+     * @server_default -1
      */
     requests_per_second?: float
     /**
-     * Custom value used to route operations to a specific shard.
+     * A custom value used to route operations to a specific shard.
      */
     routing?: Routing
     /**
-     * Query in the Lucene query string syntax.
+     * A query in the Lucene query string syntax.
      */
     q?: string
     /**
-     * Period to retain the search context for scrolling.
+     * The period to retain the search context for scrolling.
+     * @ext_doc_id scroll-search-results
      */
     scroll?: Duration
     /**
-     * Size of the scroll request that powers the operation.
+     * The size of the scroll request that powers the operation.
      * @server_default 1000
      */
     scroll_size?: long
     /**
-     * Explicit timeout for each search request.
-     * Defaults to no timeout.
+     * The explicit timeout for each search request.
+     * It defaults to no timeout.
      */
     search_timeout?: Duration
     /**
      * The type of the search operation.
-     * Available options: `query_then_fetch`, `dfs_query_then_fetch`.
+     * Available options include `query_then_fetch` and `dfs_query_then_fetch`.
      */
     search_type?: SearchType
     /**
@@ -162,17 +252,18 @@ export interface Request extends RequestBase {
      */
     slices?: Slices
     /**
-     * A comma-separated list of <field>:<direction> pairs.
+     * A comma-separated list of `<field>:<direction>` pairs.
      */
     sort?: string[]
     /**
-     * Specific `tag` of the request for logging and statistical purposes.
+     * The specific `tag` of the request for logging and statistical purposes.
      */
     stats?: string[]
     /**
-     * Maximum number of documents to collect for each shard.
+     * The maximum number of documents to collect for each shard.
      * If a query reaches this limit, Elasticsearch terminates the query early.
      * Elasticsearch collects documents before sorting.
+     *
      * Use with caution.
      * Elasticsearch applies this parameter to each shard handling the request.
      * When possible, let Elasticsearch perform early termination automatically.
@@ -180,7 +271,7 @@ export interface Request extends RequestBase {
      */
     terminate_after?: long
     /**
-     * Period each deletion request waits for active shards.
+     * The period each deletion request waits for active shards.
      * @server_default 1m
      */
     timeout?: Duration
@@ -190,12 +281,14 @@ export interface Request extends RequestBase {
     version?: boolean
     /**
      * The number of shard copies that must be active before proceeding with the operation.
-     * Set to all or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * Set to `all` or any positive integer up to the total number of shards in the index (`number_of_replicas+1`).
+     * The `timeout` value controls how long each write request waits for unavailable shards to become available.
      * @server_default 1
      */
     wait_for_active_shards?: WaitForActiveShards
     /**
      * If `true`, the request blocks until the operation is complete.
+     * If `false`, Elasticsearch performs some preflight checks, launches the request, and returns a task you can use to cancel or get the status of the task. Elasticsearch creates a record of this task as a document at `.tasks/task/${taskId}`. When you are done with a task, you should delete the task document so Elasticsearch can reclaim the space.
      * @server_default true
      */
     wait_for_completion?: boolean
@@ -206,7 +299,7 @@ export interface Request extends RequestBase {
      */
     max_docs?: long
     /**
-     * Specifies the documents to delete using the Query DSL.
+     * The documents to delete specified with Query DSL.
      */
     query?: QueryContainer
     /**

--- a/specification/_global/delete_by_query/DeleteByQueryResponse.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryResponse.ts
@@ -25,21 +25,64 @@ import { Duration, DurationValue, UnitMillis } from '@_types/Time'
 
 export class Response {
   body: {
+    /**
+     * The number of scroll responses pulled back by the delete by query.
+     */
     batches?: long
+    /**
+     * The number of documents that were successfully deleted.
+     */
     deleted?: long
+    /**
+     * An array of failures if there were any unrecoverable errors during the process.
+     * If this array is not empty, the request ended abnormally because of those failures.
+     * Delete by query is implemented using batches and any failures cause the entire process to end but all failures in the current batch are collected into the array.
+     * You can use the `conflicts` option to prevent reindex from ending on version conflicts.
+     */
     failures?: BulkIndexByScrollFailure[]
+    /**
+     * This field is always equal to zero for delete by query.
+     * It exists only so that delete by query, update by query, and reindex APIs return responses with the same structure.
+     */
     noops?: long
+    /**
+     * The number of requests per second effectively run during the delete by query.
+     */
     requests_per_second?: float
+    /**
+     * The number of retries attempted by delete by query.
+     * `bulk` is the number of bulk actions retried.
+     * `search` is the number of search actions retried.
+     */
     retries?: Retries
     slice_id?: integer
     task?: TaskId
     throttled?: Duration
+    /**
+     * The number of milliseconds the request slept to conform to `requests_per_second`.
+     */
     throttled_millis?: DurationValue<UnitMillis>
     throttled_until?: Duration
+    /**
+     * This field should always be equal to zero in a `_delete_by_query` response.
+     * It has meaning only when using the task API, where it indicates the next time (in milliseconds since epoch) a throttled request will be run again in order to conform to `requests_per_second`.
+     */
     throttled_until_millis?: DurationValue<UnitMillis>
+    /**
+     * If `true`, some requests run during the delete by query operation timed out.
+     */
     timed_out?: boolean
+    /**
+     * The number of milliseconds from start to end of the whole operation.
+     */
     took?: DurationValue<UnitMillis>
+    /**
+     * The number of documents that were successfully processed.
+     */
     total?: long
+    /**
+     * The number of version conflicts that the delete by query hit.
+     */
     version_conflicts?: long
   }
 }

--- a/specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample1.yaml
+++ b/specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample1.yaml
@@ -1,0 +1,10 @@
+summary: Delete all documents
+# method_request: POST /my-index-000001,my-index-000002/_delete_by_query
+description: Run `POST /my-index-000001,my-index-000002/_delete_by_query` to delete all documents from multiple data streams or indices.
+# type: request
+value: |-
+  {
+    "query": {
+      "match_all": {}
+    }
+  }

--- a/specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample2.yaml
+++ b/specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample2.yaml
@@ -1,0 +1,13 @@
+summary: Delete a single document
+# method_request: POST my-index-000001/_delete_by_query
+description: Run `POST my-index-000001/_delete_by_query` to delete a document by using a unique attribute.
+# type: request
+value: |-
+  {
+    "query": {
+      "term": {
+        "user.id": "kimchy"
+      }
+    },
+    "max_docs": 1
+  }

--- a/specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample3.yaml
+++ b/specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample3.yaml
@@ -1,0 +1,19 @@
+summary: Slice manually
+# method_request: POST my-index-000001/_delete_by_query
+description: >
+  Run `POST my-index-000001/_delete_by_query` to slice a delete by query manually. Provide a slice ID and total number of slices.
+# type: request
+value: |-
+  {
+    "slice": {
+      "id": 0,
+      "max": 2
+    },
+    "query": {
+      "range": {
+        "http.response.bytes": {
+          "lt": 2000000
+        }
+      }
+    }
+  }

--- a/specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample4.yaml
+++ b/specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample4.yaml
@@ -1,0 +1,16 @@
+summary: Automatic slicing
+# method_request: POST my-index-000001/_delete_by_query?refresh&slices=5
+description: >
+  Run `POST my-index-000001/_delete_by_query?refresh&slices=5` to let delete by query automatically parallelize using sliced scroll to slice on `_id`.
+  The `slices` query parameter value specifies the number of slices to use.
+# type: request
+value: |-
+  {
+    "query": {
+      "range": {
+        "http.response.bytes": {
+          "lt": 2000000
+        }
+      }
+    }
+  }

--- a/specification/_global/delete_by_query/examples/response/DeleteByQueryResponseExample1.yaml
+++ b/specification/_global/delete_by_query/examples/response/DeleteByQueryResponseExample1.yaml
@@ -1,0 +1,22 @@
+# summary:
+description: A successful response from `POST /my-index-000001/_delete_by_query`.
+# type: response
+# response_code:
+value: |-
+  {
+    "took" : 147,
+    "timed_out": false,
+    "total": 119,
+    "deleted": 119,
+    "batches": 1,
+    "version_conflicts": 0,
+    "noops": 0,
+    "retries": {
+      "bulk": 0,
+      "search": 0
+    },
+    "throttled_millis": 0,
+    "requests_per_second": -1.0,
+    "throttled_until_millis": 0,
+    "failures" : [ ]
+  }

--- a/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
+++ b/specification/_global/delete_by_query_rethrottle/DeleteByQueryRethrottleRequest.ts
@@ -30,6 +30,7 @@ import { float } from '@_types/Numeric'
  * @availability stack since=6.5.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @doc_tag document
+ * @doc_id docs-delete-by-query-rethrottle
  */
 export interface Request extends RequestBase {
   urls: [
@@ -47,6 +48,7 @@ export interface Request extends RequestBase {
   query_parameters: {
     /**
      * The throttle for this request in sub-requests per second.
+     * To disable throttling, set it to `-1`.
      */
     requests_per_second?: float
   }

--- a/specification/tasks/get/examples/200_response/GetTaskResponseExample1.yaml
+++ b/specification/tasks/get/examples/200_response/GetTaskResponseExample1.yaml
@@ -1,5 +1,6 @@
-# summary:
-description: A successful response when requesting information about the tasks currently executing in the cluster.
+summary: Get cluster actions
+description: >
+  A successful response from `GET _tasks?actions=cluster:*`, which retrieves all cluster-related tasks.
 # type: response
 # response_code: ''
 value: |-

--- a/specification/tasks/get/examples/200_response/GetTaskResponseExample2.yaml
+++ b/specification/tasks/get/examples/200_response/GetTaskResponseExample2.yaml
@@ -1,0 +1,44 @@
+summary: Get details about a delete by query
+description: >
+  A successful response from `GET _tasks?detailed=true&actions=*/delete/byquery`, which gets the status of a delete by query operation.
+  The `status` object contains the actual status.
+  `total` is the total number of operations that the reindex expects to perform.
+  You can estimate the progress by adding the `updated`, `created`, and `deleted` fields.
+  The request will finish when their sum is equal to the `total` field.
+# type: response
+# response_code: ''
+value: |-
+  {
+    "nodes" : {
+      "r1A2WoRbTwKZ516z6NEs5A" : {
+        "name" : "r1A2WoR",
+        "transport_address" : "127.0.0.1:9300",
+        "host" : "127.0.0.1",
+        "ip" : "127.0.0.1:9300",
+        "attributes" : {
+          "testattr" : "test",
+          "portsfile" : "true"
+        },
+        "tasks" : {
+          "r1A2WoRbTwKZ516z6NEs5A:36619" : {
+            "node" : "r1A2WoRbTwKZ516z6NEs5A",
+            "id" : 36619,
+            "type" : "transport",
+            "action" : "indices:data/write/delete/byquery",
+            "status" : {    
+              "total" : 6154,
+              "updated" : 0,
+              "created" : 0,
+              "deleted" : 3500,
+              "batches" : 36,
+              "version_conflicts" : 0,
+              "noops" : 0,
+              "retries": 0,
+              "throttled_millis": 0
+            },
+            "description" : ""
+          }
+        }
+      }
+    }
+  }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR adds examples copied from https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-delete-by-query.html. It also edits the descriptions and adds missing `@doc_id` details.