### PR TITLE
Run docs lint as part of CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,6 @@ filter-for-serverless: ## Generate the serverless version from the compiled sche
 dump-routes: ## Create a new schema with all generics expanded
 	@npm run dump-routes --prefix compiler
 
-contrib: | generate license-check spec-format-fix transform-to-openapi filter-for-serverless ## Pre contribution target
-
 overlay-docs: ## Apply overlays to OpenAPI documents
 	@npx bump overlay "output/openapi/elasticsearch-serverless-openapi.json" "docs/overlays/elasticsearch-serverless-openapi-overlays.yaml" > "output/openapi/elasticsearch-serverless-openapi.tmp1.json"
 	@npx bump overlay "output/openapi/elasticsearch-serverless-openapi.tmp1.json" "docs/overlays/elasticsearch-shared-overlays.yaml" > "output/openapi/elasticsearch-serverless-openapi.tmp2.json"
@@ -77,6 +75,8 @@ lint-docs-errs: ## Lint the OpenAPI documents after overlays and return only err
 
 lint-docs-serverless: ## Lint only the serverless OpenAPI document after overlays
 	@npx @stoplight/spectral-cli lint output/openapi/elasticsearch-serverless-openapi.examples.json --ruleset .spectral.yaml
+
+contrib: | generate license-check spec-format-fix transform-to-openapi filter-for-serverless lint-docs-errs ## Pre contribution target
 
 help:  ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
This will help us see issues like https://github.com/elastic/elasticsearch-specification/pull/3564 much sooner.