### PR TITLE
Change default of _create_from remove_index_blocks param to true

### DIFF
--- a/specification/indices/create_from/MigrateCreateFromRequest.ts
+++ b/specification/indices/create_from/MigrateCreateFromRequest.ts
@@ -53,7 +53,7 @@ export class CreateFrom {
   settings_override?: IndexSettings
   /**
    * If index blocks should be removed when creating destination index (optional)
-   * @server_default false
+   * @server_default true
    */
   remove_index_blocks?: boolean
 }


### PR DESCRIPTION
In the `_create_from` API, the default value for the optional boolean parameter `remove_index_blocks` was changed from false to true. ES ticket: https://github.com/elastic/elasticsearch/pull/120643