### PR TITLE
Add x-codeSamples to check document API

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -2169,3 +2169,13 @@ actions:
               examples:
                 updateTransformResponseExample1:
                   $ref: "../../specification/transform/update_transform/examples/response/UpdateTransformResponseExample1.yaml"
+## xCodeSamples
+  - target: "$.paths['/{index}/_doc/{id}']['head']"
+    description: "Add xCodeSamples for check document operation"
+    update: 
+      x-codeSamples:
+        - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsConsoleExample1.yaml"
+        - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsCurlExample1.yaml"
+        - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsJavaScriptExample1.yaml"
+        - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsPythonExample1.yaml"
+        - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsRubyExample1.yaml"

--- a/specification/_global/exists/examples/xCodeSamples/DocumentExistsConsoleExample1.yaml
+++ b/specification/_global/exists/examples/xCodeSamples/DocumentExistsConsoleExample1.yaml
@@ -1,0 +1,4 @@
+lang: Console
+# label:
+source: |
+  HEAD my-index-000001/_doc/0

--- a/specification/_global/exists/examples/xCodeSamples/DocumentExistsCurlExample1.yaml
+++ b/specification/_global/exists/examples/xCodeSamples/DocumentExistsCurlExample1.yaml
@@ -1,0 +1,4 @@
+lang: Curl
+# label:
+source: |
+  curl -I "localhost:9200/my-index-000001/_doc/0?pretty"

--- a/specification/_global/exists/examples/xCodeSamples/DocumentExistsJavaScriptExample1.yaml
+++ b/specification/_global/exists/examples/xCodeSamples/DocumentExistsJavaScriptExample1.yaml
@@ -1,0 +1,8 @@
+lang: JavaScript
+# label:
+source: |
+  const response = await client.exists({
+    index: "my-index-000001",
+    id: 0,
+  });
+  console.log(response);

--- a/specification/_global/exists/examples/xCodeSamples/DocumentExistsPythonExample1.yaml
+++ b/specification/_global/exists/examples/xCodeSamples/DocumentExistsPythonExample1.yaml
@@ -1,0 +1,8 @@
+lang: Python
+# label:
+source: |
+  resp = client.exists(
+    index="my-index-000001",
+    id="0",
+  )
+  print(resp)

--- a/specification/_global/exists/examples/xCodeSamples/DocumentExistsRubyExample1.yaml
+++ b/specification/_global/exists/examples/xCodeSamples/DocumentExistsRubyExample1.yaml
@@ -1,0 +1,8 @@
+- lang: Ruby
+  # label:
+  source: |
+    response = client.exists(
+      index: 'my-index-000001',
+      id: 0
+    )
+    puts response

--- a/specification/_global/exists/examples/xCodeSamples/DocumentExistsRubyExample1.yaml
+++ b/specification/_global/exists/examples/xCodeSamples/DocumentExistsRubyExample1.yaml
@@ -1,8 +1,8 @@
-- lang: Ruby
-  # label:
-  source: |
-    response = client.exists(
-      index: 'my-index-000001',
-      id: 0
-    )
-    puts response
+lang: Ruby
+# label:
+source: |
+  response = client.exists(
+    index: 'my-index-000001',
+    id: 0
+  )
+  puts response


### PR DESCRIPTION
This PR tests the addition of some `x-codeSamples` per https://docs.bump.sh/help/specification-support/doc-code-samples/ via an overlay for https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-exists

The examples are copied from https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html

### Preview

The examples show up in a Bump.sh preview like this:

![image](https://github.com/user-attachments/assets/98c20187-4f4f-4a29-b16d-f2deb4c4b667)

![image](https://github.com/user-attachments/assets/fd70b941-fec2-4531-ae23-f74e3211ecf2)

![image](https://github.com/user-attachments/assets/ff1157df-2504-49b8-a530-0f8cd5df9e34)
