### PR TITLE
[8.17] Run docs lint as part of CI (#3575)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,6 @@ filter-for-serverless: ## Generate the serverless version from the compiled sche
 dump-routes: ## Create a new schema with all generics expanded
 	@npm run dump-routes --prefix compiler
 
-contrib: | generate license-check spec-format-fix transform-to-openapi filter-for-serverless ## Pre contribution target
-
 overlay-docs: ## Apply overlays to OpenAPI documents
 	@npx bump overlay "output/openapi/elasticsearch-openapi.json" "docs/overlays/elasticsearch-openapi-overlays.yaml" > "output/openapi/elasticsearch-openapi.tmp1.json"
 	@npx bump overlay "output/openapi/elasticsearch-openapi.tmp1.json" "docs/overlays/elasticsearch-shared-overlays.yaml" > "output/openapi/elasticsearch-openapi.tmp2.json"
@@ -70,6 +68,8 @@ lint-docs: ## Lint the OpenAPI documents after overlays
 
 lint-docs-errs: ## Lint the OpenAPI documents after overlays and return only errors
 	@npx @stoplight/spectral-cli lint output/openapi/elasticsearch-*.examples.json --ruleset .spectral.yaml -D
+
+contrib: | generate license-check spec-format-fix transform-to-openapi filter-for-serverless lint-docs-errs ## Pre contribution target
 
 help:  ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [Run docs lint as part of CI (#3575)](https://github.com/elastic/elasticsearch-specification/pull/3575)

<!--- Backport version: 9.6.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)