### PR TITLE
Allow single strings in watcher emails

### DIFF
--- a/specification/watcher/_types/Actions.ts
+++ b/specification/watcher/_types/Actions.ts
@@ -237,15 +237,15 @@ export class DataEmailAttachment {
 
 export class Email {
   id?: Id
-  bcc?: string[]
+  bcc?: string | string[]
   body?: EmailBody
-  cc?: string[]
+  cc?: string | string[]
   from?: string
   priority?: EmailPriority
-  reply_to?: string[]
+  reply_to?: string | string[]
   sent_date?: DateTime
   subject: string
-  to: string[]
+  to: string | string[]
   attachments?: Dictionary<string, EmailAttachmentContainer>
 }
 


### PR DESCRIPTION
While the values are stored as arrays, single strings are allowed in the parser: https://github.com/elastic/elasticsearch/blob/32eada688f7de63c75a22c4b9f6464aab75c01b7/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/EmailTemplate.java#L398-L441.