### PR TITLE
[DOCS] Add examples and descriptions for script APIs

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -170,6 +170,11 @@ actions:
       # S
         - name: script
           x-displayName: Script
+          description: >
+            Use the script support APIs to get a list of supported script contexts and languages.
+            Use the stored script APIs to manage stored scripts and search templates.
+          externalDocs:
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
         - name: search
           x-displayName: Search
         - name: search_application

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -7997,7 +7997,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "Identifier for the stored script or search template.",
+            "description": "The identifier for the stored script or search template.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -8008,7 +8008,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Specify timeout for connection to master",
+            "description": "The period to wait for the master node.\nIf the master node is not available before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -8050,10 +8050,16 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script",
         "parameters": [
           {
             "$ref": "#/components/parameters/put_script#id"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -8077,10 +8083,16 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script-1",
         "parameters": [
           {
             "$ref": "#/components/parameters/put_script#id"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -8109,7 +8121,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "Identifier for the stored script or search template.",
+            "description": "The identifier for the stored script or search template.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -8120,7 +8132,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -8130,7 +8142,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -25838,6 +25850,9 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script-2",
         "parameters": [
           {
@@ -25845,6 +25860,9 @@
           },
           {
             "$ref": "#/components/parameters/put_script#context"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -25868,6 +25886,9 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script-3",
         "parameters": [
           {
@@ -25875,6 +25896,9 @@
           },
           {
             "$ref": "#/components/parameters/put_script#context"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -69650,7 +69674,7 @@
             }
           },
           "source": {
-            "description": "The script source.",
+            "description": "The script source.\nFor search templates, an object containing the search template.",
             "type": "string"
           }
         },
@@ -105234,7 +105258,7 @@
       "put_script#id": {
         "in": "path",
         "name": "id",
-        "description": "Identifier for the stored script or search template.\nMust be unique within the cluster.",
+        "description": "The identifier for the stored script or search template.\nIt must be unique within the cluster.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -105245,7 +105269,7 @@
       "put_script#context": {
         "in": "path",
         "name": "context",
-        "description": "Context in which the script or search template should run.\nTo prevent errors, the API immediately compiles the script or template in this context.",
+        "description": "The context in which the script or search template should run.\nTo prevent errors, the API immediately compiles the script or template in this context.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -105253,10 +105277,20 @@
         },
         "style": "simple"
       },
+      "put_script#context_": {
+        "in": "query",
+        "name": "context",
+        "description": "The context in which the script or search template should run.\nTo prevent errors, the API immediately compiles the script or template in this context.\nIf you specify both this and the `<context>` path parameter, the API uses the request path parameter.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Name"
+        },
+        "style": "form"
+      },
       "put_script#master_timeout": {
         "in": "query",
         "name": "master_timeout",
-        "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+        "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -105266,7 +105300,7 @@
       "put_script#timeout": {
         "in": "query",
         "name": "timeout",
-        "description": "Period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+        "description": "The period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -4509,7 +4509,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "Identifier for the stored script or search template.",
+            "description": "The identifier for the stored script or search template.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -4520,7 +4520,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Specify timeout for connection to master",
+            "description": "The period to wait for the master node.\nIf the master node is not available before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -4562,10 +4562,16 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script",
         "parameters": [
           {
             "$ref": "#/components/parameters/put_script#id"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -4589,10 +4595,16 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script-1",
         "parameters": [
           {
             "$ref": "#/components/parameters/put_script#id"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -4621,7 +4633,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "Identifier for the stored script or search template.",
+            "description": "The identifier for the stored script or search template.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -4632,7 +4644,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -4642,7 +4654,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -14785,6 +14797,9 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script-2",
         "parameters": [
           {
@@ -14792,6 +14807,9 @@
           },
           {
             "$ref": "#/components/parameters/put_script#context"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -14815,6 +14833,9 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script-3",
         "parameters": [
           {
@@ -14822,6 +14843,9 @@
           },
           {
             "$ref": "#/components/parameters/put_script#context"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -45099,7 +45123,7 @@
             }
           },
           "source": {
-            "description": "The script source.",
+            "description": "The script source.\nFor search templates, an object containing the search template.",
             "type": "string"
           }
         },
@@ -62056,7 +62080,7 @@
       "put_script#id": {
         "in": "path",
         "name": "id",
-        "description": "Identifier for the stored script or search template.\nMust be unique within the cluster.",
+        "description": "The identifier for the stored script or search template.\nIt must be unique within the cluster.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -62067,7 +62091,7 @@
       "put_script#context": {
         "in": "path",
         "name": "context",
-        "description": "Context in which the script or search template should run.\nTo prevent errors, the API immediately compiles the script or template in this context.",
+        "description": "The context in which the script or search template should run.\nTo prevent errors, the API immediately compiles the script or template in this context.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -62075,10 +62099,20 @@
         },
         "style": "simple"
       },
+      "put_script#context_": {
+        "in": "query",
+        "name": "context",
+        "description": "The context in which the script or search template should run.\nTo prevent errors, the API immediately compiles the script or template in this context.\nIf you specify both this and the `<context>` path parameter, the API uses the request path parameter.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Name"
+        },
+        "style": "form"
+      },
       "put_script#master_timeout": {
         "in": "query",
         "name": "master_timeout",
-        "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+        "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -62088,7 +62122,7 @@
       "put_script#timeout": {
         "in": "query",
         "name": "timeout",
-        "description": "Period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+        "description": "The period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -309,12 +309,6 @@
       ],
       "response": []
     },
-    "put_script": {
-      "request": [
-        "Request: missing json spec query parameter 'context'"
-      ],
-      "response": []
-    },
     "reindex": {
       "request": [
         "Request: query parameter 'require_alias' does not exist in the json spec",

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -511,7 +511,11 @@ rollup-stop-job,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 routing,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-get.html#get-routing
 run-as-privilege,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/run-as-privilege.html
 runtime-search-request,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/runtime-search-request.html
+script-contexts,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-script-contexts-api.html
+script-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-stored-script-api.html
+script-languages,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-script-languages-api.html
 script-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/script-processor.html
+script-put,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/create-stored-script-api.html
 scroll-search-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html#scroll-search-results
 search-after,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html#search-after
 search-aggregations,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations.html

--- a/specification/_global/delete_script/DeleteScriptRequest.ts
+++ b/specification/_global/delete_script/DeleteScriptRequest.ts
@@ -27,7 +27,9 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name delete_script
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage
  * @doc_tag script
+ * @doc_id script-delete
  */
 export interface Request extends RequestBase {
   urls: [
@@ -38,20 +40,22 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Identifier for the stored script or search template.
+     * The identifier for the stored script or search template.
      */
     id: Id
   }
   query_parameters: {
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
      * If no response is received before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
     master_timeout?: Duration
     /**
-     * Period to wait for a response.
+     * The period to wait for a response.
      * If no response is received before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
     timeout?: Duration

--- a/specification/_global/get_script/GetScriptRequest.ts
+++ b/specification/_global/get_script/GetScriptRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name get_script
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage
  * @doc_tag script
  */
 export interface Request extends RequestBase {
@@ -38,12 +39,17 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Identifier for the stored script or search template.
+     * The identifier for the stored script or search template.
      */
     id: Id
   }
   query_parameters: {
-    /** Specify timeout for connection to master */
+    /**
+     * The period to wait for the master node.
+     * If the master node is not available before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
+     * @server_default 
+     */
     master_timeout?: Duration
   }
 }

--- a/specification/_global/get_script/GetScriptRequest.ts
+++ b/specification/_global/get_script/GetScriptRequest.ts
@@ -48,7 +48,7 @@ export interface Request extends RequestBase {
      * The period to wait for the master node.
      * If the master node is not available before the timeout expires, the request fails and returns an error.
      * It can also be set to `-1` to indicate that the request should never timeout.
-     * @server_default 
+     * @server_default
      */
     master_timeout?: Duration
   }

--- a/specification/_global/get_script_context/GetScriptContextRequest.ts
+++ b/specification/_global/get_script_context/GetScriptContextRequest.ts
@@ -25,7 +25,9 @@ import { RequestBase } from '@_types/Base'
  * Get a list of supported script contexts and their methods.
  * @rest_spec_name get_script_context
  * @availability stack stability=stable
+ * @cluster_privileges manage
  * @doc_tag script
+ * @doc_id script-contexts
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/_global/get_script_languages/GetScriptLanguagesRequest.ts
+++ b/specification/_global/get_script_languages/GetScriptLanguagesRequest.ts
@@ -25,7 +25,9 @@ import { RequestBase } from '@_types/Base'
  * Get a list of available script types, languages, and contexts.
  * @rest_spec_name get_script_languages
  * @availability stack stability=stable
+ * @cluster_privileges manage
  * @doc_tag script
+ * @doc_id script-languages
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/_global/put_script/PutScriptRequest.ts
+++ b/specification/_global/put_script/PutScriptRequest.ts
@@ -62,7 +62,7 @@ export interface Request extends RequestBase {
      * To prevent errors, the API immediately compiles the script or template in this context.
      * If you specify both this and the `<context>` path parameter, the API uses the request path parameter.
      */
-    context?: string
+    context?: Name
     /**
      * The period to wait for a connection to the master node.
      * If no response is received before the timeout expires, the request fails and returns an error.

--- a/specification/_global/put_script/PutScriptRequest.ts
+++ b/specification/_global/put_script/PutScriptRequest.ts
@@ -28,7 +28,10 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name put_script
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage
  * @doc_tag script
+ * @doc_id script-put
+ * @ext_doc_id search-template
  */
 export interface Request extends RequestBase {
   urls: [
@@ -43,33 +46,41 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Identifier for the stored script or search template.
-     * Must be unique within the cluster.
+     * The identifier for the stored script or search template.
+     * It must be unique within the cluster.
      */
     id: Id
     /**
-     * Context in which the script or search template should run.
+     * The context in which the script or search template should run.
      * To prevent errors, the API immediately compiles the script or template in this context.
      */
     context?: Name
   }
   query_parameters: {
     /**
-     * Period to wait for a connection to the master node.
+     * The context in which the script or search template should run.
+     * To prevent errors, the API immediately compiles the script or template in this context.
+     * If you specify both this and the `<context>` path parameter, the API uses the request path parameter.
+     */
+    context?: string
+    /**
+     * The period to wait for a connection to the master node.
      * If no response is received before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
     master_timeout?: Duration
     /**
-     * Period to wait for a response.
+     * The period to wait for a response.
      * If no response is received before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
     timeout?: Duration
   }
   body: {
     /**
-     * Contains the script or search template, its parameters, and its language.
+     * The script or search template, its parameters, and its language.
      */
     script: StoredScript
   }

--- a/specification/_global/put_script/examples/request/PutScriptRequestExample1.yaml
+++ b/specification/_global/put_script/examples/request/PutScriptRequestExample1.yaml
@@ -1,0 +1,20 @@
+summary: Create a search template
+# method_request: PUT _scripts/my-search-template
+description: >
+  Run `PUT _scripts/my-search-template` to create a search template.
+# type: request
+value: |-
+  {
+    "script": {
+      "lang": "mustache",
+      "source": {
+        "query": {
+          "match": {
+            "message": "{{query_string}}"
+          }
+        },
+        "from": "{{from}}",
+        "size": "{{size}}"
+      }
+    }
+  }

--- a/specification/_global/put_script/examples/request/PutScriptRequestExample2.yaml
+++ b/specification/_global/put_script/examples/request/PutScriptRequestExample2.yaml
@@ -1,0 +1,12 @@
+summary: Create a stored script
+# method_request: PUT _scripts/my-stored-script
+description: >
+  Run `PUT _scripts/my-stored-script` to create a stored script.
+# type: request
+value: |-
+  {
+    "script": {
+      "lang": "painless",
+      "source": "Math.log(_score * 2) + params['my_modifier']"
+    }
+  }

--- a/specification/_types/Scripting.ts
+++ b/specification/_types/Scripting.ts
@@ -47,11 +47,13 @@ export enum ScriptLanguage {
 export class StoredScript {
   /**
    * The language the script is written in.
+   * For serach templates, use `mustache`.
    */
   lang: ScriptLanguage
   options?: Dictionary<string, string>
   /**
    * The script source.
+   * For search templates, an object containing the search template.
    */
   source: string
 }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR copies examples and descriptions from https://www.elastic.co/guide/en/elasticsearch/reference/current/get-script-contexts-api.html, https://www.elastic.co/guide/en/elasticsearch/reference/current/get-script-languages-api.html, https://www.elastic.co/guide/en/elasticsearch/reference/current/get-stored-script-api.html, https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-stored-script-api.html, https://www.elastic.co/guide/en/elasticsearch/reference/current/create-stored-script-api.html