### PR TITLE
[DOCS] Add examples and descriptions for explain, termvector, search APIs

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -24784,7 +24784,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors",
         "parameters": [
           {
@@ -24838,7 +24838,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-1",
         "parameters": [
           {
@@ -24894,7 +24894,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-2",
         "parameters": [
           {
@@ -24951,7 +24951,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-3",
         "parameters": [
           {
@@ -36503,7 +36503,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Get information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.\n\nYou can retrieve term vectors for documents stored in the index or for artificial documents passed in the body of the request.\nYou can specify the fields you are interested in through the `fields` parameter or by adding the fields to the request body.\nFor example:\n\n```\nGET /my-index-000001/_termvectors/1?fields=message\n```\n\nFields can be specified using wildcards, similar to the multi match query.\n\nTerm vectors are real-time by default, not near real-time.\nThis can be changed by setting `realtime` parameter to `false`.\n\nYou can request three types of values: _term information_, _term statistics_, and _field statistics_.\nBy default, all term information and field statistics are returned for all fields but term statistics are excluded.\n\n**Term information**\n\n* term frequency in the field (always returned)\n* term positions (`positions: true`)\n* start and end offsets (`offsets: true`)\n* term payloads (`payloads: true`), as base64 encoded bytes\n\nIf the requested information wasn't stored in the index, it will be computed on the fly if possible.\nAdditionally, term vectors could be computed for documents not even existing in the index, but instead provided by the user.\n\n> warn\n> Start and end offsets assume UTF-16 encoding is being used. If you want to use these offsets in order to get the original text that produced this token, you should make sure that the string you are taking a sub-string of is also encoded using UTF-16.\n\n**Behaviour**\n\nThe term and field statistics are not accurate.\nDeleted documents are not taken into account.\nThe information is only retrieved for the shard the requested document resides in.\nThe term and field statistics are therefore only useful as relative measures whereas the absolute numbers have no meaning in this context.\nBy default, when requesting term vectors of artificial documents, a shard to get the statistics from is randomly selected.\nUse `routing` only to hit a particular shard.",
         "operationId": "termvectors",
         "parameters": [
           {
@@ -36560,7 +36560,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Get information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.\n\nYou can retrieve term vectors for documents stored in the index or for artificial documents passed in the body of the request.\nYou can specify the fields you are interested in through the `fields` parameter or by adding the fields to the request body.\nFor example:\n\n```\nGET /my-index-000001/_termvectors/1?fields=message\n```\n\nFields can be specified using wildcards, similar to the multi match query.\n\nTerm vectors are real-time by default, not near real-time.\nThis can be changed by setting `realtime` parameter to `false`.\n\nYou can request three types of values: _term information_, _term statistics_, and _field statistics_.\nBy default, all term information and field statistics are returned for all fields but term statistics are excluded.\n\n**Term information**\n\n* term frequency in the field (always returned)\n* term positions (`positions: true`)\n* start and end offsets (`offsets: true`)\n* term payloads (`payloads: true`), as base64 encoded bytes\n\nIf the requested information wasn't stored in the index, it will be computed on the fly if possible.\nAdditionally, term vectors could be computed for documents not even existing in the index, but instead provided by the user.\n\n> warn\n> Start and end offsets assume UTF-16 encoding is being used. If you want to use these offsets in order to get the original text that produced this token, you should make sure that the string you are taking a sub-string of is also encoded using UTF-16.\n\n**Behaviour**\n\nThe term and field statistics are not accurate.\nDeleted documents are not taken into account.\nThe information is only retrieved for the shard the requested document resides in.\nThe term and field statistics are therefore only useful as relative measures whereas the absolute numbers have no meaning in this context.\nBy default, when requesting term vectors of artificial documents, a shard to get the statistics from is randomly selected.\nUse `routing` only to hit a particular shard.",
         "operationId": "termvectors-1",
         "parameters": [
           {
@@ -36619,7 +36619,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Get information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.\n\nYou can retrieve term vectors for documents stored in the index or for artificial documents passed in the body of the request.\nYou can specify the fields you are interested in through the `fields` parameter or by adding the fields to the request body.\nFor example:\n\n```\nGET /my-index-000001/_termvectors/1?fields=message\n```\n\nFields can be specified using wildcards, similar to the multi match query.\n\nTerm vectors are real-time by default, not near real-time.\nThis can be changed by setting `realtime` parameter to `false`.\n\nYou can request three types of values: _term information_, _term statistics_, and _field statistics_.\nBy default, all term information and field statistics are returned for all fields but term statistics are excluded.\n\n**Term information**\n\n* term frequency in the field (always returned)\n* term positions (`positions: true`)\n* start and end offsets (`offsets: true`)\n* term payloads (`payloads: true`), as base64 encoded bytes\n\nIf the requested information wasn't stored in the index, it will be computed on the fly if possible.\nAdditionally, term vectors could be computed for documents not even existing in the index, but instead provided by the user.\n\n> warn\n> Start and end offsets assume UTF-16 encoding is being used. If you want to use these offsets in order to get the original text that produced this token, you should make sure that the string you are taking a sub-string of is also encoded using UTF-16.\n\n**Behaviour**\n\nThe term and field statistics are not accurate.\nDeleted documents are not taken into account.\nThe information is only retrieved for the shard the requested document resides in.\nThe term and field statistics are therefore only useful as relative measures whereas the absolute numbers have no meaning in this context.\nBy default, when requesting term vectors of artificial documents, a shard to get the statistics from is randomly selected.\nUse `routing` only to hit a particular shard.",
         "operationId": "termvectors-2",
         "parameters": [
           {
@@ -36673,7 +36673,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Get information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.\n\nYou can retrieve term vectors for documents stored in the index or for artificial documents passed in the body of the request.\nYou can specify the fields you are interested in through the `fields` parameter or by adding the fields to the request body.\nFor example:\n\n```\nGET /my-index-000001/_termvectors/1?fields=message\n```\n\nFields can be specified using wildcards, similar to the multi match query.\n\nTerm vectors are real-time by default, not near real-time.\nThis can be changed by setting `realtime` parameter to `false`.\n\nYou can request three types of values: _term information_, _term statistics_, and _field statistics_.\nBy default, all term information and field statistics are returned for all fields but term statistics are excluded.\n\n**Term information**\n\n* term frequency in the field (always returned)\n* term positions (`positions: true`)\n* start and end offsets (`offsets: true`)\n* term payloads (`payloads: true`), as base64 encoded bytes\n\nIf the requested information wasn't stored in the index, it will be computed on the fly if possible.\nAdditionally, term vectors could be computed for documents not even existing in the index, but instead provided by the user.\n\n> warn\n> Start and end offsets assume UTF-16 encoding is being used. If you want to use these offsets in order to get the original text that produced this token, you should make sure that the string you are taking a sub-string of is also encoded using UTF-16.\n\n**Behaviour**\n\nThe term and field statistics are not accurate.\nDeleted documents are not taken into account.\nThe information is only retrieved for the shard the requested document resides in.\nThe term and field statistics are therefore only useful as relative measures whereas the absolute numbers have no meaning in this context.\nBy default, when requesting term vectors of artificial documents, a shard to get the statistics from is randomly selected.\nUse `routing` only to hit a particular shard.",
         "operationId": "termvectors-3",
         "parameters": [
           {
@@ -82041,11 +82041,11 @@
             "type": "number"
           },
           "max_num_terms": {
-            "description": "Maximum number of terms that must be returned per field.",
+            "description": "The maximum number of terms that must be returned per field.",
             "type": "number"
           },
           "max_term_freq": {
-            "description": "Ignore words with more than this frequency in the source doc.\nDefaults to unbounded.",
+            "description": "Ignore words with more than this frequency in the source doc.\nIt defaults to unbounded.",
             "type": "number"
           },
           "max_word_length": {
@@ -104798,7 +104798,7 @@
       "mtermvectors#index": {
         "in": "path",
         "name": "index",
-        "description": "Name of the index that contains the documents.",
+        "description": "The name of the index that contains the documents.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -104822,7 +104822,7 @@
       "mtermvectors#fields": {
         "in": "query",
         "name": "fields",
-        "description": "Comma-separated list or wildcard expressions of fields to include in the statistics.\nUsed as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.",
+        "description": "A comma-separated list or wildcard expressions of fields to include in the statistics.\nIt is used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
@@ -104872,7 +104872,7 @@
       "mtermvectors#preference": {
         "in": "query",
         "name": "preference",
-        "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+        "description": "The node or shard the operation should be performed on.\nIt is random by default.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -104892,7 +104892,7 @@
       "mtermvectors#routing": {
         "in": "query",
         "name": "routing",
-        "description": "Custom value used to route operations to a specific shard.",
+        "description": "A custom value used to route operations to a specific shard.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
@@ -104922,7 +104922,7 @@
       "mtermvectors#version_type": {
         "in": "query",
         "name": "version_type",
-        "description": "Specific version type.",
+        "description": "The version type.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:VersionType"
@@ -107114,7 +107114,7 @@
       "termvectors#index": {
         "in": "path",
         "name": "index",
-        "description": "Name of the index that contains the document.",
+        "description": "The name of the index that contains the document.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -107125,7 +107125,7 @@
       "termvectors#id": {
         "in": "path",
         "name": "id",
-        "description": "Unique identifier of the document.",
+        "description": "A unique identifier for the document.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -107136,7 +107136,7 @@
       "termvectors#fields": {
         "in": "query",
         "name": "fields",
-        "description": "Comma-separated list or wildcard expressions of fields to include in the statistics.\nUsed as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.",
+        "description": "A comma-separated list or wildcard expressions of fields to include in the statistics.\nIt is used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
@@ -107146,7 +107146,7 @@
       "termvectors#field_statistics": {
         "in": "query",
         "name": "field_statistics",
-        "description": "If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies.",
+        "description": "If `true`, the response includes:\n\n* The document count (how many documents contain this field).\n* The sum of document frequencies (the sum of document frequencies for all terms in this field).\n* The sum of total term frequencies (the sum of total term frequencies of each term in this field).",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -107186,7 +107186,7 @@
       "termvectors#preference": {
         "in": "query",
         "name": "preference",
-        "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+        "description": "The node or shard the operation should be performed on.\nIt is random by default.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -107206,7 +107206,7 @@
       "termvectors#routing": {
         "in": "query",
         "name": "routing",
-        "description": "Custom value used to route operations to a specific shard.",
+        "description": "A custom value that is used to route operations to a specific shard.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
@@ -107216,7 +107216,7 @@
       "termvectors#term_statistics": {
         "in": "query",
         "name": "term_statistics",
-        "description": "If `true`, the response includes term frequency and document frequency.",
+        "description": "If `true`, the response includes:\n\n* The total term frequency (how often a term occurs in all documents).\n* The document frequency (the number of documents containing the current term).\n\nBy default these values are not returned since term statistics can have a serious performance impact.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -107236,7 +107236,7 @@
       "termvectors#version_type": {
         "in": "query",
         "name": "version_type",
-        "description": "Specific version type.",
+        "description": "The version type.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:VersionType"
@@ -109295,14 +109295,14 @@
               "type": "object",
               "properties": {
                 "docs": {
-                  "description": "Array of existing or artificial documents.",
+                  "description": "An array of existing or artificial documents.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/_global.mtermvectors:Operation"
                   }
                 },
                 "ids": {
-                  "description": "Simplified syntax to specify documents by their ID if they're in the same index.",
+                  "description": "A simplified syntax to specify documents by their ID if they're in the same index.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/_types:Id"
@@ -110490,7 +110490,7 @@
                   "$ref": "#/components/schemas/_global.termvectors:Filter"
                 },
                 "per_field_analyzer": {
-                  "description": "Overrides the default per-field analyzer.",
+                  "description": "Override the default per-field analyzer.\nThis is useful in order to generate term vectors in any fashion, especially when using artificial documents.\nWhen providing an analyzer for a field that already stores term vectors, the term vectors will be regenerated.",
                   "type": "object",
                   "additionalProperties": {
                     "type": "string"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -9354,7 +9354,7 @@
           "search"
         ],
         "summary": "Explain a document match result",
-        "description": "Returns information about why a specific document matches, or doesn’t match, a query.",
+        "description": "Get information about why a specific document matches, or doesn't match, a query.\nIt computes a score explanation for a query and a specific document.",
         "operationId": "explain",
         "parameters": [
           {
@@ -9414,7 +9414,7 @@
           "search"
         ],
         "summary": "Explain a document match result",
-        "description": "Returns information about why a specific document matches, or doesn’t match, a query.",
+        "description": "Get information about why a specific document matches, or doesn't match, a query.\nIt computes a score explanation for a query and a specific document.",
         "operationId": "explain-1",
         "parameters": [
           {
@@ -28514,7 +28514,7 @@
           "search"
         ],
         "summary": "Get the search shards",
-        "description": "Get the indices and shards that a search request would be run against.\nThis information can be useful for working out issues or planning optimizations with routing and shard preferences.\nWhen filtered aliases are used, the filter is returned as part of the indices section.",
+        "description": "Get the indices and shards that a search request would be run against.\nThis information can be useful for working out issues or planning optimizations with routing and shard preferences.\nWhen filtered aliases are used, the filter is returned as part of the `indices` section.\n\nIf the Elasticsearch security features are enabled, you must have the `view_index_metadata` or `manage` index privilege for the target data stream, index, or alias.",
         "operationId": "search-shards",
         "parameters": [
           {
@@ -28550,7 +28550,7 @@
           "search"
         ],
         "summary": "Get the search shards",
-        "description": "Get the indices and shards that a search request would be run against.\nThis information can be useful for working out issues or planning optimizations with routing and shard preferences.\nWhen filtered aliases are used, the filter is returned as part of the indices section.",
+        "description": "Get the indices and shards that a search request would be run against.\nThis information can be useful for working out issues or planning optimizations with routing and shard preferences.\nWhen filtered aliases are used, the filter is returned as part of the `indices` section.\n\nIf the Elasticsearch security features are enabled, you must have the `view_index_metadata` or `manage` index privilege for the target data stream, index, or alias.",
         "operationId": "search-shards-1",
         "parameters": [
           {
@@ -28588,7 +28588,7 @@
           "search"
         ],
         "summary": "Get the search shards",
-        "description": "Get the indices and shards that a search request would be run against.\nThis information can be useful for working out issues or planning optimizations with routing and shard preferences.\nWhen filtered aliases are used, the filter is returned as part of the indices section.",
+        "description": "Get the indices and shards that a search request would be run against.\nThis information can be useful for working out issues or planning optimizations with routing and shard preferences.\nWhen filtered aliases are used, the filter is returned as part of the `indices` section.\n\nIf the Elasticsearch security features are enabled, you must have the `view_index_metadata` or `manage` index privilege for the target data stream, index, or alias.",
         "operationId": "search-shards-2",
         "parameters": [
           {
@@ -28627,7 +28627,7 @@
           "search"
         ],
         "summary": "Get the search shards",
-        "description": "Get the indices and shards that a search request would be run against.\nThis information can be useful for working out issues or planning optimizations with routing and shard preferences.\nWhen filtered aliases are used, the filter is returned as part of the indices section.",
+        "description": "Get the indices and shards that a search request would be run against.\nThis information can be useful for working out issues or planning optimizations with routing and shard preferences.\nWhen filtered aliases are used, the filter is returned as part of the `indices` section.\n\nIf the Elasticsearch security features are enabled, you must have the `view_index_metadata` or `manage` index privilege for the target data stream, index, or alias.",
         "operationId": "search-shards-3",
         "parameters": [
           {
@@ -100116,7 +100116,7 @@
       "explain#id": {
         "in": "path",
         "name": "id",
-        "description": "Defines the document ID.",
+        "description": "The document identifier.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -100127,7 +100127,7 @@
       "explain#index": {
         "in": "path",
         "name": "index",
-        "description": "Index names used to limit the request.\nOnly a single index name can be provided to this parameter.",
+        "description": "Index names that are used to limit the request.\nOnly a single index name can be provided to this parameter.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -100138,7 +100138,7 @@
       "explain#analyzer": {
         "in": "query",
         "name": "analyzer",
-        "description": "Analyzer to use for the query string.\nThis parameter can only be used when the `q` query string parameter is specified.",
+        "description": "The analyzer to use for the query string.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -100148,7 +100148,7 @@
       "explain#analyze_wildcard": {
         "in": "query",
         "name": "analyze_wildcard",
-        "description": "If `true`, wildcard and prefix queries are analyzed.",
+        "description": "If `true`, wildcard and prefix queries are analyzed.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -100158,7 +100158,7 @@
       "explain#default_operator": {
         "in": "query",
         "name": "default_operator",
-        "description": "The default operator for query string query: `AND` or `OR`.",
+        "description": "The default operator for query string query: `AND` or `OR`.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types.query_dsl:Operator"
@@ -100168,7 +100168,7 @@
       "explain#df": {
         "in": "query",
         "name": "df",
-        "description": "Field to use as default where no field prefix is given in the query string.",
+        "description": "The field to use as default where no field prefix is given in the query string.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -100178,7 +100178,7 @@
       "explain#lenient": {
         "in": "query",
         "name": "lenient",
-        "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.",
+        "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -100188,7 +100188,7 @@
       "explain#preference": {
         "in": "query",
         "name": "preference",
-        "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+        "description": "The node or shard the operation should be performed on.\nIt is random by default.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -100198,7 +100198,7 @@
       "explain#routing": {
         "in": "query",
         "name": "routing",
-        "description": "Custom value used to route operations to a specific shard.",
+        "description": "A custom value used to route operations to a specific shard.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
@@ -100208,7 +100208,7 @@
       "explain#_source": {
         "in": "query",
         "name": "_source",
-        "description": "True or false to return the `_source` field or not, or a list of fields to return.",
+        "description": "`True` or `false` to return the `_source` field or not or a list of fields to return.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_global.search._types:SourceConfigParam"
@@ -100218,7 +100218,7 @@
       "explain#_source_excludes": {
         "in": "query",
         "name": "_source_excludes",
-        "description": "A comma-separated list of source fields to exclude from the response.",
+        "description": "A comma-separated list of source fields to exclude from the response.\nYou can also use this parameter to exclude fields from the subset specified in `_source_includes` query parameter.\nIf the `_source` parameter is `false`, this parameter is ignored.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
@@ -100228,7 +100228,7 @@
       "explain#_source_includes": {
         "in": "query",
         "name": "_source_includes",
-        "description": "A comma-separated list of source fields to include in the response.",
+        "description": "A comma-separated list of source fields to include in the response.\nIf this parameter is specified, only these source fields are returned.\nYou can exclude fields from this subset using the `_source_excludes` query parameter.\nIf the `_source` parameter is `false`, this parameter is ignored.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
@@ -100248,7 +100248,7 @@
       "explain#q": {
         "in": "query",
         "name": "q",
-        "description": "Query in the Lucene query string syntax.",
+        "description": "The query in the Lucene query string syntax.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -105327,7 +105327,7 @@
       "render_search_template#id": {
         "in": "path",
         "name": "id",
-        "description": "ID of the search template to render.\nIf no `source` is specified, this or the `id` request body parameter is required.",
+        "description": "The ID of the search template to render.\nIf no `source` is specified, this or the `id` request body parameter is required.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -106056,7 +106056,7 @@
       "search_shards#index": {
         "in": "path",
         "name": "index",
-        "description": "Returns the indices and shards that a search request would be executed against.",
+        "description": "A comma-separated list of data streams, indices, and aliases to search.\nIt supports wildcards (`*`).\nTo search all data streams and indices, omit this parameter or use `*` or `_all`.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -106107,7 +106107,7 @@
       "search_shards#master_timeout": {
         "in": "query",
         "name": "master_timeout",
-        "description": "Period to wait for a connection to the master node.",
+        "description": "The period to wait for a connection to the master node.\nIf the master node is not available before the timeout expires, the request fails and returns an error.\nIT can also be set to `-1` to indicate that the request should never timeout.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -106117,7 +106117,7 @@
       "search_shards#preference": {
         "in": "query",
         "name": "preference",
-        "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+        "description": "The node or shard the operation should be performed on.\nIt is random by default.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -106127,7 +106127,7 @@
       "search_shards#routing": {
         "in": "query",
         "name": "routing",
-        "description": "Custom value used to route operations to a specific shard.",
+        "description": "A custom value used to route operations to a specific shard.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
@@ -106137,7 +106137,7 @@
       "search_template#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices,\nand aliases to search. Supports wildcards (*).",
+        "description": "A comma-separated list of data streams, indices, and aliases to search.\nIt supports wildcards (`*`).",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -106168,7 +106168,7 @@
       "search_template#expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
-        "description": "Type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nSupports comma-separated values, such as `open,hidden`.\nValid values are: `all`, `open`, `closed`, `hidden`, `none`.",
+        "description": "The type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nSupports comma-separated values, such as `open,hidden`.\nValid values are: `all`, `open`, `closed`, `hidden`, `none`.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -106189,7 +106189,7 @@
         "in": "query",
         "name": "ignore_throttled",
         "description": "If `true`, specified concrete, expanded, or aliased indices are not included in the response when throttled.",
-        "deprecated": false,
+        "deprecated": true,
         "schema": {
           "type": "boolean"
         },
@@ -106208,7 +106208,7 @@
       "search_template#preference": {
         "in": "query",
         "name": "preference",
-        "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+        "description": "The node or shard the operation should be performed on.\nIt is random by default.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -106228,7 +106228,7 @@
       "search_template#routing": {
         "in": "query",
         "name": "routing",
-        "description": "Custom value used to route operations to a specific shard.",
+        "description": "A custom value used to route operations to a specific shard.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
@@ -106258,7 +106258,7 @@
       "search_template#rest_total_hits_as_int": {
         "in": "query",
         "name": "rest_total_hits_as_int",
-        "description": "If true, hits.total are rendered as an integer in the response.",
+        "description": "If `true`, `hits.total` is rendered as an integer in the response.\nIf `false`, it is rendered as an object.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -109376,6 +109376,9 @@
             "schema": {
               "type": "object",
               "properties": {
+                "id": {
+                  "$ref": "#/components/schemas/_types:Id"
+                },
                 "file": {
                   "type": "string"
                 },
@@ -109387,7 +109390,7 @@
                   }
                 },
                 "source": {
-                  "description": "An inline search template.\nSupports the same parameters as the search API's request body.\nThese parameters also support Mustache variables.\nIf no `id` or `<templated-id>` is specified, this parameter is required.",
+                  "description": "An inline search template.\nIt supports the same parameters as the search API's request body.\nThese parameters also support Mustache variables.\nIf no `id` or `<templated-id>` is specified, this parameter is required.",
                   "type": "string"
                 }
               }
@@ -109740,7 +109743,7 @@
               "type": "object",
               "properties": {
                 "explain": {
-                  "description": "If `true`, returns detailed information about score calculation as part of each hit.",
+                  "description": "If `true`, returns detailed information about score calculation as part of each hit.\nIf you specify both this and the `explain` query parameter, the API uses only the query parameter.",
                   "type": "boolean"
                 },
                 "id": {
@@ -109758,7 +109761,7 @@
                   "type": "boolean"
                 },
                 "source": {
-                  "description": "An inline search template. Supports the same parameters as the search API's\nrequest body. Also supports Mustache variables. If no id is specified, this\nparameter is required.",
+                  "description": "An inline search template. Supports the same parameters as the search API's\nrequest body. It also supports Mustache variables. If no `id` is specified, this\nparameter is required.",
                   "type": "string"
                 }
               }

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -5532,7 +5532,7 @@
           "search"
         ],
         "summary": "Explain a document match result",
-        "description": "Returns information about why a specific document matches, or doesn’t match, a query.",
+        "description": "Get information about why a specific document matches, or doesn't match, a query.\nIt computes a score explanation for a query and a specific document.",
         "operationId": "explain",
         "parameters": [
           {
@@ -5592,7 +5592,7 @@
           "search"
         ],
         "summary": "Explain a document match result",
-        "description": "Returns information about why a specific document matches, or doesn’t match, a query.",
+        "description": "Get information about why a specific document matches, or doesn't match, a query.\nIt computes a score explanation for a query and a specific document.",
         "operationId": "explain-1",
         "parameters": [
           {
@@ -59514,7 +59514,7 @@
       "explain#id": {
         "in": "path",
         "name": "id",
-        "description": "Defines the document ID.",
+        "description": "The document identifier.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -59525,7 +59525,7 @@
       "explain#index": {
         "in": "path",
         "name": "index",
-        "description": "Index names used to limit the request.\nOnly a single index name can be provided to this parameter.",
+        "description": "Index names that are used to limit the request.\nOnly a single index name can be provided to this parameter.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -59536,7 +59536,7 @@
       "explain#analyzer": {
         "in": "query",
         "name": "analyzer",
-        "description": "Analyzer to use for the query string.\nThis parameter can only be used when the `q` query string parameter is specified.",
+        "description": "The analyzer to use for the query string.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -59546,7 +59546,7 @@
       "explain#analyze_wildcard": {
         "in": "query",
         "name": "analyze_wildcard",
-        "description": "If `true`, wildcard and prefix queries are analyzed.",
+        "description": "If `true`, wildcard and prefix queries are analyzed.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -59556,7 +59556,7 @@
       "explain#default_operator": {
         "in": "query",
         "name": "default_operator",
-        "description": "The default operator for query string query: `AND` or `OR`.",
+        "description": "The default operator for query string query: `AND` or `OR`.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types.query_dsl:Operator"
@@ -59566,7 +59566,7 @@
       "explain#df": {
         "in": "query",
         "name": "df",
-        "description": "Field to use as default where no field prefix is given in the query string.",
+        "description": "The field to use as default where no field prefix is given in the query string.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -59576,7 +59576,7 @@
       "explain#lenient": {
         "in": "query",
         "name": "lenient",
-        "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.",
+        "description": "If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.\nThis parameter can be used only when the `q` query string parameter is specified.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -59586,7 +59586,7 @@
       "explain#preference": {
         "in": "query",
         "name": "preference",
-        "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+        "description": "The node or shard the operation should be performed on.\nIt is random by default.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -59596,7 +59596,7 @@
       "explain#routing": {
         "in": "query",
         "name": "routing",
-        "description": "Custom value used to route operations to a specific shard.",
+        "description": "A custom value used to route operations to a specific shard.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
@@ -59606,7 +59606,7 @@
       "explain#_source": {
         "in": "query",
         "name": "_source",
-        "description": "True or false to return the `_source` field or not, or a list of fields to return.",
+        "description": "`True` or `false` to return the `_source` field or not or a list of fields to return.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_global.search._types:SourceConfigParam"
@@ -59616,7 +59616,7 @@
       "explain#_source_excludes": {
         "in": "query",
         "name": "_source_excludes",
-        "description": "A comma-separated list of source fields to exclude from the response.",
+        "description": "A comma-separated list of source fields to exclude from the response.\nYou can also use this parameter to exclude fields from the subset specified in `_source_includes` query parameter.\nIf the `_source` parameter is `false`, this parameter is ignored.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
@@ -59626,7 +59626,7 @@
       "explain#_source_includes": {
         "in": "query",
         "name": "_source_includes",
-        "description": "A comma-separated list of source fields to include in the response.",
+        "description": "A comma-separated list of source fields to include in the response.\nIf this parameter is specified, only these source fields are returned.\nYou can exclude fields from this subset using the `_source_excludes` query parameter.\nIf the `_source` parameter is `false`, this parameter is ignored.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
@@ -59646,7 +59646,7 @@
       "explain#q": {
         "in": "query",
         "name": "q",
-        "description": "Query in the Lucene query string syntax.",
+        "description": "The query in the Lucene query string syntax.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -62149,7 +62149,7 @@
       "render_search_template#id": {
         "in": "path",
         "name": "id",
-        "description": "ID of the search template to render.\nIf no `source` is specified, this or the `id` request body parameter is required.",
+        "description": "The ID of the search template to render.\nIf no `source` is specified, this or the `id` request body parameter is required.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -62815,7 +62815,7 @@
       "search_template#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices,\nand aliases to search. Supports wildcards (*).",
+        "description": "A comma-separated list of data streams, indices, and aliases to search.\nIt supports wildcards (`*`).",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -62846,7 +62846,7 @@
       "search_template#expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
-        "description": "Type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nSupports comma-separated values, such as `open,hidden`.\nValid values are: `all`, `open`, `closed`, `hidden`, `none`.",
+        "description": "The type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nSupports comma-separated values, such as `open,hidden`.\nValid values are: `all`, `open`, `closed`, `hidden`, `none`.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -62867,7 +62867,7 @@
         "in": "query",
         "name": "ignore_throttled",
         "description": "If `true`, specified concrete, expanded, or aliased indices are not included in the response when throttled.",
-        "deprecated": false,
+        "deprecated": true,
         "schema": {
           "type": "boolean"
         },
@@ -62886,7 +62886,7 @@
       "search_template#preference": {
         "in": "query",
         "name": "preference",
-        "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+        "description": "The node or shard the operation should be performed on.\nIt is random by default.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -62906,7 +62906,7 @@
       "search_template#routing": {
         "in": "query",
         "name": "routing",
-        "description": "Custom value used to route operations to a specific shard.",
+        "description": "A custom value used to route operations to a specific shard.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
@@ -62936,7 +62936,7 @@
       "search_template#rest_total_hits_as_int": {
         "in": "query",
         "name": "rest_total_hits_as_int",
-        "description": "If true, hits.total are rendered as an integer in the response.",
+        "description": "If `true`, `hits.total` is rendered as an integer in the response.\nIf `false`, it is rendered as an object.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -64383,6 +64383,9 @@
             "schema": {
               "type": "object",
               "properties": {
+                "id": {
+                  "$ref": "#/components/schemas/_types:Id"
+                },
                 "file": {
                   "type": "string"
                 },
@@ -64394,7 +64397,7 @@
                   }
                 },
                 "source": {
-                  "description": "An inline search template.\nSupports the same parameters as the search API's request body.\nThese parameters also support Mustache variables.\nIf no `id` or `<templated-id>` is specified, this parameter is required.",
+                  "description": "An inline search template.\nIt supports the same parameters as the search API's request body.\nThese parameters also support Mustache variables.\nIf no `id` or `<templated-id>` is specified, this parameter is required.",
                   "type": "string"
                 }
               }
@@ -64715,7 +64718,7 @@
               "type": "object",
               "properties": {
                 "explain": {
-                  "description": "If `true`, returns detailed information about score calculation as part of each hit.",
+                  "description": "If `true`, returns detailed information about score calculation as part of each hit.\nIf you specify both this and the `explain` query parameter, the API uses only the query parameter.",
                   "type": "boolean"
                 },
                 "id": {
@@ -64733,7 +64736,7 @@
                   "type": "boolean"
                 },
                 "source": {
-                  "description": "An inline search template. Supports the same parameters as the search API's\nrequest body. Also supports Mustache variables. If no id is specified, this\nparameter is required.",
+                  "description": "An inline search template. Supports the same parameters as the search API's\nrequest body. It also supports Mustache variables. If no `id` is specified, this\nparameter is required.",
                   "type": "string"
                 }
               }

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -14435,7 +14435,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors",
         "parameters": [
           {
@@ -14489,7 +14489,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-1",
         "parameters": [
           {
@@ -14545,7 +14545,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-2",
         "parameters": [
           {
@@ -14602,7 +14602,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "You can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
         "operationId": "mtermvectors-3",
         "parameters": [
           {
@@ -18736,7 +18736,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Get information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.\n\nYou can retrieve term vectors for documents stored in the index or for artificial documents passed in the body of the request.\nYou can specify the fields you are interested in through the `fields` parameter or by adding the fields to the request body.\nFor example:\n\n```\nGET /my-index-000001/_termvectors/1?fields=message\n```\n\nFields can be specified using wildcards, similar to the multi match query.\n\nTerm vectors are real-time by default, not near real-time.\nThis can be changed by setting `realtime` parameter to `false`.\n\nYou can request three types of values: _term information_, _term statistics_, and _field statistics_.\nBy default, all term information and field statistics are returned for all fields but term statistics are excluded.\n\n**Term information**\n\n* term frequency in the field (always returned)\n* term positions (`positions: true`)\n* start and end offsets (`offsets: true`)\n* term payloads (`payloads: true`), as base64 encoded bytes\n\nIf the requested information wasn't stored in the index, it will be computed on the fly if possible.\nAdditionally, term vectors could be computed for documents not even existing in the index, but instead provided by the user.\n\n> warn\n> Start and end offsets assume UTF-16 encoding is being used. If you want to use these offsets in order to get the original text that produced this token, you should make sure that the string you are taking a sub-string of is also encoded using UTF-16.\n\n**Behaviour**\n\nThe term and field statistics are not accurate.\nDeleted documents are not taken into account.\nThe information is only retrieved for the shard the requested document resides in.\nThe term and field statistics are therefore only useful as relative measures whereas the absolute numbers have no meaning in this context.\nBy default, when requesting term vectors of artificial documents, a shard to get the statistics from is randomly selected.\nUse `routing` only to hit a particular shard.",
         "operationId": "termvectors",
         "parameters": [
           {
@@ -18793,7 +18793,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Get information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.\n\nYou can retrieve term vectors for documents stored in the index or for artificial documents passed in the body of the request.\nYou can specify the fields you are interested in through the `fields` parameter or by adding the fields to the request body.\nFor example:\n\n```\nGET /my-index-000001/_termvectors/1?fields=message\n```\n\nFields can be specified using wildcards, similar to the multi match query.\n\nTerm vectors are real-time by default, not near real-time.\nThis can be changed by setting `realtime` parameter to `false`.\n\nYou can request three types of values: _term information_, _term statistics_, and _field statistics_.\nBy default, all term information and field statistics are returned for all fields but term statistics are excluded.\n\n**Term information**\n\n* term frequency in the field (always returned)\n* term positions (`positions: true`)\n* start and end offsets (`offsets: true`)\n* term payloads (`payloads: true`), as base64 encoded bytes\n\nIf the requested information wasn't stored in the index, it will be computed on the fly if possible.\nAdditionally, term vectors could be computed for documents not even existing in the index, but instead provided by the user.\n\n> warn\n> Start and end offsets assume UTF-16 encoding is being used. If you want to use these offsets in order to get the original text that produced this token, you should make sure that the string you are taking a sub-string of is also encoded using UTF-16.\n\n**Behaviour**\n\nThe term and field statistics are not accurate.\nDeleted documents are not taken into account.\nThe information is only retrieved for the shard the requested document resides in.\nThe term and field statistics are therefore only useful as relative measures whereas the absolute numbers have no meaning in this context.\nBy default, when requesting term vectors of artificial documents, a shard to get the statistics from is randomly selected.\nUse `routing` only to hit a particular shard.",
         "operationId": "termvectors-1",
         "parameters": [
           {
@@ -18852,7 +18852,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Get information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.\n\nYou can retrieve term vectors for documents stored in the index or for artificial documents passed in the body of the request.\nYou can specify the fields you are interested in through the `fields` parameter or by adding the fields to the request body.\nFor example:\n\n```\nGET /my-index-000001/_termvectors/1?fields=message\n```\n\nFields can be specified using wildcards, similar to the multi match query.\n\nTerm vectors are real-time by default, not near real-time.\nThis can be changed by setting `realtime` parameter to `false`.\n\nYou can request three types of values: _term information_, _term statistics_, and _field statistics_.\nBy default, all term information and field statistics are returned for all fields but term statistics are excluded.\n\n**Term information**\n\n* term frequency in the field (always returned)\n* term positions (`positions: true`)\n* start and end offsets (`offsets: true`)\n* term payloads (`payloads: true`), as base64 encoded bytes\n\nIf the requested information wasn't stored in the index, it will be computed on the fly if possible.\nAdditionally, term vectors could be computed for documents not even existing in the index, but instead provided by the user.\n\n> warn\n> Start and end offsets assume UTF-16 encoding is being used. If you want to use these offsets in order to get the original text that produced this token, you should make sure that the string you are taking a sub-string of is also encoded using UTF-16.\n\n**Behaviour**\n\nThe term and field statistics are not accurate.\nDeleted documents are not taken into account.\nThe information is only retrieved for the shard the requested document resides in.\nThe term and field statistics are therefore only useful as relative measures whereas the absolute numbers have no meaning in this context.\nBy default, when requesting term vectors of artificial documents, a shard to get the statistics from is randomly selected.\nUse `routing` only to hit a particular shard.",
         "operationId": "termvectors-2",
         "parameters": [
           {
@@ -18906,7 +18906,7 @@
           "document"
         ],
         "summary": "Get term vector information",
-        "description": "Get information and statistics about terms in the fields of a particular document.",
+        "description": "Get information and statistics about terms in the fields of a particular document.\n\nYou can retrieve term vectors for documents stored in the index or for artificial documents passed in the body of the request.\nYou can specify the fields you are interested in through the `fields` parameter or by adding the fields to the request body.\nFor example:\n\n```\nGET /my-index-000001/_termvectors/1?fields=message\n```\n\nFields can be specified using wildcards, similar to the multi match query.\n\nTerm vectors are real-time by default, not near real-time.\nThis can be changed by setting `realtime` parameter to `false`.\n\nYou can request three types of values: _term information_, _term statistics_, and _field statistics_.\nBy default, all term information and field statistics are returned for all fields but term statistics are excluded.\n\n**Term information**\n\n* term frequency in the field (always returned)\n* term positions (`positions: true`)\n* start and end offsets (`offsets: true`)\n* term payloads (`payloads: true`), as base64 encoded bytes\n\nIf the requested information wasn't stored in the index, it will be computed on the fly if possible.\nAdditionally, term vectors could be computed for documents not even existing in the index, but instead provided by the user.\n\n> warn\n> Start and end offsets assume UTF-16 encoding is being used. If you want to use these offsets in order to get the original text that produced this token, you should make sure that the string you are taking a sub-string of is also encoded using UTF-16.\n\n**Behaviour**\n\nThe term and field statistics are not accurate.\nDeleted documents are not taken into account.\nThe information is only retrieved for the shard the requested document resides in.\nThe term and field statistics are therefore only useful as relative measures whereas the absolute numbers have no meaning in this context.\nBy default, when requesting term vectors of artificial documents, a shard to get the statistics from is randomly selected.\nUse `routing` only to hit a particular shard.",
         "operationId": "termvectors-3",
         "parameters": [
           {
@@ -53579,11 +53579,11 @@
             "type": "number"
           },
           "max_num_terms": {
-            "description": "Maximum number of terms that must be returned per field.",
+            "description": "The maximum number of terms that must be returned per field.",
             "type": "number"
           },
           "max_term_freq": {
-            "description": "Ignore words with more than this frequency in the source doc.\nDefaults to unbounded.",
+            "description": "Ignore words with more than this frequency in the source doc.\nIt defaults to unbounded.",
             "type": "number"
           },
           "max_word_length": {
@@ -61922,7 +61922,7 @@
       "mtermvectors#index": {
         "in": "path",
         "name": "index",
-        "description": "Name of the index that contains the documents.",
+        "description": "The name of the index that contains the documents.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -61946,7 +61946,7 @@
       "mtermvectors#fields": {
         "in": "query",
         "name": "fields",
-        "description": "Comma-separated list or wildcard expressions of fields to include in the statistics.\nUsed as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.",
+        "description": "A comma-separated list or wildcard expressions of fields to include in the statistics.\nIt is used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
@@ -61996,7 +61996,7 @@
       "mtermvectors#preference": {
         "in": "query",
         "name": "preference",
-        "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+        "description": "The node or shard the operation should be performed on.\nIt is random by default.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -62016,7 +62016,7 @@
       "mtermvectors#routing": {
         "in": "query",
         "name": "routing",
-        "description": "Custom value used to route operations to a specific shard.",
+        "description": "A custom value used to route operations to a specific shard.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
@@ -62046,7 +62046,7 @@
       "mtermvectors#version_type": {
         "in": "query",
         "name": "version_type",
-        "description": "Specific version type.",
+        "description": "The version type.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:VersionType"
@@ -63060,7 +63060,7 @@
       "termvectors#index": {
         "in": "path",
         "name": "index",
-        "description": "Name of the index that contains the document.",
+        "description": "The name of the index that contains the document.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -63071,7 +63071,7 @@
       "termvectors#id": {
         "in": "path",
         "name": "id",
-        "description": "Unique identifier of the document.",
+        "description": "A unique identifier for the document.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -63082,7 +63082,7 @@
       "termvectors#fields": {
         "in": "query",
         "name": "fields",
-        "description": "Comma-separated list or wildcard expressions of fields to include in the statistics.\nUsed as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.",
+        "description": "A comma-separated list or wildcard expressions of fields to include in the statistics.\nIt is used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
@@ -63092,7 +63092,7 @@
       "termvectors#field_statistics": {
         "in": "query",
         "name": "field_statistics",
-        "description": "If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies.",
+        "description": "If `true`, the response includes:\n\n* The document count (how many documents contain this field).\n* The sum of document frequencies (the sum of document frequencies for all terms in this field).\n* The sum of total term frequencies (the sum of total term frequencies of each term in this field).",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -63132,7 +63132,7 @@
       "termvectors#preference": {
         "in": "query",
         "name": "preference",
-        "description": "Specifies the node or shard the operation should be performed on.\nRandom by default.",
+        "description": "The node or shard the operation should be performed on.\nIt is random by default.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -63152,7 +63152,7 @@
       "termvectors#routing": {
         "in": "query",
         "name": "routing",
-        "description": "Custom value used to route operations to a specific shard.",
+        "description": "A custom value that is used to route operations to a specific shard.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
@@ -63162,7 +63162,7 @@
       "termvectors#term_statistics": {
         "in": "query",
         "name": "term_statistics",
-        "description": "If `true`, the response includes term frequency and document frequency.",
+        "description": "If `true`, the response includes:\n\n* The total term frequency (how often a term occurs in all documents).\n* The document frequency (the number of documents containing the current term).\n\nBy default these values are not returned since term statistics can have a serious performance impact.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -63182,7 +63182,7 @@
       "termvectors#version_type": {
         "in": "query",
         "name": "version_type",
-        "description": "Specific version type.",
+        "description": "The version type.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:VersionType"
@@ -64316,14 +64316,14 @@
               "type": "object",
               "properties": {
                 "docs": {
-                  "description": "Array of existing or artificial documents.",
+                  "description": "An array of existing or artificial documents.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/_global.mtermvectors:Operation"
                   }
                 },
                 "ids": {
-                  "description": "Simplified syntax to specify documents by their ID if they're in the same index.",
+                  "description": "A simplified syntax to specify documents by their ID if they're in the same index.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/_types:Id"
@@ -65090,7 +65090,7 @@
                   "$ref": "#/components/schemas/_global.termvectors:Filter"
                 },
                 "per_field_analyzer": {
-                  "description": "Overrides the default per-field analyzer.",
+                  "description": "Override the default per-field analyzer.\nThis is useful in order to generate term vectors in any fashion, especially when using artificial documents.\nWhen providing an analyzer for a field that already stores term vectors, the term vectors will be regenerated.",
                   "type": "object",
                   "additionalProperties": {
                     "type": "string"

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1140,6 +1140,7 @@ export interface ReindexRethrottleResponse {
 export interface RenderSearchTemplateRequest extends RequestBase {
   id?: Id
   body?: {
+    id?: Id
     file?: string
     params?: Record<string, any>
     source?: string

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -608,6 +608,7 @@ search-request-body,https://www.elastic.co/guide/en/elasticsearch/reference/{bra
 search-search,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-search.html
 search-shards,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-shards.html
 search-template,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-template.html
+search-template-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-template-api.html
 search-terms-enum,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-terms-enum.html
 search-validate,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-validate.html
 search-vector-tile-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-vector-tile-api.html

--- a/specification/_global/explain/ExplainRequest.ts
+++ b/specification/_global/explain/ExplainRequest.ts
@@ -25,11 +25,14 @@ import { Operator } from '@_types/query_dsl/Operator'
 
 /**
  * Explain a document match result.
- * Returns information about why a specific document matches, or doesn’t match, a query.
+ * Get information about why a specific document matches, or doesn't match, a query.
+ * It computes a score explanation for a query and a specific document.
  * @rest_spec_name explain
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges read
  * @doc_tag search
+ * @doc_id search-explain
  */
 export interface Request extends RequestBase {
   urls: [
@@ -40,59 +43,68 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Defines the document ID.
+     * The document identifier.
      */
     id: Id
     /**
-     * Index names used to limit the request.
+     * Index names that are used to limit the request.
      * Only a single index name can be provided to this parameter.
      */
     index: IndexName
   }
   query_parameters: {
     /**
-     * Analyzer to use for the query string.
-     * This parameter can only be used when the `q` query string parameter is specified.
+     * The analyzer to use for the query string.
+     * This parameter can be used only when the `q` query string parameter is specified.
      */
     analyzer?: string
     /**
      * If `true`, wildcard and prefix queries are analyzed.
+     * This parameter can be used only when the `q` query string parameter is specified.
      * @server_default false
      */
     analyze_wildcard?: boolean
     /**
      * The default operator for query string query: `AND` or `OR`.
+     * This parameter can be used only when the `q` query string parameter is specified.
      * @server_default OR
      */
     default_operator?: Operator
     /**
-     * Field to use as default where no field prefix is given in the query string.
+     * The field to use as default where no field prefix is given in the query string.
+     * This parameter can be used only when the `q` query string parameter is specified.
      */
     df?: string
     /**
      * If `true`, format-based query failures (such as providing text to a numeric field) in the query string will be ignored.
+     * This parameter can be used only when the `q` query string parameter is specified.
      * @server_default false
      */
     lenient?: boolean
     /**
-     * Specifies the node or shard the operation should be performed on.
-     * Random by default.
+     * The node or shard the operation should be performed on.
+     * It is random by default.
      */
     preference?: string
     /**
-     * Custom value used to route operations to a specific shard.
+     * A custom value used to route operations to a specific shard.
      */
     routing?: Routing
     /**
-     * True or false to return the `_source` field or not, or a list of fields to return.
+     * `True` or `false` to return the `_source` field or not or a list of fields to return.
      */
     _source?: SourceConfigParam
     /**
      * A comma-separated list of source fields to exclude from the response.
+     * You can also use this parameter to exclude fields from the subset specified in `_source_includes` query parameter.
+     * If the `_source` parameter is `false`, this parameter is ignored.
      */
     _source_excludes?: Fields
     /**
      * A comma-separated list of source fields to include in the response.
+     * If this parameter is specified, only these source fields are returned.
+     * You can exclude fields from this subset using the `_source_excludes` query parameter.
+     * If the `_source` parameter is `false`, this parameter is ignored.
      */
     _source_includes?: Fields
     /**
@@ -100,7 +112,7 @@ export interface Request extends RequestBase {
      */
     stored_fields?: Fields
     /**
-     * Query in the Lucene query string syntax.
+     * The query in the Lucene query string syntax.
      */
     q?: string
   }

--- a/specification/_global/explain/examples/request/ExplainRequestExample1.yaml
+++ b/specification/_global/explain/examples/request/ExplainRequestExample1.yaml
@@ -1,0 +1,12 @@
+# summary:
+# method_request: GET /my-index-000001/_explain/0
+description: >
+  Run `GET /my-index-000001/_explain/0` with the request body.
+  Alternatively, run `GET /my-index-000001/_explain/0?q=message:elasticsearch`
+# type: request
+value: |-
+  {
+    "query" : {
+      "match" : { "message" : "elasticsearch" }
+    }
+  }

--- a/specification/_global/explain/examples/response/ExplainResponseExample1.yaml
+++ b/specification/_global/explain/examples/response/ExplainResponseExample1.yaml
@@ -1,0 +1,74 @@
+# summary:
+description: A successful response from `GET /my-index-000001/_explain/0`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "_index":"my-index-000001",
+    "_id":"0",
+    "matched":true,
+    "explanation":{
+        "value":1.6943598,
+        "description":"weight(message:elasticsearch in 0) [PerFieldSimilarity], result of:",
+        "details":[
+          {
+              "value":1.6943598,
+              "description":"score(freq=1.0), computed as boost * idf * tf from:",
+              "details":[
+                {
+                    "value":2.2,
+                    "description":"boost",
+                    "details":[]
+                },
+                {
+                    "value":1.3862944,
+                    "description":"idf, computed as log(1 + (N - n + 0.5) / (n + 0.5)) from:",
+                    "details":[
+                      {
+                          "value":1,
+                          "description":"n, number of documents containing term",
+                          "details":[]
+                      },
+                      {
+                          "value":5,
+                          "description":"N, total number of documents with field",
+                          "details":[]
+                      }
+                    ]
+                },
+                {
+                    "value":0.5555556,
+                    "description":"tf, computed as freq / (freq + k1 * (1 - b + b * dl / avgdl)) from:",
+                    "details":[
+                      {
+                          "value":1.0,
+                          "description":"freq, occurrences of term within document",
+                          "details":[]
+                      },
+                      {
+                          "value":1.2,
+                          "description":"k1, term saturation parameter",
+                          "details":[]
+                      },
+                      {
+                          "value":0.75,
+                          "description":"b, length normalization parameter",
+                          "details":[]
+                      },
+                      {
+                          "value":3.0,
+                          "description":"dl, length of field",
+                          "details":[]
+                      },
+                      {
+                          "value":5.4,
+                          "description":"avgdl, average length of field",
+                          "details":[]
+                      }
+                    ]
+                }
+              ]
+          }
+        ]
+    }
+  }

--- a/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
+++ b/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
@@ -31,6 +31,7 @@ import { Operation } from './types'
 /**
  * Get multiple term vectors.
  *
+ * Get multiple term vectors with a single request.
  * You can specify existing documents by index and ID or provide artificial documents in the body of the request.
  * You can specify the index in the request body or request URI.
  * The response contains a `docs` array with all the fetched termvectors.
@@ -38,7 +39,9 @@ import { Operation } from './types'
  * @rest_spec_name mtermvectors
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges read
  * @doc_tag document
+ * @doc_id docs-multi-termvectors
  */
 export interface Request extends RequestBase {
   urls: [
@@ -53,15 +56,15 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Name of the index that contains the documents.
+     * The name of the index that contains the documents.
      */
     index?: IndexName
   }
   query_parameters: {
     ids?: Id[]
     /**
-     * Comma-separated list or wildcard expressions of fields to include in the statistics.
-     * Used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.
+     * A comma-separated list or wildcard expressions of fields to include in the statistics.
+     * It is used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.
      */
     fields?: Fields
     /**
@@ -85,8 +88,8 @@ export interface Request extends RequestBase {
      */
     positions?: boolean
     /**
-     * Specifies the node or shard the operation should be performed on.
-     * Random by default.
+     * The node or shard the operation should be performed on.
+     * It is random by default.
      */
     preference?: string
     /**
@@ -96,7 +99,7 @@ export interface Request extends RequestBase {
      */
     realtime?: boolean
     /**
-     * Custom value used to route operations to a specific shard.
+     * A custom value used to route operations to a specific shard.
      */
     routing?: Routing
     /**
@@ -109,17 +112,17 @@ export interface Request extends RequestBase {
      */
     version?: VersionNumber
     /**
-     * Specific version type.
+     * The version type.
      */
     version_type?: VersionType
   }
   body: {
     /**
-     * Array of existing or artificial documents.
+     * An array of existing or artificial documents.
      */
     docs?: Operation[]
     /**
-     * Simplified syntax to specify documents by their ID if they're in the same index.
+     * A simplified syntax to specify documents by their ID if they're in the same index.
      */
     ids?: Id[]
   }

--- a/specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample1.yaml
+++ b/specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample1.yaml
@@ -1,0 +1,21 @@
+summary: Get multi term vectors
+# method_request: POST /my-index-000001/_mtermvectors
+description: >
+  Run `POST /my-index-000001/_mtermvectors`.
+  If you specify an index in the request URI, the index does not need to be specified for each documents in the request body.
+# type: request
+value: |-
+  {
+    "docs": [
+        {
+          "_id": "2",
+          "fields": [
+              "message"
+          ],
+          "term_statistics": true
+        },
+        {
+          "_id": "1"
+        }
+    ]
+  }

--- a/specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample2.yaml
+++ b/specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample2.yaml
@@ -1,0 +1,16 @@
+summary: Simplified syntax
+# method_request: POST /my-index-000001/_mtermvectors
+description: >
+  Run `POST /my-index-000001/_mtermvectors`.
+  If all requested documents are in same index and the parameters are the same, you can use a simplified syntax.
+# type: request
+value: |-
+  {
+    "ids": [ "1", "2" ],
+    "parameters": {
+      "fields": [
+        "message"
+      ],
+      "term_statistics": true
+    }
+  }

--- a/specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample3.yaml
+++ b/specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample3.yaml
@@ -1,0 +1,23 @@
+summary: Artificial documents
+# method_request: POST /_mtermvectors
+description: >
+  Run `POST /_mtermvectors` to generate term vectors for artificial documents provided in the body of the request.
+  The mapping used is determined by the specified `_index`.
+# type: request
+value: |-
+  {
+    "docs": [
+        {
+          "_index": "my-index-000001",
+          "doc" : {
+              "message" : "test test test"
+          }
+        },
+        {
+          "_index": "my-index-000001",
+          "doc" : {
+            "message" : "Another test ..."
+          }
+        }
+    ]
+  }

--- a/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
+++ b/specification/_global/render_search_template/RenderSearchTemplateRequest.ts
@@ -29,7 +29,9 @@ import { Id } from '@_types/common'
  * @rest_spec_name render_search_template
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges read
  * @doc_tag search
+ * @doc_id render-search-template-api
  */
 export interface Request extends RequestBase {
   urls: [
@@ -44,12 +46,18 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * ID of the search template to render.
+     * The ID of the search template to render.
      * If no `source` is specified, this or the `id` request body parameter is required.
      */
     id?: Id
   }
   body: {
+    /**
+     * The ID of the search template to render.
+     * If no `source` is specified, this or the `<template-id>` request path parameter is required.
+     * If you specify both this parameter and the `<template-id>` parameter, the API uses only `<template-id>`.
+     */
+    id?: Id
     file?: string
     /**
      * Key-value pairs used to replace Mustache variables in the template.
@@ -59,7 +67,7 @@ export interface Request extends RequestBase {
     params?: Dictionary<string, UserDefinedValue>
     /**
      * An inline search template.
-     * Supports the same parameters as the search API's request body.
+     * It supports the same parameters as the search API's request body.
      * These parameters also support Mustache variables.
      * If no `id` or `<templated-id>` is specified, this parameter is required.
      */

--- a/specification/_global/render_search_template/examples/request/RenderSearchTemplateRequestExample1.yaml
+++ b/specification/_global/render_search_template/examples/request/RenderSearchTemplateRequestExample1.yaml
@@ -1,0 +1,13 @@
+# summary:
+# method_request: POST _render/template
+description: Run `POST _render/template`
+# type: request
+value: |-
+  {
+    "id": "my-search-template",
+    "params": {
+      "query_string": "hello world",
+      "from": 20,
+      "size": 10
+    }
+  }

--- a/specification/_global/search_shards/SearchShardsRequest.ts
+++ b/specification/_global/search_shards/SearchShardsRequest.ts
@@ -26,10 +26,14 @@ import { Duration } from '@_types/Time'
  *
  * Get the indices and shards that a search request would be run against.
  * This information can be useful for working out issues or planning optimizations with routing and shard preferences.
- * When filtered aliases are used, the filter is returned as part of the indices section.
+ * When filtered aliases are used, the filter is returned as part of the `indices` section.
+ *
+ * If the Elasticsearch security features are enabled, you must have the `view_index_metadata` or `manage` index privilege for the target data stream, index, or alias.
  * @rest_spec_name search_shards
  * @availability stack stability=stable
+ * @index_privileges view_index_metadata
  * @doc_tag search
+ * @doc_id search-shards
  */
 export interface Request extends RequestBase {
   urls: [
@@ -44,7 +48,9 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Returns the indices and shards that a search request would be executed against.
+     * A comma-separated list of data streams, indices, and aliases to search.
+     * It supports wildcards (`*`).
+     * To search all data streams and indices, omit this parameter or use `*` or `_all`.
      */
     index?: Indices
   }
@@ -75,17 +81,19 @@ export interface Request extends RequestBase {
      */
     local?: boolean
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
+     * If the master node is not available before the timeout expires, the request fails and returns an error.
+     * IT can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
     master_timeout?: Duration
     /**
-     * Specifies the node or shard the operation should be performed on.
-     * Random by default.
+     * The node or shard the operation should be performed on.
+     * It is random by default.
      */
     preference?: string
     /**
-     * Custom value used to route operations to a specific shard.
+     * A custom value used to route operations to a specific shard.
      */
     routing?: Routing
   }

--- a/specification/_global/search_shards/examples/response/SearchShardsResponseExample1.yaml
+++ b/specification/_global/search_shards/examples/response/SearchShardsResponseExample1.yaml
@@ -1,0 +1,83 @@
+# summary:
+description: An abbreviated response from `GET /my-index-000001/_search_shards`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "nodes": {},
+    "indices": {
+        "my-index-000001": { }
+    },
+    "shards": [
+        [
+        {
+            "index": "my-index-000001",
+            "node": "JklnKbD7Tyqi9TP3_Q_tBg",
+            "relocating_node": null,
+            "primary": true,
+            "shard": 0,
+            "state": "STARTED",
+            "allocation_id": {"id":"0TvkCyF7TAmM1wHP4a42-A"},
+            "relocation_failure_info" : {
+            "failed_attempts" : 0
+            }
+        }
+        ],
+        [
+        {
+            "index": "my-index-000001",
+            "node": "JklnKbD7Tyqi9TP3_Q_tBg",
+            "relocating_node": null,
+            "primary": true,
+            "shard": 1,
+            "state": "STARTED",
+            "allocation_id": {"id":"fMju3hd1QHWmWrIgFnI4Ww"},
+            "relocation_failure_info" : {
+            "failed_attempts" : 0
+            }
+        }
+        ],
+        [
+        {
+            "index": "my-index-000001",
+            "node": "JklnKbD7Tyqi9TP3_Q_tBg",
+            "relocating_node": null,
+            "primary": true,
+            "shard": 2,
+            "state": "STARTED",
+            "allocation_id": {"id":"Nwl0wbMBTHCWjEEbGYGapg"},
+            "relocation_failure_info" : {
+            "failed_attempts" : 0
+            }
+        }
+        ],
+        [
+        {
+            "index": "my-index-000001",
+            "node": "JklnKbD7Tyqi9TP3_Q_tBg",
+            "relocating_node": null,
+            "primary": true,
+            "shard": 3,
+            "state": "STARTED",
+            "allocation_id": {"id":"bU_KLGJISbW0RejwnwDPKw"},
+            "relocation_failure_info" : {
+            "failed_attempts" : 0
+            }
+        }
+        ],
+        [
+        {
+            "index": "my-index-000001",
+            "node": "JklnKbD7Tyqi9TP3_Q_tBg",
+            "relocating_node": null,
+            "primary": true,
+            "shard": 4,
+            "state": "STARTED",
+            "allocation_id": {"id":"DMs7_giNSwmdqVukF7UydA"},
+            "relocation_failure_info" : {
+            "failed_attempts" : 0
+            }
+        }
+        ]
+      ]
+    }

--- a/specification/_global/search_template/SearchTemplateRequest.ts
+++ b/specification/_global/search_template/SearchTemplateRequest.ts
@@ -34,7 +34,9 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name search_template
  * @availability stack since=2.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges read
  * @doc_tag search
+ * @doc_id search-template-api
  * @ext_doc_id search-template
  */
 export interface Request extends RequestBase {
@@ -50,8 +52,8 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Comma-separated list of data streams, indices,
-     * and aliases to search. Supports wildcards (*).
+     * A comma-separated list of data streams, indices, and aliases to search.
+     * It supports wildcards (`*`).
      */
     index?: Indices
   }
@@ -68,7 +70,7 @@ export interface Request extends RequestBase {
      * @server_default false */
     ccs_minimize_roundtrips?: boolean
     /**
-     * Type of index that wildcard patterns can match.
+     * The type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
      * Supports comma-separated values, such as `open,hidden`.
      * Valid values are: `all`, `open`, `closed`, `hidden`, `none`.
@@ -80,32 +82,36 @@ export interface Request extends RequestBase {
     explain?: boolean
     /**
      * If `true`, specified concrete, expanded, or aliased indices are not included in the response when throttled.
-     * @server_default true */
+     * @server_default true
+     * @deprecated 7.16.0
+     */
     ignore_throttled?: boolean
     /**
      * If `false`, the request returns an error if it targets a missing or closed index.
      * @server_default false */
     ignore_unavailable?: boolean
     /**
-     * Specifies the node or shard the operation should be performed on.
-     * Random by default.
+     * The node or shard the operation should be performed on.
+     * It is random by default.
      */
     preference?: string
     /**
      * If `true`, the query execution is profiled.
      * @server_default false */
     profile?: boolean
-    /** Custom value used to route operations to a specific shard. */
+    /**  A custom value used to route operations to a specific shard. */
     routing?: Routing
     /**
      * Specifies how long a consistent view of the index
      * should be maintained for scrolled search.
      */
     scroll?: Duration
-    /** The type of the search operation. */
+    /**
+     * The type of the search operation. */
     search_type?: SearchType
     /**
-     * If true, hits.total are rendered as an integer in the response.
+     * If `true`, `hits.total` is rendered as an integer in the response.
+     * If `false`, it is rendered as an object.
      * @server_default false
      * @availability stack since=7.0.0
      * @availability serverless
@@ -119,10 +125,11 @@ export interface Request extends RequestBase {
   body: {
     /**
      * If `true`, returns detailed information about score calculation as part of each hit.
+     * If you specify both this and the `explain` query parameter, the API uses only the query parameter.
      * @server_default false */
     explain?: boolean
     /**
-     * ID of the search template to use. If no source is specified,
+     * The ID of the search template to use. If no `source` is specified,
      * this parameter is required.
      */
     id?: Id
@@ -138,7 +145,7 @@ export interface Request extends RequestBase {
     profile?: boolean
     /**
      * An inline search template. Supports the same parameters as the search API's
-     * request body. Also supports Mustache variables. If no id is specified, this
+     * request body. It also supports Mustache variables. If no `id` is specified, this
      * parameter is required.
      */
     source?: string

--- a/specification/_global/search_template/examples/request/SearchTemplateRequestExample1.yaml
+++ b/specification/_global/search_template/examples/request/SearchTemplateRequestExample1.yaml
@@ -1,0 +1,14 @@
+# summary:
+# method_request: GET my-index/_search/template
+description: >
+  Run `GET my-index/_search/template` to run a search with a search template.
+# type: request
+value: |-
+  {
+    "id": "my-search-template",
+    "params": {
+      "query_string": "hello world",
+      "from": 0,
+      "size": 10
+    }
+  }

--- a/specification/_global/termvectors/TermVectorsRequest.ts
+++ b/specification/_global/termvectors/TermVectorsRequest.ts
@@ -34,10 +34,50 @@ import { Filter } from './types'
  * Get term vector information.
  *
  * Get information and statistics about terms in the fields of a particular document.
+ *
+ * You can retrieve term vectors for documents stored in the index or for artificial documents passed in the body of the request.
+ * You can specify the fields you are interested in through the `fields` parameter or by adding the fields to the request body.
+ * For example:
+ *
+ * ```
+ * GET /my-index-000001/_termvectors/1?fields=message
+ * ```
+ *
+ * Fields can be specified using wildcards, similar to the multi match query.
+ *
+ * Term vectors are real-time by default, not near real-time.
+ * This can be changed by setting `realtime` parameter to `false`.
+ *
+ * You can request three types of values: _term information_, _term statistics_, and _field statistics_.
+ * By default, all term information and field statistics are returned for all fields but term statistics are excluded.
+ *
+ * **Term information**
+ *
+ * * term frequency in the field (always returned)
+ * * term positions (`positions: true`)
+ * * start and end offsets (`offsets: true`)
+ * * term payloads (`payloads: true`), as base64 encoded bytes
+ *
+ * If the requested information wasn't stored in the index, it will be computed on the fly if possible.
+ * Additionally, term vectors could be computed for documents not even existing in the index, but instead provided by the user.
+ *
+ * > warn
+ * > Start and end offsets assume UTF-16 encoding is being used. If you want to use these offsets in order to get the original text that produced this token, you should make sure that the string you are taking a sub-string of is also encoded using UTF-16.
+ *
+ * **Behaviour**
+ *
+ * The term and field statistics are not accurate.
+ * Deleted documents are not taken into account.
+ * The information is only retrieved for the shard the requested document resides in.
+ * The term and field statistics are therefore only useful as relative measures whereas the absolute numbers have no meaning in this context.
+ * By default, when requesting term vectors of artificial documents, a shard to get the statistics from is randomly selected.
+ * Use `routing` only to hit a particular shard.
  * @rest_spec_name termvectors
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges read
  * @doc_tag document
+ * @doc_id docs-termvectors
  */
 export interface Request<TDocument> extends RequestBase {
   urls: [
@@ -52,22 +92,26 @@ export interface Request<TDocument> extends RequestBase {
   ]
   path_parts: {
     /**
-     * Name of the index that contains the document.
+     * The name of the index that contains the document.
      */
     index: IndexName
     /**
-     * Unique identifier of the document.
+     * A unique identifier for the document.
      */
     id?: Id
   }
   query_parameters: {
     /**
-     *  Comma-separated list or wildcard expressions of fields to include in the statistics.
-     * Used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.
+     * A comma-separated list or wildcard expressions of fields to include in the statistics.
+     * It is used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.
      */
     fields?: Fields
     /**
-     * If `true`, the response includes the document count, sum of document frequencies, and sum of total term frequencies.
+     * If `true`, the response includes:
+     *
+     * * The document count (how many documents contain this field).
+     * * The sum of document frequencies (the sum of document frequencies for all terms in this field).
+     * * The sum of total term frequencies (the sum of total term frequencies of each term in this field).
      * @server_default true
      */
     field_statistics?: boolean
@@ -87,8 +131,8 @@ export interface Request<TDocument> extends RequestBase {
      */
     positions?: boolean
     /**
-     * Specifies the node or shard the operation should be performed on.
-     * Random by default.
+     * The node or shard the operation should be performed on.
+     * It is random by default.
      */
     preference?: string
     /**
@@ -98,11 +142,17 @@ export interface Request<TDocument> extends RequestBase {
      */
     realtime?: boolean
     /**
-     * Custom value used to route operations to a specific shard.
+     * A custom value that is used to route operations to a specific shard.
      */
     routing?: Routing
     /**
-     * If `true`, the response includes term frequency and document frequency.
+     * If `true`, the response includes:
+     *
+     * * The total term frequency (how often a term occurs in all documents).
+     * * The document frequency (the number of documents containing the current term).
+     *
+     * By default these values are not returned since term statistics can have a serious performance impact.
+     *
      * @server_default false
      */
     term_statistics?: boolean
@@ -111,7 +161,7 @@ export interface Request<TDocument> extends RequestBase {
      */
     version?: VersionNumber
     /**
-     * Specific version type.
+     * The version type.
      */
     version_type?: VersionType
   }
@@ -122,10 +172,15 @@ export interface Request<TDocument> extends RequestBase {
     doc?: TDocument
     /**
      * Filter terms based on their tf-idf scores.
+     * This could be useful in order find out a good characteristic vector of a document.
+     * This feature works in a similar manner to the second phase of the More Like This Query.
+     * @ext_doc_id query-dsl-mlt-query
      */
     filter?: Filter
     /**
-     * Overrides the default per-field analyzer.
+     * Override the default per-field analyzer.
+     * This is useful in order to generate term vectors in any fashion, especially when using artificial documents.
+     * When providing an analyzer for a field that already stores term vectors, the term vectors will be regenerated.
      */
     per_field_analyzer?: Dictionary<Field, string>
   }

--- a/specification/_global/termvectors/examples/request/TermVectorsRequestExample1.yaml
+++ b/specification/_global/termvectors/examples/request/TermVectorsRequestExample1.yaml
@@ -1,0 +1,14 @@
+summary: Return stored term vectors
+# method_request: GET /my-index-000001/_termvectors/1
+description: >
+  Run `GET /my-index-000001/_termvectors/1` to return all information and statistics for field `text` in document 1.
+# type: request
+value: |-
+  {
+    "fields" : ["text"],
+    "offsets" : true,
+    "payloads" : true,
+    "positions" : true,
+    "term_statistics" : true,
+    "field_statistics" : true
+  }

--- a/specification/_global/termvectors/examples/request/TermVectorsRequestExample2.yaml
+++ b/specification/_global/termvectors/examples/request/TermVectorsRequestExample2.yaml
@@ -1,0 +1,17 @@
+summary: Per-field analyzer
+# method_request: GET /my-index-000001/_termvectors
+description: >
+  Run `GET /my-index-000001/_termvectors/1` to set per-field analyzers.
+  A different analyzer than the one at the field may be provided by using the `per_field_analyzer` parameter.
+# type: request
+value: |-
+  {
+    "doc" : {
+      "fullname" : "John Doe",
+      "text" : "test test test"
+    },
+    "fields": ["fullname"],
+    "per_field_analyzer" : {
+      "fullname": "keyword"
+    }
+  }

--- a/specification/_global/termvectors/examples/request/TermVectorsRequestExample3.yaml
+++ b/specification/_global/termvectors/examples/request/TermVectorsRequestExample3.yaml
@@ -1,0 +1,22 @@
+summary: Terms filtering
+# method_request: GET /imdb/_termvectorss
+description: >
+  Run `GET /imdb/_termvectors` to filter the terms returned based on their tf-idf scores.
+  It returns the three most "interesting" keywords from the artificial document having the given "plot" field value.
+  Notice that the keyword "Tony" or any stop words are not part of the response, as their tf-idf must be too low.
+# type: request
+value: |-
+  {
+    "doc": {
+      "plot": "When wealthy industrialist Tony Stark is forced to build an armored suit after a life-threatening incident, he ultimately decides to use its technology to fight against evil."
+    },
+    "term_statistics": true,
+    "field_statistics": true,
+    "positions": false,
+    "offsets": false,
+    "filter": {
+      "max_num_terms": 3,
+      "min_term_freq": 1,
+      "min_doc_freq": 1
+    }
+  }

--- a/specification/_global/termvectors/examples/request/TermVectorsRequestExample4.yaml
+++ b/specification/_global/termvectors/examples/request/TermVectorsRequestExample4.yaml
@@ -1,0 +1,16 @@
+summary: Generate term vectors on the fly
+# method_request: GET /my-index-000001/_termvectors/1
+description: >
+  Run `GET /my-index-000001/_termvectors/1`.
+  Term vectors which are not explicitly stored in the index are automatically computed on the fly.
+  This request returns all information and statistics for the fields in document 1, even though the terms haven't been explicitly stored in the index.
+  Note that for the field text, the terms are not regenerated.
+# type: request
+value: |-
+  {
+    "fields" : ["text", "some_field_without_term_vectors"],
+    "offsets" : true,
+    "positions" : true,
+    "term_statistics" : true,
+    "field_statistics" : true
+  }

--- a/specification/_global/termvectors/examples/request/TermVectorsRequestExample5.yaml
+++ b/specification/_global/termvectors/examples/request/TermVectorsRequestExample5.yaml
@@ -1,0 +1,13 @@
+summary: Artificial documents
+# method_request: GET /my-index-000001/_termvectors
+description: >
+  Run `GET /my-index-000001/_termvectors`.
+  Term vectors can be generated for artificial documents, that is for documents not present in the index. If dynamic mapping is turned on (default), the document fields not in the original mapping will be dynamically created.
+# type: request
+value: |-
+  {
+    "doc" : {
+      "fullname" : "John Doe",
+      "text" : "test test test"
+    }
+  }

--- a/specification/_global/termvectors/examples/response/TermVectorsResponseExample1.yaml
+++ b/specification/_global/termvectors/examples/response/TermVectorsResponseExample1.yaml
@@ -1,0 +1,48 @@
+summary: Return stored term vectors
+description: A successful response from `GET /my-index-000001/_termvectors/1`.
+# type: response
+# response_code: ''
+value: |-
+  {
+    "_index": "my-index-000001",
+    "_id": "1",
+    "_version": 1,
+    "found": true,
+    "took": 6,
+    "term_vectors": {
+      "text": {
+        "field_statistics": {
+          "sum_doc_freq": 4,
+          "doc_count": 2,
+          "sum_ttf": 6
+        },
+        "terms": {
+          "test": {
+            "doc_freq": 2,
+            "ttf": 4,
+            "term_freq": 3,
+            "tokens": [
+              {
+                "position": 0,
+                "start_offset": 0,
+                "end_offset": 4,
+                "payload": "d29yZA=="
+              },
+              {
+                "position": 1,
+                "start_offset": 5,
+                "end_offset": 9,
+                "payload": "d29yZA=="
+              },
+              {
+                "position": 2,
+                "start_offset": 10,
+                "end_offset": 14,
+                "payload": "d29yZA=="
+              }
+            ]
+          }
+        }
+      }
+    }
+  }

--- a/specification/_global/termvectors/examples/response/TermVectorsResponseExample2.yaml
+++ b/specification/_global/termvectors/examples/response/TermVectorsResponseExample2.yaml
@@ -1,0 +1,32 @@
+summary: Per-field analyzer
+description: A successful response from `GET /my-index-000001/_termvectors` with `per_field_analyzer` in the request body.
+# type: response
+# response_code: ''
+value: |-
+  {
+    "_index": "my-index-000001",
+    "_version": 0,
+    "found": true,
+    "took": 6,
+    "term_vectors": {
+      "fullname": {
+        "field_statistics": {
+            "sum_doc_freq": 2,
+            "doc_count": 4,
+            "sum_ttf": 4
+        },
+        "terms": {
+            "John Doe": {
+              "term_freq": 1,
+              "tokens": [
+                  {
+                    "position": 0,
+                    "start_offset": 0,
+                    "end_offset": 8
+                  }
+              ]
+            }
+        }
+      }
+    }
+  }

--- a/specification/_global/termvectors/examples/response/TermVectorsResponseExample3.yaml
+++ b/specification/_global/termvectors/examples/response/TermVectorsResponseExample3.yaml
@@ -1,0 +1,39 @@
+summary: Terms filtering
+description: A successful response from `GET /my-index-000001/_termvectors` with a `filter` in the request body.
+# type: response
+# response_code: ''
+value: |-
+  {
+    "_index": "imdb",
+    "_version": 0,
+    "found": true,
+    "term_vectors": {
+        "plot": {
+          "field_statistics": {
+              "sum_doc_freq": 3384269,
+              "doc_count": 176214,
+              "sum_ttf": 3753460
+          },
+          "terms": {
+              "armored": {
+                "doc_freq": 27,
+                "ttf": 27,
+                "term_freq": 1,
+                "score": 9.74725
+              },
+              "industrialist": {
+                "doc_freq": 88,
+                "ttf": 88,
+                "term_freq": 1,
+                "score": 8.590818
+              },
+              "stark": {
+                "doc_freq": 44,
+                "ttf": 47,
+                "term_freq": 1,
+                "score": 9.272792
+              }
+          }
+        }
+    }
+  }

--- a/specification/_global/termvectors/types.ts
+++ b/specification/_global/termvectors/types.ts
@@ -53,13 +53,13 @@ export class Filter {
    */
   max_doc_freq?: integer
   /**
-   * Maximum number of terms that must be returned per field.
+   * The maximum number of terms that must be returned per field.
    * @server_default 25
    */
   max_num_terms?: integer
   /**
    * Ignore words with more than this frequency in the source doc.
-   * Defaults to unbounded.
+   * It defaults to unbounded.
    */
   max_term_freq?: integer
   /**


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR adds examples and descriptions copied from https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template-api.html,[https://www.elastic.co/guide/en/elasticsearch/reference/current/render-search-template-api.html,https://www.elastic.co/guide/en/elasticsearch/reference/current/search-shards.html, https://www.elastic.co/guide/en/elasticsearch/reference/current/search-explain.html, https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-multi-termvectors.html, https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-termvectors.html