### PR TITLE
[DOCS] Add examples for mget, msearch template APIs

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -17388,7 +17388,7 @@
           "search"
         ],
         "summary": "Run a knn search",
-        "description": "NOTE: The kNN search API has been replaced by the `knn` option in the search API.\n\nPerform a k-nearest neighbor (kNN) search on a dense_vector field and return the matching documents.\nGiven a query vector, the API finds the k closest vectors and returns those documents as search hits.\n\nElasticsearch uses the HNSW algorithm to support efficient kNN search.\nLike most kNN algorithms, HNSW is an approximate method that sacrifices result accuracy for improved search speed.\nThis means the results returned are not always the true k closest neighbors.\n\nThe kNN search API supports restricting the search using a filter.\nThe search will return the top k documents that also match the filter query.",
+        "description": "NOTE: The kNN search API has been replaced by the `knn` option in the search API.\n\nPerform a k-nearest neighbor (kNN) search on a dense_vector field and return the matching documents.\nGiven a query vector, the API finds the k closest vectors and returns those documents as search hits.\n\nElasticsearch uses the HNSW algorithm to support efficient kNN search.\nLike most kNN algorithms, HNSW is an approximate method that sacrifices result accuracy for improved search speed.\nThis means the results returned are not always the true k closest neighbors.\n\nThe kNN search API supports restricting the search using a filter.\nThe search will return the top k documents that also match the filter query.\n\nA kNN search response has the exact same structure as a search API response.\nHowever, certain sections have a meaning specific to kNN search:\n\n* The document `_score` is determined by the similarity between the query and document vector.\n* The `hits.total` object contains the total number of nearest neighbor candidates considered, which is `num_candidates * num_shards`. The `hits.total.relation` will always be `eq`, indicating an exact value.",
         "operationId": "knn-search",
         "parameters": [
           {
@@ -17414,7 +17414,7 @@
           "search"
         ],
         "summary": "Run a knn search",
-        "description": "NOTE: The kNN search API has been replaced by the `knn` option in the search API.\n\nPerform a k-nearest neighbor (kNN) search on a dense_vector field and return the matching documents.\nGiven a query vector, the API finds the k closest vectors and returns those documents as search hits.\n\nElasticsearch uses the HNSW algorithm to support efficient kNN search.\nLike most kNN algorithms, HNSW is an approximate method that sacrifices result accuracy for improved search speed.\nThis means the results returned are not always the true k closest neighbors.\n\nThe kNN search API supports restricting the search using a filter.\nThe search will return the top k documents that also match the filter query.",
+        "description": "NOTE: The kNN search API has been replaced by the `knn` option in the search API.\n\nPerform a k-nearest neighbor (kNN) search on a dense_vector field and return the matching documents.\nGiven a query vector, the API finds the k closest vectors and returns those documents as search hits.\n\nElasticsearch uses the HNSW algorithm to support efficient kNN search.\nLike most kNN algorithms, HNSW is an approximate method that sacrifices result accuracy for improved search speed.\nThis means the results returned are not always the true k closest neighbors.\n\nThe kNN search API supports restricting the search using a filter.\nThe search will return the top k documents that also match the filter query.\n\nA kNN search response has the exact same structure as a search API response.\nHowever, certain sections have a meaning specific to kNN search:\n\n* The document `_score` is determined by the similarity between the query and document vector.\n* The `hits.total` object contains the total number of nearest neighbor candidates considered, which is `num_candidates * num_shards`. The `hits.total.relation` will always be `eq`, indicating an exact value.",
         "operationId": "knn-search-1",
         "parameters": [
           {
@@ -17933,7 +17933,7 @@
           "document"
         ],
         "summary": "Get multiple documents",
-        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.\n\n**Filter source fields**\n\nBy default, the `_source` field is returned for every document (if stored).\nUse the `_source` and `_source_include` or `source_exclude` attributes to filter what fields are returned for a particular document.\nYou can include the `_source`, `_source_includes`, and `_source_excludes` query parameters in the request URI to specify the defaults to use when there are no per-document instructions.\n\n**Get stored fields**\n\nUse the `stored_fields` attribute to specify the set of stored fields you want to retrieve.\nAny requested fields that are not stored are ignored.\nYou can include the `stored_fields` query parameter in the request URI to specify the defaults to use when there are no per-document instructions.",
         "operationId": "mget",
         "parameters": [
           {
@@ -17979,7 +17979,7 @@
           "document"
         ],
         "summary": "Get multiple documents",
-        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.\n\n**Filter source fields**\n\nBy default, the `_source` field is returned for every document (if stored).\nUse the `_source` and `_source_include` or `source_exclude` attributes to filter what fields are returned for a particular document.\nYou can include the `_source`, `_source_includes`, and `_source_excludes` query parameters in the request URI to specify the defaults to use when there are no per-document instructions.\n\n**Get stored fields**\n\nUse the `stored_fields` attribute to specify the set of stored fields you want to retrieve.\nAny requested fields that are not stored are ignored.\nYou can include the `stored_fields` query parameter in the request URI to specify the defaults to use when there are no per-document instructions.",
         "operationId": "mget-1",
         "parameters": [
           {
@@ -18027,7 +18027,7 @@
           "document"
         ],
         "summary": "Get multiple documents",
-        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.\n\n**Filter source fields**\n\nBy default, the `_source` field is returned for every document (if stored).\nUse the `_source` and `_source_include` or `source_exclude` attributes to filter what fields are returned for a particular document.\nYou can include the `_source`, `_source_includes`, and `_source_excludes` query parameters in the request URI to specify the defaults to use when there are no per-document instructions.\n\n**Get stored fields**\n\nUse the `stored_fields` attribute to specify the set of stored fields you want to retrieve.\nAny requested fields that are not stored are ignored.\nYou can include the `stored_fields` query parameter in the request URI to specify the defaults to use when there are no per-document instructions.",
         "operationId": "mget-2",
         "parameters": [
           {
@@ -18076,7 +18076,7 @@
           "document"
         ],
         "summary": "Get multiple documents",
-        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.\n\n**Filter source fields**\n\nBy default, the `_source` field is returned for every document (if stored).\nUse the `_source` and `_source_include` or `source_exclude` attributes to filter what fields are returned for a particular document.\nYou can include the `_source`, `_source_includes`, and `_source_excludes` query parameters in the request URI to specify the defaults to use when there are no per-document instructions.\n\n**Get stored fields**\n\nUse the `stored_fields` attribute to specify the set of stored fields you want to retrieve.\nAny requested fields that are not stored are ignored.\nYou can include the `stored_fields` query parameter in the request URI to specify the defaults to use when there are no per-document instructions.",
         "operationId": "mget-3",
         "parameters": [
           {
@@ -24642,6 +24642,7 @@
           "search"
         ],
         "summary": "Run multiple templated searches",
+        "description": "Run multiple templated searches with a single request.\nIf you are providing a text file or text input to `curl`, use the `--data-binary` flag instead of `-d` to preserve newlines.\nFor example:\n\n```\n$ cat requests\n{ \"index\": \"my-index\" }\n{ \"id\": \"my-search-template\", \"params\": { \"query_string\": \"hello world\", \"from\": 0, \"size\": 10 }}\n{ \"index\": \"my-other-index\" }\n{ \"id\": \"my-other-search-template\", \"params\": { \"query_type\": \"match_all\" }}\n\n$ curl -H \"Content-Type: application/x-ndjson\" -XGET localhost:9200/_msearch/template --data-binary \"@requests\"; echo\n```",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -24678,6 +24679,7 @@
           "search"
         ],
         "summary": "Run multiple templated searches",
+        "description": "Run multiple templated searches with a single request.\nIf you are providing a text file or text input to `curl`, use the `--data-binary` flag instead of `-d` to preserve newlines.\nFor example:\n\n```\n$ cat requests\n{ \"index\": \"my-index\" }\n{ \"id\": \"my-search-template\", \"params\": { \"query_string\": \"hello world\", \"from\": 0, \"size\": 10 }}\n{ \"index\": \"my-other-index\" }\n{ \"id\": \"my-other-search-template\", \"params\": { \"query_type\": \"match_all\" }}\n\n$ curl -H \"Content-Type: application/x-ndjson\" -XGET localhost:9200/_msearch/template --data-binary \"@requests\"; echo\n```",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -24716,6 +24718,7 @@
           "search"
         ],
         "summary": "Run multiple templated searches",
+        "description": "Run multiple templated searches with a single request.\nIf you are providing a text file or text input to `curl`, use the `--data-binary` flag instead of `-d` to preserve newlines.\nFor example:\n\n```\n$ cat requests\n{ \"index\": \"my-index\" }\n{ \"id\": \"my-search-template\", \"params\": { \"query_string\": \"hello world\", \"from\": 0, \"size\": 10 }}\n{ \"index\": \"my-other-index\" }\n{ \"id\": \"my-other-search-template\", \"params\": { \"query_type\": \"match_all\" }}\n\n$ curl -H \"Content-Type: application/x-ndjson\" -XGET localhost:9200/_msearch/template --data-binary \"@requests\"; echo\n```",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -24755,6 +24758,7 @@
           "search"
         ],
         "summary": "Run multiple templated searches",
+        "description": "Run multiple templated searches with a single request.\nIf you are providing a text file or text input to `curl`, use the `--data-binary` flag instead of `-d` to preserve newlines.\nFor example:\n\n```\n$ cat requests\n{ \"index\": \"my-index\" }\n{ \"id\": \"my-search-template\", \"params\": { \"query_string\": \"hello world\", \"from\": 0, \"size\": 10 }}\n{ \"index\": \"my-other-index\" }\n{ \"id\": \"my-other-search-template\", \"params\": { \"query_type\": \"match_all\" }}\n\n$ curl -H \"Content-Type: application/x-ndjson\" -XGET localhost:9200/_msearch/template --data-binary \"@requests\"; echo\n```",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -82005,7 +82009,7 @@
             "type": "boolean"
           },
           "source": {
-            "description": "An inline search template. Supports the same parameters as the search API's\nrequest body. Also supports Mustache variables. If no id is specified, this\nparameter is required.",
+            "description": "An inline search template. Supports the same parameters as the search API's\nrequest body. It also supports Mustache variables. If no `id` is specified, this\nparameter is required.",
             "type": "string"
           }
         }
@@ -95776,7 +95780,7 @@
               "type": "object",
               "properties": {
                 "took": {
-                  "description": "Milliseconds it took Elasticsearch to execute the request.",
+                  "description": "The milliseconds it took Elasticsearch to run the request.",
                   "type": "number"
                 },
                 "timed_out": {
@@ -95790,14 +95794,14 @@
                   "$ref": "#/components/schemas/_global.search._types:HitsMetadata"
                 },
                 "fields": {
-                  "description": "Contains field values for the documents. These fields\nmust be specified in the request using the `fields` parameter.",
+                  "description": "The field values for the documents. These fields\nmust be specified in the request using the `fields` parameter.",
                   "type": "object",
                   "additionalProperties": {
                     "type": "object"
                   }
                 },
                 "max_score": {
-                  "description": "Highest returned document score. This value is null for requests\nthat do not sort by score.",
+                  "description": "The highest returned document score. This value is null for requests\nthat do not sort by score.",
                   "type": "number"
                 }
               },
@@ -95857,6 +95861,7 @@
               "type": "object",
               "properties": {
                 "docs": {
+                  "description": "The response includes a docs array that contains the documents in the order specified in the request.\nThe structure of the returned documents is similar to that returned by the get API.\nIf there is a failure getting a particular document, the error is included in place of the document.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/_global.mget:ResponseItem"
@@ -103329,7 +103334,7 @@
       "knn_search#index": {
         "in": "path",
         "name": "index",
-        "description": "A comma-separated list of index names to search;\nuse `_all` or to perform the operation on all indices",
+        "description": "A comma-separated list of index names to search;\nuse `_all` or to perform the operation on all indices.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -103340,7 +103345,7 @@
       "knn_search#routing": {
         "in": "query",
         "name": "routing",
-        "description": "A comma-separated list of specific routing values",
+        "description": "A comma-separated list of specific routing values.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Routing"
@@ -104792,7 +104797,7 @@
       "msearch_template#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices, and aliases to search.\nSupports wildcards (`*`).\nTo search all data streams and indices, omit this parameter or use `*`.",
+        "description": "A comma-separated list of data streams, indices, and aliases to search.\nIt supports wildcards (`*`).\nTo search all data streams and indices, omit this parameter or use `*`.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -104813,7 +104818,7 @@
       "msearch_template#max_concurrent_searches": {
         "in": "query",
         "name": "max_concurrent_searches",
-        "description": "Maximum number of concurrent searches the API can run.",
+        "description": "The maximum number of concurrent searches the API can run.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -104823,7 +104828,7 @@
       "msearch_template#search_type": {
         "in": "query",
         "name": "search_type",
-        "description": "The type of the search operation.\nAvailable options: `query_then_fetch`, `dfs_query_then_fetch`.",
+        "description": "The type of the search operation.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:SearchType"
@@ -108922,7 +108927,7 @@
                   "$ref": "#/components/schemas/_global.search._types:SourceConfig"
                 },
                 "docvalue_fields": {
-                  "description": "The request returns doc values for field names matching these patterns\nin the hits.fields property of the response. Accepts wildcard (*) patterns.",
+                  "description": "The request returns doc values for field names matching these patterns\nin the `hits.fields` property of the response.\nIt accepts wildcard (`*`) patterns.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/_types.query_dsl:FieldAndFormat"
@@ -108935,7 +108940,7 @@
                   "$ref": "#/components/schemas/_types:Fields"
                 },
                 "filter": {
-                  "description": "Query to filter the documents that can match. The kNN search will return the top\n`k` documents that also match this filter. The value can be a single query or a\nlist of queries. If `filter` isn't provided, all documents are allowed to match.",
+                  "description": "A query to filter the documents that can match. The kNN search will return the top\n`k` documents that also match this filter. The value can be a single query or a\nlist of queries. If `filter` isn't provided, all documents are allowed to match.",
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -24800,7 +24800,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.\n\n**Artificial documents**\n\nYou can also use `mtermvectors` to generate term vectors for artificial documents provided in the body of the request.\nThe mapping used is determined by the specified `_index`.",
         "operationId": "mtermvectors",
         "parameters": [
           {
@@ -24854,7 +24854,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.\n\n**Artificial documents**\n\nYou can also use `mtermvectors` to generate term vectors for artificial documents provided in the body of the request.\nThe mapping used is determined by the specified `_index`.",
         "operationId": "mtermvectors-1",
         "parameters": [
           {
@@ -24910,7 +24910,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.\n\n**Artificial documents**\n\nYou can also use `mtermvectors` to generate term vectors for artificial documents provided in the body of the request.\nThe mapping used is determined by the specified `_index`.",
         "operationId": "mtermvectors-2",
         "parameters": [
           {
@@ -24967,7 +24967,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.\n\n**Artificial documents**\n\nYou can also use `mtermvectors` to generate term vectors for artificial documents provided in the body of the request.\nThe mapping used is determined by the specified `_index`.",
         "operationId": "mtermvectors-3",
         "parameters": [
           {
@@ -28430,7 +28430,10 @@
           "search"
         ],
         "summary": "Search a vector tile",
-        "description": "Search a vector tile for geospatial values.",
+        "description": "Search a vector tile for geospatial values.\nBefore using this API, you should be familiar with the Mapbox vector tile specification.\nThe API returns results as a binary mapbox vector tile.\n\nInternally, Elasticsearch translates a vector tile search API request into a search containing:\n\n* A `geo_bounding_box` query on the `<field>`. The query uses the `<zoom>/<x>/<y>` tile as a bounding box.\n* A `geotile_grid` or `geohex_grid` aggregation on the `<field>`. The `grid_agg` parameter determines the aggregation type. The aggregation uses the `<zoom>/<x>/<y>` tile as a bounding box.\n* Optionally, a `geo_bounds` aggregation on the `<field>`. The search only includes this aggregation if the `exact_bounds` parameter is `true`.\n* If the optional parameter `with_labels` is `true`, the internal search will include a dynamic runtime field that calls the `getLabelPosition` function of the geometry doc value. This enables the generation of new point features containing suggested geometry labels, so that, for example, multi-polygons will have only one label.\n\nFor example, Elasticsearch may translate a vector tile search API request with a `grid_agg` argument of `geotile` and an `exact_bounds` argument of `true` into the following search\n\n```\nGET my-index/_search\n{\n  \"size\": 10000,\n  \"query\": {\n    \"geo_bounding_box\": {\n      \"my-geo-field\": {\n        \"top_left\": {\n          \"lat\": -40.979898069620134,\n          \"lon\": -45\n        },\n        \"bottom_right\": {\n          \"lat\": -66.51326044311186,\n          \"lon\": 0\n        }\n      }\n    }\n  },\n  \"aggregations\": {\n    \"grid\": {\n      \"geotile_grid\": {\n        \"field\": \"my-geo-field\",\n        \"precision\": 11,\n        \"size\": 65536,\n        \"bounds\": {\n          \"top_left\": {\n            \"lat\": -40.979898069620134,\n            \"lon\": -45\n          },\n          \"bottom_right\": {\n            \"lat\": -66.51326044311186,\n            \"lon\": 0\n          }\n        }\n      }\n    },\n    \"bounds\": {\n      \"geo_bounds\": {\n        \"field\": \"my-geo-field\",\n        \"wrap_longitude\": false\n      }\n    }\n  }\n}\n```\n\nThe API returns results as a binary Mapbox vector tile.\nMapbox vector tiles are encoded as Google Protobufs (PBF). By default, the tile contains three layers:\n\n* A `hits` layer containing a feature for each `<field>` value matching the `geo_bounding_box` query.\n* An `aggs` layer containing a feature for each cell of the `geotile_grid` or `geohex_grid`. The layer only contains features for cells with matching data.\n* A meta layer containing:\n  * A feature containing a bounding box. By default, this is the bounding box of the tile.\n  * Value ranges for any sub-aggregations on the `geotile_grid` or `geohex_grid`.\n  * Metadata for the search.\n\nThe API only returns features that can display at its zoom level.\nFor example, if a polygon feature has no area at its zoom level, the API omits it.\nThe API returns errors as UTF-8 encoded JSON.\n\nIMPORTANT: You can specify several options for this API as either a query parameter or request body parameter.\nIf you specify both parameters, the query parameter takes precedence.\n\n**Grid precision for geotile**\n\nFor a `grid_agg` of `geotile`, you can use cells in the `aggs` layer as tiles for lower zoom levels.\n`grid_precision` represents the additional zoom levels available through these cells. The final precision is computed by as follows: `<zoom> + grid_precision`.\nFor example, if `<zoom>` is 7 and `grid_precision` is 8, then the `geotile_grid` aggregation will use a precision of 15.\nThe maximum final precision is 29.\nThe `grid_precision` also determines the number of cells for the grid as follows: `(2^grid_precision) x (2^grid_precision)`.\nFor example, a value of 8 divides the tile into a grid of 256 x 256 cells.\nThe `aggs` layer only contains features for cells with matching data.\n\n**Grid precision for geohex**\n\nFor a `grid_agg` of `geohex`, Elasticsearch uses `<zoom>` and `grid_precision` to calculate a final precision as follows: `<zoom> + grid_precision`.\n\nThis precision determines the H3 resolution of the hexagonal cells produced by the `geohex` aggregation.\nThe following table maps the H3 resolution for each precision.\nFor example, if `<zoom>` is 3 and `grid_precision` is 3, the precision is 6.\nAt a precision of 6, hexagonal cells have an H3 resolution of 2.\nIf `<zoom>` is 3 and `grid_precision` is 4, the precision is 7.\nAt a precision of 7, hexagonal cells have an H3 resolution of 3.\n\n| Precision | Unique tile bins | H3 resolution | Unique hex bins |\tRatio |\n| --------- | ---------------- | ------------- | ----------------| ----- |\n| 1  | 4                  | 0  | 122             | 30.5           |\n| 2  | 16                 | 0  | 122             | 7.625          |\n| 3  | 64                 | 1  | 842             | 13.15625       |\n| 4  | 256                | 1  | 842             | 3.2890625      |\n| 5  | 1024               | 2  | 5882            | 5.744140625    |\n| 6  | 4096               | 2  | 5882            | 1.436035156    |\n| 7  | 16384              | 3  | 41162           | 2.512329102    |\n| 8  | 65536              | 3  | 41162           | 0.6280822754   |\n| 9  | 262144             | 4  | 288122          | 1.099098206    |\n| 10 | 1048576            | 4  | 288122          | 0.2747745514   |\n| 11 | 4194304            | 5  | 2016842         | 0.4808526039   |\n| 12 | 16777216           | 6  | 14117882        | 0.8414913416   |\n| 13 | 67108864           | 6  | 14117882        | 0.2103728354   |\n| 14 | 268435456          | 7  | 98825162        | 0.3681524172   |\n| 15 | 1073741824         | 8  | 691776122       | 0.644266719    |\n| 16 | 4294967296         | 8  | 691776122       | 0.1610666797   |\n| 17 | 17179869184        | 9  | 4842432842      | 0.2818666889   |\n| 18 | 68719476736        | 10 | 33897029882     | 0.4932667053   |\n| 19 | 274877906944       | 11 | 237279209162    | 0.8632167343   |\n| 20 | 1099511627776      | 11 | 237279209162    | 0.2158041836   |\n| 21 | 4398046511104      | 12 | 1660954464122   | 0.3776573213   |\n| 22 | 17592186044416     | 13 | 11626681248842  | 0.6609003122   |\n| 23 | 70368744177664     | 13 | 11626681248842  | 0.165225078    |\n| 24 | 281474976710656    | 14 | 81386768741882  | 0.2891438866   |\n| 25 | 1125899906842620   | 15 | 569707381193162 | 0.5060018015   |\n| 26 | 4503599627370500   | 15 | 569707381193162 | 0.1265004504   |\n| 27 | 18014398509482000  | 15 | 569707381193162 | 0.03162511259  |\n| 28 | 72057594037927900  | 15 | 569707381193162 | 0.007906278149 |\n| 29 | 288230376151712000 | 15 | 569707381193162 | 0.001976569537 |\n\nHexagonal cells don't align perfectly on a vector tile.\nSome cells may intersect more than one vector tile.\nTo compute the H3 resolution for each precision, Elasticsearch compares the average density of hexagonal bins at each resolution with the average density of tile bins at each zoom level.\nElasticsearch uses the H3 resolution that is closest to the corresponding geotile density.",
+        "externalDocs": {
+          "url": "https://github.com/mapbox/vector-tile-spec/blob/master/README.md"
+        },
         "operationId": "search-mvt-1",
         "parameters": [
           {
@@ -28485,7 +28488,10 @@
           "search"
         ],
         "summary": "Search a vector tile",
-        "description": "Search a vector tile for geospatial values.",
+        "description": "Search a vector tile for geospatial values.\nBefore using this API, you should be familiar with the Mapbox vector tile specification.\nThe API returns results as a binary mapbox vector tile.\n\nInternally, Elasticsearch translates a vector tile search API request into a search containing:\n\n* A `geo_bounding_box` query on the `<field>`. The query uses the `<zoom>/<x>/<y>` tile as a bounding box.\n* A `geotile_grid` or `geohex_grid` aggregation on the `<field>`. The `grid_agg` parameter determines the aggregation type. The aggregation uses the `<zoom>/<x>/<y>` tile as a bounding box.\n* Optionally, a `geo_bounds` aggregation on the `<field>`. The search only includes this aggregation if the `exact_bounds` parameter is `true`.\n* If the optional parameter `with_labels` is `true`, the internal search will include a dynamic runtime field that calls the `getLabelPosition` function of the geometry doc value. This enables the generation of new point features containing suggested geometry labels, so that, for example, multi-polygons will have only one label.\n\nFor example, Elasticsearch may translate a vector tile search API request with a `grid_agg` argument of `geotile` and an `exact_bounds` argument of `true` into the following search\n\n```\nGET my-index/_search\n{\n  \"size\": 10000,\n  \"query\": {\n    \"geo_bounding_box\": {\n      \"my-geo-field\": {\n        \"top_left\": {\n          \"lat\": -40.979898069620134,\n          \"lon\": -45\n        },\n        \"bottom_right\": {\n          \"lat\": -66.51326044311186,\n          \"lon\": 0\n        }\n      }\n    }\n  },\n  \"aggregations\": {\n    \"grid\": {\n      \"geotile_grid\": {\n        \"field\": \"my-geo-field\",\n        \"precision\": 11,\n        \"size\": 65536,\n        \"bounds\": {\n          \"top_left\": {\n            \"lat\": -40.979898069620134,\n            \"lon\": -45\n          },\n          \"bottom_right\": {\n            \"lat\": -66.51326044311186,\n            \"lon\": 0\n          }\n        }\n      }\n    },\n    \"bounds\": {\n      \"geo_bounds\": {\n        \"field\": \"my-geo-field\",\n        \"wrap_longitude\": false\n      }\n    }\n  }\n}\n```\n\nThe API returns results as a binary Mapbox vector tile.\nMapbox vector tiles are encoded as Google Protobufs (PBF). By default, the tile contains three layers:\n\n* A `hits` layer containing a feature for each `<field>` value matching the `geo_bounding_box` query.\n* An `aggs` layer containing a feature for each cell of the `geotile_grid` or `geohex_grid`. The layer only contains features for cells with matching data.\n* A meta layer containing:\n  * A feature containing a bounding box. By default, this is the bounding box of the tile.\n  * Value ranges for any sub-aggregations on the `geotile_grid` or `geohex_grid`.\n  * Metadata for the search.\n\nThe API only returns features that can display at its zoom level.\nFor example, if a polygon feature has no area at its zoom level, the API omits it.\nThe API returns errors as UTF-8 encoded JSON.\n\nIMPORTANT: You can specify several options for this API as either a query parameter or request body parameter.\nIf you specify both parameters, the query parameter takes precedence.\n\n**Grid precision for geotile**\n\nFor a `grid_agg` of `geotile`, you can use cells in the `aggs` layer as tiles for lower zoom levels.\n`grid_precision` represents the additional zoom levels available through these cells. The final precision is computed by as follows: `<zoom> + grid_precision`.\nFor example, if `<zoom>` is 7 and `grid_precision` is 8, then the `geotile_grid` aggregation will use a precision of 15.\nThe maximum final precision is 29.\nThe `grid_precision` also determines the number of cells for the grid as follows: `(2^grid_precision) x (2^grid_precision)`.\nFor example, a value of 8 divides the tile into a grid of 256 x 256 cells.\nThe `aggs` layer only contains features for cells with matching data.\n\n**Grid precision for geohex**\n\nFor a `grid_agg` of `geohex`, Elasticsearch uses `<zoom>` and `grid_precision` to calculate a final precision as follows: `<zoom> + grid_precision`.\n\nThis precision determines the H3 resolution of the hexagonal cells produced by the `geohex` aggregation.\nThe following table maps the H3 resolution for each precision.\nFor example, if `<zoom>` is 3 and `grid_precision` is 3, the precision is 6.\nAt a precision of 6, hexagonal cells have an H3 resolution of 2.\nIf `<zoom>` is 3 and `grid_precision` is 4, the precision is 7.\nAt a precision of 7, hexagonal cells have an H3 resolution of 3.\n\n| Precision | Unique tile bins | H3 resolution | Unique hex bins |\tRatio |\n| --------- | ---------------- | ------------- | ----------------| ----- |\n| 1  | 4                  | 0  | 122             | 30.5           |\n| 2  | 16                 | 0  | 122             | 7.625          |\n| 3  | 64                 | 1  | 842             | 13.15625       |\n| 4  | 256                | 1  | 842             | 3.2890625      |\n| 5  | 1024               | 2  | 5882            | 5.744140625    |\n| 6  | 4096               | 2  | 5882            | 1.436035156    |\n| 7  | 16384              | 3  | 41162           | 2.512329102    |\n| 8  | 65536              | 3  | 41162           | 0.6280822754   |\n| 9  | 262144             | 4  | 288122          | 1.099098206    |\n| 10 | 1048576            | 4  | 288122          | 0.2747745514   |\n| 11 | 4194304            | 5  | 2016842         | 0.4808526039   |\n| 12 | 16777216           | 6  | 14117882        | 0.8414913416   |\n| 13 | 67108864           | 6  | 14117882        | 0.2103728354   |\n| 14 | 268435456          | 7  | 98825162        | 0.3681524172   |\n| 15 | 1073741824         | 8  | 691776122       | 0.644266719    |\n| 16 | 4294967296         | 8  | 691776122       | 0.1610666797   |\n| 17 | 17179869184        | 9  | 4842432842      | 0.2818666889   |\n| 18 | 68719476736        | 10 | 33897029882     | 0.4932667053   |\n| 19 | 274877906944       | 11 | 237279209162    | 0.8632167343   |\n| 20 | 1099511627776      | 11 | 237279209162    | 0.2158041836   |\n| 21 | 4398046511104      | 12 | 1660954464122   | 0.3776573213   |\n| 22 | 17592186044416     | 13 | 11626681248842  | 0.6609003122   |\n| 23 | 70368744177664     | 13 | 11626681248842  | 0.165225078    |\n| 24 | 281474976710656    | 14 | 81386768741882  | 0.2891438866   |\n| 25 | 1125899906842620   | 15 | 569707381193162 | 0.5060018015   |\n| 26 | 4503599627370500   | 15 | 569707381193162 | 0.1265004504   |\n| 27 | 18014398509482000  | 15 | 569707381193162 | 0.03162511259  |\n| 28 | 72057594037927900  | 15 | 569707381193162 | 0.007906278149 |\n| 29 | 288230376151712000 | 15 | 569707381193162 | 0.001976569537 |\n\nHexagonal cells don't align perfectly on a vector tile.\nSome cells may intersect more than one vector tile.\nTo compute the H3 resolution for each precision, Elasticsearch compares the average density of hexagonal bins at each resolution with the average density of tile bins at each zoom level.\nElasticsearch uses the H3 resolution that is closest to the corresponding geotile density.",
+        "externalDocs": {
+          "url": "https://github.com/mapbox/vector-tile-spec/blob/master/README.md"
+        },
         "operationId": "search-mvt",
         "parameters": [
           {
@@ -36485,7 +36491,7 @@
           "search"
         ],
         "summary": "Get terms in an index",
-        "description": "Discover terms that match a partial string in an index.\nThis \"terms enum\" API is designed for low-latency look-ups used in auto-complete scenarios.\n\nIf the `complete` property in the response is false, the returned terms set may be incomplete and should be treated as approximate.\nThis can occur due to a few reasons, such as a request timeout or a node error.\n\nNOTE: The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.",
+        "description": "Discover terms that match a partial string in an index.\nThis API is designed for low-latency look-ups used in auto-complete scenarios.\n\n> info\n> The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.",
         "operationId": "terms-enum",
         "parameters": [
           {
@@ -36507,7 +36513,7 @@
           "search"
         ],
         "summary": "Get terms in an index",
-        "description": "Discover terms that match a partial string in an index.\nThis \"terms enum\" API is designed for low-latency look-ups used in auto-complete scenarios.\n\nIf the `complete` property in the response is false, the returned terms set may be incomplete and should be treated as approximate.\nThis can occur due to a few reasons, such as a request timeout or a node error.\n\nNOTE: The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.",
+        "description": "Discover terms that match a partial string in an index.\nThis API is designed for low-latency look-ups used in auto-complete scenarios.\n\n> info\n> The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.",
         "operationId": "terms-enum-1",
         "parameters": [
           {
@@ -97661,6 +97667,7 @@
                   }
                 },
                 "complete": {
+                  "description": "If `false`, the returned terms set may be incomplete and should be treated as approximate.\nThis can occur due to a few reasons, such as a request timeout or a node error.",
                   "type": "boolean"
                 }
               },
@@ -100318,7 +100325,7 @@
       "field_caps#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indices, omit this parameter or use * or _all.",
+        "description": "A comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indices, omit this parameter or use * or _all.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -100339,7 +100346,7 @@
       "field_caps#expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
-        "description": "Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.",
+        "description": "The type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -100349,7 +100356,7 @@
       "field_caps#fields": {
         "in": "query",
         "name": "fields",
-        "description": "Comma-separated list of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.",
+        "description": "A comma-separated list of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
@@ -100379,7 +100386,7 @@
       "field_caps#filters": {
         "in": "query",
         "name": "filters",
-        "description": "An optional set of filters: can include +metadata,-metadata,-nested,-multifield,-parent",
+        "description": "A comma-separated list of filters to apply to the response.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -100389,7 +100396,7 @@
       "field_caps#types": {
         "in": "query",
         "name": "types",
-        "description": "Only return results for fields that have one of the types in the list",
+        "description": "A comma-separated list of field types to include.\nAny fields that do not match one of these types will be excluded from the results.\nIt defaults to empty, meaning that all field types are returned.",
         "deprecated": false,
         "schema": {
           "type": "array",
@@ -105346,7 +105353,7 @@
       "rank_eval#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (`*`) expressions are supported.\nTo target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.",
+        "description": "A  comma-separated list of data streams, indices, and index aliases used to limit the request.\nWildcard (`*`) expressions are supported.\nTo target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -105472,7 +105479,7 @@
       "scroll#scroll": {
         "in": "query",
         "name": "scroll",
-        "description": "Period to retain the search context for scrolling.",
+        "description": "The period to retain the search context for scrolling.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -106056,7 +106063,7 @@
       "search_mvt#exact_bounds": {
         "in": "query",
         "name": "exact_bounds",
-        "description": "If false, the meta layer’s feature is the bounding box of the tile.\nIf true, the meta layer’s feature is a bounding box resulting from a\ngeo_bounds aggregation. The aggregation runs on <field> values that intersect\nthe <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting\nbounding box may be larger than the vector tile.",
+        "description": "If `false`, the meta layer's feature is the bounding box of the tile.\nIf true, the meta layer's feature is a bounding box resulting from a\ngeo_bounds aggregation. The aggregation runs on <field> values that intersect\nthe <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting\nbounding box may be larger than the vector tile.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -106066,7 +106073,7 @@
       "search_mvt#extent": {
         "in": "query",
         "name": "extent",
-        "description": "Size, in pixels, of a side of the tile. Vector tiles are square with equal sides.",
+        "description": "The size, in pixels, of a side of the tile. Vector tiles are square with equal sides.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -106086,7 +106093,7 @@
       "search_mvt#grid_precision": {
         "in": "query",
         "name": "grid_precision",
-        "description": "Additional zoom levels available through the aggs layer. For example, if <zoom> is 7\nand grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results\ndon’t include the aggs layer.",
+        "description": "Additional zoom levels available through the aggs layer. For example, if <zoom> is 7\nand grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results\ndon't include the aggs layer.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -106106,7 +106113,7 @@
       "search_mvt#size": {
         "in": "query",
         "name": "size",
-        "description": "Maximum number of features to return in the hits layer. Accepts 0-10000.\nIf 0, results don’t include the hits layer.",
+        "description": "Maximum number of features to return in the hits layer. Accepts 0-10000.\nIf 0, results don't include the hits layer.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -106116,7 +106123,7 @@
       "search_mvt#with_labels": {
         "in": "query",
         "name": "with_labels",
-        "description": "If `true`, the hits and aggs layers will contain additional point features representing\nsuggested label positions for the original features.",
+        "description": "If `true`, the hits and aggs layers will contain additional point features representing\nsuggested label positions for the original features.\n\n* `Point` and `MultiPoint` features will have one of the points selected.\n* `Polygon` and `MultiPolygon` features will have a single point generated, either the centroid, if it is within the polygon, or another point within the polygon selected from the sorted triangle-tree.\n* `LineString` features will likewise provide a roughly central point selected from the triangle-tree.\n* The aggregation results will provide one central point for each aggregation bucket.\n\nAll attributes from the original features will also be copied to the new label features.\nIn addition, the new features will be distinguishable using the tag `_mvt_label_position`.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -107173,7 +107180,7 @@
       "terms_enum#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices, and index aliases to search. Wildcard (*) expressions are supported.",
+        "description": "A comma-separated list of data streams, indices, and index aliases to search.\nWildcard (`*`) expressions are supported.\nTo search all data streams or indices, omit this parameter or use `*`  or `_all`.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -109750,22 +109757,22 @@
               "type": "object",
               "properties": {
                 "aggs": {
-                  "description": "Sub-aggregations for the geotile_grid.\n\nSupports the following aggregation types:\n- avg\n- cardinality\n- max\n- min\n- sum",
+                  "description": "Sub-aggregations for the geotile_grid.\n\nIt supports the following aggregation types:\n\n- `avg`\n- `boxplot`\n- `cardinality`\n- `extended stats`\n- `max`\n- `median absolute deviation`\n- `min`\n- `percentile`\n- `percentile-rank`\n- `stats`\n- `sum`\n- `value count`\n\nThe aggregation names can't start with `_mvt_`. The `_mvt_` prefix is reserved for internal aggregations.",
                   "type": "object",
                   "additionalProperties": {
                     "$ref": "#/components/schemas/_types.aggregations:AggregationContainer"
                   }
                 },
                 "buffer": {
-                  "description": "Size, in pixels, of a clipping buffer outside the tile. This allows renderers\nto avoid outline artifacts from geometries that extend past the extent of the tile.",
+                  "description": "The size, in pixels, of a clipping buffer outside the tile. This allows renderers\nto avoid outline artifacts from geometries that extend past the extent of the tile.",
                   "type": "number"
                 },
                 "exact_bounds": {
-                  "description": "If false, the meta layer’s feature is the bounding box of the tile.\nIf true, the meta layer’s feature is a bounding box resulting from a\ngeo_bounds aggregation. The aggregation runs on <field> values that intersect\nthe <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting\nbounding box may be larger than the vector tile.",
+                  "description": "If `false`, the meta layer's feature is the bounding box of the tile.\nIf `true`, the meta layer's feature is a bounding box resulting from a\n`geo_bounds` aggregation. The aggregation runs on <field> values that intersect\nthe `<zoom>/<x>/<y>` tile with `wrap_longitude` set to `false`. The resulting\nbounding box may be larger than the vector tile.",
                   "type": "boolean"
                 },
                 "extent": {
-                  "description": "Size, in pixels, of a side of the tile. Vector tiles are square with equal sides.",
+                  "description": "The size, in pixels, of a side of the tile. Vector tiles are square with equal sides.",
                   "type": "number"
                 },
                 "fields": {
@@ -109775,7 +109782,7 @@
                   "$ref": "#/components/schemas/_global.search_mvt._types:GridAggregationType"
                 },
                 "grid_precision": {
-                  "description": "Additional zoom levels available through the aggs layer. For example, if <zoom> is 7\nand grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results\ndon’t include the aggs layer.",
+                  "description": "Additional zoom levels available through the aggs layer. For example, if `<zoom>` is `7`\nand `grid_precision` is `8`, you can zoom in up to level 15. Accepts 0-8. If 0, results\ndon't include the aggs layer.",
                   "type": "number"
                 },
                 "grid_type": {
@@ -109788,7 +109795,7 @@
                   "$ref": "#/components/schemas/_types.mapping:RuntimeFields"
                 },
                 "size": {
-                  "description": "Maximum number of features to return in the hits layer. Accepts 0-10000.\nIf 0, results don’t include the hits layer.",
+                  "description": "The maximum number of features to return in the hits layer. Accepts 0-10000.\nIf 0, results don't include the hits layer.",
                   "type": "number"
                 },
                 "sort": {
@@ -109798,7 +109805,7 @@
                   "$ref": "#/components/schemas/_global.search._types:TrackHits"
                 },
                 "with_labels": {
-                  "description": "If `true`, the hits and aggs layers will contain additional point features representing\nsuggested label positions for the original features.",
+                  "description": "If `true`, the hits and aggs layers will contain additional point features representing\nsuggested label positions for the original features.\n\n* `Point` and `MultiPoint` features will have one of the points selected.\n* `Polygon` and `MultiPolygon` features will have a single point generated, either the centroid, if it is within the polygon, or another point within the polygon selected from the sorted triangle-tree.\n* `LineString` features will likewise provide a roughly central point selected from the triangle-tree.\n* The aggregation results will provide one central point for each aggregation bucket.\n\nAll attributes from the original features will also be copied to the new label features.\nIn addition, the new features will be distinguishable using the tag `_mvt_label_position`.",
                   "type": "boolean"
                 }
               }
@@ -110518,24 +110525,25 @@
                   "$ref": "#/components/schemas/_types:Field"
                 },
                 "size": {
-                  "description": "How many matching terms to return.",
+                  "description": "The number of matching terms to return.",
                   "type": "number"
                 },
                 "timeout": {
                   "$ref": "#/components/schemas/_types:Duration"
                 },
                 "case_insensitive": {
-                  "description": "When true the provided search string is matched against index terms without case sensitivity.",
+                  "description": "When `true`, the provided search string is matched against index terms without case sensitivity.",
                   "type": "boolean"
                 },
                 "index_filter": {
                   "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
                 },
                 "string": {
-                  "description": "The string after which terms in the index should be returned. Allows for a form of pagination if the last result from one request is passed as the search_after parameter for a subsequent request.",
+                  "description": "The string to match at the start of indexed terms.\nIf it is not provided, all terms in the field are considered.\n\n> info\n> The prefix string cannot be larger than the largest possible keyword value, which is Lucene's term byte-length limit of 32766.",
                   "type": "string"
                 },
                 "search_after": {
+                  "description": "The string after which terms in the index should be returned.\nIt allows for a form of pagination if the last result from one request is passed as the `search_after` parameter for a subsequent request.",
                   "type": "string"
                 }
               },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -9593,7 +9593,7 @@
           "document"
         ],
         "summary": "Get multiple documents",
-        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.\n\n**Filter source fields**\n\nBy default, the `_source` field is returned for every document (if stored).\nUse the `_source` and `_source_include` or `source_exclude` attributes to filter what fields are returned for a particular document.\nYou can include the `_source`, `_source_includes`, and `_source_excludes` query parameters in the request URI to specify the defaults to use when there are no per-document instructions.\n\n**Get stored fields**\n\nUse the `stored_fields` attribute to specify the set of stored fields you want to retrieve.\nAny requested fields that are not stored are ignored.\nYou can include the `stored_fields` query parameter in the request URI to specify the defaults to use when there are no per-document instructions.",
         "operationId": "mget",
         "parameters": [
           {
@@ -9636,7 +9636,7 @@
           "document"
         ],
         "summary": "Get multiple documents",
-        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.\n\n**Filter source fields**\n\nBy default, the `_source` field is returned for every document (if stored).\nUse the `_source` and `_source_include` or `source_exclude` attributes to filter what fields are returned for a particular document.\nYou can include the `_source`, `_source_includes`, and `_source_excludes` query parameters in the request URI to specify the defaults to use when there are no per-document instructions.\n\n**Get stored fields**\n\nUse the `stored_fields` attribute to specify the set of stored fields you want to retrieve.\nAny requested fields that are not stored are ignored.\nYou can include the `stored_fields` query parameter in the request URI to specify the defaults to use when there are no per-document instructions.",
         "operationId": "mget-1",
         "parameters": [
           {
@@ -9681,7 +9681,7 @@
           "document"
         ],
         "summary": "Get multiple documents",
-        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.\n\n**Filter source fields**\n\nBy default, the `_source` field is returned for every document (if stored).\nUse the `_source` and `_source_include` or `source_exclude` attributes to filter what fields are returned for a particular document.\nYou can include the `_source`, `_source_includes`, and `_source_excludes` query parameters in the request URI to specify the defaults to use when there are no per-document instructions.\n\n**Get stored fields**\n\nUse the `stored_fields` attribute to specify the set of stored fields you want to retrieve.\nAny requested fields that are not stored are ignored.\nYou can include the `stored_fields` query parameter in the request URI to specify the defaults to use when there are no per-document instructions.",
         "operationId": "mget-2",
         "parameters": [
           {
@@ -9727,7 +9727,7 @@
           "document"
         ],
         "summary": "Get multiple documents",
-        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.",
+        "description": "Get multiple JSON documents by ID from one or more indices.\nIf you specify an index in the request URI, you only need to specify the document IDs in the request body.\nTo ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.\n\n**Filter source fields**\n\nBy default, the `_source` field is returned for every document (if stored).\nUse the `_source` and `_source_include` or `source_exclude` attributes to filter what fields are returned for a particular document.\nYou can include the `_source`, `_source_includes`, and `_source_excludes` query parameters in the request URI to specify the defaults to use when there are no per-document instructions.\n\n**Get stored fields**\n\nUse the `stored_fields` attribute to specify the set of stored fields you want to retrieve.\nAny requested fields that are not stored are ignored.\nYou can include the `stored_fields` query parameter in the request URI to specify the defaults to use when there are no per-document instructions.",
         "operationId": "mget-3",
         "parameters": [
           {
@@ -14293,6 +14293,7 @@
           "search"
         ],
         "summary": "Run multiple templated searches",
+        "description": "Run multiple templated searches with a single request.\nIf you are providing a text file or text input to `curl`, use the `--data-binary` flag instead of `-d` to preserve newlines.\nFor example:\n\n```\n$ cat requests\n{ \"index\": \"my-index\" }\n{ \"id\": \"my-search-template\", \"params\": { \"query_string\": \"hello world\", \"from\": 0, \"size\": 10 }}\n{ \"index\": \"my-other-index\" }\n{ \"id\": \"my-other-search-template\", \"params\": { \"query_type\": \"match_all\" }}\n\n$ curl -H \"Content-Type: application/x-ndjson\" -XGET localhost:9200/_msearch/template --data-binary \"@requests\"; echo\n```",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -14329,6 +14330,7 @@
           "search"
         ],
         "summary": "Run multiple templated searches",
+        "description": "Run multiple templated searches with a single request.\nIf you are providing a text file or text input to `curl`, use the `--data-binary` flag instead of `-d` to preserve newlines.\nFor example:\n\n```\n$ cat requests\n{ \"index\": \"my-index\" }\n{ \"id\": \"my-search-template\", \"params\": { \"query_string\": \"hello world\", \"from\": 0, \"size\": 10 }}\n{ \"index\": \"my-other-index\" }\n{ \"id\": \"my-other-search-template\", \"params\": { \"query_type\": \"match_all\" }}\n\n$ curl -H \"Content-Type: application/x-ndjson\" -XGET localhost:9200/_msearch/template --data-binary \"@requests\"; echo\n```",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -14367,6 +14369,7 @@
           "search"
         ],
         "summary": "Run multiple templated searches",
+        "description": "Run multiple templated searches with a single request.\nIf you are providing a text file or text input to `curl`, use the `--data-binary` flag instead of `-d` to preserve newlines.\nFor example:\n\n```\n$ cat requests\n{ \"index\": \"my-index\" }\n{ \"id\": \"my-search-template\", \"params\": { \"query_string\": \"hello world\", \"from\": 0, \"size\": 10 }}\n{ \"index\": \"my-other-index\" }\n{ \"id\": \"my-other-search-template\", \"params\": { \"query_type\": \"match_all\" }}\n\n$ curl -H \"Content-Type: application/x-ndjson\" -XGET localhost:9200/_msearch/template --data-binary \"@requests\"; echo\n```",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -14406,6 +14409,7 @@
           "search"
         ],
         "summary": "Run multiple templated searches",
+        "description": "Run multiple templated searches with a single request.\nIf you are providing a text file or text input to `curl`, use the `--data-binary` flag instead of `-d` to preserve newlines.\nFor example:\n\n```\n$ cat requests\n{ \"index\": \"my-index\" }\n{ \"id\": \"my-search-template\", \"params\": { \"query_string\": \"hello world\", \"from\": 0, \"size\": 10 }}\n{ \"index\": \"my-other-index\" }\n{ \"id\": \"my-other-search-template\", \"params\": { \"query_type\": \"match_all\" }}\n\n$ curl -H \"Content-Type: application/x-ndjson\" -XGET localhost:9200/_msearch/template --data-binary \"@requests\"; echo\n```",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
         },
@@ -53543,7 +53547,7 @@
             "type": "boolean"
           },
           "source": {
-            "description": "An inline search template. Supports the same parameters as the search API's\nrequest body. Also supports Mustache variables. If no id is specified, this\nparameter is required.",
+            "description": "An inline search template. Supports the same parameters as the search API's\nrequest body. It also supports Mustache variables. If no `id` is specified, this\nparameter is required.",
             "type": "string"
           }
         }
@@ -57047,6 +57051,7 @@
               "type": "object",
               "properties": {
                 "docs": {
+                  "description": "The response includes a docs array that contains the documents in the order specified in the request.\nThe structure of the returned documents is similar to that returned by the get API.\nIf there is a failure getting a particular document, the error is included in place of the document.",
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/_global.mget:ResponseItem"
@@ -61888,7 +61893,7 @@
       "msearch_template#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices, and aliases to search.\nSupports wildcards (`*`).\nTo search all data streams and indices, omit this parameter or use `*`.",
+        "description": "A comma-separated list of data streams, indices, and aliases to search.\nIt supports wildcards (`*`).\nTo search all data streams and indices, omit this parameter or use `*`.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -61909,7 +61914,7 @@
       "msearch_template#max_concurrent_searches": {
         "in": "query",
         "name": "max_concurrent_searches",
-        "description": "Maximum number of concurrent searches the API can run.",
+        "description": "The maximum number of concurrent searches the API can run.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -61919,7 +61924,7 @@
       "msearch_template#search_type": {
         "in": "query",
         "name": "search_type",
-        "description": "The type of the search operation.\nAvailable options: `query_then_fetch`, `dfs_query_then_fetch`.",
+        "description": "The type of the search operation.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:SearchType"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -14451,7 +14451,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.\n\n**Artificial documents**\n\nYou can also use `mtermvectors` to generate term vectors for artificial documents provided in the body of the request.\nThe mapping used is determined by the specified `_index`.",
         "operationId": "mtermvectors",
         "parameters": [
           {
@@ -14505,7 +14505,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.\n\n**Artificial documents**\n\nYou can also use `mtermvectors` to generate term vectors for artificial documents provided in the body of the request.\nThe mapping used is determined by the specified `_index`.",
         "operationId": "mtermvectors-1",
         "parameters": [
           {
@@ -14561,7 +14561,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.\n\n**Artificial documents**\n\nYou can also use `mtermvectors` to generate term vectors for artificial documents provided in the body of the request.\nThe mapping used is determined by the specified `_index`.",
         "operationId": "mtermvectors-2",
         "parameters": [
           {
@@ -14618,7 +14618,7 @@
           "document"
         ],
         "summary": "Get multiple term vectors",
-        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.",
+        "description": "Get multiple term vectors with a single request.\nYou can specify existing documents by index and ID or provide artificial documents in the body of the request.\nYou can specify the index in the request body or request URI.\nThe response contains a `docs` array with all the fetched termvectors.\nEach element has the structure provided by the termvectors API.\n\n**Artificial documents**\n\nYou can also use `mtermvectors` to generate term vectors for artificial documents provided in the body of the request.\nThe mapping used is determined by the specified `_index`.",
         "operationId": "mtermvectors-3",
         "parameters": [
           {
@@ -16753,7 +16753,10 @@
           "search"
         ],
         "summary": "Search a vector tile",
-        "description": "Search a vector tile for geospatial values.",
+        "description": "Search a vector tile for geospatial values.\nBefore using this API, you should be familiar with the Mapbox vector tile specification.\nThe API returns results as a binary mapbox vector tile.\n\nInternally, Elasticsearch translates a vector tile search API request into a search containing:\n\n* A `geo_bounding_box` query on the `<field>`. The query uses the `<zoom>/<x>/<y>` tile as a bounding box.\n* A `geotile_grid` or `geohex_grid` aggregation on the `<field>`. The `grid_agg` parameter determines the aggregation type. The aggregation uses the `<zoom>/<x>/<y>` tile as a bounding box.\n* Optionally, a `geo_bounds` aggregation on the `<field>`. The search only includes this aggregation if the `exact_bounds` parameter is `true`.\n* If the optional parameter `with_labels` is `true`, the internal search will include a dynamic runtime field that calls the `getLabelPosition` function of the geometry doc value. This enables the generation of new point features containing suggested geometry labels, so that, for example, multi-polygons will have only one label.\n\nFor example, Elasticsearch may translate a vector tile search API request with a `grid_agg` argument of `geotile` and an `exact_bounds` argument of `true` into the following search\n\n```\nGET my-index/_search\n{\n  \"size\": 10000,\n  \"query\": {\n    \"geo_bounding_box\": {\n      \"my-geo-field\": {\n        \"top_left\": {\n          \"lat\": -40.979898069620134,\n          \"lon\": -45\n        },\n        \"bottom_right\": {\n          \"lat\": -66.51326044311186,\n          \"lon\": 0\n        }\n      }\n    }\n  },\n  \"aggregations\": {\n    \"grid\": {\n      \"geotile_grid\": {\n        \"field\": \"my-geo-field\",\n        \"precision\": 11,\n        \"size\": 65536,\n        \"bounds\": {\n          \"top_left\": {\n            \"lat\": -40.979898069620134,\n            \"lon\": -45\n          },\n          \"bottom_right\": {\n            \"lat\": -66.51326044311186,\n            \"lon\": 0\n          }\n        }\n      }\n    },\n    \"bounds\": {\n      \"geo_bounds\": {\n        \"field\": \"my-geo-field\",\n        \"wrap_longitude\": false\n      }\n    }\n  }\n}\n```\n\nThe API returns results as a binary Mapbox vector tile.\nMapbox vector tiles are encoded as Google Protobufs (PBF). By default, the tile contains three layers:\n\n* A `hits` layer containing a feature for each `<field>` value matching the `geo_bounding_box` query.\n* An `aggs` layer containing a feature for each cell of the `geotile_grid` or `geohex_grid`. The layer only contains features for cells with matching data.\n* A meta layer containing:\n  * A feature containing a bounding box. By default, this is the bounding box of the tile.\n  * Value ranges for any sub-aggregations on the `geotile_grid` or `geohex_grid`.\n  * Metadata for the search.\n\nThe API only returns features that can display at its zoom level.\nFor example, if a polygon feature has no area at its zoom level, the API omits it.\nThe API returns errors as UTF-8 encoded JSON.\n\nIMPORTANT: You can specify several options for this API as either a query parameter or request body parameter.\nIf you specify both parameters, the query parameter takes precedence.\n\n**Grid precision for geotile**\n\nFor a `grid_agg` of `geotile`, you can use cells in the `aggs` layer as tiles for lower zoom levels.\n`grid_precision` represents the additional zoom levels available through these cells. The final precision is computed by as follows: `<zoom> + grid_precision`.\nFor example, if `<zoom>` is 7 and `grid_precision` is 8, then the `geotile_grid` aggregation will use a precision of 15.\nThe maximum final precision is 29.\nThe `grid_precision` also determines the number of cells for the grid as follows: `(2^grid_precision) x (2^grid_precision)`.\nFor example, a value of 8 divides the tile into a grid of 256 x 256 cells.\nThe `aggs` layer only contains features for cells with matching data.\n\n**Grid precision for geohex**\n\nFor a `grid_agg` of `geohex`, Elasticsearch uses `<zoom>` and `grid_precision` to calculate a final precision as follows: `<zoom> + grid_precision`.\n\nThis precision determines the H3 resolution of the hexagonal cells produced by the `geohex` aggregation.\nThe following table maps the H3 resolution for each precision.\nFor example, if `<zoom>` is 3 and `grid_precision` is 3, the precision is 6.\nAt a precision of 6, hexagonal cells have an H3 resolution of 2.\nIf `<zoom>` is 3 and `grid_precision` is 4, the precision is 7.\nAt a precision of 7, hexagonal cells have an H3 resolution of 3.\n\n| Precision | Unique tile bins | H3 resolution | Unique hex bins |\tRatio |\n| --------- | ---------------- | ------------- | ----------------| ----- |\n| 1  | 4                  | 0  | 122             | 30.5           |\n| 2  | 16                 | 0  | 122             | 7.625          |\n| 3  | 64                 | 1  | 842             | 13.15625       |\n| 4  | 256                | 1  | 842             | 3.2890625      |\n| 5  | 1024               | 2  | 5882            | 5.744140625    |\n| 6  | 4096               | 2  | 5882            | 1.436035156    |\n| 7  | 16384              | 3  | 41162           | 2.512329102    |\n| 8  | 65536              | 3  | 41162           | 0.6280822754   |\n| 9  | 262144             | 4  | 288122          | 1.099098206    |\n| 10 | 1048576            | 4  | 288122          | 0.2747745514   |\n| 11 | 4194304            | 5  | 2016842         | 0.4808526039   |\n| 12 | 16777216           | 6  | 14117882        | 0.8414913416   |\n| 13 | 67108864           | 6  | 14117882        | 0.2103728354   |\n| 14 | 268435456          | 7  | 98825162        | 0.3681524172   |\n| 15 | 1073741824         | 8  | 691776122       | 0.644266719    |\n| 16 | 4294967296         | 8  | 691776122       | 0.1610666797   |\n| 17 | 17179869184        | 9  | 4842432842      | 0.2818666889   |\n| 18 | 68719476736        | 10 | 33897029882     | 0.4932667053   |\n| 19 | 274877906944       | 11 | 237279209162    | 0.8632167343   |\n| 20 | 1099511627776      | 11 | 237279209162    | 0.2158041836   |\n| 21 | 4398046511104      | 12 | 1660954464122   | 0.3776573213   |\n| 22 | 17592186044416     | 13 | 11626681248842  | 0.6609003122   |\n| 23 | 70368744177664     | 13 | 11626681248842  | 0.165225078    |\n| 24 | 281474976710656    | 14 | 81386768741882  | 0.2891438866   |\n| 25 | 1125899906842620   | 15 | 569707381193162 | 0.5060018015   |\n| 26 | 4503599627370500   | 15 | 569707381193162 | 0.1265004504   |\n| 27 | 18014398509482000  | 15 | 569707381193162 | 0.03162511259  |\n| 28 | 72057594037927900  | 15 | 569707381193162 | 0.007906278149 |\n| 29 | 288230376151712000 | 15 | 569707381193162 | 0.001976569537 |\n\nHexagonal cells don't align perfectly on a vector tile.\nSome cells may intersect more than one vector tile.\nTo compute the H3 resolution for each precision, Elasticsearch compares the average density of hexagonal bins at each resolution with the average density of tile bins at each zoom level.\nElasticsearch uses the H3 resolution that is closest to the corresponding geotile density.",
+        "externalDocs": {
+          "url": "https://github.com/mapbox/vector-tile-spec/blob/master/README.md"
+        },
         "operationId": "search-mvt-1",
         "parameters": [
           {
@@ -16808,7 +16811,10 @@
           "search"
         ],
         "summary": "Search a vector tile",
-        "description": "Search a vector tile for geospatial values.",
+        "description": "Search a vector tile for geospatial values.\nBefore using this API, you should be familiar with the Mapbox vector tile specification.\nThe API returns results as a binary mapbox vector tile.\n\nInternally, Elasticsearch translates a vector tile search API request into a search containing:\n\n* A `geo_bounding_box` query on the `<field>`. The query uses the `<zoom>/<x>/<y>` tile as a bounding box.\n* A `geotile_grid` or `geohex_grid` aggregation on the `<field>`. The `grid_agg` parameter determines the aggregation type. The aggregation uses the `<zoom>/<x>/<y>` tile as a bounding box.\n* Optionally, a `geo_bounds` aggregation on the `<field>`. The search only includes this aggregation if the `exact_bounds` parameter is `true`.\n* If the optional parameter `with_labels` is `true`, the internal search will include a dynamic runtime field that calls the `getLabelPosition` function of the geometry doc value. This enables the generation of new point features containing suggested geometry labels, so that, for example, multi-polygons will have only one label.\n\nFor example, Elasticsearch may translate a vector tile search API request with a `grid_agg` argument of `geotile` and an `exact_bounds` argument of `true` into the following search\n\n```\nGET my-index/_search\n{\n  \"size\": 10000,\n  \"query\": {\n    \"geo_bounding_box\": {\n      \"my-geo-field\": {\n        \"top_left\": {\n          \"lat\": -40.979898069620134,\n          \"lon\": -45\n        },\n        \"bottom_right\": {\n          \"lat\": -66.51326044311186,\n          \"lon\": 0\n        }\n      }\n    }\n  },\n  \"aggregations\": {\n    \"grid\": {\n      \"geotile_grid\": {\n        \"field\": \"my-geo-field\",\n        \"precision\": 11,\n        \"size\": 65536,\n        \"bounds\": {\n          \"top_left\": {\n            \"lat\": -40.979898069620134,\n            \"lon\": -45\n          },\n          \"bottom_right\": {\n            \"lat\": -66.51326044311186,\n            \"lon\": 0\n          }\n        }\n      }\n    },\n    \"bounds\": {\n      \"geo_bounds\": {\n        \"field\": \"my-geo-field\",\n        \"wrap_longitude\": false\n      }\n    }\n  }\n}\n```\n\nThe API returns results as a binary Mapbox vector tile.\nMapbox vector tiles are encoded as Google Protobufs (PBF). By default, the tile contains three layers:\n\n* A `hits` layer containing a feature for each `<field>` value matching the `geo_bounding_box` query.\n* An `aggs` layer containing a feature for each cell of the `geotile_grid` or `geohex_grid`. The layer only contains features for cells with matching data.\n* A meta layer containing:\n  * A feature containing a bounding box. By default, this is the bounding box of the tile.\n  * Value ranges for any sub-aggregations on the `geotile_grid` or `geohex_grid`.\n  * Metadata for the search.\n\nThe API only returns features that can display at its zoom level.\nFor example, if a polygon feature has no area at its zoom level, the API omits it.\nThe API returns errors as UTF-8 encoded JSON.\n\nIMPORTANT: You can specify several options for this API as either a query parameter or request body parameter.\nIf you specify both parameters, the query parameter takes precedence.\n\n**Grid precision for geotile**\n\nFor a `grid_agg` of `geotile`, you can use cells in the `aggs` layer as tiles for lower zoom levels.\n`grid_precision` represents the additional zoom levels available through these cells. The final precision is computed by as follows: `<zoom> + grid_precision`.\nFor example, if `<zoom>` is 7 and `grid_precision` is 8, then the `geotile_grid` aggregation will use a precision of 15.\nThe maximum final precision is 29.\nThe `grid_precision` also determines the number of cells for the grid as follows: `(2^grid_precision) x (2^grid_precision)`.\nFor example, a value of 8 divides the tile into a grid of 256 x 256 cells.\nThe `aggs` layer only contains features for cells with matching data.\n\n**Grid precision for geohex**\n\nFor a `grid_agg` of `geohex`, Elasticsearch uses `<zoom>` and `grid_precision` to calculate a final precision as follows: `<zoom> + grid_precision`.\n\nThis precision determines the H3 resolution of the hexagonal cells produced by the `geohex` aggregation.\nThe following table maps the H3 resolution for each precision.\nFor example, if `<zoom>` is 3 and `grid_precision` is 3, the precision is 6.\nAt a precision of 6, hexagonal cells have an H3 resolution of 2.\nIf `<zoom>` is 3 and `grid_precision` is 4, the precision is 7.\nAt a precision of 7, hexagonal cells have an H3 resolution of 3.\n\n| Precision | Unique tile bins | H3 resolution | Unique hex bins |\tRatio |\n| --------- | ---------------- | ------------- | ----------------| ----- |\n| 1  | 4                  | 0  | 122             | 30.5           |\n| 2  | 16                 | 0  | 122             | 7.625          |\n| 3  | 64                 | 1  | 842             | 13.15625       |\n| 4  | 256                | 1  | 842             | 3.2890625      |\n| 5  | 1024               | 2  | 5882            | 5.744140625    |\n| 6  | 4096               | 2  | 5882            | 1.436035156    |\n| 7  | 16384              | 3  | 41162           | 2.512329102    |\n| 8  | 65536              | 3  | 41162           | 0.6280822754   |\n| 9  | 262144             | 4  | 288122          | 1.099098206    |\n| 10 | 1048576            | 4  | 288122          | 0.2747745514   |\n| 11 | 4194304            | 5  | 2016842         | 0.4808526039   |\n| 12 | 16777216           | 6  | 14117882        | 0.8414913416   |\n| 13 | 67108864           | 6  | 14117882        | 0.2103728354   |\n| 14 | 268435456          | 7  | 98825162        | 0.3681524172   |\n| 15 | 1073741824         | 8  | 691776122       | 0.644266719    |\n| 16 | 4294967296         | 8  | 691776122       | 0.1610666797   |\n| 17 | 17179869184        | 9  | 4842432842      | 0.2818666889   |\n| 18 | 68719476736        | 10 | 33897029882     | 0.4932667053   |\n| 19 | 274877906944       | 11 | 237279209162    | 0.8632167343   |\n| 20 | 1099511627776      | 11 | 237279209162    | 0.2158041836   |\n| 21 | 4398046511104      | 12 | 1660954464122   | 0.3776573213   |\n| 22 | 17592186044416     | 13 | 11626681248842  | 0.6609003122   |\n| 23 | 70368744177664     | 13 | 11626681248842  | 0.165225078    |\n| 24 | 281474976710656    | 14 | 81386768741882  | 0.2891438866   |\n| 25 | 1125899906842620   | 15 | 569707381193162 | 0.5060018015   |\n| 26 | 4503599627370500   | 15 | 569707381193162 | 0.1265004504   |\n| 27 | 18014398509482000  | 15 | 569707381193162 | 0.03162511259  |\n| 28 | 72057594037927900  | 15 | 569707381193162 | 0.007906278149 |\n| 29 | 288230376151712000 | 15 | 569707381193162 | 0.001976569537 |\n\nHexagonal cells don't align perfectly on a vector tile.\nSome cells may intersect more than one vector tile.\nTo compute the H3 resolution for each precision, Elasticsearch compares the average density of hexagonal bins at each resolution with the average density of tile bins at each zoom level.\nElasticsearch uses the H3 resolution that is closest to the corresponding geotile density.",
+        "externalDocs": {
+          "url": "https://github.com/mapbox/vector-tile-spec/blob/master/README.md"
+        },
         "operationId": "search-mvt",
         "parameters": [
           {
@@ -18718,7 +18724,7 @@
           "search"
         ],
         "summary": "Get terms in an index",
-        "description": "Discover terms that match a partial string in an index.\nThis \"terms enum\" API is designed for low-latency look-ups used in auto-complete scenarios.\n\nIf the `complete` property in the response is false, the returned terms set may be incomplete and should be treated as approximate.\nThis can occur due to a few reasons, such as a request timeout or a node error.\n\nNOTE: The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.",
+        "description": "Discover terms that match a partial string in an index.\nThis API is designed for low-latency look-ups used in auto-complete scenarios.\n\n> info\n> The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.",
         "operationId": "terms-enum",
         "parameters": [
           {
@@ -18740,7 +18746,7 @@
           "search"
         ],
         "summary": "Get terms in an index",
-        "description": "Discover terms that match a partial string in an index.\nThis \"terms enum\" API is designed for low-latency look-ups used in auto-complete scenarios.\n\nIf the `complete` property in the response is false, the returned terms set may be incomplete and should be treated as approximate.\nThis can occur due to a few reasons, such as a request timeout or a node error.\n\nNOTE: The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.",
+        "description": "Discover terms that match a partial string in an index.\nThis API is designed for low-latency look-ups used in auto-complete scenarios.\n\n> info\n> The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.",
         "operationId": "terms-enum-1",
         "parameters": [
           {
@@ -57929,6 +57935,7 @@
                   }
                 },
                 "complete": {
+                  "description": "If `false`, the returned terms set may be incomplete and should be treated as approximate.\nThis can occur due to a few reasons, such as a request timeout or a node error.",
                   "type": "boolean"
                 }
               },
@@ -59688,7 +59695,7 @@
       "field_caps#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indices, omit this parameter or use * or _all.",
+        "description": "A comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indices, omit this parameter or use * or _all.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -59709,7 +59716,7 @@
       "field_caps#expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
-        "description": "Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.",
+        "description": "The type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -59719,7 +59726,7 @@
       "field_caps#fields": {
         "in": "query",
         "name": "fields",
-        "description": "Comma-separated list of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.",
+        "description": "A comma-separated list of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
@@ -59749,7 +59756,7 @@
       "field_caps#filters": {
         "in": "query",
         "name": "filters",
-        "description": "An optional set of filters: can include +metadata,-metadata,-nested,-multifield,-parent",
+        "description": "A comma-separated list of filters to apply to the response.",
         "deprecated": false,
         "schema": {
           "type": "string"
@@ -59759,7 +59766,7 @@
       "field_caps#types": {
         "in": "query",
         "name": "types",
-        "description": "Only return results for fields that have one of the types in the list",
+        "description": "A comma-separated list of field types to include.\nAny fields that do not match one of these types will be excluded from the results.\nIt defaults to empty, meaning that all field types are returned.",
         "deprecated": false,
         "schema": {
           "type": "array",
@@ -62140,7 +62147,7 @@
       "rank_eval#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (`*`) expressions are supported.\nTo target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.",
+        "description": "A  comma-separated list of data streams, indices, and index aliases used to limit the request.\nWildcard (`*`) expressions are supported.\nTo target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -62213,7 +62220,7 @@
       "scroll#scroll": {
         "in": "query",
         "name": "scroll",
-        "description": "Period to retain the search context for scrolling.",
+        "description": "The period to retain the search context for scrolling.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -62787,7 +62794,7 @@
       "search_mvt#exact_bounds": {
         "in": "query",
         "name": "exact_bounds",
-        "description": "If false, the meta layer’s feature is the bounding box of the tile.\nIf true, the meta layer’s feature is a bounding box resulting from a\ngeo_bounds aggregation. The aggregation runs on <field> values that intersect\nthe <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting\nbounding box may be larger than the vector tile.",
+        "description": "If `false`, the meta layer's feature is the bounding box of the tile.\nIf true, the meta layer's feature is a bounding box resulting from a\ngeo_bounds aggregation. The aggregation runs on <field> values that intersect\nthe <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting\nbounding box may be larger than the vector tile.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -62797,7 +62804,7 @@
       "search_mvt#extent": {
         "in": "query",
         "name": "extent",
-        "description": "Size, in pixels, of a side of the tile. Vector tiles are square with equal sides.",
+        "description": "The size, in pixels, of a side of the tile. Vector tiles are square with equal sides.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -62817,7 +62824,7 @@
       "search_mvt#grid_precision": {
         "in": "query",
         "name": "grid_precision",
-        "description": "Additional zoom levels available through the aggs layer. For example, if <zoom> is 7\nand grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results\ndon’t include the aggs layer.",
+        "description": "Additional zoom levels available through the aggs layer. For example, if <zoom> is 7\nand grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results\ndon't include the aggs layer.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -62837,7 +62844,7 @@
       "search_mvt#size": {
         "in": "query",
         "name": "size",
-        "description": "Maximum number of features to return in the hits layer. Accepts 0-10000.\nIf 0, results don’t include the hits layer.",
+        "description": "Maximum number of features to return in the hits layer. Accepts 0-10000.\nIf 0, results don't include the hits layer.",
         "deprecated": false,
         "schema": {
           "type": "number"
@@ -62847,7 +62854,7 @@
       "search_mvt#with_labels": {
         "in": "query",
         "name": "with_labels",
-        "description": "If `true`, the hits and aggs layers will contain additional point features representing\nsuggested label positions for the original features.",
+        "description": "If `true`, the hits and aggs layers will contain additional point features representing\nsuggested label positions for the original features.\n\n* `Point` and `MultiPoint` features will have one of the points selected.\n* `Polygon` and `MultiPolygon` features will have a single point generated, either the centroid, if it is within the polygon, or another point within the polygon selected from the sorted triangle-tree.\n* `LineString` features will likewise provide a roughly central point selected from the triangle-tree.\n* The aggregation results will provide one central point for each aggregation bucket.\n\nAll attributes from the original features will also be copied to the new label features.\nIn addition, the new features will be distinguishable using the tag `_mvt_label_position`.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -63091,7 +63098,7 @@
       "terms_enum#index": {
         "in": "path",
         "name": "index",
-        "description": "Comma-separated list of data streams, indices, and index aliases to search. Wildcard (*) expressions are supported.",
+        "description": "A comma-separated list of data streams, indices, and index aliases to search.\nWildcard (`*`) expressions are supported.\nTo search all data streams or indices, omit this parameter or use `*`  or `_all`.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -64697,22 +64704,22 @@
               "type": "object",
               "properties": {
                 "aggs": {
-                  "description": "Sub-aggregations for the geotile_grid.\n\nSupports the following aggregation types:\n- avg\n- cardinality\n- max\n- min\n- sum",
+                  "description": "Sub-aggregations for the geotile_grid.\n\nIt supports the following aggregation types:\n\n- `avg`\n- `boxplot`\n- `cardinality`\n- `extended stats`\n- `max`\n- `median absolute deviation`\n- `min`\n- `percentile`\n- `percentile-rank`\n- `stats`\n- `sum`\n- `value count`\n\nThe aggregation names can't start with `_mvt_`. The `_mvt_` prefix is reserved for internal aggregations.",
                   "type": "object",
                   "additionalProperties": {
                     "$ref": "#/components/schemas/_types.aggregations:AggregationContainer"
                   }
                 },
                 "buffer": {
-                  "description": "Size, in pixels, of a clipping buffer outside the tile. This allows renderers\nto avoid outline artifacts from geometries that extend past the extent of the tile.",
+                  "description": "The size, in pixels, of a clipping buffer outside the tile. This allows renderers\nto avoid outline artifacts from geometries that extend past the extent of the tile.",
                   "type": "number"
                 },
                 "exact_bounds": {
-                  "description": "If false, the meta layer’s feature is the bounding box of the tile.\nIf true, the meta layer’s feature is a bounding box resulting from a\ngeo_bounds aggregation. The aggregation runs on <field> values that intersect\nthe <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting\nbounding box may be larger than the vector tile.",
+                  "description": "If `false`, the meta layer's feature is the bounding box of the tile.\nIf `true`, the meta layer's feature is a bounding box resulting from a\n`geo_bounds` aggregation. The aggregation runs on <field> values that intersect\nthe `<zoom>/<x>/<y>` tile with `wrap_longitude` set to `false`. The resulting\nbounding box may be larger than the vector tile.",
                   "type": "boolean"
                 },
                 "extent": {
-                  "description": "Size, in pixels, of a side of the tile. Vector tiles are square with equal sides.",
+                  "description": "The size, in pixels, of a side of the tile. Vector tiles are square with equal sides.",
                   "type": "number"
                 },
                 "fields": {
@@ -64722,7 +64729,7 @@
                   "$ref": "#/components/schemas/_global.search_mvt._types:GridAggregationType"
                 },
                 "grid_precision": {
-                  "description": "Additional zoom levels available through the aggs layer. For example, if <zoom> is 7\nand grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results\ndon’t include the aggs layer.",
+                  "description": "Additional zoom levels available through the aggs layer. For example, if `<zoom>` is `7`\nand `grid_precision` is `8`, you can zoom in up to level 15. Accepts 0-8. If 0, results\ndon't include the aggs layer.",
                   "type": "number"
                 },
                 "grid_type": {
@@ -64735,7 +64742,7 @@
                   "$ref": "#/components/schemas/_types.mapping:RuntimeFields"
                 },
                 "size": {
-                  "description": "Maximum number of features to return in the hits layer. Accepts 0-10000.\nIf 0, results don’t include the hits layer.",
+                  "description": "The maximum number of features to return in the hits layer. Accepts 0-10000.\nIf 0, results don't include the hits layer.",
                   "type": "number"
                 },
                 "sort": {
@@ -64745,7 +64752,7 @@
                   "$ref": "#/components/schemas/_global.search._types:TrackHits"
                 },
                 "with_labels": {
-                  "description": "If `true`, the hits and aggs layers will contain additional point features representing\nsuggested label positions for the original features.",
+                  "description": "If `true`, the hits and aggs layers will contain additional point features representing\nsuggested label positions for the original features.\n\n* `Point` and `MultiPoint` features will have one of the points selected.\n* `Polygon` and `MultiPolygon` features will have a single point generated, either the centroid, if it is within the polygon, or another point within the polygon selected from the sorted triangle-tree.\n* `LineString` features will likewise provide a roughly central point selected from the triangle-tree.\n* The aggregation results will provide one central point for each aggregation bucket.\n\nAll attributes from the original features will also be copied to the new label features.\nIn addition, the new features will be distinguishable using the tag `_mvt_label_position`.",
                   "type": "boolean"
                 }
               }
@@ -65090,24 +65097,25 @@
                   "$ref": "#/components/schemas/_types:Field"
                 },
                 "size": {
-                  "description": "How many matching terms to return.",
+                  "description": "The number of matching terms to return.",
                   "type": "number"
                 },
                 "timeout": {
                   "$ref": "#/components/schemas/_types:Duration"
                 },
                 "case_insensitive": {
-                  "description": "When true the provided search string is matched against index terms without case sensitivity.",
+                  "description": "When `true`, the provided search string is matched against index terms without case sensitivity.",
                   "type": "boolean"
                 },
                 "index_filter": {
                   "$ref": "#/components/schemas/_types.query_dsl:QueryContainer"
                 },
                 "string": {
-                  "description": "The string after which terms in the index should be returned. Allows for a form of pagination if the last result from one request is passed as the search_after parameter for a subsequent request.",
+                  "description": "The string to match at the start of indexed terms.\nIf it is not provided, all terms in the field are considered.\n\n> info\n> The prefix string cannot be larger than the largest possible keyword value, which is Lucene's term byte-length limit of 32766.",
                   "type": "string"
                 },
                 "search_after": {
+                  "description": "The string after which terms in the index should be returned.\nIt allows for a form of pagination if the last result from one request is passed as the `search_after` parameter for a subsequent request.",
                   "type": "string"
                 }
               },

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -604,8 +604,9 @@ search-render-query,https://www.elastic.co/guide/en/elasticsearch/reference/{bra
 search-count,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-count.html
 search-explain,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-explain.html
 search-field-caps,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-field-caps.html
+search-knn,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/knn-search-api.html
 search-multi-search,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-multi-search.html
-search-multi-search,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-multi-search.html
+search-multi-search-template,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/multi-search-template.html
 search-rank-eval,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html
 search-rank-eval,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html
 search-request-body,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-request-body.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -300,6 +300,7 @@ logstash-centralized-pipeline-management,https://www.elastic.co/guide/en/logstas
 logstash-configuration-file-structure,https://www.elastic.co/guide/en/logstash/{branch}/configuration-file-structure.html
 logstash-logstash-settings-file,https://www.elastic.co/guide/en/logstash/{branch}/logstash-settings-file.html
 lowercase-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/lowercase-processor.html
+mapbox-vector-tile,https://github.com/mapbox/vector-tile-spec/blob/master/README.md
 mapping-date-format,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-date-format.html
 mapping-meta-field,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-meta-field.html
 mapping-params,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/mapping-params.html
@@ -516,6 +517,7 @@ script-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/d
 script-languages,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-script-languages-api.html
 script-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/script-processor.html
 script-put,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/create-stored-script-api.html
+scroll-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/scroll-api.html
 scroll-search-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html#scroll-search-results
 search-after,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html#search-after
 search-aggregations,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations.html

--- a/specification/_global/field_caps/FieldCapabilitiesRequest.ts
+++ b/specification/_global/field_caps/FieldCapabilitiesRequest.ts
@@ -35,6 +35,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
  * @availability serverless stability=stable visibility=public
  * @index_privileges view_index_metadata,read
  * @doc_tag search
+ * @doc_id search-field-caps
  */
 export interface Request extends RequestBase {
   urls: [
@@ -49,7 +50,7 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indices, omit this parameter or use * or _all.
+     * A comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indices, omit this parameter or use * or _all.
      */
     index?: Indices
   }
@@ -62,12 +63,12 @@ export interface Request extends RequestBase {
      */
     allow_no_indices?: boolean
     /**
-     * Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
+     * The type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as `open,hidden`.
      * @server_default open
      */
     expand_wildcards?: ExpandWildcards
     /**
-     * Comma-separated list of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.
+     * A comma-separated list of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.
      */
     fields?: Fields
     /**
@@ -81,11 +82,15 @@ export interface Request extends RequestBase {
      */
     include_unmapped?: boolean
     /**
+     * A comma-separated list of filters to apply to the response.
      * @availability stack since=8.2.0
      * @availability serverless
      */
     filters?: string
     /**
+     * A comma-separated list of field types to include.
+     * Any fields that do not match one of these types will be excluded from the results.
+     * It defaults to empty, meaning that all field types are returned.
      * @availability stack since=8.2.0
      * @availability serverless
      */
@@ -100,17 +105,21 @@ export interface Request extends RequestBase {
   }
   body: {
     /**
-     * List of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.
+     * A list of fields to retrieve capabilities for. Wildcard (`*`) expressions are supported.
      * @availability stack since=8.5.0
      * @availability serverless
      */
     fields?: Fields
     /**
-     * Allows to filter indices if the provided query rewrites to match_none on every shard.
+     * Filter indices if the provided query rewrites to `match_none` on every shard.
+     *
+     * IMPORTANT: The filtering is done on a best-effort basis, it uses index statistics and mappings to rewrite queries to `match_none` instead of fully running the request.
+     * For instance a range query over a date field can rewrite to `match_none` if all documents within a shard (including deleted documents) are outside of the provided range.
+     * However, not all queries can rewrite to `match_none` so this API may return an index even if the provided filter matches no document.
      */
     index_filter?: QueryContainer
     /**
-     * Defines ad-hoc runtime fields in the request similar to the way it is done in search requests.
+     * Define ad-hoc runtime fields in the request similar to the way it is done in search requests.
      * These fields exist only as part of the query and take precedence over fields defined with the same name in the index mappings.
      * @doc_id runtime-search-request
      * @availability stack since=7.12.0

--- a/specification/_global/field_caps/FieldCapabilitiesResponse.ts
+++ b/specification/_global/field_caps/FieldCapabilitiesResponse.ts
@@ -29,6 +29,9 @@ import { FieldCapability } from './types'
  */
 export class Response {
   body: {
+    /**
+     * The list of indices where this field has the same type family, or null if all indices have the same type family for the field.
+     */
     indices: Indices
     fields: Dictionary<Field, Dictionary<string, FieldCapability>>
   }

--- a/specification/_global/field_caps/examples/request/FieldCapabilitiesRequestExample1.yaml
+++ b/specification/_global/field_caps/examples/request/FieldCapabilitiesRequestExample1.yaml
@@ -1,0 +1,16 @@
+# summary:
+# method_request: "POST my-index-*/_field_caps?fields=rating"
+description: >
+  Run `POST my-index-*/_field_caps?fields=rating` to get field capabilities and filter indices with a query.
+  Indices that rewrite the provided filter to `match_none` on every shard will be filtered from the response.
+# type: "request"
+value: |-
+  {
+    "index_filter": {
+      "range": {
+        "@timestamp": {
+          "gte": "2018"
+        }
+      }
+    }
+  }

--- a/specification/_global/field_caps/examples/response/FieldCapabilitiesResponseExample1.yaml
+++ b/specification/_global/field_caps/examples/response/FieldCapabilitiesResponseExample1.yaml
@@ -1,0 +1,38 @@
+summary: Get two fields
+# type: "response"
+description: >
+  A successful response from `GET _field_caps?fields=rating,title`.
+  The field `rating` is defined as a long in `index1` and `index2` and as a `keyword` in `index3` and `index4`.
+  The field `rating` is not aggregatable in `index1`.
+  The field `rating` is not searchable in `index4`.
+  The field `title` is defined as text in all indices.
+# response_code: 200,
+value: |-
+  {
+    "indices": [ "index1", "index2", "index3", "index4", "index5" ],
+    "fields": {
+      "rating": {                                   
+        "long": {
+          "metadata_field": false,
+          "searchable": true,
+          "aggregatable": false,
+          "indices": [ "index1", "index2" ],
+          "non_aggregatable_indices": [ "index1" ]  
+        },
+        "keyword": {
+          "metadata_field": false,
+          "searchable": false,
+          "aggregatable": true,
+          "indices": [ "index3", "index4" ],
+          "non_searchable_indices": [ "index4" ]    
+        }
+      },
+      "title": {                                    
+        "text": {
+          "metadata_field": false,
+          "searchable": true,
+          "aggregatable": false
+        }
+      }
+    }
+  }

--- a/specification/_global/field_caps/examples/response/FieldCapabilitiesResponseExample2.yaml
+++ b/specification/_global/field_caps/examples/response/FieldCapabilitiesResponseExample2.yaml
@@ -1,0 +1,36 @@
+summary: Get unmapped fields
+# type: "response"
+description: >
+  A successful response from `GET _field_caps?fields=rating,title&include_unmapped`.
+  The response contains an entry for each field that is present in some indices but not all.
+  For example, the `rating` and `title` fields are unmapped in `index5`.
+# response_code: 200,
+value: |-
+  {
+    "indices": [ "index1", "index2", "index3", "index4", "index5" ],
+    "fields": {
+      "rating": {                                   
+        "long": {
+          "metadata_field": false,
+          "searchable": true,
+          "aggregatable": false,
+          "indices": [ "index1", "index2" ],
+          "non_aggregatable_indices": [ "index1" ]  
+        },
+        "keyword": {
+          "metadata_field": false,
+          "searchable": false,
+          "aggregatable": true,
+          "indices": [ "index3", "index4" ],
+          "non_searchable_indices": [ "index4" ]    
+        }
+      },
+      "title": {                                    
+        "text": {
+          "metadata_field": false,
+          "searchable": true,
+          "aggregatable": false
+        }
+      }
+    }
+  }

--- a/specification/_global/knn_search/KnnSearchRequest.ts
+++ b/specification/_global/knn_search/KnnSearchRequest.ts
@@ -37,10 +37,17 @@ import { Query } from './_types/Knn'
  *
  * The kNN search API supports restricting the search using a filter.
  * The search will return the top k documents that also match the filter query.
+ *
+ * A kNN search response has the exact same structure as a search API response.
+ * However, certain sections have a meaning specific to kNN search:
+ *
+ * * The document `_score` is determined by the similarity between the query and document vector.
+ * * The `hits.total` object contains the total number of nearest neighbor candidates considered, which is `num_candidates * num_shards`. The `hits.total.relation` will always be `eq`, indicating an exact value.
  * @rest_spec_name knn_search
  * @availability stack since=8.0.0 stability=experimental
  * @deprecated 8.4.0 The kNN search API has been replaced by the `knn` option in the search API.
  * @doc_tag search
+ * @doc_id search-knn
  */
 export interface Request extends RequestBase {
   urls: [
@@ -52,41 +59,44 @@ export interface Request extends RequestBase {
   path_parts: {
     /**
      * A comma-separated list of index names to search;
-     * use `_all` or to perform the operation on all indices
+     * use `_all` or to perform the operation on all indices.
      */
     index: Indices
   }
   query_parameters: {
     /**
-     * A comma-separated list of specific routing values
+     * A comma-separated list of specific routing values.
      */
     routing?: Routing
   }
   body: {
     /**
      * Indicates which source fields are returned for matching documents. These
-     * fields are returned in the hits._source property of the search response.
+     * fields are returned in the `hits._source` property of the search response.
+     * @default_server true
      */
     _source?: SourceConfig
     /**
      * The request returns doc values for field names matching these patterns
-     * in the hits.fields property of the response. Accepts wildcard (*) patterns.
+     * in the `hits.fields` property of the response.
+     * It accepts wildcard (`*`) patterns.
      */
     docvalue_fields?: FieldAndFormat[]
     /**
-     * List of stored fields to return as part of a hit. If no fields are specified,
-     * no stored fields are included in the response. If this field is specified, the _source
-     * parameter defaults to false. You can pass _source: true to return both source fields
+     * A list of stored fields to return as part of a hit. If no fields are specified,
+     * no stored fields are included in the response. If this field is specified, the `_source`
+     * parameter defaults to `false`. You can pass `_source: true` to return both source fields
      * and stored fields in the search response.
      */
     stored_fields?: Fields
     /**
      * The request returns values for field names matching these patterns
-     * in the hits.fields property of the response. Accepts wildcard (*) patterns.
+     * in the `hits.fields` property of the response.
+     * It accepts wildcard (`*`) patterns.
      */
     fields?: Fields
     /**
-     * Query to filter the documents that can match. The kNN search will return the top
+     * A query to filter the documents that can match. The kNN search will return the top
      * `k` documents that also match this filter. The value can be a single query or a
      * list of queries. If `filter` isn't provided, all documents are allowed to match.
      * @availability stack since=8.2.0
@@ -94,7 +104,7 @@ export interface Request extends RequestBase {
      */
     filter?: QueryContainer | QueryContainer[]
     /**
-     * kNN query to execute
+     * The kNN query to run.
      * @ext_doc_id query-dsl-knn-query
      */
     knn: Query

--- a/specification/_global/knn_search/KnnSearchRequest.ts
+++ b/specification/_global/knn_search/KnnSearchRequest.ts
@@ -73,7 +73,7 @@ export interface Request extends RequestBase {
     /**
      * Indicates which source fields are returned for matching documents. These
      * fields are returned in the `hits._source` property of the search response.
-     * @default_server true
+     * @server_default true
      */
     _source?: SourceConfig
     /**

--- a/specification/_global/knn_search/KnnSearchResponse.ts
+++ b/specification/_global/knn_search/KnnSearchResponse.ts
@@ -25,7 +25,7 @@ import { ShardStatistics } from '@_types/Stats'
 
 export class Response<TDocument> {
   body: {
-    /** Milliseconds it took Elasticsearch to execute the request. */
+    /** The milliseconds it took Elasticsearch to run the request. */
     took: long
     /**
      * If true, the request timed out before completion;
@@ -33,20 +33,20 @@ export class Response<TDocument> {
      */
     timed_out: boolean
     /**
-     * Contains a count of shards used for the request.
+     * A count of shards used for the request.
      */
     _shards: ShardStatistics
     /**
-     * Contains returned documents and metadata.
+     * The returned documents and metadata.
      */
     hits: HitsMetadata<TDocument>
     /**
-     * Contains field values for the documents. These fields
+     * The field values for the documents. These fields
      * must be specified in the request using the `fields` parameter.
      */
     fields?: Dictionary<string, UserDefinedValue>
     /**
-     * Highest returned document score. This value is null for requests
+     * The highest returned document score. This value is null for requests
      * that do not sort by score.
      */
     max_score?: double

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -28,11 +28,24 @@ import { Operation } from './types'
  * Get multiple JSON documents by ID from one or more indices.
  * If you specify an index in the request URI, you only need to specify the document IDs in the request body.
  * To ensure fast responses, this multi get (mget) API responds with partial results if one or more shards fail.
+ *
+ * **Filter source fields**
+ *
+ * By default, the `_source` field is returned for every document (if stored).
+ * Use the `_source` and `_source_include` or `source_exclude` attributes to filter what fields are returned for a particular document.
+ * You can include the `_source`, `_source_includes`, and `_source_excludes` query parameters in the request URI to specify the defaults to use when there are no per-document instructions.
+ *
+ * **Get stored fields**
+ *
+ * Use the `stored_fields` attribute to specify the set of stored fields you want to retrieve.
+ * Any requested fields that are not stored are ignored.
+ * You can include the `stored_fields` query parameter in the request URI to specify the defaults to use when there are no per-document instructions.
  * @rest_spec_name mget
  * @availability stack since=1.3.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @index_privileges read
  * @doc_tag document
+ * @eoc_id docs-multi-get
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/_global/mget/MultiGetRequest.ts
+++ b/specification/_global/mget/MultiGetRequest.ts
@@ -45,7 +45,7 @@ import { Operation } from './types'
  * @availability serverless stability=stable visibility=public
  * @index_privileges read
  * @doc_tag document
- * @eoc_id docs-multi-get
+ * @doc_id docs-multi-get
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/_global/mget/MultiGetResponse.ts
+++ b/specification/_global/mget/MultiGetResponse.ts
@@ -21,6 +21,11 @@ import { ResponseItem } from './types'
 
 export class Response<TDocument> {
   body: {
+    /**
+     * The response includes a docs array that contains the documents in the order specified in the request.
+     * The structure of the returned documents is similar to that returned by the get API.
+     * If there is a failure getting a particular document, the error is included in place of the document.
+     */
     docs: ResponseItem<TDocument>[]
   }
 }

--- a/specification/_global/mget/examples/request/MultiGetRequestExample1.yaml
+++ b/specification/_global/mget/examples/request/MultiGetRequestExample1.yaml
@@ -1,0 +1,17 @@
+summary: Get documents by ID
+# method_request: "GET /my-index-000001/_mget"
+description: >
+  Run `GET /my-index-000001/_mget`.
+  When you specify an index in the request URI, only the document IDs are required in the request body.
+# type: "request"
+value: |-
+  {
+    "docs": [
+      {
+        "_id": "1"
+      },
+      {
+        "_id": "2"
+      }
+    ]
+  }

--- a/specification/_global/mget/examples/request/MultiGetRequestExample2.yaml
+++ b/specification/_global/mget/examples/request/MultiGetRequestExample2.yaml
@@ -1,0 +1,31 @@
+summary: Filter source fields
+# method_request: "GET /_mget"
+description: >
+  Run `GET /_mget`.
+  This request sets `_source` to `false` for document 1 to exclude the source entirely.
+  It retrieves `field3` and `field4` from document 2.
+  It retrieves the `user` field from document 3 but filters out the `user.location` field.
+# type: "request"
+value: |-
+  {
+    "docs": [
+      {
+        "_index": "test",
+        "_id": "1",
+        "_source": false
+      },
+      {
+        "_index": "test",
+        "_id": "2",
+        "_source": [ "field3", "field4" ]
+      },
+      {
+        "_index": "test",
+        "_id": "3",
+        "_source": {
+          "include": [ "user" ],
+          "exclude": [ "user.location" ]
+        }
+      }
+    ]
+  }

--- a/specification/_global/mget/examples/request/MultiGetRequestExample3.yaml
+++ b/specification/_global/mget/examples/request/MultiGetRequestExample3.yaml
@@ -1,0 +1,21 @@
+summary: Get stored fields
+# method_request: "GET /_mget"
+description: >
+  Run `GET /_mget`.
+  This request retrieves `field1` and `field2` from document 1 and `field3` and `field4` from document 2.
+# type: "request"
+value: |-
+  {
+    "docs": [
+      {
+        "_index": "test",
+        "_id": "1",
+        "stored_fields": [ "field1", "field2" ]
+      },
+      {
+        "_index": "test",
+        "_id": "2",
+        "stored_fields": [ "field3", "field4" ]
+      }
+    ]
+  }

--- a/specification/_global/mget/examples/request/MultiGetRequestExample4.yaml
+++ b/specification/_global/mget/examples/request/MultiGetRequestExample4.yaml
@@ -1,0 +1,22 @@
+summary: Document routing
+# method_request: "GET /_mget?routing=key1"
+description: >
+  Run `GET /_mget?routing=key1`.
+  If routing is used during indexing, you need to specify the routing value to retrieve documents.
+  This request fetches `test/_doc/2` from the shard corresponding to routing key `key1`.
+  It fetches `test/_doc/1` from the shard corresponding to routing key `key2`.
+# type: "request"
+value: |-
+  {
+    "docs": [
+      {
+        "_index": "test",
+        "_id": "1",
+        "routing": "key2"
+      },
+      {
+        "_index": "test",
+        "_id": "2"
+      }
+    ]
+  }

--- a/specification/_global/mget/examples/response/PutAutoscalingPolicyResponseExample1.yaml
+++ b/specification/_global/mget/examples/response/PutAutoscalingPolicyResponseExample1.yaml
@@ -1,0 +1,5 @@
+summary: 'A successful response when creating an autoscaling policy.'
+# description: "",
+# type: "response",
+# response_code: 200,
+value: "{\n  \"acknowledged\": true\n}"

--- a/specification/_global/mget/examples/response/PutAutoscalingPolicyResponseExample1.yaml
+++ b/specification/_global/mget/examples/response/PutAutoscalingPolicyResponseExample1.yaml
@@ -1,5 +1,0 @@
-summary: 'A successful response when creating an autoscaling policy.'
-# description: "",
-# type: "response",
-# response_code: 200,
-value: "{\n  \"acknowledged\": true\n}"

--- a/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateRequest.ts
@@ -24,11 +24,26 @@ import { RequestItem } from './types'
 
 /**
  * Run multiple templated searches.
+ *
+ * Run multiple templated searches with a single request.
+ * If you are providing a text file or text input to `curl`, use the `--data-binary` flag instead of `-d` to preserve newlines.
+ * For example:
+ *
+ * ```
+ * $ cat requests
+ * { "index": "my-index" }
+ * { "id": "my-search-template", "params": { "query_string": "hello world", "from": 0, "size": 10 }}
+ * { "index": "my-other-index" }
+ * { "id": "my-other-search-template", "params": { "query_type": "match_all" }}
+ *
+ * $ curl -H "Content-Type: application/x-ndjson" -XGET localhost:9200/_msearch/template --data-binary "@requests"; echo
+ * ```
  * @rest_spec_name msearch_template
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @index_privileges read
  * @doc_tag search
+ * @doc_id search-multi-search-template
  * @ext_doc_id search-templates
  */
 export interface Request extends RequestBase {
@@ -44,8 +59,8 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Comma-separated list of data streams, indices, and aliases to search.
-     * Supports wildcards (`*`).
+     * A comma-separated list of data streams, indices, and aliases to search.
+     * It supports wildcards (`*`).
      * To search all data streams and indices, omit this parameter or use `*`.
      */
     index?: Indices
@@ -57,12 +72,11 @@ export interface Request extends RequestBase {
      */
     ccs_minimize_roundtrips?: boolean
     /**
-     * Maximum number of concurrent searches the API can run.
+     * The maximum number of concurrent searches the API can run.
      */
     max_concurrent_searches?: long
     /**
      * The type of the search operation.
-     * Available options: `query_then_fetch`, `dfs_query_then_fetch`.
      */
     search_type?: SearchType
     /**
@@ -77,6 +91,25 @@ export interface Request extends RequestBase {
      */
     typed_keys?: boolean
   }
-  /** @codegen_name search_templates */
+  /**
+   * @codegen_name search_templates
+   * The request body must be newline-delimited JSON (NDJSON) in the following format:
+   *
+   * ```
+   * <header>\n
+   * <body>\n
+   * <header>\n
+   * <body>\n
+   * ```
+   *
+   * Each `<header>` and `<body>` pair represents a search request.
+   * The `<header>` supports the same parameters as the multi search API's `<header>`.
+   * The `<body>` supports the same parameters as the search template API's request body.
+   *
+   * The `<header>` contains the parameters used to limit or change the search.
+   * It is required for each search body but can be empty `({})` or a blank line.
+   *
+   * The `<body>` contains the parameters for the search.
+   */
   body: Array<RequestItem>
 }

--- a/specification/_global/msearch_template/MultiSearchTemplateResponse.ts
+++ b/specification/_global/msearch_template/MultiSearchTemplateResponse.ts
@@ -20,5 +20,12 @@
 import { MultiSearchResult } from '@global/msearch/types'
 
 export class Response<TDocument> {
+  /**
+   * The API returns a 400 status code only if the request itself fails.
+   * If one or more searches in the request fail, the API returns a 200 status code with an error object for each failed search in the response.
+   *
+   * The body contains results for each search, returned in the order submitted.
+   * Each object uses the same properties as the search API's response.
+   */
   body: MultiSearchResult<TDocument>
 }

--- a/specification/_global/msearch_template/examples/request/MultiSearchTemplateRequestExample1.yaml
+++ b/specification/_global/msearch_template/examples/request/MultiSearchTemplateRequestExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+# method_request: GET my-index/_msearch/template
+description: Run `GET my-index/_msearch/template` to run multiple templated searches.
+# type: "request"
+value: |-
+  { }
+  { "id": "my-search-template", "params": { "query_string": "hello world", "from": 0, "size": 10 }}
+  { }
+  { "id": "my-other-search-template", "params": { "query_type": "match_all" }}

--- a/specification/_global/msearch_template/types.ts
+++ b/specification/_global/msearch_template/types.ts
@@ -31,7 +31,7 @@ export class TemplateConfig {
    * @server_default false */
   explain?: boolean
   /**
-   * ID of the search template to use. If no source is specified,
+   * The ID of the search template to use. If no `source` is specified,
    * this parameter is required.
    */
   id?: Id
@@ -47,7 +47,7 @@ export class TemplateConfig {
   profile?: boolean
   /**
    * An inline search template. Supports the same parameters as the search API's
-   * request body. Also supports Mustache variables. If no id is specified, this
+   * request body. It also supports Mustache variables. If no `id` is specified, this
    * parameter is required.
    */
   source?: string

--- a/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
+++ b/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
@@ -36,6 +36,11 @@ import { Operation } from './types'
  * You can specify the index in the request body or request URI.
  * The response contains a `docs` array with all the fetched termvectors.
  * Each element has the structure provided by the termvectors API.
+ *
+ * **Artificial documents**
+ *
+ * You can also use `mtermvectors` to generate term vectors for artificial documents provided in the body of the request.
+ * The mapping used is determined by the specified `_index`.
  * @rest_spec_name mtermvectors
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample1.yaml
+++ b/specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample1.yaml
@@ -1,9 +1,9 @@
-summary: Get multi term vectors
-# method_request: POST /my-index-000001/_mtermvectors
+summary: Get multiple term vectors
+# method_request: "POST /my-index-000001/_mtermvectors"
 description: >
   Run `POST /my-index-000001/_mtermvectors`.
-  If you specify an index in the request URI, the index does not need to be specified for each documents in the request body.
-# type: request
+  When you specify an index in the request URI, the index does not need to be specified for each documents in the request body.
+# type: "request"
 value: |-
   {
     "docs": [

--- a/specification/_global/rank_eval/RankEvalRequest.ts
+++ b/specification/_global/rank_eval/RankEvalRequest.ts
@@ -44,7 +44,8 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (`*`) expressions are supported.
+     * A  comma-separated list of data streams, indices, and index aliases used to limit the request.
+     * Wildcard (`*`) expressions are supported.
      * To target all data streams and indices in a cluster, omit this parameter or use `_all` or `*`.
      */
     index?: Indices

--- a/specification/_global/scroll/ScrollRequest.ts
+++ b/specification/_global/scroll/ScrollRequest.ts
@@ -39,7 +39,9 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name scroll
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges read
  * @doc_tag search
+ * @doc_id scroll-api
  * @ext_doc_id scroll-search-results
  */
 export interface Request extends RequestBase {
@@ -60,7 +62,7 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
-     * Period to retain the search context for scrolling.
+     * The period to retain the search context for scrolling.
      * @doc_id scroll-search-results
      * @server_default 1d
      */
@@ -75,12 +77,12 @@ export interface Request extends RequestBase {
   }
   body: {
     /**
-     * Period to retain the search context for scrolling.
+     * The period to retain the search context for scrolling.
      * @doc_id scroll-search-results
      * @server_default 1d
      */
     scroll?: Duration
-    /** Scroll ID of the search. */
+    /** The scroll ID of the search. */
     scroll_id: ScrollId
   }
 }

--- a/specification/_global/scroll/examples/request/ScrollRequestExample1.yaml
+++ b/specification/_global/scroll/examples/request/ScrollRequestExample1.yaml
@@ -1,0 +1,8 @@
+#
+# method_request: "GET /_search/scroll"
+description: Run `GET /_search/scroll` to get the next batch of results for a scrolling search.
+# type: "request"
+value: |-
+  {
+    "scroll_id" : "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ=="
+  }

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -75,6 +75,7 @@ import { Suggester } from './_types/suggester'
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
  * @index_privileges read
+ * @doc_id search-search
  * @ext_doc_id ccs-privileges
  */
 export interface Request extends RequestBase {

--- a/specification/_global/search_mvt/SearchMvtRequest.ts
+++ b/specification/_global/search_mvt/SearchMvtRequest.ts
@@ -34,11 +34,145 @@ import { ZoomLevel } from './_types/ZoomLevel'
  * Search a vector tile.
  *
  * Search a vector tile for geospatial values.
+ * Before using this API, you should be familiar with the Mapbox vector tile specification.
+ * The API returns results as a binary mapbox vector tile.
+ *
+ * Internally, Elasticsearch translates a vector tile search API request into a search containing:
+ *
+ * * A `geo_bounding_box` query on the `<field>`. The query uses the `<zoom>/<x>/<y>` tile as a bounding box.
+ * * A `geotile_grid` or `geohex_grid` aggregation on the `<field>`. The `grid_agg` parameter determines the aggregation type. The aggregation uses the `<zoom>/<x>/<y>` tile as a bounding box.
+ * * Optionally, a `geo_bounds` aggregation on the `<field>`. The search only includes this aggregation if the `exact_bounds` parameter is `true`.
+ * * If the optional parameter `with_labels` is `true`, the internal search will include a dynamic runtime field that calls the `getLabelPosition` function of the geometry doc value. This enables the generation of new point features containing suggested geometry labels, so that, for example, multi-polygons will have only one label.
+ *
+ * For example, Elasticsearch may translate a vector tile search API request with a `grid_agg` argument of `geotile` and an `exact_bounds` argument of `true` into the following search
+ *
+ * ```
+ * GET my-index/_search
+ * {
+ *   "size": 10000,
+ *   "query": {
+ *     "geo_bounding_box": {
+ *       "my-geo-field": {
+ *         "top_left": {
+ *           "lat": -40.979898069620134,
+ *           "lon": -45
+ *         },
+ *         "bottom_right": {
+ *           "lat": -66.51326044311186,
+ *           "lon": 0
+ *         }
+ *       }
+ *     }
+ *   },
+ *   "aggregations": {
+ *     "grid": {
+ *       "geotile_grid": {
+ *         "field": "my-geo-field",
+ *         "precision": 11,
+ *         "size": 65536,
+ *         "bounds": {
+ *           "top_left": {
+ *             "lat": -40.979898069620134,
+ *             "lon": -45
+ *           },
+ *           "bottom_right": {
+ *             "lat": -66.51326044311186,
+ *             "lon": 0
+ *           }
+ *         }
+ *       }
+ *     },
+ *     "bounds": {
+ *       "geo_bounds": {
+ *         "field": "my-geo-field",
+ *         "wrap_longitude": false
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * The API returns results as a binary Mapbox vector tile.
+ * Mapbox vector tiles are encoded as Google Protobufs (PBF). By default, the tile contains three layers:
+ *
+ * * A `hits` layer containing a feature for each `<field>` value matching the `geo_bounding_box` query.
+ * * An `aggs` layer containing a feature for each cell of the `geotile_grid` or `geohex_grid`. The layer only contains features for cells with matching data.
+ * * A meta layer containing:
+ *   * A feature containing a bounding box. By default, this is the bounding box of the tile.
+ *   * Value ranges for any sub-aggregations on the `geotile_grid` or `geohex_grid`.
+ *   * Metadata for the search.
+ *
+ * The API only returns features that can display at its zoom level.
+ * For example, if a polygon feature has no area at its zoom level, the API omits it.
+ * The API returns errors as UTF-8 encoded JSON.
+ *
+ * IMPORTANT: You can specify several options for this API as either a query parameter or request body parameter.
+ * If you specify both parameters, the query parameter takes precedence.
+ *
+ * **Grid precision for geotile**
+ *
+ * For a `grid_agg` of `geotile`, you can use cells in the `aggs` layer as tiles for lower zoom levels.
+ * `grid_precision` represents the additional zoom levels available through these cells. The final precision is computed by as follows: `<zoom> + grid_precision`.
+ * For example, if `<zoom>` is 7 and `grid_precision` is 8, then the `geotile_grid` aggregation will use a precision of 15.
+ * The maximum final precision is 29.
+ * The `grid_precision` also determines the number of cells for the grid as follows: `(2^grid_precision) x (2^grid_precision)`.
+ * For example, a value of 8 divides the tile into a grid of 256 x 256 cells.
+ * The `aggs` layer only contains features for cells with matching data.
+ *
+ * **Grid precision for geohex**
+ *
+ * For a `grid_agg` of `geohex`, Elasticsearch uses `<zoom>` and `grid_precision` to calculate a final precision as follows: `<zoom> + grid_precision`.
+ *
+ * This precision determines the H3 resolution of the hexagonal cells produced by the `geohex` aggregation.
+ * The following table maps the H3 resolution for each precision.
+ * For example, if `<zoom>` is 3 and `grid_precision` is 3, the precision is 6.
+ * At a precision of 6, hexagonal cells have an H3 resolution of 2.
+ * If `<zoom>` is 3 and `grid_precision` is 4, the precision is 7.
+ * At a precision of 7, hexagonal cells have an H3 resolution of 3.
+ *
+ * | Precision | Unique tile bins | H3 resolution | Unique hex bins |	Ratio |
+ * | --------- | ---------------- | ------------- | ----------------| ----- |
+ * | 1  | 4                  | 0  | 122             | 30.5           |
+ * | 2  | 16                 | 0  | 122             | 7.625          |
+ * | 3  | 64                 | 1  | 842             | 13.15625       |
+ * | 4  | 256                | 1  | 842             | 3.2890625      |
+ * | 5  | 1024               | 2  | 5882            | 5.744140625    |
+ * | 6  | 4096               | 2  | 5882            | 1.436035156    |
+ * | 7  | 16384              | 3  | 41162           | 2.512329102    |
+ * | 8  | 65536              | 3  | 41162           | 0.6280822754   |
+ * | 9  | 262144             | 4  | 288122          | 1.099098206    |
+ * | 10 | 1048576            | 4  | 288122          | 0.2747745514   |
+ * | 11 | 4194304            | 5  | 2016842         | 0.4808526039   |
+ * | 12 | 16777216           | 6  | 14117882        | 0.8414913416   |
+ * | 13 | 67108864           | 6  | 14117882        | 0.2103728354   |
+ * | 14 | 268435456          | 7  | 98825162        | 0.3681524172   |
+ * | 15 | 1073741824         | 8  | 691776122       | 0.644266719    |
+ * | 16 | 4294967296         | 8  | 691776122       | 0.1610666797   |
+ * | 17 | 17179869184        | 9  | 4842432842      | 0.2818666889   |
+ * | 18 | 68719476736        | 10 | 33897029882     | 0.4932667053   |
+ * | 19 | 274877906944       | 11 | 237279209162    | 0.8632167343   |
+ * | 20 | 1099511627776      | 11 | 237279209162    | 0.2158041836   |
+ * | 21 | 4398046511104      | 12 | 1660954464122   | 0.3776573213   |
+ * | 22 | 17592186044416     | 13 | 11626681248842  | 0.6609003122   |
+ * | 23 | 70368744177664     | 13 | 11626681248842  | 0.165225078    |
+ * | 24 | 281474976710656    | 14 | 81386768741882  | 0.2891438866   |
+ * | 25 | 1125899906842620   | 15 | 569707381193162 | 0.5060018015   |
+ * | 26 | 4503599627370500   | 15 | 569707381193162 | 0.1265004504   |
+ * | 27 | 18014398509482000  | 15 | 569707381193162 | 0.03162511259  |
+ * | 28 | 72057594037927900  | 15 | 569707381193162 | 0.007906278149 |
+ * | 29 | 288230376151712000 | 15 | 569707381193162 | 0.001976569537 |
+ *
+ * Hexagonal cells don't align perfectly on a vector tile.
+ * Some cells may intersect more than one vector tile.
+ * To compute the H3 resolution for each precision, Elasticsearch compares the average density of hexagonal bins at each resolution with the average density of tile bins at each zoom level.
+ * Elasticsearch uses the H3 resolution that is closest to the corresponding geotile density.
  * @rest_spec_name search_mvt
  * @availability stack since=7.15.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @index_privileges read
  * @doc_tag search
- *
+ * @doc_id search-vector-tile-api
+ * @ext_doc_id mapbox-vector-tile
  */
 export interface Request extends RequestBase {
   urls: [
@@ -48,21 +182,34 @@ export interface Request extends RequestBase {
     }
   ]
   path_parts: {
-    /* List of indices, data streams, or aliases to search */
+    /*
+     * A list of indices, data streams, or aliases to search.
+     * It supports wildcards (`*`).
+     * To search all data streams and indices, omit this parameter or use `*` or `_all`.
+     * To search a remote cluster, use the `<cluster>:<target>` syntax.
+     */
     index: Indices
-    /* Field containing geospatial data to return */
+    /*
+     * A field that contains the geospatial data to return.
+     * It must be a `geo_point` or `geo_shape` field.
+     * The field must have doc values enabled. It cannot be a nested field.
+     *
+     * NOTE: Vector tiles do not natively support geometry collections.
+     * For `geometrycollection` values in a `geo_shape` field, the API returns a hits layer feature for each element of the collection.
+     * This behavior may change in a future release.
+     */
     field: Field
-    /* Zoom level of the vector tile to search */
+    /* The zoom level of the vector tile to search. It accepts `0` to `29`. */
     zoom: ZoomLevel
-    /* X coordinate for the vector tile to search */
+    /* The X coordinate for the vector tile to search. */
     x: Coordinate
-    /* Y coordinate for the vector tile to search */
+    /* The Y coordinate for the vector tile to search. */
     y: Coordinate
   }
   query_parameters: {
     /**
-     * If false, the meta layer’s feature is the bounding box of the tile.
-     * If true, the meta layer’s feature is a bounding box resulting from a
+     * If `false`, the meta layer's feature is the bounding box of the tile.
+     * If true, the meta layer's feature is a bounding box resulting from a
      * geo_bounds aggregation. The aggregation runs on <field> values that intersect
      * the <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting
      * bounding box may be larger than the vector tile.
@@ -70,7 +217,7 @@ export interface Request extends RequestBase {
      */
     exact_bounds?: boolean
     /**
-     * Size, in pixels, of a side of the tile. Vector tiles are square with equal sides.
+     * The size, in pixels, of a side of the tile. Vector tiles are square with equal sides.
      * @server_default 4096
      */
     extent?: integer
@@ -81,7 +228,7 @@ export interface Request extends RequestBase {
     /**
      * Additional zoom levels available through the aggs layer. For example, if <zoom> is 7
      * and grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results
-     * don’t include the aggs layer.
+     * don't include the aggs layer.
      * @server_default 8
      */
     grid_precision?: integer
@@ -95,13 +242,21 @@ export interface Request extends RequestBase {
     grid_type?: GridType
     /**
      * Maximum number of features to return in the hits layer. Accepts 0-10000.
-     * If 0, results don’t include the hits layer.
+     * If 0, results don't include the hits layer.
      * @server_default 10000
      */
     size?: integer
     /**
      * If `true`, the hits and aggs layers will contain additional point features representing
      * suggested label positions for the original features.
+     *
+     * * `Point` and `MultiPoint` features will have one of the points selected.
+     * * `Polygon` and `MultiPolygon` features will have a single point generated, either the centroid, if it is within the polygon, or another point within the polygon selected from the sorted triangle-tree.
+     * * `LineString` features will likewise provide a roughly central point selected from the triangle-tree.
+     * * The aggregation results will provide one central point for each aggregation bucket.
+     *
+     * All attributes from the original features will also be copied to the new label features.
+     * In addition, the new features will be distinguishable using the tag `_mvt_label_position`.
      */
     with_labels?: boolean
   }
@@ -109,61 +264,72 @@ export interface Request extends RequestBase {
     /**
      * Sub-aggregations for the geotile_grid.
      *
-     * Supports the following aggregation types:
-     * - avg
-     * - cardinality
-     * - max
-     * - min
-     * - sum
+     * It supports the following aggregation types:
+     *
+     * - `avg`
+     * - `boxplot`
+     * - `cardinality`
+     * - `extended stats`
+     * - `max`
+     * - `median absolute deviation`
+     * - `min`
+     * - `percentile`
+     * - `percentile-rank`
+     * - `stats`
+     * - `sum`
+     * - `value count`
+     *
+     * The aggregation names can't start with `_mvt_`. The `_mvt_` prefix is reserved for internal aggregations.
      */
     aggs?: Dictionary<string, AggregationContainer>
     /**
-     * Size, in pixels, of a clipping buffer outside the tile. This allows renderers
+     * The size, in pixels, of a clipping buffer outside the tile. This allows renderers
      * to avoid outline artifacts from geometries that extend past the extent of the tile.
      * @server_default 5
      */
     buffer?: integer
     /**
-     * If false, the meta layer’s feature is the bounding box of the tile.
-     * If true, the meta layer’s feature is a bounding box resulting from a
-     * geo_bounds aggregation. The aggregation runs on <field> values that intersect
-     * the <zoom>/<x>/<y> tile with wrap_longitude set to false. The resulting
+     * If `false`, the meta layer's feature is the bounding box of the tile.
+     * If `true`, the meta layer's feature is a bounding box resulting from a
+     * `geo_bounds` aggregation. The aggregation runs on <field> values that intersect
+     * the `<zoom>/<x>/<y>` tile with `wrap_longitude` set to `false`. The resulting
      * bounding box may be larger than the vector tile.
      * @server_default false
      */
     exact_bounds?: boolean
     /**
-     * Size, in pixels, of a side of the tile. Vector tiles are square with equal sides.
+     * The size, in pixels, of a side of the tile. Vector tiles are square with equal sides.
      * @server_default 4096
      */
     extent?: integer
     /**
-     * Fields to return in the `hits` layer. Supports wildcards (`*`).
+     * The fields to return in the `hits` layer.
+     * It supports wildcards (`*`).
      * This parameter does not support fields with array values. Fields with array
      * values may return inconsistent results.
      */
     fields?: Fields
     /**
-     * Aggregation used to create a grid for the `field`.
+     * The aggregation used to create a grid for the `field`.
      */
     grid_agg?: GridAggregationType
     /**
-     * Additional zoom levels available through the aggs layer. For example, if <zoom> is 7
-     * and grid_precision is 8, you can zoom in up to level 15. Accepts 0-8. If 0, results
-     * don’t include the aggs layer.
+     * Additional zoom levels available through the aggs layer. For example, if `<zoom>` is `7`
+     * and `grid_precision` is `8`, you can zoom in up to level 15. Accepts 0-8. If 0, results
+     * don't include the aggs layer.
      * @server_default 8
      */
     grid_precision?: integer
     /**
      * Determines the geometry type for features in the aggs layer. In the aggs layer,
-     * each feature represents a geotile_grid cell. If 'grid' each feature is a Polygon
-     * of the cells bounding box. If 'point' each feature is a Point that is the centroid
+     * each feature represents a `geotile_grid` cell. If `grid, each feature is a polygon
+     * of the cells bounding box. If `point`, each feature is a Point that is the centroid
      * of the cell.
      * @server_default grid
      */
     grid_type?: GridType
     /**
-     * Query DSL used to filter documents for the search.
+     * The query DSL used to filter documents for the search.
      */
     query?: QueryContainer
     /**
@@ -172,19 +338,19 @@ export interface Request extends RequestBase {
      */
     runtime_mappings?: RuntimeFields
     /**
-     * Maximum number of features to return in the hits layer. Accepts 0-10000.
-     * If 0, results don’t include the hits layer.
+     * The maximum number of features to return in the hits layer. Accepts 0-10000.
+     * If 0, results don't include the hits layer.
      * @server_default 10000
      */
     size?: integer
     /**
-     * Sorts features in the hits layer. By default, the API calculates a bounding
-     * box for each feature. It sorts features based on this box’s diagonal length,
+     * Sort the features in the hits layer. By default, the API calculates a bounding
+     * box for each feature. It sorts features based on this box's diagonal length,
      * from longest to shortest.
      */
     sort?: Sort
     /**
-     * Number of hits matching the query to count accurately. If `true`, the exact number
+     * The number of hits matching the query to count accurately. If `true`, the exact number
      * of hits is returned at the cost of some performance. If `false`, the response does
      * not include the total number of hits matching the query.
      * @server_default 10000
@@ -193,6 +359,14 @@ export interface Request extends RequestBase {
     /**
      * If `true`, the hits and aggs layers will contain additional point features representing
      * suggested label positions for the original features.
+     *
+     * * `Point` and `MultiPoint` features will have one of the points selected.
+     * * `Polygon` and `MultiPolygon` features will have a single point generated, either the centroid, if it is within the polygon, or another point within the polygon selected from the sorted triangle-tree.
+     * * `LineString` features will likewise provide a roughly central point selected from the triangle-tree.
+     * * The aggregation results will provide one central point for each aggregation bucket.
+     *
+     * All attributes from the original features will also be copied to the new label features.
+     * In addition, the new features will be distinguishable using the tag `_mvt_label_position`.
      */
     with_labels?: boolean
   }

--- a/specification/_global/search_mvt/examples/request/SearchMvtRequestExample1.yaml
+++ b/specification/_global/search_mvt/examples/request/SearchMvtRequestExample1.yaml
@@ -1,0 +1,36 @@
+# summary:
+# method_request: "GET museums/_mvt/location/13/4207/2692"
+description: >
+  Run `GET museums/_mvt/location/13/4207/2692` to search an index for `location` values that intersect the `13/4207/2692` vector tile.
+# type: "request"
+value: |-
+  {
+    "grid_agg": "geotile",
+    "grid_precision": 2,
+    "fields": [
+      "name",
+      "price"
+    ],
+    "query": {
+      "term": {
+        "included": true
+      }
+    },
+    "aggs": {
+      "min_price": {
+        "min": {
+          "field": "price"
+        }
+      },
+      "max_price": {
+        "max": {
+          "field": "price"
+        }
+      },
+      "avg_price": {
+        "avg": {
+          "field": "price"
+        }
+      }
+    }
+  }

--- a/specification/_global/search_mvt/examples/response/SearchMvtResponseExample1.yaml
+++ b/specification/_global/search_mvt/examples/response/SearchMvtResponseExample1.yaml
@@ -1,0 +1,173 @@
+# summary:
+description: >
+  A successful response from `GET museums/_mvt/location/13/4207/2692`.
+  It returns results as a binary vector tile.
+  When decoded into JSON, the tile contains the following data.
+# type: "response",
+# response_code: 200,
+value: |-
+  {
+    "hits": {
+      "extent": 4096,
+      "version": 2,
+      "features": [
+        {
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              3208,
+              3864
+            ]
+          },
+          "properties": {
+            "_id": "1",
+            "_index": "museums",
+            "name": "NEMO Science Museum",
+            "price": 1750
+          },
+          "type": 1
+        },
+        {
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              3429,
+              3496
+            ]
+          },
+          "properties": {
+            "_id": "3",
+            "_index": "museums",
+            "name": "Nederlands Scheepvaartmuseum",
+            "price": 1650
+          },
+          "type": 1
+        },
+        {
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              3429,
+              3496
+            ]
+          },
+          "properties": {
+            "_id": "4",
+            "_index": "museums",
+            "name": "Amsterdam Centre for Architecture",
+            "price": 0
+          },
+          "type": 1
+        }
+      ]
+    },
+    "aggs": {
+      "extent": 4096,
+      "version": 2,
+      "features": [
+        {
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  3072,
+                  3072
+                ],
+                [
+                  4096,
+                  3072
+                ],
+                [
+                  4096,
+                  4096
+                ],
+                [
+                  3072,
+                  4096
+                ],
+                [
+                  3072,
+                  3072
+                ]
+              ]
+            ]
+          },
+          "properties": {
+            "_count": 3,
+            "max_price.value": 1750.0,
+            "min_price.value": 0.0,
+            "avg_price.value": 1133.3333333333333
+          },
+          "type": 3
+        }
+      ]
+    },
+    "meta": {
+      "extent": 4096,
+      "version": 2,
+      "features": [
+        {
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  0,
+                  0
+                ],
+                [
+                  4096,
+                  0
+                ],
+                [
+                  4096,
+                  4096
+                ],
+                [
+                  0,
+                  4096
+                ],
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          },
+          "properties": {
+            "_shards.failed": 0,
+            "_shards.skipped": 0,
+            "_shards.successful": 1,
+            "_shards.total": 1,
+            "aggregations._count.avg": 3.0,
+            "aggregations._count.count": 1,
+            "aggregations._count.max": 3.0,
+            "aggregations._count.min": 3.0,
+            "aggregations._count.sum": 3.0,
+            "aggregations.avg_price.avg": 1133.3333333333333,
+            "aggregations.avg_price.count": 1,
+            "aggregations.avg_price.max": 1133.3333333333333,
+            "aggregations.avg_price.min": 1133.3333333333333,
+            "aggregations.avg_price.sum": 1133.3333333333333,
+            "aggregations.max_price.avg": 1750.0,
+            "aggregations.max_price.count": 1,
+            "aggregations.max_price.max": 1750.0,
+            "aggregations.max_price.min": 1750.0,
+            "aggregations.max_price.sum": 1750.0,
+            "aggregations.min_price.avg": 0.0,
+            "aggregations.min_price.count": 1,
+            "aggregations.min_price.max": 0.0,
+            "aggregations.min_price.min": 0.0,
+            "aggregations.min_price.sum": 0.0,
+            "hits.max_score": 0.0,
+            "hits.total.relation": "eq",
+            "hits.total.value": 3,
+            "timed_out": false,
+            "took": 2
+          },
+          "type": 3
+        }
+      ]
+    }
+  }

--- a/specification/_global/terms_enum/TermsEnumRequest.ts
+++ b/specification/_global/terms_enum/TermsEnumRequest.ts
@@ -27,16 +27,15 @@ import { Duration } from '@_types/Time'
  * Get terms in an index.
  *
  * Discover terms that match a partial string in an index.
- * This "terms enum" API is designed for low-latency look-ups used in auto-complete scenarios.
+ * This API is designed for low-latency look-ups used in auto-complete scenarios.
  *
- * If the `complete` property in the response is false, the returned terms set may be incomplete and should be treated as approximate.
- * This can occur due to a few reasons, such as a request timeout or a node error.
- *
- * NOTE: The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.
+ * > info
+ * > The terms enum API may return terms from deleted documents. Deleted documents are initially only marked as deleted. It is not until their segments are merged that documents are actually deleted. Until that happens, the terms enum API will return terms from these documents.
  * @rest_spec_name terms_enum
  * @availability stack since=7.14.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag search
+ * @doc_id search-terms-enum
  */
 export interface Request extends RequestBase {
   urls: [
@@ -46,36 +45,49 @@ export interface Request extends RequestBase {
     }
   ]
   path_parts: {
-    /** Comma-separated list of data streams, indices, and index aliases to search. Wildcard (*) expressions are supported. */
+    /**
+     * A comma-separated list of data streams, indices, and index aliases to search.
+     * Wildcard (`*`) expressions are supported.
+     * To search all data streams or indices, omit this parameter or use `*`  or `_all`.
+     */
     index: IndexName
   }
   body: {
     /** The string to match at the start of indexed terms. If not provided, all terms in the field are considered. */
     field: Field
     /**
-     * How many matching terms to return.
+     * The number of matching terms to return.
      * @server_default 10
      */
     size?: integer
     /**
-     * The maximum length of time to spend collecting results. Defaults to "1s" (one second). If the timeout is exceeded the complete flag set to false in the response and the results may be partial or empty.
+     * The maximum length of time to spend collecting results.
+     * If the timeout is exceeded the `complete` flag set to `false` in the response and the results may be partial or empty.
      * @server_default 1s
      */
     timeout?: Duration
     /**
-     * When true the provided search string is matched against index terms without case sensitivity.
+     * When `true`, the provided search string is matched against index terms without case sensitivity.
      * @server_default false
      */
     case_insensitive?: boolean
     /**
-     * Allows to filter an index shard if the provided query rewrites to match_none.
+     * Filter an index shard if the provided query rewrites to `match_none`.
      * @doc_id query-dsl
      */
     index_filter?: QueryContainer
     /**
-     * The string after which terms in the index should be returned. Allows for a form of pagination if the last result from one request is passed as the search_after parameter for a subsequent request.
+     * The string to match at the start of indexed terms.
+     * If it is not provided, all terms in the field are considered.
+     *
+     * > info
+     * > The prefix string cannot be larger than the largest possible keyword value, which is Lucene's term byte-length limit of 32766.
      */
     string?: string
+    /**
+     * The string after which terms in the index should be returned.
+     * It allows for a form of pagination if the last result from one request is passed as the `search_after` parameter for a subsequent request.
+     */
     search_after?: string
   }
 }

--- a/specification/_global/terms_enum/TermsEnumResponse.ts
+++ b/specification/_global/terms_enum/TermsEnumResponse.ts
@@ -23,6 +23,10 @@ export class Response {
   body: {
     _shards: ShardStatistics
     terms: string[]
+    /**
+     * If `false`, the returned terms set may be incomplete and should be treated as approximate.
+     * This can occur due to a few reasons, such as a request timeout or a node error.
+     */
     complete: boolean
   }
 }

--- a/specification/_global/terms_enum/examples/request/TermsEnumRequestExample1.yaml
+++ b/specification/_global/terms_enum/examples/request/TermsEnumRequestExample1.yaml
@@ -1,0 +1,9 @@
+# summary:
+# method_request: "POST stackoverflow/_terms_enum"
+description: Run `POST stackoverflow/_terms_enum`.
+# type: "request"
+value: |-
+  {
+      "field" : "tags",
+      "string" : "kiba"
+  }

--- a/specification/_global/terms_enum/examples/response/TermsEnumResponseExample1.yaml
+++ b/specification/_global/terms_enum/examples/response/TermsEnumResponseExample1.yaml
@@ -1,0 +1,16 @@
+# summary:
+description: A successful response from `POST stackoverflow/_terms_enum`.
+# type: "response",
+# response_code: 200,
+value: |-
+  {
+    "_shards": {
+      "total": 1,
+      "successful": 1,
+      "failed": 0
+    },
+    "terms": [
+      "kibana"
+    ],
+    "complete" : true
+  }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR copies examples and descriptions from https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html, https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search-api.html, https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-search-template.html, https://www.elastic.co/guide/en/elasticsearch/reference/master/search-vector-tile-api.html, https://www.elastic.co/guide/en/elasticsearch/reference/master/search-terms-enum.html

NOTE: The vector tile API includes a table, which I've confirmed works in Bump.sh like this:

![image](https://github.com/user-attachments/assets/ac50d108-830a-42dc-a9d9-bb6fc40d210f)

I've also confirmed the behavior of an "info" callout, as described in https://docs.bump.sh/help/documentation-experience/markdown-support/#information-call-outs