### PR TITLE
[8.17] [DOCS] Add examples and descriptions for script APIs (#3613)

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -170,6 +170,11 @@ actions:
       # S
         - name: script
           x-displayName: Script
+          description: >
+            Use the script support APIs to get a list of supported script contexts and languages.
+            Use the stored script APIs to manage stored scripts and search templates.
+          externalDocs:
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
         - name: search
           x-displayName: Search
         - name: search_application

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -7790,7 +7790,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "Identifier for the stored script or search template.",
+            "description": "The identifier for the stored script or search template.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -7801,7 +7801,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Specify timeout for connection to master",
+            "description": "The period to wait for the master node.\nIf the master node is not available before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -7843,10 +7843,16 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script",
         "parameters": [
           {
             "$ref": "#/components/parameters/put_script#id"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -7870,10 +7876,16 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script-1",
         "parameters": [
           {
             "$ref": "#/components/parameters/put_script#id"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -7902,7 +7914,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "Identifier for the stored script or search template.",
+            "description": "The identifier for the stored script or search template.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -7913,7 +7925,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -7923,7 +7935,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -25419,6 +25431,9 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script-2",
         "parameters": [
           {
@@ -25426,6 +25441,9 @@
           },
           {
             "$ref": "#/components/parameters/put_script#context"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -25449,6 +25467,9 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script-3",
         "parameters": [
           {
@@ -25456,6 +25477,9 @@
           },
           {
             "$ref": "#/components/parameters/put_script#context"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -69098,7 +69122,7 @@
             }
           },
           "source": {
-            "description": "The script source.",
+            "description": "The script source.\nFor search templates, an object containing the search template.",
             "type": "string"
           }
         },
@@ -104206,7 +104230,7 @@
       "put_script#id": {
         "in": "path",
         "name": "id",
-        "description": "Identifier for the stored script or search template.\nMust be unique within the cluster.",
+        "description": "The identifier for the stored script or search template.\nIt must be unique within the cluster.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -104217,7 +104241,7 @@
       "put_script#context": {
         "in": "path",
         "name": "context",
-        "description": "Context in which the script or search template should run.\nTo prevent errors, the API immediately compiles the script or template in this context.",
+        "description": "The context in which the script or search template should run.\nTo prevent errors, the API immediately compiles the script or template in this context.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -104225,10 +104249,20 @@
         },
         "style": "simple"
       },
+      "put_script#context_": {
+        "in": "query",
+        "name": "context",
+        "description": "The context in which the script or search template should run.\nTo prevent errors, the API immediately compiles the script or template in this context.\nIf you specify both this and the `<context>` path parameter, the API uses the request path parameter.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Name"
+        },
+        "style": "form"
+      },
       "put_script#master_timeout": {
         "in": "query",
         "name": "master_timeout",
-        "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+        "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -104238,7 +104272,7 @@
       "put_script#timeout": {
         "in": "query",
         "name": "timeout",
-        "description": "Period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+        "description": "The period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -4485,7 +4485,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "Identifier for the stored script or search template.",
+            "description": "The identifier for the stored script or search template.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -4496,7 +4496,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Specify timeout for connection to master",
+            "description": "The period to wait for the master node.\nIf the master node is not available before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -4538,10 +4538,16 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script",
         "parameters": [
           {
             "$ref": "#/components/parameters/put_script#id"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -4565,10 +4571,16 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script-1",
         "parameters": [
           {
             "$ref": "#/components/parameters/put_script#id"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -4597,7 +4609,7 @@
           {
             "in": "path",
             "name": "id",
-            "description": "Identifier for the stored script or search template.",
+            "description": "The identifier for the stored script or search template.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -4608,7 +4620,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -4618,7 +4630,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -14886,6 +14898,9 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script-2",
         "parameters": [
           {
@@ -14893,6 +14908,9 @@
           },
           {
             "$ref": "#/components/parameters/put_script#context"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -14916,6 +14934,9 @@
         ],
         "summary": "Create or update a script or search template",
         "description": "Creates or updates a stored script or search template.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html"
+        },
         "operationId": "put-script-3",
         "parameters": [
           {
@@ -14923,6 +14944,9 @@
           },
           {
             "$ref": "#/components/parameters/put_script#context"
+          },
+          {
+            "$ref": "#/components/parameters/put_script#context_"
           },
           {
             "$ref": "#/components/parameters/put_script#master_timeout"
@@ -44995,7 +45019,7 @@
             }
           },
           "source": {
-            "description": "The script source.",
+            "description": "The script source.\nFor search templates, an object containing the search template.",
             "type": "string"
           }
         },
@@ -61538,7 +61562,7 @@
       "put_script#id": {
         "in": "path",
         "name": "id",
-        "description": "Identifier for the stored script or search template.\nMust be unique within the cluster.",
+        "description": "The identifier for the stored script or search template.\nIt must be unique within the cluster.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -61549,7 +61573,7 @@
       "put_script#context": {
         "in": "path",
         "name": "context",
-        "description": "Context in which the script or search template should run.\nTo prevent errors, the API immediately compiles the script or template in this context.",
+        "description": "The context in which the script or search template should run.\nTo prevent errors, the API immediately compiles the script or template in this context.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -61557,10 +61581,20 @@
         },
         "style": "simple"
       },
+      "put_script#context_": {
+        "in": "query",
+        "name": "context",
+        "description": "The context in which the script or search template should run.\nTo prevent errors, the API immediately compiles the script or template in this context.\nIf you specify both this and the `<context>` path parameter, the API uses the request path parameter.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Name"
+        },
+        "style": "form"
+      },
       "put_script#master_timeout": {
         "in": "query",
         "name": "master_timeout",
-        "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+        "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -61570,7 +61604,7 @@
       "put_script#timeout": {
         "in": "query",
         "name": "timeout",
-        "description": "Period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+        "description": "The period to wait for a response.\nIf no response is received before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -809,12 +809,6 @@
       ],
       "response": []
     },
-    "put_script": {
-      "request": [
-        "Request: missing json spec query parameter 'context'"
-      ],
-      "response": []
-    },
     "reindex": {
       "request": [
         "Request: query parameter 'require_alias' does not exist in the json spec",

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -499,7 +499,11 @@ rollup-stop-job,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 routing,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-get.html#get-routing
 run-as-privilege,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/run-as-privilege.html
 runtime-search-request,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/runtime-search-request.html
+script-contexts,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-script-contexts-api.html
+script-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-stored-script-api.html
+script-languages,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-script-languages-api.html
 script-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/script-processor.html
+script-put,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/create-stored-script-api.html
 scroll-search-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html#scroll-search-results
 search-after,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/paginate-search-results.html#search-after
 search-aggregations,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations.html

--- a/specification/_global/delete_script/DeleteScriptRequest.ts
+++ b/specification/_global/delete_script/DeleteScriptRequest.ts
@@ -27,25 +27,29 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name delete_script
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage
  * @doc_tag script
+ * @doc_id script-delete
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * Identifier for the stored script or search template.
+     * The identifier for the stored script or search template.
      */
     id: Id
   }
   query_parameters: {
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
      * If no response is received before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
     master_timeout?: Duration
     /**
-     * Period to wait for a response.
+     * The period to wait for a response.
      * If no response is received before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
     timeout?: Duration

--- a/specification/_global/get_script/GetScriptRequest.ts
+++ b/specification/_global/get_script/GetScriptRequest.ts
@@ -27,17 +27,23 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name get_script
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage
  * @doc_tag script
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * Identifier for the stored script or search template.
+     * The identifier for the stored script or search template.
      */
     id: Id
   }
   query_parameters: {
-    /** Specify timeout for connection to master */
+    /**
+     * The period to wait for the master node.
+     * If the master node is not available before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
+     * @server_default
+     */
     master_timeout?: Duration
   }
 }

--- a/specification/_global/get_script_context/GetScriptContextRequest.ts
+++ b/specification/_global/get_script_context/GetScriptContextRequest.ts
@@ -25,6 +25,8 @@ import { RequestBase } from '@_types/Base'
  * Get a list of supported script contexts and their methods.
  * @rest_spec_name get_script_context
  * @availability stack stability=stable
+ * @cluster_privileges manage
  * @doc_tag script
+ * @doc_id script-contexts
  */
 export interface Request extends RequestBase {}

--- a/specification/_global/get_script_languages/GetScriptLanguagesRequest.ts
+++ b/specification/_global/get_script_languages/GetScriptLanguagesRequest.ts
@@ -25,6 +25,8 @@ import { RequestBase } from '@_types/Base'
  * Get a list of available script types, languages, and contexts.
  * @rest_spec_name get_script_languages
  * @availability stack stability=stable
+ * @cluster_privileges manage
  * @doc_tag script
+ * @doc_id script-languages
  */
 export interface Request extends RequestBase {}

--- a/specification/_global/put_script/PutScriptRequest.ts
+++ b/specification/_global/put_script/PutScriptRequest.ts
@@ -28,38 +28,49 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name put_script
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges manage
  * @doc_tag script
+ * @doc_id script-put
+ * @ext_doc_id search-template
  */
 export interface Request extends RequestBase {
   path_parts: {
     /**
-     * Identifier for the stored script or search template.
-     * Must be unique within the cluster.
+     * The identifier for the stored script or search template.
+     * It must be unique within the cluster.
      */
     id: Id
     /**
-     * Context in which the script or search template should run.
+     * The context in which the script or search template should run.
      * To prevent errors, the API immediately compiles the script or template in this context.
      */
     context?: Name
   }
   query_parameters: {
     /**
-     * Period to wait for a connection to the master node.
+     * The context in which the script or search template should run.
+     * To prevent errors, the API immediately compiles the script or template in this context.
+     * If you specify both this and the `<context>` path parameter, the API uses the request path parameter.
+     */
+    context?: Name
+    /**
+     * The period to wait for a connection to the master node.
      * If no response is received before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
     master_timeout?: Duration
     /**
-     * Period to wait for a response.
+     * The period to wait for a response.
      * If no response is received before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
     timeout?: Duration
   }
   body: {
     /**
-     * Contains the script or search template, its parameters, and its language.
+     * The script or search template, its parameters, and its language.
      */
     script: StoredScript
   }

--- a/specification/_global/put_script/examples/request/PutScriptRequestExample1.yaml
+++ b/specification/_global/put_script/examples/request/PutScriptRequestExample1.yaml
@@ -1,0 +1,20 @@
+summary: Create a search template
+# method_request: PUT _scripts/my-search-template
+description: >
+  Run `PUT _scripts/my-search-template` to create a search template.
+# type: request
+value: |-
+  {
+    "script": {
+      "lang": "mustache",
+      "source": {
+        "query": {
+          "match": {
+            "message": "{{query_string}}"
+          }
+        },
+        "from": "{{from}}",
+        "size": "{{size}}"
+      }
+    }
+  }

--- a/specification/_global/put_script/examples/request/PutScriptRequestExample2.yaml
+++ b/specification/_global/put_script/examples/request/PutScriptRequestExample2.yaml
@@ -1,0 +1,12 @@
+summary: Create a stored script
+# method_request: PUT _scripts/my-stored-script
+description: >
+  Run `PUT _scripts/my-stored-script` to create a stored script.
+# type: request
+value: |-
+  {
+    "script": {
+      "lang": "painless",
+      "source": "Math.log(_score * 2) + params['my_modifier']"
+    }
+  }

--- a/specification/_types/Scripting.ts
+++ b/specification/_types/Scripting.ts
@@ -47,11 +47,13 @@ export enum ScriptLanguage {
 export class StoredScript {
   /**
    * The language the script is written in.
+   * For serach templates, use `mustache`.
    */
   lang: ScriptLanguage
   options?: Dictionary<string, string>
   /**
    * The script source.
+   * For search templates, an object containing the search template.
    */
   source: string
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.17`:
 - [[DOCS] Add examples and descriptions for script APIs (#3613)](https://github.com/elastic/elasticsearch-specification/pull/3613)

<!--- Backport version: 9.6.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)