### PR TITLE
[DOCS] Add missing doc_id values

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -9489,6 +9489,9 @@
         ],
         "summary": "Get the features",
         "description": "Get a list of features that can be included in snapshots using the `feature_states` field when creating a snapshot.\nYou can use this API to determine which feature states to include when taking a snapshot.\nBy default, all feature states are included in a snapshot if that snapshot includes the global state, or none if it does not.\n\nA feature state includes one or more system indices necessary for a given feature to function.\nIn order to ensure data integrity, all system indices that comprise a feature state are snapshotted and restored together.\n\nThe features listed by this API are a combination of built-in features and features defined by plugins.\nIn order for a feature state to be listed in this API and recognized as a valid feature state by the create snapshot API, the plugin that defines that feature must be installed on the master node.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-take-snapshot.html"
+        },
         "operationId": "features-get-features",
         "parameters": [
           {
@@ -12178,7 +12181,7 @@
           "data stream"
         ],
         "summary": "Get data streams",
-        "description": "Retrieves information about one or more data streams.",
+        "description": "Get information about one or more data streams.",
         "operationId": "indices-get-data-stream-1",
         "parameters": [
           {
@@ -12660,7 +12663,7 @@
           "data stream"
         ],
         "summary": "Get data stream lifecycles",
-        "description": "Retrieves the data stream lifecycle configuration of one or more data streams.",
+        "description": "Get the data stream lifecycle configuration of one or more data streams.",
         "operationId": "indices-get-data-lifecycle",
         "parameters": [
           {
@@ -13963,7 +13966,7 @@
           "data stream"
         ],
         "summary": "Get data streams",
-        "description": "Retrieves information about one or more data streams.",
+        "description": "Get information about one or more data streams.",
         "operationId": "indices-get-data-stream",
         "parameters": [
           {
@@ -16275,6 +16278,7 @@
           "inference"
         ],
         "summary": "Perform inference on the service",
+        "description": "This API enables you to use machine learning models to perform specific tasks on data that you provide as an input.\nIt returns a response with the results of the tasks.\nThe inference endpoint you use can perform one specific task that has been defined when the endpoint was created with the create inference API.\n\n> info\n> The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face. For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.",
         "operationId": "inference-inference",
         "parameters": [
           {
@@ -16371,6 +16375,7 @@
           "inference"
         ],
         "summary": "Perform inference on the service",
+        "description": "This API enables you to use machine learning models to perform specific tasks on data that you provide as an input.\nIt returns a response with the results of the tasks.\nThe inference endpoint you use can perform one specific task that has been defined when the endpoint was created with the create inference API.\n\n> info\n> The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face. For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.",
         "operationId": "inference-inference-1",
         "parameters": [
           {
@@ -16773,7 +16778,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a connection to the master node.\nIf no response is received before the timeout expires, the request fails and returns an error.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -16783,7 +16788,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -17439,7 +17444,7 @@
           "license"
         ],
         "summary": "Get license information",
-        "description": "Get information about your Elastic license including its type, its status, when it was issued, and when it expires.\n\nNOTE: If the master node is generating a new cluster state, the get license API may return a `404 Not Found` response.\nIf you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.",
+        "description": "Get information about your Elastic license including its type, its status, when it was issued, and when it expires.\n\n>info\n> If the master node is generating a new cluster state, the get license API may return a `404 Not Found` response.\n> If you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.",
         "operationId": "license-get",
         "parameters": [
           {
@@ -17552,7 +17557,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Period to wait for a connection to the master node.",
+            "description": "The period to wait for a connection to the master node.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -17562,7 +17567,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.",
+            "description": "The period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -28040,7 +28045,7 @@
           {
             "in": "path",
             "name": "name",
-            "description": "The name of the search application to delete",
+            "description": "The name of the search application to delete.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -30952,7 +30957,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Get users.s\n",
+        "summary": "Get users",
         "description": "Get information about users in the native realm and built-in users.",
         "operationId": "security-get-user",
         "parameters": [
@@ -31942,7 +31947,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Get users.s\n",
+        "summary": "Get users",
         "description": "Get information about users in the native realm and built-in users.",
         "operationId": "security-get-user-1",
         "parameters": [
@@ -32975,7 +32980,7 @@
           "security"
         ],
         "summary": "Prepare SAML authentication",
-        "description": "Create a SAML authentication request (`<AuthnRequest>`) as a URL string based on the configuration of the respective SAML realm in Elasticsearch.\n\nNOTE: This API is intended for use by custom web applications other than Kibana.\nIf you are using Kibana, refer to the documentation for configuring SAML single-sign-on on the Elastic Stack.\n\nThis API returns a URL pointing to the SAML Identity Provider.\nYou can use the URL to redirect the browser of the user in order to continue the authentication process.\nThe URL includes a single parameter named `SAMLRequest`, which contains a SAML Authentication request that is deflated and Base64 encoded.\nIf the configuration dictates that SAML authentication requests should be signed, the URL has two extra parameters named `SigAlg` and `Signature`.\nThese parameters contain the algorithm used for the signature and the signature value itself.\nIt also returns a random string that uniquely identifies this SAML Authentication request.\nThe caller of thsis API needs to store this identifier as it needs to be used in a following step of the authentication process.",
+        "description": "Create a SAML authentication request (`<AuthnRequest>`) as a URL string based on the configuration of the respective SAML realm in Elasticsearch.\n\nNOTE: This API is intended for use by custom web applications other than Kibana.\nIf you are using Kibana, refer to the documentation for configuring SAML single-sign-on on the Elastic Stack.\n\nThis API returns a URL pointing to the SAML Identity Provider.\nYou can use the URL to redirect the browser of the user in order to continue the authentication process.\nThe URL includes a single parameter named `SAMLRequest`, which contains a SAML Authentication request that is deflated and Base64 encoded.\nIf the configuration dictates that SAML authentication requests should be signed, the URL has two extra parameters named `SigAlg` and `Signature`.\nThese parameters contain the algorithm used for the signature and the signature value itself.\nIt also returns a random string that uniquely identifies this SAML Authentication request.\nThe caller of this API needs to store this identifier as it needs to be used in a following step of the authentication process.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html"
         },
@@ -103070,7 +103075,7 @@
       "inference.delete#inference_id": {
         "in": "path",
         "name": "inference_id",
-        "description": "The inference Id",
+        "description": "The inference identifier.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -103081,7 +103086,7 @@
       "inference.delete#dry_run": {
         "in": "query",
         "name": "dry_run",
-        "description": "When true, the endpoint is not deleted, and a list of ingest processors which reference this endpoint is returned",
+        "description": "When true, the endpoint is not deleted and a list of ingest processors which reference this endpoint is returned.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -103091,7 +103096,7 @@
       "inference.delete#force": {
         "in": "query",
         "name": "force",
-        "description": "When true, the inference endpoint is forcefully deleted even if it is still being used by ingest processors or semantic text fields",
+        "description": "When true, the inference endpoint is forcefully deleted even if it is still being used by ingest processors or semantic text fields.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -103123,7 +103128,7 @@
       "inference.inference#task_type": {
         "in": "path",
         "name": "task_type",
-        "description": "The task type",
+        "description": "The type of inference task that the model performs.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -103134,7 +103139,7 @@
       "inference.inference#inference_id": {
         "in": "path",
         "name": "inference_id",
-        "description": "The inference Id",
+        "description": "The unique identifier for the inference endpoint.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -103145,7 +103150,7 @@
       "inference.inference#timeout": {
         "in": "query",
         "name": "timeout",
-        "description": "Specifies the amount of time to wait for the inference request to complete.",
+        "description": "The amount of time to wait for the inference request to complete.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -103253,7 +103258,7 @@
       "ingest.get_geoip_database#id": {
         "in": "path",
         "name": "id",
-        "description": "Comma-separated list of database configuration IDs to retrieve.\nWildcard (`*`) expressions are supported.\nTo get all database configurations, omit this parameter or use `*`.",
+        "description": "A comma-separated list of database configuration IDs to retrieve.\nWildcard (`*`) expressions are supported.\nTo get all database configurations, omit this parameter or use `*`.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -103316,7 +103321,7 @@
       "ingest.simulate#id": {
         "in": "path",
         "name": "id",
-        "description": "Pipeline to test.\nIf you don’t specify a `pipeline` in the request body, this parameter is required.",
+        "description": "The pipeline to test.\nIf you don't specify a `pipeline` in the request body, this parameter is required.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -103368,7 +103373,7 @@
       "license.post#master_timeout": {
         "in": "query",
         "name": "master_timeout",
-        "description": "Period to wait for a connection to the master node.",
+        "description": "The period to wait for a connection to the master node.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -103378,7 +103383,7 @@
       "license.post#timeout": {
         "in": "query",
         "name": "timeout",
-        "description": "Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.",
+        "description": "The period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -108765,11 +108770,11 @@
               "type": "object",
               "properties": {
                 "query": {
-                  "description": "Query input, required for rerank task.\nNot required for other tasks.",
+                  "description": "The query input, which is required only for the `rerank` task.\nIt is not required for other tasks.",
                   "type": "string"
                 },
                 "input": {
-                  "description": "Inference input.\nEither a string or an array of strings.",
+                  "description": "The text on which you want to perform the inference task.\nIt can be a single string or an array.\n\n> info\n> Inference endpoints for the `completion` task type currently only support a single string as input.",
                   "oneOf": [
                     {
                       "type": "string"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -9489,9 +9489,6 @@
         ],
         "summary": "Get the features",
         "description": "Get a list of features that can be included in snapshots using the `feature_states` field when creating a snapshot.\nYou can use this API to determine which feature states to include when taking a snapshot.\nBy default, all feature states are included in a snapshot if that snapshot includes the global state, or none if it does not.\n\nA feature state includes one or more system indices necessary for a given feature to function.\nIn order to ensure data integrity, all system indices that comprise a feature state are snapshotted and restored together.\n\nThe features listed by this API are a combination of built-in features and features defined by plugins.\nIn order for a feature state to be listed in this API and recognized as a valid feature state by the create snapshot API, the plugin that defines that feature must be installed on the master node.",
-        "externalDocs": {
-          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-take-snapshot.html"
-        },
         "operationId": "features-get-features",
         "parameters": [
           {
@@ -22322,7 +22319,7 @@
           "ml data frame"
         ],
         "summary": "Preview features used by data frame analytics",
-        "description": "Previews the extracted features used by a data frame analytics config.",
+        "description": "Preview the extracted features used by a data frame analytics config.",
         "operationId": "ml-preview-data-frame-analytics",
         "requestBody": {
           "$ref": "#/components/requestBodies/ml.preview_data_frame_analytics"
@@ -22339,7 +22336,7 @@
           "ml data frame"
         ],
         "summary": "Preview features used by data frame analytics",
-        "description": "Previews the extracted features used by a data frame analytics config.",
+        "description": "Preview the extracted features used by a data frame analytics config.",
         "operationId": "ml-preview-data-frame-analytics-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/ml.preview_data_frame_analytics"
@@ -22358,7 +22355,7 @@
           "ml data frame"
         ],
         "summary": "Preview features used by data frame analytics",
-        "description": "Previews the extracted features used by a data frame analytics config.",
+        "description": "Preview the extracted features used by a data frame analytics config.",
         "operationId": "ml-preview-data-frame-analytics-2",
         "parameters": [
           {
@@ -22380,7 +22377,7 @@
           "ml data frame"
         ],
         "summary": "Preview features used by data frame analytics",
-        "description": "Previews the extracted features used by a data frame analytics config.",
+        "description": "Preview the extracted features used by a data frame analytics config.",
         "operationId": "ml-preview-data-frame-analytics-3",
         "parameters": [
           {
@@ -24105,7 +24102,7 @@
           "ml anomaly"
         ],
         "summary": "Upgrade a snapshot",
-        "description": "Upgrades an anomaly detection model snapshot to the latest major version.\nOver time, older snapshot formats are deprecated and removed. Anomaly\ndetection jobs support only snapshots that are from the current or previous\nmajor version.\nThis API provides a means to upgrade a snapshot to the current major version.\nThis aids in preparing the cluster for an upgrade to the next major version.\nOnly one snapshot per anomaly detection job can be upgraded at a time and the\nupgraded snapshot cannot be the current snapshot of the anomaly detection\njob.",
+        "description": "Upgrade an anomaly detection model snapshot to the latest major version.\nOver time, older snapshot formats are deprecated and removed. Anomaly\ndetection jobs support only snapshots that are from the current or previous\nmajor version.\nThis API provides a means to upgrade a snapshot to the current major version.\nThis aids in preparing the cluster for an upgrade to the next major version.\nOnly one snapshot per anomaly detection job can be upgraded at a time and the\nupgraded snapshot cannot be the current snapshot of the anomaly detection\njob.",
         "operationId": "ml-upgrade-job-snapshot",
         "parameters": [
           {
@@ -30955,7 +30952,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Get users",
+        "summary": "Get users.s\n",
         "description": "Get information about users in the native realm and built-in users.",
         "operationId": "security-get-user",
         "parameters": [
@@ -31945,7 +31942,7 @@
         "tags": [
           "security"
         ],
-        "summary": "Get users",
+        "summary": "Get users.s\n",
         "description": "Get information about users in the native realm and built-in users.",
         "operationId": "security-get-user-1",
         "parameters": [
@@ -32978,7 +32975,7 @@
           "security"
         ],
         "summary": "Prepare SAML authentication",
-        "description": "Create a SAML authentication request (`<AuthnRequest>`) as a URL string based on the configuration of the respective SAML realm in Elasticsearch.\n\nNOTE: This API is intended for use by custom web applications other than Kibana.\nIf you are using Kibana, refer to the documentation for configuring SAML single-sign-on on the Elastic Stack.\n\nThis API returns a URL pointing to the SAML Identity Provider.\nYou can use the URL to redirect the browser of the user in order to continue the authentication process.\nThe URL includes a single parameter named `SAMLRequest`, which contains a SAML Authentication request that is deflated and Base64 encoded.\nIf the configuration dictates that SAML authentication requests should be signed, the URL has two extra parameters named `SigAlg` and `Signature`.\nThese parameters contain the algorithm used for the signature and the signature value itself.\nIt also returns a random string that uniquely identifies this SAML Authentication request.\nThe caller of this API needs to store this identifier as it needs to be used in a following step of the authentication process.",
+        "description": "Create a SAML authentication request (`<AuthnRequest>`) as a URL string based on the configuration of the respective SAML realm in Elasticsearch.\n\nNOTE: This API is intended for use by custom web applications other than Kibana.\nIf you are using Kibana, refer to the documentation for configuring SAML single-sign-on on the Elastic Stack.\n\nThis API returns a URL pointing to the SAML Identity Provider.\nYou can use the URL to redirect the browser of the user in order to continue the authentication process.\nThe URL includes a single parameter named `SAMLRequest`, which contains a SAML Authentication request that is deflated and Base64 encoded.\nIf the configuration dictates that SAML authentication requests should be signed, the URL has two extra parameters named `SigAlg` and `Signature`.\nThese parameters contain the algorithm used for the signature and the signature value itself.\nIt also returns a random string that uniquely identifies this SAML Authentication request.\nThe caller of thsis API needs to store this identifier as it needs to be used in a following step of the authentication process.",
         "externalDocs": {
           "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/saml-guide-stack.html"
         },
@@ -37446,7 +37443,7 @@
           "transform"
         ],
         "summary": "Get transforms",
-        "description": "Retrieves configuration information for transforms.",
+        "description": "Get configuration information for transforms.",
         "operationId": "transform-get-transform",
         "parameters": [
           {
@@ -37578,7 +37575,6 @@
           "transform"
         ],
         "summary": "Delete a transform",
-        "description": "Deletes a transform.",
         "operationId": "transform-delete-transform",
         "parameters": [
           {
@@ -37644,7 +37640,7 @@
           "transform"
         ],
         "summary": "Get transforms",
-        "description": "Retrieves configuration information for transforms.",
+        "description": "Get configuration information for transforms.",
         "operationId": "transform-get-transform-1",
         "parameters": [
           {
@@ -37674,7 +37670,7 @@
           "transform"
         ],
         "summary": "Get transform stats",
-        "description": "Retrieves usage information for transforms.",
+        "description": "Get usage information for transforms.",
         "operationId": "transform-get-transform-stats",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -11280,13 +11280,13 @@
           "indices"
         ],
         "summary": "Add an index block",
-        "description": "Limits the operations allowed on an index by blocking specific operation types.",
+        "description": "Add an index block to an index.\nIndex blocks limit the operations allowed on an index by blocking specific operation types.",
         "operationId": "indices-add-block",
         "parameters": [
           {
             "in": "path",
             "name": "index",
-            "description": "A comma separated list of indices to add a block to",
+            "description": "A comma-separated list or wildcard expression of index names used to limit the request.\nBy default, you must explicitly name the indices you are adding blocks to.\nTo allow the adding of blocks to indices with `_all`, `*`, or other wildcard expressions, change the `action.destructive_requires_name` setting to `false`.\nYou can update this setting in the `elasticsearch.yml` file or by using the cluster update settings API.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -11297,7 +11297,7 @@
           {
             "in": "path",
             "name": "block",
-            "description": "The block to add (one of read, write, read_only or metadata)",
+            "description": "The block type to add to the index.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -11308,7 +11308,7 @@
           {
             "in": "query",
             "name": "allow_no_indices",
-            "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
+            "description": "If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.\nThis behavior applies even if the request targets other open indices.\nFor example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -11318,7 +11318,7 @@
           {
             "in": "query",
             "name": "expand_wildcards",
-            "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
+            "description": "The type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nIt supports comma-separated values, such as `open,hidden`.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -11328,7 +11328,7 @@
           {
             "in": "query",
             "name": "ignore_unavailable",
-            "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
+            "description": "If `false`, the request returns an error if it targets a missing or closed index.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -11338,7 +11338,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Specify timeout for connection to master",
+            "description": "The period to wait for the master node.\nIf the master node is not available before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -11348,7 +11348,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Explicit operation timeout",
+            "description": "The period to wait for a response from all relevant nodes in the cluster after updating the cluster metadata.\nIf no response is received before the timeout expires, the cluster metadata update still applies but the response will indicate that it was not completely acknowledged.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -12209,7 +12209,7 @@
           "data stream"
         ],
         "summary": "Create a data stream",
-        "description": "Creates a data stream.\nYou must have a matching index template with data stream enabled.",
+        "description": "You must have a matching index template with data stream enabled.",
         "operationId": "indices-create-data-stream",
         "parameters": [
           {
@@ -12371,7 +12371,7 @@
           "data stream"
         ],
         "summary": "Get data stream stats",
-        "description": "Retrieves statistics for one or more data streams.",
+        "description": "Get statistics for one or more data streams.",
         "operationId": "indices-data-streams-stats",
         "parameters": [
           {
@@ -12392,7 +12392,7 @@
           "data stream"
         ],
         "summary": "Get data stream stats",
-        "description": "Retrieves statistics for one or more data streams.",
+        "description": "Get statistics for one or more data streams.",
         "operationId": "indices-data-streams-stats-1",
         "parameters": [
           {
@@ -12536,7 +12536,7 @@
           "indices"
         ],
         "summary": "Check aliases",
-        "description": "Checks if one or more data stream or index aliases exist.",
+        "description": "Check if one or more data stream or index aliases exist.",
         "operationId": "indices-exists-alias-1",
         "parameters": [
           {
@@ -13454,7 +13454,7 @@
           "indices"
         ],
         "summary": "Check aliases",
-        "description": "Checks if one or more data stream or index aliases exist.",
+        "description": "Check if one or more data stream or index aliases exist.",
         "operationId": "indices-exists-alias",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -6568,7 +6568,7 @@
           "data stream"
         ],
         "summary": "Get data streams",
-        "description": "Retrieves information about one or more data streams.",
+        "description": "Get information about one or more data streams.",
         "operationId": "indices-get-data-stream-1",
         "parameters": [
           {
@@ -7331,7 +7331,7 @@
           "data stream"
         ],
         "summary": "Get data stream lifecycles",
-        "description": "Retrieves the data stream lifecycle configuration of one or more data streams.",
+        "description": "Get the data stream lifecycle configuration of one or more data streams.",
         "operationId": "indices-get-data-lifecycle",
         "parameters": [
           {
@@ -7482,7 +7482,7 @@
           "data stream"
         ],
         "summary": "Get data streams",
-        "description": "Retrieves information about one or more data streams.",
+        "description": "Get information about one or more data streams.",
         "operationId": "indices-get-data-stream",
         "parameters": [
           {
@@ -8782,6 +8782,7 @@
           "inference"
         ],
         "summary": "Perform inference on the service",
+        "description": "This API enables you to use machine learning models to perform specific tasks on data that you provide as an input.\nIt returns a response with the results of the tasks.\nThe inference endpoint you use can perform one specific task that has been defined when the endpoint was created with the create inference API.\n\n> info\n> The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face. For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.",
         "operationId": "inference-inference",
         "parameters": [
           {
@@ -8878,6 +8879,7 @@
           "inference"
         ],
         "summary": "Perform inference on the service",
+        "description": "This API enables you to use machine learning models to perform specific tasks on data that you provide as an input.\nIt returns a response with the results of the tasks.\nThe inference endpoint you use can perform one specific task that has been defined when the endpoint was created with the create inference API.\n\n> info\n> The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face. For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.",
         "operationId": "inference-inference-1",
         "parameters": [
           {
@@ -9422,7 +9424,7 @@
           "license"
         ],
         "summary": "Get license information",
-        "description": "Get information about your Elastic license including its type, its status, when it was issued, and when it expires.\n\nNOTE: If the master node is generating a new cluster state, the get license API may return a `404 Not Found` response.\nIf you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.",
+        "description": "Get information about your Elastic license including its type, its status, when it was issued, and when it expires.\n\n>info\n> If the master node is generating a new cluster state, the get license API may return a `404 Not Found` response.\n> If you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.",
         "operationId": "license-get",
         "parameters": [
           {
@@ -16499,7 +16501,7 @@
           {
             "in": "path",
             "name": "name",
-            "description": "The name of the search application to delete",
+            "description": "The name of the search application to delete.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -60904,7 +60906,7 @@
       "inference.delete#inference_id": {
         "in": "path",
         "name": "inference_id",
-        "description": "The inference Id",
+        "description": "The inference identifier.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -60915,7 +60917,7 @@
       "inference.delete#dry_run": {
         "in": "query",
         "name": "dry_run",
-        "description": "When true, the endpoint is not deleted, and a list of ingest processors which reference this endpoint is returned",
+        "description": "When true, the endpoint is not deleted and a list of ingest processors which reference this endpoint is returned.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -60925,7 +60927,7 @@
       "inference.delete#force": {
         "in": "query",
         "name": "force",
-        "description": "When true, the inference endpoint is forcefully deleted even if it is still being used by ingest processors or semantic text fields",
+        "description": "When true, the inference endpoint is forcefully deleted even if it is still being used by ingest processors or semantic text fields.",
         "deprecated": false,
         "schema": {
           "type": "boolean"
@@ -60957,7 +60959,7 @@
       "inference.inference#task_type": {
         "in": "path",
         "name": "task_type",
-        "description": "The task type",
+        "description": "The type of inference task that the model performs.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -60968,7 +60970,7 @@
       "inference.inference#inference_id": {
         "in": "path",
         "name": "inference_id",
-        "description": "The inference Id",
+        "description": "The unique identifier for the inference endpoint.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -60979,7 +60981,7 @@
       "inference.inference#timeout": {
         "in": "query",
         "name": "timeout",
-        "description": "Specifies the amount of time to wait for the inference request to complete.",
+        "description": "The amount of time to wait for the inference request to complete.",
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
@@ -61074,7 +61076,7 @@
       "ingest.simulate#id": {
         "in": "path",
         "name": "id",
-        "description": "Pipeline to test.\nIf you don’t specify a `pipeline` in the request body, this parameter is required.",
+        "description": "The pipeline to test.\nIf you don't specify a `pipeline` in the request body, this parameter is required.",
         "required": true,
         "deprecated": false,
         "schema": {
@@ -64076,11 +64078,11 @@
               "type": "object",
               "properties": {
                 "query": {
-                  "description": "Query input, required for rerank task.\nNot required for other tasks.",
+                  "description": "The query input, which is required only for the `rerank` task.\nIt is not required for other tasks.",
                   "type": "string"
                 },
                 "input": {
-                  "description": "Inference input.\nEither a string or an array of strings.",
+                  "description": "The text on which you want to perform the inference task.\nIt can be a single string or an array.\n\n> info\n> Inference endpoints for the `completion` task type currently only support a single string as input.",
                   "oneOf": [
                     {
                       "type": "string"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -12482,7 +12482,7 @@
           "ml data frame"
         ],
         "summary": "Preview features used by data frame analytics",
-        "description": "Previews the extracted features used by a data frame analytics config.",
+        "description": "Preview the extracted features used by a data frame analytics config.",
         "operationId": "ml-preview-data-frame-analytics",
         "requestBody": {
           "$ref": "#/components/requestBodies/ml.preview_data_frame_analytics"
@@ -12499,7 +12499,7 @@
           "ml data frame"
         ],
         "summary": "Preview features used by data frame analytics",
-        "description": "Previews the extracted features used by a data frame analytics config.",
+        "description": "Preview the extracted features used by a data frame analytics config.",
         "operationId": "ml-preview-data-frame-analytics-1",
         "requestBody": {
           "$ref": "#/components/requestBodies/ml.preview_data_frame_analytics"
@@ -12518,7 +12518,7 @@
           "ml data frame"
         ],
         "summary": "Preview features used by data frame analytics",
-        "description": "Previews the extracted features used by a data frame analytics config.",
+        "description": "Preview the extracted features used by a data frame analytics config.",
         "operationId": "ml-preview-data-frame-analytics-2",
         "parameters": [
           {
@@ -12540,7 +12540,7 @@
           "ml data frame"
         ],
         "summary": "Preview features used by data frame analytics",
-        "description": "Previews the extracted features used by a data frame analytics config.",
+        "description": "Preview the extracted features used by a data frame analytics config.",
         "operationId": "ml-preview-data-frame-analytics-3",
         "parameters": [
           {
@@ -18996,7 +18996,7 @@
           "transform"
         ],
         "summary": "Get transforms",
-        "description": "Retrieves configuration information for transforms.",
+        "description": "Get configuration information for transforms.",
         "operationId": "transform-get-transform",
         "parameters": [
           {
@@ -19128,7 +19128,6 @@
           "transform"
         ],
         "summary": "Delete a transform",
-        "description": "Deletes a transform.",
         "operationId": "transform-delete-transform",
         "parameters": [
           {
@@ -19194,7 +19193,7 @@
           "transform"
         ],
         "summary": "Get transforms",
-        "description": "Retrieves configuration information for transforms.",
+        "description": "Get configuration information for transforms.",
         "operationId": "transform-get-transform-1",
         "parameters": [
           {
@@ -19224,7 +19223,7 @@
           "transform"
         ],
         "summary": "Get transform stats",
-        "description": "Retrieves usage information for transforms.",
+        "description": "Get usage information for transforms.",
         "operationId": "transform-get-transform-stats",
         "parameters": [
           {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -5969,13 +5969,13 @@
           "indices"
         ],
         "summary": "Add an index block",
-        "description": "Limits the operations allowed on an index by blocking specific operation types.",
+        "description": "Add an index block to an index.\nIndex blocks limit the operations allowed on an index by blocking specific operation types.",
         "operationId": "indices-add-block",
         "parameters": [
           {
             "in": "path",
             "name": "index",
-            "description": "A comma separated list of indices to add a block to",
+            "description": "A comma-separated list or wildcard expression of index names used to limit the request.\nBy default, you must explicitly name the indices you are adding blocks to.\nTo allow the adding of blocks to indices with `_all`, `*`, or other wildcard expressions, change the `action.destructive_requires_name` setting to `false`.\nYou can update this setting in the `elasticsearch.yml` file or by using the cluster update settings API.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -5986,7 +5986,7 @@
           {
             "in": "path",
             "name": "block",
-            "description": "The block to add (one of read, write, read_only or metadata)",
+            "description": "The block type to add to the index.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -5997,7 +5997,7 @@
           {
             "in": "query",
             "name": "allow_no_indices",
-            "description": "Whether to ignore if a wildcard indices expression resolves into no concrete indices. (This includes `_all` string or when no indices have been specified)",
+            "description": "If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.\nThis behavior applies even if the request targets other open indices.\nFor example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -6007,7 +6007,7 @@
           {
             "in": "query",
             "name": "expand_wildcards",
-            "description": "Whether to expand wildcard expression to concrete indices that are open, closed or both.",
+            "description": "The type of index that wildcard patterns can match.\nIf the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.\nIt supports comma-separated values, such as `open,hidden`.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:ExpandWildcards"
@@ -6017,7 +6017,7 @@
           {
             "in": "query",
             "name": "ignore_unavailable",
-            "description": "Whether specified concrete indices should be ignored when unavailable (missing or closed)",
+            "description": "If `false`, the request returns an error if it targets a missing or closed index.",
             "deprecated": false,
             "schema": {
               "type": "boolean"
@@ -6027,7 +6027,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Specify timeout for connection to master",
+            "description": "The period to wait for the master node.\nIf the master node is not available before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -6037,7 +6037,7 @@
           {
             "in": "query",
             "name": "timeout",
-            "description": "Explicit operation timeout",
+            "description": "The period to wait for a response from all relevant nodes in the cluster after updating the cluster metadata.\nIf no response is received before the timeout expires, the cluster metadata update still applies but the response will indicate that it was not completely acknowledged.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -6599,7 +6599,7 @@
           "data stream"
         ],
         "summary": "Create a data stream",
-        "description": "Creates a data stream.\nYou must have a matching index template with data stream enabled.",
+        "description": "You must have a matching index template with data stream enabled.",
         "operationId": "indices-create-data-stream",
         "parameters": [
           {
@@ -6829,7 +6829,7 @@
           "indices"
         ],
         "summary": "Check aliases",
-        "description": "Checks if one or more data stream or index aliases exist.",
+        "description": "Check if one or more data stream or index aliases exist.",
         "operationId": "indices-exists-alias-1",
         "parameters": [
           {
@@ -7171,7 +7171,7 @@
           "indices"
         ],
         "summary": "Check aliases",
-        "description": "Checks if one or more data stream or index aliases exist.",
+        "description": "Check if one or more data stream or index aliases exist.",
         "operationId": "indices-exists-alias",
         "parameters": [
           {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -664,6 +664,8 @@ search-templates,https://www.elastic.co/guide/en/elasticsearch/reference/{branch
 secure-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/secure-settings.html
 security-api-activate-user-profile,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-activate-user-profile.html
 security-api-authenticate,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-authenticate.html
+security-api-bulk-delete-role,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-bulk-delete-role.html
+security-api-bulk-put-role,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-bulk-put-role.html
 security-api-bulk-update-key,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-bulk-update-api-keys.html
 security-api-change-password,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-change-password.html
 security-api-clear-api-key-cache,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/security-api-clear-api-key-cache.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -303,6 +303,7 @@ infer-trained-model-deployment,https://www.elastic.co/guide/en/elasticsearch/ref
 inference-api-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-inference-api.html
 inference-api-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-inference-api.html
 inference-api-post,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/post-inference-api.html
+inference-api-put,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-inference-api.html
 inference-api-stream,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/stream-inference-api.html
 inference-api-update,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-inference-api.html
 inference-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/inference-processor.html
@@ -311,6 +312,9 @@ ingest,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ingest.h
 ingest-circle-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ingest-circle-processor.html
 ingest-node-set-security-user-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{banch}/ingest-node-set-security-user-processor.html
 inner-hits,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/inner-hits.html
+ip-location-delete-database,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-ip-location-database-api.html
+ip-location-get-database,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-ip-location-database-api.html
+ip-location-put-database,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-ip-location-database-api.html
 join-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/join-processor.html
 json-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/json-processor.html
 k-precision,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#k-precision
@@ -638,6 +642,10 @@ search-aggregations-metrics-valuecount-aggregation,https://www.elastic.co/guide/
 search-aggregations-metrics-weight-avg-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-metrics-weight-avg-aggregation.html
 search-aggregations-bucket-variablewidthhistogram-aggregation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-bucket-variablewidthhistogram-aggregation.html
 search-analyzer,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-analyzer.html
+search-application-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-search-application.html
+search-application-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-search-application.html
+search-application-put,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-search-application.html
+search-application-search,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-application-search.html
 search-render-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-application-render-query.html
 search-count,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-count.html
 search-explain,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-explain.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -133,6 +133,9 @@ dangling-indices-list,https://www.elastic.co/guide/en/elasticsearch/reference/{b
 data-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/date-processor.html
 data-stream-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-delete-data-stream.html
 data-stream-delete-lifecycle,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams-delete-lifecycle.html
+data-stream-explain-lifecycle,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams-explain-lifecycle.html
+data-stream-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-get-data-stream.html
+data-stream-get-lifecycle,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams-get-lifecycle.html
 data-stream-lifecycle-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams-get-lifecycle-stats.html
 data-stream-path-param,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-create-data-stream.html#indices-create-data-stream-api-path-params
 data-stream-stats-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-stream-stats-api.html
@@ -297,6 +300,9 @@ indices-templates,https://www.elastic.co/guide/en/elasticsearch/reference/{branc
 indices-update-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-update-settings.html
 infer-trained-model,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/infer-trained-model.html
 infer-trained-model-deployment,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/infer-trained-model-deployment.html
+inference-api-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-inference-api.html
+inference-api-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-inference-api.html
+inference-api-post,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/post-inference-api.html
 inference-api-stream,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/stream-inference-api.html
 inference-api-update,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-inference-api.html
 inference-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/inference-processor.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -131,8 +131,11 @@ dangling-index-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{b
 dangling-index-import,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/dangling-index-import.html
 dangling-indices-list,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/dangling-indices-list.html
 data-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/date-processor.html
+data-stream-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-delete-data-stream.html
+data-stream-delete-lifecycle,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams-delete-lifecycle.html
 data-stream-lifecycle-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams-get-lifecycle-stats.html
 data-stream-path-param,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-create-data-stream.html#indices-create-data-stream-api-path-params
+data-stream-stats-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-stream-stats-api.html
 data-streams,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams.html
 date-index-name-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/date-index-name-processor.html
 dcg,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#_discounted_cumulative_gain_dcg
@@ -240,6 +243,7 @@ ilm-retry-policy,https://www.elastic.co/guide/en/elasticsearch/reference/{branch
 ilm-start,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ilm-start.html
 ilm-stop,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ilm-stop.html
 important-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/important-settings.html
+index-block-add,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-modules-blocks.html#add-index-block
 index-modules-blocks,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-modules-blocks.html
 index-modules-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-modules.html#index-modules-settings
 index-modules-slowlog-slowlog,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-modules-slowlog.html#index-slow-log

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -175,6 +175,7 @@ drop-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/
 enrich-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/enrich-processor.html
 enrich-stats-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/enrich-stats-api.html
 eql-async-search-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-async-eql-search-api.html
+eql-async-search-delete,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-eql-delete
 eql-async-search-status-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-async-eql-status-api.html
 eql-basic-syntax,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/eql-syntax.html#eql-basic-syntax
 eql-search-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/eql-search-api.html
@@ -208,6 +209,9 @@ fuzziness,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/commo
 gap-policy,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-pipeline.html#gap-policy
 geo-shape,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/geo-shape.html
 geo-grid-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ingest-geo-grid-processor.html
+geoip-delete-database,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-delete-geoip-database
+geoip-get-database,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-get-geoip-database
+geoip-put-database,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ingest-put-geoip-database
 geoip-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/geoip-processor.html
 geoip-stats-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/geoip-stats-api.html
 get-basic-status,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-basic-status.html
@@ -255,8 +259,10 @@ index,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index.htm
 indexing-buffer,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indexing-buffer.html
 index-modules-merge,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-modules-merge.html
 index-templates,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-templates.html
+index-templates-exist,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists-index-template
 index-templates-v1,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-templates-v1.html
 indices-aliases,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-aliases.html
+indices-aliases-exist,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists-alias
 indices-analyze,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-analyze.html
 indices-clearcache,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-clearcache.html
 indices-clone-index,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-clone-index.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -1,3 +1,4 @@
+apis,https://www.elastic.co/docs/api/doc/elasticsearch
 add-nodes,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/add-elasticsearch-nodes.html
 analysis-analyzers,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/analysis-analyzers.html
 analysis-charfilters,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/analysis-charfilters.html
@@ -45,6 +46,7 @@ cat-repositories,https://www.elastic.co/guide/en/elasticsearch/reference/{branch
 cat-segments,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-segments.html
 cat-shards,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-shards.html
 cat-snapshots,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-snapshots.html
+cat-tasks,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-tasks.html
 cat-templates,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-templates.html
 cat-thread-pool,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-thread-pool.html
 cat-trained-model,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-trained-model.html
@@ -70,6 +72,7 @@ ccs-privileges,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/
 clean-up-snapshot-repo,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/snapshots-register-repository.html#snapshots-repository-cleanup
 clear-repositories-metering-archive-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/clear-repositories-metering-archive-api.html
 clear-scroll-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/clear-scroll-api.html
+clear-trained-model,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/clear-trained-model-deployment-cache.html
 cluster-allocation-explain,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-allocation-explain.html
 cluster-get-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-get-settings.html
 cluster-health,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-health.html
@@ -77,10 +80,12 @@ cluster-info,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cl
 cluster-name,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/important-settings.html#cluster-name
 cluster-nodes-hot-threads,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-nodes-hot-threads.html
 cluster-nodes-info,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-nodes-info.html
+cluster-nodes-reload-secure-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-nodes-reload-secure-settings.html
 cluster-nodes-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-nodes-stats.html
 cluster-nodes-usage,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-nodes-usage.html
 cluster-nodes,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster.html#cluster-nodes
 cluster-pending,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-pending.html
+cluster-ping,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster.html
 cluster-remote-info,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-remote-info.html
 cluster-reroute,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-reroute.html
 cluster-state,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cluster-state.html
@@ -132,9 +137,13 @@ data-streams,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/da
 date-index-name-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/date-index-name-processor.html
 dcg,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#_discounted_cumulative_gain_dcg
 defining-roles,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/defining-roles.html
+delete-analytics-collection,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-analytics-collection.html
+delete-async-sql-search-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-async-sql-search-api.html
 delete-enrich-policy-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-enrich-policy-api.html
 delete-license,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-license.html
 delete-pipeline-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-pipeline-api.html
+delete-synonym-rule,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-synonym-rule.html
+delete-synonyms-set,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-synonyms-set.html
 delete-trained-models-aliases,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-trained-models-aliases.html
 delete-trained-models,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-trained-models.html
 delete-transform,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-transform.html
@@ -179,6 +188,7 @@ execute-enrich-policy-api,https://www.elastic.co/guide/en/elasticsearch/referenc
 expected-reciprocal,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#_expected_reciprocal_rank_err
 explain-dfanalytics,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/explain-dfanalytics.html
 fail-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/fail-processor.html
+features-reset,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/reset-features-api.html
 field-and-document-access-control,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/field-and-document-access-control.html
 field-usage-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/field-usage-stats.html
 find-field-structure,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/find-field-structure.html
@@ -202,6 +212,8 @@ get-license,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get
 get-ml-info,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-ml-info.html
 get-pipeline-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-pipeline-api.html
 get-repositories-metering-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-repositories-metering-api.html
+get-synonym-rule,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-synonym-rule.html
+get-synonyms-set,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-synonyms-set.html
 get-trained-models-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-trained-models-stats.html
 get-trained-models,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-trained-models.html
 get-transform-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-transform-stats.html
@@ -212,6 +224,7 @@ graph-explore-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branc
 grok,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/grok.html
 grok-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/grok-processor.html
 gsub-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/gsub-processor.html
+health-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/health-api.html
 ilm-delete-lifecycle,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ilm-delete-lifecycle.html
 ilm-explain-lifecycle,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ilm-explain-lifecycle.html
 ilm-get-lifecycle,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ilm-get-lifecycle.html
@@ -276,6 +289,7 @@ indices-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/i
 indices-template-exists-v1,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-template-exists-v1.html
 indices-templates,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-templates.html
 indices-update-settings,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-update-settings.html
+infer-trained-model,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/infer-trained-model.html
 infer-trained-model-deployment,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/infer-trained-model-deployment.html
 inference-api-stream,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/stream-inference-api.html
 inference-api-update,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-inference-api.html
@@ -293,6 +307,8 @@ kv-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/kv
 knn-approximate,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/knn-search.html#approximate-knn
 knn-inner-hits,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/knn-search.html#nested-knn-search-inner-hits
 license-management,https://www.elastic.co/guide/en/kibana/{branch}/managing-licenses.html
+list-analytics-collection,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/list-analytics-collection.html
+list-synonyms-sets,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/list-synonyms-sets.html
 logstash-api-delete-pipeline,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/logstash-api-delete-pipeline.html
 logstash-api-get-pipeline,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/logstash-api-get-pipeline.html
 logstash-api-put-pipeline,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/logstash-api-put-pipeline.html
@@ -328,6 +344,7 @@ ml-delete-filter,https://www.elastic.co/guide/en/elasticsearch/reference/{branch
 ml-delete-forecast,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-delete-forecast.html
 ml-delete-job,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-delete-job.html
 ml-delete-snapshot,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-delete-snapshot.html
+ml-estimate-memory,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-estimate-model-memory.html
 ml-feature-importance,https://www.elastic.co/guide/en/machine-learning/{branch}/ml-feature-importance.html
 ml-flush-job,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-flush-job.html
 ml-forecast,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-forecast.html
@@ -343,6 +360,7 @@ ml-get-influencer,https://www.elastic.co/guide/en/elasticsearch/reference/{branc
 ml-get-job-model-snapshot-upgrade-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-get-job-model-snapshot-upgrade-stats.html
 ml-get-job-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-get-job-stats.html
 ml-get-job,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-get-job.html
+ml-get-memory,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-ml-memory.html
 ml-get-overall-buckets,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-get-overall-buckets.html
 ml-get-record,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-get-record.html
 ml-get-snapshot,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/ml-get-snapshot.html
@@ -393,11 +411,15 @@ painless-execute-api,https://www.elastic.co/guide/en/elasticsearch/painless/{bra
 pipeline-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/pipeline-processor.html
 pki-realm,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/pki-realm.html
 point-in-time-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/point-in-time-api.html
+prevalidate-node-removal,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/prevalidate-node-removal-api.html
 preview-dfanalytics,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/preview-dfanalytics.html
 preview-transform,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/preview-transform.html
+put-analytics-collection,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-analytics-collection.html
 put-dfanalytics,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-dfanalytics.html
 put-enrich-policy-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-enrich-policy-api.html
 put-pipeline-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-pipeline-api.html
+put-synonym-rule,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-synonym-rule.html
+put-synonyms-set,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-synonyms-set.html
 put-trained-model-definition-part,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-trained-model-definition-part.html
 put-trained-model-vocabulary,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-trained-model-vocabulary.html
 put-trained-models-aliases,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/put-trained-models-aliases.html
@@ -512,8 +534,10 @@ rollup-stop-job,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 routing,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/docs-get.html#get-routing
 run-as-privilege,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/run-as-privilege.html
 runtime-search-request,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/runtime-search-request.html
+schedule-now-transform,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/schedule-now-transform.html
 script-contexts,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-script-contexts-api.html
 script-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/delete-stored-script-api.html
+script-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-stored-script-api.html
 script-languages,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-script-languages-api.html
 script-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/script-processor.html
 script-put,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/create-stored-script-api.html
@@ -609,7 +633,6 @@ search-field-caps,https://www.elastic.co/guide/en/elasticsearch/reference/{branc
 search-knn,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/knn-search-api.html
 search-multi-search,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-multi-search.html
 search-multi-search-template,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/multi-search-template.html
-search-rank-eval,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html
 search-rank-eval,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html
 search-request-body,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-request-body.html
 search-search,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-search.html
@@ -765,11 +788,14 @@ supported-flags,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 tasks,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/tasks.html
 templating-role-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/field-and-document-access-control.html#templating-role-query
 terminate-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/terminate-processor.html
+test-grok-pattern,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/test-grok-pattern.html
 time-value,https://github.com/elastic/elasticsearch/blob/{branch}/libs/core/src/main/java/org/elasticsearch/core/TimeValue.java
 time-zone-id,https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html
 trim-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/trim-processor.html
 update-dfanalytics,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-dfanalytics.html
+update-desired-nodes,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-desired-nodes.html
 update-license,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-license.html
+update-trained-model-deployment,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-trained-model-deployment.html
 update-transform,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/update-transform.html
 upgrade-transforms,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/upgrade-transforms.html
 uppercase-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/uppercase-processor.html

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -195,6 +195,8 @@ find-field-structure,https://www.elastic.co/guide/en/elasticsearch/reference/{br
 find-message-structure,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/find-message-structure.html
 find-structure,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/find-structure.html
 fingerprint-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/fingerprint-processor.html
+fleet-multi-search,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/fleet-multi-search.html
+fleet-search,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/fleet-search.html
 foreach-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/foreach-processor.html
 fuzziness,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/common-options.html#fuzziness
 gap-policy,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-pipeline.html#gap-policy

--- a/specification/_global/get_script/GetScriptRequest.ts
+++ b/specification/_global/get_script/GetScriptRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage
  * @doc_tag script
+ * @doc_id script-get
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/_global/health_report/Request.ts
+++ b/specification/_global/health_report/Request.ts
@@ -43,6 +43,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name health_report
  * @availability stack since=8.7.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @doc_id health-api
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/_global/msearch/MultiSearchRequest.ts
+++ b/specification/_global/msearch/MultiSearchRequest.ts
@@ -45,6 +45,7 @@ import { RequestItem } from './types'
  * @availability serverless stability=stable visibility=public
  * @index_privileges read
  * @doc_tag search
+ * @doc_id search-multi-search
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/_global/ping/PingRequest.ts
+++ b/specification/_global/ping/PingRequest.ts
@@ -26,6 +26,7 @@ import { RequestBase } from '@_types/Base'
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag cluster
+ * @doc_id cluster-ping
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/_global/rank_eval/RankEvalRequest.ts
+++ b/specification/_global/rank_eval/RankEvalRequest.ts
@@ -30,6 +30,7 @@ import { RankEvalMetric, RankEvalRequestItem } from './types'
  * @availability serverless stability=stable visibility=public
  * @index_privileges read
  * @doc_tag search
+ * @doc_id search-rank-eval
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/cat/tasks/CatTasksRequest.ts
+++ b/specification/cat/tasks/CatTasksRequest.ts
@@ -28,7 +28,7 @@ import { Duration, TimeUnit } from '@_types/Time'
  * @rest_spec_name cat.tasks
  * @availability stack since=5.0.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
- * @doc_id tasks
+ * @doc_id cat-tasks
  * @cluster_privileges monitor
  */
 export interface Request extends CatRequestBase {

--- a/specification/enrich/delete_policy/DeleteEnrichPolicyRequest.ts
+++ b/specification/enrich/delete_policy/DeleteEnrichPolicyRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name enrich.delete_policy
  * @availability stack since=7.5.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id delete-enrich-policy-api
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/enrich/get_policy/GetEnrichPolicyRequest.ts
+++ b/specification/enrich/get_policy/GetEnrichPolicyRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name enrich.get_policy
  * @availability stack since=7.5.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id get-enrich-policy-api
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/enrich/stats/EnrichStatsRequest.ts
+++ b/specification/enrich/stats/EnrichStatsRequest.ts
@@ -26,6 +26,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name enrich.stats
  * @availability stack since=7.5.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @doc_id enrich-stats-api
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/eql/delete/EqlDeleteRequest.ts
+++ b/specification/eql/delete/EqlDeleteRequest.ts
@@ -27,7 +27,7 @@ import { Id } from '@_types/common'
  * @rest_spec_name eql.delete
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
- * @doc_id apis
+ * @doc_id eql-async-search-delete
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/eql/delete/EqlDeleteRequest.ts
+++ b/specification/eql/delete/EqlDeleteRequest.ts
@@ -27,6 +27,7 @@ import { Id } from '@_types/common'
  * @rest_spec_name eql.delete
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/eql/search/EqlSearchRequest.ts
+++ b/specification/eql/search/EqlSearchRequest.ts
@@ -32,6 +32,7 @@ import { ResultPosition } from './types'
  * @rest_spec_name eql.search
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id eql-search-api
  * @ext_doc_id eql
  */
 export interface Request extends RequestBase {

--- a/specification/features/get_features/GetFeaturesRequest.ts
+++ b/specification/features/get_features/GetFeaturesRequest.ts
@@ -34,6 +34,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name features.get_features
  * @availability stack since=7.12.0 stability=stable
  * @doc_id get-features-api
+ * @ext_doc_id snapshot-create
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/features/get_features/GetFeaturesRequest.ts
+++ b/specification/features/get_features/GetFeaturesRequest.ts
@@ -33,7 +33,7 @@ import { Duration } from '@_types/Time'
  * In order for a feature state to be listed in this API and recognized as a valid feature state by the create snapshot API, the plugin that defines that feature must be installed on the master node.
  * @rest_spec_name features.get_features
  * @availability stack since=7.12.0 stability=stable
- * @ext_doc_id snapshot-create
+ * @doc_id get-features-api
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/features/reset_features/ResetFeaturesRequest.ts
+++ b/specification/features/reset_features/ResetFeaturesRequest.ts
@@ -41,6 +41,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name features.reset_features
  * @availability stack since=7.12.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
+ * @doc_id features-reset
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/fleet/global_checkpoints/GlobalCheckpointsRequest.ts
+++ b/specification/fleet/global_checkpoints/GlobalCheckpointsRequest.ts
@@ -24,11 +24,13 @@ import { Checkpoint } from '../_types/Checkpoints'
 
 /**
  * Get global checkpoints.
+ *
  * Get the current global checkpoints for an index.
  * This API is designed for internal use by the Fleet server project.
  * @rest_spec_name fleet.global_checkpoints
  * @availability stack since=7.13.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @doc_id get-global-checkpoints
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/fleet/msearch/MultiSearchRequest.ts
+++ b/specification/fleet/msearch/MultiSearchRequest.ts
@@ -37,6 +37,7 @@ import { Checkpoint } from '../_types/Checkpoints'
  * @availability stack since=7.16.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
  * @index_privileges read
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/fleet/msearch/MultiSearchRequest.ts
+++ b/specification/fleet/msearch/MultiSearchRequest.ts
@@ -37,7 +37,7 @@ import { Checkpoint } from '../_types/Checkpoints'
  * @availability stack since=7.16.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
  * @index_privileges read
- * @doc_id apis
+ * @doc_id fleet-multi-search
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/fleet/search/SearchRequest.ts
+++ b/specification/fleet/search/SearchRequest.ts
@@ -59,6 +59,7 @@ import { Checkpoint } from '../_types/Checkpoints'
  * @availability stack since=7.16.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
  * @index_privileges read
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/fleet/search/SearchRequest.ts
+++ b/specification/fleet/search/SearchRequest.ts
@@ -59,7 +59,7 @@ import { Checkpoint } from '../_types/Checkpoints'
  * @availability stack since=7.16.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
  * @index_privileges read
- * @doc_id apis
+ * @doc_id fleet-search
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/delete_lifecycle/DeleteLifecycleRequest.ts
+++ b/specification/ilm/delete_lifecycle/DeleteLifecycleRequest.ts
@@ -27,7 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ilm.delete_lifecycle
  * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm
- * @doc_id apis
+ * @doc_id ilm-delete-lifecycle
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/delete_lifecycle/DeleteLifecycleRequest.ts
+++ b/specification/ilm/delete_lifecycle/DeleteLifecycleRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ilm.delete_lifecycle
  * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/explain_lifecycle/ExplainLifecycleRequest.ts
+++ b/specification/ilm/explain_lifecycle/ExplainLifecycleRequest.ts
@@ -30,7 +30,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ilm.explain_lifecycle
  * @availability stack since=6.6.0 stability=stable
  * @index_privileges view_index_metadata,manage_ilm
- * @doc_id apis
+ * @doc_id ilm-explain-lifecycle
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/explain_lifecycle/ExplainLifecycleRequest.ts
+++ b/specification/ilm/explain_lifecycle/ExplainLifecycleRequest.ts
@@ -30,6 +30,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ilm.explain_lifecycle
  * @availability stack since=6.6.0 stability=stable
  * @index_privileges view_index_metadata,manage_ilm
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/get_lifecycle/GetLifecycleRequest.ts
+++ b/specification/ilm/get_lifecycle/GetLifecycleRequest.ts
@@ -26,7 +26,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ilm.get_lifecycle
  * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm, read_ilm
- * @doc_id apis
+ * @doc_id ilm-get-lifecycle
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/get_lifecycle/GetLifecycleRequest.ts
+++ b/specification/ilm/get_lifecycle/GetLifecycleRequest.ts
@@ -26,6 +26,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ilm.get_lifecycle
  * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm, read_ilm
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/get_status/GetIlmStatusRequest.ts
+++ b/specification/ilm/get_status/GetIlmStatusRequest.ts
@@ -25,6 +25,7 @@ import { RequestBase } from '@_types/Base'
  * @rest_spec_name ilm.get_status
  * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges read_ilm
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/get_status/GetIlmStatusRequest.ts
+++ b/specification/ilm/get_status/GetIlmStatusRequest.ts
@@ -21,11 +21,12 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Get the ILM status.
+ *
  * Get the current index lifecycle management status.
  * @rest_spec_name ilm.get_status
  * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges read_ilm
- * @doc_id apis
+ * @doc_id ilm-get-status
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/migrate_to_data_tiers/Request.ts
+++ b/specification/ilm/migrate_to_data_tiers/Request.ts
@@ -36,7 +36,7 @@ import { RequestBase } from '@_types/Base'
  * Use the stop ILM and get ILM status APIs to wait until the reported operation mode is `STOPPED`.
  * @rest_spec_name ilm.migrate_to_data_tiers
  * @availability stack since=7.14.0 stability=stable
- * @doc_id apis
+ * @doc_id ilm-migrate-to-data-tiers
  * @ext_doc_id migrate-index-allocation-filters
  */
 export interface Request extends RequestBase {

--- a/specification/ilm/migrate_to_data_tiers/Request.ts
+++ b/specification/ilm/migrate_to_data_tiers/Request.ts
@@ -36,6 +36,7 @@ import { RequestBase } from '@_types/Base'
  * Use the stop ILM and get ILM status APIs to wait until the reported operation mode is `STOPPED`.
  * @rest_spec_name ilm.migrate_to_data_tiers
  * @availability stack since=7.14.0 stability=stable
+ * @doc_id apis
  * @ext_doc_id migrate-index-allocation-filters
  */
 export interface Request extends RequestBase {

--- a/specification/ilm/move_to_step/MoveToStepRequest.ts
+++ b/specification/ilm/move_to_step/MoveToStepRequest.ts
@@ -39,7 +39,7 @@ import { StepKey } from './types'
  * @rest_spec_name ilm.move_to_step
  * @availability stack since=6.6.0 stability=stable
  * @index_privileges manage_ilm
- * @doc_id apis
+ * @doc_id ilm-move-to-step
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/move_to_step/MoveToStepRequest.ts
+++ b/specification/ilm/move_to_step/MoveToStepRequest.ts
@@ -39,6 +39,7 @@ import { StepKey } from './types'
  * @rest_spec_name ilm.move_to_step
  * @availability stack since=6.6.0 stability=stable
  * @index_privileges manage_ilm
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/put_lifecycle/PutLifecycleRequest.ts
+++ b/specification/ilm/put_lifecycle/PutLifecycleRequest.ts
@@ -31,6 +31,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm
  * @index_privileges manage
+ * @doc_id apis
  * @ext_doc_id ilm-index-lifecycle
  */
 export interface Request extends RequestBase {

--- a/specification/ilm/put_lifecycle/PutLifecycleRequest.ts
+++ b/specification/ilm/put_lifecycle/PutLifecycleRequest.ts
@@ -31,7 +31,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm
  * @index_privileges manage
- * @doc_id apis
+ * @doc_id ilm-put-lifecycle
  * @ext_doc_id ilm-index-lifecycle
  */
 export interface Request extends RequestBase {

--- a/specification/ilm/remove_policy/RemovePolicyRequest.ts
+++ b/specification/ilm/remove_policy/RemovePolicyRequest.ts
@@ -27,7 +27,7 @@ import { IndexName } from '@_types/common'
  * @rest_spec_name ilm.remove_policy
  * @availability stack since=6.6.0 stability=stable
  * @index_privileges manage_ilm
- * @doc_id apis
+ * @doc_id ilm-remove-policy
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/remove_policy/RemovePolicyRequest.ts
+++ b/specification/ilm/remove_policy/RemovePolicyRequest.ts
@@ -27,6 +27,7 @@ import { IndexName } from '@_types/common'
  * @rest_spec_name ilm.remove_policy
  * @availability stack since=6.6.0 stability=stable
  * @index_privileges manage_ilm
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/retry/RetryIlmRequest.ts
+++ b/specification/ilm/retry/RetryIlmRequest.ts
@@ -28,6 +28,7 @@ import { IndexName } from '@_types/common'
  * @rest_spec_name ilm.retry
  * @availability stack since=6.6.0 stability=stable
  * @index_privileges manage_ilm
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/retry/RetryIlmRequest.ts
+++ b/specification/ilm/retry/RetryIlmRequest.ts
@@ -28,7 +28,7 @@ import { IndexName } from '@_types/common'
  * @rest_spec_name ilm.retry
  * @availability stack since=6.6.0 stability=stable
  * @index_privileges manage_ilm
- * @doc_id apis
+ * @doc_id ilm-retry-policy
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/start/StartIlmRequest.ts
+++ b/specification/ilm/start/StartIlmRequest.ts
@@ -28,7 +28,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ilm.start
  * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm
- * @doc_id apis
+ * @doc_id ilm-start
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/start/StartIlmRequest.ts
+++ b/specification/ilm/start/StartIlmRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ilm.start
  * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/stop/StopIlmRequest.ts
+++ b/specification/ilm/stop/StopIlmRequest.ts
@@ -30,7 +30,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ilm.stop
  * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm
- * @doc_id apis
+ * @doc_id ilm-stop
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ilm/stop/StopIlmRequest.ts
+++ b/specification/ilm/stop/StopIlmRequest.ts
@@ -30,6 +30,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ilm.stop
  * @availability stack since=6.6.0 stability=stable
  * @cluster_privileges manage_ilm
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/add_block/IndicesAddBlockRequest.ts
+++ b/specification/indices/add_block/IndicesAddBlockRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name indices.add_block
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/add_block/IndicesAddBlockRequest.ts
+++ b/specification/indices/add_block/IndicesAddBlockRequest.ts
@@ -23,11 +23,13 @@ import { Duration } from '@_types/Time'
 
 /**
  * Add an index block.
- * Limits the operations allowed on an index by blocking specific operation types.
+ *
+ * Add an index block to an index.
+ * Index blocks limit the operations allowed on an index by blocking specific operation types.
  * @rest_spec_name indices.add_block
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
- * @doc_id apis
+ * @doc_id index-block-add
  */
 export interface Request extends RequestBase {
   urls: [
@@ -37,21 +39,62 @@ export interface Request extends RequestBase {
     }
   ]
   path_parts: {
+    /**
+     * A comma-separated list or wildcard expression of index names used to limit the request.
+     * By default, you must explicitly name the indices you are adding blocks to.
+     * To allow the adding of blocks to indices with `_all`, `*`, or other wildcard expressions, change the `action.destructive_requires_name` setting to `false`.
+     * You can update this setting in the `elasticsearch.yml` file or by using the cluster update settings API.
+     */
     index: IndexName
+    /**
+     * The block type to add to the index.
+     */
     block: IndicesBlockOptions
   }
   query_parameters: {
+    /**
+     * If `false`, the request returns an error if any wildcard expression, index alias, or `_all` value targets only missing or closed indices.
+     * This behavior applies even if the request targets other open indices.
+     * For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
+     * @server_default true
+     */
     allow_no_indices?: boolean // default: true
+    /**
+     * The type of index that wildcard patterns can match.
+     * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
+     * It supports comma-separated values, such as `open,hidden`.
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards // default: open
+    /**
+     * If `false`, the request returns an error if it targets a missing or closed index.
+     * @server_default false
+     */
     ignore_unavailable?: boolean // default: false
+    /**
+     * The period to wait for the master node.
+     * If the master node is not available before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
+     * @server_default 30s
+     */
     master_timeout?: Duration // default: 30s
+    /**
+     * The period to wait for a response from all relevant nodes in the cluster after updating the cluster metadata.
+     * If no response is received before the timeout expires, the cluster metadata update still applies but the response will indicate that it was not completely acknowledged.
+     * It can also be set to `-1` to indicate that the request should never timeout.
+     * @server_default 30s
+     */
     timeout?: Duration // default: 30s
   }
 }
 
 export enum IndicesBlockOptions {
+  /** Disable metadata changes, such as closing the index. */
   metadata,
+  /** Disable read operations. */
   read,
+  /** Disable write operations and metadata changes. */
   read_only,
+  /** Disable write operations. However, metadata changes are still allowed. */
   write
 }

--- a/specification/indices/add_block/examples/response/IndicesAddBlockResponseExample1.yaml
+++ b/specification/indices/add_block/examples/response/IndicesAddBlockResponseExample1.yaml
@@ -1,7 +1,13 @@
 # summary: ''
-description: 'A successful response for adding an index block to an index.'
+description: A successful response from `PUT /my-index-000001/_block/write`, which adds an index block to an index.'
 # type: response
 # response_code: 200
-value:
-  "{\n  \"acknowledged\" : true,\n  \"shards_acknowledged\" : true,\n  \"indices\"\
-  \ : [ {\n    \"name\" : \"my-index-000001\",\n    \"blocked\" : true\n  } ]\n}"
+value: |-
+  {
+    "acknowledged" : true,
+    "shards_acknowledged" : true,
+    "indices" : [ {
+      "name" : "my-index-000001",
+      "blocked" : true
+    } ]
+  }

--- a/specification/indices/clear_cache/IndicesClearCacheRequest.ts
+++ b/specification/indices/clear_cache/IndicesClearCacheRequest.ts
@@ -32,6 +32,7 @@ import { ExpandWildcards, Fields, Indices } from '@_types/common'
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=private
  * @index_privileges manage
+ * @doc_id indices-clearcache
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/clone/IndicesCloneRequest.ts
+++ b/specification/indices/clone/IndicesCloneRequest.ts
@@ -73,6 +73,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name indices.clone
  * @availability stack since=7.4.0 stability=stable
  * @index_privileges manage
+ * @doc_id indices-clone-index
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
+++ b/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
@@ -30,6 +30,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @index_privileges create_index
  * @doc_tag data stream
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
+++ b/specification/indices/create_data_stream/IndicesCreateDataStreamRequest.ts
@@ -23,14 +23,14 @@ import { Duration } from '@_types/Time'
 
 /**
  * Create a data stream.
- * Creates a data stream.
+ *
  * You must have a matching index template with data stream enabled.
  * @rest_spec_name indices.create_data_stream
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @index_privileges create_index
  * @doc_tag data stream
- * @doc_id apis
+ * @doc_id indices-create-data-stream
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -28,6 +28,7 @@ import { ExpandWildcards, IndexName } from '@_types/common'
  * @availability serverless stability=stable visibility=private
  * @index_privileges monitor
  * @doc_tag data stream
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -22,13 +22,14 @@ import { ExpandWildcards, IndexName } from '@_types/common'
 
 /**
  * Get data stream stats.
- * Retrieves statistics for one or more data streams.
+ *
+ * Get statistics for one or more data streams.
  * @rest_spec_name indices.data_streams_stats
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @index_privileges monitor
  * @doc_tag data stream
- * @doc_id apis
+ * @doc_id data-stream-stats-api
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
+++ b/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
@@ -27,7 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name indices.delete_data_lifecycle
  * @availability stack since=8.11.0 stability=stable
  * @availability serverless stability=stable visibility=private
- * @doc_id apis
+ * @doc_id data-stream-delete-lifecycle
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
+++ b/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name indices.delete_data_lifecycle
  * @availability stack since=8.11.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
+++ b/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @index_privileges delete_index
  * @doc_tag data stream
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
+++ b/specification/indices/delete_data_stream/IndicesDeleteDataStreamRequest.ts
@@ -29,7 +29,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @index_privileges delete_index
  * @doc_tag data stream
- * @doc_id apis
+ * @doc_id data-stream-delete
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
+++ b/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
@@ -23,7 +23,8 @@ import { Duration } from '@_types/Time'
 
 /**
  * Check aliases.
- * Checks if one or more data stream or index aliases exist.
+ *
+ * Check if one or more data stream or index aliases exist.
  * @rest_spec_name indices.exists_alias
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
+++ b/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
@@ -28,7 +28,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name indices.exists_alias
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
- * @doc_id apis
+ * @doc_id indices-aliases-exist
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
+++ b/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name indices.exists_alias
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/exists_index_template/IndicesExistsIndexTemplateRequest.ts
+++ b/specification/indices/exists_index_template/IndicesExistsIndexTemplateRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name indices.exists_index_template
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/exists_index_template/IndicesExistsIndexTemplateRequest.ts
+++ b/specification/indices/exists_index_template/IndicesExistsIndexTemplateRequest.ts
@@ -23,11 +23,12 @@ import { Duration } from '@_types/Time'
 
 /**
  * Check index templates.
+ *
  * Check whether index templates exist.
  * @rest_spec_name indices.exists_index_template
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
- * @doc_id apis
+ * @doc_id index-templates-exist
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts
+++ b/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.11.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag data stream
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts
+++ b/specification/indices/explain_data_lifecycle/IndicesExplainDataLifecycleRequest.ts
@@ -28,7 +28,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.11.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag data stream
- * @doc_id apis
+ * @doc_id data-stream-explain-lifecycle
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.11.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag data stream
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
+++ b/specification/indices/get_data_lifecycle/IndicesGetDataLifecycleRequest.ts
@@ -23,12 +23,13 @@ import { Duration } from '@_types/Time'
 
 /**
  * Get data stream lifecycles.
- * Retrieves the data stream lifecycle configuration of one or more data streams.
+ *
+ * Get the data stream lifecycle configuration of one or more data streams.
  * @rest_spec_name indices.get_data_lifecycle
  * @availability stack since=8.11.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag data stream
- * @doc_id apis
+ * @doc_id data-stream-get-lifecycle
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
+++ b/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @index_privileges view_index_metadata
  * @doc_tag data stream
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
+++ b/specification/indices/get_data_stream/IndicesGetDataStreamRequest.ts
@@ -23,13 +23,14 @@ import { Duration } from '@_types/Time'
 
 /**
  * Get data streams.
- * Retrieves information about one or more data streams.
+ *
+ * Get information about one or more data streams.
  * @rest_spec_name indices.get_data_stream
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @index_privileges view_index_metadata
  * @doc_tag data stream
- * @doc_id apis
+ * @doc_id data-stream-get
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/inference/delete/DeleteRequest.ts
+++ b/specification/inference/delete/DeleteRequest.ts
@@ -26,6 +26,7 @@ import { Id } from '@_types/common'
  * @rest_spec_name inference.delete
  * @availability stack since=8.11.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/inference/delete/DeleteRequest.ts
+++ b/specification/inference/delete/DeleteRequest.ts
@@ -26,7 +26,7 @@ import { Id } from '@_types/common'
  * @rest_spec_name inference.delete
  * @availability stack since=8.11.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public
- * @doc_id apis
+ * @doc_id inference-api-delete
  */
 export interface Request extends RequestBase {
   urls: [
@@ -46,19 +46,19 @@ export interface Request extends RequestBase {
     task_type?: TaskType
 
     /**
-     * The inference Id
+     * The inference identifier.
      */
     inference_id: Id
   }
   query_parameters: {
     /**
-     * When true, the endpoint is not deleted, and a list of ingest processors which reference this endpoint is returned
+     * When true, the endpoint is not deleted and a list of ingest processors which reference this endpoint is returned.
      * @server_default false
      */
     dry_run?: boolean
 
     /**
-     * When true, the inference endpoint is forcefully deleted even if it is still being used by ingest processors or semantic text fields
+     * When true, the inference endpoint is forcefully deleted even if it is still being used by ingest processors or semantic text fields.
      * @server_default false
      */
     force?: boolean

--- a/specification/inference/get/GetRequest.ts
+++ b/specification/inference/get/GetRequest.ts
@@ -26,6 +26,7 @@ import { Id } from '@_types/common'
  * @rest_spec_name inference.get
  * @availability stack since=8.11.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/inference/get/GetRequest.ts
+++ b/specification/inference/get/GetRequest.ts
@@ -26,7 +26,7 @@ import { Id } from '@_types/common'
  * @rest_spec_name inference.get
  * @availability stack since=8.11.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public
- * @doc_id apis
+ * @doc_id inference-api-get
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/inference/inference/InferenceRequest.ts
+++ b/specification/inference/inference/InferenceRequest.ts
@@ -24,11 +24,19 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
- * Perform inference on the service
+ * Perform inference on the service.
+ *
+ * This API enables you to use machine learning models to perform specific tasks on data that you provide as an input.
+ * It returns a response with the results of the tasks.
+ * The inference endpoint you use can perform one specific task that has been defined when the endpoint was created with the create inference API.
+ *
+ * > info
+ * > The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face. For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.
  * @rest_spec_name inference.inference
  * @availability stack since=8.11.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public
- * @doc_id apis
+ * @cluster_privileges monitor_inference
+ * @doc_id inference-api-post
  */
 export interface Request extends RequestBase {
   urls: [
@@ -43,34 +51,38 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * The task type
+     * The type of inference task that the model performs.
      */
     task_type?: TaskType
     /**
-     * The inference Id
+     * The unique identifier for the inference endpoint.
      */
     inference_id: Id
   }
   query_parameters: {
     /**
-     * Specifies the amount of time to wait for the inference request to complete.
+     * The amount of time to wait for the inference request to complete.
      * @server_default 30s
      */
     timeout?: Duration
   }
   body: {
     /**
-     * Query input, required for rerank task.
-     * Not required for other tasks.
+     * The query input, which is required only for the `rerank` task.
+     * It is not required for other tasks.
      */
     query?: string
     /**
-     * Inference input.
-     * Either a string or an array of strings.
+     * The text on which you want to perform the inference task.
+     * It can be a single string or an array.
+     *
+     * > info
+     * > Inference endpoints for the `completion` task type currently only support a single string as input.
      */
     input: string | Array<string>
     /**
-     * Optional task settings
+     * Task settings for the individual inference request.
+     * These settings are specific to the task type you specified and override the task settings specified when initializing the service.
      */
     task_settings?: TaskSettings
   }

--- a/specification/inference/inference/InferenceRequest.ts
+++ b/specification/inference/inference/InferenceRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name inference.inference
  * @availability stack since=8.11.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/inference/inference/examples/request/InferenceRequestExample1.yaml
+++ b/specification/inference/inference/examples/request/InferenceRequestExample1.yaml
@@ -1,0 +1,8 @@
+summary: Completion task
+description: Run `POST _inference/completion/openai_chat_completions` to perform a completion on the example question.
+# method_request: "POST _inference/completion/openai_chat_completions"
+# type: "request"
+value: |-
+  {
+    "input": "What is Elastic?"
+  }

--- a/specification/inference/inference/examples/request/InferenceRequestExample2.yaml
+++ b/specification/inference/inference/examples/request/InferenceRequestExample2.yaml
@@ -1,0 +1,9 @@
+summary: Rerank task
+description: Run `POST _inference/rerank/cohere_rerank` to perform reranking on the example input.
+# method_request: "POST _inference/rerank/cohere_rerank"
+# type: "request"
+value: |-
+  {
+    "input": ["luke", "like", "leia", "chewy","r2d2", "star", "wars"],
+    "query": "star wars main character"
+  }

--- a/specification/inference/inference/examples/request/InferenceRequestExample3.yaml
+++ b/specification/inference/inference/examples/request/InferenceRequestExample3.yaml
@@ -1,0 +1,8 @@
+summary: Sparse embedding task
+description: Run `POST _inference/sparse_embedding/my-elser-model` to perform sparse embedding on the example sentence.
+# method_request: "POST _inference/sparse_embedding/my-elser-model"
+# type: "request"
+value: |-
+  {
+    "input": "The sky above the port was the color of television tuned to a dead channel."
+  }

--- a/specification/inference/inference/examples/request/InferenceRequestExample4.yaml
+++ b/specification/inference/inference/examples/request/InferenceRequestExample4.yaml
@@ -1,0 +1,11 @@
+summary: Text embedding task
+description: Run `POST _inference/text_embedding/my-cohere-endpoint` to perform text embedding on the example sentence using the Cohere integration,
+# method_request: "POST _inference/text_embedding/my-cohere-endpoint"
+# type: "request"
+value: |-
+  {
+    "input": "The sky above the port was the color of television tuned to a dead channel.",
+    "task_settings": {
+      "input_type": "ingest"
+    }
+  }

--- a/specification/inference/inference/examples/response/InferenceResponseExample1.yaml
+++ b/specification/inference/inference/examples/response/InferenceResponseExample1.yaml
@@ -1,0 +1,13 @@
+summary: Completion task
+description: >
+  A successful response from `POST _inference/completion/openai_chat_completions`.
+# type: "response"
+# response_code:
+value: |-
+  {
+    "completion": [
+      {
+        "result": "Elastic is a company that provides a range of software solutions for search, logging, security, and analytics. Their flagship product is Elasticsearch, an open-source, distributed search engine that allows users to search, analyze, and visualize large volumes of data in real-time. Elastic also offers products such as Kibana, a data visualization tool, and Logstash, a log management and pipeline tool, as well as various other tools and solutions for data analysis and management."
+      }
+    ]
+  }

--- a/specification/inference/inference/examples/response/InferenceResponseExample2.yaml
+++ b/specification/inference/inference/examples/response/InferenceResponseExample2.yaml
@@ -1,0 +1,45 @@
+summary: Rerank task
+description: >
+  A successful response from `POST _inference/rerank/cohere_rerank`.
+# type: "response"
+# response_code:
+value: |-
+  {
+    "rerank": [
+      {
+        "index": "2",
+        "relevance_score": "0.011597361",
+        "text": "leia"
+      },
+      {
+        "index": "0",
+        "relevance_score": "0.006338922",
+        "text": "luke"
+      },
+      {
+        "index": "5",
+        "relevance_score": "0.0016166499",
+        "text": "star"
+      },
+      {
+        "index": "4",
+        "relevance_score": "0.0011695103",
+        "text": "r2d2"
+      },
+      {
+        "index": "1",
+        "relevance_score": "5.614787E-4",
+        "text": "like"
+      },
+      {
+        "index": "6",
+        "relevance_score": "3.7850367E-4",
+        "text": "wars"
+      },
+      {
+        "index": "3",
+        "relevance_score": "1.2508839E-5",
+        "text": "chewy"
+      }
+    ]
+  }

--- a/specification/inference/inference/examples/response/InferenceResponseExample3.yaml
+++ b/specification/inference/inference/examples/response/InferenceResponseExample3.yaml
@@ -1,0 +1,26 @@
+summary: Sparse embedding task
+description: >
+  An abbreviated response from `POST _inference/sparse_embedding/my-elser-model`.
+# type: "response"
+# response_code:
+value: |-
+  {
+    "sparse_embedding": [
+      {
+        "port": 2.1259406,
+        "sky": 1.7073475,
+        "color": 1.6922266,
+        "dead": 1.6247464,
+        "television": 1.3525393,
+        "above": 1.2425821,
+        "tuned": 1.1440028,
+        "colors": 1.1218185,
+        "tv": 1.0111054,
+        "ports": 1.0067928,
+        "poem": 1.0042328,
+        "channel": 0.99471164,
+        "tune": 0.96235967,
+        "scene": 0.9020516
+      }
+    ]
+  }

--- a/specification/inference/inference/examples/response/InferenceResponseExample4.yaml
+++ b/specification/inference/inference/examples/response/InferenceResponseExample4.yaml
@@ -1,0 +1,30 @@
+summary: Text embedding task
+description: >
+  An abbreviated response from `POST _inference/text_embedding/my-cohere-endpoint`.
+# type: "response"
+# response_code:
+value: |-
+  {
+    "text_embedding": [
+      {
+        "embedding": [
+          {
+            0.018569946,
+            -0.036895752,
+            0.01486969,
+            -0.0045204163,
+            -0.04385376,
+            0.0075950623,
+            0.04260254,
+            -0.004005432,
+            0.007865906,
+            0.030792236,
+            -0.050476074,
+            0.011795044,
+            -0.011642456,
+            -0.010070801
+          }
+        ]
+      }
+    ]
+  }

--- a/specification/inference/put/PutRequest.ts
+++ b/specification/inference/put/PutRequest.ts
@@ -37,7 +37,7 @@ import { Id } from '@_types/common'
  * @availability stack since=8.11.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_inference
- * @doc_id apis
+ * @doc_id inference-api-put
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/inference/put/PutRequest.ts
+++ b/specification/inference/put/PutRequest.ts
@@ -37,6 +37,7 @@ import { Id } from '@_types/common'
  * @availability stack since=8.11.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_inference
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ingest/delete_geoip_database/DeleteGeoipDatabaseRequest.ts
+++ b/specification/ingest/delete_geoip_database/DeleteGeoipDatabaseRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ingest.delete_geoip_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ingest/delete_geoip_database/DeleteGeoipDatabaseRequest.ts
+++ b/specification/ingest/delete_geoip_database/DeleteGeoipDatabaseRequest.ts
@@ -23,11 +23,12 @@ import { Duration } from '@_types/Time'
 
 /**
  * Delete GeoIP database configurations.
+ *
  * Delete one or more IP geolocation database configurations.
  * @rest_spec_name ingest.delete_geoip_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
- * @doc_id apis
+ * @doc_id geoip-delete-database
  */
 export interface Request extends RequestBase {
   urls: [
@@ -44,12 +45,12 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
      * If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s */
     master_timeout?: Duration
     /**
-     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * The period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s */
     timeout?: Duration
   }

--- a/specification/ingest/delete_ip_location_database/DeleteIpLocationDatabaseRequest.ts
+++ b/specification/ingest/delete_ip_location_database/DeleteIpLocationDatabaseRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
  * @cluster_privileges manage
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ingest/delete_ip_location_database/DeleteIpLocationDatabaseRequest.ts
+++ b/specification/ingest/delete_ip_location_database/DeleteIpLocationDatabaseRequest.ts
@@ -27,7 +27,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
  * @cluster_privileges manage
- * @doc_id apis
+ * @doc_id ip-location-delete-database
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ingest/delete_pipeline/DeletePipelineRequest.ts
+++ b/specification/ingest/delete_pipeline/DeletePipelineRequest.ts
@@ -27,7 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ingest.delete_pipeline
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
- * @doc_id apis
+ * @doc_id delete-pipeline-api
  * @ext_doc_id ingest
  */
 export interface Request extends RequestBase {

--- a/specification/ingest/delete_pipeline/DeletePipelineRequest.ts
+++ b/specification/ingest/delete_pipeline/DeletePipelineRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ingest.delete_pipeline
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id apis
  * @ext_doc_id ingest
  */
 export interface Request extends RequestBase {

--- a/specification/ingest/get_geoip_database/GetGeoipDatabaseRequest.ts
+++ b/specification/ingest/get_geoip_database/GetGeoipDatabaseRequest.ts
@@ -22,11 +22,12 @@ import { Ids } from '@_types/common'
 
 /**
  * Get GeoIP database configurations.
+ *
  * Get information about one or more IP geolocation database configurations.
  * @rest_spec_name ingest.get_geoip_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
- * @doc_id apis
+ * @doc_id geoip-get-database
  */
 export interface Request extends RequestBase {
   urls: [
@@ -41,7 +42,7 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Comma-separated list of database configuration IDs to retrieve.
+     * A comma-separated list of database configuration IDs to retrieve.
      * Wildcard (`*`) expressions are supported.
      * To get all database configurations, omit this parameter or use `*`.
      */

--- a/specification/ingest/get_geoip_database/GetGeoipDatabaseRequest.ts
+++ b/specification/ingest/get_geoip_database/GetGeoipDatabaseRequest.ts
@@ -26,6 +26,7 @@ import { Ids } from '@_types/common'
  * @rest_spec_name ingest.get_geoip_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ingest/get_ip_location_database/GetIpLocationDatabaseRequest.ts
+++ b/specification/ingest/get_ip_location_database/GetIpLocationDatabaseRequest.ts
@@ -27,6 +27,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
  * @cluster_privileges manage
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ingest/get_ip_location_database/GetIpLocationDatabaseRequest.ts
+++ b/specification/ingest/get_ip_location_database/GetIpLocationDatabaseRequest.ts
@@ -27,7 +27,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
  * @cluster_privileges manage
- * @doc_id apis
+ * @doc_id ip-location-get-database
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ingest/get_pipeline/GetPipelineRequest.ts
+++ b/specification/ingest/get_pipeline/GetPipelineRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ingest.get_pipeline
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id apis
  * @ext_doc_id ingest
  */
 export interface Request extends RequestBase {

--- a/specification/ingest/get_pipeline/GetPipelineRequest.ts
+++ b/specification/ingest/get_pipeline/GetPipelineRequest.ts
@@ -23,12 +23,13 @@ import { Duration } from '@_types/Time'
 
 /**
  * Get pipelines.
+ *
  * Get information about one or more ingest pipelines.
  * This API returns a local reference of the pipeline.
  * @rest_spec_name ingest.get_pipeline
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
- * @doc_id apis
+ * @doc_id get-pipeline-api
  * @ext_doc_id ingest
  */
 export interface Request extends RequestBase {

--- a/specification/ingest/put_geoip_database/PutGeoipDatabaseRequest.ts
+++ b/specification/ingest/put_geoip_database/PutGeoipDatabaseRequest.ts
@@ -29,7 +29,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ingest.put_geoip_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
- * @doc_id apis
+ * @doc_id geoip-put-database
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ingest/put_geoip_database/PutGeoipDatabaseRequest.ts
+++ b/specification/ingest/put_geoip_database/PutGeoipDatabaseRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name ingest.put_geoip_database
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ingest/put_geoip_database/PutGeoipDatabaseRequest.ts
+++ b/specification/ingest/put_geoip_database/PutGeoipDatabaseRequest.ts
@@ -24,6 +24,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * Create or update a GeoIP database configuration.
+ *
  * Refer to the create or update IP geolocation database configuration API.
  * @rest_spec_name ingest.put_geoip_database
  * @availability stack since=8.15.0 stability=stable

--- a/specification/ingest/put_ip_location_database/PutIpLocationDatabaseRequest.ts
+++ b/specification/ingest/put_ip_location_database/PutIpLocationDatabaseRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
  * @cluster_privileges manage
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ingest/put_ip_location_database/PutIpLocationDatabaseRequest.ts
+++ b/specification/ingest/put_ip_location_database/PutIpLocationDatabaseRequest.ts
@@ -28,7 +28,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless visibility=private
  * @cluster_privileges manage
- * @doc_id apis
+ * @doc_id ip-location-put-database
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ingest/simulate/SimulatePipelineRequest.ts
+++ b/specification/ingest/simulate/SimulatePipelineRequest.ts
@@ -29,6 +29,7 @@ import { Document } from '../_types/Simulation'
  * @rest_spec_name ingest.simulate
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ingest/simulate/SimulatePipelineRequest.ts
+++ b/specification/ingest/simulate/SimulatePipelineRequest.ts
@@ -24,12 +24,14 @@ import { Document } from '../_types/Simulation'
 
 /**
  * Simulate a pipeline.
+ *
  * Run an ingest pipeline against a set of provided documents.
  * You can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.
  * @rest_spec_name ingest.simulate
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=public
- * @doc_id apis
+ * @cluster_privileges read_pipeline
+ * @doc_id simulate-pipeline-api
  */
 export interface Request extends RequestBase {
   urls: [
@@ -44,8 +46,8 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Pipeline to test.
-     * If you don’t specify a `pipeline` in the request body, this parameter is required.
+     * The pipeline to test.
+     * If you don't specify a `pipeline` in the request body, this parameter is required.
      */
     id?: Id
   }
@@ -61,8 +63,8 @@ export interface Request extends RequestBase {
      */
     docs: Document[]
     /**
-     * Pipeline to test.
-     * If you don’t specify the `pipeline` request path parameter, this parameter is required.
+     * The pipeline to test.
+     * If you don't specify the `pipeline` request path parameter, this parameter is required.
      * If you specify both this and the request path parameter, the API only uses the request path parameter.
      */
     pipeline?: Pipeline

--- a/specification/license/delete/DeleteLicenseRequest.ts
+++ b/specification/license/delete/DeleteLicenseRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name license.delete
  * @availability stack stability=stable
  * @cluster_privileges manage
+ * @doc_id apis
  * @ext_doc_id license-management
  */
 export interface Request extends RequestBase {

--- a/specification/license/delete/DeleteLicenseRequest.ts
+++ b/specification/license/delete/DeleteLicenseRequest.ts
@@ -22,13 +22,14 @@ import { Duration } from '@_types/Time'
 
 /**
  * Delete the license.
+ *
  * When the license expires, your subscription level reverts to Basic.
  *
  * If the operator privileges feature is enabled, only operator users can use this API.
  * @rest_spec_name license.delete
  * @availability stack stability=stable
  * @cluster_privileges manage
- * @doc_id apis
+ * @doc_id delete-license
  * @ext_doc_id license-management
  */
 export interface Request extends RequestBase {
@@ -40,12 +41,12 @@ export interface Request extends RequestBase {
   ]
   query_parameters: {
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
      * @server_default 30s
      */
     master_timeout?: Duration
     /**
-     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * The period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
     timeout?: Duration

--- a/specification/license/get/GetLicenseRequest.ts
+++ b/specification/license/get/GetLicenseRequest.ts
@@ -21,14 +21,16 @@ import { RequestBase } from '@_types/Base'
 
 /**
  * Get license information.
+ *
  * Get information about your Elastic license including its type, its status, when it was issued, and when it expires.
  *
- * NOTE: If the master node is generating a new cluster state, the get license API may return a `404 Not Found` response.
- * If you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.
+ * >info
+ * > If the master node is generating a new cluster state, the get license API may return a `404 Not Found` response.
+ * > If you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.
  * @rest_spec_name license.get
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
- * @doc_id apis
+ * @doc_id get-license
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/license/get/GetLicenseRequest.ts
+++ b/specification/license/get/GetLicenseRequest.ts
@@ -28,6 +28,7 @@ import { RequestBase } from '@_types/Base'
  * @rest_spec_name license.get
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/license/get_basic_status/GetBasicLicenseStatusRequest.ts
+++ b/specification/license/get_basic_status/GetBasicLicenseStatusRequest.ts
@@ -24,7 +24,7 @@ import { RequestBase } from '@_types/Base'
  * @rest_spec_name license.get_basic_status
  * @availability stack since=6.3.0 stability=stable
  * @cluster_privileges monitor
- * @doc_id apis
+ * @doc_id get-basic-status
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/license/get_basic_status/GetBasicLicenseStatusRequest.ts
+++ b/specification/license/get_basic_status/GetBasicLicenseStatusRequest.ts
@@ -24,6 +24,7 @@ import { RequestBase } from '@_types/Base'
  * @rest_spec_name license.get_basic_status
  * @availability stack since=6.3.0 stability=stable
  * @cluster_privileges monitor
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/license/get_trial_status/GetTrialLicenseStatusRequest.ts
+++ b/specification/license/get_trial_status/GetTrialLicenseStatusRequest.ts
@@ -24,6 +24,7 @@ import { RequestBase } from '@_types/Base'
  * @rest_spec_name license.get_trial_status
  * @availability stack since=6.1.0 stability=stable
  * @cluster_privileges monitor
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/license/get_trial_status/GetTrialLicenseStatusRequest.ts
+++ b/specification/license/get_trial_status/GetTrialLicenseStatusRequest.ts
@@ -24,7 +24,7 @@ import { RequestBase } from '@_types/Base'
  * @rest_spec_name license.get_trial_status
  * @availability stack since=6.1.0 stability=stable
  * @cluster_privileges monitor
- * @doc_id apis
+ * @doc_id get-trial-status
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/license/post/PostLicenseRequest.ts
+++ b/specification/license/post/PostLicenseRequest.ts
@@ -23,6 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * Update the license.
+ *
  * You can update your license at runtime without shutting down your nodes.
  * License updates take effect immediately.
  * If the license you are installing does not support all of the features that were available with your previous license, however, you are notified in the response.
@@ -33,7 +34,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name license.post
  * @availability stack stability=stable
  * @cluster_privileges manage
- * @doc_id apis
+ * @doc_id update-license
  */
 export interface Request extends RequestBase {
   urls: [
@@ -49,12 +50,12 @@ export interface Request extends RequestBase {
      */
     acknowledge?: boolean
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
      * @server_default 30s
      */
     master_timeout?: Duration
     /**
-     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * The period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
     timeout?: Duration

--- a/specification/license/post/PostLicenseRequest.ts
+++ b/specification/license/post/PostLicenseRequest.ts
@@ -33,6 +33,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name license.post
  * @availability stack stability=stable
  * @cluster_privileges manage
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/license/post_start_basic/StartBasicLicenseRequest.ts
+++ b/specification/license/post_start_basic/StartBasicLicenseRequest.ts
@@ -33,6 +33,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name license.post_start_basic
  * @availability stack since=6.3.0 stability=stable
  * @cluster_privileges manage
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/license/post_start_basic/StartBasicLicenseRequest.ts
+++ b/specification/license/post_start_basic/StartBasicLicenseRequest.ts
@@ -22,6 +22,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * Start a basic license.
+ *
  * Start an indefinite basic license, which gives access to all the basic features.
  *
  * NOTE: In order to start a basic license, you must not currently have a basic license.
@@ -33,7 +34,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name license.post_start_basic
  * @availability stack since=6.3.0 stability=stable
  * @cluster_privileges manage
- * @doc_id apis
+ * @doc_id start-basic,
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/license/post_start_basic/StartBasicLicenseRequest.ts
+++ b/specification/license/post_start_basic/StartBasicLicenseRequest.ts
@@ -34,7 +34,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name license.post_start_basic
  * @availability stack since=6.3.0 stability=stable
  * @cluster_privileges manage
- * @doc_id start-basic,
+ * @doc_id start-basic
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheRequest.ts
+++ b/specification/ml/clear_trained_model_deployment_cache/MlClearTrainedModelDeploymentCacheRequest.ts
@@ -30,6 +30,7 @@ import { Id } from '@_types/common'
  * @availability stack since=8.5.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
+ * @doc_id clear-trained-model
  * @doc_tag ml trained model
  */
 export interface Request extends RequestBase {

--- a/specification/ml/delete_expired_data/MlDeleteExpiredDataRequest.ts
+++ b/specification/ml/delete_expired_data/MlDeleteExpiredDataRequest.ts
@@ -37,6 +37,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-delete-expired-data
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/delete_filter/MlDeleteFilterRequest.ts
+++ b/specification/ml/delete_filter/MlDeleteFilterRequest.ts
@@ -29,6 +29,7 @@ import { Id } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-delete-filter
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/delete_forecast/MlDeleteForecastRequest.ts
+++ b/specification/ml/delete_forecast/MlDeleteForecastRequest.ts
@@ -32,6 +32,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-delete-forecast
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/delete_job/MlDeleteJobRequest.ts
+++ b/specification/ml/delete_job/MlDeleteJobRequest.ts
@@ -33,6 +33,7 @@ import { Id } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-delete-job
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/delete_model_snapshot/MlDeleteModelSnapshotRequest.ts
+++ b/specification/ml/delete_model_snapshot/MlDeleteModelSnapshotRequest.ts
@@ -30,6 +30,7 @@ import { Id } from '@_types/common'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-delete-snapshot
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/delete_trained_model/MlDeleteTrainedModelRequest.ts
+++ b/specification/ml/delete_trained_model/MlDeleteTrainedModelRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml trained model
+ * @doc_id delete-trained-models
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/delete_trained_model_alias/MlDeleteTrainedModelAliasRequest.ts
+++ b/specification/ml/delete_trained_model_alias/MlDeleteTrainedModelAliasRequest.ts
@@ -30,6 +30,7 @@ import { Id, Name } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml trained model
+ * @doc_id delete-trained-models-aliases
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/estimate_model_memory/MlEstimateModelMemoryRequest.ts
+++ b/specification/ml/estimate_model_memory/MlEstimateModelMemoryRequest.ts
@@ -33,6 +33,7 @@ import { long } from '@_types/Numeric'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-estimate-memory
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/evaluate_data_frame/MlEvaluateDataFrameRequest.ts
+++ b/specification/ml/evaluate_data_frame/MlEvaluateDataFrameRequest.ts
@@ -33,6 +33,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml data frame
+ * @doc_id evaluate-dfanalytics
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/explain_data_frame_analytics/MlExplainDataFrameAnalyticsRequest.ts
+++ b/specification/ml/explain_data_frame_analytics/MlExplainDataFrameAnalyticsRequest.ts
@@ -40,6 +40,7 @@ import { integer } from '@_types/Numeric'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  * @doc_tag ml data frame
+ * @doc_id explain-dfanalytics
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/flush_job/MlFlushJobRequest.ts
+++ b/specification/ml/flush_job/MlFlushJobRequest.ts
@@ -36,6 +36,7 @@ import { DateTime } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-flush-job
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/forecast/MlForecastJobRequest.ts
+++ b/specification/ml/forecast/MlForecastJobRequest.ts
@@ -34,6 +34,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-forecast
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_buckets/MlGetBucketsRequest.ts
+++ b/specification/ml/get_buckets/MlGetBucketsRequest.ts
@@ -31,6 +31,7 @@ import { DateTime } from '@_types/Time'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-bucket
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
+++ b/specification/ml/get_calendar_events/MlGetCalendarEventsRequest.ts
@@ -29,6 +29,7 @@ import { DateTime } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-calendar-event
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_calendars/MlGetCalendarsRequest.ts
+++ b/specification/ml/get_calendars/MlGetCalendarsRequest.ts
@@ -29,6 +29,7 @@ import { integer } from '@_types/Numeric'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-calendar
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_categories/MlGetCategoriesRequest.ts
+++ b/specification/ml/get_categories/MlGetCategoriesRequest.ts
@@ -29,6 +29,7 @@ import { integer } from '@_types/Numeric'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-category
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_data_frame_analytics/MlGetDataFrameAnalyticsRequest.ts
+++ b/specification/ml/get_data_frame_analytics/MlGetDataFrameAnalyticsRequest.ts
@@ -31,6 +31,7 @@ import { integer } from '@_types/Numeric'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml data frame
+ * @doc_id get-dfanalytics
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_data_frame_analytics_stats/MlGetDataFrameAnalyticsStatsRequest.ts
+++ b/specification/ml/get_data_frame_analytics_stats/MlGetDataFrameAnalyticsStatsRequest.ts
@@ -28,6 +28,7 @@ import { integer } from '@_types/Numeric'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml data frame
+ * @doc_id get-dfanalytics-stats
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_datafeed_stats/MlGetDatafeedStatsRequest.ts
+++ b/specification/ml/get_datafeed_stats/MlGetDatafeedStatsRequest.ts
@@ -33,6 +33,7 @@ import { Ids } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-datafeed-stats
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_datafeeds/MlGetDatafeedsRequest.ts
+++ b/specification/ml/get_datafeeds/MlGetDatafeedsRequest.ts
@@ -32,6 +32,7 @@ import { Ids } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-datafeed
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_filters/MlGetFiltersRequest.ts
+++ b/specification/ml/get_filters/MlGetFiltersRequest.ts
@@ -29,6 +29,7 @@ import { integer } from '@_types/Numeric'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-filter
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_influencers/MlGetInfluencersRequest.ts
+++ b/specification/ml/get_influencers/MlGetInfluencersRequest.ts
@@ -33,6 +33,7 @@ import { DateTime } from '@_types/Time'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-influencer
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
+++ b/specification/ml/get_job_stats/MlGetJobStatsRequest.ts
@@ -27,6 +27,7 @@ import { Id } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-job-stats
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_jobs/MlGetJobsRequest.ts
+++ b/specification/ml/get_jobs/MlGetJobsRequest.ts
@@ -31,6 +31,7 @@ import { Ids } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-job
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_memory_stats/MlGetMemoryStatsRequest.ts
+++ b/specification/ml/get_memory_stats/MlGetMemoryStatsRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.2.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
+ * @doc_id ml-get-memory
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_model_snapshot_upgrade_stats/MlGetModelSnapshotUpgradeStatsRequest.ts
+++ b/specification/ml/get_model_snapshot_upgrade_stats/MlGetModelSnapshotUpgradeStatsRequest.ts
@@ -27,6 +27,7 @@ import { Id } from '@_types/common'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-job-model-snapshot-upgrade-stats
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_model_snapshots/MlGetModelSnapshotsRequest.ts
+++ b/specification/ml/get_model_snapshots/MlGetModelSnapshotsRequest.ts
@@ -30,6 +30,7 @@ import { DateTime } from '@_types/Time'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-snapshot
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
+++ b/specification/ml/get_overall_buckets/MlGetOverallBucketsRequest.ts
@@ -47,6 +47,7 @@ import { DateTime, Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-overall-buckets
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_records/MlGetAnomalyRecordsRequest.ts
+++ b/specification/ml/get_records/MlGetAnomalyRecordsRequest.ts
@@ -40,6 +40,7 @@ import { DateTime } from '@_types/Time'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-get-record
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
+++ b/specification/ml/get_trained_models/MlGetTrainedModelRequest.ts
@@ -29,6 +29,7 @@ import { integer } from '@_types/Numeric'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml trained model
+ * @doc_id get-trained-models
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsRequest.ts
+++ b/specification/ml/get_trained_models_stats/MlGetTrainedModelStatsRequest.ts
@@ -30,6 +30,7 @@ import { integer } from '@_types/Numeric'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml trained model
+ * @doc_id get-trained-models-stats
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/infer_trained_model/MlInferTrainedModelRequest.ts
+++ b/specification/ml/infer_trained_model/MlInferTrainedModelRequest.ts
@@ -30,6 +30,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.3.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag ml trained model
+ * @doc_id infer-trained-model
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/info/MlInfoRequest.ts
+++ b/specification/ml/info/MlInfoRequest.ts
@@ -32,6 +32,7 @@ import { RequestBase } from '@_types/Base'
  * @availability stack since=6.3.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_ml
+ * @doc_id get-ml-info
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/open_job/MlOpenJobRequest.ts
+++ b/specification/ml/open_job/MlOpenJobRequest.ts
@@ -34,6 +34,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-open-job
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
+++ b/specification/ml/post_calendar_events/MlPostCalendarEventsRequest.ts
@@ -28,6 +28,7 @@ import { CalendarEvent } from '../_types/CalendarEvent'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-post-calendar-event
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/post_data/MlPostJobDataRequest.ts
+++ b/specification/ml/post_data/MlPostJobDataRequest.ts
@@ -31,6 +31,7 @@ import { DateTime } from '@_types/Time'
  * @deprecated 7.11.0 Posting data directly to anomaly detection jobs is deprecated, in a future major version a datafeed will be required.
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-post-data
  */
 export interface Request<TData> extends RequestBase {
   urls: [

--- a/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsRequest.ts
+++ b/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsRequest.ts
@@ -23,12 +23,13 @@ import { DataframePreviewConfig } from './types'
 
 /**
  * Preview features used by data frame analytics.
- * Previews the extracted features used by a data frame analytics config.
+ * Preview the extracted features used by a data frame analytics config.
  * @rest_spec_name ml.preview_data_frame_analytics
  * @availability stack since=7.13.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_ml
  * @doc_tag ml data frame
+ * @doc_id preview-dfanalytics
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
@@ -39,6 +39,7 @@ import { DateTime } from '@_types/Time'
  * @index_privileges read
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-preview-datafeed
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/put_calendar/MlPutCalendarRequest.ts
+++ b/specification/ml/put_calendar/MlPutCalendarRequest.ts
@@ -27,6 +27,7 @@ import { Id } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-put-calendar
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/put_calendar_job/MlPutCalendarJobRequest.ts
+++ b/specification/ml/put_calendar_job/MlPutCalendarJobRequest.ts
@@ -27,6 +27,7 @@ import { Id, Ids } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-put-calendar-job
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
+++ b/specification/ml/put_datafeed/MlPutDatafeedRequest.ts
@@ -53,6 +53,7 @@ import { Duration } from '@_types/Time'
  * @index_privileges read
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-put-datafeed
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/put_filter/MlPutFilterRequest.ts
+++ b/specification/ml/put_filter/MlPutFilterRequest.ts
@@ -29,6 +29,7 @@ import { Id } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-put-filter
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/put_job/MlPutJobRequest.ts
+++ b/specification/ml/put_job/MlPutJobRequest.ts
@@ -37,6 +37,7 @@ import { Duration } from '@_types/Time'
  * @index_privileges read
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-put-job
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
+++ b/specification/ml/put_trained_model/MlPutTrainedModelRequest.ts
@@ -36,6 +36,7 @@ import { Definition, Input } from './types'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml trained model
+ * @doc_id put-trained-models
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/put_trained_model_alias/MlPutTrainedModelAliasRequest.ts
+++ b/specification/ml/put_trained_model_alias/MlPutTrainedModelAliasRequest.ts
@@ -43,6 +43,7 @@ import { Id, Name } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml trained model
+ * @doc_id put-trained-models-aliases
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartRequest.ts
+++ b/specification/ml/put_trained_model_definition_part/MlPutTrainedModelDefinitionPartRequest.ts
@@ -28,6 +28,7 @@ import { integer, long } from '@_types/Numeric'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml trained model
+ * @doc_id put-trained-model-definition-part
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
+++ b/specification/ml/put_trained_model_vocabulary/MlPutTrainedModelVocabularyRequest.ts
@@ -30,6 +30,7 @@ import { double } from '@_types/Numeric'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml trained model
+ * @doc_id put-trained-model-vocabulary
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/reset_job/MlResetJobRequest.ts
+++ b/specification/ml/reset_job/MlResetJobRequest.ts
@@ -31,6 +31,7 @@ import { Id } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-reset-job
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/revert_model_snapshot/MlRevertModelSnapshotRequest.ts
+++ b/specification/ml/revert_model_snapshot/MlRevertModelSnapshotRequest.ts
@@ -34,6 +34,7 @@ import { Id } from '@_types/common'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-revert-snapshot
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/set_upgrade_mode/MlSetUpgradeModeRequest.ts
+++ b/specification/ml/set_upgrade_mode/MlSetUpgradeModeRequest.ts
@@ -38,6 +38,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=6.7.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
+ * @doc_id ml-set-upgrade-mode
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/start_data_frame_analytics/MlStartDataFrameAnalyticsRequest.ts
+++ b/specification/ml/start_data_frame_analytics/MlStartDataFrameAnalyticsRequest.ts
@@ -40,6 +40,7 @@ import { Duration } from '@_types/Time'
  * @cluster_privileges manage_ml
  * @index_privileges create_index, index, manage, read, view_index_metadata
  * @doc_tag ml data frame
+ * @doc_id start-dfanalytics
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
+++ b/specification/ml/start_datafeed/MlStartDatafeedRequest.ts
@@ -40,6 +40,7 @@ import { DateTime, Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-start-datafeed
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
@@ -34,6 +34,7 @@ import {
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml trained model
+ * @doc_id start-trained-model-deployment
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/stop_data_frame_analytics/MlStopDataFrameAnalyticsRequest.ts
+++ b/specification/ml/stop_data_frame_analytics/MlStopDataFrameAnalyticsRequest.ts
@@ -30,6 +30,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml data frame
+ * @doc_id stop-dfanalytics
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
+++ b/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
@@ -30,6 +30,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-stop-datafeed
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentRequest.ts
+++ b/specification/ml/stop_trained_model_deployment/MlStopTrainedModelDeploymentRequest.ts
@@ -27,6 +27,7 @@ import { Id } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml trained model
+ * @doc_id stop-trained-model-deployment
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/update_data_frame_analytics/MlUpdateDataFrameAnalyticsRequest.ts
+++ b/specification/ml/update_data_frame_analytics/MlUpdateDataFrameAnalyticsRequest.ts
@@ -29,6 +29,7 @@ import { integer } from '@_types/Numeric'
  * @cluster_privileges manage_ml
  * @index_privileges read, create_index, manage, index, view_index_metadata
  * @doc_tag ml data frame
+ * @doc_id update-dfanalytics
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedRequest.ts
@@ -39,6 +39,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-update-datafeed
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/update_filter/MlUpdateFilterRequest.ts
+++ b/specification/ml/update_filter/MlUpdateFilterRequest.ts
@@ -28,6 +28,7 @@ import { Id } from '@_types/common'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-update-filter
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/update_job/MlUpdateJobRequest.ts
+++ b/specification/ml/update_job/MlUpdateJobRequest.ts
@@ -38,6 +38,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-update-job
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/update_model_snapshot/MlUpdateModelSnapshotRequest.ts
+++ b/specification/ml/update_model_snapshot/MlUpdateModelSnapshotRequest.ts
@@ -28,6 +28,7 @@ import { Id } from '@_types/common'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-update-snapshot
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/update_trained_model_deployment/MlUpdateTrainedModelDeploymentRequest.ts
+++ b/specification/ml/update_trained_model_deployment/MlUpdateTrainedModelDeploymentRequest.ts
@@ -28,6 +28,7 @@ import { integer } from '@_types/Numeric'
  * @availability serverless stability=beta visibility=public
  * @cluster_privileges manage_ml
  * @doc_tag ml trained model
+ * @doc_id update-trained-model-deployment
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/upgrade_job_snapshot/MlUpgradeJobSnapshotRequest.ts
+++ b/specification/ml/upgrade_job_snapshot/MlUpgradeJobSnapshotRequest.ts
@@ -23,7 +23,7 @@ import { Duration } from '@_types/Time'
 
 /**
  * Upgrade a snapshot.
- * Upgrades an anomaly detection model snapshot to the latest major version.
+ * Upgrade an anomaly detection model snapshot to the latest major version.
  * Over time, older snapshot formats are deprecated and removed. Anomaly
  * detection jobs support only snapshots that are from the current or previous
  * major version.
@@ -37,6 +37,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_ml
  * @doc_tag ml anomaly
+ * @doc_id ml-upgrade-job-model-snapshot
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/ml/validate_detector/MlValidateDetectorRequest.ts
+++ b/specification/ml/validate_detector/MlValidateDetectorRequest.ts
@@ -26,6 +26,7 @@ import { RequestBase } from '@_types/Base'
  * @availability stack since=5.4.0 stability=stable visibility=private
  * @availability serverless stability=stable visibility=private
  * @doc_tag ml anomaly
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/monitoring/bulk/BulkMonitoringRequest.ts
+++ b/specification/monitoring/bulk/BulkMonitoringRequest.ts
@@ -26,6 +26,7 @@ import { Duration } from '@_types/Time'
  * This API is used by the monitoring features to send monitoring data.
  * @rest_spec_name monitoring.bulk
  * @availability stack since=6.3.0 stability=stable visibility=private
+ * @doc_id apis
  */
 export interface Request<TDocument, TPartialDocument> extends RequestBase {
   urls: [

--- a/specification/nodes/reload_secure_settings/ReloadSecureSettingsRequest.ts
+++ b/specification/nodes/reload_secure_settings/ReloadSecureSettingsRequest.ts
@@ -34,6 +34,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name nodes.reload_secure_settings
  * @availability stack since=6.5.0 stability=stable
  * @doc_tag cluster
+ * @doc_id cluster-nodes-reload-secure-settings
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/delete/SearchApplicationsDeleteRequest.ts
+++ b/specification/search_application/delete/SearchApplicationsDeleteRequest.ts
@@ -27,6 +27,7 @@ import { Name } from '@_types/common'
  * @availability serverless stability=beta visibility=public
  * @cluster_privileges manage_search_application
  * @index_privileges manage
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/delete/SearchApplicationsDeleteRequest.ts
+++ b/specification/search_application/delete/SearchApplicationsDeleteRequest.ts
@@ -21,13 +21,14 @@ import { Name } from '@_types/common'
 
 /**
  * Delete a search application.
+ *
  * Remove a search application and its associated alias. Indices attached to the search application are not removed.
  * @rest_spec_name search_application.delete
  * @availability stack since=8.8.0 stability=beta
  * @availability serverless stability=beta visibility=public
  * @cluster_privileges manage_search_application
  * @index_privileges manage
- * @doc_id apis
+ * @doc_id search-application-delete
  */
 export interface Request extends RequestBase {
   urls: [
@@ -38,7 +39,7 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * The name of the search application to delete
+     * The name of the search application to delete.
      */
     name: Name
   }

--- a/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteRequest.ts
+++ b/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteRequest.ts
@@ -26,6 +26,7 @@ import { Name } from '@_types/common'
  * @availability stack since=8.8.0 stability=experimental
  * @availability serverless stability=experimental visibility=public
  * @doc_tag analytics
+ * @doc_id delete-analytics-collection
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/get/SearchApplicationsGetRequest.ts
+++ b/specification/search_application/get/SearchApplicationsGetRequest.ts
@@ -25,7 +25,7 @@ import { Name } from '@_types/common'
  * @availability stack since=8.8.0 stability=beta
  * @availability serverless stability=beta visibility=public
  * @cluster_privileges manage_search_application
- * @doc_id apis
+ * @doc_id search-application-get
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/get/SearchApplicationsGetRequest.ts
+++ b/specification/search_application/get/SearchApplicationsGetRequest.ts
@@ -25,6 +25,7 @@ import { Name } from '@_types/common'
  * @availability stack since=8.8.0 stability=beta
  * @availability serverless stability=beta visibility=public
  * @cluster_privileges manage_search_application
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
+++ b/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
@@ -25,7 +25,7 @@ import { Name } from '@_types/common'
  * @availability stack since=8.8.0 stability=experimental
  * @availability serverless stability=experimental visibility=public
  * @doc_tag analytics
- * @doc_id apis
+ * @doc_id list-analytics-collection
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
+++ b/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
@@ -25,6 +25,7 @@ import { Name } from '@_types/common'
  * @availability stack since=8.8.0 stability=experimental
  * @availability serverless stability=experimental visibility=public
  * @doc_tag analytics
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/list/SearchApplicationsListRequest.ts
+++ b/specification/search_application/list/SearchApplicationsListRequest.ts
@@ -26,6 +26,7 @@ import { integer } from '@_types/Numeric'
  * @availability stack since=8.8.0 stability=beta
  * @availability serverless stability=beta visibility=public
  * @cluster_privileges manage_search_application
+ * @doc_id list-analytics-collection
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/put/SearchApplicationsPutRequest.ts
+++ b/specification/search_application/put/SearchApplicationsPutRequest.ts
@@ -27,6 +27,7 @@ import { SearchApplicationParameters } from '../_types/SearchApplicationParamete
  * @availability serverless stability=beta visibility=public
  * @cluster_privileges manage_search_application
  * @index_privileges manage
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/put/SearchApplicationsPutRequest.ts
+++ b/specification/search_application/put/SearchApplicationsPutRequest.ts
@@ -27,7 +27,7 @@ import { SearchApplicationParameters } from '../_types/SearchApplicationParamete
  * @availability serverless stability=beta visibility=public
  * @cluster_privileges manage_search_application
  * @index_privileges manage
- * @doc_id apis
+ * @doc_id search-application-put
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutRequest.ts
+++ b/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutRequest.ts
@@ -25,6 +25,7 @@ import { Name } from '@_types/common'
  * @availability stack since=8.8.0 stability=experimental
  * @availability serverless stability=experimental visibility=public
  * @doc_tag analytics
+ * @doc_id put-analytics-collection
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/search/SearchApplicationsSearchRequest.ts
+++ b/specification/search_application/search/SearchApplicationsSearchRequest.ts
@@ -28,6 +28,7 @@ import { Name } from '@_types/common'
  * @rest_spec_name search_application.search
  * @availability stack since=8.8.0 stability=beta
  * @availability serverless stability=beta visibility=public
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/search/SearchApplicationsSearchRequest.ts
+++ b/specification/search_application/search/SearchApplicationsSearchRequest.ts
@@ -28,7 +28,7 @@ import { Name } from '@_types/common'
  * @rest_spec_name search_application.search
  * @availability stack since=8.8.0 stability=beta
  * @availability serverless stability=beta visibility=public
- * @doc_id apis
+ * @doc_id search-application-search
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
+++ b/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
@@ -29,6 +29,7 @@ import { Refresh } from '@_types/common'
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_security
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
+++ b/specification/security/bulk_delete_role/SecurityBulkDeleteRoleRequest.ts
@@ -29,7 +29,7 @@ import { Refresh } from '@_types/common'
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_security
- * @doc_id apis
+ * @doc_id security-api-bulk-delete-role
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/security/bulk_put_role/SecurityBulkPutRoleRequest.ts
+++ b/specification/security/bulk_put_role/SecurityBulkPutRoleRequest.ts
@@ -31,6 +31,7 @@ import { Refresh } from '@_types/common'
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_security
+ * @doc_id apis
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/security/bulk_put_role/SecurityBulkPutRoleRequest.ts
+++ b/specification/security/bulk_put_role/SecurityBulkPutRoleRequest.ts
@@ -31,7 +31,7 @@ import { Refresh } from '@_types/common'
  * @availability stack since=8.15.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_security
- * @doc_id apis
+ * @doc_id security-api-bulk-put-role
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/security/get_user/SecurityGetUserRequest.ts
+++ b/specification/security/get_user/SecurityGetUserRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Username } from '@_types/common'
 
 /**
- * Get users.s
+ * Get users.
  *
  * Get information about users in the native realm and built-in users.
  * @rest_spec_name security.get_user

--- a/specification/security/get_user/SecurityGetUserRequest.ts
+++ b/specification/security/get_user/SecurityGetUserRequest.ts
@@ -21,7 +21,7 @@ import { RequestBase } from '@_types/Base'
 import { Username } from '@_types/common'
 
 /**
- * Get users.
+ * Get users.s
  *
  * Get information about users in the native realm and built-in users.
  * @rest_spec_name security.get_user

--- a/specification/security/saml_prepare_authentication/Request.ts
+++ b/specification/security/saml_prepare_authentication/Request.ts
@@ -33,7 +33,7 @@ import { RequestBase } from '@_types/Base'
  * If the configuration dictates that SAML authentication requests should be signed, the URL has two extra parameters named `SigAlg` and `Signature`.
  * These parameters contain the algorithm used for the signature and the signature value itself.
  * It also returns a random string that uniquely identifies this SAML Authentication request.
- * The caller of this API needs to store this identifier as it needs to be used in a following step of the authentication process.
+ * The caller of thsis API needs to store this identifier as it needs to be used in a following step of the authentication process.
  * @rest_spec_name security.saml_prepare_authentication
  * @availability stack since=7.5.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/security/saml_prepare_authentication/Request.ts
+++ b/specification/security/saml_prepare_authentication/Request.ts
@@ -33,7 +33,7 @@ import { RequestBase } from '@_types/Base'
  * If the configuration dictates that SAML authentication requests should be signed, the URL has two extra parameters named `SigAlg` and `Signature`.
  * These parameters contain the algorithm used for the signature and the signature value itself.
  * It also returns a random string that uniquely identifies this SAML Authentication request.
- * The caller of thsis API needs to store this identifier as it needs to be used in a following step of the authentication process.
+ * The caller of this API needs to store this identifier as it needs to be used in a following step of the authentication process.
  * @rest_spec_name security.saml_prepare_authentication
  * @availability stack since=7.5.0 stability=stable
  * @availability serverless stability=stable visibility=private

--- a/specification/text_structure/test_grok_pattern/TestGrokPatternRequest.ts
+++ b/specification/text_structure/test_grok_pattern/TestGrokPatternRequest.ts
@@ -27,6 +27,7 @@ import { GrokPattern } from '@_types/common'
  * @rest_spec_name text_structure.test_grok_pattern
  * @availability stack since=8.13.0 stability=stable
  * @availability serverless stability=stable visibility=private
+ * @doc_id test-grok-pattern
  * @ext_doc_id grok
  */
 export interface Request extends RequestBase {

--- a/specification/transform/delete_transform/DeleteTransformRequest.ts
+++ b/specification/transform/delete_transform/DeleteTransformRequest.ts
@@ -23,11 +23,11 @@ import { Duration } from '@_types/Time'
 
 /**
  * Delete a transform.
- * Deletes a transform.
  * @rest_spec_name transform.delete_transform
  * @availability stack since=7.5.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
+ * @doc_id delete-transform
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/transform/get_transform/GetTransformRequest.ts
+++ b/specification/transform/get_transform/GetTransformRequest.ts
@@ -23,11 +23,12 @@ import { integer } from '@_types/Numeric'
 
 /**
  * Get transforms.
- * Retrieves configuration information for transforms.
+ * Get configuration information for transforms.
  * @rest_spec_name transform.get_transform
  * @availability stack since=7.5.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_transform
+ * @doc_id get-transform
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/transform/get_transform_stats/GetTransformStatsRequest.ts
+++ b/specification/transform/get_transform_stats/GetTransformStatsRequest.ts
@@ -24,12 +24,13 @@ import { Duration } from '@_types/Time'
 
 /**
  * Get transform stats.
- * Retrieves usage information for transforms.
+ * Get usage information for transforms.
  * @rest_spec_name transform.get_transform_stats
  * @availability stack since=7.5.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor_transform
  * @index_privileges read, view_index_metadata
+ * @doc_id get-transform-stats
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/transform/preview_transform/PreviewTransformRequest.ts
+++ b/specification/transform/preview_transform/PreviewTransformRequest.ts
@@ -42,6 +42,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
  * @index_privileges read, view_index_metadata
+ * @doc_id preview-transform
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/transform/put_transform/PutTransformRequest.ts
+++ b/specification/transform/put_transform/PutTransformRequest.ts
@@ -59,6 +59,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
  * @index_privileges create_index, read, index, view_index_metadata
+ * @doc_id put-transform
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/transform/reset_transform/ResetTransformRequest.ts
+++ b/specification/transform/reset_transform/ResetTransformRequest.ts
@@ -30,6 +30,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.1.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
+ * @doc_id reset-transform
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/transform/schedule_now_transform/ScheduleNowTransformRequest.ts
+++ b/specification/transform/schedule_now_transform/ScheduleNowTransformRequest.ts
@@ -32,6 +32,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.7.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
+ * @doc_id schedule-now-transform
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/transform/start_transform/StartTransformRequest.ts
+++ b/specification/transform/start_transform/StartTransformRequest.ts
@@ -44,6 +44,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
  * @index_privileges read, view_index_metadata
+ * @doc_id start-transform
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/transform/stop_transform/StopTransformRequest.ts
+++ b/specification/transform/stop_transform/StopTransformRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=7.5.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
+ * @doc_id stop-transform
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/transform/update_transform/UpdateTransformRequest.ts
+++ b/specification/transform/update_transform/UpdateTransformRequest.ts
@@ -42,6 +42,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_transform
  * @index_privileges read, index, view_index_metadata
+ * @doc_id update-transform
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/transform/upgrade_transforms/UpgradeTransformsRequest.ts
+++ b/specification/transform/upgrade_transforms/UpgradeTransformsRequest.ts
@@ -39,6 +39,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=7.16.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges manage_transform
+ * @doc_id upgrade-transforms
  */
 export interface Request extends RequestBase {
   urls: [


### PR DESCRIPTION
This PR adds the missing doc_id values so that we can subsequently update the target URLs to the new API site.

It also adds some missing descriptions and examples that were found while making these changes. In particular, copied from https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-blocks.html#add-index-block and https://www.elastic.co/guide/en/elasticsearch/reference/current/post-inference-api.html