### PR TITLE
Add default values for EQL allow_partial_search_results and allow_partial_sequence_results

### DIFF
--- a/specification/eql/search/EqlSearchRequest.ts
+++ b/specification/eql/search/EqlSearchRequest.ts
@@ -117,7 +117,19 @@ export interface Request extends RequestBase {
     keep_alive?: Duration
     keep_on_completion?: boolean
     wait_for_completion_timeout?: Duration
+    /**
+     * Allow query execution also in case of shard failures.
+     * If true, the query will keep running and will return results based on the available shards.
+     * For sequences, the behavior can be further refined using allow_partial_sequence_results
+     * @server_default true
+     */
     allow_partial_search_results?: boolean
+    /**
+     * This flag applies only to sequences and has effect only if allow_partial_search_results=true.
+     * If true, the sequence query will return results based on the available shards, ignoring the others.
+     * If false, the sequence query will return successfully, but will always have empty results.
+     * @server_default false
+     */
     allow_partial_sequence_results?: boolean
     /**
      * For basic queries, the maximum number of matching events to return. Defaults to 10


### PR DESCRIPTION
Adding description and default values for EQL `allow_partial_search_results` and `allow_partial_sequence_results`

Wait for https://github.com/elastic/elasticsearch/pull/120887 before backporting