### PR TITLE
[8.x] [DOCS] Add overlays to pull in _global examples (#3634)

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -62,26 +62,131 @@ actions:
         - basicAuth: []
         - bearerAuth: []
 # Examples that apply only to the Elasticsearch OpenAPI document
-  - target: "$.paths['/_features']['get']"
-    description: "Add examples for get features operation"
+## Examples for autoscaling
+  - target: "$.paths['/_autoscaling/policy/{name}']['delete']"
+    description: "Add examples for delete autoscaling policy response"
     update:
       responses:
         200:
           content:
             application/json:
               examples:
-                getFeaturesResponseExample1:
-                  $ref: "../../specification/features/get_features/examples/response/GetFeaturesResponseExample1.yaml"
-  - target: "$.paths['/_features/_reset']['post']"
-    description: "Add examples for reset features operation"
+                deleteAutoscalingPolicyResponseExample1:
+                  $ref: "../../specification/autoscaling/delete_autoscaling_policy/examples/response/DeleteAutoscalingPolicyResponseExample1.yaml"
+  - target: "$.paths['/_autoscaling/capacity']['get']"
+    description: "Add examples for get autoscaling capacity response"
     update:
       responses:
         200:
           content:
             application/json:
               examples:
-                resetFeaturesResponseExample1:
-                  $ref: "../../specification/features/reset_features/examples/response/ResetFeaturesResponseExample1.yaml"
+                getAutoscalingCapacityResponseExample1:
+                  $ref: "../../specification/autoscaling/get_autoscaling_capacity/examples/200_response/GetAutoscalingCapacityResponseExample1.yaml"
+  - target: "$.paths['/_autoscaling/policy/{name}']['get']"
+    description: "Add examples for get autoscaling policy response"
+    update:
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                getAutoscalingPolicyResponseExample1:
+                  $ref: "../../specification/autoscaling/get_autoscaling_policy/examples/200_response/GetAutoscalingPolicyResponseExample1.yaml"
+  - target: "$.paths['/_autoscaling/policy/{name}']['put']"
+    description: "Add examples for create autoscaling policy operation"
+    update:
+      requestBody: 
+        content: 
+          application/json: 
+            examples:
+              createAutoscalingPolicyRequestExample1: 
+                $ref: "../../specification/autoscaling/put_autoscaling_policy/examples/request/PutAutoscalingPolicyRequestExample1.yaml"
+              createAutoscalingPolicyRequestExample2: 
+                $ref: "../../specification/autoscaling/put_autoscaling_policy/examples/request/PutAutoscalingPolicyRequestExample2.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                createAutoscalingPolicyResponseExample1:
+                  $ref: "../../specification/autoscaling/put_autoscaling_policy/examples/200_response/PutAutoscalingPolicyResponseExample1.yaml"
+## Examples for behavioral analytics
+  - target: "$.paths['/_application/analytics/{collection_name}/event/{event_type}']['post']"
+    description: "Add examples for post analytics collection event operation"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              postBehavioralAnalyticsEventRequestExample1:
+                $ref: "../../specification/search_application/post_behavioral_analytics_event/examples/request/BehavioralAnalyticsEventPostRequestExample1.yaml"
+## Examples for ccr
+  - target: "$.paths['/{index}/_ccr/follow']['put']"
+    description: "Add examples for create follower operation"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              createFollowIndexRequestExample1: 
+                $ref: "../../specification/ccr/follow/examples/request/CreateFollowIndexRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                createFollowIndexResponseExample1:
+                  $ref: "../../specification/ccr/follow/examples/response/CreateFollowIndexResponseExample1.yaml"
+  - target: "$.paths['/{index}/_ccr/forget_follower']['post']"
+    description: "Add examples for forget follower operation"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              createFollowIndexRequestExample1: 
+                $ref: "../../specification/ccr/forget_follower/examples/request/ForgetFollowerIndexRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                createFollowIndexResponseExample1:
+                  $ref: "../../specification/ccr/forget_follower/examples/response/ForgetFollowerIndexResponseExample1.yaml"
+  - target: "$.paths['/_ccr/auto_follow/{name}']['put']"
+    description: "Add examples for create auto-follow pattern operation"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              putAutoFollowPatternRequestExample1: 
+                $ref: "../../specification/ccr/put_auto_follow_pattern/examples/request/PutAutoFollowPatternRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                putAutoFollowPatternResponseExample1:
+                  $ref: "../../specification/ccr/put_auto_follow_pattern/examples/response/PutAutoFollowPatternResponseExample1.yaml"
+  - target: "$.paths['/{index}/_ccr/resume_follow']['post']"
+    description: "Add examples for resume a follower operation"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              resumeFollowIndexRequestExample1: 
+                $ref: "../../specification/ccr/resume_follow/examples/request/ResumeFollowIndexRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                resumeFollowIndexResponseExample1:
+                  $ref: "../../specification/ccr/resume_follow/examples/response/ResumeFollowIndexResponseExample1.yaml"
+## Examples for cluster
   - target: "$.components['requestBodies']['cluster.allocation_explain']"
     description: "Add examples for cluster allocation explain operation"
     update: 
@@ -132,16 +237,6 @@ actions:
           examples:
             clusterNodesReloadSecureSettingsResponseExample1:
               $ref: "../../specification/nodes/reload_secure_settings/examples/response/ReloadSecureSettingsResponseExample1.yaml"
-  - target: "$.paths['/_tasks']['get']"
-    description: "Add examples for task management operation"
-    update:
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                getTasksResponseExample1:
-                  $ref: "../../specification/tasks/get/examples/200_response/GetTaskResponseExample1.yaml"
   - target: "$.components['responses']['nodes.info#200']"
     description: "Add response examples for nodes info"
     update: 
@@ -150,6 +245,48 @@ actions:
           examples:
             nodesInfoResponseExample1:
               $ref: "../../specification/nodes/info/examples/200_response/nodesInfoResponseExample1.yaml"
+  - target: "$.paths['/_resolve/cluster/{name}']['get']"
+    description: "Add examples for resolve cluster operation"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                resolveClusterResponseExample1:
+                  $ref: "../../specification/indices/resolve_cluster/examples/200_response/ResolveClusterResponseExample1.yaml"
+## Examples for esql
+  - target: "$.paths['/_query/async']['post']"
+    description: "Add examples for async esql query operation"
+    update:
+      requestBody: 
+        content: 
+          application/json: 
+            examples:
+              esqlAsyncQueryRequestExample1:
+                 $ref: "../../specification/esql/async_query/examples/request/AsyncQueryRequestExample1.yaml"
+## Examples for features
+  - target: "$.paths['/_features']['get']"
+    description: "Add examples for get features operation"
+    update:
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                getFeaturesResponseExample1:
+                  $ref: "../../specification/features/get_features/examples/response/GetFeaturesResponseExample1.yaml"
+  - target: "$.paths['/_features/_reset']['post']"
+    description: "Add examples for reset features operation"
+    update:
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                resetFeaturesResponseExample1:
+                  $ref: "../../specification/features/reset_features/examples/response/ResetFeaturesResponseExample1.yaml"
+## Examples for ilm
   - target: "$.paths['/_ilm/policy/{policy}']['delete']"
     description: "Add examples for delete lifecycle policy operation"
     update:
@@ -268,6 +405,17 @@ actions:
               examples:
                 removePolicyResponseExample1:
                   $ref: "../../specification/ilm/remove_policy/examples/response/RemovePolicyResponseExample1.yaml"
+## Examples for indices
+  - target: "$.paths['/_lifecycle/stats']['get']"
+    description: "Add examples for get lifecycle stats operation"
+    update:
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                dataStreamLifecycleStatsResponseExample1:
+                  $ref: "../../specification/indices/get_data_lifecycle_stats/examples/response/IndicesGetDataLifecycleStatsResponseExample1.yaml"
   - target: "$.components['requestBodies']['indices.clone']"
     description: "Add examples for clone index request"
     update: 
@@ -304,54 +452,6 @@ actions:
               examples:
                 indicesOpenResponseExample1:
                   $ref: "../../specification/indices/open/examples/200_response/indicesOpenResponseExample1.yaml"
-  - target: "$.paths['/_autoscaling/policy/{name}']['delete']"
-    description: "Add examples for delete autoscaling policy response"
-    update:
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                deleteAutoscalingPolicyResponseExample1:
-                  $ref: "../../specification/autoscaling/delete_autoscaling_policy/examples/response/DeleteAutoscalingPolicyResponseExample1.yaml"
-  - target: "$.paths['/_autoscaling/capacity']['get']"
-    description: "Add examples for get autoscaling capacity response"
-    update:
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                getAutoscalingCapacityResponseExample1:
-                  $ref: "../../specification/autoscaling/get_autoscaling_capacity/examples/200_response/GetAutoscalingCapacityResponseExample1.yaml"
-  - target: "$.paths['/_autoscaling/policy/{name}']['get']"
-    description: "Add examples for get autoscaling policy response"
-    update:
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                getAutoscalingPolicyResponseExample1:
-                  $ref: "../../specification/autoscaling/get_autoscaling_policy/examples/200_response/GetAutoscalingPolicyResponseExample1.yaml"
-  - target: "$.paths['/_autoscaling/policy/{name}']['put']"
-    description: "Add examples for create autoscaling policy operation"
-    update:
-      requestBody: 
-        content: 
-          application/json: 
-            examples:
-              createAutoscalingPolicyRequestExample1: 
-                $ref: "../../specification/autoscaling/put_autoscaling_policy/examples/request/PutAutoscalingPolicyRequestExample1.yaml"
-              createAutoscalingPolicyRequestExample2: 
-                $ref: "../../specification/autoscaling/put_autoscaling_policy/examples/request/PutAutoscalingPolicyRequestExample2.yaml"
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                createAutoscalingPolicyResponseExample1:
-                  $ref: "../../specification/autoscaling/put_autoscaling_policy/examples/200_response/PutAutoscalingPolicyResponseExample1.yaml"
   - target: "$.components['responses']['indices.recovery#200']"
     description: "Add example for get index recovery response"
     update: 
@@ -360,16 +460,6 @@ actions:
           examples:
             getIndicesRecoveryResponseExample1:
                   $ref: "../../specification/indices/recovery/examples/200_response/indicesRecoveryResponseExample1.yaml"
-  - target: "$.paths['/_resolve/cluster/{name}']['get']"
-    description: "Add examples for resolve cluster operation"
-    update: 
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                resolveClusterResponseExample1:
-                  $ref: "../../specification/indices/resolve_cluster/examples/200_response/ResolveClusterResponseExample1.yaml"
   - target: "$.components['requestBodies']['indices.shrink']"
     description: "Add example for shrink index request"
     update: 
@@ -394,37 +484,15 @@ actions:
           examples:
             indicesLegacyPutTemplateRequestExample1:
               $ref: "../../specification/indices/put_template/examples/request/indicesPutTemplateRequestExample1.yaml"
-## Examples for behavioral analytics
-  - target: "$.paths['/_application/analytics/{collection_name}/event/{event_type}']['post']"
-    description: "Add examples for post analytics collection event operation"
-    update: 
-      requestBody: 
-        content: 
-          application/json: 
-            examples: 
-              postBehavioralAnalyticsEventRequestExample1:
-                $ref: "../../specification/search_application/post_behavioral_analytics_event/examples/request/BehavioralAnalyticsEventPostRequestExample1.yaml"
-## Examples for esql
-  - target: "$.paths['/_query/async']['post']"
-    description: "Add examples for async esql query operation"
+## Examples for inference
+  - target: "$.components['requestBodies']['inference.stream_inference']"
+    description: "Add example for inference stream request"
     update:
-      requestBody: 
-        content: 
-          application/json: 
-            examples:
-              esqlAsyncQueryRequestExample1:
-                 $ref: "../../specification/esql/async_query/examples/request/AsyncQueryRequestExample1.yaml"
-## Examples for indices
-  - target: "$.paths['/_lifecycle/stats']['get']"
-    description: "Add examples for get lifecycle stats operation"
-    update:
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                dataStreamLifecycleStatsResponseExample1:
-                  $ref: "../../specification/indices/get_data_lifecycle_stats/examples/response/IndicesGetDataLifecycleStatsResponseExample1.yaml"
+      content:
+        application/json:
+          examples:
+            streamInferenceRequestExample1:
+              $ref: "../../specification/inference/stream_inference/examples/request/StreamInferenceRequestExample1.yaml"
 ## Examples for ingest
   - target: "$.components['requestBodies']['simulate.ingest']"
     description: "Add example for simulate ingest request"
@@ -519,7 +587,7 @@ actions:
             examples:
               renderSearchApplicationQueryRequestExample1: 
                 $ref: "../../specification/search_application/render_query/examples/request/SearchApplicationsRenderQueryRequestExample1.yaml"
-# Examples for security
+## Examples for security
   - target: "$.paths['/_security/api_key/_bulk_update']['post']"
     description: "Add examples for bulk update API keys operation"
     update:
@@ -554,6 +622,17 @@ actions:
               examples:
                 delegatePkiResponseExample1:
                   $ref: "../../specification/security/delegate_pki/examples/200_response/SecurityDelegatePkiResponseExample1.yaml"
+## Examples for tasks
+  - target: "$.paths['/_tasks']['get']"
+    description: "Add examples for task management operation"
+    update:
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                getTasksResponseExample1:
+                  $ref: "../../specification/tasks/get/examples/200_response/GetTaskResponseExample1.yaml"
 ## Examples for watcher
   - target: "$.paths['/_watcher/settings']['put']"
     description: "Add request example for update watcher settings"
@@ -574,12 +653,3 @@ actions:
               examples:
                 updateWatcherSettingsRequestExample1: 
                   $ref: "../../specification/watcher/get_settings/examples/200_response/WatcherGetSettingsResponseExample1.yaml"
-## Examples for inference
-  - target: "$.components['requestBodies']['inference.stream_inference']"
-    description: "Add example for inference stream request"
-    update:
-      content:
-        application/json:
-          examples:
-            streamInferenceRequestExample1:
-              $ref: "../../specification/inference/stream_inference/examples/request/StreamInferenceRequestExample1.yaml"

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -1075,296 +1075,6 @@ actions:
       aggregations:
         x-model: true
 # Examples
-  - target: "$.components['requestBodies']['async_search.submit']"
-    description: "Add example for asynch search submit request"
-    update: 
-      content:
-        application/json:
-          examples:
-            asyncSearchSubmitRequestExample1:
-              $ref: "../../specification/async_search/submit/examples/request/AsyncSearchSubmitRequestExample1.yaml"
-  - target: "$.components['responses']['async_search.submit#200']"
-    description: "Add example for asynch search submit response"
-    update: 
-      content:
-        application/json:
-          examples:
-            asyncSearchSubmitResponseExample1:
-              $ref: "../../specification/async_search/submit/examples/response/AsyncSearchSubmitResponseExample1.yaml"
-  - target: "$.paths['/_transform/{transform_id}']['put']"
-    description: "Add examples for create transform operation"
-    update: 
-      requestBody: 
-        content: 
-          application/json: 
-            examples: 
-              createTransformRequestExample1: 
-                $ref: "../../specification/transform/put_transform/examples/request/PutTransformRequestExample1.yaml"
-              createTransformRequestExample2:
-                $ref: "../../specification/transform/put_transform/examples/request/PutTransformRequestExample2.yaml"
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                createTransformResponseExample1:
-                  $ref: "../../specification/transform/put_transform/examples/response/PutTransformResponseExample1.yaml"
-  - target: "$.components['requestBodies']['transform.preview_transform']"
-    description: "Add examples for preview transform operation"
-    update: 
-      content: 
-        application/json: 
-          examples: 
-            previewTransformRequestExample1: 
-              $ref: "../../specification/transform/preview_transform/examples/request/PreviewTransformRequestExample1.yaml"
-  - target: "$.components['responses']['transform.preview_transform#200']"
-    description: "Add examples for preview transform operation"
-    update: 
-      content:
-        application/json:
-          examples:
-            previewTransformResponseExample1:
-              $ref: "../../specification/transform/preview_transform/examples/response/PreviewTransformResponseExample1.yaml"
-  - target: "$.paths['/_transform/{transform_id}/_update']['post']"
-    description: "Add examples for update transform operation"
-    update: 
-      requestBody: 
-        content: 
-          application/json: 
-            examples: 
-              updateTransformRequestExample1: 
-                $ref: "../../specification/transform/update_transform/examples/request/UpdateTransformRequestExample1.yaml"
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                updateTransformResponseExample1:
-                  $ref: "../../specification/transform/update_transform/examples/response/UpdateTransformResponseExample1.yaml"
-  - target: "$.paths['/_eql/search/status/{id}']['get']"
-    description: "Add examples for get async EQL status operation"
-    update: 
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                eqlGetStatusResponseExample1:
-                  $ref: "../../specification/eql/get_status/examples/response/EqlGetStatusResponseExample1.yaml"
-  - target: "$.components['requestBodies']['eql.search']"
-    description: "Add examples for EQL search operation"
-    update: 
-      content: 
-        application/json: 
-          examples: 
-            eqlSearchRequestExample1: 
-              $ref: "../../specification/eql/search/examples/request/EqlSearchRequestExample1.yaml"
-            eqlSearchRequestExample2: 
-              $ref: "../../specification/eql/search/examples/request/EqlSearchRequestExample2.yaml"
-  - target: "$.components['reponses']['eql.search#200']"
-    description: "Add examples for EQL search operation"
-    update: 
-      content:
-        application/json:
-          examples:
-            eqlSearchResponseExample2:
-              $ref: "../../specification/eql/search/examples/response/EqlSearchResponseExample2.yaml"
-  - target: "$.paths['/_query']['post']"
-    description: "Add examples for ES|QL query operation"
-    update: 
-      requestBody: 
-        content: 
-          application/json: 
-            examples: 
-              esqlQueryRequestExample1: 
-                $ref: "../../specification/esql/query/examples/request/QueryRequestExample1.yaml"
-  - target: "$.components['requestBodies']['graph.explore']"
-    description: "Add example for graph explore request"
-    update: 
-      content:
-        application/json:
-          examples:
-            graphExploreRequestExample1:
-              $ref: "../../specification/graph/explore/examples/request/GraphExploreRequestExample1.yaml"
-  - target: "$.paths['/{index}/_block/{block}']['put']"
-    description: "Add examples for add index block operation"
-    update: 
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                indicesAddBlockResponseExample1:
-                  $ref: "../../specification/indices/add_block/examples/response/IndicesAddBlockResponseExample1.yaml"
-  - target: "$.components['requestBodies']['indices.analyze']"
-    description: "Add example for analyze API request"
-    update: 
-      content:
-        application/json:
-          examples:
-            indicesAnalyzeRequestExample1:
-              $ref: "../../specification/indices/analyze/examples/request/indicesAnalyzeRequestExample1.yaml"
-  - target: "$.paths['/{index}']['put']"
-    description: "Add examples for create index request"
-    update: 
-      requestBody:
-        content:
-          application/json:
-            examples:
-              indicesCreateRequestExample1:
-                $ref: "../../specification/indices/create/examples/request/indicesCreateRequestExample1.yaml"
-              indicesCreateRequestExample2:
-                $ref: "../../specification/indices/create/examples/request/indicesCreateRequestExample2.yaml"
-  - target: "$.paths['/_data_stream/{name}/_lifecycle']['delete']"
-    description: "Add example for delete data stream lifecycle response"
-    update: 
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                indicesDeleteDataLifecycleResponseExample1:
-                  $ref: "../../specification/indices/delete_data_lifecycle/examples/200_response/IndicesDeleteDataLifecycleResponseExample1.yaml"
-  - target: "$.paths['/_data_stream/{name}/_lifecycle']['get']"
-    description: "Add example for get data stream lifecycle response"
-    update: 
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                indicesGetDataLifecycleResponseExample1:
-                  $ref: "../../specification/indices/get_data_lifecycle/examples/response/IndicesGetDataLifecycleResponseExample1.yaml"
-  - target: "$.components['responses']['indices.get_data_stream#200']"
-    description: "Add example for get data stream response"
-    update: 
-      content:
-        application/json:
-          examples:
-            indicesGetDataStreamResponseExample:
-              $ref: "../../specification/indices/get_data_stream/examples/200_response/indicesGetDataStreamResponseExample1.yaml"
-  - target: "$.paths['/_data_stream/{name}/_lifecycle']['put']"
-    description: "Add examples update data stream lifecycle request and response"
-    update: 
-      requestBody: 
-        content: 
-          application/json: 
-            examples: 
-              indicesPutDataLifecycleRequestExample1: 
-                $ref: "../../specification/indices/put_data_lifecycle/examples/request/IndicesPutDataLifecycleRequestExample1.yaml"
-              indicesPutLifecycleRequestExample2:
-                $ref: "../../specification/indices/put_data_lifecycle/examples/request/IndicesPutDataLifecycleRequestExample2.yaml"
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                indicesPutDataLifecycleResponseExample1:
-                  $ref: "../../specification/indices/put_data_lifecycle/examples/200_response/IndicesPutDataLifecycleResponseExample1.yaml"
-  - target: "$.paths['/{index}/_lifecycle/explain']['get']"
-    description: "Add example for explain data stream lifecycle response"
-    update: 
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                indicesExplainDataLifecycleResponseExample:
-                  $ref: "../../specification/indices/explain_data_lifecycle/examples/response/IndicesExplainDataLifecycleResponseExample1.yaml"
-  - target: "$.components['responses']['ingest.get_pipeline#200']"
-    description: "Add example for get pipeline response"
-    update: 
-      content:
-        application/json:
-          examples:
-            indicesGetDataStreamResponseExample:
-              $ref: "../../specification/ingest/get_pipeline/examples/200_response/GetPipelineResponseExample1.yaml"
-  - target: "$.paths['/_ingest/pipeline/{id}']['put']"
-    description: "Add examples for create pipeline"
-    update: 
-      requestBody: 
-        content: 
-          application/json: 
-            examples: 
-              putPipelineRequestExample1: 
-                $ref: "../../specification/ingest/put_pipeline/examples/request/PutPipelineRequestExample1.yaml"
-              putPipelineRequestExample2: 
-                $ref: "../../specification/ingest/put_pipeline/examples/request/PutPipelineRequestExample2.yaml"
-  - target: "$.components['requestBodies']['ingest.simulate']"
-    description: "Add example for simulate pipeline request"
-    update: 
-      content:
-        application/json:
-          examples:
-            simulatePipelineRequestExample1:
-              $ref: "../../specification/ingest/simulate/examples/request/SimulatePipelineRequestExample1.yaml"
-  - target: "$.components['responses']['ingest.simulate#200']"
-    description: "Add example for simulate pipeline response"
-    update: 
-      content:
-        application/json:
-          examples:
-            simulatePipelineResponseExample1:
-              $ref: "../../specification/ingest/simulate/examples/response/SimulatePipelineResponseExample1.yaml"
-  - target: "$.components['requestBodies']['indices.put_index_template']"
-    description: "Add example for create index template request"
-    update: 
-      content:
-        application/json:
-          examples:
-            indicesPutIndexTemplateRequestExample1:
-              $ref: "../../specification/indices/put_index_template/examples/request/indicesPutIndexTemplateRequestExample1.yaml"
-  - target: "$.components['requestBodies']['indices.put_mapping']"
-    description: "Add example for update mapping request"
-    update: 
-      content:
-        application/json:
-          examples:
-            indicesPutSettingRequestExample1:
-              $ref: "../../specification/indices/put_mapping/examples/request/indicesPutMappingRequestExample1.yaml"
-  - target: "$.components['requestBodies']['indices.put_settings']"
-    description: "Add example for update index settings request"
-    update: 
-      content:
-        application/json:
-          examples:
-            indicesPutSettingRequestExample1:
-              $ref: "../../specification/indices/put_settings/examples/request/IndicesPutSettingsRequestExample1.yaml"
-  - target: "$.paths['/_resolve/index/{name}']['get']"
-    description: "Add examples for resolve index operation"
-    update: 
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                indicesResolveResponseExample1:
-                  $ref: "../../specification/indices/resolve_index/examples/response/ResolveIndexResponseExample1.yaml"
-  - target: "$.components['requestBodies']['indices.rollover']"
-    description: "Add example for rollover index request"
-    update: 
-      content:
-        application/json:
-          examples:
-            indicesRolloverRequestExample1:
-              $ref: "../../specification/indices/rollover/examples/request/indicesRolloverRequestExample1.yaml"
-  - target: "$.components['responses']['indices.rollover#200']"
-    description: "Add example for rollover index response"
-    update: 
-      content:
-        application/json:
-          examples:
-            indicesRolloverResponseExample1:
-              $ref: "../../specification/indices/rollover/examples/200_response/indicesRolloverResponseExample1.yaml"
-## Examples for behavioral analytics
-  - target: "$.components['responses']['search_application.get_behavioral_analytics#200']"
-    description: "Add example for get behavioral analytics collections response"
-    update: 
-      content:
-        application/json:
-          examples:
-            getBehavioralAnalyticsCollectionsResponseExample1:
-              $ref: "../../specification/search_application/get_behavioral_analytics/examples/200_response/BehavioralAnalyticsGetResponseExample1.yaml"
 ## Examples for cat
   - target: "$.components['responses']['cat.aliases#200']"
     description: "Add example for cat aliases response"
@@ -1652,6 +1362,457 @@ actions:
               examples:
                 catTasksResponseExample1: 
                   $ref: "../../specification/cat/tasks/examples/200_response/CatTasksResponseExample1.yaml"
+## Examples for data streams
+  - target: "$.paths['/_data_stream/{name}/_lifecycle']['delete']"
+    description: "Add example for delete data stream lifecycle response"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                indicesDeleteDataLifecycleResponseExample1:
+                  $ref: "../../specification/indices/delete_data_lifecycle/examples/200_response/IndicesDeleteDataLifecycleResponseExample1.yaml"
+  - target: "$.paths['/_data_stream/{name}/_lifecycle']['get']"
+    description: "Add example for get data stream lifecycle response"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                indicesGetDataLifecycleResponseExample1:
+                  $ref: "../../specification/indices/get_data_lifecycle/examples/response/IndicesGetDataLifecycleResponseExample1.yaml"
+  - target: "$.components['responses']['indices.get_data_stream#200']"
+    description: "Add example for get data stream response"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesGetDataStreamResponseExample:
+              $ref: "../../specification/indices/get_data_stream/examples/200_response/indicesGetDataStreamResponseExample1.yaml"
+  - target: "$.paths['/_data_stream/{name}/_lifecycle']['put']"
+    description: "Add examples update data stream lifecycle request and response"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              indicesPutDataLifecycleRequestExample1: 
+                $ref: "../../specification/indices/put_data_lifecycle/examples/request/IndicesPutDataLifecycleRequestExample1.yaml"
+              indicesPutLifecycleRequestExample2:
+                $ref: "../../specification/indices/put_data_lifecycle/examples/request/IndicesPutDataLifecycleRequestExample2.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                indicesPutDataLifecycleResponseExample1:
+                  $ref: "../../specification/indices/put_data_lifecycle/examples/200_response/IndicesPutDataLifecycleResponseExample1.yaml"
+  - target: "$.paths['/{index}/_lifecycle/explain']['get']"
+    description: "Add example for explain data stream lifecycle response"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                indicesExplainDataLifecycleResponseExample:
+                  $ref: "../../specification/indices/explain_data_lifecycle/examples/response/IndicesExplainDataLifecycleResponseExample1.yaml"
+## Examples for documents
+  - target: "$.components['requestBodies']['bulk']"
+    description: "Add example for bulk index or delete documents"
+    update: 
+      content:
+        application/json:
+          examples:
+            bulkDocumentRequestExample1:
+              $ref: "../../specification/_global/bulk/examples/request/BulkRequestExample1.yaml"
+            bulkDocumentRequestExample2:
+              $ref: "../../specification/_global/bulk/examples/request/BulkRequestExample2.yaml"
+            bulkDocumentRequestExample3:
+              $ref: "../../specification/_global/bulk/examples/request/BulkRequestExample3.yaml"
+            bulkDocumentRequestExample4:
+              $ref: "../../specification/_global/bulk/examples/request/BulkRequestExample4.yaml"
+  - target: "$.components['responses']['bulk#200']"
+    description: "Add example for bulk indext or delete documents response"
+    update: 
+      content:
+        application/json:
+          examples:
+            bulkDocumentResponseExample1:
+              $ref: "../../specification/_global/bulk/examples/response/BulkResponseExample1.yaml"
+            bulkDocumentResponseExample2:
+              $ref: "../../specification/_global/bulk/examples/response/BulkResponseExample2.yaml"
+            bulkDocumentResponseExample3:
+              $ref: "../../specification/_global/bulk/examples/response/BulkResponseExample3.yaml"
+  - target: "$.components['requestBodies']['create']"
+    description: "Add example for create documents"
+    update: 
+      content:
+        application/json:
+          examples:
+            createDocumentRequestExample1:
+              $ref: "../../specification/_global/create/examples/request/CreateRequestExample1.yaml"
+  - target: "$.paths['/{index}/_doc/{id}']['delete']"
+    description: "Add examples for delete document operation"
+    update: 
+      responses:
+        200: 
+          content: 
+            application/json: 
+              examples: 
+                deleteDocumentResponseExample1: 
+                  $ref: "../../specification/_global/delete/examples/response/DeleteResponseExample1.yaml"
+  - target: "$.paths['/{index}/_delete_by_query']['post']"
+    description: "Add examples delete by query operation"
+    update:
+      requestBody:
+        content:
+          application/json:
+            examples:
+              deleteByQueryRequestExample1:
+                $ref: "../../specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample1.yaml"
+              deleteByQueryRequestExample2:
+                $ref: "../../specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample2.yaml"
+              deleteByQueryRequestExample3:
+                $ref: "../../specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample3.yaml"
+              deleteByQueryRequestExample4:
+                $ref: "../../specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample4.yaml"
+      responses:
+        200: 
+          content: 
+            application/json: 
+              examples: 
+                deleteDocumentResponseExample1: 
+                  $ref: "../../specification/_global/delete_by_query/examples/response/DeleteByQueryResponseExample1.yaml"
+  - target: "$.paths['/{index}/_doc/{id}']['get']"
+    description: "Add examples for get document operation"
+    update: 
+      responses:
+        200: 
+          content: 
+            application/json: 
+              examples: 
+                getDocumentResponseExample1: 
+                  $ref: "../../specification/_global/get/examples/response/GetResponseExample1.yaml"
+                getDocumentResponseExample2: 
+                  $ref: "../../specification/_global/get/examples/response/GetResponseExample2.yaml"
+                getDocumentResponseExample3: 
+                  $ref: "../../specification/_global/get/examples/response/GetResponseExample3.yaml"
+  - target: "$.components['requestBodies']['index']"
+    description: "Add example for index request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indexRequestExample1:
+              $ref: "../../specification/_global/index/examples/request/IndexRequestExample1.yaml"
+            indexRequestExample2:
+              $ref: "../../specification/_global/index/examples/request/IndexRequestExample2.yaml"
+  - target: "$.components['responses']['index#200']"
+    description: "Add example for index response"
+    update: 
+      content:
+        application/json:
+          examples:
+            indexResponseExample1:
+              $ref: "../../specification/_global/index/examples/response/IndexResponseExample1.yaml"
+            indexResponseExample2:
+              $ref: "../../specification/_global/index/examples/response/IndexResponseExample2.yaml"
+  - target: "$.components['requestBodies']['mget']"
+    description: "Add example for mget request"
+    update: 
+      content:
+        application/json:
+          examples:
+            mgetRequestExample1:
+              $ref: "../../specification/_global/mget/examples/request/MultiGetRequestExample1.yaml"
+            mgetRequestExample2:
+              $ref: "../../specification/_global/mget/examples/request/MultiGetRequestExample2.yaml"
+            mgetRequestExample3:
+              $ref: "../../specification/_global/mget/examples/request/MultiGetRequestExample3.yaml"
+            mgetRequestExample4:
+              $ref: "../../specification/_global/mget/examples/request/MultiGetRequestExample4.yaml"
+  - target: "$.components['requestBodies']['mtermvectors']"
+    description: "Add example for multi term vectors request"
+    update: 
+      content:
+        application/json:
+          examples:
+            multiTermVectorsRequestExample1:
+              $ref: "../../specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample1.yaml"
+            multiTermVectorsRequestExample2:
+              $ref: "../../specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample2.yaml"
+            multiTermVectorsRequestExample3:
+              $ref: "../../specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample3.yaml"
+  - target: "$.paths['/_reindex']['post']"
+    description: "Add examples for reindex operation"
+    update:
+      requestBody:
+        content:
+          application/json:
+            examples:
+              reindexRequestExample1:
+                $ref: "../../specification/_global/reindex/examples/request/ReindexRequestExample1.yaml"
+              reindexRequestExample2:
+                $ref: "../../specification/_global/reindex/examples/request/ReindexRequestExample2.yaml"
+              reindexRequestExample3:
+                $ref: "../../specification/_global/reindex/examples/request/ReindexRequestExample3.yaml"
+              reindexRequestExample4:
+                $ref: "../../specification/_global/reindex/examples/request/ReindexRequestExample4.yaml"
+              reindexRequestExample5:
+                $ref: "../../specification/_global/reindex/examples/request/ReindexRequestExample5.yaml"
+              reindexRequestExample6:
+                $ref: "../../specification/_global/reindex/examples/request/ReindexRequestExample6.yaml"
+              reindexRequestExample7:
+                $ref: "../../specification/_global/reindex/examples/request/ReindexRequestExample7.yaml"
+              reindexRequestExample8:
+                $ref: "../../specification/_global/reindex/examples/request/ReindexRequestExample8.yaml"
+              reindexRequestExample9:
+                $ref: "../../specification/_global/reindex/examples/request/ReindexRequestExample9.yaml"
+              reindexRequestExample10:
+                $ref: "../../specification/_global/reindex/examples/request/ReindexRequestExample10.yaml"
+              reindexRequestExample11:
+                $ref: "../../specification/_global/reindex/examples/request/ReindexRequestExample11.yaml"
+              reindexRequestExample12:
+                $ref: "../../specification/_global/reindex/examples/request/ReindexRequestExample12.yaml"
+  - target: "$.paths['/{index}/_update/{id}']['post']"
+    description: "Add examples for update document operation"
+    update:
+      requestBody:
+        content:
+          application/json:
+            examples:
+              updateRequestExample1:
+                $ref: "../../specification/_global/update/examples/request/UpdateRequestExample1.yaml"
+              updateRequestExample2:
+                $ref: "../../specification/_global/update/examples/request/UpdateRequestExample2.yaml"
+              updateRequestExample3:
+                $ref: "../../specification/_global/update/examples/request/UpdateRequestExample3.yaml"
+              updateRequestExample4:
+                $ref: "../../specification/_global/update/examples/request/UpdateRequestExample4.yaml"
+              updateRequestExample5:
+                $ref: "../../specification/_global/update/examples/request/UpdateRequestExample5.yaml"
+              updateRequestExample6:
+                $ref: "../../specification/_global/update/examples/request/UpdateRequestExample6.yaml"
+              updateRequestExample7:
+                $ref: "../../specification/_global/update/examples/request/UpdateRequestExample7.yaml"
+              updateRequestExample8:
+                $ref: "../../specification/_global/update/examples/request/UpdateRequestExample8.yaml"
+              updateRequestExample9:
+                $ref: "../../specification/_global/update/examples/request/UpdateRequestExample9.yaml"
+              updateRequestExample10:
+                $ref: "../../specification/_global/update/examples/request/UpdateRequestExample10.yaml"
+              updateRequestExample11:
+                $ref: "../../specification/_global/update/examples/request/UpdateRequestExample11.yaml"
+      responses:
+        200: 
+          content:
+            application/json:
+              examples:
+                updateResponseExample1: 
+                  $ref: "../../specification/_global/update/examples/response/UpdateResponseExample1.yaml"
+  - target: "$.paths['/{index}/_update_by_query']['post']"
+    description: "Add examples for update by query operation"
+    update:
+      requestBody:
+        content:
+          application/json:
+            examples:
+              updateByQueryRequestExample1:
+                $ref: "../../specification/_global/update_by_query/examples/request/UpdateByQueryRequestExample1.yaml"
+              updateByQueryRequestExample2:
+                $ref: "../../specification/_global/update_by_query/examples/request/UpdateByQueryRequestExample2.yaml"
+              updateByQueryRequestExample3:
+                $ref: "../../specification/_global/update_by_query/examples/request/UpdateByQueryRequestExample3.yaml"
+              updateByQueryRequestExample4:
+                $ref: "../../specification/_global/update_by_query/examples/request/UpdateByQueryRequestExample4.yaml"
+## Examples for EQL
+  - target: "$.paths['/_eql/search/status/{id}']['get']"
+    description: "Add examples for get async EQL status operation"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                eqlGetStatusResponseExample1:
+                  $ref: "../../specification/eql/get_status/examples/response/EqlGetStatusResponseExample1.yaml"
+  - target: "$.components['requestBodies']['eql.search']"
+    description: "Add examples for EQL search operation"
+    update: 
+      content: 
+        application/json: 
+          examples: 
+            eqlSearchRequestExample1: 
+              $ref: "../../specification/eql/search/examples/request/EqlSearchRequestExample1.yaml"
+            eqlSearchRequestExample2: 
+              $ref: "../../specification/eql/search/examples/request/EqlSearchRequestExample2.yaml"
+  - target: "$.components['reponses']['eql.search#200']"
+    description: "Add examples for EQL search operation"
+    update: 
+      content:
+        application/json:
+          examples:
+            eqlSearchResponseExample2:
+              $ref: "../../specification/eql/search/examples/response/EqlSearchResponseExample2.yaml"
+## Examples for ESQL
+  - target: "$.paths['/_query']['post']"
+    description: "Add examples for ES|QL query operation"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              esqlQueryRequestExample1: 
+                $ref: "../../specification/esql/query/examples/request/QueryRequestExample1.yaml"
+## Examples for graph
+  - target: "$.components['requestBodies']['graph.explore']"
+    description: "Add example for graph explore request"
+    update: 
+      content:
+        application/json:
+          examples:
+            graphExploreRequestExample1:
+              $ref: "../../specification/graph/explore/examples/request/GraphExploreRequestExample1.yaml"
+## Examples for indices
+  - target: "$.components['requestBodies']['indices.put_index_template']"
+    description: "Add example for create index template request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesPutIndexTemplateRequestExample1:
+              $ref: "../../specification/indices/put_index_template/examples/request/indicesPutIndexTemplateRequestExample1.yaml"
+  - target: "$.components['requestBodies']['indices.put_mapping']"
+    description: "Add example for update mapping request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesPutSettingRequestExample1:
+              $ref: "../../specification/indices/put_mapping/examples/request/indicesPutMappingRequestExample1.yaml"
+  - target: "$.components['requestBodies']['indices.put_settings']"
+    description: "Add example for update index settings request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesPutSettingRequestExample1:
+              $ref: "../../specification/indices/put_settings/examples/request/IndicesPutSettingsRequestExample1.yaml"
+  - target: "$.paths['/_resolve/index/{name}']['get']"
+    description: "Add examples for resolve index operation"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                indicesResolveResponseExample1:
+                  $ref: "../../specification/indices/resolve_index/examples/response/ResolveIndexResponseExample1.yaml"
+  - target: "$.components['requestBodies']['indices.rollover']"
+    description: "Add example for rollover index request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesRolloverRequestExample1:
+              $ref: "../../specification/indices/rollover/examples/request/indicesRolloverRequestExample1.yaml"
+  - target: "$.components['responses']['indices.rollover#200']"
+    description: "Add example for rollover index response"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesRolloverResponseExample1:
+              $ref: "../../specification/indices/rollover/examples/200_response/indicesRolloverResponseExample1.yaml"
+  - target: "$.paths['/{index}/_block/{block}']['put']"
+    description: "Add examples for add index block operation"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                indicesAddBlockResponseExample1:
+                  $ref: "../../specification/indices/add_block/examples/response/IndicesAddBlockResponseExample1.yaml"
+  - target: "$.components['requestBodies']['indices.analyze']"
+    description: "Add example for analyze API request"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesAnalyzeRequestExample1:
+              $ref: "../../specification/indices/analyze/examples/request/indicesAnalyzeRequestExample1.yaml"
+  - target: "$.paths['/{index}']['put']"
+    description: "Add examples for create index request"
+    update: 
+      requestBody:
+        content:
+          application/json:
+            examples:
+              indicesCreateRequestExample1:
+                $ref: "../../specification/indices/create/examples/request/indicesCreateRequestExample1.yaml"
+              indicesCreateRequestExample2:
+                $ref: "../../specification/indices/create/examples/request/indicesCreateRequestExample2.yaml"
+  - target: "$.components['requestBodies']['cluster.put_component_template']"
+    description: "Add example for put component template request"
+    update: 
+      content:
+        application/json:
+          examples:
+            clusterPutComponentTemplateRequestExample1:
+              $ref: "../../specification/cluster/put_component_template/examples/request/ClusterPutComponentTemplateRequestExample1.yaml"
+            clusterPutComponentTemplateRequestExample2:
+              $ref: "../../specification/cluster/put_component_template/examples/request/ClusterPutComponentTemplateRequestExample2.yaml"
+## Examples for info
+  - target: "$.paths['/']['get']"
+    description: "Add examples for cluster info"
+    update: 
+      responses:
+        200: 
+          content:
+            application/json:
+              examples:
+                catMasterResponseExample1: 
+                  $ref: "../../specification/_global/info/examples/response/RootNodeInfoResponseExample1.yaml"
+## Examples for ingest
+  - target: "$.components['responses']['ingest.get_pipeline#200']"
+    description: "Add example for get pipeline response"
+    update: 
+      content:
+        application/json:
+          examples:
+            indicesGetDataStreamResponseExample:
+              $ref: "../../specification/ingest/get_pipeline/examples/200_response/GetPipelineResponseExample1.yaml"
+  - target: "$.paths['/_ingest/pipeline/{id}']['put']"
+    description: "Add examples for create pipeline"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              putPipelineRequestExample1: 
+                $ref: "../../specification/ingest/put_pipeline/examples/request/PutPipelineRequestExample1.yaml"
+              putPipelineRequestExample2: 
+                $ref: "../../specification/ingest/put_pipeline/examples/request/PutPipelineRequestExample2.yaml"
+  - target: "$.components['requestBodies']['ingest.simulate']"
+    description: "Add example for simulate pipeline request"
+    update: 
+      content:
+        application/json:
+          examples:
+            simulatePipelineRequestExample1:
+              $ref: "../../specification/ingest/simulate/examples/request/SimulatePipelineRequestExample1.yaml"
+  - target: "$.components['responses']['ingest.simulate#200']"
+    description: "Add example for simulate pipeline response"
+    update: 
+      content:
+        application/json:
+          examples:
+            simulatePipelineResponseExample1:
+              $ref: "../../specification/ingest/simulate/examples/response/SimulatePipelineResponseExample1.yaml"## Examples for behavioral analytics
 ## Examples for licensing
   - target: "$.paths['/_license']['get']"
     description: "Add example for get license response"
@@ -1663,6 +1824,254 @@ actions:
               examples:
                 getLicenseResponseExample1:
                   $ref: "../../specification/license/get/examples/response/GetLicenseResponseExample1.yaml"
+## Examples for script
+  - target: "$.components['requestBodies']['put_script']"
+    description: "Add example for create script request"
+    update: 
+      content:
+        application/json:
+          examples:
+            putScriptRequestExample1:
+              $ref: "../../specification/_global/put_script/examples/request/PutScriptRequestExample1.yaml"
+            putScriptRequestExample2:
+              $ref: "../../specification/_global/put_script/examples/request/PutScriptRequestExample2.yaml"
+  - target: "$.components['requestBodies']['scripts_painless_execute']"
+    description: "Add example for run painless script request"
+    update: 
+      content:
+        application/json:
+          examples:
+            runPainlessScriptRequestExample1:
+              $ref: "../../specification/_global/scripts_painless_execute/examples/request/ExecutePainlessScriptRequestExample1.yaml"
+            runPainlessScriptRequestExample2:
+              $ref: "../../specification/_global/scripts_painless_execute/examples/request/ExecutePainlessScriptRequestExample2.yaml"
+            runPainlessScriptRequestExample3:
+              $ref: "../../specification/_global/scripts_painless_execute/examples/request/ExecutePainlessScriptRequestExample3.yaml"
+  - target: "$.components['responses']['scripts_painless_execute#200']"
+    description: "Add example for run painless script response"
+    update: 
+      content:
+        application/json:
+          examples:
+            runPainlessScriptResponseExample1:
+              $ref: "../../specification/_global/scripts_painless_execute/examples/response/ExecutePainlessScriptResponseExample1.yaml"
+            runPainlessScriptResponseExample2:
+              $ref: "../../specification/_global/scripts_painless_execute/examples/response/ExecutePainlessScriptResponseExample2.yaml"
+            runPainlessScriptResponseExample3:
+              $ref: "../../specification/_global/scripts_painless_execute/examples/response/ExecutePainlessScriptResponseExample3.yaml"
+## Examples for search
+  - target: "$.components['requestBodies']['clear_scroll']"
+    description: "Add example for clear scroll request"
+    update: 
+      content:
+        application/json:
+          examples:
+            clearScrollRequestExample1:
+              $ref: "../../specification/_global/clear_scroll/examples/request/ClearScrollRequestExample1.yaml"
+  - target: "$.paths['/_pit']['delete']"
+    description: "Add examples for close PIT operation"
+    update:
+      requestBody:
+        content:
+          application/json:
+            examples:
+              closePointInTimeRequestExample1: 
+                $ref: "../../specification/_global/close_point_in_time/examples/request/ClosePointInTimeRequestExample1.yaml"
+      responses:
+        200: 
+          content: 
+            application/json: 
+              examples: 
+                closePointInTimeResponseExample1: 
+                  $ref: "../../specification/_global/close_point_in_time/examples/200_response/ClosePointInTimeResponseExample1.yaml"
+  - target: "$.components['requestBodies']['count']"
+    description: "Add example for count request"
+    update: 
+      content:
+        application/json:
+          examples:
+            countRequestExample1:
+              $ref: "../../specification/_global/count/examples/request/CountRequestExample1.yaml"
+  - target: "$.components['responses']['count#200']"
+    description: "Add example for count response"
+    update: 
+      content:
+        application/json:
+          examples:
+            countResponseExample1:
+              $ref: "../../specification/_global/count/examples/200_response/CountResponseExample1.yaml"
+  - target: "$.components['requestBodies']['explain']"
+    description: "Add example for explain request"
+    update: 
+      content:
+        application/json:
+          examples:
+            explainRequestExample1:
+              $ref: "../../specification/_global/explain/examples/request/ExplainRequestExample1.yaml"
+  - target: "$.components['responses']['explain#200']"
+    description: "Add example for explain response"
+    update: 
+      content:
+        application/json:
+          examples:
+            explainResponseExample1:
+              $ref: "../../specification/_global/explain/examples/response/ExplainResponseExample1.yaml"
+  - target: "$.components['requestBodies']['field_caps']"
+    description: "Add example for field capabilities request"
+    update: 
+      content:
+        application/json:
+          examples:
+            fieldCapabilitiesRequestExample1:
+              $ref: "../../specification/_global/field_caps/examples/request/FieldCapabilitiesRequestExample1.yaml"
+  - target: "$.components['responses']['field_caps#200']"
+    description: "Add example for field capabilities response"
+    update: 
+      content:
+        application/json:
+          examples:
+            fieldCapabilitiesResponseExample1:
+              $ref: "../../specification/_global/field_caps/examples/response/FieldCapabilitiesResponseExample1.yaml"
+            fieldCapabilitiesResponseExample2:
+              $ref: "../../specification/_global/field_caps/examples/response/FieldCapabilitiesResponseExample2.yaml"
+  - target: "$.components['requestBodies']['msearch_template']"
+    description: "Add example for multi search template request"
+    update: 
+      content:
+        application/json:
+          examples:
+            multiSearchTemplateRequestExample1:
+              $ref: "../../specification/_global/msearch_template/examples/request/MultiSearchTemplateRequestExample1.yaml"
+  - target: "$.paths['/{index}/_pit']['post']"
+    description: "Add examples for open PIT operation"
+    update:
+      responses:
+        200: 
+          content: 
+            application/json: 
+              examples: 
+                openPointInTimeResponseExample1: 
+                  $ref: "../../specification/_global/open_point_in_time/examples/response/OpenPointInTimeResponseExample1.yaml"
+  - target: "$.components['requestBodies']['scroll']"
+    description: "Add example for scroll request"
+    update: 
+      content:
+        application/json:
+          examples:
+            scrollRequestExample1:
+              $ref: "../../specification/_global/scroll/examples/request/ScrollRequestExample1.yaml"
+  - target: "$.components['requestBodies']['search']"
+    description: "Add example for search request"
+    update: 
+      content:
+        application/json:
+          examples:
+            searchRequestExample1:
+              $ref: "../../specification/_global/search/examples/request/SearchRequestExample1.yaml"
+            searchRequestExample2:
+              $ref: "../../specification/_global/search/examples/request/SearchRequestExample2.yaml"
+            searchRequestExample3:
+              $ref: "../../specification/_global/search/examples/request/SearchRequestExample3.yaml"
+  - target: "$.components['responses']['search#200']"
+    description: "Add example for search response"
+    update: 
+      content:
+        application/json:
+          examples:
+            searchResponseExample1:
+              $ref: "../../specification/_global/search/examples/200_response/SearchResponseExample1.yaml"
+  - target: "$.components['requestBodies']['search_mvt']"
+    description: "Add example for search MVT request"
+    update: 
+      content:
+        application/json:
+          examples:
+            searchMvtRequestExample1:
+              $ref: "../../specification/_global/search_mvt/examples/request/SearchMvtRequestExample1.yaml"
+  - target: "$.components['responses']['search_mvt#200']"
+    description: "Add example for search MVT response"
+    update: 
+      content:
+        application/json:
+          examples:
+            searchMvtResponseExample1:
+              $ref: "../../specification/_global/search_mvt/examples/response/SearchMvtResponseExample1.yaml"
+  - target: "$.components['responses']['search_shards#200']"
+    description: "Add example for search shards response"
+    update: 
+      content:
+        application/json:
+          examples:
+            searchShardsResponseExample1:
+              $ref: "../../specification/_global/search_shards/examples/response/SearchShardsResponseExample1.yaml"
+  - target: "$.components['requestBodies']['search_template']"
+    description: "Add example for search template request"
+    update: 
+      content:
+        application/json:
+          examples:
+            searchTemplateRequestExample1:
+              $ref: "../../specification/_global/search_template/examples/request/SearchTemplateRequestExample1.yaml"
+  - target: "$.components['requestBodies']['terms_enum']"
+    description: "Add example for terms enum request"
+    update: 
+      content:
+        application/json:
+          examples:
+            termsEnumRequestExample1:
+              $ref: "../../specification/_global/terms_enum/examples/request/TermsEnumRequestExample1.yaml"
+  - target: "$.components['responses']['terms_enum#200']"
+    description: "Add example for terms enum response"
+    update: 
+      content:
+        application/json:
+          examples:
+            termsEnumResponseExample1:
+              $ref: "../../specification/_global/terms_enum/examples/response/TermsEnumResponseExample1.yaml"
+  - target: "$.components['requestBodies']['termvectors']"
+    description: "Add example for term vectors request"
+    update: 
+      content:
+        application/json:
+          examples:
+            termVectorsRequestExample1:
+              $ref: "../../specification/_global/termvectors/examples/request/TermVectorsRequestExample1.yaml"
+            termVectorsRequestExample2:
+              $ref: "../../specification/_global/termvectors/examples/request/TermVectorsRequestExample2.yaml"
+            termVectorsRequestExample3:
+              $ref: "../../specification/_global/termvectors/examples/request/TermVectorsRequestExample3.yaml"
+            termVectorsRequestExample4:
+              $ref: "../../specification/_global/termvectors/examples/request/TermVectorsRequestExample4.yaml"
+            termVectorsRequestExample5:
+              $ref: "../../specification/_global/termvectors/examples/request/TermVectorsRequestExample5.yaml"
+  - target: "$.components['responses']['termvectors#200']"
+    description: "Add example for term vectors response"
+    update: 
+      content:
+        application/json:
+          examples:
+            termVectorsResponseExample1:
+              $ref: "../../specification/_global/termvectors/examples/response/TermVectorsResponseExample1.yaml"
+            termVectorsResponseExample2:
+              $ref: "../../specification/_global/termvectors/examples/response/TermVectorsResponseExample2.yaml"
+            termVectorsResponseExample3:
+              $ref: "../../specification/_global/termvectors/examples/response/TermVectorsResponseExample3.yaml"
+  - target: "$.components['requestBodies']['async_search.submit']"
+    description: "Add example for asynch search submit request"
+    update: 
+      content:
+        application/json:
+          examples:
+            asyncSearchSubmitRequestExample1:
+              $ref: "../../specification/async_search/submit/examples/request/AsyncSearchSubmitRequestExample1.yaml"
+  - target: "$.components['responses']['async_search.submit#200']"
+    description: "Add example for asynch search submit response"
+    update: 
+      content:
+        application/json:
+          examples:
+            asyncSearchSubmitResponseExample1:
+              $ref: "../../specification/async_search/submit/examples/response/AsyncSearchSubmitResponseExample1.yaml"
 ## Examples for search applications
   - target: "$.paths['/_application/search_application']['get']"
     description: "Add examples for get search applications operation"
@@ -1701,3 +2110,62 @@ actions:
           examples:
             searchApplicationSearchRequestExample1:
               $ref: "../../specification/search_application/search/examples/request/SearchApplicationsSearchRequestExample1.yaml"
+  - target: "$.components['responses']['search_application.get_behavioral_analytics#200']"
+    description: "Add example for get behavioral analytics collections response"
+    update: 
+      content:
+        application/json:
+          examples:
+            getBehavioralAnalyticsCollectionsResponseExample1:
+              $ref: "../../specification/search_application/get_behavioral_analytics/examples/200_response/BehavioralAnalyticsGetResponseExample1.yaml"
+## Examples for transforms
+  - target: "$.paths['/_transform/{transform_id}']['put']"
+    description: "Add examples for create transform operation"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              createTransformRequestExample1: 
+                $ref: "../../specification/transform/put_transform/examples/request/PutTransformRequestExample1.yaml"
+              createTransformRequestExample2:
+                $ref: "../../specification/transform/put_transform/examples/request/PutTransformRequestExample2.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                createTransformResponseExample1:
+                  $ref: "../../specification/transform/put_transform/examples/response/PutTransformResponseExample1.yaml"
+  - target: "$.components['requestBodies']['transform.preview_transform']"
+    description: "Add examples for preview transform operation"
+    update: 
+      content: 
+        application/json: 
+          examples: 
+            previewTransformRequestExample1: 
+              $ref: "../../specification/transform/preview_transform/examples/request/PreviewTransformRequestExample1.yaml"
+  - target: "$.components['responses']['transform.preview_transform#200']"
+    description: "Add examples for preview transform operation"
+    update: 
+      content:
+        application/json:
+          examples:
+            previewTransformResponseExample1:
+              $ref: "../../specification/transform/preview_transform/examples/response/PreviewTransformResponseExample1.yaml"
+  - target: "$.paths['/_transform/{transform_id}/_update']['post']"
+    description: "Add examples for update transform operation"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              updateTransformRequestExample1: 
+                $ref: "../../specification/transform/update_transform/examples/request/UpdateTransformRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                updateTransformResponseExample1:
+                  $ref: "../../specification/transform/update_transform/examples/response/UpdateTransformResponseExample1.yaml"

--- a/specification/_global/info/RootNodeInfoRequest.ts
+++ b/specification/_global/info/RootNodeInfoRequest.ts
@@ -27,6 +27,7 @@ import { RequestBase } from '@_types/Base'
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges monitor
  * @doc_id api-root
+ * @doc_tag info
  */
 export interface Request extends RequestBase {
   urls: [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Add overlays to pull in _global examples (#3634)](https://github.com/elastic/elasticsearch-specification/pull/3634)

This PR must be merged after https://github.com/elastic/elasticsearch-specification/pull/3609

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)