### PR TITLE
Update spec for ESQL async query stop

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -8920,10 +8920,15 @@
                     "is_running": {
                       "description": "Indicates whether the query is still running.\nIf the value is false, the async query has finished and the results are returned.",
                       "type": "boolean"
+                    },
+                    "is_partial": {
+                      "description": "Indicates whether the query returned partial result, e.g. because if was stopped.",
+                      "type": "boolean"
                     }
                   },
                   "required": [
-                    "is_running"
+                    "is_running",
+                    "is_partial"
                   ]
                 }
               }
@@ -8968,6 +8973,72 @@
           }
         },
         "x-state": "Added in 8.13.0"
+      }
+    },
+    "/_query/async/{id}/stop": {
+      "post": {
+        "tags": [
+          "esql"
+        ],
+        "summary": "Stop async ES|QL query",
+        "description": "Interrupts the query execution and returns the results so far.\nIf the Elasticsearch security features are enabled, only the user who first submitted the ES|QL query can stop it.",
+        "externalDocs": {
+          "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html"
+        },
+        "operationId": "esql-async-query-stop",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "description": "The unique identifier of the query.\nA query ID is provided in the ES|QL async query API response for a query that does not complete in the designated time.\nA query ID is also provided when the request was submitted with the `keep_on_completion` parameter set to `true`.",
+            "required": true,
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Id"
+            },
+            "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "drop_null_columns",
+            "description": "Indicates whether columns that are entirely `null` will be removed from the `columns` and `values` portion of the results.\nIf `true`, the response will include an extra section under the name `all_columns` which has the name of all the columns.",
+            "deprecated": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "style": "form"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "columns": {
+                      "$ref": "#/components/schemas/_types:EsqlColumns"
+                    },
+                    "is_running": {
+                      "description": "Indicates whether the query is still running.\nFor stopped query results, this will always be false.",
+                      "type": "boolean"
+                    },
+                    "is_partial": {
+                      "description": "Indicates whether the query returned partial result, e.g. because if was stopped.\nThis will be false if the query completed before the stop command was issued.",
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "is_running",
+                    "is_partial"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "x-state": "Added in 8.18.0"
       }
     },
     "/_query": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10572,6 +10572,18 @@ export interface EsqlAsyncQueryGetRequest extends RequestBase {
 export interface EsqlAsyncQueryGetResponse {
   columns?: EsqlColumns
   is_running: boolean
+  is_partial: boolean
+}
+
+export interface EsqlAsyncQueryStopRequest extends RequestBase {
+  id: Id
+  drop_null_columns?: boolean
+}
+
+export interface EsqlAsyncQueryStopResponse {
+  columns?: EsqlColumns
+  is_running: boolean
+  is_partial: boolean
 }
 
 export interface EsqlQueryRequest extends RequestBase {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -187,6 +187,7 @@ esql,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/esql.html
 esql-async-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/esql-async-query-api.html
 esql-async-query-delete,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/esql-async-query-delete-api.html
 esql-async-query-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/esql-async-query-get-api.html
+esql-async-query-stop,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/esql-async-query-stop-api.html
 esql-query,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/esql-rest.html
 esql-query-params,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/esql-rest.html#esql-rest-params
 esql-returning-localized-results,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/esql-rest.html#esql-locale-param

--- a/specification/_json_spec/esql.async_query_stop.json
+++ b/specification/_json_spec/esql.async_query_stop.json
@@ -1,0 +1,27 @@
+{
+  "esql.async_query_stop": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-async-query-stop-api.html",
+      "description": "Stops a previously submitted async query request given its ID and collects the results."
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": ["application/json"]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_query/async/{id}/stop",
+          "methods": ["POST"],
+          "parts": {
+            "id": {
+              "type": "string",
+              "description": "The async query ID"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/specification/esql/async_query_get/AsyncQueryGetResponse.ts
+++ b/specification/esql/async_query_get/AsyncQueryGetResponse.ts
@@ -27,5 +27,9 @@ export class Response {
      * If the value is false, the async query has finished and the results are returned.
      */
     is_running: boolean
+    /**
+     * Indicates whether the query returned partial result, e.g. because if was stopped.
+     */
+    is_partial: boolean
   }
 }

--- a/specification/esql/async_query_stop/AsyncQueryStopRequest.ts
+++ b/specification/esql/async_query_stop/AsyncQueryStopRequest.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Id } from '@_types/common'
+
+/**
+ * Stop async ES|QL query.
+ * Interrupts the query execution and returns the results so far.
+ * If the Elasticsearch security features are enabled, only the user who first submitted the ES|QL query can stop it.
+ * @rest_spec_name esql.async_query_stop
+ * @availability stack since=8.18.0 stability=stable visibility=public
+ * @doc_id esql-async-query-stop
+ * @ext_doc_id esql
+ */
+export interface Request extends RequestBase {
+  path_parts: {
+    /**
+     * The unique identifier of the query.
+     * A query ID is provided in the ES|QL async query API response for a query that does not complete in the designated time.
+     * A query ID is also provided when the request was submitted with the `keep_on_completion` parameter set to `true`.
+     */
+    id: Id
+  }
+  query_parameters: {
+    /**
+     * Indicates whether columns that are entirely `null` will be removed from the `columns` and `values` portion of the results.
+     * If `true`, the response will include an extra section under the name `all_columns` which has the name of all the columns.
+     * @server_default false
+     */
+    drop_null_columns?: boolean
+  }
+}

--- a/specification/esql/async_query_stop/AsyncQueryStopResponse.ts
+++ b/specification/esql/async_query_stop/AsyncQueryStopResponse.ts
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { EsqlColumns } from '@_types/Binary'
+
+export class Response {
+  body: {
+    columns?: EsqlColumns
+    /**
+     * Indicates whether the query is still running.
+     * For stopped query results, this will always be false.
+     */
+    is_running: boolean
+    /**
+     * Indicates whether the query returned partial result, e.g. because if was stopped.
+     * This will be false if the query completed before the stop command was issued.
+     */
+    is_partial: boolean
+  }
+}


### PR DESCRIPTION
Update spec for:
* ESQL async `POST query/stop` API
* is_partial in ESQL query response