### PR TITLE
[DOCS] Add overlays for connector API examples

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -121,6 +121,19 @@ actions:
             examples: 
               postBehavioralAnalyticsEventRequestExample1:
                 $ref: "../../specification/search_application/post_behavioral_analytics_event/examples/request/BehavioralAnalyticsEventPostRequestExample1.yaml"
+## Examples for cat
+  - target: "$.components['responses']['cat.thread_pool#200']"
+    description: "Add example for cat thread pool response"
+    update: 
+      content:
+        text/plain:
+          schema:
+            type: string
+          examples:
+            catThreadPoolResponseExample1:
+              $ref: "../../specification/cat/thread_pool/examples/200_response/CatThreadPoolResponseExample1.yaml"
+            catThreadPoolResponseExample2:
+              $ref: "../../specification/cat/thread_pool/examples/200_response/CatThreadPoolResponseExample2.yaml"
 ## Examples for ccr
   - target: "$.paths['/{index}/_ccr/follow']['put']"
     description: "Add examples for create follower operation"
@@ -145,14 +158,14 @@ actions:
         content: 
           application/json: 
             examples: 
-              createFollowIndexRequestExample1: 
+              forgetFollowerRequestExample1: 
                 $ref: "../../specification/ccr/forget_follower/examples/request/ForgetFollowerIndexRequestExample1.yaml"
       responses:
         200:
           content:
             application/json:
               examples:
-                createFollowIndexResponseExample1:
+                forgetFollowerResponseExample1:
                   $ref: "../../specification/ccr/forget_follower/examples/response/ForgetFollowerIndexResponseExample1.yaml"
   - target: "$.paths['/_ccr/auto_follow/{name}']['put']"
     description: "Add examples for create auto-follow pattern operation"

--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -188,14 +188,6 @@ actions:
                   $ref: "../../specification/ccr/resume_follow/examples/response/ResumeFollowIndexResponseExample1.yaml"
 ## Examples for cluster
   - target: "$.components['requestBodies']['cluster.allocation_explain']"
-    description: "Add example for cluster allocation exaplain request"
-    update:
-      content:
-        application/json:
-          examples:
-            clusterAllocationExplainRequestExample1:
-              $ref: "../../specification/cluster/allocation_explain/examples/request/ClusterAllocationExplainRequestExample1.yaml"
-  - target: "$.components['requestBodies']['cluster.allocation_explain']"
     description: "Add examples for cluster allocation explain operation"
     update: 
       content: 
@@ -494,16 +486,6 @@ actions:
           examples:
             indicesLegacyPutTemplateRequestExample1:
               $ref: "../../specification/indices/put_template/examples/request/indicesPutTemplateRequestExample1.yaml"
-  - target: "$.paths['/_lifecycle/stats']['get']"
-    description: "Add examples for get lifecycle stats operation"
-    update:
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                dataStreamLifecycleStatsResponseExample1:
-                  $ref: "../../specification/indices/get_data_lifecycle_stats/examples/response/IndicesGetDataLifecycleStatsResponseExample1.yaml"
 ## Examples for inference
   - target: "$.components['requestBodies']['inference.stream_inference']"
     description: "Add example for inference stream request"

--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -260,6 +260,34 @@ actions:
           examples:
             nodesInfoResponseExample1:
               $ref: "../../specification/nodes/info/examples/200_response/nodesInfoResponseExample1.yaml"
+## Examples for connectors
+  - target: "$.paths['/_connector/_sync_job/{connector_sync_job_id}/_error']['put']"
+    description: "Add examples for connector job sync error operation"
+    update:
+      requestBody: 
+        content: 
+          application/json: 
+            examples:
+              syncJobErrorRequestExample1:
+                 $ref: "../../specification/connector/sync_job_error/examples/request/SyncJobErrorRequestExample1.yaml"
+  - target: "$.paths['/_connector/{connector_id}/_features']['put']"
+    description: "Add examples for update connector features"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              connectorUpdateFeaturesRequestExample1: 
+                $ref: "../../specification/connector/update_features/examples/request/ConnectorUpdateFeaturesRequestExample1.yaml"
+              connectorUpdateFeaturesRequestExample2: 
+                $ref: "../../specification/connector/update_features/examples/request/ConnectorUpdateFeaturesRequestExample2.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorUpdateFeaturesResponseExample1:
+                  $ref: "../../specification/connector/update_features/examples/response/ConnectorUpdateFeaturesResponseExample1.yaml"
 ## Examples for esql
   - target: "$.paths['/_query/async']['post']"
     description: "Add examples for async esql query operation"

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -1350,6 +1350,230 @@ actions:
               examples:
                 catTasksResponseExample1: 
                   $ref: "../../specification/cat/tasks/examples/200_response/CatTasksResponseExample1.yaml"
+## Examples for connectors
+  - target: "$.paths['/_connector/{connector_id}/_check_in']['put']"
+    description: "Add example for check in connector response"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorCheckInResponseExample1:
+                  $ref: "../../specification/connector/check_in/examples/response/ConnectorCheckInResponseExample1.yaml"
+  - target: "$.paths['/_connector/{connector_id}']['delete']"
+    description: "Add example for delete connector response"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorDeleteResponseExample1:
+                  $ref: "../../specification/connector/delete/examples/response/ConnectorDeleteResponseExample1.yaml"
+  - target: "$.components['requestBodies']['connector.put']"
+    description: "Add example for create connector request"
+    update: 
+      content:
+        application/json:
+          examples:
+            connectorPutRequestExample1:
+              $ref: "../../specification/connector/put/examples/request/ConnectorPutRequestExample1.yaml"
+            connectorPutRequestExample2:
+              $ref: "../../specification/connector/put/examples/request/ConnectorPutRequestExample2.yaml"
+  - target: "$.components['responses']['connector.put#200']"
+    description: "Add example for create connector response"
+    update: 
+      content:
+        application/json:
+          examples:
+            connectorPutResponseExample:
+              $ref: "../../specification/connector/put/examples/response/ConnectorPutResponseExample1.yaml"
+  - target: "$.paths['/_connector/_sync_job/{connector_sync_job_id}']['delete']"
+    description: "Add example for delete sync job response"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                syncJobDeleteResponseExample1:
+                  $ref: "../../specification/connector/sync_job_delete/examples/response/SyncJobDeleteResponseExample1.yaml"
+  - target: "$.paths['/_connector/_sync_job']['post']"
+    description: "Add example for create sync job"
+    update: 
+      requestBody:
+        content:
+          application/json:
+            examples:
+              syncJobPostRequestExample1:
+                $ref: "../../specification/connector/sync_job_post/examples/request/SyncJobPostRequestExample1.yaml"
+  - target: "$.paths['/_connector/{connector_id}/_api_key_id']['put']"
+    description: "Add examples for update connector API key ID"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              connectorUpdateApiKeyIdRequestExample1: 
+                $ref: "../../specification/connector/update_api_key_id/examples/request/ConnectorUpdateApiKeyIDRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorUpdateApiKeyIdResponseExample1:
+                  $ref: "../../specification/connector/update_api_key_id/examples/response/ConnectorUpdateApiKeyIDResponseExample1.yaml"
+  - target: "$.paths['/_connector/{connector_id}/_configuration']['put']"
+    description: "Add examples for update connector configuration"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              connectorUpdateConfigurationRequestExample1: 
+                $ref: "../../specification/connector/update_configuration/examples/request/ConnectorUpdateConfigurationRequestExample1.yaml"
+              connectorUpdateConfigurationRequestExample2: 
+                $ref: "../../specification/connector/update_configuration/examples/request/ConnectorUpdateConfigurationRequestExample2.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorUpdateConfigurationResponseExample1:
+                  $ref: "../../specification/connector/update_configuration/examples/response/ConnectorUpdateConfigurationResponseExample1.yaml"
+  - target: "$.paths['/_connector/{connector_id}/_error']['put']"
+    description: "Add examples for update connector error field"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              connectorUpdateConfigurationRequestExample1: 
+                $ref: "../../specification/connector/update_error/examples/request/ConnectorUpdateErrorRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorUpdateErrorResponseExample1:
+                  $ref: "../../specification/connector/update_error/examples/response/ConnectorUpdateErrorResponseExample1.yaml"
+  - target: "$.paths['/_connector/{connector_id}/_filtering']['put']"
+    description: "Add examples for update connector filtering"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              connectorUpdateFilteringRequestExample1: 
+                $ref: "../../specification/connector/update_filtering/examples/request/ConnectorUpdateFilteringRequestExample1.yaml"
+              connectorUpdateFilteringRequestExample2: 
+                $ref: "../../specification/connector/update_filtering/examples/request/ConnectorUpdateFilteringRequestExample2.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorUpdateFilteringResponseExample1:
+                  $ref: "../../specification/connector/update_filtering/examples/response/ConnectorUpdateFilteringResponseExample1.yaml"
+  - target: "$.paths['/_connector/{connector_id}/_index_name']['put']"
+    description: "Add examples for update connector index name"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              connectorUpdateIndexNameRequestExample1: 
+                $ref: "../../specification/connector/update_index_name/examples/request/ConnectorUpdateIndexNameRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorUpdateIndexNameResponseExample1:
+                  $ref: "../../specification/connector/update_index_name/examples/response/ConnectorUpdateIndexNameResponseExample1.yaml"
+  - target: "$.paths['/_connector/{connector_id}/_name']['put']"
+    description: "Add examples for update connector name"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              connectorUpdateNameRequestExample1: 
+                $ref: "../../specification/connector/update_name/examples/request/ConnectorUpdateNameRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorUpdateNameResponseExample1:
+                  $ref: "../../specification/connector/update_name/examples/response/ConnectorUpdateNameResponseExample1.yaml"
+  - target: "$.paths['/_connector/{connector_id}/_pipeline']['put']"
+    description: "Add examples for update connector pipeline"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              connectorUpdatePipelineRequestExample1: 
+                $ref: "../../specification/connector/update_pipeline/examples/request/ConnectorUpdatePipelineRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorUpdatePipelineResponseExample1:
+                  $ref: "../../specification/connector/update_pipeline/examples/response/ConnectorUpdatePipelineResponseExample1.yaml"
+  - target: "$.paths['/_connector/{connector_id}/_scheduling']['put']"
+    description: "Add examples for update connector scheduling"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              connectorUpdateSchedulingRequestExample1: 
+                $ref: "../../specification/connector/update_scheduling/examples/request/ConnectorUpdateSchedulingRequestExample1.yaml"
+              connectorUpdateSchedulingRequestExample2: 
+                $ref: "../../specification/connector/update_scheduling/examples/request/ConnectorUpdateSchedulingRequestExample2.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorUpdateSchedulingResponseExample1:
+                  $ref: "../../specification/connector/update_scheduling/examples/response/ConnectorUpdateSchedulingResponseExample1.yaml"
+  - target: "$.paths['/_connector/{connector_id}/_service_type']['put']"
+    description: "Add examples for update connector service type"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              connectorUpdateServiceTypeRequestExample1: 
+                $ref: "../../specification/connector/update_service_type/examples/request/ConnectorUpdateServiceTypeRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorUpdateServiceTypeResponseExample1:
+                  $ref: "../../specification/connector/update_service_type/examples/response/ConnectorUpdateServiceTypeResponseExample1.yaml"
+  - target: "$.paths['/_connector/{connector_id}/_status']['put']"
+    description: "Add examples for update connector status"
+    update: 
+      requestBody: 
+        content: 
+          application/json: 
+            examples: 
+              connectorUpdateStatusRequestExample1: 
+                $ref: "../../specification/connector/update_status/examples/request/ConnectorUpdateStatusRequestExample1.yaml"
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                connectorUpdateStatusResponseExample1:
+                  $ref: "../../specification/connector/update_status/examples/response/ConnectorUpdateStatusResponseExample1.yaml"
 ## Examples for data streams
   - target: "$.paths['/_data_stream/{name}/_lifecycle']['delete']"
     description: "Add example for delete data stream lifecycle response"

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -1242,18 +1242,6 @@ actions:
           examples:
             catTemplatesResponseExample1:
               $ref: "../../specification/cat/templates/examples/200_response/CatTemplatesResponseExample1.yaml"
-  - target: "$.components['responses']['cat.thread_pool#200']"
-    description: "Add example for cat thread pool response"
-    update: 
-      content:
-        text/plain:
-          schema:
-            type: string
-          examples:
-            catThreadPoolResponseExample1:
-              $ref: "../../specification/cat/thread_pool/examples/200_response/CatThreadPoolResponseExample1.yaml"
-            catThreadPoolResponseExample2:
-              $ref: "../../specification/cat/thread_pool/examples/200_response/CatThreadPoolResponseExample2.yaml"
   - target: "$.components['responses']['cat.transforms#200']"
     description: "Add example for cat transforms response"
     update: 
@@ -1272,7 +1260,7 @@ actions:
               schema:
                 type: string
               examples:
-                catMasterResponseExample1: 
+                catHealthResponseExample1: 
                   $ref: "../../specification/cat/health/examples/200_response/CatHealthResponseExample1.yaml"
   - target: "$.paths['/_cat/master']['get']"
     description: "Add examples for cat master operation"
@@ -1775,7 +1763,7 @@ actions:
           content:
             application/json:
               examples:
-                catMasterResponseExample1: 
+                clusterInfoResponseExample1: 
                   $ref: "../../specification/_global/info/examples/response/RootNodeInfoResponseExample1.yaml"
 ## Examples for ingest
   - target: "$.components['responses']['ingest.get_pipeline#200']"


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/2482

This PR adds the connector API examples to the OpenAPI document via overlays.
It also fixes some duplicate labels and incorrect entries (e.g. cat threadpool should not exist in Serverless) in the overlay files.