### PR TITLE
Add templates and ilm_policies to the Deprecation API response.

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -95900,6 +95900,24 @@
                   "items": {
                     "$ref": "#/components/schemas/migration.deprecations:Deprecation"
                   }
+                },
+                "templates": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/migration.deprecations:Deprecation"
+                    }
+                  }
+                },
+                "ilm_policies": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/migration.deprecations:Deprecation"
+                    }
+                  }
                 }
               },
               "required": [
@@ -95907,7 +95925,9 @@
                 "index_settings",
                 "data_streams",
                 "node_settings",
-                "ml_settings"
+                "ml_settings",
+                "templates",
+                "ilm_policies"
               ]
             }
           }

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13986,6 +13986,8 @@ export interface MigrationDeprecationsResponse {
   data_streams: Record<string, MigrationDeprecationsDeprecation[]>
   node_settings: MigrationDeprecationsDeprecation[]
   ml_settings: MigrationDeprecationsDeprecation[]
+  templates: Record<string, MigrationDeprecationsDeprecation[]>
+  ilm_policies: Record<string, MigrationDeprecationsDeprecation[]>
 }
 
 export interface MigrationGetFeatureUpgradeStatusMigrationFeature {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "elasticsearch-specification",
       "dependencies": {
         "@stoplight/spectral-cli": "^6.14.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "elasticsearch-specification",
       "dependencies": {
         "@stoplight/spectral-cli": "^6.14.2"
       }

--- a/specification/migration/deprecations/DeprecationInfoResponse.ts
+++ b/specification/migration/deprecations/DeprecationInfoResponse.ts
@@ -41,5 +41,14 @@ export class Response {
      * Machine learning-related deprecation warnings.
      */
     ml_settings: Deprecation[]
+    /**
+     * Template warnings are sectioned off per template and include deprecations for both component templates and
+     * index templates.
+     */
+    templates: Dictionary<string, Deprecation[]>
+    /**
+     * ILM policy warnings are sectioned off per policy.
+     */
+    ilm_policies: Dictionary<string, Deprecation[]>
   }
 }


### PR DESCRIPTION
We added a two new fields in the deprecation info api response in https://github.com/elastic/elasticsearch/pull/120505, namely `templates` and `ilm_policies`.

