### PR TITLE
[8.x] Add x-codeSamples to check document API (#3594)

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -2381,3 +2381,13 @@ actions:
               examples:
                 updateTransformResponseExample1:
                   $ref: "../../specification/transform/update_transform/examples/response/UpdateTransformResponseExample1.yaml"
+## xCodeSamples
+  - target: "$.paths['/{index}/_doc/{id}']['head']"
+    description: "Add xCodeSamples for check document operation"
+    update: 
+      x-codeSamples:
+        - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsConsoleExample1.yaml"
+        - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsCurlExample1.yaml"
+        - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsJavaScriptExample1.yaml"
+        - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsPythonExample1.yaml"
+        - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsRubyExample1.yaml"

--- a/specification/_global/exists/examples/xCodeSamples/DocumentExistsConsoleExample1.yaml
+++ b/specification/_global/exists/examples/xCodeSamples/DocumentExistsConsoleExample1.yaml
@@ -1,0 +1,4 @@
+lang: Console
+# label:
+source: |
+  HEAD my-index-000001/_doc/0

--- a/specification/_global/exists/examples/xCodeSamples/DocumentExistsCurlExample1.yaml
+++ b/specification/_global/exists/examples/xCodeSamples/DocumentExistsCurlExample1.yaml
@@ -1,0 +1,4 @@
+lang: Curl
+# label:
+source: |
+  curl -I "localhost:9200/my-index-000001/_doc/0?pretty"

--- a/specification/_global/exists/examples/xCodeSamples/DocumentExistsJavaScriptExample1.yaml
+++ b/specification/_global/exists/examples/xCodeSamples/DocumentExistsJavaScriptExample1.yaml
@@ -1,0 +1,8 @@
+lang: JavaScript
+# label:
+source: |
+  const response = await client.exists({
+    index: "my-index-000001",
+    id: 0,
+  });
+  console.log(response);

--- a/specification/_global/exists/examples/xCodeSamples/DocumentExistsPythonExample1.yaml
+++ b/specification/_global/exists/examples/xCodeSamples/DocumentExistsPythonExample1.yaml
@@ -1,0 +1,8 @@
+lang: Python
+# label:
+source: |
+  resp = client.exists(
+    index="my-index-000001",
+    id="0",
+  )
+  print(resp)

--- a/specification/_global/exists/examples/xCodeSamples/DocumentExistsRubyExample1.yaml
+++ b/specification/_global/exists/examples/xCodeSamples/DocumentExistsRubyExample1.yaml
@@ -1,0 +1,8 @@
+lang: Ruby
+# label:
+source: |
+  response = client.exists(
+    index: 'my-index-000001',
+    id: 0
+  )
+  puts response


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Add x-codeSamples to check document API (#3594)](https://github.com/elastic/elasticsearch-specification/pull/3594)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)