### PR TITLE
[DOCS] Fix overlay for resolve cluster

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -493,16 +493,17 @@ actions:
           examples:
             getIndicesRecoveryResponseExample1:
                   $ref: "../../specification/indices/recovery/examples/200_response/indicesRecoveryResponseExample1.yaml"
-  - target: "$.paths['/_resolve/cluster/{name}']['get']"
+  - target: "$.components['responses']['indices.resolve_cluster#200']"
     description: "Add examples for resolve cluster operation"
     update: 
       responses:
-        200:
-          content:
-            application/json:
-              examples:
-                resolveClusterResponseExample1:
-                  $ref: "../../specification/indices/resolve_cluster/examples/200_response/ResolveClusterResponseExample1.yaml"
+        content:
+          application/json:
+            examples:
+              resolveClusterResponseExample1:
+                $ref: "../../specification/indices/resolve_cluster/examples/200_response/ResolveClusterResponseExample1.yaml"
+              resolveClusterResponseExample2:
+                $ref: "../../specification/indices/resolve_cluster/examples/200_response/ResolveClusterResponseExample2.yaml"
   - target: "$.components['requestBodies']['indices.shrink']"
     description: "Add example for shrink index request"
     update: 

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -66107,7 +66107,7 @@
             "type": "number"
           },
           "cluster_credentials": {
-            "description": "This field presents and has value of ::es_redacted:: only when the remote cluster is configured with the API key based model. Otherwise, the field is not present.",
+            "description": "This field is present and has a value of `::es_redacted::` only when the remote cluster is configured with the API key based model. Otherwise, the field is not present.",
             "type": "string"
           }
         },

--- a/specification/cluster/remote_info/ClusterRemoteInfoResponse.ts
+++ b/specification/cluster/remote_info/ClusterRemoteInfoResponse.ts
@@ -78,6 +78,6 @@ export class ClusterRemoteProxyInfo {
   num_proxy_sockets_connected: integer
   /** The maximum number of socket connections to the remote cluster when proxy mode is configured. */
   max_proxy_socket_connections: integer
-  /** This field presents and has value of ::es_redacted:: only when the remote cluster is configured with the API key based model. Otherwise, the field is not present. */
+  /** This field is present and has a value of `::es_redacted::` only when the remote cluster is configured with the API key based model. Otherwise, the field is not present. */
   cluster_credentials?: string
 }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/pull/3655

This PR updates our overlays to pick up the second example for the resolve cluster API and attaches them to where they now exist in the OpenAPI output (in the components section instead of the paths section).

It also fixes one description string.