### PR TITLE
[8.x] [DOCS] Fix overlay for resolve cluster (#3670)

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -258,16 +258,6 @@ actions:
           examples:
             nodesInfoResponseExample1:
               $ref: "../../specification/nodes/info/examples/200_response/nodesInfoResponseExample1.yaml"
-  - target: "$.paths['/_resolve/cluster/{name}']['get']"
-    description: "Add examples for resolve cluster operation"
-    update:      
-      responses:
-        200:
-          content:
-            application/json:
-              examples:
-                resolveClusterResponseExample1:
-                  $ref: "../../specification/indices/resolve_cluster/examples/200_response/ResolveClusterResponseExample1.yaml"
 ## Examples for connectors
   - target: "$.paths['/_connector/_sync_job/{connector_sync_job_id}/_error']['put']"
     description: "Add examples for connector job sync error operation"
@@ -501,6 +491,17 @@ actions:
           examples:
             getIndicesRecoveryResponseExample1:
                   $ref: "../../specification/indices/recovery/examples/200_response/indicesRecoveryResponseExample1.yaml"
+  - target: "$.components['responses']['indices.resolve_cluster#200']"
+    description: "Add examples for resolve cluster operation"
+    update: 
+      responses:
+        content:
+          application/json:
+            examples:
+              resolveClusterResponseExample1:
+                $ref: "../../specification/indices/resolve_cluster/examples/200_response/ResolveClusterResponseExample1.yaml"
+              resolveClusterResponseExample2:
+                $ref: "../../specification/indices/resolve_cluster/examples/200_response/ResolveClusterResponseExample2.yaml"
   - target: "$.components['requestBodies']['indices.shrink']"
     description: "Add example for shrink index request"
     update: 

--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -494,14 +494,13 @@ actions:
   - target: "$.components['responses']['indices.resolve_cluster#200']"
     description: "Add examples for resolve cluster operation"
     update: 
-      responses:
-        content:
-          application/json:
-            examples:
-              resolveClusterResponseExample1:
-                $ref: "../../specification/indices/resolve_cluster/examples/200_response/ResolveClusterResponseExample1.yaml"
-              resolveClusterResponseExample2:
-                $ref: "../../specification/indices/resolve_cluster/examples/200_response/ResolveClusterResponseExample2.yaml"
+      content:
+        application/json:
+          examples:
+            resolveClusterResponseExample1:
+              $ref: "../../specification/indices/resolve_cluster/examples/200_response/ResolveClusterResponseExample1.yaml"
+            resolveClusterResponseExample2:
+              $ref: "../../specification/indices/resolve_cluster/examples/200_response/ResolveClusterResponseExample2.yaml"
   - target: "$.components['requestBodies']['indices.shrink']"
     description: "Add example for shrink index request"
     update: 

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -66189,7 +66189,7 @@
             "type": "number"
           },
           "cluster_credentials": {
-            "description": "This field presents and has value of ::es_redacted:: only when the remote cluster is configured with the API key based model. Otherwise, the field is not present.",
+            "description": "This field is present and has a value of `::es_redacted::` only when the remote cluster is configured with the API key based model. Otherwise, the field is not present.",
             "type": "string"
           }
         },
@@ -108130,9 +108130,11 @@
                   "$ref": "#/components/schemas/_types:Duration"
                 },
                 "allow_partial_search_results": {
+                  "description": "Allow query execution also in case of shard failures.\nIf true, the query will keep running and will return results based on the available shards.\nFor sequences, the behavior can be further refined using allow_partial_sequence_results",
                   "type": "boolean"
                 },
                 "allow_partial_sequence_results": {
+                  "description": "This flag applies only to sequences and has effect only if allow_partial_search_results=true.\nIf true, the sequence query will return results based on the available shards, ignoring the others.\nIf false, the sequence query will return successfully, but will always have empty results.",
                   "type": "boolean"
                 },
                 "size": {

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -63602,9 +63602,11 @@
                   "$ref": "#/components/schemas/_types:Duration"
                 },
                 "allow_partial_search_results": {
+                  "description": "Allow query execution also in case of shard failures.\nIf true, the query will keep running and will return results based on the available shards.\nFor sequences, the behavior can be further refined using allow_partial_sequence_results",
                   "type": "boolean"
                 },
                 "allow_partial_sequence_results": {
+                  "description": "This flag applies only to sequences and has effect only if allow_partial_search_results=true.\nIf true, the sequence query will return results based on the available shards, ignoring the others.\nIf false, the sequence query will return successfully, but will always have empty results.",
                   "type": "boolean"
                 },
                 "size": {

--- a/specification/cluster/remote_info/ClusterRemoteInfoResponse.ts
+++ b/specification/cluster/remote_info/ClusterRemoteInfoResponse.ts
@@ -78,6 +78,6 @@ export class ClusterRemoteProxyInfo {
   num_proxy_sockets_connected: integer
   /** The maximum number of socket connections to the remote cluster when proxy mode is configured. */
   max_proxy_socket_connections: integer
-  /** This field presents and has value of ::es_redacted:: only when the remote cluster is configured with the API key based model. Otherwise, the field is not present. */
+  /** This field is present and has a value of `::es_redacted::` only when the remote cluster is configured with the API key based model. Otherwise, the field is not present. */
   cluster_credentials?: string
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [[DOCS] Fix overlay for resolve cluster (#3670)](https://github.com/elastic/elasticsearch-specification/pull/3670)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)