### PR TITLE
Remove `UserDefinedValue` from `FieldValue`

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1539,7 +1539,7 @@ export interface SearchHit<TDocument = unknown> {
   matched_queries?: string[] | Record<string, double>
   _nested?: SearchNestedIdentity
   _ignored?: string[]
-  ignored_field_values?: Record<string, FieldValue[]>
+  ignored_field_values?: Record<string, any[]>
   _shard?: string
   _node?: string
   _routing?: string

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10544,7 +10544,7 @@ export interface EsqlAsyncQueryRequest extends RequestBase {
     columnar?: boolean
     filter?: QueryDslQueryContainer
     locale?: string
-    params?: any[]
+    params?: FieldValue[]
     profile?: boolean
     query: string
     tables?: Record<string, Record<string, EsqlTableValuesContainer>>
@@ -10583,7 +10583,7 @@ export interface EsqlQueryRequest extends RequestBase {
     columnar?: boolean
     filter?: QueryDslQueryContainer
     locale?: string
-    params?: any[]
+    params?: FieldValue[]
     profile?: boolean
     query: string
     tables?: Record<string, Record<string, EsqlTableValuesContainer>>

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -2354,7 +2354,7 @@ export interface FieldSort {
 
 export type FieldSortNumericType = 'long' | 'double' | 'date' | 'date_nanos'
 
-export type FieldValue = long | double | string | boolean | null | any
+export type FieldValue = long | double | string | boolean | null
 
 export interface FielddataStats {
   evictions?: long
@@ -10544,7 +10544,7 @@ export interface EsqlAsyncQueryRequest extends RequestBase {
     columnar?: boolean
     filter?: QueryDslQueryContainer
     locale?: string
-    params?: FieldValue[]
+    params?: any[]
     profile?: boolean
     query: string
     tables?: Record<string, Record<string, EsqlTableValuesContainer>>
@@ -10583,7 +10583,7 @@ export interface EsqlQueryRequest extends RequestBase {
     columnar?: boolean
     filter?: QueryDslQueryContainer
     locale?: string
-    params?: FieldValue[]
+    params?: any[]
     profile?: boolean
     query: string
     tables?: Record<string, Record<string, EsqlTableValuesContainer>>

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -23,7 +23,6 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import {
   Field,
   Fields,
-  FieldValue,
   Id,
   IndexName,
   Name,
@@ -53,7 +52,7 @@ export class Hit<TDocument> {
   matched_queries?: string[] | Dictionary<string, double>
   _nested?: NestedIdentity
   _ignored?: string[]
-  ignored_field_values?: Dictionary<string, FieldValue[]>
+  ignored_field_values?: Dictionary<string, UserDefinedValue[]>
   _shard?: string
   _node?: string
   _routing?: string

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -28,12 +28,7 @@ import { double, integer, long } from './Numeric'
  */
 // Note: the ending `UserDefinedValue` includes all other union members, but we keep them explicit so that
 // code generators can provide direct access to scalar values, which are the most common use case.
-export type FieldValue =
-  | long
-  | double
-  | string
-  | boolean
-  | null
+export type FieldValue = long | double | string | boolean | null
 
 /**
  * A scalar value.

--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -24,7 +24,7 @@ import { double, integer, long } from './Numeric'
 
 /**
  * A field value.
- * @codegen_names long, double, string, boolean, null, any
+ * @codegen_names long, double, string, boolean, null
  */
 // Note: the ending `UserDefinedValue` includes all other union members, but we keep them explicit so that
 // code generators can provide direct access to scalar values, which are the most common use case.
@@ -34,7 +34,6 @@ export type FieldValue =
   | string
   | boolean
   | null
-  | UserDefinedValue
 
 /**
  * A scalar value.

--- a/specification/esql/async_query/AsyncQueryRequest.ts
+++ b/specification/esql/async_query/AsyncQueryRequest.ts
@@ -24,6 +24,7 @@ import { RequestBase } from '@_types/Base'
 import { FieldValue } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Duration } from '@_types/Time'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * Run an async ES|QL query.
@@ -97,7 +98,7 @@ export interface Request extends RequestBase {
      * To avoid any attempts of hacking or code injection, extract the values in a separate list of parameters. Use question mark placeholders (?) in the query string for each of the parameters.
      * @doc_id esql-query-params
      */
-    params?: Array<FieldValue>
+    params?: Array<UserDefinedValue>
     /**
      * If provided and `true` the response will include an extra `profile` object
      * with information on how the query was executed. This information is for human debugging

--- a/specification/esql/async_query/AsyncQueryRequest.ts
+++ b/specification/esql/async_query/AsyncQueryRequest.ts
@@ -20,8 +20,8 @@
 import { EsqlFormat } from '@esql/_types/QueryParameters'
 import { TableValuesContainer } from '@esql/_types/TableValuesContainer'
 import { Dictionary } from '@spec_utils/Dictionary'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RequestBase } from '@_types/Base'
+import { FieldValue } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Duration } from '@_types/Time'
 
@@ -97,7 +97,7 @@ export interface Request extends RequestBase {
      * To avoid any attempts of hacking or code injection, extract the values in a separate list of parameters. Use question mark placeholders (?) in the query string for each of the parameters.
      * @doc_id esql-query-params
      */
-    params?: Array<UserDefinedValue>
+    params?: Array<FieldValue>
     /**
      * If provided and `true` the response will include an extra `profile` object
      * with information on how the query was executed. This information is for human debugging

--- a/specification/esql/async_query/AsyncQueryRequest.ts
+++ b/specification/esql/async_query/AsyncQueryRequest.ts
@@ -20,11 +20,10 @@
 import { EsqlFormat } from '@esql/_types/QueryParameters'
 import { TableValuesContainer } from '@esql/_types/TableValuesContainer'
 import { Dictionary } from '@spec_utils/Dictionary'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RequestBase } from '@_types/Base'
-import { FieldValue } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Duration } from '@_types/Time'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * Run an async ES|QL query.

--- a/specification/esql/query/QueryRequest.ts
+++ b/specification/esql/query/QueryRequest.ts
@@ -23,6 +23,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { RequestBase } from '@_types/Base'
 import { FieldValue } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
+import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
  * Run an ES|QL query.
@@ -77,7 +78,7 @@ export interface Request extends RequestBase {
      * To avoid any attempts of hacking or code injection, extract the values in a separate list of parameters. Use question mark placeholders (?) in the query string for each of the parameters.
      * @doc_id esql-query-params
      */
-    params?: Array<FieldValue>
+    params?: Array<UserDefinedValue>
     /**
      * If provided and `true` the response will include an extra `profile` object
      * with information on how the query was executed. This information is for human debugging

--- a/specification/esql/query/QueryRequest.ts
+++ b/specification/esql/query/QueryRequest.ts
@@ -20,8 +20,8 @@
 import { EsqlFormat } from '@esql/_types/QueryParameters'
 import { TableValuesContainer } from '@esql/_types/TableValuesContainer'
 import { Dictionary } from '@spec_utils/Dictionary'
-import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { RequestBase } from '@_types/Base'
+import { FieldValue } from '@_types/common'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 
 /**
@@ -77,7 +77,7 @@ export interface Request extends RequestBase {
      * To avoid any attempts of hacking or code injection, extract the values in a separate list of parameters. Use question mark placeholders (?) in the query string for each of the parameters.
      * @doc_id esql-query-params
      */
-    params?: Array<UserDefinedValue>
+    params?: Array<FieldValue>
     /**
      * If provided and `true` the response will include an extra `profile` object
      * with information on how the query was executed. This information is for human debugging

--- a/specification/esql/query/QueryRequest.ts
+++ b/specification/esql/query/QueryRequest.ts
@@ -20,10 +20,9 @@
 import { EsqlFormat } from '@esql/_types/QueryParameters'
 import { TableValuesContainer } from '@esql/_types/TableValuesContainer'
 import { Dictionary } from '@spec_utils/Dictionary'
-import { RequestBase } from '@_types/Base'
-import { FieldValue } from '@_types/common'
-import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
+import { RequestBase } from '@_types/Base'
+import { QueryContainer } from '@_types/query_dsl/abstractions'
 
 /**
  * Run an ES|QL query.


### PR DESCRIPTION
Some types like e.g. `TermQuery` have a shortcut to a property with the `FieldValue` type.

According to the specification, `FieldValue` was allowed to contain `UserDefinedValue`/`any`. This complicates deserialization in the shortcut property case since we can't simply rely on the JSON token type (`!= Object`) to know that we are handling a shortcut property. While this can be worked around, I still started to check, if `FieldValue` should even be supposed to contain non-scalar values.

@pquentin checked the validation results and found 3 issues:

1. ES|QL queries where params is typed as `FieldValue[]` but named parameters like `{"n1": 300}` are allowed.
2. [ignored_field_values](https://github.com/elastic/elasticsearch-specification/blob/41f2f0a0e1a4df480de14d2d0de5b72861c2f187/specification/_global/search/_types/hits.ts#L56) in responses which can be [a string (keyword in this example) or a dictionary (flat in this example)](https://github.com/elastic/clients-flight-recordings/blob/2471aee1d380161c283ff3a83f76d4b19d057592/elasticsearch/tmp-free/search/e34fc0ebc0b84832658e77dd3e8dab83.json#L80-L89)
3. [TermsQuery](https://github.com/elastic/elasticsearch-specification/blob/41f2f0a0e1a4df480de14d2d0de5b72861c2f187/specification/_types/query_dsl/term.ts#L257-L268) where additional properties are of type FieldValue[] but can be [lists](https://github.com/elastic/clients-flight-recorder/blob/a46c880364c4ad3c85c44f75154c2e2aa533b122/recordings/nest-tests/search/QueryDsl/QueryDslIntegrationTestsBase/QueryDslIntegrationTestsBase__ClientUsage_b__19_0_9__request.json#L9-L14) or [dictionaries](https://github.com/elastic/clients-flight-recorder/blob/main/recordings/nest-tests/search/Cat/CatFielddata/CatFielddataApiTests/unknown_IntegrationSetup_50__request.json) in NEST tests

Checking these cases shows the following:

1. We know that ESQL params are currently not modelled in the best way possible.

   Proposal: Replace with `UserDefinedValue` until we fixed the core issue.
2. https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#retrieve-unmapped-fields
   According to this quote, we are currently using the wrong type as the returned values are not canonical field-values:
   > The response will contain ignored field values under the ignored_field_values path. These values are retrieved from the document’s original JSON source and **are raw so will not be formatted or treated in any way**, unlike the successfully indexed fields which are returned in the fields section.

   Proposal: Replace with `UserDefinedValue`.
3. The first test is wrong `"error": true`. The second test is syntactically valid, but according to another test @pquentin did, does not return semantically correct results.

   Conclusion: Remove/ignore these tests and continue to use `FieldValue`.

Request:
```
# Create an index
PUT /my-index


# Add a document to my-index
POST /my-index/_doc
{
  "curatedTags": {
    "added": "foo",
    "name": "et"
  }
}

POST /my-index/_doc
{
  "curatedTags": {
    "added": "foo",
    "name": "no"
  }
}

GET /my-index/_search
{
  "query": {
    "terms": {
      "curatedTags.added": [
        {
          "added": "foo",
          "name": "et"
        },
        {
          "added": "foo",
          "name": "dolores"
        }
      ]
    }
  }
}
```

Response:
```
{
  "took": 7,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 2,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "my-index",
        "_id": "IMbdy5QBS5uc1xLClKFI",
        "_score": 1,
        "_source": {
          "curatedTags": {
            "added": "foo",
            "name": "et"
          }
        }
      },
      {
        "_index": "my-index",
        "_id": "Icbdy5QBS5uc1xLCvqFt",
        "_score": 1,
        "_source": {
          "curatedTags": {
            "added": "foo",
            "name": "no"
          }
        }
      }
    ]
  }
}
```