### PR TITLE
Update inference.update.json with the correct verb

### DIFF
--- a/specification/_json_spec/inference.update.json
+++ b/specification/_json_spec/inference.update.json
@@ -14,7 +14,7 @@
       "paths": [
         {
           "path": "/_inference/{inference_id}/_update",
-          "methods": ["POST"],
+          "methods": ["PUT"],
           "parts": {
             "inference_id": {
               "type": "string",
@@ -24,7 +24,7 @@
         },
         {
           "path": "/_inference/{task_type}/{inference_id}/_update",
-          "methods": ["POST"],
+          "methods": ["PUT"],
           "parts": {
             "task_type": {
               "type": "string",


### PR DESCRIPTION
The Inference Update API is a `PUT` API not `POST`

The mistake is probably due to the same error in the Elasticsearch repo which has been fixed in https://github.com/elastic/elasticsearch/pull/121048