### PR TITLE
[DOCS] Convert final examples from JSON to YAML

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -267,6 +267,28 @@ actions:
               examples:
                 ccrFollowerStatsResponseExample1:
                   $ref: "../../specification/ccr/follow_stats/examples/response/FollowIndexStatsResponseExample1.yaml"
+  - target: "$.paths['/{index}/_ccr/info']['get']"
+    description: "Add examples for get follower info"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                ccrFollowerInfoResponseExample1:
+                  $ref: "../../specification/ccr/follow_info/examples/response/FollowInfoResponseExample1.yaml"
+                ccrFollowerInfoResponseExample2:
+                  $ref: "../../specification/ccr/follow_info/examples/response/FollowInfoResponseExample2.yaml"
+  - target: "$.paths['/_ccr/auto_follow/{name}']['delete']"
+    description: "Add examples for delete auto follow pattern"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                ccrAutoFollowPatternDeleteResponseExample1:
+                  $ref: "../../specification/ccr/delete_auto_follow_pattern/examples/response/DeleteAutoFollowPatternResponseExample1.yaml"
 ## Examples for cluster
   - target: "$.components['requestBodies']['cluster.allocation_explain']"
     description: "Add examples for cluster allocation explain operation"

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -2463,6 +2463,30 @@ actions:
           examples:
             asyncSearchSubmitResponseExample1:
               $ref: "../../specification/async_search/submit/examples/response/AsyncSearchSubmitResponseExample1.yaml"
+  - target: "$.paths['/_async_search/status/{id}']['get']"
+    description: "Add examples for get async search status"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                asyncSearchStatusResponseExample1:
+                  $ref: "../../specification/async_search/status/examples/response/AsyncSearchStatusResponseExample1.yaml"
+                asyncSearchStatusResponseExample2:
+                  $ref: "../../specification/async_search/status/examples/response/AsyncSearchStatusResponseExample2.yaml"
+                asyncSearchStatusResponseExample3:
+                  $ref: "../../specification/async_search/status/examples/response/AsyncSearchStatusResponseExample3.yaml"
+  - target: "$.paths['/_async_search/{id}']['get']"
+    description: "Add examples for get async search"
+    update: 
+      responses:
+        200:
+          content:
+            application/json:
+              examples:
+                asyncSearchResponseExample1:
+                  $ref: "../../specification/async_search/get/examples/response/AsyncSearchGetResponseExample1.yaml"
 ## Examples for search applications
   - target: "$.paths['/_application/search_application']['get']"
     description: "Add examples for get search applications operation"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -2573,7 +2573,7 @@
           {
             "in": "path",
             "name": "name",
-            "description": "The name of the auto follow pattern.",
+            "description": "The auto-follow pattern collection to delete.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -2584,7 +2584,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Period to wait for a connection to the master node.",
+            "description": "The period to wait for a connection to the master node.\nIf the master node is not available before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -2759,7 +2759,7 @@
           {
             "in": "path",
             "name": "index",
-            "description": "A comma-separated list of index patterns; use `_all` to perform the operation on all indices",
+            "description": "A comma-delimited list of follower index patterns.",
             "required": true,
             "deprecated": false,
             "schema": {
@@ -2770,7 +2770,7 @@
           {
             "in": "query",
             "name": "master_timeout",
-            "description": "Period to wait for a connection to the master node.",
+            "description": "The period to wait for a connection to the master node.\nIf the master node is not available before the timeout expires, the request fails and returns an error.\nIt can also be set to `-1` to indicate that the request should never timeout.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"

--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -32,7 +32,7 @@
           {
             "in": "query",
             "name": "keep_alive",
-            "description": "Specifies how long the async search should be available in the cluster.\nWhen not specified, the `keep_alive` set with the corresponding submit async request will be used.\nOtherwise, it is possible to override the value and extend the validity of the request.\nWhen this period expires, the search, if still running, is cancelled.\nIf the search is completed, its saved results are deleted.",
+            "description": "The length of time that the async search should be available in the cluster.\nWhen not specified, the `keep_alive` set with the corresponding submit async request will be used.\nOtherwise, it is possible to override the value and extend the validity of the request.\nWhen this period expires, the search, if still running, is cancelled.\nIf the search is completed, its saved results are deleted.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -115,7 +115,7 @@
           "search"
         ],
         "summary": "Get the async search status",
-        "description": "Get the status of a previously submitted async search request given its identifier, without retrieving search results.\nIf the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.",
+        "description": "Get the status of a previously submitted async search request given its identifier, without retrieving search results.\nIf the Elasticsearch security features are enabled, the access to the status of a specific async search is restricted to:\n\n* The user or API key that submitted the original async search request.\n* Users that have the `monitor` cluster privilege or greater privileges.",
         "operationId": "async-search-status",
         "parameters": [
           {
@@ -132,7 +132,7 @@
           {
             "in": "query",
             "name": "keep_alive",
-            "description": "Specifies how long the async search needs to be available.\nOngoing async searches and any saved search results are deleted after this period.",
+            "description": "The length of time that the async search needs to be available.\nOngoing async searches and any saved search results are deleted after this period.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -40023,7 +40023,7 @@
         "type": "object",
         "properties": {
           "aggregations": {
-            "description": "Partial aggregations results, coming from the shards that have already completed the execution of the query.",
+            "description": "Partial aggregations results, coming from the shards that have already completed running the query.",
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/_types.aggregations:Aggregate"
@@ -45006,7 +45006,7 @@
             "type": "boolean"
           },
           "is_running": {
-            "description": "Indicates whether the search is still running or has completed.\nNOTE: If the search failed after some shards returned their results or the node that is coordinating the async search dies, results may be partial even though `is_running` is `false`.",
+            "description": "Indicates whether the search is still running or has completed.\n\n> info\n> If the search failed after some shards returned their results or the node that is coordinating the async search dies, results may be partial even though `is_running` is `false`.",
             "type": "boolean"
           },
           "expiration_time": {
@@ -45061,7 +45061,7 @@
                 "$ref": "#/components/schemas/_types:ClusterStatistics"
               },
               "completion_status": {
-                "description": "If the async search completed, this field shows the status code of the search.\nFor example, 200 indicates that the async search was successfully completed.\n503 indicates that the async search was completed with an error.",
+                "description": "If the async search completed, this field shows the status code of the search.\nFor example, `200` indicates that the async search was successfully completed.\n`503` indicates that the async search was completed with an error.",
                 "type": "number"
               }
             },

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -32,7 +32,7 @@
           {
             "in": "query",
             "name": "keep_alive",
-            "description": "Specifies how long the async search should be available in the cluster.\nWhen not specified, the `keep_alive` set with the corresponding submit async request will be used.\nOtherwise, it is possible to override the value and extend the validity of the request.\nWhen this period expires, the search, if still running, is cancelled.\nIf the search is completed, its saved results are deleted.",
+            "description": "The length of time that the async search should be available in the cluster.\nWhen not specified, the `keep_alive` set with the corresponding submit async request will be used.\nOtherwise, it is possible to override the value and extend the validity of the request.\nWhen this period expires, the search, if still running, is cancelled.\nIf the search is completed, its saved results are deleted.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -115,7 +115,7 @@
           "search"
         ],
         "summary": "Get the async search status",
-        "description": "Get the status of a previously submitted async search request given its identifier, without retrieving search results.\nIf the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.",
+        "description": "Get the status of a previously submitted async search request given its identifier, without retrieving search results.\nIf the Elasticsearch security features are enabled, the access to the status of a specific async search is restricted to:\n\n* The user or API key that submitted the original async search request.\n* Users that have the `monitor` cluster privilege or greater privileges.",
         "operationId": "async-search-status",
         "parameters": [
           {
@@ -132,7 +132,7 @@
           {
             "in": "query",
             "name": "keep_alive",
-            "description": "Specifies how long the async search needs to be available.\nOngoing async searches and any saved search results are deleted after this period.",
+            "description": "The length of time that the async search needs to be available.\nOngoing async searches and any saved search results are deleted after this period.",
             "deprecated": false,
             "schema": {
               "$ref": "#/components/schemas/_types:Duration"
@@ -20512,7 +20512,7 @@
         "type": "object",
         "properties": {
           "aggregations": {
-            "description": "Partial aggregations results, coming from the shards that have already completed the execution of the query.",
+            "description": "Partial aggregations results, coming from the shards that have already completed running the query.",
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/_types.aggregations:Aggregate"
@@ -25495,7 +25495,7 @@
             "type": "boolean"
           },
           "is_running": {
-            "description": "Indicates whether the search is still running or has completed.\nNOTE: If the search failed after some shards returned their results or the node that is coordinating the async search dies, results may be partial even though `is_running` is `false`.",
+            "description": "Indicates whether the search is still running or has completed.\n\n> info\n> If the search failed after some shards returned their results or the node that is coordinating the async search dies, results may be partial even though `is_running` is `false`.",
             "type": "boolean"
           },
           "expiration_time": {
@@ -25550,7 +25550,7 @@
                 "$ref": "#/components/schemas/_types:ClusterStatistics"
               },
               "completion_status": {
-                "description": "If the async search completed, this field shows the status code of the search.\nFor example, 200 indicates that the async search was successfully completed.\n503 indicates that the async search was completed with an error.",
+                "description": "If the async search completed, this field shows the status code of the search.\nFor example, `200` indicates that the async search was successfully completed.\n`503` indicates that the async search was completed with an error.",
                 "type": "number"
               }
             },

--- a/specification/_global/bulk/examples/request/BulkRequestExample4.yaml
+++ b/specification/_global/bulk/examples/request/BulkRequestExample4.yaml
@@ -1,5 +1,5 @@
 summary: Dynamic templates
-method_request: POST /_bulk
+# method_request: POST /_bulk
 description: >
   Run `POST /_bulk` to perform a bulk request that consists of index and create actions with the `dynamic_templates` parameter.
   The bulk request creates two new fields `work_location` and `home_location` with type `geo_point` according to the `dynamic_templates` parameter.

--- a/specification/async_search/_types/AsyncSearch.ts
+++ b/specification/async_search/_types/AsyncSearch.ts
@@ -29,7 +29,7 @@ import { ClusterStatistics, ShardStatistics } from '@_types/Stats'
 
 export class AsyncSearch<TDocument> {
   /**
-   * Partial aggregations results, coming from the shards that have already completed the execution of the query.
+   * Partial aggregations results, coming from the shards that have already completed running the query.
    */
   aggregations?: Dictionary<AggregateName, Aggregate>
   _clusters?: ClusterStatistics

--- a/specification/async_search/_types/AsyncSearchResponseBase.ts
+++ b/specification/async_search/_types/AsyncSearchResponseBase.ts
@@ -30,7 +30,9 @@ export class AsyncSearchResponseBase {
   is_partial: boolean
   /**
    * Indicates whether the search is still running or has completed.
-   * NOTE: If the search failed after some shards returned their results or the node that is coordinating the async search dies, results may be partial even though `is_running` is `false`.
+   *
+   * > info
+   * > If the search failed after some shards returned their results or the node that is coordinating the async search dies, results may be partial even though `is_running` is `false`.
    */
   is_running: boolean
   /**
@@ -41,8 +43,8 @@ export class AsyncSearchResponseBase {
   start_time?: DateTime
   start_time_in_millis: EpochTime<UnitMillis>
   /**
-   * Indicates when the async search completed. Only present
-   * when the search has completed.
+   * Indicates when the async search completed.
+   * It is present only when the search has completed.
    */
   completion_time?: DateTime
   completion_time_in_millis?: EpochTime<UnitMillis>

--- a/specification/async_search/get/AsyncSearchGetRequest.ts
+++ b/specification/async_search/get/AsyncSearchGetRequest.ts
@@ -45,7 +45,7 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
-     * Specifies how long the async search should be available in the cluster.
+     * The length of time that the async search should be available in the cluster.
      * When not specified, the `keep_alive` set with the corresponding submit async request will be used.
      * Otherwise, it is possible to override the value and extend the validity of the request.
      * When this period expires, the search, if still running, is cancelled.

--- a/specification/async_search/get/AsyncSearchGetResponseExample1.json
+++ b/specification/async_search/get/AsyncSearchGetResponseExample1.json
@@ -1,7 +1,0 @@
-{
-  "summary": "A succesful response when retrieving the results of a previously submitted async search request given its identifier.",
-  "description": "",
-  "type": "response",
-  "response_code": 200,
-  "value": "{\n  \"id\" : \"FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\",\n  \"is_partial\" : false,\n  \"is_running\" : false,\n  \"start_time_in_millis\" : 1583945890986,\n  \"expiration_time_in_millis\" : 1584377890986,\n  \"completion_time_in_millis\" : 1583945903130,\n  \"response\" : {\n    \"took\" : 12144,\n    \"timed_out\" : false,\n    \"num_reduce_phases\" : 46,\n    \"_shards\" : {\n      \"total\" : 562,\n      \"successful\" : 188,\n      \"skipped\" : 0,\n      \"failed\" : 0\n    },\n    \"hits\" : {\n      \"total\" : {\n        \"value\" : 456433,\n        \"relation\" : \"eq\"\n      },\n      \"max_score\" : null,\n      \"hits\" : [ ]\n    },\n    \"aggregations\" : {\n      \"sale_date\" :  {\n        \"buckets\" : []\n      }\n    }\n  }\n}"
-}

--- a/specification/async_search/get/AsyncSearchGetResponseExample2.json
+++ b/specification/async_search/get/AsyncSearchGetResponseExample2.json
@@ -1,7 +1,0 @@
-{
-  "summary": "A succesful response when retrieving the status of a previously submitted and completed async search without the results.",
-  "description": "For an async search that has been completed, the status response has an additional `completion_status` field that shows the status code of the completed async search which was – in this case – a success.",
-  "type": "response",
-  "response_code": 200,
-  "value": "{\n  \"id\" : \"FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\",\n  \"is_running\" : false,\n  \"is_partial\" : false,\n  \"start_time_in_millis\" : 1583945890986,\n  \"expiration_time_in_millis\" : 1584377890986,\n  \"_shards\" : {\n      \"total\" : 562,\n      \"successful\" : 562,\n      \"skipped\" : 0,\n      \"failed\" : 0\n  },\n \"completion_status\" : 200\n}"
-}

--- a/specification/async_search/get/AsyncSearchGetResponseExample3.json
+++ b/specification/async_search/get/AsyncSearchGetResponseExample3.json
@@ -1,7 +1,0 @@
-{
-  "summary": "A succesful response when retrieving the status of a previously submitted and completed async search without the results.",
-  "description": "For an async search that has been completed, the status response has an additional `completion_status` field that shows the status code of the completed async search which was completed – in this case – with an error.",
-  "type": "response",
-  "response_code": 200,
-  "value": "{\n  \"id\" : \"FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\",\n  \"is_running\" : false,\n  \"is_partial\" : true,\n  \"start_time_in_millis\" : 1583945890986,\n  \"expiration_time_in_millis\" : 1584377890986,\n  \"_shards\" : {\n      \"total\" : 562,\n      \"successful\" : 450,\n      \"skipped\" : 0,\n      \"failed\" : 112\n  },\n \"completion_status\" : 503\n}"
-}

--- a/specification/async_search/get/examples/response/AsyncSearchGetResponseExample1.yaml
+++ b/specification/async_search/get/examples/response/AsyncSearchGetResponseExample1.yaml
@@ -1,0 +1,37 @@
+# summary:
+description: A succesful response from `GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=`.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "id" : "FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=",
+    "is_partial" : false, 
+    "is_running" : false, 
+    "start_time_in_millis" : 1583945890986,
+    "expiration_time_in_millis" : 1584377890986, 
+    "completion_time_in_millis" : 1583945903130, 
+    "response" : {
+      "took" : 12144,
+      "timed_out" : false,
+      "num_reduce_phases" : 46, 
+      "_shards" : {
+        "total" : 562,
+        "successful" : 188, 
+        "skipped" : 0,
+        "failed" : 0
+      },
+      "hits" : {
+        "total" : {
+          "value" : 456433,
+          "relation" : "eq"
+        },
+        "max_score" : null,
+        "hits" : [ ]
+      },
+      "aggregations" : { 
+        "sale_date" :  {
+          "buckets" : []
+        }
+      }
+    }
+  }

--- a/specification/async_search/status/AsyncSearchStatusRequest.ts
+++ b/specification/async_search/status/AsyncSearchStatusRequest.ts
@@ -25,10 +25,14 @@ import { Duration } from '@_types/Time'
  * Get the async search status.
  *
  * Get the status of a previously submitted async search request given its identifier, without retrieving search results.
- * If the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.
+ * If the Elasticsearch security features are enabled, the access to the status of a specific async search is restricted to:
+ *
+ * * The user or API key that submitted the original async search request.
+ * * Users that have the `monitor` cluster privilege or greater privileges.
  * @rest_spec_name async_search.status
  * @availability stack since=7.11.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @cluster_privileges monitor
  * @doc_id async-search
  * @doc_tag search
  */
@@ -45,7 +49,7 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
-     * Specifies how long the async search needs to be available.
+     * The length of time that the async search needs to be available.
      * Ongoing async searches and any saved search results are deleted after this period.
      * @server_default 5d
      */

--- a/specification/async_search/status/AsyncSearchStatusResponse.ts
+++ b/specification/async_search/status/AsyncSearchStatusResponse.ts
@@ -22,17 +22,17 @@ import { integer } from '@_types/Numeric'
 import { ClusterStatistics, ShardStatistics } from '@_types/Stats'
 
 export class StatusResponseBase extends AsyncSearchResponseBase {
-  /** Indicates how many shards have run the query so far. */
+  /** The number of shards that have run the query so far. */
   _shards: ShardStatistics
   /**
    * Metadata about clusters involved in the cross-cluster search.
-   * Not shown for local-only searches.
+   * It is not shown for local-only searches.
    */
   _clusters?: ClusterStatistics
   /**
    * If the async search completed, this field shows the status code of the search.
-   * For example, 200 indicates that the async search was successfully completed.
-   * 503 indicates that the async search was completed with an error.
+   * For example, `200` indicates that the async search was successfully completed.
+   * `503` indicates that the async search was completed with an error.
    */
   completion_status?: integer
 }

--- a/specification/async_search/status/AsyncSearchStatusResponseExample1.json
+++ b/specification/async_search/status/AsyncSearchStatusResponseExample1.json
@@ -1,7 +1,0 @@
-{
-  "summary": "A succesful response when retrieving the status of a previously submitted async search without the results.",
-  "description": "",
-  "type": "response",
-  "response_code": 200,
-  "value": "{\n  \"id\" : \"FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\",\n  \"is_running\" : true,\n  \"is_partial\" : true,\n  \"start_time_in_millis\" : 1583945890986,\n  \"expiration_time_in_millis\" : 1584377890986,\n  \"_shards\" : {\n      \"total\" : 562,\n      \"successful\" : 188,\n      \"skipped\" : 0,\n      \"failed\" : 0\n  }\n}"
-}

--- a/specification/async_search/status/examples/response/AsyncSearchStatusResponseExample1.yaml
+++ b/specification/async_search/status/examples/response/AsyncSearchStatusResponseExample1.yaml
@@ -1,0 +1,18 @@
+summary: An active async search
+description: A succesful response from `GET /_async_search/status/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=`, which retrieves the status of a previously submitted async search without the results.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "id" : "FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=",
+    "is_running" : true,
+    "is_partial" : true,
+    "start_time_in_millis" : 1583945890986,
+    "expiration_time_in_millis" : 1584377890986,
+    "_shards" : {
+        "total" : 562,
+        "successful" : 188, 
+        "skipped" : 0,
+        "failed" : 0
+    }
+  }

--- a/specification/async_search/status/examples/response/AsyncSearchStatusResponseExample2.yaml
+++ b/specification/async_search/status/examples/response/AsyncSearchStatusResponseExample2.yaml
@@ -1,0 +1,21 @@
+summary: A completed async search
+description: >
+  A succesful response from `GET /_async_search/status/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=` for an async search that has completed.
+  The status response has an additional `completion_status` field that shows the status code of the completed async search.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "id" : "FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=",
+    "is_running" : false,
+    "is_partial" : false,
+    "start_time_in_millis" : 1583945890986,
+    "expiration_time_in_millis" : 1584377890986,
+    "_shards" : {
+        "total" : 562,
+        "successful" : 562,
+        "skipped" : 0,
+        "failed" : 0
+    },
+  "completion_status" : 200 
+  }

--- a/specification/async_search/status/examples/response/AsyncSearchStatusResponseExample3.yaml
+++ b/specification/async_search/status/examples/response/AsyncSearchStatusResponseExample3.yaml
@@ -1,0 +1,21 @@
+summary: A failed async search
+description: >
+  A response from `GET /_async_search/status/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=` for an async search that has completed with an error.
+  The status response has an additional `completion_status` field that shows the status code of the completed async search.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "id" : "FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=",
+    "is_running" : false,
+    "is_partial" : true,
+    "start_time_in_millis" : 1583945890986,
+    "expiration_time_in_millis" : 1584377890986,
+    "_shards" : {
+        "total" : 562,
+        "successful" : 450,
+        "skipped" : 0,
+        "failed" : 112
+    },
+  "completion_status" : 503 
+  }

--- a/specification/ccr/delete_auto_follow_pattern/DeleteAutoFollowPatternRequest.ts
+++ b/specification/ccr/delete_auto_follow_pattern/DeleteAutoFollowPatternRequest.ts
@@ -23,9 +23,11 @@ import { Duration } from '@_types/Time'
 
 /**
  * Delete auto-follow patterns.
+ *
  * Delete a collection of cross-cluster replication auto-follow patterns.
  * @rest_spec_name ccr.delete_auto_follow_pattern
  * @availability stack since=6.5.0 stability=stable
+ * @cluster_privileges manage_ccr
  * @doc_id ccr-delete-auto-follow-pattern
  * @ext_doc_id ccr-auto-follow
  */
@@ -37,11 +39,14 @@ export interface Request extends RequestBase {
     }
   ]
   path_parts: {
+    /** The auto-follow pattern collection to delete. */
     name: Name
   }
   query_parameters: {
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
+     * If the master node is not available before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
     master_timeout?: Duration

--- a/specification/ccr/delete_auto_follow_pattern/ccrApisAutoFollowDeleteAutoFollowPatternResponseExample1.json
+++ b/specification/ccr/delete_auto_follow_pattern/ccrApisAutoFollowDeleteAutoFollowPatternResponseExample1.json
@@ -1,7 +1,0 @@
-{
-  "summary": "A successful response for deleting an auto-follow pattern.",
-  "description": "",
-  "type": "response",
-  "response_code": 200,
-  "value": "{\n  \"acknowledged\" : true\n}"
-}

--- a/specification/ccr/delete_auto_follow_pattern/examples/response/DeleteAutoFollowPatternResponseExample1.yaml
+++ b/specification/ccr/delete_auto_follow_pattern/examples/response/DeleteAutoFollowPatternResponseExample1.yaml
@@ -1,0 +1,8 @@
+# summary:
+description: A successful response from `DELETE /_ccr/auto_follow/my_auto_follow_pattern`, which deletes an auto-follow pattern.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "acknowledged" : true
+  }

--- a/specification/ccr/follow/examples/request/CreateFollowIndexRequestExample1.yaml
+++ b/specification/ccr/follow/examples/request/CreateFollowIndexRequestExample1.yaml
@@ -1,5 +1,22 @@
 # summary: "Create a follower index named `follower_index`."
 # method_request: "PUT /follower_index/_ccr/follow?wait_for_active_shards=1"
-description: Run `PUT /follower_index/_ccr/follow?wait_for_active_shards=1`."
+description: Run `PUT /follower_index/_ccr/follow?wait_for_active_shards=1` to create a follower index named `follower_index`.
 # type: "request"
-value: "{\n  \"remote_cluster\" : \"remote_cluster\",\n  \"leader_index\" : \"leader_index\",\n  \"settings\": {\n    \"index.number_of_replicas\": 0\n  },\n  \"max_read_request_operation_count\" : 1024,\n  \"max_outstanding_read_requests\" : 16,\n  \"max_read_request_size\" : \"1024k\",\n  \"max_write_request_operation_count\" : 32768,\n  \"max_write_request_size\" : \"16k\",\n  \"max_outstanding_write_requests\" : 8,\n  \"max_write_buffer_count\" : 512,\n  \"max_write_buffer_size\" : \"512k\",\n  \"max_retry_delay\" : \"10s\",\n  \"read_poll_timeout\" : \"30s\"\n}"
+value: |-
+  {
+    "remote_cluster" : "remote_cluster",
+    "leader_index" : "leader_index",
+    "settings": {
+      "index.number_of_replicas": 0
+    },
+    "max_read_request_operation_count" : 1024,
+    "max_outstanding_read_requests" : 16,
+    "max_read_request_size" : "1024k",
+    "max_write_request_operation_count" : 32768,
+    "max_write_request_size" : "16k",
+    "max_outstanding_write_requests" : 8,
+    "max_write_buffer_count" : 512,
+    "max_write_buffer_size" : "512k",
+    "max_retry_delay" : "10s",
+    "read_poll_timeout" : "30s"
+  }

--- a/specification/ccr/follow/examples/response/CreateFollowIndexResponseExample1.yaml
+++ b/specification/ccr/follow/examples/response/CreateFollowIndexResponseExample1.yaml
@@ -1,7 +1,10 @@
-{
-  'summary': 'A successful response for creating a follower index.',
-  'description': '',
-  'type': 'response',
-  'response_code': 200,
-  'value': "{\n  \"follow_index_created\" : true,\n  \"follow_index_shards_acked\" : true,\n  \"index_following_started\" : true\n}"
-}
+# summary:
+description: A successful response from `PUT /follower_index/_ccr/follow?wait_for_active_shards=1`.
+# type: 'response',
+# response_code: 200,
+value: |-
+  {
+    "follow_index_created" : true,
+    "follow_index_shards_acked" : true,
+    "index_following_started" : true
+  }

--- a/specification/ccr/follow_info/FollowInfoRequest.ts
+++ b/specification/ccr/follow_info/FollowInfoRequest.ts
@@ -23,10 +23,12 @@ import { Duration } from '@_types/Time'
 
 /**
  * Get follower information.
+ *
  * Get information about all cross-cluster replication follower indices.
  * For example, the results include follower index names, leader index names, replication options, and whether the follower indices are active or paused.
  * @rest_spec_name ccr.follow_info
  * @availability stack since=6.7.0 stability=stable
+ * @cluster_privileges monitor
  * @doc_id ccr-get-follow-info
  * @ext_doc_id ccr
  */
@@ -38,11 +40,14 @@ export interface Request extends RequestBase {
     }
   ]
   path_parts: {
+    /** A comma-delimited list of follower index patterns. */
     index: Indices
   }
   query_parameters: {
     /**
-     * Period to wait for a connection to the master node.
+     * The period to wait for a connection to the master node.
+     * If the master node is not available before the timeout expires, the request fails and returns an error.
+     * It can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
     master_timeout?: Duration

--- a/specification/ccr/follow_info/ccrApisFollowGetFollowInfoResponseExample1.json
+++ b/specification/ccr/follow_info/ccrApisFollowGetFollowInfoResponseExample1.json
@@ -1,7 +1,0 @@
-{
-  "summary": "A successful response for retrieving information about all follower indices",
-  "description": "This may be a response to `GET /follower_index/_ccr/info`.",
-  "type": "response",
-  "response_code": 200,
-  "value": "{\n  \"follower_indices\": [\n    {\n      \"follower_index\": \"follower_index\",\n      \"remote_cluster\": \"remote_cluster\",\n      \"leader_index\": \"leader_index\",\n      \"status\": \"active\",\n      \"parameters\": {\n        \"max_read_request_operation_count\": 5120,\n        \"max_read_request_size\": \"32mb\",\n        \"max_outstanding_read_requests\": 12,\n        \"max_write_request_operation_count\": 5120,\n        \"max_write_request_size\": \"9223372036854775807b\",\n        \"max_outstanding_write_requests\": 9,\n        \"max_write_buffer_count\": 2147483647,\n        \"max_write_buffer_size\": \"512mb\",\n        \"max_retry_delay\": \"500ms\",\n        \"read_poll_timeout\": \"1m\"\n      }\n    }\n  ]\n}"
-}

--- a/specification/ccr/follow_info/ccrApisFollowGetFollowInfoResponseExample2.json
+++ b/specification/ccr/follow_info/ccrApisFollowGetFollowInfoResponseExample2.json
@@ -1,7 +1,0 @@
-{
-  "summary": "A successful response for retrieving information about a paused follower index.",
-  "description": "",
-  "type": "response",
-  "response_code": "200",
-  "value": "{\n  \"follower_indices\": [\n    {\n      \"follower_index\": \"follower_index\",\n      \"remote_cluster\": \"remote_cluster\",\n      \"leader_index\": \"leader_index\",\n      \"status\": \"paused\"\n    }\n  ]\n}"
-}

--- a/specification/ccr/follow_info/examples/response/FollowInfoResponseExample1.yaml
+++ b/specification/ccr/follow_info/examples/response/FollowInfoResponseExample1.yaml
@@ -1,0 +1,27 @@
+summary: An active follower index
+description: A successful response from `GET /follower_index/_ccr/info` when the follower index is active.
+# type: response
+# response_code: 200
+value: |-
+  {
+    "follower_indices": [
+      {
+        "follower_index": "follower_index",
+        "remote_cluster": "remote_cluster",
+        "leader_index": "leader_index",
+        "status": "active",
+        "parameters": {
+          "max_read_request_operation_count": 5120,
+          "max_read_request_size": "32mb",
+          "max_outstanding_read_requests": 12,
+          "max_write_request_operation_count": 5120,
+          "max_write_request_size": "9223372036854775807b",
+          "max_outstanding_write_requests": 9,
+          "max_write_buffer_count": 2147483647,
+          "max_write_buffer_size": "512mb",
+          "max_retry_delay": "500ms",
+          "read_poll_timeout": "1m"
+        }
+      }
+    ]
+  }

--- a/specification/ccr/follow_info/examples/response/FollowInfoResponseExample2.yaml
+++ b/specification/ccr/follow_info/examples/response/FollowInfoResponseExample2.yaml
@@ -1,0 +1,15 @@
+summary: A paused follower index
+description: A successful response from `GET /follower_index/_ccr/info` when the follower index is paused.
+# type: response
+# response_code: '200'
+value: |-
+  {
+    "follower_indices": [
+      {
+        "follower_index": "follower_index",
+        "remote_cluster": "remote_cluster",
+        "leader_index": "leader_index",
+        "status": "paused"
+      }
+    ]
+  }

--- a/specification/ccr/follow_info/types.ts
+++ b/specification/ccr/follow_info/types.ts
@@ -22,10 +22,15 @@ import { integer, long } from '@_types/Numeric'
 import { Duration } from '@_types/Time'
 
 export class FollowerIndex {
+  /** The name of the follower index. */
   follower_index: IndexName
+  /** The name of the index in the leader cluster that is followed. */
   leader_index: IndexName
+  /** An object that encapsulates cross-cluster replication parameters. If the follower index's status is paused, this object is omitted. */
   parameters?: FollowerIndexParameters
+  /** The remote cluster that contains the leader index. */
   remote_cluster: Name
+  /** The status of the index following: `active` or `paused`. */
   status: FollowerIndexStatus
 }
 

--- a/specification/cluster/health/examples/response/ClusterHealthResponseExample1.yaml
+++ b/specification/cluster/health/examples/response/ClusterHealthResponseExample1.yaml
@@ -2,8 +2,8 @@
 description: >
   A successful response from `GET _cluster/health`.
   It is the health status of a quiet single node cluster with a single index with one shard and one replica.
-type: response
-response_code: 200
+# type: response
+# response_code: 200
 value: |-
   {
     "cluster_name" : "testcluster",

--- a/specification/ingest/put_pipeline/examples/request/PutPipelineRequestExample2.yaml
+++ b/specification/ingest/put_pipeline/examples/request/PutPipelineRequestExample2.yaml
@@ -1,7 +1,7 @@
 summary: Create an ingest pipeline with metadata.
 # method_request: PUT /_ingest/pipeline/my-pipeline-id
 description: You can use the `_meta` parameter to add arbitrary metadata to a pipeline.
-type: request
+# type: request
 value:
   "{\n  \"description\" : \"My optional pipeline description\",\n  \"processors\"\
   \ : [\n    {\n      \"set\" : {\n        \"description\" : \"My optional processor\

--- a/specification/ml/close_job/examples/response/MlCloseJobResponseExample1.yaml
+++ b/specification/ml/close_job/examples/response/MlCloseJobResponseExample1.yaml
@@ -1,4 +1,4 @@
-summary:
+# summary:
 description: A successful response when closing anomaly detection jobs.
 # type: response
 # response_code: 200

--- a/specification/ml/delete_calendar_event/examples/response/MlDeleteCalendarEventResponseExample1.yaml
+++ b/specification/ml/delete_calendar_event/examples/response/MlDeleteCalendarEventResponseExample1.yaml
@@ -1,4 +1,4 @@
-summary:
+# summary:
 description: A successful response when deleting a calendar event.
 # type: response
 # response_code: 200

--- a/specification/ml/estimate_model_memory/examples/response/MlEstimateModelMemoryResponseExample1.yaml
+++ b/specification/ml/estimate_model_memory/examples/response/MlEstimateModelMemoryResponseExample1.yaml
@@ -1,6 +1,6 @@
 # summary:
 description: A successful response from `POST _ml/anomaly_detectors/_estimate_model_memory`.
-type: response
-response_code: 200
+# type: response
+# response_code: 200
 value:
   model_memory_estimate: 21mb


### PR DESCRIPTION
This PR converts more examples from JSON to YAML to address linting errors related to invalid fields in those files.
It also comments out some of those lingering fields from existing example files.