### PR TITLE
[ML] Adding text embedding bit to inference result output 

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -12998,6 +12998,7 @@ export interface InferenceInferenceEndpointInfo extends InferenceInferenceEndpoi
 
 export interface InferenceInferenceResult {
   text_embedding_bytes?: InferenceTextEmbeddingByteResult[]
+  text_embedding_bits?: InferenceTextEmbeddingByteResult[]
   text_embedding?: InferenceTextEmbeddingResult[]
   sparse_embedding?: InferenceSparseEmbeddingResult[]
   completion?: InferenceCompletionResult[]

--- a/specification/inference/_types/Results.ts
+++ b/specification/inference/_types/Results.ts
@@ -82,6 +82,7 @@ export class RankedDocument {
  */
 export class InferenceResult {
   text_embedding_bytes?: Array<TextEmbeddingByteResult>
+  text_embedding_bits?: Array<TextEmbeddingByteResult>
   text_embedding?: Array<TextEmbeddingResult>
   sparse_embedding?: Array<SparseEmbeddingResult>
   completion?: Array<CompletionResult>


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/120751, added `text_embedding_bits` as an output field to store binary embeddings from the Cohere inference API. Although the field name is different, the type is the same as `text_embedding_bytes` because Cohere returns binary embeddings encoded as bytes with `int8` precision.

<!--

Hello there!

Thank you for opening a pull request!
Please make sure to follow the steps below when opening a pr:

- Sign the CLA https://www.elastic.co/contributor-agreement/
- Tag the relative issue (if any) and give a brief explanation on what your changes are doing
- If you did a spec change, remember to generate again the outputs, you can do it by running `make contrib`
- Add the appropriate backport labels. If you need to backport a breaking change (e.g. changing the structure of a type or changing the type/optionality of a field), please follow these rules:
  - If the API is unusable without the change -> every supported version
  - If the API is usable, but fix is on the response side -> every supported version
  - If the API is usable, but fix is on the request side -> no backport, unless the API is _partially_ usable and the fix unlocks a missing feature that has no workaround

Happy coding!

-->
