### PR TITLE
Add failure_store enum to bulk responses

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -23,6 +23,8 @@ export interface BulkCreateOperation extends BulkWriteOperation {
 export interface BulkDeleteOperation extends BulkOperationBase {
 }
 
+export type BulkFailureStoreStatus = 'not_applicable_or_unknown' | 'used' | 'not_enabled' | 'failed'
+
 export interface BulkIndexOperation extends BulkWriteOperation {
 }
 
@@ -73,6 +75,7 @@ export interface BulkResponseItem {
   _id?: string | null
   _index: string
   status: integer
+  failure_store?: BulkFailureStoreStatus
   error?: ErrorCause
   _primary_term?: long
   result?: string

--- a/specification/_global/bulk/types.ts
+++ b/specification/_global/bulk/types.ts
@@ -48,6 +48,7 @@ export class ResponseItem {
    * The HTTP status code returned for the operation.
    */
   status: integer
+  failure_store?: FailureStoreStatus
   /**
    * Additional information about the failed operation.
    * The property is returned only for failed operations.
@@ -80,6 +81,13 @@ export class ResponseItem {
   _version?: VersionNumber
   forced_refresh?: boolean
   get?: InlineGet<Dictionary<string, UserDefinedValue>>
+}
+
+export enum FailureStoreStatus {
+  not_applicable_or_unknown,
+  used,
+  not_enabled,
+  failed
 }
 
 export enum OperationType {


### PR DESCRIPTION
As per:
* https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/action/bulk/BulkItemResponse.java
* https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/action/bulk/IndexDocFailureStoreStatus.java