### PR TITLE
[ML]rename rerank score to relevance_score

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -46475,7 +46475,7 @@
           "index": {
             "type": "number"
           },
-          "score": {
+          "relevance_score": {
             "type": "number"
           },
           "text": {
@@ -46484,7 +46484,7 @@
         },
         "required": [
           "index",
-          "score"
+          "relevance_score"
         ]
       },
       "inference.unified_inference:Message": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13016,7 +13016,7 @@ export interface InferenceInferenceResult {
 
 export interface InferenceRankedDocument {
   index: integer
-  score: float
+  relevance_score: float
   text?: string
 }
 

--- a/specification/inference/_types/Results.ts
+++ b/specification/inference/_types/Results.ts
@@ -67,12 +67,12 @@ export class CompletionResult {
 /**
  * The rerank result object representing a single ranked document
  * id: the original index of the document in the request
- * score: the score of the document relative to the query
+ * relevance_score: the relevance_score of the document relative to the query
  * text: Optional, the text of the document, if requested
  */
 export class RankedDocument {
   index: integer
-  score: float
+  relevance_score: float
   text?: string
 }
 


### PR DESCRIPTION
When we call the inference rerank interface using the Elasticsearch Java client, we encountered the following error：

```
status: 200, [es/inference.inference] Failed to decode response
	at co.elastic.clients.transport.ElasticsearchTransportBase.decodeTransportResponse(ElasticsearchTransportBase.java:404)
	at co.elastic.clients.transport.ElasticsearchTransportBase.getApiResponse(ElasticsearchTransportBase.java:363)
	at co.elastic.clients.transport.ElasticsearchTransportBase.performRequest(ElasticsearchTransportBase.java:147)
	at co.elastic.clients.elasticsearch.inference.ElasticsearchInferenceClient.inference(ElasticsearchInferenceClient.java:162)
	at org.example.Main.main(Main.java:50)
Caused by: co.elastic.clients.json.JsonpMappingException: Error deserializing co.elastic.clients.elasticsearch.inference.InferenceResult: co.elastic.clients.util.MissingRequiredPropertyException: Missing required property 'RankedDocument.score' (JSON path: rerank[0]) (line no=1, column no=52, offset=-1)
	at co.elastic.clients.json.JsonpMappingException.from0(JsonpMappingException.java:134)
	at co.elastic.clients.json.JsonpMappingException.from(JsonpMappingException.java:125)
	at co.elastic.clients.json.JsonpDeserializerBase$ArrayDeserializer.deserialize(JsonpDeserializerBase.java:322)
	at co.elastic.clients.json.JsonpDeserializerBase$ArrayDeserializer.deserialize(JsonpDeserializerBase.java:280)
	at co.elastic.clients.json.JsonpDeserializer.deserialize(JsonpDeserializer.java:77)
	at co.elastic.clients.json.ObjectDeserializer$FieldObjectDeserializer.deserialize(ObjectDeserializer.java:78)
	at co.elastic.clients.json.ObjectDeserializer.deserializeInner(ObjectDeserializer.java:214)
	at co.elastic.clients.json.ObjectDeserializer.deserialize(ObjectDeserializer.java:166)
	at co.elastic.clients.json.ObjectDeserializer.deserialize(ObjectDeserializer.java:157)
	at co.elastic.clients.json.BuildFunctionDeserializer.deserialize(BuildFunctionDeserializer.java:53)
	at co.elastic.clients.json.DelegatingDeserializer$SameType.deserialize(DelegatingDeserializer.java:48)
	at co.elastic.clients.elasticsearch.inference.InferenceResponse.lambda$createInferenceResponseDeserializer$0(InferenceResponse.java:152)
	at co.elastic.clients.json.JsonpDeserializer$3.deserialize(JsonpDeserializer.java:136)
	at co.elastic.clients.json.JsonpDeserializer.deserialize(JsonpDeserializer.java:77)
	at co.elastic.clients.transport.ElasticsearchTransportBase.decodeTransportResponse(ElasticsearchTransportBase.java:399)
	... 4 more
Caused by: co.elastic.clients.util.MissingRequiredPropertyException: Missing required property 'RankedDocument.score'
	at co.elastic.clients.util.ApiTypeHelper.requireNonNull(ApiTypeHelper.java:76)
	at co.elastic.clients.elasticsearch.inference.RankedDocument.<init>(RankedDocument.java:80)
	at co.elastic.clients.elasticsearch.inference.RankedDocument.<init>(RankedDocument.java:67)
	at co.elastic.clients.elasticsearch.inference.RankedDocument$Builder.build(RankedDocument.java:193)
	at co.elastic.clients.elasticsearch.inference.RankedDocument$Builder.build(RankedDocument.java:147)
	at co.elastic.clients.json.ObjectBuilderDeserializer.deserialize(ObjectBuilderDeserializer.java:86)
	at co.elastic.clients.json.DelegatingDeserializer$SameType.deserialize(DelegatingDeserializer.java:48)
	at co.elastic.clients.json.JsonpDeserializerBase$ArrayDeserializer.deserialize(JsonpDeserializerBase.java:318)
	... 16 more
```
We found that the relevant serialization code in the [Elasticsearch Java client](https://github.com/elastic/elasticsearch-java) is as follows:
```
private RankedDocument(Builder builder) {
    this.index = ApiTypeHelper.requireNonNull(builder.index, this, "index");
    this.score = ApiTypeHelper.requireNonNull(builder.score, this, "score");
    this.text = builder.text;
}
```
The RankedDocument in the Elasticsearch Java client requires a non-null score, but the rerank interface returns a relevance_score (which is also documented here: [Perform inference API Rerank Example](https://www.elastic.co/guide/en/elasticsearch/reference/8.15/post-inference-api.html#inference-example-rerank)).

The Elasticsearch Java client indicates that this code is generated according to the Elasticsearch API specification:
```
//----------------------------------------------------------------
//       THIS CODE IS GENERATED. MANUAL EDITS WILL BE LOST.
//----------------------------------------------------------------
//
// This code is generated from the Elasticsearch API specification
// at https://github.com/elastic/elasticsearch-specification
//
// Manual updates to this file will be lost when the code is
// re-generated.
//
// If you find a property that is missing or wrongly typed, please
// open an issue or a PR on the API specification repository.
//
//----------------------------------------------------------------

// typedef: inference._types.RankedDocument
```
Therefore, should we change the `score` value here to `relevance_score`?

Steps to Reproduce
Elasticsearch version: 8.15.1
dependencies:
```
<dependencies>
        <dependency>
            <groupId>co.elastic.clients</groupId>
            <artifactId>elasticsearch-java</artifactId>
            <version>8.15.1</version>
        </dependency>

        <dependency>
            <groupId>com.fasterxml.jackson.core</groupId>
            <artifactId>jackson-databind</artifactId>
            <version>2.17.0</version>
        </dependency>
    </dependencies>
```

We referred to this document: [Getting Started with Elasticsearch Java Client](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.15/getting-started-java.html#_connecting)

```
// Create the low-level client
RestClient restClient = RestClient
        .builder(HttpHost.create(serverUrl))
        .setDefaultHeaders(new Header[]{
                new BasicHeader("Authorization", apiKey)
        })
        .build();

// Create the transport with a Jackson mapper
ElasticsearchTransport transport = new RestClientTransport(
        restClient, new JacksonJsonpMapper());

// And create the API client
ElasticsearchClient esClient = new ElasticsearchClient(transport);

// Use the client...
InferenceRequest request = InferenceRequest.of(i -> i.inferenceId("os-rerank")
        .input("luke", "like", "leia", "chewy", "r2d2", "star", "wars")
        .query("star wars main character"));

System.out.println(request.toString());

InferenceResponse response = esClient.inference().inference(request);

System.out.println(response.toString());

// Close the transport, freeing the underlying thread
transport.close();

```