### PR TITLE
[DOCS] Trim connector intro to make all relevant info visible

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -33,7 +33,7 @@ actions:
           description: >
             The connector and sync jobs APIs provide a convenient way to create and manage Elastic connectors and sync jobs in an internal index.
             
-            Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure.
+            Connectors are Elasticsearch integrations for syncing content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure.
             
             This API provides an alternative to relying solely on Kibana UI for connector and sync job management. The API comes with a set of validations and assertions to ensure that the state representation in the internal index remains valid.
 

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -33,12 +33,7 @@ actions:
           description: >
             The connector and sync jobs APIs provide a convenient way to create and manage Elastic connectors and sync jobs in an internal index.
             
-            Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure:
-            
-            * Elastic managed connectors (Native connectors) are a managed service on Elastic Cloud
-            
-            * Self-managed connectors (Connector clients) are self-managed on your infrastructure.
-            
+            Connectors are Elasticsearch integrations that bring content from third-party data sources, which can be deployed on Elastic Cloud or hosted on your own infrastructure.
             
             This API provides an alternative to relying solely on Kibana UI for connector and sync job management. The API comes with a set of validations and assertions to ensure that the state representation in the internal index remains valid.
 


### PR DESCRIPTION
Follow up on https://github.com/elastic/elasticsearch-specification/pull/3721, because that info is [not visible currently](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-connector-check-in)