### PR TITLE
Mark Behavioral Analytics CRUD APIs as deprecated in 9.0.0

### DIFF
--- a/specification/_json_spec/search_application.delete_behavioral_analytics.json
+++ b/specification/_json_spec/search_application.delete_behavioral_analytics.json
@@ -6,6 +6,10 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "9.0.0",
+      "description": "Behavioral Analytics has been deprecated and will be removed in a future release."
+    },
     "headers": {
       "accept": ["application/json"]
     },

--- a/specification/_json_spec/search_application.get_behavioral_analytics.json
+++ b/specification/_json_spec/search_application.get_behavioral_analytics.json
@@ -6,6 +6,10 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "9.0.0",
+      "description": "Behavioral Analytics has been deprecated and will be removed in a future release."
+    },
     "headers": {
       "accept": ["application/json"]
     },

--- a/specification/_json_spec/search_application.post_behavioral_analytics_event.json
+++ b/specification/_json_spec/search_application.post_behavioral_analytics_event.json
@@ -6,6 +6,10 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "9.0.0",
+      "description": "Behavioral Analytics has been deprecated and will be removed in a future release."
+    },
     "headers": {
       "accept": ["application/json"],
       "content_type": ["application/json"]

--- a/specification/_json_spec/search_application.put_behavioral_analytics.json
+++ b/specification/_json_spec/search_application.put_behavioral_analytics.json
@@ -6,6 +6,10 @@
     },
     "stability": "experimental",
     "visibility": "public",
+    "deprecated": {
+      "version": "9.0.0",
+      "description": "Behavioral Analytics has been deprecated and will be removed in a future release."
+    },
     "headers": {
       "accept": ["application/json"]
     },

--- a/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteRequest.ts
+++ b/specification/search_application/delete_behavioral_analytics/BehavioralAnalyticsDeleteRequest.ts
@@ -27,6 +27,7 @@ import { Name } from '@_types/common'
  * @availability serverless stability=experimental visibility=public
  * @doc_tag analytics
  * @doc_id delete-analytics-collection
+ * @deprecated 9.0.0
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
+++ b/specification/search_application/get_behavioral_analytics/BehavioralAnalyticsGetRequest.ts
@@ -26,6 +26,7 @@ import { Name } from '@_types/common'
  * @availability serverless stability=experimental visibility=public
  * @doc_tag analytics
  * @doc_id list-analytics-collection
+ * @deprecated 9.0.0
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequest.ts
+++ b/specification/search_application/post_behavioral_analytics_event/BehavioralAnalyticsEventPostRequest.ts
@@ -28,6 +28,7 @@ import { EventType } from '../_types/AnalyticsEvent'
  * @doc_tag analytics
  * @doc_id behavioral-analytics-collection-event
  * @ext_doc_id behavioral-analytics-event-reference
+ * @deprecated 9.0.0
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutRequest.ts
+++ b/specification/search_application/put_behavioral_analytics/BehavioralAnalyticsPutRequest.ts
@@ -26,6 +26,7 @@ import { Name } from '@_types/common'
  * @availability serverless stability=experimental visibility=public
  * @doc_tag analytics
  * @doc_id put-analytics-collection
+ * @deprecated 9.0.0
  */
 export interface Request extends RequestBase {
   urls: [


### PR DESCRIPTION
Marks the Behavioral Analytics CRUD APIs as deprecated, to go along with https://github.com/elastic/elasticsearch/pull/122960 

See SEARCH-862 for more information. 