### PR TITLE
Add missing index parameter to _cat/recovery

### DIFF
--- a/specification/cat/recovery/CatRecoveryRequest.ts
+++ b/specification/cat/recovery/CatRecoveryRequest.ts
@@ -69,6 +69,10 @@ export interface Request extends CatRequestBase {
      */
     detailed?: boolean
     /**
+     * Comma-separated list or wildcard expression of index names to limit the returned information
+     */
+    index?: Indices
+    /**
      * List of columns to appear in the response. Supports simple wildcards.
      */
     h?: Names


### PR DESCRIPTION
While it is redundant with the path part with the same name, it is indeed accepted.