### PR TITLE
[8.18] Fix property defined in an ancestor class errors (#3800)

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -922,6 +922,12 @@
         "operationId": "cat-aliases",
         "parameters": [
           {
+            "$ref": "#/components/parameters/cat.aliases#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.aliases#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.aliases#expand_wildcards"
           },
           {
@@ -949,6 +955,12 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.aliases#name"
+          },
+          {
+            "$ref": "#/components/parameters/cat.aliases#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.aliases#s"
           },
           {
             "$ref": "#/components/parameters/cat.aliases#expand_wildcards"
@@ -980,6 +992,12 @@
             "$ref": "#/components/parameters/cat.allocation#bytes"
           },
           {
+            "$ref": "#/components/parameters/cat.allocation#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.allocation#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.allocation#local"
           },
           {
@@ -1009,6 +1027,12 @@
             "$ref": "#/components/parameters/cat.allocation#bytes"
           },
           {
+            "$ref": "#/components/parameters/cat.allocation#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.allocation#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.allocation#local"
           },
           {
@@ -1031,6 +1055,12 @@
         "description": "Get information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "operationId": "cat-component-templates",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/cat.component_templates#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.component_templates#s"
+          },
           {
             "$ref": "#/components/parameters/cat.component_templates#local"
           },
@@ -1059,6 +1089,12 @@
             "$ref": "#/components/parameters/cat.component_templates#name"
           },
           {
+            "$ref": "#/components/parameters/cat.component_templates#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.component_templates#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.component_templates#local"
           },
           {
@@ -1081,6 +1117,14 @@
         "summary": "Get a document count",
         "description": "Get quick access to a document count for a data stream, an index, or an entire cluster.\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
         "operationId": "cat-count",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cat.count#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.count#s"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/cat.count#200"
@@ -1099,6 +1143,12 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.count#index"
+          },
+          {
+            "$ref": "#/components/parameters/cat.count#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.count#s"
           }
         ],
         "responses": {
@@ -1122,6 +1172,12 @@
           },
           {
             "$ref": "#/components/parameters/cat.fielddata#fields_"
+          },
+          {
+            "$ref": "#/components/parameters/cat.fielddata#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.fielddata#s"
           }
         ],
         "responses": {
@@ -1148,6 +1204,12 @@
           },
           {
             "$ref": "#/components/parameters/cat.fielddata#fields_"
+          },
+          {
+            "$ref": "#/components/parameters/cat.fielddata#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.fielddata#s"
           }
         ],
         "responses": {
@@ -1183,6 +1245,26 @@
             "deprecated": false,
             "schema": {
               "type": "boolean"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "h",
+            "description": "List of columns to appear in the response. Supports simple wildcards.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "s",
+            "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
             },
             "style": "form"
           }
@@ -1255,6 +1337,12 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices#master_timeout"
+          },
+          {
+            "$ref": "#/components/parameters/cat.indices#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.indices#s"
           }
         ],
         "responses": {
@@ -1296,6 +1384,12 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices#master_timeout"
+          },
+          {
+            "$ref": "#/components/parameters/cat.indices#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.indices#s"
           }
         ],
         "responses": {
@@ -1314,6 +1408,26 @@
         "description": "Get information about the master node, including the ID, bound IP address, and name.\n\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-master",
         "parameters": [
+          {
+            "in": "query",
+            "name": "h",
+            "description": "List of columns to appear in the response. Supports simple wildcards.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "s",
+            "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
           {
             "in": "query",
             "name": "local",
@@ -1645,6 +1759,26 @@
         "parameters": [
           {
             "in": "query",
+            "name": "h",
+            "description": "List of columns to appear in the response. Supports simple wildcards.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "s",
+            "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "local",
             "description": "If `true`, the request computes the list of selected nodes from the\nlocal cluster state. If `false` the list of selected nodes are computed\nfrom the cluster state of the master node. In both cases the coordinating\nnode will send requests for further information to each selected node.",
             "deprecated": false,
@@ -1729,6 +1863,26 @@
           },
           {
             "in": "query",
+            "name": "h",
+            "description": "List of columns to appear in the response. Supports simple wildcards.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "s",
+            "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "master_timeout",
             "description": "Period to wait for a connection to the master node.",
             "deprecated": false,
@@ -1774,6 +1928,26 @@
         "description": "Get information about cluster-level changes that have not yet taken effect.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the pending cluster tasks API.",
         "operationId": "cat-pending-tasks",
         "parameters": [
+          {
+            "in": "query",
+            "name": "h",
+            "description": "List of columns to appear in the response. Supports simple wildcards.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "s",
+            "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
           {
             "in": "query",
             "name": "local",
@@ -1831,6 +2005,26 @@
         "description": "Get a list of plugins running on each node of a cluster.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-plugins",
         "parameters": [
+          {
+            "in": "query",
+            "name": "h",
+            "description": "List of columns to appear in the response. Supports simple wildcards.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "s",
+            "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
           {
             "in": "query",
             "name": "include_bootstrap",
@@ -1898,6 +2092,12 @@
             "$ref": "#/components/parameters/cat.recovery#detailed"
           },
           {
+            "$ref": "#/components/parameters/cat.recovery#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.recovery#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.recovery#time"
           }
         ],
@@ -1930,6 +2130,12 @@
             "$ref": "#/components/parameters/cat.recovery#detailed"
           },
           {
+            "$ref": "#/components/parameters/cat.recovery#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.recovery#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.recovery#time"
           }
         ],
@@ -1949,6 +2155,26 @@
         "description": "Get a list of snapshot repositories for a cluster.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the get snapshot repository API.",
         "operationId": "cat-repositories",
         "parameters": [
+          {
+            "in": "query",
+            "name": "h",
+            "description": "List of columns to appear in the response. Supports simple wildcards.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "s",
+            "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
           {
             "in": "query",
             "name": "local",
@@ -2001,6 +2227,12 @@
             "$ref": "#/components/parameters/cat.segments#bytes"
           },
           {
+            "$ref": "#/components/parameters/cat.segments#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.segments#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.segments#local"
           },
           {
@@ -2030,6 +2262,12 @@
             "$ref": "#/components/parameters/cat.segments#bytes"
           },
           {
+            "$ref": "#/components/parameters/cat.segments#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.segments#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.segments#local"
           },
           {
@@ -2054,6 +2292,12 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.shards#bytes"
+          },
+          {
+            "$ref": "#/components/parameters/cat.shards#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.shards#s"
           },
           {
             "$ref": "#/components/parameters/cat.shards#master_timeout"
@@ -2085,6 +2329,12 @@
             "$ref": "#/components/parameters/cat.shards#bytes"
           },
           {
+            "$ref": "#/components/parameters/cat.shards#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.shards#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.shards#master_timeout"
           },
           {
@@ -2109,6 +2359,12 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.snapshots#ignore_unavailable"
+          },
+          {
+            "$ref": "#/components/parameters/cat.snapshots#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.snapshots#s"
           },
           {
             "$ref": "#/components/parameters/cat.snapshots#master_timeout"
@@ -2139,6 +2395,12 @@
           },
           {
             "$ref": "#/components/parameters/cat.snapshots#ignore_unavailable"
+          },
+          {
+            "$ref": "#/components/parameters/cat.snapshots#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.snapshots#s"
           },
           {
             "$ref": "#/components/parameters/cat.snapshots#master_timeout"
@@ -2212,6 +2474,26 @@
           },
           {
             "in": "query",
+            "name": "h",
+            "description": "List of columns to appear in the response. Supports simple wildcards.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "s",
+            "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types:Names"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
             "name": "time",
             "description": "Unit used to display time values.",
             "deprecated": false,
@@ -2269,6 +2551,12 @@
         "operationId": "cat-templates",
         "parameters": [
           {
+            "$ref": "#/components/parameters/cat.templates#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.templates#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.templates#local"
           },
           {
@@ -2296,6 +2584,12 @@
             "$ref": "#/components/parameters/cat.templates#name"
           },
           {
+            "$ref": "#/components/parameters/cat.templates#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.templates#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.templates#local"
           },
           {
@@ -2319,6 +2613,12 @@
         "description": "Get thread pool statistics for each node in a cluster.\nReturned information includes all built-in thread pools and custom thread pools.\nIMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console. They are not intended for use by applications. For application consumption, use the nodes info API.",
         "operationId": "cat-thread-pool",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/cat.thread_pool#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.thread_pool#s"
+          },
           {
             "$ref": "#/components/parameters/cat.thread_pool#time"
           },
@@ -2347,6 +2647,12 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.thread_pool#thread_pool_patterns"
+          },
+          {
+            "$ref": "#/components/parameters/cat.thread_pool#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.thread_pool#s"
           },
           {
             "$ref": "#/components/parameters/cat.thread_pool#time"
@@ -98823,6 +99129,26 @@
         },
         "style": "simple"
       },
+      "cat.aliases#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.aliases#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
       "cat.aliases#expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
@@ -98874,6 +99200,26 @@
         },
         "style": "form"
       },
+      "cat.allocation#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.allocation#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
       "cat.allocation#local": {
         "in": "query",
         "name": "local",
@@ -98904,6 +99250,26 @@
           "type": "string"
         },
         "style": "simple"
+      },
+      "cat.component_templates#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.component_templates#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
       },
       "cat.component_templates#local": {
         "in": "query",
@@ -98936,6 +99302,26 @@
         },
         "style": "simple"
       },
+      "cat.count#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.count#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
       "cat.fielddata#fields": {
         "in": "path",
         "name": "fields",
@@ -98964,6 +99350,26 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Fields"
+        },
+        "style": "form"
+      },
+      "cat.fielddata#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.fielddata#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
         },
         "style": "form"
       },
@@ -99045,6 +99451,26 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
+        },
+        "style": "form"
+      },
+      "cat.indices#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.indices#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
         },
         "style": "form"
       },
@@ -99343,6 +99769,26 @@
         },
         "style": "form"
       },
+      "cat.recovery#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.recovery#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
       "cat.recovery#time": {
         "in": "query",
         "name": "time",
@@ -99371,6 +99817,26 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Bytes"
+        },
+        "style": "form"
+      },
+      "cat.segments#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.segments#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
         },
         "style": "form"
       },
@@ -99415,6 +99881,26 @@
         },
         "style": "form"
       },
+      "cat.shards#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.shards#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
       "cat.shards#master_timeout": {
         "in": "query",
         "name": "master_timeout",
@@ -99456,6 +99942,26 @@
         },
         "style": "form"
       },
+      "cat.snapshots#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.snapshots#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
       "cat.snapshots#master_timeout": {
         "in": "query",
         "name": "master_timeout",
@@ -99487,6 +99993,26 @@
         },
         "style": "simple"
       },
+      "cat.templates#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.templates#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
       "cat.templates#local": {
         "in": "query",
         "name": "local",
@@ -99517,6 +100043,26 @@
           "$ref": "#/components/schemas/_types:Names"
         },
         "style": "simple"
+      },
+      "cat.thread_pool#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.thread_pool#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
       },
       "cat.thread_pool#time": {
         "in": "query",

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -700,6 +700,12 @@
         "operationId": "cat-aliases",
         "parameters": [
           {
+            "$ref": "#/components/parameters/cat.aliases#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.aliases#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.aliases#expand_wildcards"
           },
           {
@@ -729,6 +735,12 @@
             "$ref": "#/components/parameters/cat.aliases#name"
           },
           {
+            "$ref": "#/components/parameters/cat.aliases#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.aliases#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.aliases#expand_wildcards"
           },
           {
@@ -754,6 +766,12 @@
         "description": "Get information about component templates in a cluster.\nComponent templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the get component template API.",
         "operationId": "cat-component-templates",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/cat.component_templates#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.component_templates#s"
+          },
           {
             "$ref": "#/components/parameters/cat.component_templates#local"
           },
@@ -782,6 +800,12 @@
             "$ref": "#/components/parameters/cat.component_templates#name"
           },
           {
+            "$ref": "#/components/parameters/cat.component_templates#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.component_templates#s"
+          },
+          {
             "$ref": "#/components/parameters/cat.component_templates#local"
           },
           {
@@ -804,6 +828,14 @@
         "summary": "Get a document count",
         "description": "Get quick access to a document count for a data stream, an index, or an entire cluster.\nThe document count only includes live documents, not deleted documents which have not yet been removed by the merge process.\n\nIMPORTANT: CAT APIs are only intended for human consumption using the command line or Kibana console.\nThey are not intended for use by applications. For application consumption, use the count API.",
         "operationId": "cat-count",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cat.count#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.count#s"
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/cat.count#200"
@@ -822,6 +854,12 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cat.count#index"
+          },
+          {
+            "$ref": "#/components/parameters/cat.count#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.count#s"
           }
         ],
         "responses": {
@@ -882,6 +920,12 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices#master_timeout"
+          },
+          {
+            "$ref": "#/components/parameters/cat.indices#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.indices#s"
           }
         ],
         "responses": {
@@ -923,6 +967,12 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices#master_timeout"
+          },
+          {
+            "$ref": "#/components/parameters/cat.indices#h"
+          },
+          {
+            "$ref": "#/components/parameters/cat.indices#s"
           }
         ],
         "responses": {
@@ -58643,6 +58693,26 @@
         },
         "style": "simple"
       },
+      "cat.aliases#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.aliases#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
       "cat.aliases#expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
@@ -58684,6 +58754,26 @@
         },
         "style": "simple"
       },
+      "cat.component_templates#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.component_templates#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
       "cat.component_templates#local": {
         "in": "query",
         "name": "local",
@@ -58714,6 +58804,26 @@
           "$ref": "#/components/schemas/_types:Indices"
         },
         "style": "simple"
+      },
+      "cat.count#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.count#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
       },
       "cat.indices#index": {
         "in": "path",
@@ -58793,6 +58903,26 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/_types:Duration"
+        },
+        "style": "form"
+      },
+      "cat.indices#h": {
+        "in": "query",
+        "name": "h",
+        "description": "List of columns to appear in the response. Supports simple wildcards.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
+        },
+        "style": "form"
+      },
+      "cat.indices#s": {
+        "in": "query",
+        "name": "s",
+        "description": "List of columns that determine how the table should be sorted.\nSorting defaults to ascending and can be changed by setting `:asc`\nor `:desc` as a suffix to the column name.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types:Names"
         },
         "style": "form"
       },

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -78,32 +78,24 @@
     },
     "cat.ml_data_frame_analytics": {
       "request": [
-        "request definition cat.ml_data_frame_analytics:Request / query - Property 'h' is already defined in an ancestor class",
-        "request definition cat.ml_data_frame_analytics:Request / query - Property 's' is already defined in an ancestor class",
         "request definition cat.ml_data_frame_analytics:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.ml_datafeeds": {
       "request": [
-        "request definition cat.ml_datafeeds:Request / query - Property 'h' is already defined in an ancestor class",
-        "request definition cat.ml_datafeeds:Request / query - Property 's' is already defined in an ancestor class",
         "request definition cat.ml_datafeeds:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.ml_jobs": {
       "request": [
-        "request definition cat.ml_jobs:Request / query - Property 'h' is already defined in an ancestor class",
-        "request definition cat.ml_jobs:Request / query - Property 's' is already defined in an ancestor class",
         "request definition cat.ml_jobs:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
     },
     "cat.ml_trained_models": {
       "request": [
-        "request definition cat.ml_trained_models:Request / query - Property 'h' is already defined in an ancestor class",
-        "request definition cat.ml_trained_models:Request / query - Property 's' is already defined in an ancestor class",
         "request definition cat.ml_trained_models:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []
@@ -187,8 +179,6 @@
     },
     "cat.transforms": {
       "request": [
-        "request definition cat.transforms:Request / query - Property 'h' is already defined in an ancestor class",
-        "request definition cat.transforms:Request / query - Property 's' is already defined in an ancestor class",
         "request definition cat.transforms:Request / body - A request with inherited properties must have a PropertyBody"
       ],
       "response": []

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -6980,6 +6980,8 @@ export interface CatAliasesAliasesRecord {
 
 export interface CatAliasesRequest extends CatCatRequestBase {
   name?: Names
+  h?: Names
+  s?: Names
   expand_wildcards?: ExpandWildcards
   local?: boolean
   master_timeout?: Duration
@@ -7026,6 +7028,8 @@ export interface CatAllocationAllocationRecord {
 export interface CatAllocationRequest extends CatCatRequestBase {
   node_id?: NodeIds
   bytes?: Bytes
+  h?: Names
+  s?: Names
   local?: boolean
   master_timeout?: Duration
 }
@@ -7044,6 +7048,8 @@ export interface CatComponentTemplatesComponentTemplate {
 
 export interface CatComponentTemplatesRequest extends CatCatRequestBase {
   name?: string
+  h?: Names
+  s?: Names
   local?: boolean
   master_timeout?: Duration
 }
@@ -7066,6 +7072,8 @@ export interface CatCountCountRecord {
 
 export interface CatCountRequest extends CatCatRequestBase {
   index?: Indices
+  h?: Names
+  s?: Names
 }
 
 export type CatCountResponse = CatCountCountRecord[]
@@ -7085,6 +7093,8 @@ export interface CatFielddataFielddataRecord {
 export interface CatFielddataRequest extends CatCatRequestBase {
   fields?: Fields
   bytes?: Bytes
+  h?: Names
+  s?: Names
 }
 
 export type CatFielddataResponse = CatFielddataFielddataRecord[]
@@ -7145,6 +7155,8 @@ export interface CatHealthHealthRecord {
 export interface CatHealthRequest extends CatCatRequestBase {
   time?: TimeUnit
   ts?: boolean
+  h?: Names
+  s?: Names
 }
 
 export type CatHealthResponse = CatHealthHealthRecord[]
@@ -7455,6 +7467,8 @@ export interface CatIndicesRequest extends CatCatRequestBase {
   pri?: boolean
   time?: TimeUnit
   master_timeout?: Duration
+  h?: Names
+  s?: Names
 }
 
 export type CatIndicesResponse = CatIndicesIndicesRecord[]
@@ -7469,6 +7483,8 @@ export interface CatMasterMasterRecord {
 }
 
 export interface CatMasterRequest extends CatCatRequestBase {
+  h?: Names
+  s?: Names
   local?: boolean
   master_timeout?: Duration
 }
@@ -7839,6 +7855,8 @@ export interface CatNodeattrsNodeAttributesRecord {
 }
 
 export interface CatNodeattrsRequest extends CatCatRequestBase {
+  h?: Names
+  s?: Names
   local?: boolean
   master_timeout?: Duration
 }
@@ -8119,6 +8137,8 @@ export interface CatNodesRequest extends CatCatRequestBase {
   bytes?: Bytes
   full_id?: boolean | string
   include_unloaded_segments?: boolean
+  h?: Names
+  s?: Names
   master_timeout?: Duration
   time?: TimeUnit
 }
@@ -8137,6 +8157,8 @@ export interface CatPendingTasksPendingTasksRecord {
 }
 
 export interface CatPendingTasksRequest extends CatCatRequestBase {
+  h?: Names
+  s?: Names
   local?: boolean
   master_timeout?: Duration
   time?: TimeUnit
@@ -8159,6 +8181,8 @@ export interface CatPluginsPluginsRecord {
 }
 
 export interface CatPluginsRequest extends CatCatRequestBase {
+  h?: Names
+  s?: Names
   include_bootstrap?: boolean
   local?: boolean
   master_timeout?: Duration
@@ -8229,6 +8253,8 @@ export interface CatRecoveryRequest extends CatCatRequestBase {
   active_only?: boolean
   bytes?: Bytes
   detailed?: boolean
+  h?: Names
+  s?: Names
   time?: TimeUnit
 }
 
@@ -8242,6 +8268,8 @@ export interface CatRepositoriesRepositoriesRecord {
 }
 
 export interface CatRepositoriesRequest extends CatCatRequestBase {
+  h?: Names
+  s?: Names
   local?: boolean
   master_timeout?: Duration
 }
@@ -8251,6 +8279,8 @@ export type CatRepositoriesResponse = CatRepositoriesRepositoriesRecord[]
 export interface CatSegmentsRequest extends CatCatRequestBase {
   index?: Indices
   bytes?: Bytes
+  h?: Names
+  s?: Names
   local?: boolean
   master_timeout?: Duration
 }
@@ -8302,6 +8332,8 @@ export interface CatSegmentsSegmentsRecord {
 export interface CatShardsRequest extends CatCatRequestBase {
   index?: Indices
   bytes?: Bytes
+  h?: Names
+  s?: Names
   master_timeout?: Duration
   time?: TimeUnit
 }
@@ -8526,6 +8558,8 @@ export interface CatShardsShardsRecord {
 export interface CatSnapshotsRequest extends CatCatRequestBase {
   repository?: Names
   ignore_unavailable?: boolean
+  h?: Names
+  s?: Names
   master_timeout?: Duration
   time?: TimeUnit
 }
@@ -8571,6 +8605,8 @@ export interface CatTasksRequest extends CatCatRequestBase {
   detailed?: boolean
   nodes?: string[]
   parent_task_id?: string
+  h?: Names
+  s?: Names
   time?: TimeUnit
   timeout?: Duration
   wait_for_completion?: boolean
@@ -8615,6 +8651,8 @@ export interface CatTasksTasksRecord {
 
 export interface CatTemplatesRequest extends CatCatRequestBase {
   name?: Name
+  h?: Names
+  s?: Names
   local?: boolean
   master_timeout?: Duration
 }
@@ -8637,6 +8675,8 @@ export interface CatTemplatesTemplatesRecord {
 
 export interface CatThreadPoolRequest extends CatCatRequestBase {
   thread_pool_patterns?: Names
+  h?: Names
+  s?: Names
   time?: TimeUnit
   local?: boolean
   master_timeout?: Duration
@@ -22133,9 +22173,7 @@ export interface SpecUtilsCommonQueryParameters {
 
 export interface SpecUtilsCommonCatQueryParameters {
   format?: string
-  h?: Names
   help?: boolean
-  s?: Names
   v?: boolean
 }
 

--- a/specification/_spec_utils/behaviors.ts
+++ b/specification/_spec_utils/behaviors.ts
@@ -16,14 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/*
- * This file hosts `behaviors`. We use this interfaces that are marked with a `@behavior` JS Doc annotation
- * to signal complicated mappings to the compiler -> canonical json -> client generators.
- *
- * These are problem sets that need a custom client solution.
- */
-
-import { Names } from '@_types/common'
 
 /**
  * In some places in the specification an object consists of the union of a set of known properties
@@ -95,21 +87,11 @@ export interface CommonCatQueryParameters {
    */
   format?: string
   /**
-   * List of columns to appear in the response. Supports simple wildcards.
-   */
-  h?: Names
-  /**
    * When set to `true` will output available columns. This option
    * can't be combined with any other query string option.
    * @server_default false
    */
   help?: boolean
-  /**
-   * List of columns that determine how the table should be sorted.
-   * Sorting defaults to ascending and can be changed by setting `:asc`
-   * or `:desc` as a suffix to the column name.
-   */
-  s?: Names
   /**
    * When set to `true` will enable verbose output.
    * @server_default false

--- a/specification/cat/aliases/CatAliasesRequest.ts
+++ b/specification/cat/aliases/CatAliasesRequest.ts
@@ -51,6 +51,16 @@ export interface Request extends CatRequestBase {
   }
   query_parameters: {
     /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
+    /**
      * The type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
      * It supports comma-separated values, such as `open,hidden`.

--- a/specification/cat/allocation/CatAllocationRequest.ts
+++ b/specification/cat/allocation/CatAllocationRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
-import { Bytes, NodeIds } from '@_types/common'
+import { Bytes, Names, NodeIds } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
@@ -51,6 +51,16 @@ export interface Request extends CatRequestBase {
   query_parameters: {
     /** The unit used to display byte values. */
     bytes?: Bytes
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * If `true`, the request computes the list of selected nodes from the
      * local cluster state. If `false` the list of selected nodes are computed

--- a/specification/cat/component_templates/CatComponentTemplatesRequest.ts
+++ b/specification/cat/component_templates/CatComponentTemplatesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
+import { Names } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
@@ -53,6 +54,16 @@ export interface Request extends CatRequestBase {
     name?: string
   }
   query_parameters: {
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * If `true`, the request computes the list of selected nodes from the
      * local cluster state. If `false` the list of selected nodes are computed

--- a/specification/cat/count/CatCountRequest.ts
+++ b/specification/cat/count/CatCountRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
-import { Indices } from '@_types/common'
+import { Indices, Names } from '@_types/common'
 
 /**
  * Get a document count.
@@ -52,5 +52,17 @@ export interface Request extends CatRequestBase {
      * To target all data streams and indices, omit this parameter or use `*` or `_all`.
      */
     index?: Indices
+  }
+  query_parameters: {
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
   }
 }

--- a/specification/cat/fielddata/CatFielddataRequest.ts
+++ b/specification/cat/fielddata/CatFielddataRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
-import { Bytes, Fields } from '@_types/common'
+import { Bytes, Fields, Names } from '@_types/common'
 
 /**
  * Get field data cache information.
@@ -56,5 +56,15 @@ export interface Request extends CatRequestBase {
     bytes?: Bytes
     /** Comma-separated list of fields used to limit returned information. */
     fields?: Fields
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
   }
 }

--- a/specification/cat/health/CatHealthRequest.ts
+++ b/specification/cat/health/CatHealthRequest.ts
@@ -18,6 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
+import { Names } from '@_types/common'
 import { TimeUnit } from '@_types/Time'
 
 /**
@@ -55,5 +56,15 @@ export interface Request extends CatRequestBase {
      * @server_default true
      */
     ts?: boolean
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
   }
 }

--- a/specification/cat/indices/CatIndicesRequest.ts
+++ b/specification/cat/indices/CatIndicesRequest.ts
@@ -18,7 +18,13 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
-import { Bytes, ExpandWildcards, HealthStatus, Indices } from '@_types/common'
+import {
+  Bytes,
+  ExpandWildcards,
+  HealthStatus,
+  Indices,
+  Names
+} from '@_types/common'
 import { Duration, TimeUnit } from '@_types/Time'
 
 /**
@@ -89,5 +95,15 @@ export interface Request extends CatRequestBase {
      * @server_default 30s
      */
     master_timeout?: Duration
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
   }
 }

--- a/specification/cat/master/CatMasterRequest.ts
+++ b/specification/cat/master/CatMasterRequest.ts
@@ -18,6 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
+import { Names } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
@@ -40,6 +41,16 @@ export interface Request extends CatRequestBase {
     }
   ]
   query_parameters: {
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * If `true`, the request computes the list of selected nodes from the
      * local cluster state. If `false` the list of selected nodes are computed

--- a/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
+++ b/specification/cat/nodeattrs/CatNodeAttributesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
+import { Names } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
@@ -39,6 +40,16 @@ export interface Request extends CatRequestBase {
     }
   ]
   query_parameters: {
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * If `true`, the request computes the list of selected nodes from the
      * local cluster state. If `false` the list of selected nodes are computed

--- a/specification/cat/nodes/CatNodesRequest.ts
+++ b/specification/cat/nodes/CatNodesRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
-import { Bytes } from '@_types/common'
+import { Bytes, Names } from '@_types/common'
 import { Duration, TimeUnit } from '@_types/Time'
 
 /**
@@ -54,6 +54,16 @@ export interface Request extends CatRequestBase {
      * @server_default false
      */
     include_unloaded_segments?: boolean
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * Period to wait for a connection to the master node.
      * @server_default 30s

--- a/specification/cat/pending_tasks/CatPendingTasksRequest.ts
+++ b/specification/cat/pending_tasks/CatPendingTasksRequest.ts
@@ -18,6 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
+import { Names } from '@_types/common'
 import { Duration, TimeUnit } from '@_types/Time'
 
 /**
@@ -39,6 +40,16 @@ export interface Request extends CatRequestBase {
     }
   ]
   query_parameters: {
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * If `true`, the request computes the list of selected nodes from the
      * local cluster state. If `false` the list of selected nodes are computed

--- a/specification/cat/plugins/CatPluginsRequest.ts
+++ b/specification/cat/plugins/CatPluginsRequest.ts
@@ -18,6 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
+import { Names } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
@@ -39,6 +40,16 @@ export interface Request extends CatRequestBase {
     }
   ]
   query_parameters: {
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * Include bootstrap plugins in the response
      * @server_default false

--- a/specification/cat/recovery/CatRecoveryRequest.ts
+++ b/specification/cat/recovery/CatRecoveryRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
-import { Bytes, Indices } from '@_types/common'
+import { Bytes, Indices, Names } from '@_types/common'
 import { TimeUnit } from '@_types/Time'
 
 /**
@@ -68,6 +68,16 @@ export interface Request extends CatRequestBase {
      * @server_default false
      */
     detailed?: boolean
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * Unit used to display time values.
      */

--- a/specification/cat/repositories/CatRepositoriesRequest.ts
+++ b/specification/cat/repositories/CatRepositoriesRequest.ts
@@ -18,6 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
+import { Names } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
@@ -39,6 +40,16 @@ export interface Request extends CatRequestBase {
     }
   ]
   query_parameters: {
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * If `true`, the request computes the list of selected nodes from the
      * local cluster state. If `false` the list of selected nodes are computed

--- a/specification/cat/segments/CatSegmentsRequest.ts
+++ b/specification/cat/segments/CatSegmentsRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
-import { Bytes, Indices } from '@_types/common'
+import { Bytes, Indices, Names } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
@@ -58,6 +58,16 @@ export interface Request extends CatRequestBase {
      * The unit used to display byte values.
      */
     bytes?: Bytes
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * If `true`, the request computes the list of selected nodes from the
      * local cluster state. If `false` the list of selected nodes are computed

--- a/specification/cat/shards/CatShardsRequest.ts
+++ b/specification/cat/shards/CatShardsRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
-import { Bytes, Indices } from '@_types/common'
+import { Bytes, Indices, Names } from '@_types/common'
 import { Duration, TimeUnit } from '@_types/Time'
 
 /**
@@ -58,6 +58,16 @@ export interface Request extends CatRequestBase {
      * The unit used to display byte values.
      */
     bytes?: Bytes
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * Period to wait for a connection to the master node.
      * @server_default 30s

--- a/specification/cat/snapshots/CatSnapshotsRequest.ts
+++ b/specification/cat/snapshots/CatSnapshotsRequest.ts
@@ -60,6 +60,16 @@ export interface Request extends CatRequestBase {
      */
     ignore_unavailable?: boolean
     /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
+    /**
      * Period to wait for a connection to the master node.
      * @server_default 30s
      */

--- a/specification/cat/tasks/CatTasksRequest.ts
+++ b/specification/cat/tasks/CatTasksRequest.ts
@@ -18,6 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
+import { Names } from '@_types/common'
 import { Duration, TimeUnit } from '@_types/Time'
 
 /**
@@ -52,6 +53,16 @@ export interface Request extends CatRequestBase {
     nodes?: string[]
     /** The parent task identifier, which is used to limit the response. */
     parent_task_id?: string
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * Unit used to display time values.
      */

--- a/specification/cat/templates/CatTemplatesRequest.ts
+++ b/specification/cat/templates/CatTemplatesRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { CatRequestBase } from '@cat/_types/CatBase'
-import { Name } from '@_types/common'
+import { Name, Names } from '@_types/common'
 import { Duration } from '@_types/Time'
 
 /**
@@ -52,6 +52,16 @@ export interface Request extends CatRequestBase {
     name?: Name
   }
   query_parameters: {
+    /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
     /**
      * If `true`, the request computes the list of selected nodes from the
      * local cluster state. If `false` the list of selected nodes are computed

--- a/specification/cat/thread_pool/CatThreadPoolRequest.ts
+++ b/specification/cat/thread_pool/CatThreadPoolRequest.ts
@@ -53,6 +53,16 @@ export interface Request extends CatRequestBase {
   }
   query_parameters: {
     /**
+     * List of columns to appear in the response. Supports simple wildcards.
+     */
+    h?: Names
+    /**
+     * List of columns that determine how the table should be sorted.
+     * Sorting defaults to ascending and can be changed by setting `:asc`
+     * or `:desc` as a suffix to the column name.
+     */
+    s?: Names
+    /**
      * The unit used to display time values.
      */
     time?: TimeUnit


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Fix property defined in an ancestor class errors (#3800)](https://github.com/elastic/elasticsearch-specification/pull/3800)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)