### PR TITLE
`IndicesPutMappingRequest.dynamic_templates` should not be "single or many"

### DIFF
--- a/specification/indices/put_mapping/IndicesPutMappingRequest.ts
+++ b/specification/indices/put_mapping/IndicesPutMappingRequest.ts
@@ -141,9 +141,7 @@ export interface Request extends RequestBase {
     /**
      * Specify dynamic templates for the mapping.
      */
-    dynamic_templates?:
-      | Dictionary<string, DynamicTemplate>
-      | Dictionary<string, DynamicTemplate>[]
+    dynamic_templates?: Dictionary<string, DynamicTemplate>[]
     /**
      * Control whether field names are enabled for the index.
      */


### PR DESCRIPTION
As titled.

Related server test: https://github.com/elastic/elasticsearch/blob/f5e2a92a3171808bd163570c3e1546230ec7c5ac/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java?email_source=slack

Thanks @l-trotta for confirming.

Related to: https://github.com/elastic/elasticsearch-net/issues/7968