### PR TITLE
Disable Kibana checks for 8.x branches

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -43,15 +43,3 @@ spec:
           branch: 'main'
           cronline: '0 4 * * *'
           message: 'Daily run for main branch'
-        Daily 8.x:
-          branch: '8.x'
-          cronline: '0 4 * * *'
-          message: 'Daily run for 8.x branch'
-        Daily 8.17:
-          branch: '8.17'
-          cronline: '0 4 * * *'
-          message: 'Daily run for 8.17 branch'
-        Daily 8.18:
-          branch: '8.18'
-          cronline: '0 4 * * *'
-          message: 'Daily run for 8.18 branch'


### PR DESCRIPTION
Since we're testing against Kibana main, using 8.x branches is not going to work. If needed, in the future, we can test Kibana 8.x against branch 8.x of the Elasticsearch specification.
