### PR TITLE
Replace broken master links

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ endpoint of Elasticsearch and the respective type mapping. For example:
         "application/json"
       ],
       "description": "Creates or updates a document in an index.",
-      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html",
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html",
       "name": "index",
       "request": {
         "name": "Request",

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -39,7 +39,7 @@ actions:
 
             This API requires the `manage_connector` privilege or, for read-only endpoints, the `monitor_connector` privilege.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/es-connectors-tutorial-api.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/es-connectors-tutorial-api.html
             description: Check out the connector API tutorial
         - name: ccr
           x-displayName: Cross-cluster replication
@@ -48,12 +48,12 @@ actions:
           x-displayName: Data stream
           externalDocs:
             description: Learn more about data streams. 
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams.html
         - name: document
           x-displayName: Document
           externalDocs:
             description: Learn more about reading and writing documents.
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-replication.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-replication.html
       # E  
         - name: enrich
           x-displayName: Enrich
@@ -62,14 +62,14 @@ actions:
           description: >
             Event Query Language (EQL) is a query language for event-based time series data, such as logs, metrics, and traces.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/eql.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html
             description: Learn more about EQL search.
         - name: esql
           x-displayName: ES|QL
           description: >
             The Elasticsearch Query Language (ES|QL) provides a powerful way to filter, transform, and analyze data stored in Elasticsearch, and in the future in other runtimes.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/esql.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/esql.html
             description: Learn more about ES|QL.
       # F
         - name: features
@@ -83,7 +83,7 @@ actions:
           description: >
             The graph explore API enables you to extract and summarize information about the documents and terms in an Elasticsearch data stream or index.
           externalDocs:
-            url: https://www.elastic.co/guide/en/kibana/master/xpack-graph.html
+            url: https://www.elastic.co/guide/en/kibana/current/xpack-graph.html
             description: Get started with Graph.
       # I
         - name: indices
@@ -93,7 +93,7 @@ actions:
         - name: ilm
           x-displayName: Index lifecycle management
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/index-lifecycle-management.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/index-lifecycle-management.html
             description: Learn more about managing the index lifecycle.
         - name: inference
           x-displayName: Inference
@@ -118,7 +118,7 @@ actions:
           description: >
             Logstash APIs enable you to manage pipelines that are used by Logstash Central Management.
           externalDocs:
-            url: https://www.elastic.co/guide/en/logstash/master/logstash-centralized-pipeline-management.html
+            url: https://www.elastic.co/guide/en/logstash/current/logstash-centralized-pipeline-management.html
             description: Learn more about centralized pipeline management.
       # M
         - name: ml
@@ -127,19 +127,19 @@ actions:
           x-displayName: Machine learning anomaly detection
           # description:
           externalDocs:
-            url: https://www.elastic.co/guide/en/machine-learning/master/ml-ad-finding-anomalies.html
+            url: https://www.elastic.co/guide/en/machine-learning/current/ml-ad-finding-anomalies.html
             description: Learn more about finding anomalies.
         - name: ml data frame
           x-displayName: Machine learning data frame analytics
           # description:
           externalDocs:
-            url: https://www.elastic.co/guide/en/machine-learning/master/ml-dfa-overview.html
+            url: https://www.elastic.co/guide/en/machine-learning/current/ml-dfa-overview.html
             description: Learn more about data frame analytics.
         - name: ml trained model
           x-displayName: Machine learning trained model
           # description:
           externalDocs:
-            url: https://www.elastic.co/guide/en/machine-learning/master/ml-nlp-overview.html
+            url: https://www.elastic.co/guide/en/machine-learning/current/ml-nlp-overview.html
             description: Learn more about natural language processing.
         - name: migration
           x-displayName: Migration
@@ -159,7 +159,7 @@ actions:
             If a query matches one or more rules in the ruleset, the query is re-written to apply the rules before searching.
             This allows pinning documents for only queries that match a specific term.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-rule-query.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-rule-query.html
             description: Learn more about the rule query.
       # R
         - name: rollup
@@ -171,7 +171,7 @@ actions:
             Use the script support APIs to get a list of supported script contexts and languages.
             Use the stored script APIs to manage stored scripts and search templates.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html
         - name: search
           x-displayName: Search
         - name: search_application
@@ -185,21 +185,21 @@ actions:
           description: >
             Snapshot and restore APIs enable you to set up snapshot repositories, manage snapshot backups, and restore snapshots to a running cluster.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/snapshot-restore.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshot-restore.html
             description: Learn more about snapshot and restore operations.
         - name: slm
           x-displayName: Snapshot lifecycle management
           description: >
             Snapshot lifecycle management (SLM) APIs enable you to set up policies to automatically take snapshots and control how long they are retained.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/snapshots-take-snapshot.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/snapshots-take-snapshot.html
             description: Learn more about creating a snapshot.
         - name: sql
           x-displayName: SQL
           description: >
             Elasticsearch's SQL APIs enable you to run SQL queries on Elasticsearch indices and data streams.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/xpack-sql.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-sql.html
             description: Check out the overview and tutorials for the Elasticsearch SQL features.
         - name: synonyms
           x-displayName: Synonyms
@@ -223,7 +223,7 @@ actions:
           description: >
             You can use Watcher to watch for changes or anomalies in your data and perform the necessary actions in response.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/xpack-alerting.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/xpack-alerting.html
             description: Learn more about Watcher.
 # Add x-model and/or abbreviate schemas that should point to other references
   - target: "$.components['schemas']['_types.query_dsl:QueryContainer']"
@@ -257,7 +257,7 @@ actions:
       x-model: true
       externalDocs:
         description: Templating a role query
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/field-and-document-access-control.html#templating-role-query
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/field-and-document-access-control.html#templating-role-query
   - target: "$.components['schemas']['_types.query_dsl:DistanceFeatureQuery']"
     description: Add x-model for distance feature query
     update:
@@ -1006,7 +1006,7 @@ actions:
           All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch.
           By default, this property has the following value: `{"match_all": {"boost": 1}}`.
         externalDocs:
-          url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl.html
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
           description: Query DSL
   - target: "$.components['schemas']['ml._types:CategorizationAnalyzerDefinition'].properties.tokenizer"
     description: Remove tokenizer object from ML anomaly detection analysis config
@@ -1027,7 +1027,7 @@ actions:
           Additionally, the `ml_classic` tokenizer is available, which tokenizes in the same way as the non-customizable tokenizer in old versions of the product (before 6.2).
           `ml_classic` was the default categorization tokenizer in versions 6.2 to 7.13, so if you need categorization identical to the default for jobs created in these versions, specify `"tokenizer": "ml_classic"` in your `categorization_analyzer`.
         externalDocs:
-          url: https://www.elastic.co/guide/en/elasticsearch/reference/master/analysis-tokenizers.html
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-tokenizers.html
           description: Tokenizer reference
   - target: "$.components['schemas']['ml._types:DataframeAnalyticsSource'].properties.query"
     description: Remove query object from data frame analytics source
@@ -1044,7 +1044,7 @@ actions:
           All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch.
           By default, this property has the following value: `{"match_all": {}}`.
         externalDocs:
-          url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl.html
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
           description: Query DSL
   - target: "$.components['schemas']['transform._types:Source'].properties.query"
     description: Remove query object from transform source
@@ -1058,14 +1058,14 @@ actions:
         description: >
           A query clause that retrieves a subset of data from the source index.
         externalDocs:
-          url: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl.html
+          url: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html
           description: Query DSL
   - target: "$.components['schemas']['_global.search._types:FieldCollapse']"
     description: Add x-model and externalDocs
     update:
       x-model: true
       externalDocs:
-        url: https://www.elastic.co/guide/en/elasticsearch/reference/master/collapse-search-results.html
+        url: https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html
   - target: "$.components['schemas']['_global.msearch:MultisearchBody'].properties"
     description: Add x-model
     update:

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -1,6 +1,7 @@
 apis,https://www.elastic.co/docs/api/doc/elasticsearch
 add-nodes,https://www.elastic.co/guide/en/elasticsearch/reference/current/add-elasticsearch-nodes.html
 alias-update,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-alias
+aliases-update,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-update-aliases
 analysis-analyzers,https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-analyzers.html
 analysis-charfilters,https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-charfilters.html
 analysis-normalizers,https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-normalizers.html
@@ -140,7 +141,9 @@ data-stream-get-lifecycle,https://www.elastic.co/docs/api/doc/elasticsearch/oper
 data-stream-lifecycle-stats,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-data-lifecycle-stats
 data-stream-migrate,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-migrate-to-data-stream
 data-stream-promote,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-promote-data-stream
+data-stream-put-lifecycle,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-data-lifecycle
 data-stream-stats-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-data-streams-stats-1
+data-stream-update,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-modify-data-stream
 data-streams,https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams.html
 date-index-name-processor,https://www.elastic.co/guide/en/elasticsearch/reference/current/date-index-name-processor.html
 dcg,https://www.elastic.co/guide/en/elasticsearch/reference/current/search-rank-eval.html#_discounted_cumulative_gain_dcg
@@ -263,6 +266,7 @@ indexing-buffer,https://www.elastic.co/guide/en/elasticsearch/reference/current/
 index-modules-merge,https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-merge.html
 index-templates,https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html
 index-templates-exist,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists-index-template
+index-templates-put,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-index-template
 index-templates-v1,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-template
 indices-aliases,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-update-aliases
 indices-aliases-exist,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists-alias

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -1,5 +1,6 @@
 apis,https://www.elastic.co/docs/api/doc/elasticsearch
 add-nodes,https://www.elastic.co/guide/en/elasticsearch/reference/current/add-elasticsearch-nodes.html
+alias-update,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-put-alias
 analysis-analyzers,https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-analyzers.html
 analysis-charfilters,https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-charfilters.html
 analysis-normalizers,https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-normalizers.html
@@ -137,6 +138,8 @@ data-stream-explain-lifecycle,https://www.elastic.co/docs/api/doc/elasticsearch/
 data-stream-get,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-data-stream
 data-stream-get-lifecycle,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-data-lifecycle
 data-stream-lifecycle-stats,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-get-data-lifecycle-stats
+data-stream-migrate,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-migrate-to-data-stream
+data-stream-promote,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-promote-data-stream
 data-stream-stats-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-data-streams-stats-1
 data-streams,https://www.elastic.co/guide/en/elasticsearch/reference/current/data-streams.html
 date-index-name-processor,https://www.elastic.co/guide/en/elasticsearch/reference/current/date-index-name-processor.html

--- a/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
+++ b/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
@@ -38,6 +38,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @index_privileges manage
  * @doc_tag data stream
+ * @doc_id data-stream-migrate
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/modify_data_stream/IndicesModifyDataStreamRequest.ts
+++ b/specification/indices/modify_data_stream/IndicesModifyDataStreamRequest.ts
@@ -27,6 +27,7 @@ import { Action } from './types'
  * @availability stack since=7.16.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag data stream
+ * @doc_id data-stream-update
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/promote_data_stream/IndicesPromoteDataStreamRequest.ts
+++ b/specification/indices/promote_data_stream/IndicesPromoteDataStreamRequest.ts
@@ -36,6 +36,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name indices.promote_data_stream
  * @availability stack since=7.9.0 stability=stable
  * @doc_tag data stream
+ * @doc_id data-stream-promote
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/put_alias/IndicesPutAliasRequest.ts
+++ b/specification/indices/put_alias/IndicesPutAliasRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name indices.put_alias
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id alias-update
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
+++ b/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.11.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag data stream
+ * @doc_id data-stream-put-lifecycle
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
@@ -67,6 +67,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_index_templates
+ * @doc_id index-templates-put
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/update_aliases/IndicesUpdateAliasesRequest.ts
+++ b/specification/indices/update_aliases/IndicesUpdateAliasesRequest.ts
@@ -27,6 +27,7 @@ import { Action } from './types'
  * @rest_spec_name indices.update_aliases
  * @availability stack since=1.3.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id aliases-update
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/validate_query/IndicesValidateQueryRequest.ts
+++ b/specification/indices/validate_query/IndicesValidateQueryRequest.ts
@@ -28,6 +28,7 @@ import { Operator } from '@_types/query_dsl/Operator'
  * @rest_spec_name indices.validate_query
  * @availability stack since=1.3.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id search-validate
  */
 export interface Request extends RequestBase {
   urls: [


### PR DESCRIPTION
This PR removes the use of `/master/` URLs in the overlays and readmes. It also adds `doc_id` values to new APIs so they don't default to the old `master` URLs.