### PR TITLE
[8.x] Replace broken master links (#3858)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ endpoint of Elasticsearch and the respective type mapping. For example:
         "application/json"
       ],
       "description": "Creates or updates a document in an index.",
-      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html",
+      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html",
       "name": "index",
       "request": {
         "name": "Request",

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -174,7 +174,7 @@ actions:
             Use the script support APIs to get a list of supported script contexts and languages.
             Use the stored script APIs to manage stored scripts and search templates.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-scripting.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html
         - name: search
           x-displayName: Search
         - name: search_application

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -1,5 +1,7 @@
 apis,https://www.elastic.co/docs/api/doc/elasticsearch/v8
 add-nodes,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/add-elasticsearch-nodes.html
+alias-update,https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-indices-put-alias
+aliases-update,https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-indices-update-aliases
 analysis-analyzers,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/analysis-analyzers.html
 analysis-charfilters,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/analysis-charfilters.html
 analysis-normalizers,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/analysis-normalizers.html
@@ -138,7 +140,11 @@ data-stream-get,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 data-stream-get-lifecycle,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams-get-lifecycle.html
 data-stream-lifecycle-stats,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams-get-lifecycle-stats.html
 data-stream-path-param,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-create-data-stream.html#indices-create-data-stream-api-path-params
+data-stream-migrate,https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-indices-migrate-to-data-stream
+data-stream-promote,https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-indices-promote-data-stream
+data-stream-put-lifecycle,https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-indices-put-data-lifecycle
 data-stream-stats-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-stream-stats-api.html
+data-stream-update,https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-indices-modify-data-stream
 data-streams,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/data-streams.html
 date-index-name-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/date-index-name-processor.html
 dcg,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-rank-eval.html#_discounted_cumulative_gain_dcg
@@ -261,6 +267,7 @@ indexing-buffer,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 index-modules-merge,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-modules-merge.html
 index-templates,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/index-templates.html
 index-templates-exist,https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-indices-exists-index-template
+index-templates-put,https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-indices-put-index-template
 index-templates-v1,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-templates-v1.html
 indices-aliases,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/indices-aliases.html
 indices-aliases-exist,https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-indices-exists-alias

--- a/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
+++ b/specification/indices/migrate_to_data_stream/IndicesMigrateToDataStreamRequest.ts
@@ -38,6 +38,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=public
  * @index_privileges manage
  * @doc_tag data stream
+ * @doc_id data-stream-migrate
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/modify_data_stream/IndicesModifyDataStreamRequest.ts
+++ b/specification/indices/modify_data_stream/IndicesModifyDataStreamRequest.ts
@@ -27,6 +27,7 @@ import { Action } from './types'
  * @availability stack since=7.16.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag data stream
+ * @doc_id data-stream-update
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/promote_data_stream/IndicesPromoteDataStreamRequest.ts
+++ b/specification/indices/promote_data_stream/IndicesPromoteDataStreamRequest.ts
@@ -36,6 +36,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name indices.promote_data_stream
  * @availability stack since=7.9.0 stability=stable
  * @doc_tag data stream
+ * @doc_id data-stream-promote
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/put_alias/IndicesPutAliasRequest.ts
+++ b/specification/indices/put_alias/IndicesPutAliasRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
  * @rest_spec_name indices.put_alias
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id alias-update
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
+++ b/specification/indices/put_data_lifecycle/IndicesPutDataLifecycleRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=8.11.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_tag data stream
+ * @doc_id data-stream-put-lifecycle
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
+++ b/specification/indices/put_index_template/IndicesPutIndexTemplateRequest.ts
@@ -67,6 +67,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=7.9.0 stability=stable
  * @availability serverless stability=stable visibility=public
  * @cluster_privileges manage_index_templates
+ * @doc_id index-templates-put
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/update_aliases/IndicesUpdateAliasesRequest.ts
+++ b/specification/indices/update_aliases/IndicesUpdateAliasesRequest.ts
@@ -27,6 +27,7 @@ import { Action } from './types'
  * @rest_spec_name indices.update_aliases
  * @availability stack since=1.3.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id aliases-update
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/indices/validate_query/IndicesValidateQueryRequest.ts
+++ b/specification/indices/validate_query/IndicesValidateQueryRequest.ts
@@ -28,6 +28,7 @@ import { Operator } from '@_types/query_dsl/Operator'
  * @rest_spec_name indices.validate_query
  * @availability stack since=1.3.0 stability=stable
  * @availability serverless stability=stable visibility=public
+ * @doc_id search-validate
  */
 export interface Request extends RequestBase {
   urls: [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [Replace broken master links (#3858)](https://github.com/elastic/elasticsearch-specification/pull/3858)

<!--- Backport version: 9.6.4 -->

NOTE: This PR has different URLs for the doc IDs, since they must point to the v8 APIs.

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)