### PR TITLE
Add OpenAPI steps to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ $ make generate
 $ cat output/schema/schema.json
 ```
 
+## How to generate the OpenAPI representation
+
+Follow the steps to generate the JSON representation, then:
+
+```
+# Generate the OpenAPI representation
+$ make transform-to-openapi
+
+# Apply fixes
+$ make overlay-docs
+
+# The generated output can be found in ./output/openapi/
+```
+
 ## Make Targets
 
 ```


### PR DESCRIPTION
This PR adds an OpenAPI section to the readme, so that we can reference it from https://github.com/elastic/elasticsearch/blob/main/docs/README.md