### PR TITLE
fix typo in `index_template_substitutions` body argument

### DIFF
--- a/output/openapi/elasticsearch-openapi.json
+++ b/output/openapi/elasticsearch-openapi.json
@@ -111437,7 +111437,7 @@
                     "$ref": "#/components/schemas/cluster._types:ComponentTemplateNode"
                   }
                 },
-                "index_template_subtitutions": {
+                "index_template_substitutions": {
                   "description": "A map of index template names to substitute index template definition objects.",
                   "type": "object",
                   "additionalProperties": {

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -19598,7 +19598,7 @@ export interface SimulateIngestRequest extends RequestBase {
   body?: {
     docs: IngestDocument[]
     component_template_substitutions?: Record<string, ClusterComponentTemplateNode>
-    index_template_subtitutions?: Record<string, IndicesIndexTemplate>
+    index_template_substitutions?: Record<string, IndicesIndexTemplate>
     mapping_addition?: MappingTypeMapping
     pipeline_substitutions?: Record<string, IngestPipeline>
   }

--- a/specification/simulate/ingest/SimulateIngestRequest.ts
+++ b/specification/simulate/ingest/SimulateIngestRequest.ts
@@ -88,7 +88,7 @@ export interface Request extends RequestBase {
     /**
      * A map of index template names to substitute index template definition objects.
      */
-    index_template_subtitutions?: Dictionary<string, IndexTemplate>
+    index_template_substitutions?: Dictionary<string, IndexTemplate>
     mapping_addition?: TypeMapping
     /**
      * Pipelines to test.


### PR DESCRIPTION
A failure in the request converter integration tests led me to find this typo.
