### PR TITLE
Add index-time scripts to date properties

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -5439,6 +5439,8 @@ export interface MappingDateNanosProperty extends MappingDocValuesPropertyBase {
   format?: string
   ignore_malformed?: boolean
   index?: boolean
+  script?: Script | string
+  on_script_error?: MappingOnScriptError
   null_value?: DateTime
   precision_step?: integer
   type: 'date_nanos'
@@ -5450,6 +5452,8 @@ export interface MappingDateProperty extends MappingDocValuesPropertyBase {
   format?: string
   ignore_malformed?: boolean
   index?: boolean
+  script?: Script | string
+  on_script_error?: MappingOnScriptError
   null_value?: DateTime
   precision_step?: integer
   locale?: string

--- a/specification/_types/mapping/core.ts
+++ b/specification/_types/mapping/core.ts
@@ -69,6 +69,8 @@ export class DateProperty extends DocValuesPropertyBase {
   format?: string
   ignore_malformed?: boolean
   index?: boolean
+  script?: Script
+  on_script_error?: OnScriptError
   null_value?: DateTime
   precision_step?: integer
   locale?: string
@@ -80,6 +82,8 @@ export class DateNanosProperty extends DocValuesPropertyBase {
   format?: string
   ignore_malformed?: boolean
   index?: boolean
+  script?: Script
+  on_script_error?: OnScriptError
   null_value?: DateTime
   precision_step?: integer
   type: 'date_nanos'


### PR DESCRIPTION
As added in https://github.com/elastic/elasticsearch/pull/71633.

Today, the code is in [DateFieldMapper.Builder](https://github.com/elastic/elasticsearch/blob/c702eb9efad65a09ae01fe049e314923934a18da/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java#L262-L266) and [CONTENT_TYPE/DATE_NANOS_CONTENT_TYPE](https://github.com/elastic/elasticsearch/blob/c702eb9efad65a09ae01fe049e314923934a18da/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java#L91-L92) suggests that it applies both to `date` and `date_nanos`.

This fixes the indices.get_index_template API.