### PR TITLE
Implement `OrderedDictionary<K, V>` type

### DIFF
--- a/compiler/src/model/metamodel.ts
+++ b/compiler/src/model/metamodel.ts
@@ -88,6 +88,7 @@ export class DictionaryOf {
   key: ValueOf
   value: ValueOf
   singleKey: boolean
+  ordered: boolean
 }
 
 /**

--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -281,7 +281,8 @@ export function modelType (node: Node): model.ValueOf {
             kind: 'dictionary_of',
             key,
             value,
-            singleKey: false
+            singleKey: false,
+            ordered: false
           }
           return type
         }
@@ -294,7 +295,21 @@ export function modelType (node: Node): model.ValueOf {
             kind: 'dictionary_of',
             key,
             value,
-            singleKey: true
+            singleKey: true,
+            ordered: false
+          }
+          return type
+        }
+
+        case 'OrderedDictionary': {
+          assert(node, node.getTypeArguments().length === 2, 'A OrderedDictionary must have two arguments')
+          const [key, value] = node.getTypeArguments().map(node => modelType(node))
+          const type: model.DictionaryOf = {
+            kind: 'dictionary_of',
+            key,
+            value,
+            singleKey: false,
+            ordered: true
           }
           return type
         }
@@ -500,7 +515,7 @@ export function modelEnumDeclaration (declaration: EnumDeclaration): model.Enum 
   }
 
   if (typeof tags.es_quirk === 'string') {
-    type.esQuirk = tags.es_quirk
+    type.esQuirk = tags.es_quirk.replace(/\r/g, '')
   }
 
   return type
@@ -892,7 +907,7 @@ function hoistPropertyAnnotations (property: model.Property, jsDocs: JSDoc[]): v
       assert(jsDocs, value === 'container_property', `Unknown 'variant' value '${value}' on property ${property.name}`)
       property.containerProperty = true
     } else if (tag === 'es_quirk') {
-      property.esQuirk = value
+      property.esQuirk = value.replace(/\r/g, '')
     } else {
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on property ${property.name}`)
     }

--- a/compiler/src/transform/expand-generics.ts
+++ b/compiler/src/transform/expand-generics.ts
@@ -359,7 +359,8 @@ export function expandGenerics (inputModel: Model, config?: ExpansionConfig): Mo
           kind: 'dictionary_of',
           key: expandValueOf(value.key, mappings),
           value: expandValueOf(value.value, mappings),
-          singleKey: value.singleKey
+          singleKey: value.singleKey,
+          ordered: value.ordered
         }
 
       case 'instance_of': {

--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -24,9 +24,23 @@ For example:
 ```json
 {
   "property1": "type",
-  "property2": "other-type",
+  "property2": "other-type"
 }
 ```
+
+### OrderedDictionary
+
+Represents a dynamic key value map that preserves the order of items:
+
+```ts
+property: OrderedDictionary<string, TypeDefinition>
+```
+
+The JSON specification and most dictionary implementations do not make guarantees about item ordering. 
+`OrderedDictionary` can be used to express this fact in the Elasticsearch specification.
+
+> [!WARNING]
+> This type should only be used for legacy types and should otherwise be avoided as far as possible.
 
 ### SingleKeyDictionary
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "elasticsearch-specification",
+  "name": "spec",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/specification/_spec_utils/Dictionary.ts
+++ b/specification/_spec_utils/Dictionary.ts
@@ -20,3 +20,5 @@
 export class Dictionary<TKey, TValue> {}
 
 export class SingleKeyDictionary<TKey, TValue> {}
+
+export class OrderedDictionary<TKey, TValue> {}

--- a/typescript-generator/src/metamodel.ts
+++ b/typescript-generator/src/metamodel.ts
@@ -88,6 +88,7 @@ export class DictionaryOf {
   key: ValueOf
   value: ValueOf
   singleKey: boolean
+  ordered: boolean
 }
 
 /**


### PR DESCRIPTION
Adds a new builtin dictionary type `OrderedDictionary<K, V>` that can be used instead of `Dictionary<K, V>` when the order of items is important.

## Motivation

Some dictionaries require a fixed order (e.g. `aggregations`), but currently we do not model this fact at all.

This is quite special since the JSON spec does not make any guarantees about the order of properties in an object, but still Elasticsearch relies on that.

Closes: #3908
Related to: #3909