### PR TITLE
[ML] Updating the streaming completion description to match what is in ES

### DIFF
--- a/specification/_json_spec/inference.stream_completion.json
+++ b/specification/_json_spec/inference.stream_completion.json
@@ -2,7 +2,7 @@
   "inference.stream_completion": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/post-stream-inference-api.html",
-      "description": "Perform streaming inference"
+      "description": "Perform streaming completion inference"
     },
     "stability": "stable",
     "visibility": "public",


### PR DESCRIPTION
Elasticsearch's description for the `inference.stream_completion` api is here: https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/main/resources/rest-api-spec/api/inference.stream_completion.json#L5

This PR just aligns them to `Perform streaming completion inference`