### PR TITLE
Fix overlay for inference stream

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -618,14 +618,15 @@ actions:
             indicesLegacyPutTemplateRequestExample1:
               $ref: "../../specification/indices/put_template/examples/request/indicesPutTemplateRequestExample1.yaml"
 ## Examples for inference
-  - target: "$.components['requestBodies']['inference.stream_inference']"
+  - target: "$.paths['/_inference/chat_completion/{inference_id}/_stream']['post']"
     description: "Add example for inference stream request"
     update:
-      content:
-        application/json:
-          examples:
-            streamInferenceRequestExample1:
-              $ref: "../../specification/inference/stream_inference/examples/request/StreamInferenceRequestExample1.yaml"
+      requestBody:
+        content:
+          application/json:
+            examples:
+              streamInferenceRequestExample1:
+                $ref: "../../specification/inference/stream_completion/examples/request/StreamInferenceRequestExample1.yaml"
 ## Examples for ingest
   - target: "$.components['requestBodies']['simulate.ingest']"
     description: "Add example for simulate ingest request"


### PR DESCRIPTION
This PR fixes the following error that occurs when `make overlay-docs` runs:

```
 Error: Error opening file "elasticsearch-specification/specification/inference/stream_inference/examples/request/StreamInferenceRequestExample1.yaml" 
 ›   ENOENT: no such file or directory...
```

I believe this is due to files that moved in https://github.com/elastic/elasticsearch-specification/pull/3545
This is the type of overlay fragility that will be fixed by https://github.com/elastic/elasticsearch-specification/pull/3737
