### PR TITLE
Generate elasticsearch-js before Kibana type checks

### DIFF
--- a/.buildkite/kibana.yml
+++ b/.buildkite/kibana.yml
@@ -3,7 +3,6 @@ agents:
   cpu: "4"
   ephemeralStorage: 15Gi
 
-
 steps:
   - label: "Run Kibana type checks"
     command: .buildkite/kibana.sh


### PR DESCRIPTION
This avoids relying on elasticsearch-js merges, which happens at most once per week.
