### PR TITLE
Use path alias in imports

### DIFF
--- a/specification/connector/update_filtering_validation/ConnectorUpdateFilteringValidationRequest.ts
+++ b/specification/connector/update_filtering_validation/ConnectorUpdateFilteringValidationRequest.ts
@@ -18,7 +18,7 @@
  */
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
-import { FilteringRulesValidation } from 'connector/_types/Connector'
+import { FilteringRulesValidation } from '@connector/_types/Connector'
 
 /**
  * Update the connector draft filtering validation.

--- a/specification/connector/update_filtering_validation/ConnectorUpdateFilteringValidationRequest.ts
+++ b/specification/connector/update_filtering_validation/ConnectorUpdateFilteringValidationRequest.ts
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { FilteringRulesValidation } from '@connector/_types/Connector'
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
-import { FilteringRulesValidation } from '@connector/_types/Connector'
 
 /**
  * Update the connector draft filtering validation.

--- a/specification/fleet/msearch/MultiSearchResponse.ts
+++ b/specification/fleet/msearch/MultiSearchResponse.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { ResponseItem } from '_global/msearch/types'
+import { ResponseItem } from '@global/msearch/types'
 
 // Keep changes in sync with:
 // - msearch

--- a/specification/tsconfig.json
+++ b/specification/tsconfig.json
@@ -12,7 +12,6 @@
     "removeComments": true,
     "noLib": false,
     "preserveConstEnums": true,
-    "suppressImplicitAnyIndexErrors": true,
     "noEmit": true,
     "typeRoots": ["./**/*.ts"],
     "baseUrl": "./",

--- a/specification/tsconfig.json
+++ b/specification/tsconfig.json
@@ -25,6 +25,7 @@
       "@cat/*": ["cat/*"],
       "@ccr/*": ["ccr/*"],
       "@cluster/*": ["cluster/*"],
+      "@connector/*": ["connector/*"],
       "@dangling_indices/*": ["dangling_indices/*"],
       "@enrich/*": ["enrich/*"],
       "@eql/*": ["eql/*"],


### PR DESCRIPTION
Level the imports declaration with the rest of the spec.
Makes the type tree compatible with the current `typescript-go` state for testing purposes.