### PR TITLE
[9.0] Fix allow_partial_search_results default value

### DIFF
--- a/specification/eql/search/EqlSearchRequest.ts
+++ b/specification/eql/search/EqlSearchRequest.ts
@@ -52,7 +52,7 @@ export interface Request extends RequestBase {
     allow_no_indices?: boolean
     /**
      * If true, returns partial results if there are shard failures. If false, returns an error with no partial results.
-     * @server_default false
+     * @server_default true
      */
     allow_partial_search_results?: boolean
     /**


### PR DESCRIPTION
I missed that when merging https://github.com/elastic/elasticsearch-specification/pull/3817. Thanks @flobernd for noticing!