### PR TITLE
compiler: fix quote syntax

### DIFF
--- a/compiler/run-validations.js
+++ b/compiler/run-validations.js
@@ -108,7 +108,7 @@ async function run () {
   const isCompilerInstalled = await $`[[ -d ${path.join(compilerPath, 'node_modules')} ]]`.exitCode === 0
   const isTsGeneratorInstalled = await $`[[ -d ${path.join(tsGeneratorPath, 'node_modules')} ]]`.exitCode === 0
   if (noCache || !isCompilerInstalled || !isTsGeneratorInstalled) {
-    spinner.text = 'It looks like you didn't install the project dependencies, doing that for you'
+    spinner.text = "It looks like you didn't install the project dependencies, doing that for you"
     await $`npm install --prefix ${compilerPath}`
     await $`npm install --prefix ${tsGeneratorPath}`
   }


### PR DESCRIPTION
I introduced this error in https://github.com/elastic/elasticsearch-specification/pull/4005. For some reason, it's not a parse error until the code is executed?