### PR TITLE
[8.18] Stop reporting missing endpoints as errors (#4031)

### DIFF
--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -215,14 +215,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
       return
     }
 
-    if (endpoint.request == null) {
-      if (endpoint.response == null) {
-        modelError('Missing request & response')
-        return
-      } else {
-        modelError('Missing request')
-      }
-    } else {
+    if (endpoint.request !== null) {
       const reqType = getTypeDef(endpoint.request)
 
       if (reqType == null) {
@@ -266,9 +259,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
 
     setRootContext(endpoint.name, 'response')
 
-    if (endpoint.response == null) {
-      modelError('Missing response')
-    } else {
+    if (endpoint.response !== null) {
       const respType = getTypeDef(endpoint.response)
 
       if (respType == null) {

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -13,12 +13,6 @@
       ],
       "response": []
     },
-    "capabilities": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "cat.aliases": {
       "request": [
         "Request: query parameter 'master_timeout' does not exist in the json spec",
@@ -182,30 +176,6 @@
       ],
       "response": []
     },
-    "connector.secret_delete": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
-    "connector.secret_get": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
-    "connector.secret_post": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
-    "connector.secret_put": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
     "create": {
       "request": [
         "Request: query parameter 'if_primary_term' does not exist in the json spec",
@@ -229,24 +199,6 @@
         "Request: query parameter 'keep_alive' does not exist in the json spec",
         "Request: query parameter 'keep_on_completion' does not exist in the json spec",
         "Request: query parameter 'wait_for_completion_timeout' does not exist in the json spec"
-      ],
-      "response": []
-    },
-    "fleet.delete_secret": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
-    "fleet.get_secret": {
-      "request": [
-        "Missing request & response"
-      ],
-      "response": []
-    },
-    "fleet.post_secret": {
-      "request": [
-        "Missing request & response"
       ],
       "response": []
     },
@@ -300,12 +252,6 @@
     "index": {
       "request": [
         "Request: missing json spec query parameter 'require_data_stream'"
-      ],
-      "response": []
-    },
-    "inference.put_mistral": {
-      "request": [
-        "Missing request & response"
       ],
       "response": []
     },
@@ -416,12 +362,6 @@
     "snapshot.repository_analyze": {
       "request": [
         "Request: query parameter 'register_operation_count' does not exist in the json spec"
-      ],
-      "response": []
-    },
-    "transform.get_node_stats": {
-      "request": [
-        "Missing request & response"
       ],
       "response": []
     },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Stop reporting missing endpoints as errors (#4031)](https://github.com/elastic/elasticsearch-specification/pull/4031)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)