### PR TITLE
Update branch in overlay

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -14,7 +14,7 @@ actions:
         
         ## Documentation source and versions
         
-        This documentation is derived from the `main` branch of the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification) repository.
+        This documentation is derived from the `9.0` branch of the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification) repository.
         It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
 
         This documentation contains work-in-progress information for future Elastic Stack releases.


### PR DESCRIPTION
This PR updates the branch name that's included in the OpenAPI introduction now that we're publishing from the 9.0 branch.