### PR TITLE
Update documentation for watcher update settings endpoint

### DIFF
--- a/specification/watcher/update_settings/WatcherUpdateSettingsRequest.ts
+++ b/specification/watcher/update_settings/WatcherUpdateSettingsRequest.ts
@@ -25,7 +25,10 @@ import { Duration } from '@_types/Time'
  * Update Watcher index settings.
  * Update settings for the Watcher internal index (`.watches`).
  * Only a subset of settings can be modified.
- * This includes `index.auto_expand_replicas` and `index.number_of_replicas`.
+ * This includes `index.auto_expand_replicas`, `index.number_of_replicas`, `index.routing.allocation.exclude.*`,
+ * `index.routing.allocation.include.*` and `index.routing.allocation.require.*`.
+ * Modification of `index.routing.allocation.include._tier_preference` is an exception and is not allowed as the
+ * Watcher shards must always be in the `data_content` tier.
  * @rest_spec_name watcher.update_settings
  * @availability stack stability=stable visibility=public
  * @cluster_privileges manage_watcher


### PR DESCRIPTION
This pull request includes an update to the `WatcherUpdateSettingsRequest` documentation to clarify which settings can be modified for the Watcher internal index after https://github.com/elastic/elasticsearch/pull/115251 was merged.