### PR TITLE
Fixing execute policy resp

### DIFF
--- a/specification/enrich/execute_policy/ExecuteEnrichPolicyResponse.ts
+++ b/specification/enrich/execute_policy/ExecuteEnrichPolicyResponse.ts
@@ -23,6 +23,6 @@ import { ExecuteEnrichPolicyStatus } from './types'
 export class Response {
   body: {
     status?: ExecuteEnrichPolicyStatus
-    task_id?: TaskId
+    task?: TaskId
   }
 }

--- a/specification/enrich/execute_policy/types.ts
+++ b/specification/enrich/execute_policy/types.ts
@@ -19,11 +19,13 @@
 
 export class ExecuteEnrichPolicyStatus {
   phase: EnrichPolicyPhase
+  step?: string
 }
 
 export enum EnrichPolicyPhase {
   SCHEDULED,
   RUNNING,
   COMPLETE,
-  FAILED
+  FAILED,
+  CANCELLED
 }


### PR DESCRIPTION
`task_id` in ExecuteEnrichPolicyResponse.ts actually being `task` -> [server code](https://github.com/elastic/elasticsearch/blob/1d6c6a59c86de232c65a29579a12e0fdb0eb97ad/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/ExecuteEnrichPolicyAction.java#L137)
missing `step` field in ExecuteEnrichPolicyStatus -> [server code](https://github.com/elastic/elasticsearch/blob/1d6c6a59c86de232c65a29579a12e0fdb0eb97ad/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/ExecuteEnrichPolicyStatus.java#L80)
missing CANCELLED phase in ExecuteEnrichPolicyStatus -> [server code](https://github.com/elastic/elasticsearch/blob/1d6c6a59c86de232c65a29579a12e0fdb0eb97ad/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/ExecuteEnrichPolicyStatus.java#L25)