### PR TITLE
Missing field and wrong value in ClusterHealthResponse

### DIFF
--- a/specification/cluster/health/ClusterHealthResponse.ts
+++ b/specification/cluster/health/ClusterHealthResponse.ts
@@ -19,7 +19,7 @@
 
 import { Dictionary } from '@spec_utils/Dictionary'
 import { HealthStatus, IndexName, Name } from '@_types/common'
-import { integer, Percentage } from '@_types/Numeric'
+import { double, integer } from '@_types/Numeric'
 import { Duration, DurationValue, UnitMillis } from '@_types/Time'
 import { IndexHealthStats } from './types'
 
@@ -42,8 +42,10 @@ export class HealthResponseBody {
   active_primary_shards: integer
   /** The total number of active primary and replica shards. */
   active_shards: integer
+  /** The ratio of active shards in the cluster expressed as a string formatted percentage. */
+  active_shards_percent?: string
   /** The ratio of active shards in the cluster expressed as a percentage. */
-  active_shards_percent_as_number: Percentage
+  active_shards_percent_as_number: double
   /** The name of the cluster. */
   cluster_name: Name
   /** The number of shards whose allocation has been delayed by the timeout settings. */


### PR DESCRIPTION
`active_shards_percent_as_number` is not a string nor float, it's a [double](https://github.com/elastic/elasticsearch/blob/717d00d96de34b1c44610436e1e8942cda14f59d/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java#L231) - [server code](https://github.com/elastic/elasticsearch/blob/717d00d96de34b1c44610436e1e8942cda14f59d/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponse.java#L277). 
also there's the optional string version of this field, `active_shards_percent` - [server code](https://github.com/elastic/elasticsearch/blob/717d00d96de34b1c44610436e1e8942cda14f59d/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentBuilder.java#L1183)

