### PR TITLE
Add new write load metrics to `IndexingStats`

### DIFF
--- a/specification/_types/Stats.ts
+++ b/specification/_types/Stats.ts
@@ -159,6 +159,8 @@ export class IndexingStats {
   index_failed: long
   types?: Dictionary<string, IndexingStats>
   write_load?: double
+  recent_write_load?: double
+  peak_write_load?: double
 }
 
 export class MergesStats {


### PR DESCRIPTION
This adds the fields added in
https://github.com/elastic/elasticsearch/pull/125521 and https://github.com/elastic/elasticsearch/pull/124652 to the spec.
