### PR TITLE
Missing fields in inference processor

### DIFF
--- a/specification/ingest/_types/Processors.ts
+++ b/specification/ingest/_types/Processors.ts
@@ -1044,6 +1044,24 @@ export class InferenceProcessor extends ProcessorBase {
    * Contains the inference type and its options.
    */
   inference_config?: InferenceConfig
+
+  /**
+   * Input fields for inference and output (destination) fields for the inference results.
+   * This option is incompatible with the target_field and field_map options.
+   */
+  input_output?: InputConfig[]
+
+  /**
+   * If true and any of the input fields defined in input_ouput are missing
+   * then those missing fields are quietly ignored, otherwise a missing field causes a failure.
+   * Only applies when using input_output configurations to explicitly list the input fields.
+   */
+  ignore_missing?: boolean
+}
+
+export class InputConfig {
+  input_field: string
+  output_field: string
 }
 
 /**


### PR DESCRIPTION
[Docs](https://www.elastic.co/guide/en/elasticsearch/reference/8.17/inference-processor.html), [server code](https://github.com/elastic/elasticsearch/blob/a152b4e29b19fac4f5a36fed40a39611860f2827/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java#L103), [original report](https://github.com/elastic/elasticsearch-java/issues/985).