### PR TITLE
Reverting "making range aggregation untagged union (#2725)"

### DIFF
--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -597,8 +597,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
 
       validateValueOf(valueOf, openGenerics)
     } else if (variants.kind === 'untagged') {
-      if (fqn(parentName) !== '_types.aggregations:AggregationRange' &&
-          fqn(parentName) !== '_types.query_dsl:DecayFunction' &&
+      if (fqn(parentName) !== '_types.query_dsl:DecayFunction' &&
           fqn(parentName) !== '_types.query_dsl:DistanceFeatureQuery' &&
           fqn(parentName) !== '_types.query_dsl:RangeQuery') {
         throw new Error(`Please contact the devtools team before adding new untagged variant ${fqn(parentName)}`)

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -295,7 +295,7 @@ export class DateRangeAggregation extends BucketAggregationBase {
   /**
    * Array of date ranges.
    */
-  ranges?: DateAggregationRange[]
+  ranges?: DateRangeExpression[]
   /**
    * Time zone used to convert dates from another time zone to UTC.
    */
@@ -306,6 +306,33 @@ export class DateRangeAggregation extends BucketAggregationBase {
   keyed?: boolean
 }
 
+/**
+ * A date range limit, represented either as a DateMath expression or a number expressed
+ * according to the target field's precision.
+ *
+ * @codegen_names expr, value
+ */
+// ES: DateRangeAggregationBuilder.innerBuild()
+export type FieldDateMath = DateMath | double
+
+export class DateRangeExpression {
+  /**
+   * Start of the range (inclusive).
+   */
+  from?: FieldDateMath
+  /**
+   * Custom key to return the range with.
+   */
+  key?: string
+  /**
+   * End of the range (exclusive).
+   */
+  to?: FieldDateMath
+}
+
+/**
+ * @ext_doc_id search-aggregations-bucket-diversified-sampler-aggregation
+ */
 export class DiversifiedSamplerAggregation extends BucketAggregationBase {
   /**
    * The type of value used for de-duplication.
@@ -661,21 +688,11 @@ export class RangeAggregation extends BucketAggregationBase {
   format?: string
 }
 
-/**
- * @codegen_names untyped, date, number, term
- * @variants untagged untyped=_types.aggregations.UntypedAggregationRange
- */
-export type AggregationRange =
-  | UntypedAggregationRange
-  | DateAggregationRange
-  | NumberAggregationRange
-  | TermAggregationRange
-
-export class AggregationRangeBase<T> {
+export class AggregationRange {
   /**
    * Start of the range (inclusive).
    */
-  from?: T
+  from?: double | null
   /**
    * Custom key to return the range with.
    */
@@ -683,26 +700,12 @@ export class AggregationRangeBase<T> {
   /**
    * End of the range (exclusive).
    */
-  to?: T
+  to?: double | null
 }
 
-export class NumberAggregationRange extends AggregationRangeBase<double> {}
-
-export class TermAggregationRange extends AggregationRangeBase<string> {}
-
-export class UntypedAggregationRange extends AggregationRangeBase<UserDefinedValue> {}
-
-export class DateAggregationRange extends AggregationRangeBase<FieldDateMath> {}
-
 /**
- * A date range limit, represented either as a DateMath expression or a number expressed
- * according to the target field's precision.
- *
- * @codegen_names expr, value
+ * @ext_doc_id search-aggregations-bucket-rare-terms-aggregation
  */
-// ES: DateRangeAggregationBuilder.innerBuild()
-export type FieldDateMath = DateMath | double
-
 export class RareTermsAggregation extends BucketAggregationBase {
   /**
    * Terms that should be excluded from the aggregation.


### PR DESCRIPTION
Reverting #2725 as RangeAggregation doesn't actually support a Date format, and it only supports String to parse them to Double. 
