### PR TITLE
[8.x] OpenAPI: Update overlays with new path separator (#4250)

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -174,7 +174,7 @@ actions:
             Use the script support APIs to get a list of supported script contexts and languages.
             Use the stored script APIs to manage stored scripts and search templates.
           externalDocs:
-            url: https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html
+            url: https://www.elastic.co/guide/en/elasticsearch/reference/8.x/modules-scripting.html
         - name: search
           x-displayName: Search
         - name: search_application
@@ -229,775 +229,775 @@ actions:
             url: https://www.elastic.co/guide/en/elasticsearch/reference/8.x/xpack-alerting.html
             description: Learn more about Watcher.
 # Add x-model and/or abbreviate schemas that should point to other references
-  - target: "$.components['schemas']['_types.query_dsl:QueryContainer']"
+  - target: "$.components['schemas']['_types.query_dsl.QueryContainer']"
     description: Add x-model for the QueryContainer object
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.analysis:CharFilter'].oneOf"
+  - target: "$.components['schemas']['_types.analysis.CharFilter'].oneOf"
     description: Remove existing oneOf definition for CharFilter
     remove: true
-  - target: "$.components['schemas']['_types.analysis:CharFilter']"
+  - target: "$.components['schemas']['_types.analysis.CharFilter']"
     description: Simplify CharFilter definition
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.analysis:Tokenizer'].oneOf"
+  - target: "$.components['schemas']['_types.analysis.Tokenizer'].oneOf"
     description: Remove existing oneOf definition for tokenizer
     remove: true
-  - target: "$.components['schemas']['_types.analysis:Tokenizer']"
+  - target: "$.components['schemas']['_types.analysis.Tokenizer']"
     description: Simplify tokenizer definition
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.analysis:TokenFilter'].oneOf"
+  - target: "$.components['schemas']['_types.analysis.TokenFilter'].oneOf"
     description: Remove existing oneOf definition for tokenfilter
     remove: true
-  - target: "$.components['schemas']['_types.analysis:TokenFilter']"
+  - target: "$.components['schemas']['_types.analysis.TokenFilter']"
     description: Simplify tokenfilter definition
     update:
       x-model: true
-  - target: "$.components['schemas']['security._types:RoleTemplateScript']"
+  - target: "$.components['schemas']['security._types.RoleTemplateScript']"
     description: Add x-model where recommended by Bump.sh
     update:
       x-model: true
       externalDocs:
         description: Templating a role query
         url: https://www.elastic.co/guide/en/elasticsearch/reference/8.x/field-and-document-access-control.html#templating-role-query
-  - target: "$.components['schemas']['_types.query_dsl:DistanceFeatureQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.DistanceFeatureQuery']"
     description: Add x-model for distance feature query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:GeoShapeQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.GeoShapeQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:GeoPolygonQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.GeoPolygonQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:GeoDistanceQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.GeoDistanceQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:DistanceFeatureQueryBase']"
+  - target: "$.components['schemas']['_types.query_dsl.DistanceFeatureQueryBase']"
     description: Add x-model to distance feature query base
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:GeoDistanceFeatureQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.GeoDistanceFeatureQuery']"
     description: Add x-model to geo distance feature query 
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:DistanceFeatureQueryBaseGeoLocationDistance']"
+  - target: "$.components['schemas']['_types.query_dsl.DistanceFeatureQueryBaseGeoLocationDistance']"
     description: Add x-model to distance feature query base geolocation distance
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:DateDistanceFeatureQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.DateDistanceFeatureQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:DistanceFeatureQueryBaseDateMathDuration']"
+  - target: "$.components['schemas']['_types.query_dsl.DistanceFeatureQueryBaseDateMathDuration']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:MoreLikeThisQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.MoreLikeThisQuery']"
     description: Add x-model for more like this query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:PercolateQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.PercolateQuery']"
     description: Add x-model for percolate query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:RankFeatureQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.RankFeatureQuery']"
     description: Add x-model for rank feature query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:ScriptQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.ScriptQuery']"
     description: Add x-model for script query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:ScriptScoreFunction']"
+  - target: "$.components['schemas']['_types.query_dsl.ScriptScoreFunction']"
     description: Add x-model for script score query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:ScriptScoreQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.ScriptScoreQuery']"
     description: Add x-model for script score query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:WrapperQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.WrapperQuery']"
     description: Add x-model for wrapper query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:PinnedQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.PinnedQuery']"
     description: Add x-model for pinned query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:RuleQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.RuleQuery']"
     description: Add x-model for rule query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:BoolQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.BoolQuery']"
     description: Add x-model for boolean query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:QueryBase']"
+  - target: "$.components['schemas']['_types.query_dsl.QueryBase']"
     description: Add x-model for query base
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:BoostingQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.BoostingQuery']"
     description: Add x-model for query base
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:CommonTermsQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.CommonTermsQuery']"
     description: Add x-model for common terms query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:CombinedFieldsQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.CombinedFieldsQuery']"
     description: Add x-model for combined fields query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:ConstantScoreQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.ConstantScoreQuery']"
     description: Add x-model for constant score query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:DisMaxQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.DisMaxQuery']"
     description: Add x-model to Disjunction max query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:UntypedDistanceFeatureQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.UntypedDistanceFeatureQuery']"
     description: Add x-model to untyped distance feature query
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:ExistsQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.ExistsQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:FunctionScoreQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.FunctionScoreQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:FunctionScoreContainer']"
+  - target: "$.components['schemas']['_types.query_dsl.FunctionScoreContainer']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:DecayFunction']"
+  - target: "$.components['schemas']['_types.query_dsl.DecayFunction']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:UntypedDecayFunction']"
+  - target: "$.components['schemas']['_types.query_dsl.UntypedDecayFunction']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:DecayFunctionBase']"
+  - target: "$.components['schemas']['_types.query_dsl.DecayFunctionBase']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:MultiValueMode']"
+  - target: "$.components['schemas']['_types.query_dsl.MultiValueMode']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:DateDecayFunction']"
+  - target: "$.components['schemas']['_types.query_dsl.DateDecayFunction']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:DecayFunctionBaseDateMathDuration']"
+  - target: "$.components['schemas']['_types.query_dsl.DecayFunctionBaseDateMathDuration']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:NumericDecayFunction']"
+  - target: "$.components['schemas']['_types.query_dsl.NumericDecayFunction']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:DecayFunctionBasedoubledouble']"
+  - target: "$.components['schemas']['_types.query_dsl.DecayFunctionBasedoubledouble']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:GeoDecayFunction']"
+  - target: "$.components['schemas']['_types.query_dsl.GeoDecayFunction']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:DecayFunctionBaseGeoLocationDistance']"
+  - target: "$.components['schemas']['_types.query_dsl.DecayFunctionBaseGeoLocationDistance']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:FieldValueFactorScoreFunction']"
+  - target: "$.components['schemas']['_types.query_dsl.FieldValueFactorScoreFunction']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:RandomScoreFunction']"
+  - target: "$.components['schemas']['_types.query_dsl.RandomScoreFunction']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:FuzzyQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.FuzzyQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:GeoBoundingBoxQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.GeoBoundingBoxQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:HasChildQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.HasChildQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:HasParentQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.HasParentQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:ParentIdQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.ParentIdQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:IntervalsQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.IntervalsQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:IntervalsAllOf']"
+  - target: "$.components['schemas']['_types.query_dsl.IntervalsAllOf']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:IntervalsContainer']"
+  - target: "$.components['schemas']['_types.query_dsl.IntervalsContainer']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:IntervalsAnyOf']"
+  - target: "$.components['schemas']['_types.query_dsl.IntervalsAnyOf']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:IntervalsFilter']"
+  - target: "$.components['schemas']['_types.query_dsl.IntervalsFilter']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:IntervalsFuzzy']"
+  - target: "$.components['schemas']['_types.query_dsl.IntervalsFuzzy']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:IntervalsMatch']"
+  - target: "$.components['schemas']['_types.query_dsl.IntervalsMatch']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:IntervalsPrefix']"
+  - target: "$.components['schemas']['_types.query_dsl.IntervalsPrefix']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:IntervalsWildcard']"
+  - target: "$.components['schemas']['_types.query_dsl.IntervalsWildcard']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:MatchQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.MatchQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:MatchBoolPrefixQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.MatchBoolPrefixQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:MatchPhraseQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.MatchPhraseQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:MatchPhrasePrefixQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.MatchPhrasePrefixQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:MultiMatchQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.MultiMatchQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:QueryStringQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.QueryStringQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:SimpleQueryStringQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.SimpleQueryStringQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:ShapeQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.ShapeQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:NestedQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.NestedQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:MatchAllQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.MatchAllQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:MatchNoneQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.MatchNoneQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:SpanContainingQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.SpanContainingQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:SpanFieldMaskingQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.SpanFieldMaskingQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:SpanFirstQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.SpanFirstQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:SpanMultiTermQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.SpanMultiTermQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:SpanNearQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.SpanNearQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:SpanNotQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.SpanNotQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:SpanOrQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.SpanOrQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:SpanTermQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.SpanTermQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:SpanWithinQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.SpanWithinQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types:KnnQuery']"
+  - target: "$.components['schemas']['_types.KnnQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:SparseVectorQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.SparseVectorQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:SemanticQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.SemanticQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:TextExpansionQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.TextExpansionQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:WeightedTokensQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.WeightedTokensQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:IdsQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.IdsQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:PrefixQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.PrefixQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:RangeQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.RangeQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:RegexpQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.RegexpQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:TermQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.TermQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:TermsQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.TermsQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:TermsSetQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.TermsSetQuery']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.query_dsl:WildcardQuery']"
+  - target: "$.components['schemas']['_types.query_dsl.WildcardQuery']"
     description: Add x-model
     update:
       x-model: true
 # Abbreviate and annotate items that are not shown in Bump.sh due to depth limits
-  - target: "$.components['schemas']['_types.aggregations:Aggregate']"
+  - target: "$.components['schemas']['_types.aggregations.Aggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:CardinalityAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.CardinalityAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:HdrPercentilesAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.HdrPercentilesAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:HdrPercentileRanksAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.HdrPercentileRanksAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:PercentileRanksAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.PercentileRanksAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:TDigestPercentilesAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.TDigestPercentilesAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:TDigestPercentileRanksAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.TDigestPercentileRanksAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:PercentilesBucketAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.PercentilesBucketAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:MedianAbsoluteDeviationAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.MedianAbsoluteDeviationAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:MinAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.MinAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:MaxAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.MaxAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:SumAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.SumAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:AvgAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.AvgAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:WeightedAvgAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.WeightedAvgAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:ValueCountAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.ValueCountAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:SimpleValueAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.SimpleValueAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:DerivativeAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.DerivativeAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:BucketMetricValueAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.BucketMetricValueAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:StatsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.StatsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:StatsBucketAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.StatsBucketAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:ExtendedStatsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.ExtendedStatsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:ExtendedStatsBucketAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.ExtendedStatsBucketAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:GeoBoundsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.GeoBoundsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:GeoCentroidAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.GeoCentroidAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:HistogramAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.HistogramAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:DateHistogramAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.DateHistogramAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:AutoDateHistogramAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.AutoDateHistogramAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:VariableWidthHistogramAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.VariableWidthHistogramAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:StringTermsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.StringTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:LongTermsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.LongTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:DoubleTermsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.DoubleTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:UnmappedTermsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.UnmappedTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:LongRareTermsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.LongRareTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:StringRareTermsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.StringRareTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:UnmappedRareTermsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.UnmappedRareTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:MultiTermsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.MultiTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:MissingAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.MissingAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:NestedAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.NestedAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:ReverseNestedAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.ReverseNestedAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:GlobalAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.GlobalAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:FilterAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.FilterAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:ChildrenAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.ChildrenAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:ParentAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.ParentAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:SamplerAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.SamplerAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:UnmappedSamplerAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.UnmappedSamplerAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:GeoHashGridAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.GeoHashGridAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:GeoTileGridAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.GeoTileGridAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:GeoHexGridAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.GeoHexGridAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:RangeAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.RangeAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:DateRangeAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.DateRangeAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:GeoDistanceAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.GeoDistanceAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:IpRangeAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.IpRangeAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:IpPrefixAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.IpPrefixAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:FiltersAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.FiltersAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:AdjacencyMatrixAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.AdjacencyMatrixAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:SignificantLongTermsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.SignificantLongTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:SignificantStringTermsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.SignificantStringTermsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:UnmappedSignificantTermsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.UnmappedSignificantTermsAggregate']"
     description: Add x-model
     update:
       x-model: true 
-  - target: "$.components['schemas']['_types.aggregations:SignificantTermsAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.SignificantTermsAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:CompositeAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.CompositeAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:FrequentItemSetsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.FrequentItemSetsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:TimeSeriesAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.TimeSeriesAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:ScriptedMetricAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.ScriptedMetricAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:TopHitsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.TopHitsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:InferenceAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.InferenceAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:StringStatsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.StringStatsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:BoxPlotAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.BoxPlotAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:TopMetricsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.TopMetricsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:TTestAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.TTestAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:RateAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.RateAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:CumulativeCardinalityAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.CumulativeCardinalityAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:MatrixStatsAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.MatrixStatsAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:GeoLineAggregate']"
+  - target: "$.components['schemas']['_types.aggregations.GeoLineAggregate']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:AutoDateHistogramAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.AutoDateHistogramAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:CategorizeTextAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.CategorizeTextAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:DiversifiedSamplerAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.DiversifiedSamplerAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:RandomSamplerAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.RandomSamplerAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:RareTermsAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.RareTermsAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:SignificantTextAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.SignificantTextAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:TermsAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.TermsAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:AverageBucketAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.AverageBucketAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:BucketScriptAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.BucketScriptAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:BucketKsAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.BucketKsAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:BucketCorrelationAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.BucketCorrelationAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:BucketSelectorAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.BucketSelectorAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:BucketSortAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.BucketSortAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:CumulativeSumAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.CumulativeSumAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:MaxBucketAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.MaxBucketAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:MinBucketAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.MinBucketAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:MovingFunctionAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.MovingFunctionAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:MovingPercentilesAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.MovingPercentilesAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:NormalizeAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.NormalizeAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:SerialDifferencingAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.SerialDifferencingAggregation']"
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations:SumBucketAggregation']"
+  - target: "$.components['schemas']['_types.aggregations.SumBucketAggregation']"
     description: Add x-model
     update:
       x-model: true 
-  - target: "$.components['schemas']['_types.query_dsl:LikeDocument']"
+  - target: "$.components['schemas']['_types.query_dsl.LikeDocument']"
     description: Add x-model to LikeDocument schema
     update:
       x-model: true
-  - target: "$.components['schemas']['ml._types:Datafeed'].properties.query"
+  - target: "$.components['schemas']['ml._types.Datafeed'].properties.query"
     description: Remove query object from anomaly detection datafeed
     remove: true
-  - target: "$.components['schemas']['ml._types:Datafeed'].properties"
+  - target: "$.components['schemas']['ml._types.Datafeed'].properties"
     description: Re-add a simplified query object in anomaly detection datafeed
     update:
       query:
@@ -1011,10 +1011,10 @@ actions:
         externalDocs:
           url: https://www.elastic.co/guide/en/elasticsearch/reference/8.x/query-dsl.html
           description: Query DSL
-  - target: "$.components['schemas']['ml._types:CategorizationAnalyzerDefinition'].properties.tokenizer"
+  - target: "$.components['schemas']['ml._types.CategorizationAnalyzerDefinition'].properties.tokenizer"
     description: Remove tokenizer object from ML anomaly detection analysis config
     remove: true
-  - target: "$.components['schemas']['ml._types:CategorizationAnalyzerDefinition'].properties"
+  - target: "$.components['schemas']['ml._types.CategorizationAnalyzerDefinition'].properties"
     description: Re-add a simplified tokenizer object in anomaly detection analysis config
     update:
       tokenizer:
@@ -1032,10 +1032,10 @@ actions:
         externalDocs:
           url: https://www.elastic.co/guide/en/elasticsearch/reference/8.x/analysis-tokenizers.html
           description: Tokenizer reference
-  - target: "$.components['schemas']['ml._types:DataframeAnalyticsSource'].properties.query"
+  - target: "$.components['schemas']['ml._types.DataframeAnalyticsSource'].properties.query"
     description: Remove query object from data frame analytics source
     remove: true
-  - target: "$.components['schemas']['ml._types:DataframeAnalyticsSource'].properties"
+  - target: "$.components['schemas']['ml._types.DataframeAnalyticsSource'].properties"
     description: Re-add a simplified query object in data frame analytics source
     update:
       query:
@@ -1049,10 +1049,10 @@ actions:
         externalDocs:
           url: https://www.elastic.co/guide/en/elasticsearch/reference/8.x/query-dsl.html
           description: Query DSL
-  - target: "$.components['schemas']['transform._types:Source'].properties.query"
+  - target: "$.components['schemas']['transform._types.Source'].properties.query"
     description: Remove query object from transform source
     remove: true
-  - target: "$.components['schemas']['transform._types:Source'].properties"
+  - target: "$.components['schemas']['transform._types.Source'].properties"
     description: Re-add a simplified query object in transform source
     update:
       query:
@@ -1063,17 +1063,17 @@ actions:
         externalDocs:
           url: https://www.elastic.co/guide/en/elasticsearch/reference/8.x/query-dsl.html
           description: Query DSL
-  - target: "$.components['schemas']['_global.search._types:FieldCollapse']"
+  - target: "$.components['schemas']['_global.search._types.FieldCollapse']"
     description: Add x-model and externalDocs
     update:
       x-model: true
       externalDocs:
         url: https://www.elastic.co/guide/en/elasticsearch/reference/8.x/collapse-search-results.html
-  - target: "$.components['schemas']['_global.msearch:MultisearchBody'].properties"
-    description: Add x-model
-    update:
-      aggregations:
-        x-model: true
+  # - target: "$.components['schemas']['_global.msearch.MultisearchBody'].properties"
+  #   description: Add x-model
+  #   update:
+  #     aggregations:
+  #       x-model: true
 # Examples
 ## xCodeSamples
   - target: "$.paths['/{index}/_doc/{id}']['head']"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.x`:
 - [OpenAPI: Update overlays with new path separator (#4250)](https://github.com/elastic/elasticsearch-specification/pull/4250)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)