### PR TITLE
[DOCS] Update more URLs in table.csv

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -96,7 +96,7 @@ cluster-nodes-info,https://www.elastic.co/docs/api/doc/elasticsearch/operation/o
 cluster-nodes-reload-secure-settings,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-reload-secure-settings
 cluster-nodes-stats,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-stats
 cluster-nodes-usage,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-usage
-cluster-nodes,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/cluster.html#cluster-nodes
+cluster-nodes,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/api-conventions#cluster-nodes
 cluster-pending,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-pending-tasks
 cluster-ping,https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-cluster
 cluster-remote-info,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-remote-info
@@ -159,7 +159,7 @@ data-stream-stats-api,https://www.elastic.co/docs/api/doc/elasticsearch/operatio
 data-stream-update,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-modify-data-stream
 data-streams,https://www.elastic.co/docs/manage-data/data-store/data-streams
 date-index-name-processor,https://www.elastic.co/docs/reference/enrich-processor/date-index-name-processor
-dcg,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/search-rank-eval.html
+dcg,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/search-rank-eval#_discounted_cumulative_gain_dcg
 defining-roles,https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles
 delete-analytics-collection,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-delete-behavioral-analytics
 delete-async-sql-search-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-sql-delete-async
@@ -371,7 +371,7 @@ jinaAi-rate-limit,https://jina.ai/contact-sales/#rate-limit
 join-processor,https://www.elastic.co/docs/reference/enrich-processor/join-processor
 json-processor,https://www.elastic.co/docs/reference/enrich-processor/json-processor
 k-precision,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rank-eval#k-precision
-k-recall,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/search-rank-eval.html#k-recall
+k-recall,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/search-rank-eval#k-recall
 kv-processor,https://www.elastic.co/docs/reference/enrich-processor/kv-processor
 knn-approximate,https://www.elastic.co/docs/solutions/search/vector/knn#approximate-knn
 knn-inner-hits,https://www.elastic.co/docs/solutions/search/vector/knn#nested-knn-search-inner-hits
@@ -394,7 +394,7 @@ mapping-roles,https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-d
 mapping-settings-limit,https://www.elastic.co/docs/reference/elasticsearch/index-settings/mapping-limit
 mapping-source-field,https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/mapping-source-field
 mapping,https://www.elastic.co/docs/manage-data/data-store/mapping
-mean-reciprocal,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/search-rank-eval.html#_mean_reciprocal_rank
+mean-reciprocal,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/search-rank-eval#_mean_reciprocal_rank
 migrate,https://www.elastic.co/guide/en/elasticsearch/reference/current/migrate-data-stream.html
 migrate-index-allocation-filters,https://www.elastic.co/docs/manage-data/lifecycle/index-lifecycle-management/migrate-index-allocation-filters-to-node-roles
 migration-api-deprecation,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-migration-deprecations


### PR DESCRIPTION
This PR updates a few more URLs in the `table.csv` file, since the appropriate target pages now exist due to https://github.com/elastic/elasticsearch/pull/126571 and https://github.com/elastic/elasticsearch/pull/126577