### PR TITLE
[9.0] [DOCS] Update more URLs in table.csv (#4262)

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -96,7 +96,7 @@ cluster-nodes-info,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operatio
 cluster-nodes-reload-secure-settings,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-nodes-reload-secure-settings
 cluster-nodes-stats,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-nodes-stats
 cluster-nodes-usage,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-nodes-usage
-cluster-nodes,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/cluster.html#cluster-nodes
+cluster-nodes,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/api-conventions#cluster-nodes
 cluster-pending,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-cluster-pending-tasks
 cluster-ping,https://www.elastic.co/docs/api/doc/elasticsearch/v9/group/endpoint-cluster
 cluster-remote-info,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-cluster-remote-info
@@ -159,7 +159,7 @@ data-stream-stats-api,https://www.elastic.co/docs/api/doc/elasticsearch/v9/opera
 data-stream-update,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-indices-modify-data-stream
 data-streams,https://www.elastic.co/docs/manage-data/data-store/data-streams
 date-index-name-processor,https://www.elastic.co/docs/reference/enrich-processor/date-index-name-processor
-dcg,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/search-rank-eval.html
+dcg,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/search-rank-eval#_discounted_cumulative_gain_dcg
 defining-roles,https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/defining-roles
 delete-analytics-collection,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-search-application-delete-behavioral-analytics
 delete-async-sql-search-api,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-sql-delete-async


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[DOCS] Update more URLs in table.csv (#4262)](https://github.com/elastic/elasticsearch-specification/pull/4262)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)