### PR TITLE
[9.0] [DOCS] Fix connector, migration, and k-precision URLs (#4269)

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -361,7 +361,7 @@ inference-processor,https://www.elastic.co/docs/reference/enrich-processor/infer
 info-api,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-info
 ingest,https://www.elastic.co/docs/manage-data/ingest/transform-enrich/ingest-pipelines
 ingest-circle-processor,https://www.elastic.co/docs/reference/enrich-processor/ingest-circle-processor
-ingest-node-set-security-user-processor,https://www.elastic.co/docs/reference/enrich-processor/ingest-geo-grid-processor
+ingest-node-set-security-user-processor,https://www.elastic.co/docs/reference/enrich-processor/ingest-node-set-security-user-processor
 inner-hits,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/retrieve-inner-hits
 ip-location-delete-database,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-ingest-delete-ip-location-database
 ip-location-get-database,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-ingest-get-ip-location-database
@@ -370,8 +370,8 @@ jinaAi-embeddings,https://jina.ai/embeddings/
 jinaAi-rate-limit,https://jina.ai/contact-sales/#rate-limit
 join-processor,https://www.elastic.co/docs/reference/enrich-processor/join-processor
 json-processor,https://www.elastic.co/docs/reference/enrich-processor/json-processor
-k-precision,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-rank-eval#k-precision
-k-recall,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/search-rank-eval.html#k-recall
+k-precision,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/search-rank-eval#k-precision
+k-recall,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/search-rank-eval#k-recall
 kv-processor,https://www.elastic.co/docs/reference/enrich-processor/kv-processor
 knn-approximate,https://www.elastic.co/docs/solutions/search/vector/knn#approximate-knn
 knn-inner-hits,https://www.elastic.co/docs/solutions/search/vector/knn#nested-knn-search-inner-hits
@@ -394,11 +394,14 @@ mapping-roles,https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-d
 mapping-settings-limit,https://www.elastic.co/docs/reference/elasticsearch/index-settings/mapping-limit
 mapping-source-field,https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/mapping-source-field
 mapping,https://www.elastic.co/docs/manage-data/data-store/mapping
-mean-reciprocal,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/search-rank-eval.html#_mean_reciprocal_rank
+mean-reciprocal,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/search-rank-eval#_mean_reciprocal_rank
 migrate,https://www.elastic.co/docs/api/doc/elasticsearch/v9/group/endpoint-migration
 migrate-index-allocation-filters,https://www.elastic.co/docs/manage-data/lifecycle/index-lifecycle-management/migrate-index-allocation-filters-to-node-roles
+migration-api-cancel,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-indices-cancel-migrate-reindex
+migration-api-create-from,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-indices-create-from
 migration-api-deprecation,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-migration-deprecations
 migration-api-feature-upgrade,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-migration-get-feature-upgrade-status
+migration-api-reindex,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-indices-migrate-reindex
 mistral-api-keys,https://console.mistral.ai/api-keys/
 mistral-api-models,https://docs.mistral.ai/getting-started/models/
 ml-apis,https://www.elastic.co/docs/api/doc/elasticsearch/v9/group/endpoint-ml

--- a/specification/indices/cancel_migrate_reindex/MigrateCancelReindexRequest.ts
+++ b/specification/indices/cancel_migrate_reindex/MigrateCancelReindexRequest.ts
@@ -27,7 +27,7 @@ import { Indices } from '@_types/common'
  * @rest_spec_name indices.cancel_migrate_reindex
  * @availability stack since=8.18.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
- * @doc_id migrate
+ * @doc_id migration-api-cancel
  * @doc_tag migration
  */
 export interface Request extends RequestBase {

--- a/specification/indices/create_from/MigrateCreateFromRequest.ts
+++ b/specification/indices/create_from/MigrateCreateFromRequest.ts
@@ -29,7 +29,7 @@ import { TypeMapping } from '@_types/mapping/TypeMapping'
  * @rest_spec_name indices.create_from
  * @availability stack since=8.18.0 stability=experimental
  * @availability serverless stability=experimental visibility=private
- * @doc_id migrate
+ * @doc_id migration-api-create-from
  * @doc_tag migration
  */
 export interface Request extends RequestBase {

--- a/specification/indices/migrate_reindex/MigrateReindexRequest.ts
+++ b/specification/indices/migrate_reindex/MigrateReindexRequest.ts
@@ -28,7 +28,7 @@ import { IndexName } from '@_types/common'
  * The persistent task ID is returned immediately and the reindexing work is completed in that task.
  * @rest_spec_name indices.migrate_reindex
  * @availability stack since=8.18.0 stability=experimental
- * @doc_id migrate
+ * @doc_id migration-api-reindex
  * @doc_tag migration
  */
 export interface Request extends RequestBase {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[DOCS] Fix connector, migration, and k-precision URLs (#4269)](https://github.com/elastic/elasticsearch-specification/pull/4269)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)