### PR TITLE
[9.0] [DOCS] Add overlays to work around deployment failure (#4285)

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -1071,6 +1071,15 @@ actions:
   #   update:
   #     aggregations:
   #       x-model: true
+  - target: "$.components['schemas']['_types.ScriptSource'].oneOf"
+    description: Remove oneOf temporarily from ScriptSource
+    remove: true
+  - target: "$.components['schemas']['_types.ScriptSource']"
+    description: Re-add simplified oneOf temporarily in ScriptSource
+    update:
+      oneOf:
+        - type: string
+        - type: object
 # Examples
 ## xCodeSamples
   - target: "$.paths['/{index}/_doc/{id}']['head']"

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -1071,15 +1071,6 @@ actions:
   #   update:
   #     aggregations:
   #       x-model: true
-  - target: "$.components['schemas']['_types.ScriptSource'].oneOf"
-    description: Remove oneOf temporarily from ScriptSource
-    remove: true
-  - target: "$.components['schemas']['_types.ScriptSource']"
-    description: Re-add simplified oneOf temporarily in ScriptSource
-    update:
-      oneOf:
-        - type: string
-        - type: object
 # Examples
 ## xCodeSamples
   - target: "$.paths['/{index}/_doc/{id}']['head']"

--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -29869,6 +29869,9 @@
         "type": "object",
         "properties": {
           "aggregations": {
+            "externalDocs": {
+              "url": "https://www.elastic.co/docs/explore-analyze/query-filter/aggregations"
+            },
             "description": "Defines the aggregations that are run as part of the search request.",
             "type": "object",
             "additionalProperties": {
@@ -69483,6 +69486,9 @@
               "type": "object",
               "properties": {
                 "aggregations": {
+                  "externalDocs": {
+                    "url": "https://www.elastic.co/docs/explore-analyze/query-filter/aggregations"
+                  },
                   "description": "Defines the aggregations that are run as part of the search request.",
                   "type": "object",
                   "additionalProperties": {

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -709,10 +709,12 @@ search-render-query,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operati
 search-count,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-count
 search-explain,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-explain
 search-field-caps,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-field-caps
+search-highlight,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/highlighting
 search-knn,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-knn-search
 search-multi-search,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-msearch
 search-multi-search-template,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-msearch-template
 search-rank-eval,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-rank-eval
+search-retrievers,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/retrievers
 search-search,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-search
 search-shards,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-search-shards
 search-template,https://www.elastic.co/docs/solutions/search/search-templates

--- a/specification/_global/search/SearchRequest.ts
+++ b/specification/_global/search/SearchRequest.ts
@@ -387,7 +387,9 @@ export interface Request extends RequestBase {
   body: {
     /**
      * Defines the aggregations that are run as part of the search request.
-     * @aliases aggs */ // ES uses "aggregations" in serialization
+     * @aliases aggs
+     * @ext_doc_id search-aggregations
+     */ // ES uses "aggregations" in serialization
     aggregations?: Dictionary<string, AggregationContainer>
     /**
      * Collapses search results the values of the specified field.
@@ -411,6 +413,7 @@ export interface Request extends RequestBase {
     from?: integer
     /**
      * Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.
+     * @ext_doc_id search-highlight
      */
     highlight?: Highlight
     /**
@@ -477,6 +480,7 @@ export interface Request extends RequestBase {
      * A retriever replaces other elements of the search API that also return top documents such as `query` and `knn`.
      * @availability stack since=8.14.0 stability=stable
      * @availability serverless stability=stable
+     * @ext_doc_id search-retrievers
      */
     retriever?: RetrieverContainer
     /**

--- a/specification/_global/search/_types/SearchRequestBody.ts
+++ b/specification/_global/search/_types/SearchRequestBody.ts
@@ -42,7 +42,9 @@ import { Sort, SortResults } from '@_types/sort'
 export class SearchRequestBody {
   /**
    * Defines the aggregations that are run as part of the search request.
-   * @aliases aggs */ // ES uses "aggregations" in serialization
+   * @aliases aggs
+   * @ext_doc_id search-aggregations
+   */ // ES uses "aggregations" in serialization
   aggregations?: Dictionary<string, AggregationContainer>
   /**
    * Collapses search results the values of the specified field.
@@ -66,6 +68,7 @@ export class SearchRequestBody {
   from?: integer
   /**
    * Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.
+   * @ext_doc_id search-highlight
    */
   highlight?: Highlight
   /**
@@ -132,6 +135,7 @@ export class SearchRequestBody {
    * A retriever replaces other elements of the search API that also return top documents such as `query` and `knn`.
    * @availability stack since=8.14.0 stability=stable
    * @availability serverless stability=stable
+   * @ext_doc_id search-retrievers
    */
   retriever?: RetrieverContainer
   /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [[DOCS] Add overlays to work around deployment failure (#4285)](https://github.com/elastic/elasticsearch-specification/pull/4285)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)