### PR TITLE
[DOCS] Remove deployment work-around from overlays

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -1071,15 +1071,6 @@ actions:
   #   update:
   #     aggregations:
   #       x-model: true
-  - target: "$.components['schemas']['_types.ScriptSource'].oneOf"
-    description: Remove oneOf temporarily from ScriptSource
-    remove: true
-  - target: "$.components['schemas']['_types.ScriptSource']"
-    description: Re-add simplified oneOf temporarily in ScriptSource
-    update:
-      oneOf:
-        - type: string
-        - type: object
 # Examples
 ## xCodeSamples
   - target: "$.paths['/{index}/_doc/{id}']['head']"


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/pull/4285#issuecomment-2813842759

This PR removes two overlays that were temporary work-arounds.
The same change is included in the 9.0 branch via https://github.com/elastic/elasticsearch-specification/pull/4286