### PR TITLE
Removes erroneous flavour text from PUT inference API pages

### DIFF
--- a/specification/inference/put/PutRequest.ts
+++ b/specification/inference/put/PutRequest.ts
@@ -24,11 +24,6 @@ import { Id } from '@_types/common'
 
 /**
  * Create an inference endpoint.
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  *
  * IMPORTANT: The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Mistral, Azure OpenAI, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face.
  * For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models.

--- a/specification/inference/put_alibabacloud/PutAlibabaCloudRequest.ts
+++ b/specification/inference/put_alibabacloud/PutAlibabaCloudRequest.ts
@@ -31,12 +31,6 @@ import { Id } from '@_types/common'
  * Create an AlibabaCloud AI Search inference endpoint.
  *
  * Create an inference endpoint to perform an inference task with the `alibabacloud-ai-search` service.
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_alibabacloud
  * @availability stack since=8.16.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_amazonbedrock/PutAmazonBedrockRequest.ts
+++ b/specification/inference/put_amazonbedrock/PutAmazonBedrockRequest.ts
@@ -34,12 +34,6 @@ import { Id } from '@_types/common'
  *
  * >info
  * > You need to provide the access and secret keys only once, during the inference model creation. The get inference API does not retrieve your access or secret keys. After creating the inference model, you cannot change the associated key pairs. If you want to use a different access and secret key pair, delete the inference model and recreate it with the same name and the updated keys.
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_amazonbedrock
  * @availability stack since=8.12.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_anthropic/PutAnthropicRequest.ts
+++ b/specification/inference/put_anthropic/PutAnthropicRequest.ts
@@ -31,12 +31,6 @@ import { Id } from '@_types/common'
  * Create an Anthropic inference endpoint.
  *
  * Create an inference endpoint to perform an inference task with the `anthropic` service.
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_anthropic
  * @availability stack since=8.16.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_azureaistudio/PutAzureAiStudioRequest.ts
+++ b/specification/inference/put_azureaistudio/PutAzureAiStudioRequest.ts
@@ -31,12 +31,6 @@ import { Id } from '@_types/common'
  * Create an Azure AI studio inference endpoint.
  *
  * Create an inference endpoint to perform an inference task with the `azureaistudio` service.
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_azureaistudio
  * @availability stack since=8.14.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_azureopenai/PutAzureOpenAiRequest.ts
+++ b/specification/inference/put_azureopenai/PutAzureOpenAiRequest.ts
@@ -38,12 +38,6 @@ import { Id } from '@_types/common'
  * * [GPT-3.5](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models?tabs=global-standard%2Cstandard-chat-completions#gpt-35)
  *
  * The list of embeddings models that you can choose from in your deployment can be found in the [Azure models documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models?tabs=global-standard%2Cstandard-chat-completions#embeddings).
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_azureopenai
  * @availability stack since=8.14.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_cohere/PutCohereRequest.ts
+++ b/specification/inference/put_cohere/PutCohereRequest.ts
@@ -31,12 +31,6 @@ import { Id } from '@_types/common'
  * Create a Cohere inference endpoint.
  *
  * Create an inference endpoint to perform an inference task with the `cohere` service.
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_cohere
  * @availability stack since=8.13.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_googleaistudio/PutGoogleAiStudioRequest.ts
+++ b/specification/inference/put_googleaistudio/PutGoogleAiStudioRequest.ts
@@ -30,12 +30,6 @@ import { Id } from '@_types/common'
  * Create an Google AI Studio inference endpoint.
  *
  * Create an inference endpoint to perform an inference task with the `googleaistudio` service.
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_googleaistudio
  * @availability stack since=8.15.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_googlevertexai/PutGoogleVertexAiRequest.ts
+++ b/specification/inference/put_googlevertexai/PutGoogleVertexAiRequest.ts
@@ -31,12 +31,6 @@ import { Id } from '@_types/common'
  * Create a Google Vertex AI inference endpoint.
  *
  * Create an inference endpoint to perform an inference task with the `googlevertexai` service.
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_googlevertexai
  * @availability stack since=8.15.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_hugging_face/PutHuggingFaceRequest.ts
+++ b/specification/inference/put_hugging_face/PutHuggingFaceRequest.ts
@@ -44,12 +44,6 @@ import { Id } from '@_types/common'
  * * `e5-small-v2`
  * * `multilingual-e5-base`
  * * `multilingual-e5-small`
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_hugging_face
  * @availability stack since=8.12.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_jinaai/PutJinaAiRequest.ts
+++ b/specification/inference/put_jinaai/PutJinaAiRequest.ts
@@ -34,12 +34,6 @@ import { Id } from '@_types/common'
  *
  * To review the available `rerank` models, refer to <https://jina.ai/reranker>.
  * To review the available `text_embedding` models, refer to the <https://jina.ai/embeddings/>.
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_jinaai
  * @availability stack since=8.18.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_mistral/PutMistralRequest.ts
+++ b/specification/inference/put_mistral/PutMistralRequest.ts
@@ -30,12 +30,6 @@ import { Id } from '@_types/common'
  * Create a Mistral inference endpoint.
  *
  * Creates an inference endpoint to perform an inference task with the `mistral` service.
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_mistral
  * @availability stack since=8.15.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_openai/PutOpenAiRequest.ts
+++ b/specification/inference/put_openai/PutOpenAiRequest.ts
@@ -31,12 +31,6 @@ import { Id } from '@_types/common'
  * Create an OpenAI inference endpoint.
  *
  * Create an inference endpoint to perform an inference task with the `openai` service or `openai` compatible APIs.
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_openai
  * @availability stack since=8.12.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_watsonx/PutWatsonxRequest.ts
+++ b/specification/inference/put_watsonx/PutWatsonxRequest.ts
@@ -31,12 +31,6 @@ import { Id } from '@_types/common'
  * Create an inference endpoint to perform an inference task with the `watsonxai` service.
  * You need an IBM Cloud Databases for Elasticsearch deployment to use the `watsonxai` inference service.
  * You can provision one through the IBM catalog, the Cloud Databases CLI plug-in, the Cloud Databases API, or Terraform.
- *
- * When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
- * After creating the endpoint, wait for the model deployment to complete before using it.
- * To verify the deployment status, use the get trained model statistics API.
- * Look for `"state": "fully_allocated"` in the response and ensure that the `"allocation_count"` matches the `"target_allocation_count"`.
- * Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
  * @rest_spec_name inference.put_watsonx
  * @availability stack since=8.16.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public


### PR DESCRIPTION
## Overview

This PR removes a paragraph of text from the various inference API integration docs pages that is only relevant for `elaser` and `elasticsearch`.