### PR TITLE
Range query from/to parameters were removed in 9.0

### DIFF
--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -141,10 +141,6 @@ export class RangeQueryBase<T> extends QueryBase {
    * Less than or equal to.
    */
   lte?: T
-  /** @deprecated 8.16.0 Use gte or gt instead */
-  from?: T | null
-  /** @deprecated 8.16.0 Use lte or lt instead */
-  to?: T | null
 }
 
 export class UntypedRangeQuery extends RangeQueryBase<UserDefinedValue> {


### PR DESCRIPTION
Range query fields `from` and `to` were deprecated in 8.16 and [are no longer exposed](https://github.com/elastic/elasticsearch/blob/79d3aa827789652cafba569e3261e5fd632d743e/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java#L46-L52) in 9.0+.

Fixes https://github.com/elastic/elasticsearch-js/issues/2846.
