### PR TITLE
Adds new `embedding_type` values to PUT Cohere inference endpoint

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -627,6 +627,8 @@ export enum CohereServiceType {
 }
 
 export enum CohereEmbeddingType {
+  binary,
+  bit,
   byte,
   float,
   int8

--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -585,6 +585,8 @@ export class CohereServiceSettings {
   api_key: string
   /**
    * For a `text_embedding` task, the types of embeddings you want to get back.
+   * Use `binary` for binary embeddings, which are encoded as bytes with signed int8 precision.
+   * Use `bit` for binary embeddings, which are encoded as bytes with signed int8 precision (this is a synonym of `binary`).
    * Use `byte` for signed int8 embeddings (this is a synonym of `int8`).
    * Use `float` for the default float embeddings.
    * Use `int8` for signed int8 embeddings.


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/docs-content/issues/310

Two new embedding types are supported via https://github.com/elastic/elasticsearch/pull/120751. This PR expands the `embedding_type` value description of the PUT Cohere inference endpoint to reflect the changes.