### PR TITLE
Allow missing shard stats for restarted nodes for `_snapshot/_status`

### DIFF
--- a/specification/snapshot/status/SnapshotStatusRequest.ts
+++ b/specification/snapshot/status/SnapshotStatusRequest.ts
@@ -30,6 +30,11 @@ import { Duration } from '@_types/Time'
  *
  * If you omit the `<snapshot>` request path parameter, the request retrieves information only for currently running snapshots.
  * This usage is preferred.
+ * Note that if a node has been restarted or has left the cluster since completing a shard snapshot the stats for that shard will be unavailable.
+ * Loading the stats from the repository is an expensive operation (see the WARNING below), so to minimize latency for returning stats for currently
+ * running snapshots the stats values will be zero for these shards even though the "stage" value will be "DONE".  A "description" field will be set
+ * on these shard stats instances indicating why they are empty.  Note that the total stats for the index will be less than expected due to the
+ * missing values from these shards.
  * If needed, you can specify `<repository>` and `<snapshot>` to retrieve information for specific snapshots, even if they're not currently running.
  *
  * WARNING: Using the API to return the status of any snapshots other than currently running snapshots can be expensive.


### PR DESCRIPTION
Adds a note explaining the change made in elasticsearch [PR #128399](https://github.com/elastic/elasticsearch/pull/128399) to reduce latency when getting stats for currently running snapshots.

Leaving as draft until elasticsearch PR #128399 has been merged.

Relates ES-10982