### PR TITLE
[DOCS] Update modeling-guide.md

### DIFF
--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -671,6 +671,9 @@ class Request {
 }
 ```
 
+You can see the existing tag values in [elasticsearch-shared-overlays.yaml](https://github.com/elastic/elasticsearch-specification/blob/main/docs/overlays/elasticsearch-shared-overlays.yaml).
+If you add a new tag value in your specification, you must also add it to this file.
+
 NOTE: In the OpenAPI specification, operations can have multiple tags. However, we currently support only a single tag.
 
 


### PR DESCRIPTION
This PR adds a tip about where to see the existing tag values and the requirement that the overlay be kept up-to-date until such time as they're generated per https://github.com/elastic/elasticsearch-specification/issues/2984
