### PR TITLE
[DOCS] Remove cat anomaly detectors enum values via overlay

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -1082,3 +1082,7 @@ actions:
         - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsJavaScriptExample1.yaml"
         - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsPythonExample1.yaml"
         - $ref: "../../specification/_global/exists/examples/xCodeSamples/DocumentExistsRubyExample1.yaml"
+# Remove long lists of enum values
+  - target: "$.components['schemas']['cat._types.CatAnomalyDetectorColumn'].enum"
+    description: Remove enum array
+    remove: true


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/issues/4345
In particular, relates to the following caveat from https://github.com/elastic/elasticsearch-specification/pull/4313

> Caveat: for unary values (i.e. not an array or lenient array), bump.sh will still render its list below the descriptions added by this PR. This could be avoided by removing the enumeration values from the OpenAPI spec...

This PR tests that suggestion for the following cat API: https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-ml-jobs

## Preview

### Before

Redundant list exists (though collapsed by default):

![image](https://github.com/user-attachments/assets/0dd0fc18-304a-43b7-aeb7-5231607e1a5d)

### After

Redundant list is removed:

![image](https://github.com/user-attachments/assets/4338bdc2-fb97-459b-af53-2e51ac9704a4)
