### PR TITLE
[DOCS] Remove RandomSamplerAggregation overlay from serverless

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -61,3 +61,8 @@ actions:
         - apiKeyAuth: []
         - basicAuth: []
         - bearerAuth: []
+# Abbreviate and annotate items that are not shown in Bump.sh due to depth limits
+  - target: "$.components['schemas']['_types.aggregations.RandomSamplerAggregation']"
+    description: Add x-model
+    update:
+      x-model: true

--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -915,10 +915,6 @@ actions:
     description: Add x-model
     update:
       x-model: true
-  - target: "$.components['schemas']['_types.aggregations.RandomSamplerAggregation']"
-    description: Add x-model
-    update:
-      x-model: true
   - target: "$.components['schemas']['_types.aggregations.RareTermsAggregation']"
     description: Add x-model
     update:


### PR DESCRIPTION
This PR addresses the following warning from the `make overlay-docs` command:

> 
WARNING: Action target '$.components['schemas']['_types.aggregations.RandomSamplerAggregation']' has no matching elements

This seems to be occurring because the `RandomSamplerAggregation` schema does not exist in the Serverless OpenAPI document, so the overlays have been updated accordingly.