### PR TITLE
[8.19] [backport] Removes note from chat completion API

### DIFF
--- a/specification/inference/chat_completion_unified/UnifiedRequest.ts
+++ b/specification/inference/chat_completion_unified/UnifiedRequest.ts
@@ -23,13 +23,10 @@ import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
 /**
  * Perform chat completion inference
- * 
- * The chat completion inference API enables real-time responses for chat completion tasks by delivering answers incrementally, reducing response times during computation. 
- * It only works with the `chat_completion` task type for `openai`, `elastic` and `googlevertexai` inference services.
-
- * IMPORTANT: The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face.
- * For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models. However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.
- * 
+ *
+ * The chat completion inference API enables real-time responses for chat completion tasks by delivering answers incrementally, reducing response times during computation.
+ * It only works with the `chat_completion` task type for `openai` and `elastic` inference services.
+ *
  * NOTE: The `chat_completion` task type is only available within the _stream API and only supports streaming.
  * The Chat completion inference API and the Stream inference API differ in their response structure and capabilities.
  * The Chat completion inference API provides more comprehensive customization options through more fields and function calling support.


### PR DESCRIPTION
(cherry picked from commit 081147ba218ee52f994f548e738c25d2c3a69ae5)
