### PR TITLE
Add l2 norm to linear retriever

### DIFF
--- a/specification/_types/Retriever.ts
+++ b/specification/_types/Retriever.ts
@@ -87,7 +87,8 @@ export class InnerRetriever {
 
 export enum ScoreNormalizer {
   none,
-  minmax
+  minmax,
+  l2_norm
 }
 
 export class SpecifiedDocument {


### PR DESCRIPTION
Addition to #4420, but only for 9.1/8.19. `l2_norm` was recently added as option for ScoreNormalizer in LinearRetriever https://github.com/elastic/elasticsearch/pull/128504
