### PR TITLE
Correct type for policy stats

### DIFF
--- a/specification/slm/_types/SnapshotLifecycle.ts
+++ b/specification/slm/_types/SnapshotLifecycle.ts
@@ -149,3 +149,11 @@ export class Invocation {
   snapshot_name: Name
   time: DateTime
 }
+
+export class SnapshotPolicyStats {
+  policy: string
+  snapshots_taken: long
+  snapshots_failed: long
+  snapshots_deleted: long
+  snapshot_deletion_failures: long
+}

--- a/specification/slm/get_stats/GetSnapshotLifecycleStatsResponse.ts
+++ b/specification/slm/get_stats/GetSnapshotLifecycleStatsResponse.ts
@@ -19,6 +19,7 @@
 
 import { long } from '@_types/Numeric'
 import { Duration, DurationValue, UnitMillis } from '@_types/Time'
+import {SnapshotPolicyStats} from "@slm/_types/SnapshotLifecycle";
 
 export class Response {
   body: {
@@ -31,6 +32,6 @@ export class Response {
     total_snapshot_deletion_failures: long
     total_snapshots_failed: long
     total_snapshots_taken: long
-    policy_stats: string[]
+    policy_stats: SnapshotPolicyStats[]
   }
 }


### PR DESCRIPTION
Originally reported in https://github.com/elastic/elasticsearch-java/issues/1021
`policy_stats` in [GetSnapshotLifecycleStatsResponse.ts](https://github.com/elastic/elasticsearch-specification/blob/d06f13ec1a00ff1e32a872a8cef424983eaf278f/specification/slm/get_stats/GetSnapshotLifecycleStatsResponse.ts#L34) is currently mapped as a string array, while actually it's a string of SnapshotPolicyStats objects -> [server code](https://github.com/elastic/elasticsearch/blob/f18f4ee9d0d326ddd6d4cc4ed910511f5e0a0126/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleStats.java#L245). 
