### PR TITLE
Add configuration for sorenlouv/backport tool

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,6 @@
+{
+  "repoOwner": "elastic",
+  "repoName": "elasticsearch-specification",
+  "targetBranchChoices": ["9.0", "8.19", "8.18", "8.17"],
+  "fork": false
+}


### PR DESCRIPTION
Elastic engineers commonly use https://github.com/sorenlouv/backport to perform backports. I've been using it in the elasticsearch-specification repository for months now.

Since pull request forks are not accepted in this repository, committing the configuration is helpful to avoid backports being pushed to forks. It will mean that active branches will have to be maintained here, but that's okay. I've had this locally for a while now, and I update it whenever I notice any missing branches.

(I'm backporting this change because it's easy to do, but it's not needed as backports are done from main.)