### PR TITLE
Add since and method_request to data stream settings

### DIFF
--- a/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
+++ b/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
@@ -22,9 +22,10 @@ import { Duration } from '@_types/Time'
 
 /**
  * Get cluster-wide settings.
+ *
  * By default, it returns only settings that have been explicitly defined.
  * @rest_spec_name cluster.get_settings
- * @availability stack stability=stable
+ * @availability stack since=9.1.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor
  * @doc_id cluster-get-settings

--- a/specification/indices/get_data_stream_settings/examples/200_response/IndicesGetDataStreamSettingsResponseExample1.yaml
+++ b/specification/indices/get_data_stream_settings/examples/200_response/IndicesGetDataStreamSettingsResponseExample1.yaml
@@ -4,6 +4,7 @@ description: >
   `effective_settings` field shows additional settings that are pulled from its template.
 # type: response
 # response_code: 200
+method_request: GET /_data_stream/my-data-stream/_settings
 value: |-
   {
     "data_streams": [

--- a/specification/indices/put_data_stream_settings/IndicesPutDataStreamSettingsRequest.ts
+++ b/specification/indices/put_data_stream_settings/IndicesPutDataStreamSettingsRequest.ts
@@ -30,7 +30,7 @@ import { IndexSettings } from '@indices/_types/IndexSettings'
  * only certain settings are allowed. If possible, the setting change is applied to all
  * backing indices. Otherwise, it will be applied when the data stream is next rolled over.
  * @rest_spec_name indices.put_data_stream_settings
- * @availability stack stability=stable visibility=public
+ * @availability stack since=9.1.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public
  * @index_privileges manage
  * @doc_id indices-put-data-stream-settings

--- a/specification/indices/put_data_stream_settings/examples/200_response/IndicesPutDataStreamSettingsResponseExample1.yaml
+++ b/specification/indices/put_data_stream_settings/examples/200_response/IndicesPutDataStreamSettingsResponseExample1.yaml
@@ -5,6 +5,7 @@ description: >
   the write index on rollover. The setting `index.lifecycle.name` is applied to the data stream and all backing indices.
 # type: response
 # response_code: 200
+method_request: PUT /_data_stream/my-data-stream/_settings
 value: |-
   {
     "data_streams": [

--- a/specification/indices/put_data_stream_settings/examples/200_response/IndicesPutDataStreamSettingsResponseExample2.yaml
+++ b/specification/indices/put_data_stream_settings/examples/200_response/IndicesPutDataStreamSettingsResponseExample2.yaml
@@ -5,6 +5,7 @@ description: >
   reports that the setting was not successfully applied to that index.
 # type: response
 # response_code: 200
+method_request: PUT /_data_stream/my-data-stream/_settings
 value: |-
   {
     "data_streams": [

--- a/specification/indices/put_data_stream_settings/examples/200_response/IndicesPutDataStreamSettingsResponseExample3.yaml
+++ b/specification/indices/put_data_stream_settings/examples/200_response/IndicesPutDataStreamSettingsResponseExample3.yaml
@@ -4,6 +4,7 @@ description: >
   not allowed on a data stream. As a result, no change was applied to the data stream.
 # type: response
 # response_code: 200
+method_request: PUT /_data_stream/my-data-stream/_settings
 value: |-
   {
     "data_streams": [

--- a/specification/indices/put_data_stream_settings/examples/request/IndicesPutDataStreamSettingsRequestExample1.yaml
+++ b/specification/indices/put_data_stream_settings/examples/request/IndicesPutDataStreamSettingsRequestExample1.yaml
@@ -1,5 +1,5 @@
 summary: Change a data stream setting
-# method_request: PUT /_data_stream/my-data-stream/_settings
+method_request: PUT /_data_stream/my-data-stream/_settings
 description: >
   This is a request to change two settings on a data stream.
 # type: request


### PR DESCRIPTION
This PR is follow-up to https://github.com/elastic/elasticsearch-specification/pull/4416 to add the `since` availability details and the `method_request` values related to https://github.com/elastic/elasticsearch-specification/pull/4445