### PR TITLE
Adds an external link to Cluster allocation explain API spec

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -87,6 +87,7 @@ clear-repositories-metering-archive-api,https://www.elastic.co/docs/api/doc/elas
 clear-scroll-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-clear-scroll
 clear-trained-model,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-clear-trained-model-deployment-cache
 cluster-allocation-explain,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-allocation-explain
+cluster-allocation-explain-examples,https://www.elastic.co/docs/troubleshoot/elasticsearch/cluster-allocation-api-examples
 cluster-get-settings,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-get-settings
 cluster-health,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-health
 cluster-info,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cluster-info

--- a/specification/cluster/allocation_explain/ClusterAllocationExplainRequest.ts
+++ b/specification/cluster/allocation_explain/ClusterAllocationExplainRequest.ts
@@ -32,6 +32,7 @@ import { Duration } from '@_types/Time'
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @doc_id cluster-allocation-explain
+ * @ext_doc_id cluster-allocation-explain-examples
  * @doc_tag cluster
  */
 export interface Request extends RequestBase {

--- a/specification/cluster/allocation_explain/ClusterAllocationExplainRequest.ts
+++ b/specification/cluster/allocation_explain/ClusterAllocationExplainRequest.ts
@@ -28,6 +28,7 @@ import { Duration } from '@_types/Time'
  * For unassigned shards, it provides an explanation for why the shard is unassigned.
  * For assigned shards, it provides an explanation for why the shard is remaining on its current node and has not moved or rebalanced to another node.
  * This API can be very useful when attempting to diagnose why a shard is unassigned or why a shard continues to remain on its current node when you might expect otherwise.
+ * Refer to the linked documentation for examples of how to troubleshoot allocation issues using this API.
  * @rest_spec_name cluster.allocation_explain
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=private


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/docs-projects/issues/302 and https://github.com/elastic/docs-content/pull/1698

DO NOT MERGE BEFORE https://github.com/elastic/docs-content/pull/1698

This PR adds a link to the Cluster allocation explain API description that points to the more complex API example page in the Troubleshooting section.