### PR TITLE
[Backport 9.0] Adds an external link to Cluster allocation explain API spec

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -87,6 +87,7 @@ clear-repositories-metering-archive-api,https://www.elastic.co/docs/api/doc/elas
 clear-scroll-api,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-clear-scroll
 clear-trained-model,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-ml-clear-trained-model-deployment-cache
 cluster-allocation-explain,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-cluster-allocation-explain
+cluster-allocation-explain-examples,https://www.elastic.co/docs/troubleshoot/elasticsearch/cluster-allocation-api-examples
 cluster-get-settings,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-cluster-get-settings
 cluster-health,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-cluster-health
 cluster-info,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-cluster-info

--- a/specification/cluster/allocation_explain/ClusterAllocationExplainRequest.ts
+++ b/specification/cluster/allocation_explain/ClusterAllocationExplainRequest.ts
@@ -28,10 +28,12 @@ import { Duration } from '@_types/Time'
  * For unassigned shards, it provides an explanation for why the shard is unassigned.
  * For assigned shards, it provides an explanation for why the shard is remaining on its current node and has not moved or rebalanced to another node.
  * This API can be very useful when attempting to diagnose why a shard is unassigned or why a shard continues to remain on its current node when you might expect otherwise.
+ * Refer to the linked documentation for examples of how to troubleshoot allocation issues using this API.
  * @rest_spec_name cluster.allocation_explain
  * @availability stack since=5.0.0 stability=stable
  * @availability serverless stability=stable visibility=private
  * @doc_id cluster-allocation-explain
+ * @ext_doc_id cluster-allocation-explain-examples
  * @doc_tag cluster
  */
 export interface Request extends RequestBase {


### PR DESCRIPTION
Backport of Adds an external link to Cluster allocation explain API spec #4523