### PR TITLE
Adds an external link to term vectors API spec

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -876,6 +876,7 @@ synonym-solr,https://www.elastic.co/docs/reference/text-analysis/analysis-synony
 supported-flags,https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-simple-query-string-query#supported-flags
 tasks,https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-tasks
 templating-role-query,https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/controlling-access-at-document-field-level#templating-role-query
+term-vectors-examples,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/term-vectors-examples
 terminate-processor,https://www.elastic.co/docs/reference/enrich-processor/terminate-processor
 test-grok-pattern,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-text-structure-test-grok-pattern
 time-value,https://github.com/elastic/elasticsearch/blob/current/libs/core/src/main/java/org/elasticsearch/core/TimeValue.java

--- a/specification/_global/termvectors/TermVectorsRequest.ts
+++ b/specification/_global/termvectors/TermVectorsRequest.ts
@@ -72,12 +72,14 @@ import { Filter } from './types'
  * The term and field statistics are therefore only useful as relative measures whereas the absolute numbers have no meaning in this context.
  * By default, when requesting term vectors of artificial documents, a shard to get the statistics from is randomly selected.
  * Use `routing` only to hit a particular shard.
+ * Refer to the linked documentation for detailed examples of how to use this API.
  * @rest_spec_name termvectors
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
  * @index_privileges read
  * @doc_tag document
  * @doc_id docs-termvectors
+ * @ext_doc_id term-vectors-examples
  */
 export interface Request<TDocument> extends RequestBase {
   urls: [


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/docs-projects/issues/302 and https://github.com/elastic/elasticsearch/pull/129328

DO NOT MERGE BEFORE https://github.com/elastic/elasticsearch/pull/129328

This PR adds a link to the term vectors API description that points to the more complex API example page in the ES reference section.
