### PR TITLE
Add `skip` to `ilm.explain_lifecycle` response

### DIFF
--- a/specification/ilm/explain_lifecycle/types.ts
+++ b/specification/ilm/explain_lifecycle/types.ts
@@ -49,6 +49,7 @@ export class LifecycleExplainManaged {
   phase_execution?: LifecycleExplainPhaseExecution
   /* `index_creation_date` as a duration */
   time_since_index_creation?: Duration
+  skip: boolean
 }
 
 export class LifecycleExplainUnmanaged {


### PR DESCRIPTION
This is a trick to run CI on https://github.com/elastic/elasticsearch-specification/pull/4552, which was incorrectly opened from a fork.