### PR TITLE
[8.19] Update readme, gitignore (#4503)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ output/openapi/elasticsearch-serverless-openapi.tmp*.json
 output/openapi/elasticsearch-serverless-openapi.examples.json
 output/openapi/elasticsearch-openapi.tmp*.json
 output/openapi/elasticsearch-openapi.examples.json
+output/openapi/elasticsearch-serverless-openapi-docs.json
+output/openapi/elasticsearch-openapi-docs.json

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Follow the steps to generate the JSON representation, then:
 ```
 # Generate the OpenAPI representation
 $ make transform-to-openapi
+```
+
+To generate the JSON representation that is used for documentation purposes, the commands are different:
+
+```
+# Generate the OpenAPI files
+$ make transform-to-openapi-for-docs
 
 # Apply fixes
 $ make overlay-docs


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add elasticsearch-serverless-openapi-docs.json (#4503)](https://github.com/elastic/elasticsearch-specification/pull/4503)

NOTE: The serverless output file is not applicable in this branch, so only the readme and gitigore changes are included in the backport.

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)