### PR TITLE
Fix update-rest-api-json CI

### DIFF
--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['main', '9.0', '8.19', '8.18', '8.17', '8.16', '7.17']
+        branch: ['main', '9.0', '8.19', '8.18', '8.17']
 
     steps:
       - uses: actions/checkout@v4
@@ -28,8 +28,7 @@ jobs:
       - name: Install deps
         run: |
           npm install --prefix .github/download-artifacts
-          npm install --prefix compiler
-          npm install --prefix typescript-generator
+          make setup
 
       - name: Download artifacts
         run: |
@@ -53,12 +52,3 @@ jobs:
           delete-branch: true
           reviewers: Anaethelion,ezimuel,flobernd,JoshMock,l-trotta,miguelgrinberg,picandocodigo,pquentin,swallez,technige
           branch: automated/rest-api-spec-update-${{ matrix.branch }}
-
-      - name: Open an issue if the action fails
-        if: ${{ failure() }}
-        uses: nashmaniac/create-issue-action@v1.2
-        with:
-          title: rest-api-spec update failed
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: bug
-          body: The rest-api-spec action is currently failing, see [here](https://github.com/elastic/elasticsearch-specification/actions/workflows/update-rest-api-json.yml).


### PR DESCRIPTION
I'm fixing three unrelated things here:

* Remove 8.16 and 7.17 branches
* Use `make setup` instead of installing specific dependencies, as example generation was breaking validation here
* Stop trying to open an issue on failure, this has been broken since 2022