### PR TITLE
[Backport 9.0] Adds an external link to find text structure API

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -223,6 +223,7 @@ field-usage-stats,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation
 find-field-structure,https://www.elastic.co/docs/api/doc/elasticsearch/v9/group/endpoint-text_structure
 find-message-structure,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-text-structure-find-message-structure
 find-structure,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-text-structure-find-structure
+find-text-structure-examples,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/find-text-structure-examples
 fingerprint-processor,https://www.elastic.co/docs/reference/enrich-processor/fingerprint-processor
 fleet-multi-search,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-fleet-msearch
 fleet-search,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-fleet-search

--- a/specification/text_structure/find_structure/FindStructureRequest.ts
+++ b/specification/text_structure/find_structure/FindStructureRequest.ts
@@ -44,6 +44,7 @@ import { Duration } from '@_types/Time'
  * @availability serverless stability=stable visibility=private
  * @cluster_privileges monitor_text_structure
  * @doc_id find-structure
+ * @ext_doc_id find-text-structure-examples
  */
 export interface Request<TJsonDocument> {
   urls: [


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch-specification/pull/4591