### PR TITLE
Weighted token as lenient dict

### DIFF
--- a/specification/_types/query_dsl/WeightedTokensQuery.ts
+++ b/specification/_types/query_dsl/WeightedTokensQuery.ts
@@ -18,7 +18,7 @@
  */
 
 import { float } from '@_types/Numeric'
-import { SingleKeyDictionary } from '@spec_utils/Dictionary'
+import { Dictionary } from '@spec_utils/Dictionary'
 import { QueryBase } from './abstractions'
 import { TokenPruningConfig } from './TokenPruningConfig'
 
@@ -27,7 +27,7 @@ import { TokenPruningConfig } from './TokenPruningConfig'
  */
 export class WeightedTokensQuery extends QueryBase {
   /** The tokens representing this query */
-  tokens: SingleKeyDictionary<string, float>[]
+  tokens: Dictionary<string, float> | Dictionary<string, float>[]
   /** Token pruning configurations */
   pruning_config?: TokenPruningConfig
 }


### PR DESCRIPTION
Partially reverting #4469, making the `tokens` field as lenient as it is in the server. No server side proof, all the variants were tested in the console. Thanks @flobernd for noticing the mistake!