### PR TITLE
[compiler] Rename external to typed_keys_quirk

### DIFF
--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -1094,7 +1094,7 @@ export function parseVariantsTag (jsDoc: JSDoc[]): model.Variants | undefined {
   const nonExhaustive = (typeof tags.non_exhaustive === 'string') ? true : undefined
 
   const [type, ...values] = tags.variants.split(' ')
-  if (type === 'external') {
+  if (type === 'typed_keys_quirk') {
     return {
       kind: 'external_tag',
       nonExhaustive: nonExhaustive

--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -334,6 +334,8 @@ An example of internal variants are the type mapping properties.
 
 #### typed_keys_quirk
 
+**Note**: this feature exists because of some early Elasticsearch APIs where tagging was forgotten, and added after the fact using this quirk to avoid breaking compatibility. **It should not be used for new APIs.**
+
 The key that defines the variant is external to the definition, like in the
 case of aggregations in responses or suggesters.
 

--- a/docs/modeling-guide.md
+++ b/docs/modeling-guide.md
@@ -332,7 +332,7 @@ type FooOrBar = Foo | Bar
 
 An example of internal variants are the type mapping properties.
 
-#### External
+#### typed_keys_quirk
 
 The key that defines the variant is external to the definition, like in the
 case of aggregations in responses or suggesters.
@@ -343,7 +343,7 @@ name in the definition itself.
 The syntax is:
 
 ```ts
-/** @variants external */
+/** @variants typed_keys_quirk */
 
 /** @variant name='<field-name>' */
 ```
@@ -351,7 +351,7 @@ The syntax is:
 For example:
 
 ```ts
-/** @variants external */
+/** @variants typed_keys_quirk */
 type FooAlias = Faz | Bar
 
 /** @variant name='faz' */
@@ -369,7 +369,7 @@ In the example above, `FooAlias` will look like this:
 
 ```json
 {
-  "faz": {
+  "name#faz": {
     "prop": "hello world"
   }
 }
@@ -379,7 +379,7 @@ or:
 
 ```json
 {
-  "bar": {
+  "name#bar": {
     "prop": true
   }
 }

--- a/specification/_global/search/_types/suggester.ts
+++ b/specification/_global/search/_types/suggester.ts
@@ -33,7 +33,7 @@ import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
- * @variants external
+ * @variants typed_keys_quirk
  */
 export type Suggest<TDocument> =
   | CompletionSuggest<TDocument>

--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -36,7 +36,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import { Void } from '@spec_utils/VoidValue'
 
 /**
- * @variants external
+ * @variants typed_keys_quirk
  * @non_exhaustive
  * @ext_doc_id search-aggregations
  */

--- a/specification/ml/_types/inference.ts
+++ b/specification/ml/_types/inference.ts
@@ -91,7 +91,7 @@ export class LearningToRankConfig {
 }
 
 /**
- * @variants external
+ * @variants typed_keys_quirk
  */
 export type FeatureExtractor = QueryFeatureExtractor
 

--- a/specification/security/query_api_keys/types.ts
+++ b/specification/security/query_api_keys/types.ts
@@ -120,7 +120,7 @@ export class ApiKeyAggregationContainer {
 }
 
 /**
- * @variants external
+ * @variants typed_keys_quirk
  * @non_exhaustive
  */
 export type ApiKeyAggregate =


### PR DESCRIPTION
This PR changes the variant name `external` to `typed_keys_quirk` to better highlight its specific use.

The real external tagging being `container` resolving types by the field name and able to be non-exhaustive.

The internal naming `external_tag` remains intact for backward compatibility with existing generators.