### PR TITLE
Stop referencing GCS_CREDENTIALS

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -60,8 +60,6 @@ jobs:
           fi
           node scripts/upload-recording/download.js --branch $branch --git
           node scripts/clone-elasticsearch/index.js --branch $branch
-        env:
-          GCS_CREDENTIALS: ${{ secrets.GCS_CREDENTIALS }}
 
       - name: Run validation
         id: validation


### PR DESCRIPTION
We now use git to download recordings. Removed that from secrets already.