### PR TITLE
[DOCS] Add link to stored fields example in reference docs, take 2

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -607,6 +607,7 @@ reroute-processor,https://www.elastic.co/docs/reference/enrich-processor/reroute
 render-search-template-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-render-search-template,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/render-search-template-api.html
 reset-transform,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-reset-transform,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/reset-transform.html
 restore-snapshot,https://www.elastic.co/docs/deploy-manage/tools/snapshot-and-restore/restore-snapshot,
+retrieve-stored-fields,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/retrieve-stored-fields
 role-restriction,https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/role-restriction,
 rollup-agg-limitations,https://www.elastic.co/docs/manage-data/lifecycle/rollup/rollup-aggregation-limitations,
 rollup-delete-job,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-delete-job,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/rollup-delete-job.html

--- a/specification/_global/get/GetRequest.ts
+++ b/specification/_global/get/GetRequest.ts
@@ -110,7 +110,7 @@ export interface Request extends RequestBase {
   query_parameters: {
     /**
      * Indicates whether the request forces synthetic `_source`.
-     * Use this paramater to test if the mapping supports synthetic `_source` and to get a sense of the worst case performance.
+     * Use this parameter to test if the mapping supports synthetic `_source` and to get a sense of the worst case performance.
      * Fetches with this parameter enabled will be slower than enabling synthetic source natively in the index.
      * @availability stack since=8.4.0 visibility=feature_flag feature_flag=es.index_mode_feature_flag_registered
      */
@@ -163,8 +163,9 @@ export interface Request extends RequestBase {
      * A comma-separated list of stored fields to return as part of a hit.
      * If no fields are specified, no stored fields are included in the response.
      * If this field is specified, the `_source` parameter defaults to `false`.
-     * Only leaf fields can be retrieved with the `stored_field` option.
-     * Object fields can't be returned;​if specified, the request fails.
+     * Only leaf fields can be retrieved with the `stored_fields` option.
+     * Object fields can't be returned; if specified, the request fails.
+     * @ext_doc_id retrieve-stored-fields
      */
     stored_fields?: Fields
     /**


### PR DESCRIPTION
Replaces #4576, which had gnarly conflicts. This PR makes the same changes on a clean branch.

Related to elastic/docs-projects#302 and https://github.com/elastic/elasticsearch/pull/129380

✅ requisite example page already merged https://github.com/elastic/elasticsearch/pull/129380

- Add example link to `stored_fields` parameter description
- Fix unrelated typos 