### PR TITLE
Adds a link to the update cross cluster API key API spec

### DIFF
--- a/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
+++ b/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-import { Access } from '@security/_types/Access'
 import { RequestBase } from '@_types/Base'
 import { Id, Metadata } from '@_types/common'
 import { Duration } from '@_types/Time'
+import { Access } from '@security/_types/Access'
 
 /**
  * Update a cross-cluster API key.

--- a/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
+++ b/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
@@ -40,6 +40,8 @@ import { Access } from '@security/_types/Access'
  * The owner user's information, such as the `username` and `realm`, is also updated automatically on every call.
  *
  * NOTE: This API cannot update REST API keys, which should be updated by either the update API key or bulk update API keys API.
+ * 
+ * To learn more about how to use this API, refer to the [Update cross cluter API key API examples page](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/term-vectors-examples).
  * @rest_spec_name security.update_cross_cluster_api_key
  * @availability stack stability=stable
  * @cluster_privileges manage_security

--- a/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
+++ b/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
@@ -17,10 +17,10 @@
  * under the License.
  */
 
+import { Access } from '@security/_types/Access'
 import { RequestBase } from '@_types/Base'
 import { Id, Metadata } from '@_types/common'
 import { Duration } from '@_types/Time'
-import { Access } from '@security/_types/Access'
 
 /**
  * Update a cross-cluster API key.
@@ -40,7 +40,7 @@ import { Access } from '@security/_types/Access'
  * The owner user's information, such as the `username` and `realm`, is also updated automatically on every call.
  *
  * NOTE: This API cannot update REST API keys, which should be updated by either the update API key or bulk update API keys API.
- * 
+ *
  * To learn more about how to use this API, refer to the [Update cross cluter API key API examples page](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/term-vectors-examples).
  * @rest_spec_name security.update_cross_cluster_api_key
  * @availability stack stability=stable

--- a/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
+++ b/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
@@ -41,7 +41,7 @@ import { Access } from '@security/_types/Access'
  *
  * NOTE: This API cannot update REST API keys, which should be updated by either the update API key or bulk update API keys API.
  *
- * To learn more about how to use this API, refer to the [Update cross cluter API key API examples page](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/term-vectors-examples).
+ * To learn more about how to use this API, refer to the [Update cross cluter API key API examples page](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/update-cc-api-key-examples).
  * @rest_spec_name security.update_cross_cluster_api_key
  * @availability stack stability=stable
  * @cluster_privileges manage_security


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/docs-projects/issues/302 and https://github.com/elastic/elasticsearch/pull/129843

DO NOT MERGE BEFORE https://github.com/elastic/elasticsearch/pull/129843

This PR adds a link to the update cross cluster API key API description that points to the more complex API example page in the ES reference section.