### PR TITLE
Fix validation for _global APIs

### DIFF
--- a/.github/validate-pr/index.js
+++ b/.github/validate-pr/index.js
@@ -110,7 +110,7 @@ async function run() {
           ci: false,
           verbose: false
         })
-        const [namespace, _method] = api.split('.')
+        const namespace = getNamespace(api)
         // Asked to validate a specific API, so we only store that one
         reports.set(api, report.get(namespace)[0])
       }
@@ -125,7 +125,7 @@ async function run() {
         verbose: false
       })
 
-      const [namespace, _method] = api.split('.')
+      const namespace = getNamespace(api)
       // Asked to validate a specific API, so we only store that one
       reports.set(api, report.get(namespace)[0])
     }
@@ -164,7 +164,6 @@ async function run() {
 function getApi (file) {
   return file.split('/').slice(1, 3).filter(s => !privateNames.includes(s)).filter(Boolean).join('.')
 }
-
 
 function findBaselineReport(apiName, baselineValidation) {
   const [namespace, method] = apiName.split('.')


### PR DESCRIPTION
The existing namespace computation was too naive. We now use this version instead:

```js
export function getNamespace (api) {
  if (api.includes('.')) return api.split('.')[0]
  return 'global'
}
```