### PR TITLE
[8.19] Stop referencing GCS_CREDENTIALS (#4624)

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -61,8 +61,6 @@ jobs:
           fi
           node scripts/upload-recording/download.js --branch $branch --git
           node scripts/clone-elasticsearch/index.js --branch $branch
-        env:
-          GCS_CREDENTIALS: ${{ secrets.GCS_CREDENTIALS }}
 
       - name: Run validation
         id: validation


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Stop referencing GCS_CREDENTIALS (#4624)](https://github.com/elastic/elasticsearch-specification/pull/4624)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)