### PR TITLE
Adds external link to Rollup search API

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -612,6 +612,7 @@ retrieve-stored-fields,https://www.elastic.co/docs/reference/elasticsearch/rest-
 role-restriction,https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/role-restriction,
 rollup-agg-limitations,https://www.elastic.co/docs/manage-data/lifecycle/rollup/rollup-aggregation-limitations,
 rollup-delete-job,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-delete-job,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/rollup-delete-job.html
+rollup-examples,https://www.elastic.co/docs/manage-data/lifecycle/rollup/getting-started-api#historical-only-search-example,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/rollup-search.html#rollup-search-example
 rollup-get-job,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-get-jobs,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/rollup-get-job.html
 rollup-get-rollup-caps,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-get-rollup-caps,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/rollup-get-rollup-caps.html
 rollup-get-rollup-index-caps,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-rollup-get-rollup-index-caps,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/rollup-get-rollup-index-caps.html

--- a/specification/rollup/rollup_search/RollupSearchRequest.ts
+++ b/specification/rollup/rollup_search/RollupSearchRequest.ts
@@ -35,36 +35,13 @@ import { Dictionary } from '@spec_utils/Dictionary'
  * `size`: Because rollups work on pre-aggregated data, no search hits can be returned and so size must be set to zero or omitted entirely.
  * `highlighter`, `suggestors`, `post_filter`, `profile`, `explain`: These are similarly disallowed.
  *
- * **Searching both historical rollup and non-rollup data**
+ * For more detailed examples of using the rollup search API, including querying rolled-up data only or combining rolled-up and live data, refer to the External documentation.
  *
- * The rollup search API has the capability to search across both "live" non-rollup data and the aggregated rollup data.
- * This is done by simply adding the live indices to the URI. For example:
- *
- * ```
- * GET sensor-1,sensor_rollup/_rollup_search
- * {
- *   "size": 0,
- *   "aggregations": {
- *      "max_temperature": {
- *       "max": {
- *         "field": "temperature"
- *       }
- *     }
- *   }
- * }
- * ```
- *
- * The rollup search endpoint does two things when the search runs:
- *
- * * The original request is sent to the non-rollup index unaltered.
- * * A rewritten version of the original request is sent to the rollup index.
- *
- * When the two responses are received, the endpoint rewrites the rollup response and merges the two together.
- * During the merging process, if there is any overlap in buckets between the two responses, the buckets from the non-rollup index are used.
  * @rest_spec_name rollup.rollup_search
  * @availability stack since=6.3.0 stability=experimental
  * @deprecated 8.11.0
  * @doc_id rollup-search
+ * @ext_doc_id rollup-examples
  */
 export interface Request extends RequestBase {
   urls: [


### PR DESCRIPTION
DO NOT MERGE BEFORE https://github.com/elastic/docs-content/pull/1893

This PR adds an external link to the Rollup search API and removes unnecessary/redundant Request examples.

Related issue: https://github.com/elastic/docs-projects/issues/302