### PR TITLE
Fix string used to find previous comment

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: 'Following you can find the validation results'
+          body-includes: 'Following you can find the validation changes'
 
       - name: Create or update comment
         if: steps.validation.outputs.has_results == 'true'


### PR DESCRIPTION
This was changed in https://github.com/elastic/elasticsearch-specification/pull/4642.