### PR TITLE
[8.18] Fix string used to find previous comment (#4677)

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: 'Following you can find the validation results'
+          body-includes: 'Following you can find the validation changes'
 
       - name: Create or update comment
         if: steps.validation.outputs.has_results == 'true'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Fix string used to find previous comment (#4677)](https://github.com/elastic/elasticsearch-specification/pull/4677)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)