### PR TITLE
Add `format` query option to `esql.async_query_get` endpoint

### DIFF
--- a/specification/esql/async_query_get/AsyncQueryGetRequest.ts
+++ b/specification/esql/async_query_get/AsyncQueryGetRequest.ts
@@ -20,6 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
 import { Duration } from '@_types/Time'
+import { EsqlFormat } from '@esql/_types/QueryParameters'
 
 /**
  * Get async ES|QL query results.
@@ -46,6 +47,10 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     drop_null_columns?: boolean
+    /**
+     * A short version of the Accept header, for example `json` or `yaml`.
+     */
+    format?: EsqlFormat
     /**
      * The period for which the query and its results are stored in the cluster.
      * When this period expires, the query and its results are deleted, even if the query is still ongoing.


### PR DESCRIPTION
This adds the missing `format` query string option to ESQL's `async_query_get` endpoint.

Reported in https://github.com/elastic/elasticsearch-py/pull/2987.