### PR TITLE
Start automation on 9.1 branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,6 @@
 {
   "repoOwner": "elastic",
   "repoName": "elasticsearch-specification",
-  "targetBranchChoices": ["9.0", "8.19", "8.18", "8.17"],
+  "targetBranchChoices": ["9.1", "9.0", "8.19", "8.18"],
   "fork": false
 }

--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['main', '9.0', '8.19', '8.18', '8.17']
+        branch: ['main', '9.1', '9.0', '8.19', '8.18']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I also removed 8.17 since it's currently failing as I did not backport many of the recent changes to it: https://github.com/elastic/elasticsearch-specification/actions/runs/15892771826/job/44818325550.