### PR TITLE
[compiler] Include exceptions to schema

### DIFF
--- a/compiler-rs/clients_schema/src/transform/expand_generics.rs
+++ b/compiler-rs/clients_schema/src/transform/expand_generics.rs
@@ -211,8 +211,10 @@ pub fn expand(model: IndexedModel, config: ExpandConfig) -> anyhow::Result<Index
 
         expand_behaviors(&mut resp.behaviors, &mappings, model, ctx)?;
         expand_body(&mut resp.body, &mappings, model, ctx)?;
-
-        // TODO: exceptions
+        
+        for exception in &mut resp.exceptions {
+            expand_body(&mut exception.body, &mappings, model, ctx)?;
+        }
 
         Ok(resp.into())
     }

--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -502,10 +502,10 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
       for (const ex of typeDef.exceptions) {
         switch (ex.body.kind) {
           case 'properties':
-            validateProperties(ex.body.properties, new Set<string>(), new Set<string>())
+            validateProperties(ex.body.properties, openGenerics, new Set<string>())
             break
           case 'value':
-            validateValueOf(ex.body.value, new Set<string>())
+            validateValueOf(ex.body.value, openGenerics)
             break
           case 'no_body':
             // Nothing to validate

--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -21,7 +21,7 @@ import * as model from '../model/metamodel'
 import { ValidationErrors } from '../validation-errors'
 import { JsonSpec } from '../model/json-spec'
 import assert from 'assert'
-import { TypeName } from '../model/metamodel'
+import { ResponseException, TypeName } from '../model/metamodel'
 
 enum TypeDefKind {
   type,
@@ -497,6 +497,23 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         throw new Error(`Unknown kind: ${typeDef.body.kind}`)
     }
+
+    if (typeDef.exceptions) {
+      for (const ex of typeDef.exceptions) {
+        switch (ex.body.kind) {
+          case 'properties':
+            validateProperties(ex.body.properties, new Set<string>(), new Set<string>())
+            break
+          case 'value':
+            validateValueOf(ex.body.value, new Set<string>())
+            break
+          case 'no_body':
+            // Nothing to validate
+            break
+        }
+      }
+    }
+
     context.pop()
   }
 

--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -21,7 +21,7 @@ import * as model from '../model/metamodel'
 import { ValidationErrors } from '../validation-errors'
 import { JsonSpec } from '../model/json-spec'
 import assert from 'assert'
-import { ResponseException, TypeName } from '../model/metamodel'
+import { TypeName } from '../model/metamodel'
 
 enum TypeDefKind {
   type,
@@ -498,7 +498,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
         throw new Error(`Unknown kind: ${typeDef.body.kind}`)
     }
 
-    if (typeDef.exceptions) {
+    if (typeDef.exceptions != null) {
       for (const ex of typeDef.exceptions) {
         switch (ex.body.kind) {
           case 'properties':

--- a/compiler/src/transform/expand-generics.ts
+++ b/compiler/src/transform/expand-generics.ts
@@ -294,12 +294,12 @@ export function expandGenerics (inputModel: Model, config?: ExpansionConfig): Mo
       const result = { ...resp }
       result.body = expandBody(resp.body, genericParamMapping(resp.generics, params))
       if (resp.exceptions != null) {
-        result.exceptions = [];
+        result.exceptions = []
         for (const exception of resp.exceptions) {
           const except: ResponseException = {
-              description: exception.description,
-              statusCodes: exception.statusCodes,
-              body: expandBody(exception.body, genericParamMapping(resp.generics, params))
+            description: exception.description,
+            statusCodes: exception.statusCodes,
+            body: expandBody(exception.body, genericParamMapping(resp.generics, params))
           }
           result.exceptions.push(except)
         }

--- a/compiler/src/transform/expand-generics.ts
+++ b/compiler/src/transform/expand-generics.ts
@@ -27,7 +27,7 @@ import {
   Request,
   Response,
   Body,
-  InstanceOf, Inherits, Property
+  InstanceOf, Inherits, Property, ResponseException
 } from '../model/metamodel'
 import { readFile, writeFile } from 'fs/promises'
 import stringify from 'safe-stable-stringify'
@@ -293,6 +293,17 @@ export function expandGenerics (inputModel: Model, config?: ExpansionConfig): Mo
     return addIfNotSeen(resp.name, () => {
       const result = { ...resp }
       result.body = expandBody(resp.body, genericParamMapping(resp.generics, params))
+      if (resp.exceptions != null) {
+        result.exceptions = [];
+        for (const exception of resp.exceptions) {
+          const except: ResponseException = {
+              description: exception.description,
+              statusCodes: exception.statusCodes,
+              body: expandBody(exception.body, genericParamMapping(resp.generics, params))
+          }
+          result.exceptions.push(except)
+        }
+      }
       result.generics = undefined
       return result
     })

--- a/specification/indices/get_alias/_types/response.ts
+++ b/specification/indices/get_alias/_types/response.ts
@@ -17,21 +17,17 @@
  * under the License.
  */
 
-import { ErrorResponseBase } from '@_types/Base'
-import { IndexName } from '@_types/common'
-import {
-  IndexAliases,
-  NotFoundAliases
-} from '@indices/get_alias/_types/response'
+import { AliasDefinition } from '@indices/_types/AliasDefinition'
+import { AdditionalProperties } from '@spec_utils/behaviors'
 import { Dictionary } from '@spec_utils/Dictionary'
 
-export class Response {
-  /** @codegen_name aliases */
-  body: Dictionary<IndexName, IndexAliases>
-  exceptions: [
-    {
-      statusCodes: [404]
-      body: NotFoundAliases | ErrorResponseBase
-    }
-  ]
+export class IndexAliases {
+  aliases: Dictionary<string, AliasDefinition>
+}
+
+export class NotFoundAliases
+  implements AdditionalProperties<string, IndexAliases>
+{
+  error: string
+  status: number
 }


### PR DESCRIPTION
Types only found in exceptions are not included in the final `schema.json` because the compiler has not "seen" them.

This fixes the `NotFoundAliases` exception present in `indices.get_alias`.

This adds the following to the output:

```json
    {
      "kind": "interface",
      "name": {
        "name": "IndexAliases",
        "namespace": "indices.get_alias._types"
      },
      "properties": [
        {
          "name": "aliases",
          "required": true,
          "type": {
            "kind": "dictionary_of",
            "key": {
              "kind": "instance_of",
              "type": {
                "name": "string",
                "namespace": "_builtins"
              }
            },
            "singleKey": false,
            "value": {
              "kind": "instance_of",
              "type": {
                "name": "AliasDefinition",
                "namespace": "indices._types"
              }
            }
          }
        }
      ],
      "specLocation": "indices/get_alias/_types/response.ts#L24-L26"
    },
    {
      "kind": "interface",
      "attachedBehaviors": [
        "AdditionalProperties"
      ],
      "behaviors": [
        {
          "generics": [
            {
              "kind": "instance_of",
              "type": {
                "name": "string",
                "namespace": "_builtins"
              }
            },
            {
              "kind": "instance_of",
              "type": {
                "name": "IndexAliases",
                "namespace": "indices.get_alias._types"
              }
            }
          ],
          "type": {
            "name": "AdditionalProperties",
            "namespace": "_spec_utils"
          }
        }
      ],
      "name": {
        "name": "NotFoundAliases",
        "namespace": "indices.get_alias._types"
      },
      "properties": [
        {
          "name": "error",
          "required": true,
          "type": {
            "kind": "instance_of",
            "type": {
              "name": "string",
              "namespace": "_builtins"
            }
          }
        },
        {
          "name": "status",
          "required": true,
          "type": {
            "kind": "instance_of",
            "type": {
              "name": "number",
              "namespace": "_builtins"
            }
          }
        }
      ],
      "specLocation": "indices/get_alias/_types/response.ts#L28-L33"
    },
```