### PR TITLE
Add missing annotation on NotFoundAliases

### DIFF
--- a/specification/indices/get_alias/_types/response.ts
+++ b/specification/indices/get_alias/_types/response.ts
@@ -25,6 +25,9 @@ export class IndexAliases {
   aliases: Dictionary<string, AliasDefinition>
 }
 
+/**
+ * @behavior_meta AdditionalProperties fieldname=aliases description="The index aliases"
+ */
 export class NotFoundAliases
   implements AdditionalProperties<string, IndexAliases>
 {


### PR DESCRIPTION
This adds the missing `behavior_meta` to `NotFoundAliases`.