### PR TITLE
[OpenApi] Add branch option to cli

### DIFF
--- a/compiler-rs/clients_schema/src/lib.rs
+++ b/compiler-rs/clients_schema/src/lib.rs
@@ -1003,7 +1003,6 @@ pub struct UrlTemplate {
 pub struct ModelInfo {
     pub title: String,
     pub license: License,
-    pub version: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/compiler-rs/clients_schema_to_openapi/src/cli.rs
+++ b/compiler-rs/clients_schema_to_openapi/src/cli.rs
@@ -24,6 +24,10 @@ pub struct Cli {
     #[argh(option)]
     pub namespace: Vec<String>,
 
+    /// the branch to generate [9.0, 8.19, current, etc... - default = current]
+    #[argh(option)]
+    pub branch: Option<String>,
+
     /// add enum descriptions to property descriptions [default = true]
     #[argh(switch)]
     pub lift_enum_descriptions: bool,
@@ -72,9 +76,12 @@ impl From<Cli> for Configuration {
             SchemaFlavor::Serverless => Some(Flavor::Serverless),
             SchemaFlavor::Stack => Some(Flavor::Stack),
         };
+        
+        let branch = cli.branch;
 
         Configuration {
             flavor,
+            branch,
             lift_enum_descriptions: cli.lift_enum_descriptions,
             merge_multipath_endpoints: cli.merge_multipath_endpoints,
             multipath_redirects: cli.multipath_redirects,

--- a/compiler-rs/clients_schema_to_openapi/src/lib.rs
+++ b/compiler-rs/clients_schema_to_openapi/src/lib.rs
@@ -32,6 +32,7 @@ use crate::components::TypesAndComponents;
 pub struct Configuration {
     pub flavor: Option<Flavor>,
     pub namespaces: Option<Vec<String>>,
+    pub branch: Option<String>,
 
     /// If a property value is an enumeration, the description of possible values will be copied in the
     /// property's description (also works for arrays of enums).

--- a/compiler-rs/clients_schema_to_openapi/src/schemas.rs
+++ b/compiler-rs/clients_schema_to_openapi/src/schemas.rs
@@ -209,19 +209,14 @@ impl<'a> TypesAndComponents<'a> {
     pub fn convert_external_docs(&self, obj: &impl clients_schema::ExternalDocument) -> Option<ExternalDocumentation> {
         // FIXME: does the model contain resolved doc_id?
         obj.ext_doc_url().map(|url| {
-            let branch: &str = self
-                .model
-                .info
-                .as_ref()
-                .and_then(|i| i.version.as_deref())
-                .unwrap_or("current");
+            let branch = self.config.branch.clone();
             let mut extensions: IndexMap<String,serde_json::Value> = Default::default();
             if let Some(previous_version_doc_url) = obj.ext_previous_version_doc_url() {
                 extensions.insert("x-previousVersionUrl".to_string(), serde_json::json!(previous_version_doc_url));
             }
             ExternalDocumentation {
                 description: None,
-                url: url.trim().replace("{branch}", branch),
+                url: url.trim().replace("{branch}", &branch.unwrap_or("current".to_string())),
                 extensions,
             }
         })


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-specification/issues/4628.
This doesn't affect main or 9.x, it's only an old docs system issue, but I'll port this everywhere for consistency.
In the old docs the branch name in `ext_docs_url` (`externalDocs` in openapi)  is a `{branch}` placeholder that gets resolved in the rust openapi converter by getting the correct branch value from the schema model. The problem is that the branch/version doesn't exist in the schema model anymore, because it was causing problems with PRs, so right now it always defaults to "current".

This PR gets the version for `externalDocs` from a CLI argument instead. This is a temporary solution, since the whole logic will get rewritten when the repo is transfered. 

So no changes for branches main, 9.1, 9.0, while for 8.18 and 8.19 it will be possible to run:
```
npm run transform-to-openapi -- --schema output/schema/schema.json --flavor stack --output output/openapi/elasticsearch-openapi.json --branch 8.19
```

and fix the url issue. 

Output preview for 8.19: https://github.com/elastic/elasticsearch-specification/blob/backport-4722-to-8.19/output/openapi/elasticsearch-openapi.json