### PR TITLE
[8.19] Adds custom InferenceEndpointInfo classes (#4444)

### DIFF
--- a/specification/inference/_types/Services.ts
+++ b/specification/inference/_types/Services.ts
@@ -22,7 +22,21 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 import {
   TaskType,
   TaskTypeAlibabaCloudAI,
-  TaskTypeJinaAi
+  TaskTypeAmazonBedrock,
+  TaskTypeAnthropic,
+  TaskTypeAzureAIStudio,
+  TaskTypeAzureOpenAI,
+  TaskTypeCohere,
+  TaskTypeElasticsearch,
+  TaskTypeELSER,
+  TaskTypeGoogleAIStudio,
+  TaskTypeGoogleVertexAI,
+  TaskTypeHuggingFace,
+  TaskTypeJinaAi,
+  TaskTypeMistral,
+  TaskTypeOpenAI,
+  TaskTypeVoyageAI,
+  TaskTypeWatsonx
 } from '../_types/TaskType'
 
 /**
@@ -81,6 +95,160 @@ export class InferenceEndpointInfoAlibabaCloudAI extends InferenceEndpoint {
    * The task type
    */
   task_type: TaskTypeAlibabaCloudAI
+}
+
+export class InferenceEndpointInfoAmazonBedrock extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeAmazonBedrock
+}
+
+export class InferenceEndpointInfoAnthropic extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeAnthropic
+}
+
+export class InferenceEndpointInfoAzureAIStudio extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeAzureAIStudio
+}
+
+export class InferenceEndpointInfoAzureOpenAI extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeAzureOpenAI
+}
+
+export class InferenceEndpointInfoCohere extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeCohere
+}
+
+export class InferenceEndpointInfoElasticsearch extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeElasticsearch
+}
+
+export class InferenceEndpointInfoELSER extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeELSER
+}
+
+export class InferenceEndpointInfoGoogleAIStudio extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeGoogleAIStudio
+}
+
+export class InferenceEndpointInfoGoogleVertexAI extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeGoogleVertexAI
+}
+
+export class InferenceEndpointInfoHuggingFace extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeHuggingFace
+}
+
+export class InferenceEndpointInfoMistral extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeMistral
+}
+
+export class InferenceEndpointInfoOpenAI extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeOpenAI
+}
+
+export class InferenceEndpointInfoVoyageAI extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeVoyageAI
+}
+
+export class InferenceEndpointInfoWatsonx extends InferenceEndpoint {
+  /**
+   * The inference Id
+   */
+  inference_id: string
+  /**
+   * The task type
+   */
+  task_type: TaskTypeWatsonx
 }
 
 /**

--- a/specification/inference/_types/TaskType.ts
+++ b/specification/inference/_types/TaskType.ts
@@ -39,3 +39,71 @@ export enum TaskTypeAlibabaCloudAI {
   completion,
   sparse_embedding
 }
+
+export enum TaskTypeAmazonBedrock {
+  text_embedding,
+  completion
+}
+
+export enum TaskTypeAnthropic {
+  completion
+}
+
+export enum TaskTypeAzureAIStudio {
+  text_embedding,
+  completion
+}
+
+export enum TaskTypeAzureOpenAI {
+  text_embedding,
+  completion
+}
+
+export enum TaskTypeCohere {
+  text_embedding,
+  rerank,
+  completion
+}
+
+export enum TaskTypeElasticsearch {
+  sparse_embedding,
+  text_embedding,
+  rerank
+}
+
+export enum TaskTypeELSER {
+  sparse_embedding
+}
+
+export enum TaskTypeGoogleAIStudio {
+  text_embedding,
+  completion
+}
+
+export enum TaskTypeGoogleVertexAI {
+  text_embedding,
+  rerank
+}
+
+export enum TaskTypeHuggingFace {
+  text_embedding
+}
+
+export enum TaskTypeMistral {
+  text_embedding
+}
+
+export enum TaskTypeOpenAI {
+  text_embedding,
+  chat_completion,
+  completion
+}
+
+export enum TaskTypeVoyageAI {
+  text_embedding,
+  rerank
+}
+
+export enum TaskTypeWatsonx {
+  text_embedding
+}

--- a/specification/inference/put_amazonbedrock/PutAmazonBedrockResponse.ts
+++ b/specification/inference/put_amazonbedrock/PutAmazonBedrockResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoAmazonBedrock } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoAmazonBedrock
 }

--- a/specification/inference/put_anthropic/PutAnthropicResponse.ts
+++ b/specification/inference/put_anthropic/PutAnthropicResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoAnthropic } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoAnthropic
 }

--- a/specification/inference/put_azureaistudio/PutAzureAiStudioResponse.ts
+++ b/specification/inference/put_azureaistudio/PutAzureAiStudioResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoAzureAIStudio } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoAzureAIStudio
 }

--- a/specification/inference/put_azureopenai/PutAzureOpenAiResponse.ts
+++ b/specification/inference/put_azureopenai/PutAzureOpenAiResponse.ts
@@ -20,13 +20,5 @@
 import { InferenceEndpointInfoAzureOpenAI } from '@inference/_types/Services'
 
 export class Response {
-<<<<<<< HEAD
-  body: InferenceEndpointInfo
-||||||| parent of 6baef2fa4 (Adds custom InferenceEndpointInfo classes (#4444))
-  /** @codegen_name endpoint_info */
-  body: InferenceEndpointInfo
-=======
-  /** @codegen_name endpoint_info */
   body: InferenceEndpointInfoAzureOpenAI
->>>>>>> 6baef2fa4 (Adds custom InferenceEndpointInfo classes (#4444))
 }

--- a/specification/inference/put_azureopenai/PutAzureOpenAiResponse.ts
+++ b/specification/inference/put_azureopenai/PutAzureOpenAiResponse.ts
@@ -17,8 +17,16 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoAzureOpenAI } from '@inference/_types/Services'
 
 export class Response {
+<<<<<<< HEAD
   body: InferenceEndpointInfo
+||||||| parent of 6baef2fa4 (Adds custom InferenceEndpointInfo classes (#4444))
+  /** @codegen_name endpoint_info */
+  body: InferenceEndpointInfo
+=======
+  /** @codegen_name endpoint_info */
+  body: InferenceEndpointInfoAzureOpenAI
+>>>>>>> 6baef2fa4 (Adds custom InferenceEndpointInfo classes (#4444))
 }

--- a/specification/inference/put_cohere/PutCohereResponse.ts
+++ b/specification/inference/put_cohere/PutCohereResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoCohere } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoCohere
 }

--- a/specification/inference/put_elasticsearch/PutElasticsearchResponse.ts
+++ b/specification/inference/put_elasticsearch/PutElasticsearchResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoElasticsearch } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoElasticsearch
 }

--- a/specification/inference/put_elser/PutElserResponse.ts
+++ b/specification/inference/put_elser/PutElserResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoELSER } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoELSER
 }

--- a/specification/inference/put_googleaistudio/PutGoogleAiStudioResponse.ts
+++ b/specification/inference/put_googleaistudio/PutGoogleAiStudioResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoGoogleAIStudio } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoGoogleAIStudio
 }

--- a/specification/inference/put_googlevertexai/PutGoogleVertexAiResponse.ts
+++ b/specification/inference/put_googlevertexai/PutGoogleVertexAiResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoGoogleVertexAI } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoGoogleVertexAI
 }

--- a/specification/inference/put_hugging_face/PutHuggingFaceResponse.ts
+++ b/specification/inference/put_hugging_face/PutHuggingFaceResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoHuggingFace } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoHuggingFace
 }

--- a/specification/inference/put_mistral/PutMistralResponse.ts
+++ b/specification/inference/put_mistral/PutMistralResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoMistral } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoMistral
 }

--- a/specification/inference/put_openai/PutOpenAiResponse.ts
+++ b/specification/inference/put_openai/PutOpenAiResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoOpenAI } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoOpenAI
 }

--- a/specification/inference/put_voyageai/PutVoyageAIResponse.ts
+++ b/specification/inference/put_voyageai/PutVoyageAIResponse.ts
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoVoyageAI } from '@inference/_types/Services'
 
 export class Response {
   /** @codegen_name endpoint_info */
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoVoyageAI
 }

--- a/specification/inference/put_watsonx/PutWatsonxResponse.ts
+++ b/specification/inference/put_watsonx/PutWatsonxResponse.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { InferenceEndpointInfo } from '@inference/_types/Services'
+import { InferenceEndpointInfoWatsonx } from '@inference/_types/Services'
 
 export class Response {
-  body: InferenceEndpointInfo
+  body: InferenceEndpointInfoWatsonx
 }


### PR DESCRIPTION
This was never backported properly, and it currently blocks other backports.

# Backport

This will backport the following commits from `main` to `8.19`:
 - [Adds custom InferenceEndpointInfo classes (#4444)](https://github.com/elastic/elasticsearch-specification/pull/4444)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)