### PR TITLE
[Backport 9.0] Adds external link to 'Update a document API' (#4657)

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -891,6 +891,7 @@ time-zone-id,https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html,
 trim-processor,https://www.elastic.co/docs/reference/enrich-processor/trim-processor,
 update-dfanalytics,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-ml-update-data-frame-analytics,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/update-dfanalytics.html
 update-desired-nodes,https://www.elastic.co/docs/api/doc/elasticsearch/v9/group/endpoint-cluster,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/cluster.html
+update-document,https://www.elastic.co/docs/reference/elasticsearch/rest-apis/update-document,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/docs-update.html#update-api-example
 update-license,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-license-post,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/update-license.html
 update-trained-model-deployment,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-ml-update-trained-model-deployment,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/update-trained-model-deployment.html
 update-transform,https://www.elastic.co/docs/api/doc/elasticsearch/v9/operation/operation-transform-update-transform,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/update-transform.html

--- a/specification/_global/update/UpdateRequest.ts
+++ b/specification/_global/update/UpdateRequest.ts
@@ -55,11 +55,13 @@ import {
  *
  * The `_source` field must be enabled to use this API.
  * In addition to `_source`, you can access the following variables through the `ctx` map: `_index`, `_type`, `_id`, `_version`, `_routing`, and `_now` (the current timestamp).
+ * For usage examples such as partial updates, upserts, and scripted updates, see the External documentation.
  * @rest_spec_name update
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
  * @index_privileges write
  * @doc_tag document
+ * @ext_doc_id update-document
  * @doc_id docs-update
  */
 export interface Request<TDocument, TPartialDocument> extends RequestBase {


### PR DESCRIPTION
This PR backports #4657 to the 9.0 branch.
