### PR TITLE
Adds missing required cluster privilege information

### DIFF
--- a/specification/indices/exists_index_template/IndicesExistsIndexTemplateRequest.ts
+++ b/specification/indices/exists_index_template/IndicesExistsIndexTemplateRequest.ts
@@ -29,6 +29,7 @@ import { Duration } from '@_types/Time'
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public
  * @doc_id index-templates-exist
+ * @cluster_privileges manage_index_templates
  */
 export interface Request extends RequestBase {
   urls: [


### PR DESCRIPTION
This PR adds required cluster privilege information to the [Check index templates API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-exists-index-template). 

Related issue: https://github.com/elastic/docs-content/issues/2040