### PR TITLE
[9.0] Output validation comments even without changes (#4781)

### DIFF
--- a/.github/validate-pr/index.js
+++ b/.github/validate-pr/index.js
@@ -144,20 +144,18 @@ async function run() {
   }
   changedApis.sort((a, b) => a.api.localeCompare(b.api))
 
+  let comment = `Following you can find the validation changes against the target branch for the API${changedApis.length === 1 ? '' : 's'}.\n\n`
   if (changedApis.length > 0) {
-    let comment = `Following you can find the validation changes for the API${changedApis.length === 1 ? '' : 's'} you have modified.\n\n`
     comment += '| API | Status | Request | Response |\n'
     comment += '| --- | --- | --- | --- |\n'
     for (const change of changedApis) {
       comment += buildDiffTableLine(change)
     }
-    comment += `\nYou can validate ${changedApis.length === 1 ? 'this' : 'these'} API${changedApis.length === 1 ? '' : 's'} yourself by using the ${tick}make validate${tick} target.\n`
-
-    core.setOutput('has_results', 'true')
-    core.setOutput('comment_body', comment)
   } else {
-    core.setOutput('has_results', 'false')
+    comment += '**No changes detected**.\n'
   }
+  comment += `\nYou can validate ${changedApis.length === 1 ? 'this' : 'these'} API${changedApis.length === 1 ? '' : 's'} yourself by using the ${tick}make validate${tick} target.\n`
+  core.setOutput('comment_body', comment)
 
   core.info('Done!')
 }

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -78,7 +78,6 @@ jobs:
           body-includes: 'Following you can find the validation changes'
 
       - name: Create or update comment
-        if: steps.validation.outputs.has_results == 'true'
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Output validation comments even without changes (#4781)](https://github.com/elastic/elasticsearch-specification/pull/4781)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)