### PR TITLE
[9.1] Adds new 'none' and 'recursive' chunking strategies to Inference APIs

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -85,6 +85,7 @@ ccr-put-follow,https://www.elastic.co/docs/api/doc/elasticsearch/operation/opera
 ccr-resume-auto-follow-pattern,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ccr-resume-auto-follow-pattern,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/ccr-resume-auto-follow-pattern.html,
 ccs-network-delays,https://www.elastic.co/docs/solutions/search/cross-cluster-search#ccs-network-delays,,
 ccs-privileges,https://www.elastic.co/docs/deploy-manage/remote-clusters/remote-clusters-cert#remote-clusters-privileges-ccs,,
+chunking-strategies,https://www.elastic.co/docs/explore-analyze/elastic-inference/inference-api#chunking-strategies,
 clean-up-snapshot-repo,https://www.elastic.co/docs/deploy-manage/tools/snapshot-and-restore/self-managed#snapshots-repository-cleanup,,
 clear-repositories-metering-archive-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-nodes-clear-repositories-metering-archive,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/clear-repositories-metering-archive-api.html,
 clear-scroll-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-clear-scroll,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/clear-scroll-api.html,

--- a/specification/_types/mapping/ChunkingSettings.ts
+++ b/specification/_types/mapping/ChunkingSettings.ts
@@ -24,6 +24,10 @@ import { OverloadOf } from '@spec_utils/behaviors'
 export class ChunkingSettings implements OverloadOf<InferenceChunkingSettings> {
   strategy: string
 
+  separator_group: string
+
+  separators: string[]
+
   max_chunk_size: integer
 
   overlap?: integer

--- a/specification/inference/_types/Services.ts
+++ b/specification/inference/_types/Services.ts
@@ -314,7 +314,7 @@ export class InferenceChunkingSettings {
    * - `max_chunk_size`
    * - either `separators` or`separator_group`
    *
-   * Learn more about different chunking strategies in the External documentation.
+   * Learn more about different chunking strategies in the linked documentation.
    * @server_default sentence
    * @ext_doc_id chunking-strategies
    */

--- a/specification/inference/_types/Services.ts
+++ b/specification/inference/_types/Services.ts
@@ -288,7 +288,7 @@ export class InferenceChunkingSettings {
    */
   sentence_overlap?: integer
   /**
-   * The chunking strategy: `sentence` or `word`.
+   * The chunking strategy: `sentence`, `word`, `none` or `recursive`. Learn more about [chunking strategies](https://www.elastic.co/docs/explore-analyze/elastic-inference/inference-api#chunking-strategies).
    * @server_default sentence
    */
   strategy?: string

--- a/specification/inference/_types/Services.ts
+++ b/specification/inference/_types/Services.ts
@@ -288,7 +288,33 @@ export class InferenceChunkingSettings {
    */
   sentence_overlap?: integer
   /**
-   * The chunking strategy: `sentence`, `word`, `none` or `recursive`. Learn more about chunking strategies in the External documentation.
+   * This parameter is only applicable when using the `recursive` chunking strategy.
+   *
+   * Sets a predefined list of separators in the saved chunking settings based on the selected text type.
+   * Values can be `markdown` or `plaintext`.
+   *
+   * Using this parameter is an alternative to manually specifying a custom `separators` list.
+   */
+  separator_group: string
+  /**
+   * A list of strings used as possible split points when chunking text with the `recursive` strategy.
+   *
+   * Each string can be a plain string or a regular expression (regex) pattern.
+   * The system tries each separator in order to split the text, starting from the first item in the list.
+   *
+   * After splitting, it attempts to recombine smaller pieces into larger chunks that stay within
+   * the `max_chunk_size` limit, to reduce the total number of chunks generated.
+   */
+  separators: string[]
+  /**
+   * The chunking strategy: `sentence`, `word`, `none` or `recursive`.
+   *
+   *  * If `strategy` is set to `recursive`, you must also specify:
+   *
+   * - `max_chunk_size`
+   * - either `separators` or`separator_group`
+   *
+   * Learn more about different chunking strategies in the External documentation.
    * @server_default sentence
    * @ext_doc_id chunking-strategies
    */

--- a/specification/inference/_types/Services.ts
+++ b/specification/inference/_types/Services.ts
@@ -288,7 +288,7 @@ export class InferenceChunkingSettings {
    */
   sentence_overlap?: integer
   /**
-   * The chunking strategy: `sentence`, `word`, `none` or `recursive`.
+   * The chunking strategy: `sentence`, `word`, `none` or `recursive`. Learn more about chunking strategies in the External documentation.
    * @server_default sentence
    * @ext_doc_id chunking-strategies
    */

--- a/specification/inference/_types/Services.ts
+++ b/specification/inference/_types/Services.ts
@@ -288,8 +288,9 @@ export class InferenceChunkingSettings {
    */
   sentence_overlap?: integer
   /**
-   * The chunking strategy: `sentence`, `word`, `none` or `recursive`. Learn more about [chunking strategies](https://www.elastic.co/docs/explore-analyze/elastic-inference/inference-api#chunking-strategies).
+   * The chunking strategy: `sentence`, `word`, `none` or `recursive`.
    * @server_default sentence
+   * @ext_doc_id chunking-strategies
    */
   strategy?: string
 }

--- a/specification/inference/put/examples/request/InferencePutExample1.yaml
+++ b/specification/inference/put/examples/request/InferencePutExample1.yaml
@@ -7,4 +7,8 @@ value: |-
      "model_id": "rerank-english-v3.0",
      "api_key": "{{COHERE_API_KEY}}"
    }
+   "chunking_settings": {
+     "strategy": "recursive",
+     "max_chunk_size": 200,
+     "separator_group": "markdown"
   }


### PR DESCRIPTION
This PR adds the new 'none' and 'recursive' chunking strategies to Inference APIs.
Related issue: https://github.com/elastic/developer-docs-team/issues/308