### PR TITLE
Adds input_type parameter to POST inference docs at the root level.

### DIFF
--- a/specification/inference/inference/InferenceRequest.ts
+++ b/specification/inference/inference/InferenceRequest.ts
@@ -83,6 +83,19 @@ export interface Request extends RequestBase {
      */
     input: string | Array<string>
     /**
+     * Specifies the input data type. Possible values include:
+     * * `SEARCH`
+     * * `INGEST`
+     * * `CLASSIFICATION`
+     * * `CLUSTERING`
+     * Not all services support all values. Unsupported values will trigger a validation exception.
+     * Accepted values depend on the configured inference service, refer to the relevant service-specific documentation for more info.
+     *
+     * > info
+     * > The `input_type` parameter specified on the root level of the request body will take precedence over the `input_type` parameter specified in `task_settings`.
+     */
+    input_type?: string
+    /**
      * Task settings for the individual inference request.
      * These settings are specific to the task type you specified and override the task settings specified when initializing the service.
      */


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/developer-docs-team/issues/306

This PR adds the `input_type` parameter to the body parameters section of the POST inference API docs.