### PR TITLE
Allow containers with a single variant

### DIFF
--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -579,17 +579,10 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
 
     if (typeDef.variants?.kind === 'container') {
       const variants = typeDef.properties.filter(prop => !(prop.containerProperty ?? false))
-      if (variants.length === 1) {
-        // Single-variant containers must have a required property
-        if (!variants[0].required) {
-          modelError(`Property ${variants[0].name} is a single-variant and must be required`)
-        }
-      } else {
-        // Multiple variants must all be optional
-        for (const v of variants) {
-          if (v.required) {
-            modelError(`Variant ${variants[0].name} must be optional`)
-          }
+      // Variants must all be optional
+      for (const v of variants) {
+        if (v.required) {
+          modelError(`Variant ${variants[0].name} must be optional`)
         }
       }
     }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1,12 +1,5 @@
 {
   "endpointErrors": {
-    "async_search.submit": {
-      "request": [
-        "interface definition _types:QueryVectorBuilder - Property text_embedding is a single-variant and must be required",
-        "interface definition _types:RankContainer - Property rrf is a single-variant and must be required"
-      ],
-      "response": []
-    },
     "create": {
       "request": [
         "Request: query parameter 'if_primary_term' does not exist in the json spec",
@@ -81,21 +74,6 @@
         "Request: query parameter 'register_operation_count' does not exist in the json spec"
       ],
       "response": []
-    },
-    "transform.get_transform": {
-      "request": [],
-      "response": [
-        "interface definition transform._types:RetentionPolicyContainer - Property time is a single-variant and must be required",
-        "interface definition transform._types:SyncContainer - Property time is a single-variant and must be required"
-      ]
-    },
-    "watcher.execute_watch": {
-      "request": [
-        "interface definition watcher._types:TriggerContainer - Property schedule is a single-variant and must be required"
-      ],
-      "response": [
-        "interface definition watcher._types:TriggerEventContainer - Property schedule is a single-variant and must be required"
-      ]
     },
     "xpack.info": {
       "request": [


### PR DESCRIPTION
As discussed in https://github.com/elastic/elasticsearch-specification/issues/4796 (and offline with @Anaethelion and @swallez), it can make sense to allow single variants. This usually happens because the other variants are not exposed or have not been implemented yet.