### PR TITLE
[8.18] Allow containers with a single variant (#4853)

### DIFF
--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -584,17 +584,10 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
 
     if (typeDef.variants?.kind === 'container') {
       const variants = typeDef.properties.filter(prop => !(prop.containerProperty ?? false))
-      if (variants.length === 1) {
-        // Single-variant containers must have a required property
-        if (!variants[0].required) {
-          modelError(`Property ${variants[0].name} is a single-variant and must be required`)
-        }
-      } else {
-        // Multiple variants must all be optional
-        for (const v of variants) {
-          if (v.required) {
-            modelError(`Variant ${variants[0].name} must be optional`)
-          }
+      // Variants must all be optional
+      for (const v of variants) {
+        if (v.required) {
+          modelError(`Variant ${variants[0].name} must be optional`)
         }
       }
     }

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -2,8 +2,7 @@
   "endpointErrors": {
     "async_search.submit": {
       "request": [
-        "Request: query parameter 'min_compatible_shard_node' does not exist in the json spec",
-        "interface definition _types:QueryVectorBuilder - Property text_embedding is a single-variant and must be required"
+        "Request: query parameter 'min_compatible_shard_node' does not exist in the json spec"
       ],
       "response": []
     },
@@ -281,12 +280,6 @@
       ],
       "response": []
     },
-    "search": {
-      "request": [
-        "interface definition _types:RankContainer - Property rrf is a single-variant and must be required"
-      ],
-      "response": []
-    },
     "search_mvt": {
       "request": [
         "Request: query parameter 'grid_agg' does not exist in the json spec",
@@ -325,21 +318,6 @@
         "Request: query parameter 'register_operation_count' does not exist in the json spec"
       ],
       "response": []
-    },
-    "transform.get_transform": {
-      "request": [],
-      "response": [
-        "interface definition transform._types:RetentionPolicyContainer - Property time is a single-variant and must be required",
-        "interface definition transform._types:SyncContainer - Property time is a single-variant and must be required"
-      ]
-    },
-    "watcher.execute_watch": {
-      "request": [
-        "interface definition watcher._types:TriggerContainer - Property schedule is a single-variant and must be required"
-      ],
-      "response": [
-        "interface definition watcher._types:TriggerEventContainer - Property schedule is a single-variant and must be required"
-      ]
     },
     "xpack.info": {
       "request": [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Allow containers with a single variant (#4853)](https://github.com/elastic/elasticsearch-specification/pull/4853)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)