### PR TITLE
upgrade the request converter to apply a bug fix

### DIFF
--- a/docs/examples/generate-language-examples.js
+++ b/docs/examples/generate-language-examples.js
@@ -45,7 +45,7 @@ async function generateLanguages(example) {
       code: (await convertRequests(request, lang, {})).trim(),
     });
   }
-  data.alternatives = alternatives.concat(data.alternatives.filter(pair => !LANGUAGES.includes(pair.language)));
+  data.alternatives = alternatives.concat((data.alternatives ?? []).filter(pair => !LANGUAGES.includes(pair.language)));
 
   // specific java example generator
   if (process.argv[2] === "java") {

--- a/docs/examples/package-lock.json
+++ b/docs/examples/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@elastic/request-converter": "^9.1.1",
+        "@elastic/request-converter": "^9.1.2",
         "@redocly/cli": "^1.34.3",
         "@stoplight/spectral-cli": "^6.14.2",
         "java-caller": "^4.1.1",
@@ -54,9 +54,9 @@
       }
     },
     "node_modules/@elastic/request-converter": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@elastic/request-converter/-/request-converter-9.1.1.tgz",
-      "integrity": "sha512-aFNNKvYgyasn97bh2cJx0dL0NgLFQuFMHCLQGnAebe1cwE/vc2mOh+DWWMGICndIKeP/F1aVpCy7KYbCXmyjzA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@elastic/request-converter/-/request-converter-9.1.2.tgz",
+      "integrity": "sha512-7UTpzcKMAAB75ObfUpTvsE1v00rC5zyoZf2f12KkWsxmCZvaG0RLtYXrsxufSJe9SscUqzTeEgdK/tv3ZJNhYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64url": "^3.0.1",

--- a/docs/examples/package.json
+++ b/docs/examples/package.json
@@ -3,7 +3,7 @@
     "transform-to-openapi": "npm run transform-to-openapi --prefix compiler --"
   },
   "dependencies": {
-    "@elastic/request-converter": "^9.1.1",
+    "@elastic/request-converter": "^9.1.2",
     "@redocly/cli": "^1.34.3",
     "@stoplight/spectral-cli": "^6.14.2",
     "yaml": "^2.8.0",


### PR DESCRIPTION
This upgrade allows conversions of URLs that end with `_mappings`, which were incorrectly treated as a special case before.