### PR TITLE
[9.1] Updates 'model_id' and 'input_type' as required parameters for Cohere V2

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13706,7 +13706,7 @@ export type InferenceCohereInputType = 'classification' | 'clustering' | 'ingest
 export interface InferenceCohereServiceSettings {
   api_key: string
   embedding_type?: InferenceCohereEmbeddingType
-  model_id?: string
+  model_id: string
   rate_limit?: InferenceRateLimitSetting
   similarity?: InferenceCohereSimilarityType
 }
@@ -13716,7 +13716,7 @@ export type InferenceCohereServiceType = 'cohere'
 export type InferenceCohereSimilarityType = 'cosine' | 'dot_product' | 'l2_norm'
 
 export interface InferenceCohereTaskSettings {
-  input_type?: InferenceCohereInputType
+  input_type: InferenceCohereInputType
   return_documents?: boolean
   top_n?: integer
   truncate?: InferenceCohereTruncateType

--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -670,10 +670,8 @@ export class CohereServiceSettings {
    * * For the available `completion` models, refer to the [Cohere command docs](https://docs.cohere.com/docs/models#command).
    * * For the available `rerank` models, refer to the [Cohere rerank docs](https://docs.cohere.com/reference/rerank-1).
    * * For the available `text_embedding` models, refer to [Cohere embed docs](https://docs.cohere.com/reference/embed).
-   *
-   * The default value for a text embedding task is `embed-english-v2.0`.
    */
-  model_id?: string
+  model_id: string
   /**
    * This setting helps to minimize the number of rate limit errors returned from Cohere.
    * By default, the `cohere` service sets the number of requests allowed per minute to 10000.
@@ -736,7 +734,7 @@ export class CohereTaskSettings {
    *
    * IMPORTANT: The `input_type` field is required when using embedding models `v3` and higher.
    */
-  input_type?: CohereInputType
+  input_type: CohereInputType
   /**
    * For a `rerank` task, return doc text within the results.
    */


### PR DESCRIPTION
This PR updates the `model_id` and `input_type` parameters to be required for the Cohere V2 inference endpoint starting from 9.1.

I also removed the default value for `model_id`, assuming that it no longer has one since it's now required. @davidkyle  could you please confirm if this assumption is correct?
