### PR TITLE
Updated ES specification to support simplified retrievers

### DIFF
--- a/specification/_types/Retriever.ts
+++ b/specification/_types/Retriever.ts
@@ -69,6 +69,9 @@ export class LinearRetriever extends RetrieverBase {
   /** Inner retrievers. */
   retrievers?: InnerRetriever[]
   rank_window_size?: integer
+  query?: string
+  fields?: string[]
+  normalizer?: ScoreNormalizer
 }
 
 export class PinnedRetriever extends RetrieverBase {
@@ -136,6 +139,8 @@ export class RRFRetriever extends RetrieverBase {
   rank_constant?: integer
   /** This value determines the size of the individual result sets per query.  */
   rank_window_size?: integer
+  query?: string
+  fields?: string[]
 }
 
 export class TextSimilarityReranker extends RetrieverBase {


### PR DESCRIPTION
This PR introduces the following optional fields to [specification/_types/Retriever.ts](cci:7://file:///Users/mrids/git_tree/elasticsearch-specification/specification/_types/Retriever.ts:0:0-0:0):

*   **[LinearRetriever](cci:2://file:///Users/mrids/git_tree/elasticsearch-specification/specification/_types/Retriever.ts:67:0-74:1)**:
    *   `query?: string`: A query string for a text-based search.
    *   `fields?: string[]`: The fields to run the query against.
    *   `normalizer?: ScoreNormalizer`: The normalizer to use for scoring.
*   **[RRFRetriever](cci:2://file:///Users/mrids/git_tree/elasticsearch-specification/specification/_types/Retriever.ts:131:0-138:1)**:
    *   `query?: string`: A query string for a text-based search.
    *   `fields?: string[]`: The fields to run the query against.

These additions allow users to specify a simple query string directly within the retriever, aligning it with recent changes made in the Kibana Dev Console ([SEARCH-1091](https://github.com/elastic/kibana/pull/227444)).

#### Validation

The specification was validated against the `search` API using `make validate api=search branch=main`. 