### PR TITLE
[9.0] Add timeout params for PUT inference and POST inference/_stream (#4895)

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -10603,6 +10603,9 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/inference.put-inference_id"
+          },
+          {
+            "$ref": "#/components/parameters/inference.put-timeout"
           }
         ],
         "requestBody": {
@@ -10724,6 +10727,9 @@
           },
           {
             "$ref": "#/components/parameters/inference.put-inference_id"
+          },
+          {
+            "$ref": "#/components/parameters/inference.put-timeout"
           }
         ],
         "requestBody": {
@@ -10861,6 +10867,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -10963,6 +10979,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -11055,6 +11081,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -11141,6 +11177,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -11233,6 +11279,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -11325,6 +11381,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -11417,6 +11483,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -11535,6 +11611,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -11631,6 +11717,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -11715,6 +11811,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -11807,6 +11913,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -11835,11 +11951,6 @@
                   "summary": "A text embedding task",
                   "description": "Run `PUT _inference/text_embedding/hugging-face-embeddings` to create an inference endpoint that performs a `text_embedding` task type.",
                   "value": "{\n    \"service\": \"hugging_face\",\n    \"service_settings\": {\n        \"api_key\": \"hugging-face-access-token\", \n        \"url\": \"url-endpoint\" \n    }\n}"
-                },
-                "PutHuggingFaceRequestExample2": {
-                  "summary": "A rerank task",
-                  "description": "Run `PUT _inference/rerank/hugging-face-rerank` to create an inference endpoint that performs a `rerank` task type.",
-                  "value": "{\n    \"service\": \"hugging_face\",\n    \"service_settings\": {\n        \"api_key\": \"hugging-face-access-token\", \n        \"url\": \"url-endpoint\" \n    },\n    \"task_settings\": {\n        \"return_documents\": true,\n        \"top_n\": 3\n    }\n}"
                 }
               }
             }
@@ -11896,6 +12007,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -11988,6 +12109,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -12071,6 +12202,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -12163,6 +12304,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -12255,6 +12406,16 @@
               "$ref": "#/components/schemas/_types.Id"
             },
             "style": "simple"
+          },
+          {
+            "in": "query",
+            "name": "timeout",
+            "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+            "deprecated": false,
+            "schema": {
+              "$ref": "#/components/schemas/_types.Duration"
+            },
+            "style": "form"
           }
         ],
         "requestBody": {
@@ -12374,16 +12535,6 @@
                   "summary": "Rerank task",
                   "description": "Run `POST _inference/rerank/cohere_rerank` to perform reranking on the example input.",
                   "value": "{\n  \"input\": [\"luke\", \"like\", \"leia\", \"chewy\",\"r2d2\", \"star\", \"wars\"],\n  \"query\": \"star wars main character\"\n}"
-                },
-                "RerankRequestExample2": {
-                  "summary": "Rerank task",
-                  "description": "Run `POST _inference/rerank/bge-reranker-base-mkn` to perform reranking on the example input via Hugging Face",
-                  "value": "{\n  \"input\": [\"luke\", \"like\", \"leia\", \"chewy\",\"r2d2\", \"star\", \"wars\"],\n  \"query\": \"star wars main character\",\n  \"return_documents\": false,\n  \"top_n\": 2\n}"
-                },
-                "RerankRequestExample3": {
-                  "summary": "Rerank task",
-                  "description": "Run `POST _inference/rerank/bge-reranker-base-mkn` to perform reranking on the example input via Hugging Face",
-                  "value": "{\n  \"input\": [\"luke\", \"like\", \"leia\", \"chewy\",\"r2d2\", \"star\", \"wars\"],\n  \"query\": \"star wars main character\",\n  \"return_documents\": true,\n  \"top_n\": 3\n}"
                 }
               }
             }
@@ -70674,6 +70825,16 @@
           "$ref": "#/components/schemas/_types.Id"
         },
         "style": "simple"
+      },
+      "inference.put-timeout": {
+        "in": "query",
+        "name": "timeout",
+        "description": "Specifies the amount of time to wait for the inference endpoint to be created.",
+        "deprecated": false,
+        "schema": {
+          "$ref": "#/components/schemas/_types.Duration"
+        },
+        "style": "form"
       },
       "ingest.get_pipeline-id": {
         "in": "path",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13940,6 +13940,7 @@ export type InferenceInferenceResponse = InferenceInferenceResult
 export interface InferencePutRequest extends RequestBase {
   task_type?: InferenceTaskType
   inference_id: Id
+  timeout?: Duration
   body?: InferenceInferenceEndpoint
 }
 
@@ -13948,6 +13949,7 @@ export type InferencePutResponse = InferenceInferenceEndpointInfo
 export interface InferencePutAlibabacloudRequest extends RequestBase {
   task_type: InferenceAlibabaCloudTaskType
   alibabacloud_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceAlibabaCloudServiceType
@@ -13961,6 +13963,7 @@ export type InferencePutAlibabacloudResponse = InferenceInferenceEndpointInfoAli
 export interface InferencePutAmazonbedrockRequest extends RequestBase {
   task_type: InferenceAmazonBedrockTaskType
   amazonbedrock_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceAmazonBedrockServiceType
@@ -13974,6 +13977,7 @@ export type InferencePutAmazonbedrockResponse = InferenceInferenceEndpointInfoAm
 export interface InferencePutAnthropicRequest extends RequestBase {
   task_type: InferenceAnthropicTaskType
   anthropic_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceAnthropicServiceType
@@ -13987,6 +13991,7 @@ export type InferencePutAnthropicResponse = InferenceInferenceEndpointInfoAnthro
 export interface InferencePutAzureaistudioRequest extends RequestBase {
   task_type: InferenceAzureAiStudioTaskType
   azureaistudio_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceAzureAiStudioServiceType
@@ -14000,6 +14005,7 @@ export type InferencePutAzureaistudioResponse = InferenceInferenceEndpointInfoAz
 export interface InferencePutAzureopenaiRequest extends RequestBase {
   task_type: InferenceAzureOpenAITaskType
   azureopenai_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceAzureOpenAIServiceType
@@ -14013,6 +14019,7 @@ export type InferencePutAzureopenaiResponse = InferenceInferenceEndpointInfoAzur
 export interface InferencePutCohereRequest extends RequestBase {
   task_type: InferenceCohereTaskType
   cohere_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceCohereServiceType
@@ -14026,6 +14033,7 @@ export type InferencePutCohereResponse = InferenceInferenceEndpointInfoCohere
 export interface InferencePutElasticsearchRequest extends RequestBase {
   task_type: InferenceElasticsearchTaskType
   elasticsearch_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceElasticsearchServiceType
@@ -14039,6 +14047,7 @@ export type InferencePutElasticsearchResponse = InferenceInferenceEndpointInfoEl
 export interface InferencePutElserRequest extends RequestBase {
   task_type: InferenceElserTaskType
   elser_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceElserServiceType
@@ -14051,6 +14060,7 @@ export type InferencePutElserResponse = InferenceInferenceEndpointInfoELSER
 export interface InferencePutGoogleaistudioRequest extends RequestBase {
   task_type: InferenceGoogleAiStudioTaskType
   googleaistudio_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceGoogleAiServiceType
@@ -14063,6 +14073,7 @@ export type InferencePutGoogleaistudioResponse = InferenceInferenceEndpointInfoG
 export interface InferencePutGooglevertexaiRequest extends RequestBase {
   task_type: InferenceGoogleVertexAITaskType
   googlevertexai_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceGoogleVertexAIServiceType
@@ -14076,6 +14087,7 @@ export type InferencePutGooglevertexaiResponse = InferenceInferenceEndpointInfoG
 export interface InferencePutHuggingFaceRequest extends RequestBase {
   task_type: InferenceHuggingFaceTaskType
   huggingface_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceHuggingFaceServiceType
@@ -14088,6 +14100,7 @@ export type InferencePutHuggingFaceResponse = InferenceInferenceEndpointInfoHugg
 export interface InferencePutJinaaiRequest extends RequestBase {
   task_type: InferenceJinaAITaskType
   jinaai_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceJinaAIServiceType
@@ -14101,6 +14114,7 @@ export type InferencePutJinaaiResponse = InferenceInferenceEndpointInfoJinaAi
 export interface InferencePutMistralRequest extends RequestBase {
   task_type: InferenceMistralTaskType
   mistral_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceMistralServiceType
@@ -14113,6 +14127,7 @@ export type InferencePutMistralResponse = InferenceInferenceEndpointInfoMistral
 export interface InferencePutOpenaiRequest extends RequestBase {
   task_type: InferenceOpenAITaskType
   openai_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceOpenAIServiceType
@@ -14126,6 +14141,7 @@ export type InferencePutOpenaiResponse = InferenceInferenceEndpointInfoOpenAI
 export interface InferencePutVoyageaiRequest extends RequestBase {
   task_type: InferenceVoyageAITaskType
   voyageai_inference_id: Id
+  timeout?: Duration
   body?: {
     chunking_settings?: InferenceInferenceChunkingSettings
     service: InferenceVoyageAIServiceType
@@ -14139,6 +14155,7 @@ export type InferencePutVoyageaiResponse = InferenceInferenceEndpointInfoVoyageA
 export interface InferencePutWatsonxRequest extends RequestBase {
   task_type: InferenceWatsonxTaskType
   watsonx_inference_id: Id
+  timeout?: Duration
   body?: {
     service: InferenceWatsonxServiceType
     service_settings: InferenceWatsonxServiceSettings
@@ -14172,6 +14189,7 @@ export type InferenceSparseEmbeddingResponse = InferenceSparseEmbeddingInference
 
 export interface InferenceStreamCompletionRequest extends RequestBase {
   inference_id: Id
+  timeout?: Duration
   body?: {
     input: string | string[]
     task_settings?: InferenceTaskSettings

--- a/specification/inference/put/PutRequest.ts
+++ b/specification/inference/put/PutRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import { InferenceEndpoint } from '@inference/_types/Services'
 import { TaskType } from '@inference/_types/TaskType'
 
@@ -72,6 +73,13 @@ export interface Request extends RequestBase {
      * The inference Id
      */
     inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   /** @codegen_name inference_config */
   body: InferenceEndpoint

--- a/specification/inference/put_alibabacloud/PutAlibabaCloudRequest.ts
+++ b/specification/inference/put_alibabacloud/PutAlibabaCloudRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   AlibabaCloudServiceSettings,
   AlibabaCloudServiceType,
@@ -53,6 +54,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     alibabacloud_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_amazonbedrock/PutAmazonBedrockRequest.ts
+++ b/specification/inference/put_amazonbedrock/PutAmazonBedrockRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   AmazonBedrockServiceSettings,
   AmazonBedrockServiceType,
@@ -56,6 +57,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     amazonbedrock_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_anthropic/PutAnthropicRequest.ts
+++ b/specification/inference/put_anthropic/PutAnthropicRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   AnthropicServiceSettings,
   AnthropicServiceType,
@@ -54,6 +55,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     anthropic_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_azureaistudio/PutAzureAiStudioRequest.ts
+++ b/specification/inference/put_azureaistudio/PutAzureAiStudioRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   AzureAiStudioServiceSettings,
   AzureAiStudioServiceType,
@@ -53,6 +54,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     azureaistudio_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_azureopenai/PutAzureOpenAiRequest.ts
+++ b/specification/inference/put_azureopenai/PutAzureOpenAiRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   AzureOpenAIServiceSettings,
   AzureOpenAIServiceType,
@@ -61,6 +62,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     azureopenai_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_cohere/PutCohereRequest.ts
+++ b/specification/inference/put_cohere/PutCohereRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   CohereServiceSettings,
   CohereServiceType,
@@ -53,6 +54,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     cohere_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_elasticsearch/PutElasticsearchRequest.ts
+++ b/specification/inference/put_elasticsearch/PutElasticsearchRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   ElasticsearchServiceSettings,
   ElasticsearchServiceType,
@@ -67,6 +68,13 @@ export interface Request extends RequestBase {
      * The must not match the `model_id`.
      */
     elasticsearch_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_elser/PutElserRequest.ts
+++ b/specification/inference/put_elser/PutElserRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   ElserServiceSettings,
   ElserServiceType,
@@ -67,6 +68,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     elser_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_googleaistudio/PutGoogleAiStudioRequest.ts
+++ b/specification/inference/put_googleaistudio/PutGoogleAiStudioRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   GoogleAiServiceType,
   GoogleAiStudioServiceSettings,
@@ -52,6 +53,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     googleaistudio_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_googlevertexai/PutGoogleVertexAiRequest.ts
+++ b/specification/inference/put_googlevertexai/PutGoogleVertexAiRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   GoogleVertexAIServiceSettings,
   GoogleVertexAIServiceType,
@@ -53,6 +54,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     googlevertexai_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_hugging_face/PutHuggingFaceRequest.ts
+++ b/specification/inference/put_hugging_face/PutHuggingFaceRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   HuggingFaceServiceSettings,
   HuggingFaceServiceType,
@@ -66,6 +67,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     huggingface_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_jinaai/PutJinaAiRequest.ts
+++ b/specification/inference/put_jinaai/PutJinaAiRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   JinaAIServiceSettings,
   JinaAIServiceType,
@@ -56,6 +57,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     jinaai_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_mistral/PutMistralRequest.ts
+++ b/specification/inference/put_mistral/PutMistralRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   MistralServiceSettings,
   MistralServiceType,
@@ -53,6 +54,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     mistral_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_openai/PutOpenAiRequest.ts
+++ b/specification/inference/put_openai/PutOpenAiRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   OpenAIServiceSettings,
   OpenAIServiceType,
@@ -54,6 +55,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     openai_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_voyageai/PutVoyageAIRequest.ts
+++ b/specification/inference/put_voyageai/PutVoyageAIRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   VoyageAIServiceSettings,
   VoyageAIServiceType,
@@ -55,6 +56,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     voyageai_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/put_watsonx/PutWatsonxRequest.ts
+++ b/specification/inference/put_watsonx/PutWatsonxRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import {
   WatsonxServiceSettings,
   WatsonxServiceType,
@@ -54,6 +55,13 @@ export interface Request extends RequestBase {
      * The unique identifier of the inference endpoint.
      */
     watsonx_inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * Specifies the amount of time to wait for the inference endpoint to be created.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**

--- a/specification/inference/stream_completion/StreamInferenceRequest.ts
+++ b/specification/inference/stream_completion/StreamInferenceRequest.ts
@@ -19,6 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { Id } from '@_types/common'
+import { Duration } from '@_types/Time'
 import { TaskSettings } from '@inference/_types/Services'
 
 /**
@@ -46,6 +47,13 @@ export interface Request extends RequestBase {
      * The unique identifier for the inference endpoint.
      */
     inference_id: Id
+  }
+  query_parameters: {
+    /**
+     * The amount of time to wait for the inference request to complete.
+     * @server_default 30s
+     */
+    timeout?: Duration
   }
   body: {
     /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Add timeout params for PUT inference and POST inference/_stream (#4895)](https://github.com/elastic/elasticsearch-specification/pull/4895)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)