### PR TITLE
[8.19] Allow duplicate Query and ClusterInfo

### DIFF
--- a/compiler/src/steps/validate-model.ts
+++ b/compiler/src/steps/validate-model.ts
@@ -214,6 +214,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
     const existingDuplicates: Record<string, string[]> = {
       Action: ['indices.modify_data_stream', 'indices.update_aliases', 'watcher._types'],
       Actions: ['ilm._types', 'security.put_privileges', 'watcher._types'],
+      ClusterInfo: ['cluster.allocation_explain', 'esql._types'],
       ComponentTemplate: ['cat.component_templates', 'cluster._types'],
       Context: ['_global.get_script_context', '_global.search._types', 'nodes._types'],
       DatabaseConfigurationMetadata: ['ingest.get_geoip_database', 'ingest.get_ip_location_database'],
@@ -231,6 +232,7 @@ export default async function validateModel (apiModel: model.Model, restSpec: Ma
       Phases: ['ilm._types', 'xpack.usage'],
       Pipeline: ['ingest._types', 'logstash._types'],
       Policy: ['enrich._types', 'ilm._types', 'slm._types'],
+      Query: ['_global.knn_search._types', 'xpack.usage'],
       RequestItem: ['_global.msearch', '_global.msearch_template'],
       ResponseItem: ['_global.bulk', '_global.mget', '_global.msearch'],
       RoleMapping: ['security._types', 'xpack.usage'],

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -106,8 +106,5 @@
       "response": []
     }
   },
-  "generalErrors": [
-    "Query is present in multiple namespaces: _global.knn_search._types and xpack.usage",
-    "ClusterInfo is present in multiple namespaces: cluster.allocation_explain and esql._types"
-  ]
+  "generalErrors": []
 }


### PR DESCRIPTION
Those are not problems in 9.x because:

* We renamed the ES|QL types in https://github.com/elastic/elasticsearch-specification/pull/4245. I'm open to doing it for 8.19 but that's a breaking change
* We removed the knn_search API in 9.x: https://github.com/elastic/elasticsearch-specification/pull/4276