### PR TITLE
Added key field to filter bucket agg

### DIFF
--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -642,7 +642,9 @@ export class IpRangeBucket extends MultiBucketBase {
  */
 export class FiltersAggregate extends MultiBucketAggregateBase<FiltersBucket> {}
 
-export class FiltersBucket extends MultiBucketBase {}
+export class FiltersBucket extends MultiBucketBase {
+  key?: string
+}
 
 /**
  * @variant name=adjacency_matrix


### PR DESCRIPTION
As reported in a [Java client issue](https://github.com/elastic/elasticsearch-java/issues/1040), the FiltersBucket aggregation result can have a `key` field if `keyed` was set as false in the request. 

~~No server code, `key` is a common field in aggregation and I couldn't find where it's added to the FiltersAggregation result.~~

[server code](https://github.com/elastic/elasticsearch/blob/f393dbab36e4a0cd5e47898ab7b0908694a9bffc/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java#L87)

Here's a reproducer: 

```json
PUT /logs/_bulk?refresh
{ "index" : { "_id" : 1 } }
{ "body" : "warning: page could not be rendered" }
{ "index" : { "_id" : 2 } }
{ "body" : "authentication error" }
{ "index" : { "_id" : 3 } }
{ "body" : "warning: connection timed out" }
```
```json
GET logs/_search
{
  "size": 0,
  "aggs" : {
    "messages" : {
      "filters" : {
        "filters" : {
          "errors" :   { "match" : { "body" : "error"   }},
          "warnings" : { "match" : { "body" : "warning" }}
        },
        "keyed": false
      }
    }
  }
}
```

Response without ` "keyed": false` is:

```json
  "aggregations": {
    "messages": {
      "buckets": {
        "errors": {
          "doc_count": 1
        },
        "warnings": {
          "doc_count": 2
        }
      }
    }
  }
```

with ` "keyed": false` it's:

```json
  "aggregations": {
    "messages": {
      "buckets": [
        {
          "key": "errors",
          "doc_count": 1
        },
        {
          "key": "warnings",
          "doc_count": 2
        }
      ]
    }
  }
```
