### PR TITLE
Update spec automation branch 9

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
       - '7.17'
       - '8.[0-9]+'
+      - '9.[0-9]+'
 
   # For debugging purposes:
   # pull_request:


### PR DESCRIPTION
The "generate automation" github workflow should work for 9.x
