### PR TITLE
SQL fix params type

### DIFF
--- a/specification/sql/query/QuerySqlRequest.ts
+++ b/specification/sql/query/QuerySqlRequest.ts
@@ -22,7 +22,6 @@ import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Duration, TimeZone } from '@_types/Time'
-import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
 /**
@@ -118,7 +117,7 @@ export interface Request extends RequestBase {
     /**
      * The values for parameters in the query.
      */
-    params?: Dictionary<string, UserDefinedValue>
+    params?: UserDefinedValue[]
     /**
      * The SQL query to run.
      * @ext_doc_id sql-spec


### PR DESCRIPTION
Originally reported in https://github.com/elastic/elasticsearch-java/issues/721, `params` in SQL query request is an array of objects, not a map, as per the [documentation](https://www.elastic.co/docs/explore-analyze/query-filter/languages/sql-rest-params) and the [server](https://github.com/elastic/elasticsearch/blob/d8e6cc2096aa7814d1502a756ace7669864f2614/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/Payloads.java#L209). 
