### PR TITLE
[Backport 8.17][DOCS]: Clarify GET / response on Serverless

### DIFF
--- a/specification/_global/info/RootNodeInfoRequest.ts
+++ b/specification/_global/info/RootNodeInfoRequest.ts
@@ -22,6 +22,7 @@ import { RequestBase } from '@_types/Base'
 /**
  * Get cluster info.
  * Get basic build, version, and cluster information.
+ * ::: In Serverless, this API is retained for backward compatibility only. Some response fields, such as the version number, should be ignored.
  * @rest_spec_name info
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public

--- a/specification/_global/info/examples/response/RootNodeInfoResponseExample1.yaml
+++ b/specification/_global/info/examples/response/RootNodeInfoResponseExample1.yaml
@@ -1,19 +1,19 @@
-# summary: ''
-description: A successful response from `GET /`s.
+summary: Stack response
+description: A successful response from `GET /`.
 # type: response
 # response_code: 200
 value:
   name: instance-0000000000
   cluster_name: my_test_cluster
-  cluster_uuid: 5QaxoN0pRZuOmWSxstBBwQ
+  cluster_uuid: zk-HjQtYQGyL3NFSSu7InA
   version:
-    build_date: '2024-02-01T13:07:13.727175297Z'
-    minimum_wire_compatibility_version: 7.17.0
-    build_hash: 6185ba65d27469afabc9bc951cded6c17c21e3f3
-    number: 8.12.1
-    lucene_version: 9.9.2
-    minimum_index_compatibility_version: 7.0.0
+    number: 9.1.0
     build_flavor: default
-    build_snapshot: false
     build_type: docker
+    build_hash: 00000000
+    build_date: 2025-07-09T22:10:13.578182715Z
+    build_snapshot: false
+    lucene_version: 10.2.2
+    minimum_wire_compatibility_version: 8.19.0
+    minimum_index_compatibility_version: 8.0.0
   tagline: 'You Know, for Search'

--- a/specification/_global/info/examples/response/RootNodeInfoResponseExample2.yaml
+++ b/specification/_global/info/examples/response/RootNodeInfoResponseExample2.yaml
@@ -1,0 +1,19 @@
+summary: Serverless response
+description: A successful response from `GET /` on Serverless. This API is retained for backward compatibility only. Some fields, such as the version number, return static values and should be ignored.
+# type: response
+# response_code: 200
+value:
+  name: serverless
+  cluster_name: my_test_serverless_cluster
+  cluster_uuid: 8xx0pi24Squnf4PFDOAtwg
+  version:
+    number: 8.11.0
+    build_flavor: serverless
+    build_type: docker
+    build_hash: 00000000
+    build_date: 2023-10-31
+    build_snapshot: false
+    lucene_version: 9.7.0
+    minimum_wire_compatibility_version: 8.11.0
+    minimum_index_compatibility_version: 8.11.0
+  tagline: 'You Know, for Search'

--- a/specification/_types/Base.ts
+++ b/specification/_types/Base.ts
@@ -110,6 +110,9 @@ export class ElasticsearchVersionInfo {
   minimum_wire_compatibility_version: VersionString
   /**
    * The Elasticsearch version number.
+   *
+   * ::: IMPORTANT: For Serverless deployments, this static value is always `8.11.0` and is used solely for backward compatibility with legacy clients.
+   * Serverless environments are versionless and automatically upgraded, so this value can be safely ignored.
    */
   number: string
 }


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch-specification/pull/4981
