### PR TITLE
Expand docs for `include_defaults`

### DIFF
--- a/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
+++ b/specification/cluster/get_settings/ClusterGetSettingsRequest.ts
@@ -45,7 +45,12 @@ export interface Request extends RequestBase {
      */
     flat_settings?: boolean
     /**
-     * If `true`, returns default cluster settings from the local node.
+     * If `true`, also returns default values for all other cluster settings, reflecting the values
+     * in the `elasticsearch.yml` file of one of the nodes in the cluster. If the nodes in your
+     * cluster do not all have the same values in their `elasticsearch.yml` config files then the
+     * values returned by this API may vary from invocation to invocation and may not reflect the
+     * values that Elasticsearch uses in all situations. Use the `GET _nodes/settings` API to
+     * observe the settings on individual nodes in your cluster.
      * @server_default false
      */
     include_defaults?: boolean


### PR DESCRIPTION
This parameter is trappy, its notion of "default" includes the values
from some arbitrary node's `elasticsearch.yml` file which means they
aren't really defaults. But then again the real default values would be
even less useful in the (common) case that some setting is overridden on
all nodes.