### PR TITLE
Use strings instead of integer ids for simulate examples

### DIFF
--- a/specification/simulate/ingest/examples/request/SimulateIngestRequestExample1.yaml
+++ b/specification/simulate/ingest/examples/request/SimulateIngestRequestExample1.yaml
@@ -7,11 +7,11 @@ description:
 # type: request
 value:
   docs:
-    - _id: 123
+    - _id: "123"
       _index: my-index
       _source:
         foo: bar
-    - _id: 456
+    - _id: "456"
       _index: my-index
       _source:
         foo: rab

--- a/specification/simulate/ingest/examples/request/SimulateIngestRequestExample1.yaml
+++ b/specification/simulate/ingest/examples/request/SimulateIngestRequestExample1.yaml
@@ -7,11 +7,11 @@ description:
 # type: request
 value:
   docs:
-    - _id: "123"
+    - _id: '123'
       _index: my-index
       _source:
         foo: bar
-    - _id: "456"
+    - _id: '456'
       _index: my-index
       _source:
         foo: rab

--- a/specification/simulate/ingest/examples/request/SimulateIngestRequestExample2.yaml
+++ b/specification/simulate/ingest/examples/request/SimulateIngestRequestExample2.yaml
@@ -9,11 +9,11 @@ description:
 value:
   docs:
     - _index: my-index
-      _id: 123
+      _id: "123"
       _source:
         foo: bar
     - _index: my-index
-      _id: 456
+      _id: "456"
       _source:
         foo: rab
   pipeline_substitutions:

--- a/specification/simulate/ingest/examples/request/SimulateIngestRequestExample2.yaml
+++ b/specification/simulate/ingest/examples/request/SimulateIngestRequestExample2.yaml
@@ -9,11 +9,11 @@ description:
 value:
   docs:
     - _index: my-index
-      _id: "123"
+      _id: '123'
       _source:
         foo: bar
     - _index: my-index
-      _id: "456"
+      _id: '456'
       _source:
         foo: rab
   pipeline_substitutions:


### PR DESCRIPTION
These examples were being rendered with the `_id` as an integer, however, that is invalid and we only allow strings for integers.
