### PR TITLE
Change `TermVectorsRequest.fields` from `Fields` to `Field[]`

### DIFF
--- a/specification/_global/termvectors/TermVectorsRequest.ts
+++ b/specification/_global/termvectors/TermVectorsRequest.ts
@@ -189,7 +189,7 @@ export interface Request<TDocument> extends RequestBase {
      * A list of fields to include in the statistics.
      * It is used as the default list unless a specific field list is provided in the `completion_fields` or `fielddata_fields` parameters.
      */
-    fields?: Fields
+    fields?: Field[]
     /**
      * If `true`, the response includes:
      *


### PR DESCRIPTION
`TermVectorsRequest.fields` always expects an array.

Related to https://github.com/elastic/elasticsearch-net/issues/8641