### PR TITLE
Fix broken docs link

### DIFF
--- a/specification/indices/put_mapping/IndicesPutMappingRequest.ts
+++ b/specification/indices/put_mapping/IndicesPutMappingRequest.ts
@@ -50,8 +50,8 @@ import { Dictionary, SingleKeyDictionary } from '@spec_utils/Dictionary'
  * - Update supported mapping parameters
  * - Change a field's mapping using reindexing
  * - Rename a field using a field alias
- * 
- * Learn how to use the update mapping API with practical examples in the [Update mapping API examples](https://www.elastic.co/docs//manage-data/data-store/mapping/update-mappings-examples) guide.
+ *
+ * Learn how to use the update mapping API with practical examples in the [Update mapping API examples](https://www.elastic.co/docs/manage-data/data-store/mapping/update-mappings-examples) guide.
  * @rest_spec_name indices.put_mapping
  * @availability stack stability=stable
  * @availability serverless stability=stable visibility=public


### PR DESCRIPTION
Docs tests found a broken link in a docstring, which @KOTungseth fixed in https://github.com/elastic/elasticsearch-js/pull/2959. Just porting the fix to the spec so it stays fixed after the next codegen.
