### PR TITLE
Add _data_stream metadata to search hit

### DIFF
--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -18,6 +18,7 @@
  */
 
 import {
+  DataStreamName,
   Field,
   Fields,
   Id,
@@ -62,6 +63,7 @@ export class Hit<TDocument> {
   _primary_term?: long
   _version?: VersionNumber
   sort?: SortResults
+  _data_stream?: DataStreamName
 }
 
 export class HitsMetadata<T> {


### PR DESCRIPTION
Per https://github.com/elastic/elasticsearch/pull/132476, add _data_stream metadata to search hit