### PR TITLE
Change `KeyedPercentiles` value type from `long` to `double`

### DIFF
--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -157,7 +157,7 @@ type Percentiles = KeyedPercentiles | Array<ArrayPercentilesItem>
 // <key_name>_as_string? string - present if a format was provided
 //
 // Note: defined as type alias and not inline, as some clients may want to implement it in a more usable way.
-type KeyedPercentiles = Dictionary<string, string | long | null>
+type KeyedPercentiles = Dictionary<string, string | double | null>
 
 export class ArrayPercentilesItem {
   key: string


### PR DESCRIPTION
As titled.

Related to https://github.com/elastic/elasticsearch-net/issues/8570