### PR TITLE
Change type of `ArrayPercentilesItem.key` from `string` to `double`

### DIFF
--- a/specification/_types/aggregations/Aggregate.ts
+++ b/specification/_types/aggregations/Aggregate.ts
@@ -160,7 +160,7 @@ type Percentiles = KeyedPercentiles | Array<ArrayPercentilesItem>
 type KeyedPercentiles = Dictionary<string, string | double | null>
 
 export class ArrayPercentilesItem {
-  key: string
+  key: double
   value: double | null
   value_as_string?: string
 }


### PR DESCRIPTION
As titled.

Related to https://github.com/elastic/elasticsearch-net/issues/8570