### PR TITLE
Adding the merge_type param to the ingest simulate API

### DIFF
--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1,5 +1,12 @@
 {
-  "endpointErrors": {},
+  "endpointErrors": {
+    "simulate.ingest": {
+      "request": [
+        "Request: query parameter 'merge_type' does not exist in the json spec"
+      ],
+      "response": []
+    }
+  },
   "generalErrors": [
     "Dangling type '_global.scripts_painless_execute:PainlessExecutionPosition'",
     "Dangling type '_global.scripts_painless_execute:PainlessScript'",

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1,12 +1,5 @@
 {
-  "endpointErrors": {
-    "simulate.ingest": {
-      "request": [
-        "Request: query parameter 'merge_type' does not exist in the json spec"
-      ],
-      "response": []
-    }
-  },
+  "endpointErrors": {},
   "generalErrors": [
     "Dangling type '_global.scripts_painless_execute:PainlessExecutionPosition'",
     "Dangling type '_global.scripts_painless_execute:PainlessScript'",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -21166,9 +21166,12 @@ export interface SimulateIngestIngestDocumentSimulationKeys {
 export type SimulateIngestIngestDocumentSimulation = SimulateIngestIngestDocumentSimulationKeys
   & { [property: string]: string | Id | IndexName | Record<string, any> | SpecUtilsStringified<VersionNumber> | string[] | Record<string, string>[] | ErrorCause }
 
+export type SimulateIngestMergeType = 'index' | 'template'
+
 export interface SimulateIngestRequest extends RequestBase {
   index?: IndexName
   pipeline?: PipelineName
+  merge_type?: SimulateIngestMergeType
   body?: {
     docs: IngestDocument[]
     component_template_substitutions?: Record<string, ClusterComponentTemplateNode>

--- a/specification/_json_spec/simulate.ingest.json
+++ b/specification/_json_spec/simulate.ingest.json
@@ -35,7 +35,7 @@
       },
       "merge_type": {
         "type": "string",
-        "description": "The way that mapping_additions ought to be merged into existing mappings"
+        "description": "The method to be used when merging mapping_additions existing mappings"
       }
     },
     "body": {

--- a/specification/_json_spec/simulate.ingest.json
+++ b/specification/_json_spec/simulate.ingest.json
@@ -32,6 +32,10 @@
       "pipeline": {
         "type": "string",
         "description": "The pipeline id to preprocess incoming documents with if no pipeline is given for a particular document"
+      },
+      "merge_type": {
+        "type": "string",
+        "description": "The way that mapping_additions ought to be merged into existing mappings"
       }
     },
     "body": {

--- a/specification/simulate/ingest/SimulateIngestRequest.ts
+++ b/specification/simulate/ingest/SimulateIngestRequest.ts
@@ -75,6 +75,13 @@ export interface Request extends RequestBase {
      * This value can be used to override the default pipeline of the index.
      */
     pipeline?: PipelineName
+    /**
+     * The way that mapping_additions ought to be merged into existing mappings -- in the way mapping changes are merged into an existing index, or in
+     * the way mapping changes are merged into existing templates. Some changes are allowed to templates that are not allowed to indices. For example,
+     * a field cannot be changed to an incompatible type in an index, but can in a template.
+     * @server_default index
+     */
+    merge_type?: MergeType
   }
   body: {
     /**
@@ -97,4 +104,9 @@ export interface Request extends RequestBase {
      */
     pipeline_substitutions?: Dictionary<string, Pipeline>
   }
+}
+
+enum MergeType {
+  index,
+  template
 }

--- a/specification/simulate/ingest/SimulateIngestRequest.ts
+++ b/specification/simulate/ingest/SimulateIngestRequest.ts
@@ -76,7 +76,7 @@ export interface Request extends RequestBase {
      */
     pipeline?: PipelineName
     /**
-     * The way that mapping_additions ought to be merged into existing mappings -- in the way mapping changes are merged into an existing index, or in
+     * The method to be used when merging mapping_additions existing mappings. Mappings can be merged in the way mapping changes are merged into an existing index, or in
      * the way mapping changes are merged into existing templates. Some changes are allowed to templates that are not allowed to indices. For example,
      * a field cannot be changed to an incompatible type in an index, but can in a template.
      * @server_default index


### PR DESCRIPTION
This adds the new `merge_type` query parameter to the specification for the simulate ingest API. The parameter was added in https://github.com/elastic/elasticsearch/pull/132210.