### PR TITLE
Adding effective-mapping to the ingest simulate response

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -21162,9 +21162,10 @@ export interface SimulateIngestIngestDocumentSimulationKeys {
   executed_pipelines: string[]
   ignored_fields?: Record<string, string>[]
   error?: ErrorCause
+  effective_mapping?: MappingTypeMapping
 }
 export type SimulateIngestIngestDocumentSimulation = SimulateIngestIngestDocumentSimulationKeys
-  & { [property: string]: string | Id | IndexName | Record<string, any> | SpecUtilsStringified<VersionNumber> | string[] | Record<string, string>[] | ErrorCause }
+  & { [property: string]: string | Id | IndexName | Record<string, any> | SpecUtilsStringified<VersionNumber> | string[] | Record<string, string>[] | ErrorCause | MappingTypeMapping }
 
 export type SimulateIngestMergeType = 'index' | 'template'
 

--- a/specification/simulate/ingest/SimulateIngestResponse.ts
+++ b/specification/simulate/ingest/SimulateIngestResponse.ts
@@ -19,6 +19,7 @@
 
 import { Id, IndexName, VersionNumber } from '@_types/common'
 import { ErrorCause } from '@_types/Errors'
+import { TypeMapping } from '@_types/mapping/TypeMapping'
 import { AdditionalProperties } from '@spec_utils/behaviors'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { Stringified } from '@spec_utils/Stringified'
@@ -75,4 +76,5 @@ export class IngestDocumentSimulation
    * doc.
    */
   error?: ErrorCause
+  effective_mapping?: TypeMapping
 }

--- a/specification/simulate/ingest/examples/response/SimulateIngestResponseExample3.yaml
+++ b/specification/simulate/ingest/examples/response/SimulateIngestResponseExample3.yaml
@@ -13,7 +13,16 @@ value: |-
           "_source": {
             "foo": "foo"
           },
-          "executed_pipelines": []
+          "executed_pipelines": [],
+          "effective_mapping": {
+            "_doc": {
+              "properties": {
+                "foo": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
         }
       },
       {
@@ -24,7 +33,16 @@ value: |-
           "_source": {
             "bar": "rab"
           },
-        "executed_pipelines": []
+        "executed_pipelines": [],
+          "effective_mapping": {
+            "_doc": {
+              "properties": {
+                "bar": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
         }
       }
     ]


### PR DESCRIPTION
The `effective_mapping` field was added to the simulate ingest response in https://github.com/elastic/elasticsearch/pull/132833. This adds it to the specification.