### PR TITLE
Use `Sort` object in "delete by query"

### DIFF
--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -31,6 +31,7 @@ import { float, long } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { Operator } from '@_types/query_dsl/Operator'
 import { SlicedScroll } from '@_types/SlicedScroll'
+import { Sort } from '@_types/sort'
 import { Duration } from '@_types/Time'
 
 /**
@@ -310,5 +311,9 @@ export interface Request extends RequestBase {
      * Slice the request manually using the provided slice ID and total number of slices.
      */
     slice?: SlicedScroll
+    /**
+     * A sort object that specifies the order of deleted documents.
+     */
+    sort?: Sort
   }
 }


### PR DESCRIPTION
<!-- Hello there! Thank you for opening a pull request. See CONTRIBUTING.md for instructions. -->

The delete by query API's `sort` property supports the `Sort` object:
```
"sort": {
  "timestamp": {
    "order": "desc",
    "unmapped_type": "date"
  }
}
```
~~But the property's type does not reflect this fact.~~

~~This PR changes the type of `sort` from `string[]` to the more general `Sort` object (as used by the search API):~~

But the body is missing the sort parameter, this PR adds it as `Sort` object.