### PR TITLE
Add tip about availability since across majors

### DIFF
--- a/docs/add-new-api.md
+++ b/docs/add-new-api.md
@@ -56,7 +56,7 @@ Furthermore, every request definition **must** contain these JS Doc tags:
   - `stability`: the API stability, one of `experimental`, `beta`, `stable`
   - `visibility`: the API stability, one of `public` or `private`.
   - `since`: the version of Elasticsearch when the API has been introduced (eg: `7.7.0`).
-    This field is only available for `stack`.
+    This field is only available for `stack`. If the API is introduced in multiple major versions (eg: `8.19.0` and `9.1.0`), use the appropriate value in each branch.
   - `feature_flag`: the feature flag value, only valid if the `visibility` is set to `feature_flag`.
     This field is only available for `stack`.
 


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/pull/5148

This PR adds a sentence to `add-new-api.md` to clarify recommended behaviour for the `@availability since` property when an API is added to multiple major versions.