### PR TITLE
[DOCS] Update repo branch in API docs intro

### DIFF
--- a/docs/overlays/elasticsearch-openapi-overlays.yaml
+++ b/docs/overlays/elasticsearch-openapi-overlays.yaml
@@ -14,7 +14,7 @@ actions:
         
         ## Documentation source and versions
         
-        This documentation is derived from the `main` branch of the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification) repository.
+        This documentation is derived from the `9.1` branch of the [elasticsearch-specification](https://github.com/elastic/elasticsearch-specification) repository.
         It is provided under license [Attribution-NonCommercial-NoDerivatives 4.0 International](https://creativecommons.org/licenses/by-nc-nd/4.0/).
 
         This documentation contains work-in-progress information for future Elastic Stack releases.


### PR DESCRIPTION
This PR fixes the [detail in the Elasticsearch API docs](https://www.elastic.co/docs/api/doc/elasticsearch/v9/#topic-documentation-source-and-versions) that indicates which branch it's derived from. It incorrectly indicates that the branch used for the v9 API docs is main but it is in fact 9.1.