### PR TITLE
[Backport 9.0] Adds links that point to the API contrib guidelines to repo docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The repository has the following structure:
 This JSON representation is formally defined by [a set of TypeScript definitions (a meta-model)](./compiler/src/model/metamodel.ts)
 that also explains the various properties and their values.
 
+> [!TIP]
+> To learn more about how to write docs specifically for our [API references](https://www.elastic.co/docs/api/), refer to the [Contribute to Elastic API docs](https://www.elastic.co/docs/extend/contribute/api-docs/).
 
 ## Prepare the environment
 
@@ -73,6 +75,19 @@ $ make overlay-docs
 
 # The generated output can be found in ./output/openapi/
 ```
+
+## Specification Viewer
+
+An interactive viewer for the Elasticsearch specification is available
+[here](https://elastic.github.io/specification-viewer/).
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md)
+
+Refer to the
+[Contribute to Elastic API docs](https://www.elastic.co/docs/extend/contribute/api-docs/)
+for more details about the API documentation guidelines.
 
 ## Make Targets
 

--- a/docs/add-new-api.md
+++ b/docs/add-new-api.md
@@ -5,6 +5,9 @@ in this repository, or we do have an endpoint definition in [`/specification/_js
 but we don't have a type definition for it.
 In this document you will see how to add a new endpopint and how to add a new endpoint definition.
 
+> [!TIP]
+> To learn more about how to write docs specifically for our [API references](https://www.elastic.co/docs/api/), refer to the [Contribute to Elastic API docs](https://www.elastic.co/docs/extend/contribute/api-docs/).
+
 ## How to add a new endpoint
 
 Add a new endpoint is straightforward, you only need to copy-paste the json rest-api-spec defintion

--- a/docs/doc-comments-guide.md
+++ b/docs/doc-comments-guide.md
@@ -5,7 +5,7 @@ A specification is not only about formalizing data structures, it's also about e
 Documentation of the TypeScript specification is made using [JSDoc](https://jsdoc.app/) comments, i.e. multiline comments starting with `/**` above a type or field declaration.
 
 The first phrase is used as the mandatory operation summary in the OpenAPI document.
-Refer to [API documentation guidelines](https://docs.elastic.dev/content-architecture/oas#summaries).
+Refer to the [Elastic API docs contribution guidelines](https://www.elastic.co/docs/extend/contribute/api-docs/guidelines) to learn more about how to create great documentation for your API.
 
 > [!NOTE] 
 > You must add a period at the end of the phrase for it to parse correctly. The period will be properly omitted from the output OpenAPI document.
@@ -75,6 +75,8 @@ Each of these targets has a different way to format inline documentation: Java c
 GFM also has implementations in most languages, meaning that code generators will be able to easily parse the doc comments and transcode them.
 
 ## Structuring a doc-comment
+
+For guidelines of how to write great doc-comments, refer to the [Contribute to Elastic API docs](https://www.elastic.co/docs/extend/contribute/api-docs/guidelines#write-descriptions) page.
 
 ### Terseness
 

--- a/docs/schema-structure.md
+++ b/docs/schema-structure.md
@@ -12,6 +12,9 @@ for describing APIs that can't be represented in the specification.
 Refer to the [documentation guide](doc-comments-guide.md) to add documentation to types and fields,
 and to the [modeling guide](modeling-guide.md) to learn how to model the different types.
 
+> [!TIP]
+> To learn more about how to write docs specifically for our [API references](https://www.elastic.co/docs/api/), refer to the [Contribute to Elastic API docs](https://www.elastic.co/docs/extend/contribute/api-docs/).
+
 You can find the schema representing all APIs and types in the [output folder](output/schema/schema.json).
 The schema is structured as follows:
 


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch-specification/pull/5131 to 9.0.
