### PR TITLE
Deprecating sort in delete by query

### DIFF
--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -257,6 +257,7 @@ export interface Request extends RequestBase {
     slices?: Slices
     /**
      * A comma-separated list of `<field>:<direction>` pairs.
+     * @deprecated 9.0.0 this query parameter is not supported and will be removed
      */
     sort?: string[]
     /**


### PR DESCRIPTION
DeleteByQuery doesn't support the query parameter `sort`