### PR TITLE
Shard Failure alternatives support

### DIFF
--- a/specification/_types/Errors.ts
+++ b/specification/_types/Errors.ts
@@ -50,11 +50,15 @@ export class ErrorCause
 }
 
 export class ShardFailure {
+  /** @aliases _index */
   index?: IndexName
+  /** @aliases _node */
   node?: string
   reason: ErrorCause
-  shard: integer
+  /** @aliases _shard */
+  shard?: integer
   status?: string
+  primary?: boolean
 }
 
 export class BulkIndexByScrollFailure {


### PR DESCRIPTION
Originally reported in https://github.com/elastic/elasticsearch-java/issues/408.
ShardFailure has 3 variants in the server code: 

1. [ShardSearchFailure](https://github.com/elastic/elasticsearch/blob/c498dae033262c9141a88b70c96119f200f61e94/server/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java#L28), the one we currently map, commonly used by most Search responses
2. [SearchFailure](https://github.com/elastic/elasticsearch/blob/8b31a775d6ad66bd00d2c504c96c1e638762a951/server/src/main/java/org/elasticsearch/index/reindex/ScrollableHitSource.java#L361), which is a bit different (`shard` is nullable and there's `status`), and it's used by Scrollable responses
3. [Failure](https://github.com/elastic/elasticsearch/blob/4c1c51e87001f4df27667ad23e40729071646faa/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java#L233), which uses underscores in most fields and adds `primary`, and is used by every response that extends ReplicationResponse (mainly Update, Delete and Index, but also some Bulk)

To support all 3 without creating specific classes and introduce breaking changes we have decided to have ShardFailure support all variants by using aliases and making additional fields nullable (with `reason` being the only non optional field that every variant supports)

