### PR TITLE
Update rollover new index operation request for serverless

### DIFF
--- a/specification/indices/rollover/examples/request/indicesRolloverRequestExample1.yaml
+++ b/specification/indices/rollover/examples/request/indicesRolloverRequestExample1.yaml
@@ -1,4 +1,4 @@
-summary: Create a new index for a data stream.
+summary: Stack request
 method_request: POST my-data-stream/_rollover
 # description: ''
 # type: request

--- a/specification/indices/rollover/examples/request/indicesRolloverRequestExample1.yaml
+++ b/specification/indices/rollover/examples/request/indicesRolloverRequestExample1.yaml
@@ -1,6 +1,6 @@
 summary: Stack request
 method_request: POST my-data-stream/_rollover
-# description: ''
+description: 'Create a new index for a data stream'
 # type: request
 value: "{
 

--- a/specification/indices/rollover/examples/request/indicesRolloverRequestExample2.yaml
+++ b/specification/indices/rollover/examples/request/indicesRolloverRequestExample2.yaml
@@ -1,2 +1,4 @@
 summary: Serverless request
 method_request: POST my-data-stream/_rollover
+description: 'Create a new index for a data stream'
+value: '{}'

--- a/specification/indices/rollover/examples/request/indicesRolloverRequestExample2.yaml
+++ b/specification/indices/rollover/examples/request/indicesRolloverRequestExample2.yaml
@@ -1,0 +1,2 @@
+summary: Serverless request
+method_request: POST my-data-stream/_rollover


### PR DESCRIPTION
Linked to https://github.com/elastic/docs-content/issues/2385
Added an example for Serverless request without `conditions` object since Serverless doesn't support conditions.