### PR TITLE
[8.18] [Transform] Upgrade Mode (#5165)

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -22025,6 +22025,13 @@ export interface TransformScheduleNowTransformRequest extends RequestBase {
 
 export type TransformScheduleNowTransformResponse = AcknowledgedResponseBase
 
+export interface TransformSetUpgradeModeRequest extends RequestBase {
+  enabled?: boolean
+  timeout?: Duration
+}
+
+export type TransformSetUpgradeModeResponse = AcknowledgedResponseBase
+
 export interface TransformStartTransformRequest extends RequestBase {
   transform_id: Id
   timeout?: Duration

--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -863,6 +863,7 @@ terminate-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{bra
 test-grok-pattern,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/test-grok-pattern.html,,
 time-value,https://github.com/elastic/elasticsearch/blob/{branch}/libs/core/src/main/java/org/elasticsearch/core/TimeValue.java,,
 time-zone-id,https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html,,
+transform-set-upgrade-mode,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-set-upgrade-mode,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/transform-set-upgrade-mode.html,
 trim-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/trim-processor.html,,
 unfreeze-index-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/unfreeze-index-api.html,,
 update-dfanalytics,https://www.elastic.co/docs/api/doc/elasticsearch/v8/operation/operation-ml-update-data-frame-analytics,,

--- a/specification/transform/set_upgrade_mode/TransformSetUpgradeModeRequest.ts
+++ b/specification/transform/set_upgrade_mode/TransformSetUpgradeModeRequest.ts
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Duration } from '@_types/Time'
+
+/**
+ * Set upgrade_mode for transform indices.
+ * Sets a cluster wide upgrade_mode setting that prepares transform
+ * indices for an upgrade.
+ * When upgrading your cluster, in some circumstances you must restart your
+ * nodes and reindex your transform indices. In those circumstances,
+ * there must be no transforms running. You can close the transforms,
+ * do the upgrade, then open all the transforms again. Alternatively,
+ * you can use this API to temporarily halt tasks associated with the transforms
+ * and prevent new transforms from opening. You can also use this API
+ * during upgrades that do not require you to reindex your transform
+ * indices, though stopping transforms is not a requirement in that case.
+ * You can see the current value for the upgrade_mode setting by using the get
+ * transform info API.
+ * @rest_spec_name transform.set_upgrade_mode
+ * @availability stack since=8.18.0 stability=stable
+ * @availability serverless stability=stable visibility=private
+ * @cluster_privileges manage_transform
+ * @doc_id transform-set-upgrade-mode
+ */
+export interface Request extends RequestBase {
+  urls: [
+    {
+      path: '/_transform/set_upgrade_mode'
+      methods: ['POST']
+    }
+  ]
+  query_parameters: {
+    /**
+     * When `true`, it enables `upgrade_mode` which temporarily halts all
+     * transform tasks and prohibits new transform tasks from
+     * starting.
+     * @server_default false
+     */
+    enabled?: boolean
+    /**
+     * The time to wait for the request to be completed.
+     * @server_default 30s
+     */
+    timeout?: Duration
+  }
+}

--- a/specification/transform/set_upgrade_mode/TransformSetUpgradeModeResponse.ts
+++ b/specification/transform/set_upgrade_mode/TransformSetUpgradeModeResponse.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AcknowledgedResponseBase } from '@_types/Base'
+
+export class Response {
+  /** @codegen_name result */
+  body: AcknowledgedResponseBase
+}

--- a/specification/transform/set_upgrade_mode/examples/request/TransformSetUpgradeModeExample1.yaml
+++ b/specification/transform/set_upgrade_mode/examples/request/TransformSetUpgradeModeExample1.yaml
@@ -1,0 +1,1 @@
+method_request: POST _transform/set_upgrade_mode?enabled=true


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [[Transform] Upgrade Mode (#5165)](https://github.com/elastic/elasticsearch-specification/pull/5165)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)