### PR TITLE
Fixes API examples

### DIFF
--- a/specification/indices/put_template/examples/request/indicesPutTemplateRequestExample1.yaml
+++ b/specification/indices/put_template/examples/request/indicesPutTemplateRequestExample1.yaml
@@ -11,9 +11,9 @@ value:
   mappings:
     _source:
       enabled: false
-  properties:
-    host_name:
-      type: keyword
-    created_at:
-      type: date
-      format: 'EEE MMM dd HH:mm:ss Z yyyy'
+    properties:
+     host_name:
+       type: keyword
+     created_at:
+       type: date
+       format: 'EEE MMM dd HH:mm:ss Z yyyy'

--- a/specification/indices/reload_search_analyzers/examples/request/ReloadSearchAnalyzersRequestExample1.yaml
+++ b/specification/indices/reload_search_analyzers/examples/request/ReloadSearchAnalyzersRequestExample1.yaml
@@ -1,15 +1,1 @@
-# summary:
 method_request: POST /my-index-000001/_reload_search_analyzers
-# description: ''
-# type: request
-value:
-  _shards:
-    total: 2
-    successful: 2
-    failed: 0
-  reload_details:
-    - index: my-index-000001
-      reloaded_analyzers:
-        - my_synonyms
-      reloaded_node_ids:
-        - mfdqTXn_T7SGr2Ho2KT8uw

--- a/specification/indices/reload_search_analyzers/examples/response/ReloadSearchAnalyzersResponseExample1.yaml
+++ b/specification/indices/reload_search_analyzers/examples/response/ReloadSearchAnalyzersResponseExample1.yaml
@@ -1,7 +1,7 @@
-summary: Create a template
-method_request: PUT _component_template/template_1
-# description:
-# type: request
+# summary:
+description: A successful response when reloading a search analyzer of an index.
+# type: response
+# response_code: 200
 value:
   template:
    settings:


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/elasticsearch-specification/issues/3966

This PR fixes API request examples that don't work due to indentation problems in the yaml files containing the examples.