### PR TITLE
Sets 'separators' and 'separators_group' parameters to optional and updates descriptions

### DIFF
--- a/specification/_types/mapping/ChunkingSettings.ts
+++ b/specification/_types/mapping/ChunkingSettings.ts
@@ -24,9 +24,9 @@ import { OverloadOf } from '@spec_utils/behaviors'
 export class ChunkingSettings implements OverloadOf<InferenceChunkingSettings> {
   strategy: string
 
-  separator_group: string
+  separator_group?: string
 
-  separators: string[]
+  separators?: string[]
 
   max_chunk_size: integer
 

--- a/specification/inference/_types/Services.ts
+++ b/specification/inference/_types/Services.ts
@@ -345,7 +345,7 @@ export class InferenceChunkingSettings {
   separator_group?: string
   /**
    * Only applicable to the `recursive` strategy and required when using it.
-   * 
+   *
    * A list of strings used as possible split points when chunking text.
    *
    * Each string can be a plain string or a regular expression (regex) pattern.

--- a/specification/inference/_types/Services.ts
+++ b/specification/inference/_types/Services.ts
@@ -335,16 +335,18 @@ export class InferenceChunkingSettings {
    */
   sentence_overlap?: integer
   /**
-   * This parameter is only applicable when using the `recursive` chunking strategy.
+   * Only applicable to the `recursive` strategy and required when using it.
    *
    * Sets a predefined list of separators in the saved chunking settings based on the selected text type.
    * Values can be `markdown` or `plaintext`.
    *
    * Using this parameter is an alternative to manually specifying a custom `separators` list.
    */
-  separator_group: string
+  separator_group?: string
   /**
-   * A list of strings used as possible split points when chunking text with the `recursive` strategy.
+   * Only applicable to the `recursive` strategy and required when using it.
+   * 
+   * A list of strings used as possible split points when chunking text.
    *
    * Each string can be a plain string or a regular expression (regex) pattern.
    * The system tries each separator in order to split the text, starting from the first item in the list.
@@ -352,7 +354,7 @@ export class InferenceChunkingSettings {
    * After splitting, it attempts to recombine smaller pieces into larger chunks that stay within
    * the `max_chunk_size` limit, to reduce the total number of chunks generated.
    */
-  separators: string[]
+  separators?: string[]
   /**
    * The chunking strategy: `sentence`, `word`, `none` or `recursive`.
    *


### PR DESCRIPTION
This PR updates the `InferenceChunkingSettings` type by making the `separator_group` and `separators` fields optional.
These fields are only applicable to the `recursive` strategy and required when using it.
Updated the field descriptions to clarify their usage.