### PR TITLE
[9.0] Enforce doc_id tag on public APIs (#5198)

### DIFF
--- a/compiler/src/model/utils.ts
+++ b/compiler/src/model/utils.ts
@@ -724,6 +724,11 @@ export function hoistRequestAnnotations (
       assert(jsDocs, false, `Unhandled tag: '${tag}' with value: '${value}' on request ${request.name.name}`)
     }
   })
+
+  if (endpoint.availability.stack?.visibility !== 'private') {
+    assert(jsDocs, tags.doc_id !== '' && tags.doc_id !== null && tags.doc_id !== undefined,
+      `Request ${request.name.name} needs a @doc_id annotation`)
+  }
 }
 
 /** Lifts jsDoc type annotations to fixed properties on Type */

--- a/compiler/test/body-codegen-name/specification/_global/index/request.ts
+++ b/compiler/test/body-codegen-name/specification/_global/index/request.ts
@@ -20,6 +20,7 @@
 /**
  * @rest_spec_name index
  * @availability stack since=0.0.0 stability=stable
+ * @doc_id docs-index
  */
 export interface Request {
   body: Foo

--- a/compiler/test/duplicate-body-codegen-name/specification/_global/index/request.ts
+++ b/compiler/test/duplicate-body-codegen-name/specification/_global/index/request.ts
@@ -20,6 +20,7 @@
 /**
  * @rest_spec_name index
  * @availability stack since=0.0.0 stability=stable
+ * @doc_id docs-index
  */
 export interface Request {
   path_parts: {

--- a/compiler/test/no-body/specification/_global/info/request.ts
+++ b/compiler/test/no-body/specification/_global/info/request.ts
@@ -20,6 +20,7 @@
 /**
  * @rest_spec_name info
  * @availability stack since=0.0.0 stability=stable
+ * @doc_id api-root
  */
 export interface Request {
   body: {

--- a/compiler/test/no-doc-id/specification/_global/info/request.ts
+++ b/compiler/test/no-doc-id/specification/_global/info/request.ts
@@ -19,30 +19,10 @@
 
 /**
  * @rest_spec_name index
- * @availability stack stability=stable since=0.0.0
- * @doc_id docs-index
+ * @availability stack since=0.0.0 stability=stable
  */
-export interface Request<TDocument> {
-  path_parts: {
-    id?: string
-    index: string
-  }
-  query_parameters: {
-    if_primary_term?: number
-    if_seq_no?: number
-    op_type?: string
-    pipeline?: string
-    refresh?: string
-    routing?: string
-    timeout?: string
-    version?: number
-    version_type?: string
-    wait_for_active_shards?: string
-    require_alias?: boolean
-  }
-  /** @codegen_name document */
-  body?: TDocument
-  headers: {
-    'content-type': string
+export interface Request {
+  body: {
+    foo: string
   }
 }

--- a/compiler/test/no-doc-id/specification/tsconfig.json
+++ b/compiler/test/no-doc-id/specification/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../../specification/tsconfig.json",
+  "typeRoots": ["./**/*.ts"],
+  "include": ["./**/*.ts"]
+}

--- a/compiler/test/no-doc-id/test.ts
+++ b/compiler/test/no-doc-id/test.ts
@@ -17,32 +17,16 @@
  * under the License.
  */
 
-/**
- * @rest_spec_name index
- * @availability stack stability=stable since=0.0.0
- * @doc_id docs-index
- */
-export interface Request<TDocument> {
-  path_parts: {
-    id?: string
-    index: string
-  }
-  query_parameters: {
-    if_primary_term?: number
-    if_seq_no?: number
-    op_type?: string
-    pipeline?: string
-    refresh?: string
-    routing?: string
-    timeout?: string
-    version?: number
-    version_type?: string
-    wait_for_active_shards?: string
-    require_alias?: boolean
-  }
-  /** @codegen_name document */
-  body?: TDocument
-  headers: {
-    'content-type': string
-  }
-}
+import { join } from 'path'
+import test from 'ava'
+import Compiler from '../../src/compiler'
+import * as Model from '../../src/model/metamodel'
+
+const specsFolder = join(__dirname, 'specification')
+const outputFolder = join(__dirname, 'output')
+
+test("Body cannot be defined if the API methods don't allow it", t => {
+  const compiler = new Compiler(specsFolder, outputFolder)
+  const error = t.throws(() => compiler.generateModel())
+  t.is(error?.message, "Request Request needs a @doc_id annotation")
+})

--- a/compiler/test/request-availability/specification/_global/index/request.ts
+++ b/compiler/test/request-availability/specification/_global/index/request.ts
@@ -21,6 +21,7 @@
  * @rest_spec_name index
  * @availability serverless visibility=private stability=experimental
  * @availability stack stability=beta since=1.2.3 visibility=feature_flag feature_flag=abc
+ * @doc_id docs-index
  */
 export interface Request<TDocument> {
   path_parts: {

--- a/compiler/test/types/specification/_global/info/request.ts
+++ b/compiler/test/types/specification/_global/info/request.ts
@@ -20,5 +20,6 @@
 /**
  * @rest_spec_name info
  * @availability stack since=0.0.0 stability=stable
+ * @doc_id api-root
  */
 export interface Request {}

--- a/compiler/test/types/test.ts
+++ b/compiler/test/types/test.ts
@@ -92,7 +92,7 @@ test('type_alias', t => {
 test('request', t => {
   const definition = model.types.find(t => t.kind === 'request') as Model.Request
   t.assert(definition)
-  t.true(definition?.specLocation.endsWith('test/types/specification/_global/info/request.ts#L20-L24'))
+  t.true(definition?.specLocation.endsWith('test/types/specification/_global/info/request.ts#L20-L25'))
   t.deepEqual(definition?.name, {
     name: 'Request',
     namespace: '_global.info'

--- a/compiler/test/writes-to-output/specification/_global/index/request.ts
+++ b/compiler/test/writes-to-output/specification/_global/index/request.ts
@@ -20,5 +20,6 @@
 /**
  * @rest_spec_name index
  * @availability stack since=0.0.0 stability=stable
+ * @doc_id docs-index
  */
 export interface Request {}

--- a/compiler/test/wrong-namespace/specification/_global/foobar/request.ts
+++ b/compiler/test/wrong-namespace/specification/_global/foobar/request.ts
@@ -20,5 +20,6 @@
 /**
  * @rest_spec_name info
  * @availability stack since=0.0.0 stability=stable
+ * @doc_id api-root
  */
 export interface Request {}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.0`:
 - [Enforce doc_id tag on public APIs (#5198)](https://github.com/elastic/elasticsearch-specification/pull/5198)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)