### PR TITLE
Revert "max_score and _score are required (and can be null)"

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1480,7 +1480,7 @@ export type SearchHighlighterType = 'plain' | 'fvh' | 'unified'| string
 export interface SearchHit<TDocument = unknown> {
   _index: IndexName
   _id?: Id
-  _score: double | null
+  _score?: double | null
   _explanation?: ExplainExplanation
   fields?: Record<string, any>
   highlight?: Record<string, string[]>
@@ -1503,7 +1503,7 @@ export interface SearchHit<TDocument = unknown> {
 export interface SearchHitsMetadata<T = unknown> {
   total?: SearchTotalHits | long
   hits: SearchHit<T>[]
-  max_score: double | null
+  max_score?: double | null
 }
 
 export interface SearchInnerHits {

--- a/specification/_global/search/_types/hits.ts
+++ b/specification/_global/search/_types/hits.ts
@@ -44,7 +44,7 @@ export class Hit<TDocument> {
    * on a search request. Otherwise the field is always present on hits.
    */
   _id?: Id
-  _score: double | null
+  _score?: double | null
   _explanation?: Explanation
   fields?: Dictionary<string, UserDefinedValue>
   highlight?: Dictionary<string, string[]>
@@ -69,7 +69,7 @@ export class HitsMetadata<T> {
   total?: TotalHits | long
   hits: Hit<T>[]
 
-  max_score: double | null
+  max_score?: double | null
 }
 
 export class HitMetadata<TDocument> {


### PR DESCRIPTION
Reverts elastic/elasticsearch-specification#1144

I spent hours getting Kibana type checking to work with this change, but it's just too much work:

 * There are thousands of tests that use mock search responses, they all need to be changed to `_score`, `max_score` or both.
 * Some code is taking advantage of the fact that the get response and search hits have the same required fields.
 * Some Kibana types are extending the search hits.

Since making those types required offers little benefit, let's revert the change.