### PR TITLE
Adds description for the 'frequency' parameter in responses

### DIFF
--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -43,6 +43,9 @@ export class Datafeed {
   authorization?: DatafeedAuthorization
   chunking_config?: ChunkingConfig
   datafeed_id: Id
+  /**
+   * The interval at which scheduled queries are made while the datafeed runs in real time. The default value is either the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket span. For example: `150s`. When `frequency` is shorter than the bucket span, interim results for the last (partial) bucket are written then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value must be divisible by the interval of the date histogram aggregation.
+   */
   frequency?: Duration
   indices: string[]
   indexes?: string[]

--- a/specification/ml/update_datafeed/MlUpdateDatafeedResponse.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedResponse.ts
@@ -35,6 +35,9 @@ export class Response {
     chunking_config: ChunkingConfig
     delayed_data_check_config?: DelayedDataCheckConfig
     datafeed_id: Id
+    /**
+    * The interval at which scheduled queries are made while the datafeed runs in real time. The default value is either the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket span. For example: `150s`. When `frequency` is shorter than the bucket span, interim results for the last (partial) bucket are written then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value must be divisible by the interval of the date histogram aggregation.
+    */
     frequency?: Duration
     indices: string[]
     indices_options?: IndicesOptions

--- a/specification/ml/update_datafeed/MlUpdateDatafeedResponse.ts
+++ b/specification/ml/update_datafeed/MlUpdateDatafeedResponse.ts
@@ -36,8 +36,8 @@ export class Response {
     delayed_data_check_config?: DelayedDataCheckConfig
     datafeed_id: Id
     /**
-    * The interval at which scheduled queries are made while the datafeed runs in real time. The default value is either the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket span. For example: `150s`. When `frequency` is shorter than the bucket span, interim results for the last (partial) bucket are written then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value must be divisible by the interval of the date histogram aggregation.
-    */
+     * The interval at which scheduled queries are made while the datafeed runs in real time. The default value is either the bucket span for short bucket spans, or, for longer bucket spans, a sensible fraction of the bucket span. For example: `150s`. When `frequency` is shorter than the bucket span, interim results for the last (partial) bucket are written then eventually overwritten by the full bucket results. If the datafeed uses aggregations, this value must be divisible by the interval of the date histogram aggregation.
+     */
     frequency?: Duration
     indices: string[]
     indices_options?: IndicesOptions


### PR DESCRIPTION
As per [this issue](https://github.com/elastic/docs-content/issues/1463), the descriptions for the `frequency` parameter were missing from the ML anomaly detection APIs.

[This issue](https://github.com/elastic/elasticsearch-specification/issues/4473) fixed the parameter descriptions in the request bodies, but the response descriptions were still missing.

After discussing with @l-trotta, we decided to add them manually. This PR adds the missing descriptions for the following API responses:

- Create an anomaly detection job
- Preview a datafeed
- Update an anomaly detection job
- Update a datafeed


