### PR TITLE
Fix optional bodies

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -10997,6 +10997,15 @@
             "style": "form"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/indices._types.IndexTemplate"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -13502,6 +13502,7 @@ export interface IndicesSimulateIndexTemplateRequest extends RequestBase {
   cause?: string
   master_timeout?: Duration
   include_defaults?: boolean
+  body?: IndicesIndexTemplate
 }
 
 export interface IndicesSimulateIndexTemplateResponse {

--- a/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
+++ b/specification/_global/mtermvectors/MultiTermVectorsRequest.ts
@@ -121,7 +121,7 @@ export interface Request extends RequestBase {
      */
     version_type?: VersionType
   }
-  body: {
+  body?: {
     /**
      * An array of existing or artificial documents.
      */

--- a/specification/_global/search_mvt/SearchMvtRequest.ts
+++ b/specification/_global/search_mvt/SearchMvtRequest.ts
@@ -221,7 +221,7 @@ export interface Request extends RequestBase {
      */
     with_labels?: boolean
   }
-  body: {
+  body?: {
     /**
      * Sub-aggregations for the geotile_grid.
      *

--- a/specification/_global/termvectors/TermVectorsRequest.ts
+++ b/specification/_global/termvectors/TermVectorsRequest.ts
@@ -167,7 +167,7 @@ export interface Request<TDocument> extends RequestBase {
      */
     version_type?: VersionType
   }
-  body: {
+  body?: {
     /**
      * An artificial document (a document not present in the index) for which you want to retrieve term vectors.
      */

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -158,7 +158,7 @@ export interface Request extends RequestBase {
     from?: integer
     sort?: string | string[]
   }
-  body: {
+  body?: {
     /** @aliases aggs */
     aggregations?: Dictionary<string, AggregationContainer>
     collapse?: FieldCollapse

--- a/specification/ccr/resume_follow/ResumeFollowIndexRequest.ts
+++ b/specification/ccr/resume_follow/ResumeFollowIndexRequest.ts
@@ -50,7 +50,7 @@ export interface Request extends RequestBase {
      */
     master_timeout?: Duration
   }
-  body: {
+  body?: {
     max_outstanding_read_requests?: long
     max_outstanding_write_requests?: long
     max_read_request_operation_count?: long

--- a/specification/ilm/migrate_to_data_tiers/Request.ts
+++ b/specification/ilm/migrate_to_data_tiers/Request.ts
@@ -62,7 +62,7 @@ export interface Request extends RequestBase {
      */
     master_timeout?: Duration
   }
-  body: {
+  body?: {
     legacy_template_to_delete?: string
     node_attribute?: string
   }

--- a/specification/indices/create_from/MigrateCreateFromRequest.ts
+++ b/specification/indices/create_from/MigrateCreateFromRequest.ts
@@ -40,7 +40,7 @@ export interface Request extends RequestBase {
     dest: IndexName
   }
   /** @codegen_name create_from */
-  body: CreateFrom
+  body?: CreateFrom
 }
 
 export class CreateFrom {

--- a/specification/indices/put_alias/IndicesPutAliasRequest.ts
+++ b/specification/indices/put_alias/IndicesPutAliasRequest.ts
@@ -70,7 +70,7 @@ export interface Request extends RequestBase {
      */
     timeout?: Duration
   }
-  body: {
+  body?: {
     /**
      * Query used to limit documents the alias can access.
      */

--- a/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
+++ b/specification/indices/simulate_index_template/IndicesSimulateIndexTemplateRequest.ts
@@ -20,6 +20,7 @@
 import { RequestBase } from '@_types/Base'
 import { Name } from '@_types/common'
 import { Duration } from '@_types/Time'
+import { IndexTemplate } from '@indices/_types/IndexTemplate'
 
 /**
  * Simulate an index.
@@ -64,4 +65,6 @@ export interface Request extends RequestBase {
      */
     include_defaults?: boolean
   }
+  /** @codegen_name index_template */
+  body?: IndexTemplate
 }

--- a/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
+++ b/specification/indices/simulate_template/IndicesSimulateTemplateRequest.ts
@@ -74,7 +74,7 @@ export interface Request extends RequestBase {
      */
     include_defaults?: boolean
   }
-  body: {
+  body?: {
     /**
      * This setting overrides the value of the `action.auto_create_index` cluster setting.
      * If set to `true` in a template, then indices can be automatically created using that template even if auto-creation of indices is disabled via `actions.auto_create_index`.

--- a/specification/ml/close_job/MlCloseJobRequest.ts
+++ b/specification/ml/close_job/MlCloseJobRequest.ts
@@ -66,7 +66,7 @@ export interface Request extends RequestBase {
      * @server_default 30m */
     timeout?: Duration
   }
-  body: {
+  body?: {
     /**
      * Refer to the description for the `allow_no_match` query parameter.
      * @server_default true

--- a/specification/ml/explain_data_frame_analytics/MlExplainDataFrameAnalyticsRequest.ts
+++ b/specification/ml/explain_data_frame_analytics/MlExplainDataFrameAnalyticsRequest.ts
@@ -62,7 +62,7 @@ export interface Request extends RequestBase {
      */
     id?: Id
   }
-  body: {
+  body?: {
     /**
      * The configuration of how to source the analysis data. It requires an
      * index. Optionally, query and _source may be specified.

--- a/specification/ml/forecast/MlForecastJobRequest.ts
+++ b/specification/ml/forecast/MlForecastJobRequest.ts
@@ -75,7 +75,7 @@ export interface Request extends RequestBase {
      */
     max_model_memory?: string
   }
-  body: {
+  body?: {
     /**
      * Refer to the description for the `duration` query parameter.
      * @server_default 1d

--- a/specification/ml/open_job/MlOpenJobRequest.ts
+++ b/specification/ml/open_job/MlOpenJobRequest.ts
@@ -57,7 +57,7 @@ export interface Request extends RequestBase {
      */
     timeout?: Duration
   }
-  body: {
+  body?: {
     /**
      * Refer to the description for the `timeout` query parameter.
      * @server_default 30m

--- a/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsRequest.ts
+++ b/specification/ml/preview_data_frame_analytics/MlPreviewDataFrameAnalyticsRequest.ts
@@ -48,7 +48,7 @@ export interface Request extends RequestBase {
      */
     id?: Id
   }
-  body: {
+  body?: {
     /**
      * A data frame analytics config as described in create data frame analytics
      * jobs. Note that `id` and `dest` don’t need to be provided in the context of

--- a/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
+++ b/specification/ml/preview_datafeed/MlPreviewDatafeedRequest.ts
@@ -65,7 +65,7 @@ export interface Request extends RequestBase {
     start?: DateTime
     end?: DateTime
   }
-  body: {
+  body?: {
     /**
      * The datafeed definition to preview.
      */

--- a/specification/ml/put_calendar/MlPutCalendarRequest.ts
+++ b/specification/ml/put_calendar/MlPutCalendarRequest.ts
@@ -40,7 +40,7 @@ export interface Request extends RequestBase {
     /** A string that uniquely identifies a calendar. */
     calendar_id: Id
   }
-  body: {
+  body?: {
     /**
      * An array of anomaly detection job identifiers.
      */

--- a/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
+++ b/specification/ml/start_trained_model_deployment/MlStartTrainedModelDeploymentRequest.ts
@@ -100,7 +100,7 @@ export interface Request extends RequestBase {
      */
     wait_for?: DeploymentAllocationState
   }
-  body: {
+  body?: {
     /**
      * Adaptive allocations configuration. When enabled, the number of allocations
      * is set based on the current load.

--- a/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
+++ b/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
@@ -69,7 +69,7 @@ export interface Request extends RequestBase {
      *  @server_default 20s */
     timeout?: Duration
   }
-  body: {
+  body?: {
     /**
      * Refer to the description for the `allow_no_match` query parameter.
      * @server_default true */

--- a/specification/ml/update_trained_model_deployment/MlUpdateTrainedModelDeploymentRequest.ts
+++ b/specification/ml/update_trained_model_deployment/MlUpdateTrainedModelDeploymentRequest.ts
@@ -56,7 +56,7 @@ export interface Request extends RequestBase {
      */
     number_of_allocations?: integer
   }
-  body: {
+  body?: {
     /**
      * The number of model allocations on each node where the model is deployed.
      * All allocations on a node share the same copy of the model in memory but use

--- a/specification/nodes/reload_secure_settings/ReloadSecureSettingsRequest.ts
+++ b/specification/nodes/reload_secure_settings/ReloadSecureSettingsRequest.ts
@@ -61,7 +61,7 @@ export interface Request extends RequestBase {
      */
     timeout?: Duration
   }
-  body: {
+  body?: {
     /**
      * The password for the Elasticsearch keystore.
      */

--- a/specification/search_application/render_query/SearchApplicationsRenderQueryRequest.ts
+++ b/specification/search_application/render_query/SearchApplicationsRenderQueryRequest.ts
@@ -48,7 +48,7 @@ export interface Request extends RequestBase {
   /**
    * Contains parameters for a search application.
    */
-  body: {
+  body?: {
     params?: Dictionary<string, UserDefinedValue>
   }
 }

--- a/specification/search_application/search/SearchApplicationsSearchRequest.ts
+++ b/specification/search_application/search/SearchApplicationsSearchRequest.ts
@@ -52,7 +52,7 @@ export interface Request extends RequestBase {
      */
     typed_keys?: boolean
   }
-  body: {
+  body?: {
     /**
      * Query parameters specific to this request, which will override any defaults specified in the template.
      */

--- a/specification/security/query_api_keys/QueryApiKeysRequest.ts
+++ b/specification/security/query_api_keys/QueryApiKeysRequest.ts
@@ -72,7 +72,7 @@ export interface Request extends RequestBase {
      */
     typed_keys?: boolean
   }
-  body: {
+  body?: {
     /**
      * Any aggregations to run over the corpus of returned API keys.
      * Aggregations and queries work together. Aggregations are computed only on the API keys that match the query.

--- a/specification/security/query_role/QueryRolesRequest.ts
+++ b/specification/security/query_role/QueryRolesRequest.ts
@@ -43,7 +43,7 @@ export interface Request extends RequestBase {
       methods: ['GET', 'POST']
     }
   ]
-  body: {
+  body?: {
     /**
      * A query to filter which roles to return.
      * If the query parameter is missing, it is equivalent to a `match_all` query.

--- a/specification/security/query_user/SecurityQueryUserRequest.ts
+++ b/specification/security/query_user/SecurityQueryUserRequest.ts
@@ -43,7 +43,7 @@ export interface Request extends RequestBase {
       methods: ['GET', 'POST']
     }
   ]
-  body: {
+  body?: {
     /**
      * A query to filter which users to return.
      * If the query parameter is missing, it is equivalent to a `match_all` query.

--- a/specification/security/suggest_user_profiles/Request.ts
+++ b/specification/security/suggest_user_profiles/Request.ts
@@ -52,7 +52,7 @@ export interface Request extends RequestBase {
      */
     data?: string | string[]
   }
-  body: {
+  body?: {
     /**
      * A query string used to match name-related fields in user profile documents.
      * Name-related fields are the user's `username`, `full_name`, and `email`.

--- a/specification/security/update_api_key/Request.ts
+++ b/specification/security/update_api_key/Request.ts
@@ -63,7 +63,7 @@ export interface Request extends RequestBase {
      */
     id: Id
   }
-  body: {
+  body?: {
     /**
      * The role descriptors to assign to this API key.
      * The API key's effective permissions are an intersection of its assigned privileges and the point in time snapshot of permissions of the owner user.

--- a/specification/snapshot/create/SnapshotCreateRequest.ts
+++ b/specification/snapshot/create/SnapshotCreateRequest.ts
@@ -64,7 +64,7 @@ export interface Request extends RequestBase {
      */
     wait_for_completion?: boolean
   }
-  body: {
+  body?: {
     /**
      * Determines how wildcard patterns in the `indices` parameter match data streams and indices.
      * It supports comma-separated values such as `open,hidden`.

--- a/specification/snapshot/restore/SnapshotRestoreRequest.ts
+++ b/specification/snapshot/restore/SnapshotRestoreRequest.ts
@@ -83,7 +83,7 @@ export interface Request extends RequestBase {
      */
     wait_for_completion?: boolean
   }
-  body: {
+  body?: {
     /**
      * The feature states to restore.
      * If `include_global_state` is `true`, the request restores all feature states in the snapshot by default.

--- a/specification/transform/preview_transform/PreviewTransformRequest.ts
+++ b/specification/transform/preview_transform/PreviewTransformRequest.ts
@@ -70,7 +70,7 @@ export interface Request extends RequestBase {
      */
     timeout?: Duration
   }
-  body: {
+  body?: {
     /**
      * The destination for the transform.
      */

--- a/specification/watcher/execute_watch/WatcherExecuteWatchRequest.ts
+++ b/specification/watcher/execute_watch/WatcherExecuteWatchRequest.ts
@@ -71,7 +71,7 @@ export interface Request extends RequestBase {
      */
     debug?: boolean
   }
-  body: {
+  body?: {
     /**
      * Determines how to handle the watch actions as part of the watch execution.
      */

--- a/specification/watcher/query_watches/WatcherQueryWatchesRequest.ts
+++ b/specification/watcher/query_watches/WatcherQueryWatchesRequest.ts
@@ -39,7 +39,7 @@ export interface Request extends RequestBase {
       methods: ['GET', 'POST']
     }
   ]
-  body: {
+  body?: {
     /**
      * The offset from the first result to fetch.
      * It must be non-negative.


### PR DESCRIPTION
Many bodies were correctly set as optional in the rest-api-spec, but incorrectly set as required in the Elasticsearch specification. There are three errors in rest-api-spec too. When I fix them, I can commit the compiler change that allowed me to see this.