### PR TITLE
Update get-license default for ?local

### DIFF
--- a/specification/license/get/GetLicenseRequest.ts
+++ b/specification/license/get/GetLicenseRequest.ts
@@ -50,7 +50,7 @@ export interface Request extends RequestBase {
     /**
      * Specifies whether to retrieve local information.
      * From 9.2 onwards the default value is `true`, which means the information is retrieved from the responding node.
-     * In earlier versions the default is `false`.
+     * In earlier versions the default is `false`, which means the information is retrieved from the elected master node.
      * @server_default true
      */
     local?: boolean


### PR DESCRIPTION
The default for the `?local` parameter to the `GET _license` API changed
from `false` to `true` in elastic/elasticsearch#134457. This commit
adjusts the documentation to match.