### PR TITLE
Marks job_type in anomaly job config as a private parameter

### DIFF
--- a/specification/ml/_types/Job.ts
+++ b/specification/ml/_types/Job.ts
@@ -242,7 +242,8 @@ export class JobConfig {
   job_id?: Id
   /**
    * Reserved for future use, currently set to `anomaly_detector`.
-   * @availability visibility=private
+   * @availability stack visibility=private
+   * @availability serverless visibility=private
    */
   job_type?: string
   /**


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/docs-content/issues/2914

This PR adds `visibility=private` to the `job_type` in `JobConfig` for both Stack and Serverless. It will hide the `job_type` parameter in requests for anomaly detection APIs, as this is an internal-only parameter, and the request will fail if it is set.

I tested the changes, and they work. This is from the staging site with the changes:

<img width="1237" height="394" alt="Screenshot 2025-09-15 at 15 14 39" src="https://github.com/user-attachments/assets/f0c21856-89aa-4da1-9436-e55a64657d6a" />

This is the production site currently:

<img width="989" height="411" alt="Screenshot 2025-09-15 at 15 22 33" src="https://github.com/user-attachments/assets/60268687-e022-4e6a-8851-388087912181" />

