### PR TITLE
Add common cat API parameters for unit rendering

### DIFF
--- a/specification/_spec_utils/behaviors.ts
+++ b/specification/_spec_utils/behaviors.ts
@@ -97,6 +97,28 @@ export interface CommonCatQueryParameters {
    * @server_default false
    */
   v?: boolean
+  /**
+   * Sets the units for columns that contain a byte-size value.
+   * Note that byte-size value units work in terms of powers of 1024. For instance `1kb` means 1024 bytes, not 1000 bytes.
+   * If omitted, byte-size values are rendered with a suffix such as `kb`, `mb`, or `gb`, chosen such that the numeric value of the column is as small as possible whilst still being at least `1.0`.
+   * If given, byte-size values are rendered as an integer with no suffix, representing the value of the column in the chosen unit.
+   * Values that are not an exact multiple of the chosen unit are rounded down.
+   */
+  bytes?: 'b' | 'kb' | 'mb' | 'gb' | 'tb' | 'pb'
+  /**
+   * Sets the units for columns that contain a size value which is not a byte-size value.
+   * If omitted, size values are rendered with a suffix such as `k`, `m`, or `g`, chosen such that the numeric value of the column is as small as possible whilst still being at least `1.0`.
+   * If given, size values are rendered as an integer with no suffix, representing the value of the column in the chosen unit.
+   * Values that are not an exact multiple of the chosen unit are rounded down.
+   */
+  size?: '' | 'k' | 'm' | 'g' | 't' | 'p'
+  /**
+   * Sets the units for columns that contain a time duration.
+   * If omitted, time duration values are rendered with a suffix such as `ms`, `s`, `m` or `h`, chosen such that the numeric value of the column is as small as possible whilst still being at least `1.0`.
+   * If given, time duration values are rendered as an integer with no suffix.
+   * Values that are not an exact multiple of the chosen unit are rounded down.
+   */
+  time?: 'nanos' | 'micros' | 'ms' | 's' | 'm' | 'h' | 'd'
 }
 
 /**


### PR DESCRIPTION
Describes the `?bytes=`, `?size=` and `?time=` parameters which are
accepted by all the `GET _cat/...` APIs.