### PR TITLE
Add common cat API parameters for unit rendering

### DIFF
--- a/specification/_spec_utils/behaviors.ts
+++ b/specification/_spec_utils/behaviors.ts
@@ -97,6 +97,28 @@ export interface CommonCatQueryParameters {
    * @server_default false
    */
   v?: boolean
+  /**
+   * Sets the units for columns that contain a byte-size value.
+   * Note that byte-size value units work in terms of powers of 1024. For instance `1kb` means 1024 bytes, not 1000 bytes.
+   * If omitted, byte-size values are rendered with a suffix such as `kb`, `mb`, or `gb`, chosen such that the numeric value of the column is as small as possible whilst still being at least `1.0`.
+   * If given, byte-size values are rendered as an integer with no suffix, representing the value of the column in the chosen unit.
+   * Values that are not an exact multiple of the chosen unit are rounded down.
+   */
+  bytes?: Bytes
+  /**
+   * Sets the units for columns that contain a size value which is not a byte-size value.
+   * If omitted, size values are rendered with a suffix such as `k`, `m`, or `g`, chosen such that the numeric value of the column is as small as possible whilst still being at least `1.0`.
+   * If given, size values are rendered as an integer with no suffix, representing the value of the column in the chosen unit.
+   * Values that are not an exact multiple of the chosen unit are rounded down.
+   */
+  size?: '' | 'k' | 'm' | 'g' | 't' | 'p'
+  /**
+   * Sets the units for columns that contain a time duration.
+   * If omitted, time duration values are rendered with a suffix such as `ms`, `s`, `m` or `h`, chosen such that the numeric value of the column is as small as possible whilst still being at least `1.0`.
+   * If given, time duration values are rendered as an integer with no suffix.
+   * Values that are not an exact multiple of the chosen unit are rounded down.
+   */
+  time?: TimeUnit
 }
 
 /**

--- a/specification/cat/allocation/CatAllocationRequest.ts
+++ b/specification/cat/allocation/CatAllocationRequest.ts
@@ -49,8 +49,6 @@ export interface Request extends CatRequestBase {
     node_id?: NodeIds
   }
   query_parameters: {
-    /** The unit used to display byte values. */
-    bytes?: Bytes
     /**
      * A comma-separated list of columns names to display. It supports simple wildcards.
      */

--- a/specification/cat/fielddata/CatFielddataRequest.ts
+++ b/specification/cat/fielddata/CatFielddataRequest.ts
@@ -52,8 +52,6 @@ export interface Request extends CatRequestBase {
     fields?: Fields
   }
   query_parameters: {
-    /** The unit used to display byte values. */
-    bytes?: Bytes
     /** Comma-separated list of fields used to limit returned information. */
     fields?: Fields
     /**

--- a/specification/cat/health/CatHealthRequest.ts
+++ b/specification/cat/health/CatHealthRequest.ts
@@ -48,10 +48,6 @@ export interface Request extends CatRequestBase {
   ]
   query_parameters: {
     /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
-    /**
      * If true, returns `HH:MM:SS` and Unix epoch timestamps.
      * @server_default true
      */

--- a/specification/cat/indices/CatIndicesRequest.ts
+++ b/specification/cat/indices/CatIndicesRequest.ts
@@ -70,8 +70,6 @@ export interface Request extends CatRequestBase {
     index?: Indices
   }
   query_parameters: {
-    /** The unit used to display byte values. */
-    bytes?: Bytes
     /**
      * The type of index that wildcard patterns can match.
      */
@@ -88,8 +86,6 @@ export interface Request extends CatRequestBase {
      * @server_default false
      */
     pri?: boolean
-    /** The unit used to display time values. */
-    time?: TimeUnit
     /**
      * Period to wait for a connection to the master node.
      * @server_default 30s

--- a/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
+++ b/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
@@ -52,7 +52,6 @@ export interface Request extends CatRequestBase {
   }
   query_parameters: {
     allow_no_match?: boolean
-    bytes?: Bytes
     /**
      * Comma-separated list of column names to display.
      * @server_default create_time,id,state,type
@@ -62,9 +61,5 @@ export interface Request extends CatRequestBase {
      * response.
      */
     s?: CatDfaColumns
-    /**
-     * Unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -77,9 +77,5 @@ export interface Request extends CatRequestBase {
     h?: CatDatafeedColumns
     /** Comma-separated list of column names or column aliases used to sort the response. */
     s?: CatDatafeedColumns
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -71,19 +71,11 @@ export interface Request extends CatRequestBase {
      */
     allow_no_match?: boolean
     /**
-     * The unit used to display byte values.
-     */
-    bytes?: Bytes
-    /**
      * Comma-separated list of column names to display.
      * @server_default buckets.count,data.processed_records,forecasts.total,id,model.bytes,model.memory_status,state
      */
     h?: CatAnomalyDetectorColumns
     /** Comma-separated list of column names or column aliases used to sort the response. */
     s?: CatAnomalyDetectorColumns
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
+++ b/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
@@ -62,8 +62,6 @@ export interface Request extends CatRequestBase {
      * @server_default true
      */
     allow_no_match?: boolean
-    /** The unit used to display byte values. */
-    bytes?: Bytes
     /** A comma-separated list of column names to display. */
     h?: CatTrainedModelsColumns
     /** A comma-separated list of column names or aliases used to sort the response. */
@@ -72,9 +70,5 @@ export interface Request extends CatRequestBase {
     from?: integer
     /** The maximum number of transforms to display. */
     size?: integer
-    /**
-     * Unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/nodes/CatNodesRequest.ts
+++ b/specification/cat/nodes/CatNodesRequest.ts
@@ -41,10 +41,6 @@ export interface Request extends CatRequestBase {
   ]
   query_parameters: {
     /**
-     * The unit used to display byte values.
-     */
-    bytes?: Bytes
-    /**
      * If `true`, return the full node ID. If `false`, return the shortened node ID.
      * @server_default false
      */
@@ -71,9 +67,5 @@ export interface Request extends CatRequestBase {
      * @server_default 30s
      */
     master_timeout?: Duration
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/pending_tasks/CatPendingTasksRequest.ts
+++ b/specification/cat/pending_tasks/CatPendingTasksRequest.ts
@@ -63,9 +63,5 @@ export interface Request extends CatRequestBase {
      * @server_default 30s
      */
     master_timeout?: Duration
-    /**
-     * Unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/recovery/CatRecoveryRequest.ts
+++ b/specification/cat/recovery/CatRecoveryRequest.ts
@@ -60,10 +60,6 @@ export interface Request extends CatRequestBase {
      */
     active_only?: boolean
     /**
-     * The unit used to display byte values.
-     */
-    bytes?: Bytes
-    /**
      * If `true`, the response includes detailed information about shard recoveries.
      * @server_default false
      */
@@ -84,9 +80,5 @@ export interface Request extends CatRequestBase {
      * or `:desc` as a suffix to the column name.
      */
     s?: Names
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/segments/CatSegmentsRequest.ts
+++ b/specification/cat/segments/CatSegmentsRequest.ts
@@ -55,10 +55,6 @@ export interface Request extends CatRequestBase {
   }
   query_parameters: {
     /**
-     * The unit used to display byte values.
-     */
-    bytes?: Bytes
-    /**
      * A comma-separated list of columns names to display.
      * It supports simple wildcards.
      * @server_default ip,hp,rp,r,m,n,cpu,l

--- a/specification/cat/shards/CatShardsRequest.ts
+++ b/specification/cat/shards/CatShardsRequest.ts
@@ -55,10 +55,6 @@ export interface Request extends CatRequestBase {
   }
   query_parameters: {
     /**
-     * The unit used to display byte values.
-     */
-    bytes?: Bytes
-    /**
      * List of columns to appear in the response. Supports simple wildcards.
      */
     h?: CatShardColumns
@@ -73,9 +69,5 @@ export interface Request extends CatRequestBase {
      * @server_default 30s
      */
     master_timeout?: Duration
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/snapshots/CatSnapshotsRequest.ts
+++ b/specification/cat/snapshots/CatSnapshotsRequest.ts
@@ -76,9 +76,5 @@ export interface Request extends CatRequestBase {
      * @server_default 30s
      */
     master_timeout?: Duration
-    /**
-     * Unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/tasks/CatTasksRequest.ts
+++ b/specification/cat/tasks/CatTasksRequest.ts
@@ -64,10 +64,6 @@ export interface Request extends CatRequestBase {
      */
     s?: Names
     /**
-     * Unit used to display time values.
-     */
-    time?: TimeUnit
-    /**
      * Period to wait for a response.
      * If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s

--- a/specification/cat/thread_pool/CatThreadPoolRequest.ts
+++ b/specification/cat/thread_pool/CatThreadPoolRequest.ts
@@ -63,10 +63,6 @@ export interface Request extends CatRequestBase {
      */
     s?: Names
     /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
-    /**
      * If `true`, the request computes the list of selected nodes from the
      * local cluster state. If `false` the list of selected nodes are computed
      * from the cluster state of the master node. In both cases the coordinating

--- a/specification/cat/transforms/CatTransformsRequest.ts
+++ b/specification/cat/transforms/CatTransformsRequest.ts
@@ -77,10 +77,6 @@ export interface Request extends CatRequestBase {
      */
     s?: CatTransformColumns
     /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
-    /**
      * The maximum number of transforms to obtain.
      * @server_default 100
      */

--- a/specification/shutdown/delete_node/ShutdownDeleteNodeRequest.ts
+++ b/specification/shutdown/delete_node/ShutdownDeleteNodeRequest.ts
@@ -51,11 +51,11 @@ export interface Request extends RequestBase {
      * Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
-    master_timeout?: TimeUnit
+    master_timeout?: Duration
     /**
      * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
-    timeout?: TimeUnit
+    timeout?: Duration
   }
 }

--- a/specification/shutdown/get_node/ShutdownGetNodeRequest.ts
+++ b/specification/shutdown/get_node/ShutdownGetNodeRequest.ts
@@ -54,6 +54,6 @@ export interface Request extends RequestBase {
      * Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
-    master_timeout?: TimeUnit
+    master_timeout?: Duration
   }
 }

--- a/specification/shutdown/put_node/ShutdownPutNodeRequest.ts
+++ b/specification/shutdown/put_node/ShutdownPutNodeRequest.ts
@@ -66,13 +66,13 @@ export interface Request extends RequestBase {
      * If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
-    master_timeout?: TimeUnit
+    master_timeout?: Duration
     /**
      * The period to wait for a response.
      * If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
-    timeout?: TimeUnit
+    timeout?: Duration
   }
   body: {
     /**


### PR DESCRIPTION
Describes the `?bytes=`, `?size=` and `?time=` parameters which are
accepted by all the `GET _cat/...` APIs.