### PR TITLE
[8.19] Add common cat API parameters for unit rendering

### DIFF
--- a/output/openapi/elasticsearch-serverless-openapi.json
+++ b/output/openapi/elasticsearch-serverless-openapi.json
@@ -1017,9 +1017,6 @@
         "operationId": "cat-indices",
         "parameters": [
           {
-            "$ref": "#/components/parameters/cat.indices-bytes"
-          },
-          {
             "$ref": "#/components/parameters/cat.indices-expand_wildcards"
           },
           {
@@ -1030,9 +1027,6 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices-pri"
-          },
-          {
-            "$ref": "#/components/parameters/cat.indices-time"
           },
           {
             "$ref": "#/components/parameters/cat.indices-master_timeout"
@@ -1071,9 +1065,6 @@
             "$ref": "#/components/parameters/cat.indices-index"
           },
           {
-            "$ref": "#/components/parameters/cat.indices-bytes"
-          },
-          {
             "$ref": "#/components/parameters/cat.indices-expand_wildcards"
           },
           {
@@ -1084,9 +1075,6 @@
           },
           {
             "$ref": "#/components/parameters/cat.indices-pri"
-          },
-          {
-            "$ref": "#/components/parameters/cat.indices-time"
           },
           {
             "$ref": "#/components/parameters/cat.indices-master_timeout"
@@ -1125,16 +1113,10 @@
             "$ref": "#/components/parameters/cat.ml_data_frame_analytics-allow_no_match"
           },
           {
-            "$ref": "#/components/parameters/cat.ml_data_frame_analytics-bytes"
-          },
-          {
             "$ref": "#/components/parameters/cat.ml_data_frame_analytics-h"
           },
           {
             "$ref": "#/components/parameters/cat.ml_data_frame_analytics-s"
-          },
-          {
-            "$ref": "#/components/parameters/cat.ml_data_frame_analytics-time"
           }
         ],
         "responses": {
@@ -1167,16 +1149,10 @@
             "$ref": "#/components/parameters/cat.ml_data_frame_analytics-allow_no_match"
           },
           {
-            "$ref": "#/components/parameters/cat.ml_data_frame_analytics-bytes"
-          },
-          {
             "$ref": "#/components/parameters/cat.ml_data_frame_analytics-h"
           },
           {
             "$ref": "#/components/parameters/cat.ml_data_frame_analytics-s"
-          },
-          {
-            "$ref": "#/components/parameters/cat.ml_data_frame_analytics-time"
           }
         ],
         "responses": {
@@ -1210,9 +1186,6 @@
           },
           {
             "$ref": "#/components/parameters/cat.ml_datafeeds-s"
-          },
-          {
-            "$ref": "#/components/parameters/cat.ml_datafeeds-time"
           }
         ],
         "responses": {
@@ -1249,9 +1222,6 @@
           },
           {
             "$ref": "#/components/parameters/cat.ml_datafeeds-s"
-          },
-          {
-            "$ref": "#/components/parameters/cat.ml_datafeeds-time"
           }
         ],
         "responses": {
@@ -1281,16 +1251,10 @@
             "$ref": "#/components/parameters/cat.ml_jobs-allow_no_match"
           },
           {
-            "$ref": "#/components/parameters/cat.ml_jobs-bytes"
-          },
-          {
             "$ref": "#/components/parameters/cat.ml_jobs-h"
           },
           {
             "$ref": "#/components/parameters/cat.ml_jobs-s"
-          },
-          {
-            "$ref": "#/components/parameters/cat.ml_jobs-time"
           }
         ],
         "responses": {
@@ -1323,16 +1287,10 @@
             "$ref": "#/components/parameters/cat.ml_jobs-allow_no_match"
           },
           {
-            "$ref": "#/components/parameters/cat.ml_jobs-bytes"
-          },
-          {
             "$ref": "#/components/parameters/cat.ml_jobs-h"
           },
           {
             "$ref": "#/components/parameters/cat.ml_jobs-s"
-          },
-          {
-            "$ref": "#/components/parameters/cat.ml_jobs-time"
           }
         ],
         "responses": {
@@ -1362,9 +1320,6 @@
             "$ref": "#/components/parameters/cat.ml_trained_models-allow_no_match"
           },
           {
-            "$ref": "#/components/parameters/cat.ml_trained_models-bytes"
-          },
-          {
             "$ref": "#/components/parameters/cat.ml_trained_models-h"
           },
           {
@@ -1375,9 +1330,6 @@
           },
           {
             "$ref": "#/components/parameters/cat.ml_trained_models-size"
-          },
-          {
-            "$ref": "#/components/parameters/cat.ml_trained_models-time"
           }
         ],
         "responses": {
@@ -1410,9 +1362,6 @@
             "$ref": "#/components/parameters/cat.ml_trained_models-allow_no_match"
           },
           {
-            "$ref": "#/components/parameters/cat.ml_trained_models-bytes"
-          },
-          {
             "$ref": "#/components/parameters/cat.ml_trained_models-h"
           },
           {
@@ -1423,9 +1372,6 @@
           },
           {
             "$ref": "#/components/parameters/cat.ml_trained_models-size"
-          },
-          {
-            "$ref": "#/components/parameters/cat.ml_trained_models-time"
           }
         ],
         "responses": {
@@ -1462,9 +1408,6 @@
           },
           {
             "$ref": "#/components/parameters/cat.transforms-s"
-          },
-          {
-            "$ref": "#/components/parameters/cat.transforms-time"
           },
           {
             "$ref": "#/components/parameters/cat.transforms-size"
@@ -1507,9 +1450,6 @@
           },
           {
             "$ref": "#/components/parameters/cat.transforms-s"
-          },
-          {
-            "$ref": "#/components/parameters/cat.transforms-time"
           },
           {
             "$ref": "#/components/parameters/cat.transforms-size"
@@ -45596,17 +45536,6 @@
         "description": "Time of day, expressed as HH:MM:SS",
         "type": "string"
       },
-      "_types.Bytes": {
-        "type": "string",
-        "enum": [
-          "b",
-          "kb",
-          "mb",
-          "gb",
-          "tb",
-          "pb"
-        ]
-      },
       "_types.HealthStatus": {
         "type": "string",
         "enum": [
@@ -45618,18 +45547,6 @@
           "RED",
           "unknown",
           "unavailable"
-        ]
-      },
-      "_types.TimeUnit": {
-        "type": "string",
-        "enum": [
-          "nanos",
-          "micros",
-          "ms",
-          "s",
-          "m",
-          "h",
-          "d"
         ]
       },
       "cat.indices.IndicesRecord": {
@@ -80848,16 +80765,6 @@
         },
         "style": "simple"
       },
-      "cat.indices-bytes": {
-        "in": "query",
-        "name": "bytes",
-        "description": "The unit used to display byte values.",
-        "deprecated": false,
-        "schema": {
-          "$ref": "#/components/schemas/_types.Bytes"
-        },
-        "style": "form"
-      },
       "cat.indices-expand_wildcards": {
         "in": "query",
         "name": "expand_wildcards",
@@ -80895,16 +80802,6 @@
         "deprecated": false,
         "schema": {
           "type": "boolean"
-        },
-        "style": "form"
-      },
-      "cat.indices-time": {
-        "in": "query",
-        "name": "time",
-        "description": "The unit used to display time values.",
-        "deprecated": false,
-        "schema": {
-          "$ref": "#/components/schemas/_types.TimeUnit"
         },
         "style": "form"
       },
@@ -80959,16 +80856,6 @@
         },
         "style": "form"
       },
-      "cat.ml_data_frame_analytics-bytes": {
-        "in": "query",
-        "name": "bytes",
-        "description": "The unit in which to display byte values",
-        "deprecated": false,
-        "schema": {
-          "$ref": "#/components/schemas/_types.Bytes"
-        },
-        "style": "form"
-      },
       "cat.ml_data_frame_analytics-h": {
         "in": "query",
         "name": "h",
@@ -80986,16 +80873,6 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/cat._types.CatDfaColumns"
-        },
-        "style": "form"
-      },
-      "cat.ml_data_frame_analytics-time": {
-        "in": "query",
-        "name": "time",
-        "description": "Unit used to display time values.",
-        "deprecated": false,
-        "schema": {
-          "$ref": "#/components/schemas/_types.TimeUnit"
         },
         "style": "form"
       },
@@ -81040,16 +80917,6 @@
         },
         "style": "form"
       },
-      "cat.ml_datafeeds-time": {
-        "in": "query",
-        "name": "time",
-        "description": "The unit used to display time values.",
-        "deprecated": false,
-        "schema": {
-          "$ref": "#/components/schemas/_types.TimeUnit"
-        },
-        "style": "form"
-      },
       "cat.ml_jobs-job_id": {
         "in": "path",
         "name": "job_id",
@@ -81068,16 +80935,6 @@
         "deprecated": false,
         "schema": {
           "type": "boolean"
-        },
-        "style": "form"
-      },
-      "cat.ml_jobs-bytes": {
-        "in": "query",
-        "name": "bytes",
-        "description": "The unit used to display byte values.",
-        "deprecated": false,
-        "schema": {
-          "$ref": "#/components/schemas/_types.Bytes"
         },
         "style": "form"
       },
@@ -81101,16 +80958,6 @@
         },
         "style": "form"
       },
-      "cat.ml_jobs-time": {
-        "in": "query",
-        "name": "time",
-        "description": "The unit used to display time values.",
-        "deprecated": false,
-        "schema": {
-          "$ref": "#/components/schemas/_types.TimeUnit"
-        },
-        "style": "form"
-      },
       "cat.ml_trained_models-model_id": {
         "in": "path",
         "name": "model_id",
@@ -81129,16 +80976,6 @@
         "deprecated": false,
         "schema": {
           "type": "boolean"
-        },
-        "style": "form"
-      },
-      "cat.ml_trained_models-bytes": {
-        "in": "query",
-        "name": "bytes",
-        "description": "The unit used to display byte values.",
-        "deprecated": false,
-        "schema": {
-          "$ref": "#/components/schemas/_types.Bytes"
         },
         "style": "form"
       },
@@ -81179,16 +81016,6 @@
         "deprecated": false,
         "schema": {
           "type": "number"
-        },
-        "style": "form"
-      },
-      "cat.ml_trained_models-time": {
-        "in": "query",
-        "name": "time",
-        "description": "Unit used to display time values.",
-        "deprecated": false,
-        "schema": {
-          "$ref": "#/components/schemas/_types.TimeUnit"
         },
         "style": "form"
       },
@@ -81240,16 +81067,6 @@
         "deprecated": false,
         "schema": {
           "$ref": "#/components/schemas/cat._types.CatTransformColumns"
-        },
-        "style": "form"
-      },
-      "cat.transforms-time": {
-        "in": "query",
-        "name": "time",
-        "description": "The unit used to display time values.",
-        "deprecated": false,
-        "schema": {
-          "$ref": "#/components/schemas/_types.TimeUnit"
         },
         "style": "form"
       },

--- a/output/schema/validation-errors.json
+++ b/output/schema/validation-errors.json
@@ -1,5 +1,122 @@
 {
-  "endpointErrors": {},
+  "endpointErrors": {
+    "cat.aliases": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec",
+        "Request: query parameter 'time' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.allocation": {
+      "request": [
+        "Request: query parameter 'time' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.component_templates": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec",
+        "Request: query parameter 'time' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.count": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec",
+        "Request: query parameter 'time' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.fielddata": {
+      "request": [
+        "Request: query parameter 'time' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.health": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.master": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec",
+        "Request: query parameter 'time' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.ml_datafeeds": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.nodeattrs": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec",
+        "Request: query parameter 'time' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.pending_tasks": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.plugins": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec",
+        "Request: query parameter 'time' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.repositories": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec",
+        "Request: query parameter 'time' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.segments": {
+      "request": [
+        "Request: query parameter 'time' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.snapshots": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.tasks": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.templates": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec",
+        "Request: query parameter 'time' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.thread_pool": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec"
+      ],
+      "response": []
+    },
+    "cat.transforms": {
+      "request": [
+        "Request: query parameter 'bytes' does not exist in the json spec"
+      ],
+      "response": []
+    }
+  },
   "generalErrors": [
     "Dangling type '_global.scripts_painless_execute:PainlessExecutionPosition'",
     "Dangling type '_global.scripts_painless_execute:PainlessScript'",

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -7317,7 +7317,6 @@ export interface CatAllocationAllocationRecord {
 
 export interface CatAllocationRequest extends CatCatRequestBase {
   node_id?: NodeIds
-  bytes?: Bytes
   h?: CatCatAllocationColumns
   s?: Names
   local?: boolean
@@ -7382,7 +7381,6 @@ export interface CatFielddataFielddataRecord {
 
 export interface CatFielddataRequest extends CatCatRequestBase {
   fields?: Fields
-  bytes?: Bytes
   h?: CatCatFieldDataColumns
   s?: Names
 }
@@ -7443,7 +7441,6 @@ export interface CatHealthHealthRecord {
 }
 
 export interface CatHealthRequest extends CatCatRequestBase {
-  time?: TimeUnit
   ts?: boolean
   h?: Names
   s?: Names
@@ -7750,12 +7747,10 @@ export interface CatIndicesIndicesRecord {
 
 export interface CatIndicesRequest extends CatCatRequestBase {
   index?: Indices
-  bytes?: Bytes
   expand_wildcards?: ExpandWildcards
   health?: HealthStatus
   include_unloaded_segments?: boolean
   pri?: boolean
-  time?: TimeUnit
   master_timeout?: Duration
   h?: Names
   s?: Names
@@ -7828,10 +7823,8 @@ export interface CatMlDataFrameAnalyticsDataFrameAnalyticsRecord {
 export interface CatMlDataFrameAnalyticsRequest extends CatCatRequestBase {
   id?: Id
   allow_no_match?: boolean
-  bytes?: Bytes
   h?: CatCatDfaColumns
   s?: CatCatDfaColumns
-  time?: TimeUnit
 }
 
 export type CatMlDataFrameAnalyticsResponse = CatMlDataFrameAnalyticsDataFrameAnalyticsRecord[]
@@ -7876,7 +7869,6 @@ export interface CatMlDatafeedsRequest extends CatCatRequestBase {
   allow_no_match?: boolean
   h?: CatCatDatafeedColumns
   s?: CatCatDatafeedColumns
-  time?: TimeUnit
 }
 
 export type CatMlDatafeedsResponse = CatMlDatafeedsDatafeedsRecord[]
@@ -8061,10 +8053,8 @@ export interface CatMlJobsJobsRecord {
 export interface CatMlJobsRequest extends CatCatRequestBase {
   job_id?: Id
   allow_no_match?: boolean
-  bytes?: Bytes
   h?: CatCatAnomalyDetectorColumns
   s?: CatCatAnomalyDetectorColumns
-  time?: TimeUnit
 }
 
 export type CatMlJobsResponse = CatMlJobsJobsRecord[]
@@ -8072,12 +8062,10 @@ export type CatMlJobsResponse = CatMlJobsJobsRecord[]
 export interface CatMlTrainedModelsRequest extends CatCatRequestBase {
   model_id?: Id
   allow_no_match?: boolean
-  bytes?: Bytes
   h?: CatCatTrainedModelsColumns
   s?: CatCatTrainedModelsColumns
   from?: integer
   size?: integer
-  time?: TimeUnit
 }
 
 export type CatMlTrainedModelsResponse = CatMlTrainedModelsTrainedModelsRecord[]
@@ -8424,13 +8412,11 @@ export interface CatNodesNodesRecord {
 }
 
 export interface CatNodesRequest extends CatCatRequestBase {
-  bytes?: Bytes
   full_id?: boolean | string
   include_unloaded_segments?: boolean
   h?: CatCatNodeColumns
   s?: Names
   master_timeout?: Duration
-  time?: TimeUnit
 }
 
 export type CatNodesResponse = CatNodesNodesRecord[]
@@ -8451,7 +8437,6 @@ export interface CatPendingTasksRequest extends CatCatRequestBase {
   s?: Names
   local?: boolean
   master_timeout?: Duration
-  time?: TimeUnit
 }
 
 export type CatPendingTasksResponse = CatPendingTasksPendingTasksRecord[]
@@ -8541,11 +8526,9 @@ export interface CatRecoveryRecoveryRecord {
 export interface CatRecoveryRequest extends CatCatRequestBase {
   index?: Indices
   active_only?: boolean
-  bytes?: Bytes
   detailed?: boolean
   h?: CatCatRecoveryColumns
   s?: Names
-  time?: TimeUnit
 }
 
 export type CatRecoveryResponse = CatRecoveryRecoveryRecord[]
@@ -8568,7 +8551,6 @@ export type CatRepositoriesResponse = CatRepositoriesRepositoriesRecord[]
 
 export interface CatSegmentsRequest extends CatCatRequestBase {
   index?: Indices
-  bytes?: Bytes
   h?: CatCatSegmentsColumns
   s?: Names
   local?: boolean
@@ -8621,11 +8603,9 @@ export interface CatSegmentsSegmentsRecord {
 
 export interface CatShardsRequest extends CatCatRequestBase {
   index?: Indices
-  bytes?: Bytes
   h?: CatCatShardColumns
   s?: Names
   master_timeout?: Duration
-  time?: TimeUnit
 }
 
 export type CatShardsResponse = CatShardsShardsRecord[]
@@ -8851,7 +8831,6 @@ export interface CatSnapshotsRequest extends CatCatRequestBase {
   h?: CatCatSnapshotsColumns
   s?: Names
   master_timeout?: Duration
-  time?: TimeUnit
 }
 
 export type CatSnapshotsResponse = CatSnapshotsSnapshotsRecord[]
@@ -8897,7 +8876,6 @@ export interface CatTasksRequest extends CatCatRequestBase {
   parent_task_id?: string
   h?: Names
   s?: Names
-  time?: TimeUnit
   timeout?: Duration
   wait_for_completion?: boolean
 }
@@ -8967,7 +8945,6 @@ export interface CatThreadPoolRequest extends CatCatRequestBase {
   thread_pool_patterns?: Names
   h?: CatCatThreadPoolColumns
   s?: Names
-  time?: TimeUnit
   local?: boolean
   master_timeout?: Duration
 }
@@ -9023,7 +9000,6 @@ export interface CatTransformsRequest extends CatCatRequestBase {
   from?: integer
   h?: CatCatTransformColumns
   s?: CatCatTransformColumns
-  time?: TimeUnit
   size?: integer
 }
 
@@ -20838,8 +20814,8 @@ export type ShutdownType = 'restart' | 'remove' | 'replace'
 
 export interface ShutdownDeleteNodeRequest extends RequestBase {
   node_id: NodeId
-  master_timeout?: TimeUnit
-  timeout?: TimeUnit
+  master_timeout?: Duration
+  timeout?: Duration
 }
 
 export type ShutdownDeleteNodeResponse = AcknowledgedResponseBase
@@ -20865,7 +20841,7 @@ export interface ShutdownGetNodePluginsStatus {
 
 export interface ShutdownGetNodeRequest extends RequestBase {
   node_id?: NodeIds
-  master_timeout?: TimeUnit
+  master_timeout?: Duration
 }
 
 export interface ShutdownGetNodeResponse {
@@ -20882,8 +20858,8 @@ export type ShutdownGetNodeShutdownType = 'remove' | 'restart'
 
 export interface ShutdownPutNodeRequest extends RequestBase {
   node_id: NodeId
-  master_timeout?: TimeUnit
-  timeout?: TimeUnit
+  master_timeout?: Duration
+  timeout?: Duration
   body?: {
     type: ShutdownType
     reason: string
@@ -23583,5 +23559,7 @@ export interface SpecUtilsCommonCatQueryParameters {
   format?: string
   help?: boolean
   v?: boolean
+  bytes?: Bytes
+  time?: TimeUnit
 }
 

--- a/specification/_spec_utils/behaviors.ts
+++ b/specification/_spec_utils/behaviors.ts
@@ -17,6 +17,9 @@
  * under the License.
  */
 
+import { Bytes } from '@_types/common'
+import { TimeUnit } from '@_types/Time'
+
 /**
  * In some places in the specification an object consists of the union of a set of known properties
  * and a set of runtime injected properties. Meaning that object should theoretically extend Dictionary but expose
@@ -97,6 +100,21 @@ export interface CommonCatQueryParameters {
    * @server_default false
    */
   v?: boolean
+  /**
+   * Sets the units for columns that contain a byte-size value.
+   * Note that byte-size value units work in terms of powers of 1024. For instance `1kb` means 1024 bytes, not 1000 bytes.
+   * If omitted, byte-size values are rendered with a suffix such as `kb`, `mb`, or `gb`, chosen such that the numeric value of the column is as small as possible whilst still being at least `1.0`.
+   * If given, byte-size values are rendered as an integer with no suffix, representing the value of the column in the chosen unit.
+   * Values that are not an exact multiple of the chosen unit are rounded down.
+   */
+  bytes?: Bytes
+  /**
+   * Sets the units for columns that contain a time duration.
+   * If omitted, time duration values are rendered with a suffix such as `ms`, `s`, `m` or `h`, chosen such that the numeric value of the column is as small as possible whilst still being at least `1.0`.
+   * If given, time duration values are rendered as an integer with no suffix.
+   * Values that are not an exact multiple of the chosen unit are rounded down.
+   */
+  time?: TimeUnit
 }
 
 /**

--- a/specification/cat/allocation/CatAllocationRequest.ts
+++ b/specification/cat/allocation/CatAllocationRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Bytes, Names, NodeIds } from '@_types/common'
+import { Names, NodeIds } from '@_types/common'
 import { Duration } from '@_types/Time'
 import { CatAllocationColumns, CatRequestBase } from '@cat/_types/CatBase'
 
@@ -49,8 +49,6 @@ export interface Request extends CatRequestBase {
     node_id?: NodeIds
   }
   query_parameters: {
-    /** The unit used to display byte values. */
-    bytes?: Bytes
     /**
      * A comma-separated list of columns names to display. It supports simple wildcards.
      */

--- a/specification/cat/fielddata/CatFielddataRequest.ts
+++ b/specification/cat/fielddata/CatFielddataRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Bytes, Fields, Names } from '@_types/common'
+import { Fields, Names } from '@_types/common'
 import { CatFieldDataColumns, CatRequestBase } from '@cat/_types/CatBase'
 
 /**
@@ -52,8 +52,6 @@ export interface Request extends CatRequestBase {
     fields?: Fields
   }
   query_parameters: {
-    /** The unit used to display byte values. */
-    bytes?: Bytes
     /** Comma-separated list of fields used to limit returned information. */
     fields?: Fields
     /**

--- a/specification/cat/health/CatHealthRequest.ts
+++ b/specification/cat/health/CatHealthRequest.ts
@@ -18,7 +18,6 @@
  */
 
 import { Names } from '@_types/common'
-import { TimeUnit } from '@_types/Time'
 import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
@@ -47,10 +46,6 @@ export interface Request extends CatRequestBase {
     }
   ]
   query_parameters: {
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
     /**
      * If true, returns `HH:MM:SS` and Unix epoch timestamps.
      * @server_default true

--- a/specification/cat/indices/CatIndicesRequest.ts
+++ b/specification/cat/indices/CatIndicesRequest.ts
@@ -17,14 +17,8 @@
  * under the License.
  */
 
-import {
-  Bytes,
-  ExpandWildcards,
-  HealthStatus,
-  Indices,
-  Names
-} from '@_types/common'
-import { Duration, TimeUnit } from '@_types/Time'
+import { ExpandWildcards, HealthStatus, Indices, Names } from '@_types/common'
+import { Duration } from '@_types/Time'
 import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
@@ -70,8 +64,6 @@ export interface Request extends CatRequestBase {
     index?: Indices
   }
   query_parameters: {
-    /** The unit used to display byte values. */
-    bytes?: Bytes
     /**
      * The type of index that wildcard patterns can match.
      */
@@ -88,8 +80,6 @@ export interface Request extends CatRequestBase {
      * @server_default false
      */
     pri?: boolean
-    /** The unit used to display time values. */
-    time?: TimeUnit
     /**
      * Period to wait for a connection to the master node.
      * @server_default 30s

--- a/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
+++ b/specification/cat/ml_data_frame_analytics/CatDataFrameAnalyticsRequest.ts
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-import { Bytes, Id } from '@_types/common'
-import { TimeUnit } from '@_types/Time'
+import { Id } from '@_types/common'
 import { CatDfaColumns, CatRequestBase } from '@cat/_types/CatBase'
 
 /**
@@ -52,7 +51,6 @@ export interface Request extends CatRequestBase {
   }
   query_parameters: {
     allow_no_match?: boolean
-    bytes?: Bytes
     /**
      * Comma-separated list of column names to display.
      * @server_default create_time,id,state,type
@@ -62,9 +60,5 @@ export interface Request extends CatRequestBase {
      * response.
      */
     s?: CatDfaColumns
-    /**
-     * Unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
+++ b/specification/cat/ml_datafeeds/CatDatafeedsRequest.ts
@@ -18,7 +18,6 @@
  */
 
 import { Id } from '@_types/common'
-import { TimeUnit } from '@_types/Time'
 import { CatDatafeedColumns, CatRequestBase } from '@cat/_types/CatBase'
 
 /**
@@ -77,9 +76,5 @@ export interface Request extends CatRequestBase {
     h?: CatDatafeedColumns
     /** Comma-separated list of column names or column aliases used to sort the response. */
     s?: CatDatafeedColumns
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/ml_jobs/CatJobsRequest.ts
+++ b/specification/cat/ml_jobs/CatJobsRequest.ts
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-import { Bytes, Id } from '@_types/common'
-import { TimeUnit } from '@_types/Time'
+import { Id } from '@_types/common'
 import { CatAnomalyDetectorColumns, CatRequestBase } from '@cat/_types/CatBase'
 
 /**
@@ -71,19 +70,11 @@ export interface Request extends CatRequestBase {
      */
     allow_no_match?: boolean
     /**
-     * The unit used to display byte values.
-     */
-    bytes?: Bytes
-    /**
      * Comma-separated list of column names to display.
      * @server_default buckets.count,data.processed_records,forecasts.total,id,model.bytes,model.memory_status,state
      */
     h?: CatAnomalyDetectorColumns
     /** Comma-separated list of column names or column aliases used to sort the response. */
     s?: CatAnomalyDetectorColumns
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
+++ b/specification/cat/ml_trained_models/CatTrainedModelsRequest.ts
@@ -17,9 +17,8 @@
  * under the License.
  */
 
-import { Bytes, Id } from '@_types/common'
+import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
-import { TimeUnit } from '@_types/Time'
 import { CatRequestBase, CatTrainedModelsColumns } from '@cat/_types/CatBase'
 
 /**
@@ -62,8 +61,6 @@ export interface Request extends CatRequestBase {
      * @server_default true
      */
     allow_no_match?: boolean
-    /** The unit used to display byte values. */
-    bytes?: Bytes
     /** A comma-separated list of column names to display. */
     h?: CatTrainedModelsColumns
     /** A comma-separated list of column names or aliases used to sort the response. */
@@ -72,9 +69,5 @@ export interface Request extends CatRequestBase {
     from?: integer
     /** The maximum number of transforms to display. */
     size?: integer
-    /**
-     * Unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/nodes/CatNodesRequest.ts
+++ b/specification/cat/nodes/CatNodesRequest.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { Bytes, Names } from '@_types/common'
-import { Duration, TimeUnit } from '@_types/Time'
+import { Names } from '@_types/common'
+import { Duration } from '@_types/Time'
 import { CatNodeColumns, CatRequestBase } from '@cat/_types/CatBase'
 
 /**
@@ -40,10 +40,6 @@ export interface Request extends CatRequestBase {
     }
   ]
   query_parameters: {
-    /**
-     * The unit used to display byte values.
-     */
-    bytes?: Bytes
     /**
      * If `true`, return the full node ID. If `false`, return the shortened node ID.
      * @server_default false
@@ -71,9 +67,5 @@ export interface Request extends CatRequestBase {
      * @server_default 30s
      */
     master_timeout?: Duration
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/pending_tasks/CatPendingTasksRequest.ts
+++ b/specification/cat/pending_tasks/CatPendingTasksRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { Names } from '@_types/common'
-import { Duration, TimeUnit } from '@_types/Time'
+import { Duration } from '@_types/Time'
 import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
@@ -63,9 +63,5 @@ export interface Request extends CatRequestBase {
      * @server_default 30s
      */
     master_timeout?: Duration
-    /**
-     * Unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/recovery/CatRecoveryRequest.ts
+++ b/specification/cat/recovery/CatRecoveryRequest.ts
@@ -17,8 +17,7 @@
  * under the License.
  */
 
-import { Bytes, Indices, Names } from '@_types/common'
-import { TimeUnit } from '@_types/Time'
+import { Indices, Names } from '@_types/common'
 import { CatRecoveryColumns, CatRequestBase } from '@cat/_types/CatBase'
 
 /**
@@ -60,10 +59,6 @@ export interface Request extends CatRequestBase {
      */
     active_only?: boolean
     /**
-     * The unit used to display byte values.
-     */
-    bytes?: Bytes
-    /**
      * If `true`, the response includes detailed information about shard recoveries.
      * @server_default false
      */
@@ -84,9 +79,5 @@ export interface Request extends CatRequestBase {
      * or `:desc` as a suffix to the column name.
      */
     s?: Names
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/segments/CatSegmentsRequest.ts
+++ b/specification/cat/segments/CatSegmentsRequest.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Bytes, Indices, Names } from '@_types/common'
+import { Indices, Names } from '@_types/common'
 import { Duration } from '@_types/Time'
 import { CatRequestBase, CatSegmentsColumns } from '@cat/_types/CatBase'
 
@@ -54,10 +54,6 @@ export interface Request extends CatRequestBase {
     index?: Indices
   }
   query_parameters: {
-    /**
-     * The unit used to display byte values.
-     */
-    bytes?: Bytes
     /**
      * A comma-separated list of columns names to display.
      * It supports simple wildcards.

--- a/specification/cat/shards/CatShardsRequest.ts
+++ b/specification/cat/shards/CatShardsRequest.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { Bytes, Indices, Names } from '@_types/common'
-import { Duration, TimeUnit } from '@_types/Time'
+import { Indices, Names } from '@_types/common'
+import { Duration } from '@_types/Time'
 import { CatRequestBase, CatShardColumns } from '@cat/_types/CatBase'
 
 /**
@@ -55,10 +55,6 @@ export interface Request extends CatRequestBase {
   }
   query_parameters: {
     /**
-     * The unit used to display byte values.
-     */
-    bytes?: Bytes
-    /**
      * List of columns to appear in the response. Supports simple wildcards.
      */
     h?: CatShardColumns
@@ -73,9 +69,5 @@ export interface Request extends CatRequestBase {
      * @server_default 30s
      */
     master_timeout?: Duration
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/snapshots/CatSnapshotsRequest.ts
+++ b/specification/cat/snapshots/CatSnapshotsRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { Names } from '@_types/common'
-import { Duration, TimeUnit } from '@_types/Time'
+import { Duration } from '@_types/Time'
 import { CatRequestBase, CatSnapshotsColumns } from '@cat/_types/CatBase'
 
 /**
@@ -76,9 +76,5 @@ export interface Request extends CatRequestBase {
      * @server_default 30s
      */
     master_timeout?: Duration
-    /**
-     * Unit used to display time values.
-     */
-    time?: TimeUnit
   }
 }

--- a/specification/cat/tasks/CatTasksRequest.ts
+++ b/specification/cat/tasks/CatTasksRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { Names } from '@_types/common'
-import { Duration, TimeUnit } from '@_types/Time'
+import { Duration } from '@_types/Time'
 import { CatRequestBase } from '@cat/_types/CatBase'
 
 /**
@@ -63,10 +63,6 @@ export interface Request extends CatRequestBase {
      * or `:desc` as a suffix to the column name.
      */
     s?: Names
-    /**
-     * Unit used to display time values.
-     */
-    time?: TimeUnit
     /**
      * Period to wait for a response.
      * If no response is received before the timeout expires, the request fails and returns an error.

--- a/specification/cat/thread_pool/CatThreadPoolRequest.ts
+++ b/specification/cat/thread_pool/CatThreadPoolRequest.ts
@@ -18,7 +18,7 @@
  */
 
 import { Names } from '@_types/common'
-import { Duration, TimeUnit } from '@_types/Time'
+import { Duration } from '@_types/Time'
 import { CatRequestBase, CatThreadPoolColumns } from '@cat/_types/CatBase'
 
 /**
@@ -62,10 +62,6 @@ export interface Request extends CatRequestBase {
      * or `:desc` as a suffix to the column name.
      */
     s?: Names
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
     /**
      * If `true`, the request computes the list of selected nodes from the
      * local cluster state. If `false` the list of selected nodes are computed

--- a/specification/cat/transforms/CatTransformsRequest.ts
+++ b/specification/cat/transforms/CatTransformsRequest.ts
@@ -19,7 +19,6 @@
 
 import { Id } from '@_types/common'
 import { integer } from '@_types/Numeric'
-import { TimeUnit } from '@_types/Time'
 import { CatRequestBase, CatTransformColumns } from '@cat/_types/CatBase'
 
 /**
@@ -76,10 +75,6 @@ export interface Request extends CatRequestBase {
     /** Comma-separated list of column names or column aliases used to sort the response.
      */
     s?: CatTransformColumns
-    /**
-     * The unit used to display time values.
-     */
-    time?: TimeUnit
     /**
      * The maximum number of transforms to obtain.
      * @server_default 100

--- a/specification/shutdown/delete_node/ShutdownDeleteNodeRequest.ts
+++ b/specification/shutdown/delete_node/ShutdownDeleteNodeRequest.ts
@@ -19,7 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { NodeId } from '@_types/common'
-import { TimeUnit } from '@_types/Time'
+import { Duration } from '@_types/Time'
 
 /**
  * Cancel node shutdown preparations.
@@ -51,11 +51,11 @@ export interface Request extends RequestBase {
      * Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
-    master_timeout?: TimeUnit
+    master_timeout?: Duration
     /**
      * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
-    timeout?: TimeUnit
+    timeout?: Duration
   }
 }

--- a/specification/shutdown/get_node/ShutdownGetNodeRequest.ts
+++ b/specification/shutdown/get_node/ShutdownGetNodeRequest.ts
@@ -19,7 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { NodeIds } from '@_types/common'
-import { TimeUnit } from '@_types/Time'
+import { Duration } from '@_types/Time'
 
 /**
  * Get the shutdown status.
@@ -54,6 +54,6 @@ export interface Request extends RequestBase {
      * Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
-    master_timeout?: TimeUnit
+    master_timeout?: Duration
   }
 }

--- a/specification/shutdown/put_node/ShutdownPutNodeRequest.ts
+++ b/specification/shutdown/put_node/ShutdownPutNodeRequest.ts
@@ -19,7 +19,7 @@
 
 import { RequestBase } from '@_types/Base'
 import { NodeId } from '@_types/common'
-import { TimeUnit } from '@_types/Time'
+import { Duration } from '@_types/Time'
 import { Type } from '../_types/types'
 
 /**
@@ -66,13 +66,13 @@ export interface Request extends RequestBase {
      * If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
-    master_timeout?: TimeUnit
+    master_timeout?: Duration
     /**
      * The period to wait for a response.
      * If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
-    timeout?: TimeUnit
+    timeout?: Duration
   }
   body: {
     /**


### PR DESCRIPTION
Describes the `?bytes=` and `?time=` parameters which are accepted by
all the `GET _cat/...` APIs.

Backport of #5298 to `8.19`