### PR TITLE
Edit the log streams endpoint docs

### DIFF
--- a/specification/streams/logs_disable/StreamsLogsDisableRequest.ts
+++ b/specification/streams/logs_disable/StreamsLogsDisableRequest.ts
@@ -21,9 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { Duration } from '@_types/Time'
 
 /**
- * Disable logs stream
+ * Disable logs stream.
  *
- * This disables the logs stream feature for this cluster.
+ * Turn off the logs stream feature for this cluster.
  * @rest_spec_name streams.logs_disable
  * @availability stack since=9.1.0 stability=experimental visibility=feature_flag feature_flag=logs_stream
  * @cluster_privileges manage

--- a/specification/streams/logs_enable/StreamsLogsEnableRequest.ts
+++ b/specification/streams/logs_enable/StreamsLogsEnableRequest.ts
@@ -21,13 +21,13 @@ import { RequestBase } from '@_types/Base'
 import { Duration } from '@_types/Time'
 
 /**
- * Enable logs stream
+ * Enable logs stream.
  *
- * This enables the logs stream feature for this cluster.
+ * Turn on the logs stream feature for this cluster.
  *
- * Note: To protect existing data, this feature can only be enabled on a cluster if
- * it does not have existing indices or data streams matching the pattern `logs|logs.*`.
- * If this is the case, a `409 - Conflict` response and error will be returned.
+ * NOTE: To protect existing data, this feature can be turned on only if the
+ * cluster does not have existing indices or data streams that match the pattern `logs|logs.*`.
+ * If those indices or data streams exist, a `409 - Conflict` response and error is returned.
  * @rest_spec_name streams.logs_enable
  * @availability stack since=9.1.0 stability=experimental visibility=feature_flag feature_flag=logs_stream
  * @cluster_privileges manage

--- a/specification/streams/status/StreamsStatusRequest.ts
+++ b/specification/streams/status/StreamsStatusRequest.ts
@@ -21,9 +21,9 @@ import { RequestBase } from '@_types/Base'
 import { TimeUnit } from '@_types/Time'
 
 /**
- * Get the status of streams
+ * Get the status of streams.
  *
- * Gets the current status of all stream types
+ * Get the current status for all types of streams.
  * @rest_spec_name streams.status
  * @availability stack since=9.1.0 stability=experimental visibility=feature_flag feature_flag=logs_stream
  * @cluster_privileges monitor

--- a/specification/streams/status/StreamsStatusResponse.ts
+++ b/specification/streams/status/StreamsStatusResponse.ts
@@ -24,5 +24,8 @@ export class Response {
 }
 
 export class LogsStatus {
+  /**
+   * If true, the logs stream feature is enabled.
+   */
   enabled: boolean
 }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/pull/5258

This PR adds some simple edits to:

- add a missing description for the `enabled` property
- add use of "turn off" and "turn on" alongside "disable" and "enable" to align with word choice guidelines
