### PR TITLE
[Transform] Specify use_point_in_time in settings

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -22396,6 +22396,7 @@ export interface TransformSettings {
   deduce_mappings?: boolean
   docs_per_second?: float
   max_page_search_size?: integer
+  use_point_in_time?: boolean
   unattended?: boolean
 }
 

--- a/specification/transform/_types/Transform.ts
+++ b/specification/transform/_types/Transform.ts
@@ -130,6 +130,12 @@ export class Settings {
    * @server_default 500
    */
   max_page_search_size?: integer
+  /**
+   * Specifies whether the transform checkpoint will use the Point In Time API while searching over the source index.
+   * @doc_id point-in-time-api
+   * @server_default true
+   */
+  use_point_in_time?: boolean
 
   /**
    * If `true`, the transform runs in unattended mode. In unattended mode, the transform retries indefinitely in case


### PR DESCRIPTION
`use_point_in_time` has been in the docs since before 8.18

Resolve https://github.com/elastic/elasticsearch/issues/134841