### PR TITLE
`CompositeAggregation.sources` expects an array of single-key objects

### DIFF
--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -148,6 +148,9 @@ export class CompositeAggregation extends BucketAggregationBase {
   sources?: Array<SingleKeyDictionary<string, CompositeAggregationSource>>
 }
 
+/**
+ * @variants container
+ */
 export class CompositeAggregationSource {
   /**
    * A terms aggregation.

--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -145,7 +145,7 @@ export class CompositeAggregation extends BucketAggregationBase {
    * The value sources used to build composite buckets.
    * Keys are returned in the order of the `sources` definition.
    */
-  sources?: Array<Dictionary<string, CompositeAggregationSource>>
+  sources?: Array<SingleKeyDictionary<string, CompositeAggregationSource>>
 }
 
 export class CompositeAggregationSource {


### PR DESCRIPTION
As titled. Also marks `CompositeAggregationSource` as a container since the aggregations are mutually exclusive.

This fix as well greatly improves the quality of the generated code for the .NET client (see [#8704](https://github.com/elastic/elasticsearch-net/issues/8704)).

Server code:
https://github.com/elastic/elasticsearch/blob/a59c182f9f7e9d1bf3d6eecbc0e44f24ff91d053/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceParserHelper.java#L78

No backport, since this is a breaking change for statically typed languages.