### PR TITLE
Update availability documentation in GraphExploreRequest

### DIFF
--- a/specification/graph/explore/GraphExploreRequest.ts
+++ b/specification/graph/explore/GraphExploreRequest.ts
@@ -35,6 +35,7 @@ import { Hop } from '../_types/Hop'
  * @doc_id graph-explore-api
  * @rest_spec_name graph.explore
  * @availability stack stability=stable
+ * @availability serverless stability=stable visibility=private
  * @ext_doc_id graph
  */
 export interface Request extends RequestBase {


### PR DESCRIPTION
Per https://github.com/elastic/elasticsearch/commit/487b217afe200028d1f27a25546e29cf8160983f the Graph API was removed from serverless scope . So the spec should be updated to reflect that. 

<!-- Hello there! Thank you for opening a pull request. See CONTRIBUTING.md for instructions. -->
