### PR TITLE
Validate PRs against correct branch

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -25,7 +25,7 @@ jobs:
           repository: elastic/clients-flight-recorder
           path: ./clients-flight-recorder
           token: ${{ secrets.PAT }}
-          ref: main
+          ref: ${{ github.base_ref }}
 
       - name: Use Node.js 22
         uses: actions/setup-node@v4


### PR DESCRIPTION
As you can see in https://github.com/elastic/elasticsearch-specification/pull/5342, we currently validate backports PRs against the main branch, which creates huge diffs. https://github.com/elastic/elasticsearch-specification/pull/5341 will make this even worse. This should fix it when backported.