### PR TITLE
[8.18] Validate PRs against correct branch (#5344)

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -26,7 +26,7 @@ jobs:
           repository: elastic/clients-flight-recorder
           path: ./clients-flight-recorder
           token: ${{ secrets.PAT }}
-          ref: main
+          ref: ${{ github.base_ref }}
 
       - name: Use Node.js 22
         uses: actions/setup-node@v4


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.18`:
 - [Validate PRs against correct branch (#5344)](https://github.com/elastic/elasticsearch-specification/pull/5344)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)