### PR TITLE
Rely on npm more in make validate

### DIFF
--- a/compiler/run-validations.js
+++ b/compiler/run-validations.js
@@ -127,18 +127,6 @@ async function run () {
     await $`npm install --prefix ${tsValidationPath}`
   }
 
-  const isCompilerBuilt = await $`[[ -d ${path.join(compilerPath, 'lib')} ]]`.exitCode === 0
-  if (noCache || isStale || !isCompilerBuilt) {
-    spinner.text = 'Optimizing the compiler'
-    await $`npm run build --prefix ${compilerPath}`
-  }
-
-  const isTsGeneratorBuilt = await $`[[ -d ${path.join(tsGeneratorPath, 'lib')} ]]`.exitCode === 0
-  if (noCache || isStale || !isTsGeneratorBuilt) {
-    spinner.text = 'Optimizing the ts generator'
-    await $`npm run build --prefix ${tsGeneratorPath}`
-  }
-
   {
     spinner.text = 'Compiling specification'
     const Process = await nothrow($`npm run compile:specification --prefix ${compilerPath}`)
@@ -150,7 +138,7 @@ async function run () {
 
   {
     spinner.text = 'Generating schema'
-    const Process = await nothrow($`node ${path.join(compilerPath, 'lib', 'index.js')} --spec ${specPath} --output ${outputPath}`)
+    const Process = await nothrow($`npm run generate-schema --prefix ${compilerPath} -- --spec ${specPath} --output ${outputPath}`)
     if (Process.exitCode !== 0) {
       spinner.fail(removeHeader(Process.stdout))
       console.log(Process.stderr)
@@ -160,7 +148,7 @@ async function run () {
 
   {
     spinner.text = 'Generating typescript view'
-    const Process = await nothrow($`node ${path.join(tsGeneratorPath, 'lib', 'index.js')}`)
+    const Process = await nothrow($`npm run start --prefix ${tsGeneratorPath}`)
     if (Process.exitCode !== 0) {
       spinner.fail(removeHeader(Process.toString()))
       process.exit(1)


### PR DESCRIPTION
I had trouble running `make validate` on 8.19, and it turns out it was a weird interaction with an outdated `lib` content. Using the npm commands referenced by `make contrib` is simpler and more robust.