### PR TITLE
Add dimensions field to Google Vertex AI service settings

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -272,6 +272,7 @@ get-transform,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operat
 get-trial-status,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-license-get-trial-status,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/get-trial-status.html,
 googlevertexai-locations,https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations,,
 googlevertexai-models,https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api,,
+googlevertexai-output-dimensionality,https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings,,
 googlevertexai-thinking,https://ai.google.dev/gemini-api/docs/thinking#set-budget,,
 googleaistudio-models,https://ai.google.dev/gemini-api/docs/models,,
 graph,https://www.elastic.co/docs/explore-analyze/visualize/graph,,

--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -1366,6 +1366,13 @@ export class GoogleVertexAIServiceSettings {
    * A valid service account in JSON format for the Google Vertex AI API.
    */
   service_account_json: string
+  /**
+   * For a `text_embedding` task, the number of dimensions the resulting output embeddings should have.
+   * By default, the model's standard output dimension is used.
+   * Refer to the Google documentation for more information.
+   * @ext_doc_id googlevertexai-output-dimensionality
+   */
+  dimensions?: integer
 }
 
 export class GoogleVertexAITaskSettings {


### PR DESCRIPTION
This PR adds the `dimensions` field to Google Vertex AI. It was added in Elasticsearch in this PR: https://github.com/elastic/elasticsearch/pull/132689