### PR TITLE
Add extended search usage to spec

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10106,6 +10106,10 @@ export interface ClusterStatsDenseVectorStats {
   off_heap?: ClusterStatsDenseVectorOffHeapStats
 }
 
+export interface ClusterStatsExtendedSearchUsage {
+  retrievers?: Record<Name, Record<Name, long>>
+}
+
 export interface ClusterStatsFieldTypes {
   name: Name
   count: integer
@@ -10233,6 +10237,7 @@ export interface ClusterStatsSearchUsageStats {
   rescorers: Record<Name, long>
   sections: Record<Name, long>
   retrievers: Record<Name, long>
+  extended: Record<Name, ClusterStatsExtendedSearchUsage>
 }
 
 export type ClusterStatsShardState = 'INIT' | 'SUCCESS' | 'FAILED' | 'ABORTED' | 'MISSING' | 'WAITING' | 'QUEUED' | 'PAUSED_FOR_NODE_REMOVAL'

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -10106,8 +10106,16 @@ export interface ClusterStatsDenseVectorStats {
   off_heap?: ClusterStatsDenseVectorOffHeapStats
 }
 
+export interface ClusterStatsExtendedRetrieversSearchUsage {
+  text_similarity_reranker?: ClusterStatsExtendedTextSimilarityRetrieverUsage
+}
+
 export interface ClusterStatsExtendedSearchUsage {
-  retrievers?: Record<Name, Record<Name, long>>
+  retrievers?: ClusterStatsExtendedRetrieversSearchUsage
+}
+
+export interface ClusterStatsExtendedTextSimilarityRetrieverUsage {
+  chunk_rescorer?: long
 }
 
 export interface ClusterStatsFieldTypes {

--- a/specification/cluster/stats/types.ts
+++ b/specification/cluster/stats/types.ts
@@ -29,6 +29,7 @@ import {
   StoreStats
 } from '@_types/Stats'
 import { DateFormat, Duration, DurationValue, UnitMillis } from '@_types/Time'
+import { ContentObject } from '@inference/_types/CommonTypes'
 import { IndexingPressureMemory } from '@nodes/_types/Stats'
 import { Dictionary } from '@spec_utils/Dictionary'
 
@@ -152,6 +153,12 @@ export class SearchUsageStats {
   rescorers: Dictionary<Name, long>
   sections: Dictionary<Name, long>
   retrievers: Dictionary<Name, long>
+  /* @availability stack since=9.2.0 */
+  extended: Dictionary<Name, ExtendedSearchUsage>
+}
+
+export class ExtendedSearchUsage {
+  retrievers?: Dictionary<Name, Dictionary<Name, long>>
 }
 
 export class DenseVectorStats {

--- a/specification/cluster/stats/types.ts
+++ b/specification/cluster/stats/types.ts
@@ -157,7 +157,15 @@ export class SearchUsageStats {
 }
 
 export class ExtendedSearchUsage {
-  retrievers?: Dictionary<Name, Dictionary<Name, long>>
+  retrievers?: ExtendedRetrieversSearchUsage
+}
+
+export class ExtendedRetrieversSearchUsage {
+  text_similarity_reranker?: ExtendedTextSimilarityRetrieverUsage
+}
+
+export class ExtendedTextSimilarityRetrieverUsage {
+  chunk_rescorer?: long
 }
 
 export class DenseVectorStats {

--- a/specification/cluster/stats/types.ts
+++ b/specification/cluster/stats/types.ts
@@ -29,7 +29,6 @@ import {
   StoreStats
 } from '@_types/Stats'
 import { DateFormat, Duration, DurationValue, UnitMillis } from '@_types/Time'
-import { ContentObject } from '@inference/_types/CommonTypes'
 import { IndexingPressureMemory } from '@nodes/_types/Stats'
 import { Dictionary } from '@spec_utils/Dictionary'
 


### PR DESCRIPTION
Adds the extended search usage implemented in https://github.com/elastic/elasticsearch/pull/135306 to the specification
