### PR TITLE
Add deprecation notice for max_size rollover condition

### DIFF
--- a/specification/ilm/_types/Phase.ts
+++ b/specification/ilm/_types/Phase.ts
@@ -97,6 +97,9 @@ export class SetPriorityAction {
 }
 
 export class RolloverAction {
+  /**
+   * The `max_size` condition has been deprecated in 9.3.0 and `max_primary_shard_size` should be used instead
+   * @deprecated 9.3.0 */
   max_size?: ByteSize
   max_primary_shard_size?: ByteSize
   max_age?: Duration

--- a/specification/indices/rollover/types.ts
+++ b/specification/indices/rollover/types.ts
@@ -27,6 +27,9 @@ export class RolloverConditions {
   max_age_millis?: DurationValue<UnitMillis>
   min_docs?: long
   max_docs?: long
+  /**
+   * The `max_size` condition has been deprecated in 9.3.0 and `max_primary_shard_size` should be used instead
+   * @deprecated 9.3.0 */
   max_size?: ByteSize
   max_size_bytes?: long
   min_size?: ByteSize


### PR DESCRIPTION
Add deprecation notice for the `max_size` condition used for rollovers and ILM policies

Relates to: elastic/elasticsearch#130737