### PR TITLE
Search and reindex fixes

### DIFF
--- a/specification/_global/reindex/types.ts
+++ b/specification/_global/reindex/types.ts
@@ -18,7 +18,6 @@
  */
 
 import {
-  Fields,
   IndexName,
   Indices,
   OpType,
@@ -34,6 +33,7 @@ import { QueryContainer } from '@_types/query_dsl/abstractions'
 import { SlicedScroll } from '@_types/SlicedScroll'
 import { Sort } from '@_types/sort'
 import { Duration } from '@_types/Time'
+import { SourceConfig } from '@global/search/_types/SourceFilter'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class Destination {
@@ -105,7 +105,7 @@ export class Source {
    * Set it to a list to reindex select fields.
    * @server_default true
    * @codegen_name source_fields */
-  _source?: Fields
+  _source?: SourceConfig
   runtime_mappings?: RuntimeFields
 }
 

--- a/specification/_types/Geo.ts
+++ b/specification/_types/Geo.ts
@@ -95,12 +95,6 @@ export type GeoTile = string
 
 /** A map hex cell (H3) reference */
 export type GeoHexCell = string
-
-export class LatLon {
-  lat: double
-  lon: double
-}
-
 /**
  * A latitude/longitude as a 2 dimensional point. It can be represented in various ways:
  * - as a `{lat, long}` object
@@ -126,6 +120,11 @@ export class LatLonGeoLocation {
    * Longitude
    */
   lon: double
+}
+
+export class CartesianPoint {
+  x: double
+  y: double
 }
 
 export class GeoHashLocation {

--- a/specification/_types/aggregations/AggregationContainer.ts
+++ b/specification/_types/aggregations/AggregationContainer.ts
@@ -60,6 +60,8 @@ import {
   AverageAggregation,
   BoxplotAggregation,
   CardinalityAggregation,
+  CartesianBoundsAggregation,
+  CartesianCentroidAggregation,
   ExtendedStatsAggregation,
   GeoBoundsAggregation,
   GeoCentroidAggregation,
@@ -87,6 +89,7 @@ import {
   BucketScriptAggregation,
   BucketSelectorAggregation,
   BucketSortAggregation,
+  ChangePointAggregation,
   CumulativeCardinalityAggregation,
   CumulativeSumAggregation,
   DerivativeAggregation,
@@ -184,12 +187,30 @@ export class AggregationContainer {
    */
   cardinality?: CardinalityAggregation
   /**
+   * A metric aggregation that computes the spatial bounding box containing all values for a Point or Shape field.
+   * @ext_doc_id search-aggregations-metrics-cartesian-bounds-aggregation
+   */
+  cartesian_bounds?: CartesianBoundsAggregation
+  /**
+   * A metric aggregation that computes the weighted centroid from all coordinate values for point and shape fields.
+   * @ext_doc_id search-aggregations-metrics-cartesian-centroid-aggregation
+   */
+  cartesian_centroid?: CartesianCentroidAggregation
+  /**
    * A multi-bucket aggregation that groups semi-structured text into buckets.
    * @ext_doc_id search-aggregations-bucket-categorize-text-aggregation
    * @availability stack stability=experimental
    * @availability serverless stability=experimental
    */
   categorize_text?: CategorizeTextAggregation
+  /**
+   * A sibling pipeline that detects, spikes, dips, and change points in a metric.
+   * Given a distribution of values provided by the sibling multi-bucket aggregation,
+   * this aggregation indicates the bucket of any spike or dip and/or the bucket at which
+   * the largest change in the distribution of values, if they are statistically significant.
+   * @ext_doc_id search-aggregations-change-point-aggregation
+   */
+  change_point?: ChangePointAggregation
   /**
    * A single bucket aggregation that selects child documents that have the specified type, as defined in a `join` field.
    * @ext_doc_id search-aggregations-bucket-children-aggregation
@@ -245,6 +266,7 @@ export class AggregationContainer {
   /**
    * A bucket aggregation which finds frequent item sets, a form of association rules mining that identifies items that often occur together.
    * @ext_doc_id search-aggregations-bucket-frequent-item-sets-aggregation
+   * @aliases frequent_items
    */
   frequent_item_sets?: FrequentItemSetsAggregation
   /**

--- a/specification/_types/aggregations/metric.ts
+++ b/specification/_types/aggregations/metric.ts
@@ -111,6 +111,10 @@ export class ExtendedStatsAggregation extends FormatMetricAggregationBase {
   sigma?: double
 }
 
+export class CartesianBoundsAggregation extends MetricAggregationBase {}
+
+export class CartesianCentroidAggregation extends MetricAggregationBase {}
+
 /**
  * @ext_doc_id search-aggregations-metrics-geobounds-aggregation
  */

--- a/specification/_types/aggregations/pipeline.ts
+++ b/specification/_types/aggregations/pipeline.ts
@@ -203,6 +203,8 @@ export class BucketSortAggregation extends Aggregation {
   sort?: Sort
 }
 
+export class ChangePointAggregation extends PipelineAggregationBase {}
+
 /**
  * @ext_doc_id search-aggregations-pipeline-cumulative-cardinality-aggregation
  */


### PR DESCRIPTION
Some validation fixes, mainly missing aggregations.

### Reindex

- Field `_source` should be the same type as in SearchRequest, so a `SearchConfig`. [server code](https://github.com/elastic/elasticsearch/blob/e702edcbab3720c0f99a78fa472af24cafaab850/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java#L91)

### Search

-  Missing cartesian_bounds aggregation: [Request](https://github.com/elastic/elasticsearch/blob/ae6d18037953609d58a2069121e37b484eba5c87/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianBoundsAggregationBuilder.java#L29), [Response](https://github.com/elastic/elasticsearch/blob/609e8059eb4949b17aef69d62720ee27ace0b637/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianBounds.java#L27)
- Missing cartesian_centroid aggregation: [Request](https://github.com/elastic/elasticsearch/blob/ae6d18037953609d58a2069121e37b484eba5c87/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianCentroidAggregationBuilder.java#L30), [Response](https://github.com/elastic/elasticsearch/blob/638c86c5579e4561bcb17721c81a052fcf080437/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianCentroid.java#L22)
- Missing change_point aggregation: [Request](https://github.com/elastic/elasticsearch/blob/19257125b19ff05a6b014f37693f9417ca579626/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregationBuilder.java#L28), [Response](https://github.com/elastic/elasticsearch/blob/609e8059eb4949b17aef69d62720ee27ace0b637/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/InternalChangePointAggregation.java#L22)

These should all be safe to backport.
