### PR TITLE
Add specification for certificate_identity field for cross-cluster ap…

### DIFF
--- a/specification/security/_types/ApiKey.ts
+++ b/specification/security/_types/ApiKey.ts
@@ -100,6 +100,13 @@ export class ApiKey {
    * @availability serverless
    */
   access?: Access
+    /**
+     * The certificate identity associated with a cross-cluster API key.
+     * Restricts the API key to connections authenticated by a specific TLS certificate.
+     * Only applicable to cross-cluster API keys.
+     * @availability stack since=9.3.0
+     */
+    certificate_identity?: string
   /**
    * The profile uid for the API key owner principal, if requested and if it exists
    * @availability stack since=8.14.0

--- a/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyRequest.ts
+++ b/specification/security/create_cross_cluster_api_key/CreateCrossClusterApiKeyRequest.ts
@@ -76,5 +76,11 @@ export interface Request extends RequestBase {
     metadata?: Metadata
     /** Specifies the name for this API key. */
     name: Name
+    /**
+     * The certificate identity to associate with this API key.
+     * This field is used to restrict the API key to connections authenticated by a specific TLS certificate.
+     * The value should match the certificate's distinguished name (DN) pattern.
+     */
+    certificate_identity?: string
   }
 }

--- a/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
+++ b/specification/security/update_cross_cluster_api_key/UpdateCrossClusterApiKeyRequest.ts
@@ -81,5 +81,14 @@ export interface Request extends RequestBase {
      * When specified, this information fully replaces metadata previously associated with the API key.
      */
     metadata?: Metadata
+    /**
+     * The certificate identity to associate with this API key.
+     * This field is used to restrict the API key to connections authenticated by a specific TLS certificate.
+     * The value should match the certificate's distinguished name (DN) pattern.
+     * When specified, this fully replaces any previously assigned certificate identity.
+     * To clear an existing certificate identity, explicitly set this field to `null`.
+     * When omitted, the existing certificate identity remains unchanged.
+     */
+    certificate_identity?: string
   }
 }


### PR DESCRIPTION
Add certificate_identity field to API key specs

Updates TypeScript specs for create/update cross-cluster API key endpoints and ApiKey response type to include certificate_identity field.
