### PR TITLE
Add some docs details for get tags

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -525,7 +525,7 @@ point-in-time-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/op
 prevalidate-node-removal,https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-cluster,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/cluster.html,
 preview-dfanalytics,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-preview-data-frame-analytics,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/preview-dfanalytics.html,
 preview-transform,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-preview-transform,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/preview-transform.html,
-project-tags,,,
+project-tags,https://www.elastic.co/docs/api/doc/elasticsearch-serverless/operation/operation-project-tags,,Get tags
 put-analytics-collection,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-search-application-put-behavioral-analytics,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/put-analytics-collection.html,
 put-dfanalytics,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-ml-put-data-frame-analytics,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/put-dfanalytics.html,
 put-enrich-policy-api,https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-enrich-put-policy,https://www.elastic.co/guide/en/elasticsearch/reference/8.18/put-enrich-policy-api.html,

--- a/specification/project/tags/TagsRequest.ts
+++ b/specification/project/tags/TagsRequest.ts
@@ -20,10 +20,13 @@
 import { RequestBase } from '@_types/Base'
 
 /**
+ * Get tags.
+ * Get the tags that are defined for the project.
  * @doc_id project-tags
  * @rest_spec_name project.tags
  * @availability serverless stability=experimental visibility=public
  * @cluster_privileges monitor
+ * @doc_tag project
  */
 export interface Request extends RequestBase {
   urls: [


### PR DESCRIPTION
This PR adds a summary, description, and URL for the new get tags endpoint, which was added in https://github.com/elastic/elasticsearch-specification/pull/5293

Descriptions should also be added for the properties in the response.
