### PR TITLE
Serverless-only availability hack

### DIFF
--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -89,6 +89,13 @@ export function compileEndpoints (): Record<string, model.Endpoint> {
         }
       })
     }
+
+    // temporary workaround for APIs that are serverless-only
+    // until we can stop depending on rest-api-spec for availability
+    if (api === "project.tags") {
+      delete map[api].availability.stack
+    }
+
     if (typeof spec.feature_flag === 'string') {
       map[api].availability.stack.featureFlag = spec.feature_flag
     }

--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -92,7 +92,7 @@ export function compileEndpoints (): Record<string, model.Endpoint> {
 
     // temporary workaround for APIs that are serverless-only
     // until we can stop depending on rest-api-spec for availability
-    if (api === "project.tags") {
+    if (api === 'project.tags') {
       delete map[api].availability.stack
     }
 

--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -7270,7 +7270,7 @@ export type CatCatNodeColumn = 'build' | 'b' | 'completion.size' | 'cs' | 'compl
 
 export type CatCatNodeColumns = CatCatNodeColumn | CatCatNodeColumn[]
 
-export type CatCatNodeattrsColumn = 'node' | 'id' | 'id' | 'nodeId' | 'pid' | 'p' | 'host' | 'h' | 'ip' | 'i' | 'port' | 'po' | 'attr' | 'attr.name' | 'value' | 'attr.value'| string
+export type CatCatNodeattrsColumn = 'node' | 'id' | 'id' | 'nodeId' | 'pid' | 'host' | 'h' | 'ip' | 'i' | 'port' | 'po' | 'attr' | 'attr.name' | 'value' | 'attr.value'| string
 
 export type CatCatNodeattrsColumns = CatCatNodeattrsColumn | CatCatNodeattrsColumn[]
 


### PR DESCRIPTION
While we still depend on visibility and stability from rest-api-spec JSON, we have to override availability.stack for APIs that are only available on serverless.
