### PR TITLE
Compiler: late sync endpoints availability from json-spec

### DIFF
--- a/compiler/src/compiler.ts
+++ b/compiler/src/compiler.ts
@@ -21,7 +21,11 @@ import { writeFile, mkdir } from 'fs/promises'
 import { join } from 'path'
 import stringify from 'safe-stable-stringify'
 import { Model } from './model/metamodel'
-import { compileEndpoints, compileSpecification } from './model/build-model'
+import {
+  compileEndpoints,
+  compileSpecification,
+  reAddAvailability
+} from './model/build-model'
 import buildJsonSpec, { JsonSpec } from './model/json-spec'
 import { ValidationErrors } from './validation-errors'
 
@@ -54,6 +58,7 @@ export default class Compiler {
     this.jsonSpec = buildJsonSpec()
     const endpoints = compileEndpoints()
     this.model = compileSpecification(endpoints, this.specsFolder, this.outputFolder)
+    this.model = reAddAvailability(this.model) // resync availability information based on json spec if typescript has none.
     return this
   }
 

--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -62,7 +62,7 @@ export function reAddAvailability (model: model.Model): model.Model {
   for (const [api, spec] of jsonSpec.entries()) {
     for (const endpoint of model.endpoints) {
       if (endpoint.name === api) {
-        if ((spec.stability || spec.visibility) && (endpoint.availability.stack === undefined && endpoint.availability.serverless === undefined)) {
+        if ((spec.stability != null || spec.visibility != null) && (endpoint.availability.stack === undefined && endpoint.availability.serverless === undefined)) {
           endpoint.availability = {
             stack: {
               stability: spec.stability,
@@ -103,7 +103,7 @@ export function compileEndpoints (): Record<string, model.Endpoint> {
       })
     }
     if (typeof spec.feature_flag === 'string') {
-      map[api].availability.stack = {featureFlag: spec.feature_flag}
+      map[api].availability.stack = { featureFlag: spec.feature_flag }
     }
   }
   return map

--- a/compiler/src/model/build-model.ts
+++ b/compiler/src/model/build-model.ts
@@ -58,6 +58,24 @@ import {
 
 const jsonSpec = buildJsonSpec()
 
+export function reAddAvailability (model: model.Model): model.Model {
+  for (const [api, spec] of jsonSpec.entries()) {
+    for (const endpoint of model.endpoints) {
+      if (endpoint.name === api) {
+        if ((spec.stability || spec.visibility) && (endpoint.availability.stack === undefined && endpoint.availability.serverless === undefined)) {
+          endpoint.availability = {
+            stack: {
+              stability: spec.stability,
+              visibility: spec.visibility
+            }
+          }
+        }
+      }
+    }
+  }
+  return model
+}
+
 export function compileEndpoints (): Record<string, model.Endpoint> {
   // Create endpoints and merge them with
   // the recorded mappings if present.
@@ -72,12 +90,7 @@ export function compileEndpoints (): Record<string, model.Endpoint> {
       // Setting these values by default should be removed
       // when we no longer use rest-api-spec stubs as the
       // source of truth for stability/visibility.
-      availability: {
-        stack: {
-          stability: spec.stability,
-          visibility: spec.visibility
-        }
-      },
+      availability: {},
       request: null,
       requestBodyRequired: Boolean(spec.body?.required),
       response: null,
@@ -90,7 +103,7 @@ export function compileEndpoints (): Record<string, model.Endpoint> {
       })
     }
     if (typeof spec.feature_flag === 'string') {
-      map[api].availability.stack.featureFlag = spec.feature_flag
+      map[api].availability.stack = {featureFlag: spec.feature_flag}
     }
   }
   return map


### PR DESCRIPTION
`json-spec` files do not differentiate `stack` from `serverless` as the recent `project.tags` endpoint has shown.
This moves the propagation for the availability sync from early on to last step to avoid assigning to stack by default if the endpoint has the relevant information in the typescript files.