### PR TITLE
Stop passing token to validate-pr

### DIFF
--- a/.github/workflows/validate-apis.yml
+++ b/.github/workflows/validate-apis.yml
@@ -91,7 +91,7 @@ jobs:
         if: github.event_name == 'pull_request'
         id: validation
         working-directory: ./elasticsearch-specification
-        run: node .github/validate-pr --token ${{ secrets.GITHUB_TOKEN }}
+        run: node .github/validate-pr
 
       - name: Find existing comment
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
We're no longer using the GitHub API in this script.