### PR TITLE
Start automation on 9.2 branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,6 @@
 {
   "repoOwner": "elastic",
   "repoName": "elasticsearch-specification",
-  "targetBranchChoices": ["9.1", "9.0", "8.19", "8.18"],
+  "targetBranchChoices": ["9.2", "9.1", "9.0", "8.19"],
   "fork": false
 }

--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['main', '9.1', '9.0', '8.19', '8.18']
+        branch: ['main', '9.2', '9.1', '9.0', '8.19']
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
There's one release left for 8.18, but realistically, most clients will either not release it or will not want to make meaningful changes to it.