### PR TITLE
Clarifies that the `docs.count` field in the `_cat/indices` API includes hidden nested documents.

### DIFF
--- a/specification/cat/indices/types.ts
+++ b/specification/cat/indices/types.ts
@@ -57,7 +57,7 @@ export class IndicesRecord {
   /**
    * The number of documents in the index, including hidden nested documents.
    * For indices with `semantic_text` fields or other nested field types, this count
-   * includes the internal nested documents used for storing chunks and embeddings.
+   * includes the internal nested documents.
    * To get the logical document count (excluding nested documents), use the `_count`
    * API or `_cat/count` API instead.
    * @aliases dc,docsCount


### PR DESCRIPTION
## Summary
Clarifies that the `docs.count` field in the `_cat/indices` API includes hidden nested documents, which can lead to higher counts than expected when using field types like `semantic_text`.

## Changes
- Updated the documentation for `docs.count` in `CatIndicesRequest.ts` to explicitly state that it includes nested documents
- Added guidance to use `_count` or `_cat/count` APIs for logical document count

## Related Issues
Fixes #127354

## Related PRs
- elasticsearch [#136329 ](https://github.com/elastic/elasticsearch/pull/136329)(semantic_text documentation update)