### PR TITLE
Add externalDocs for inference tag

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -129,6 +129,9 @@ actions:
             Inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Azure, Google AI Studio or Hugging Face.
             For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models.
             However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.
+          externalDocs:
+            url: https://www.elastic.co/docs/explore-analyze/elastic-inference/inference-api
+            description: Learn about default inference endpoints, adaptive allocations, and chunking.
         - name: info
           x-displayName: Info
           description: >


### PR DESCRIPTION
This PR adds an `externalDocs` link from https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-inference to https://www.elastic.co/docs/explore-analyze/elastic-inference/inference-api since internal users were having difficulty finding the latter.