### PR TITLE
Adding headers for openai

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -947,7 +947,7 @@ export class CohereTaskSettings {
 
 export class CustomServiceSettings {
   /**
-   * Specifies the HTTP header parameters – such as `Authentication` or `Contet-Type` – that are required to access the custom service.
+   * Specifies the HTTP header parameters – such as `Authentication` or `Content-Type` – that are required to access the custom service.
    * For example:
    * ```
    * "headers":{


### PR DESCRIPTION
This PR adds a new optional field `headers` to the openai integration corresponding to this PR: https://github.com/elastic/elasticsearch/pull/134960