### PR TITLE
Nullable mode in kuromoji analyzer

### DIFF
--- a/specification/_types/analysis/kuromoji-plugin.ts
+++ b/specification/_types/analysis/kuromoji-plugin.ts
@@ -25,7 +25,7 @@ import { TokenizerBase } from './tokenizers'
 
 export class KuromojiAnalyzer {
   type: 'kuromoji'
-  mode: KuromojiTokenizationMode
+  mode?: KuromojiTokenizationMode
   user_dictionary?: string
 }
 


### PR DESCRIPTION
As reported in https://github.com/elastic/elasticsearch-java/issues/1082, `mode` in KuromojiAnalyzer is nullable, the server gets it from settings if not present -> [server code](https://github.com/elastic/elasticsearch/blob/756bc9dc0f0134b246b1fd9613fb05220eea4aef/plugins/analysis-kuromoji/src/main/java/org/elasticsearch/plugin/analysis/kuromoji/KuromojiAnalyzerProvider.java#L31)
