### PR TITLE
[Backport 9.2] Adding headers for openai (#5497)

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -947,7 +947,7 @@ export class CohereTaskSettings {
 
 export class CustomServiceSettings {
   /**
-   * Specifies the HTTPS header parameters – such as `Authentication` or `Contet-Type` – that are required to access the custom service.
+   * Specifies the HTTP header parameters – such as `Authentication` or `Content-Type` – that are required to access the custom service.
    * For example:
    * ```
    * "headers":{
@@ -1729,6 +1729,17 @@ export class OpenAITaskSettings {
    * This information can be used for abuse detection.
    */
   user?: string
+  /**
+   * Specifies custom HTTP header parameters.
+   * For example:
+   * ```
+   * "headers":{
+   *   "Custom-Header": "Some-Value",
+   *   "Another-Custom-Header": "Another-Value"
+   * }
+   * ```
+   */
+  headers?: UserDefinedValue
 }
 
 export enum OpenAITaskType {


### PR DESCRIPTION
Backport of: https://github.com/elastic/elasticsearch-specification/pull/5497


(cherry picked from commit f9b2639d75d6cd0cb745872d4cee90b113507902)


