### PR TITLE
Adding embedding type for custom service

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -1079,7 +1079,7 @@ export class CustomResponseParams {
    * }
    *
    * If `embedding_type` is not specified, it defaults to `float`.
-   * 
+   *
    * # sparse_embedding
    * # For a response like this:
    *


### PR DESCRIPTION
This PR adds the docs for the `embedding_type` field for the Custom service added in 9.2.


This original PR for elasticsearch is here: https://github.com/elastic/elasticsearch/pull/130141