### PR TITLE
Adding batch size to custom service

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -853,6 +853,7 @@ security-saml-guide,https://www.elastic.co/docs/deploy-manage/users-roles/cluste
 security-settings-api-keys,https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/security-settings#api-key-service-settings,,
 security-settings-hashing,https://www.elastic.co/docs/reference/elasticsearch/configuration-reference/security-settings#hashing-settings,,
 security-user-cache,https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/controlling-user-cache,,
+sematic-text-chunking,https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/semantic-text#auto-text-chunking,,
 service-accounts,https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/service-accounts,,
 set-processor,https://www.elastic.co/docs/reference/enrich-processor/set-processor,,
 shape,https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/shape,,

--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -948,6 +948,9 @@ export class CohereTaskSettings {
 export class CustomServiceSettings {
   /**
    * Specifies the batch size used for the semantic_text field. If the field is not provided, the default is 10.
+   * The batch size is the maximum number of inputs in a single request to the upstream service.
+   * The chunk within the batch are controlled by the selected chunking strategy for the semantic_text field.
+   * @ext_doc_id sematic-text-chunking
    */
   batch_size?: integer
   /**


### PR DESCRIPTION
This PR updates the docs to include `batch_size` which I forgot to add.

The original ES PR is here: https://github.com/elastic/elasticsearch/pull/129558