### PR TITLE
Optional fields in cluster allocation explain response

### DIFF
--- a/specification/cluster/allocation_explain/types.ts
+++ b/specification/cluster/allocation_explain/types.ts
@@ -101,7 +101,7 @@ export enum Decision {
 }
 
 export class NodeAllocationExplanation {
-  deciders: AllocationDecision[]
+  deciders?: AllocationDecision[]
   node_attributes: Dictionary<string, string>
   node_decision: Decision
   node_id: Id
@@ -113,7 +113,7 @@ export class NodeAllocationExplanation {
   roles: NodeRoles
   store?: AllocationStore
   transport_address: TransportAddress
-  weight_ranking: integer
+  weight_ranking?: integer
 }
 
 export enum StoreCopy {


### PR DESCRIPTION
Server code: https://github.com/elastic/elasticsearch/blob/d93d333141fbea72ec082592a526ce59bcbe92f3/server/src/main/java/org/elasticsearch/cluster/routing/allocation/NodeAllocationResult.java#L149
