### PR TITLE
[9.1] Fix GitHub Actions warning (#5494)

### DIFF
--- a/.github/workflows/validate-apis.yml
+++ b/.github/workflows/validate-apis.yml
@@ -93,8 +93,6 @@ jobs:
         with:
           path: ./clients-flight-recorder/recordings/types-validation/types-validation.json
           key: types-validation-json-${{ format('{0}-{1}', github.ref_name, github.sha) }}
-          restore-keys: |
-            types-validation-json-${{ github.ref_name }}-
 
       - name: Run validation (PR)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Fix GitHub Actions warning (#5494)](https://github.com/elastic/elasticsearch-specification/pull/5494)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)