### PR TITLE
Switch Prettier endOfLine to "auto"

### DIFF
--- a/compiler/.prettierrc.json
+++ b/compiler/.prettierrc.json
@@ -6,6 +6,6 @@
   "singleQuote": true,
   "quoteProps": "as-needed",
   "bracketSpacing": true,
-  "endOfLine": "lf",
+  "endOfLine": "auto",
   "bracketSameLine": true
 }


### PR DESCRIPTION
This is in line with `.gitattributes`, and should give a more pleasant experience on Windows.