### PR TITLE
Remove swallez from rest-api-json updates reviewers

### DIFF
--- a/.github/workflows/update-rest-api-json.yml
+++ b/.github/workflows/update-rest-api-json.yml
@@ -50,5 +50,5 @@ jobs:
           commit-message: 'Update rest-api-spec'
           labels: specification,skip-backport
           delete-branch: true
-          reviewers: Anaethelion,ezimuel,flobernd,JoshMock,l-trotta,miguelgrinberg,picandocodigo,pquentin,swallez,technige
+          reviewers: Anaethelion,ezimuel,flobernd,JoshMock,l-trotta,miguelgrinberg,picandocodigo,pquentin,technige
           branch: automated/rest-api-spec-update-${{ matrix.branch }}


### PR DESCRIPTION
As titled. Maybe replace this list with a GitHub team?


Closes #5550