### PR TITLE
Fixes descriptions in the Inference APIs

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -30,7 +30,7 @@ export class RequestChatCompletion {
    */
   messages: Array<Message>
   /**
-   * The ID of the model to use.
+   * The ID of the model to use. By default, the model ID is set to the value included when creating the inference endpoint.
    */
   model?: string
   /**

--- a/specification/inference/completion/CompletionRequest.ts
+++ b/specification/inference/completion/CompletionRequest.ts
@@ -62,7 +62,7 @@ export interface Request extends RequestBase {
      */
     input: string | Array<string>
     /**
-     * Optional task settings
+     * Task settings for the individual inference request. These settings are specific to the <task_type> you specified and override the task settings specified when initializing the service.
      */
     task_settings?: TaskSettings
   }

--- a/specification/inference/delete/DeleteRequest.ts
+++ b/specification/inference/delete/DeleteRequest.ts
@@ -52,7 +52,7 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     /**
-     * When true, the endpoint is not deleted and a list of ingest processors which reference this endpoint is returned.
+     * When true, checks the semantic_text fields and inference processors that reference the endpoint and returns them in a list, but does not delete the endpoint.
      * @server_default false
      */
     dry_run?: boolean

--- a/specification/inference/put_anthropic/PutAnthropicRequest.ts
+++ b/specification/inference/put_anthropic/PutAnthropicRequest.ts
@@ -74,7 +74,7 @@ export interface Request extends RequestBase {
      */
     service: AnthropicServiceType
     /**
-     * Settings used to install the inference model. These settings are specific to the `watsonxai` service.
+     * Settings used to install the inference model. These settings are specific to the `anthropic` service.
      */
     service_settings: AnthropicServiceSettings
     /**

--- a/specification/inference/put_azureaistudio/PutAzureAiStudioRequest.ts
+++ b/specification/inference/put_azureaistudio/PutAzureAiStudioRequest.ts
@@ -73,7 +73,7 @@ export interface Request extends RequestBase {
      */
     service: AzureAiStudioServiceType
     /**
-     * Settings used to install the inference model. These settings are specific to the `openai` service.
+     * Settings used to install the inference model. These settings are specific to the `azureaistudio` service.
      */
     service_settings: AzureAiStudioServiceSettings
     /**

--- a/specification/inference/sparse_embedding/SparseEmbeddingRequest.ts
+++ b/specification/inference/sparse_embedding/SparseEmbeddingRequest.ts
@@ -56,7 +56,7 @@ export interface Request extends RequestBase {
      */
     input: string | Array<string>
     /**
-     * Optional task settings
+     * Task settings for the individual inference request. These settings are specific to the <task_type> you specified and override the task settings specified when initializing the service.
      */
     task_settings?: TaskSettings
   }

--- a/specification/inference/stream_completion/StreamInferenceRequest.ts
+++ b/specification/inference/stream_completion/StreamInferenceRequest.ts
@@ -64,7 +64,7 @@ export interface Request extends RequestBase {
      */
     input: string | string[]
     /**
-     * Optional task settings
+     * Task settings for the individual inference request. These settings are specific to the <task_type> you specified and override the task settings specified when initializing the service.
      */
     task_settings?: TaskSettings
   }

--- a/specification/inference/text_embedding/TextEmbeddingRequest.ts
+++ b/specification/inference/text_embedding/TextEmbeddingRequest.ts
@@ -69,7 +69,7 @@ export interface Request extends RequestBase {
      */
     input_type?: string
     /**
-     * Optional task settings
+     * Task settings for the individual inference request. These settings are specific to the <task_type> you specified and override the task settings specified when initializing the service.
      */
     task_settings?: TaskSettings
   }


### PR DESCRIPTION
This PR fixes description errors discovered during the [comparison](https://github.com/elastic/docs-content-internal/issues/280) of the 8.x and 9.x API documentation.

Closes the following issues:

- [Incomplete description for the `model` parameter](https://github.com/elastic/elasticsearch-specification/issues/5504)
- [Improve the`dry_run` parameter's description](https://github.com/elastic/elasticsearch-specification/issues/5505)
- [Improve the `task_settings` parameter's description](https://github.com/elastic/elasticsearch-specification/issues/5506)
- [Errors in the `service_settings` parameter's description](https://github.com/elastic/elasticsearch-specification/issues/5507)
- half of https://github.com/elastic/elasticsearch-specification/issues/5512