### PR TITLE
Restore and update java examples

### DIFF
--- a/docs/examples/languageExamples.json
+++ b/docs/examples/languageExamples.json
@@ -19,6 +19,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_xpack/usage\""
+    },
+    {
+      "language": "Java",
+      "code": "client.xpack().usage(u -> u);\n"
     }
   ],
   "specification/xpack/info/examples/request/XPackInfoRequestExample1.yaml": [
@@ -41,6 +45,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_xpack\""
+    },
+    {
+      "language": "Java",
+      "code": "client.xpack().info(i -> i);\n"
     }
   ],
   "specification/cat/shards/examples/request/CatShardsRequestExample1.yaml": [
@@ -63,6 +71,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/shards?format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().shards();\n"
     }
   ],
   "specification/cat/component_templates/examples/request/CatComponentTemplatesRequestExample1.yaml": [
@@ -85,6 +97,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/component_templates/my-template-*?v=true&s=name&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().componentTemplates();\n"
     }
   ],
   "specification/cat/tasks/examples/request/CatTasksRequestExample1.yaml": [
@@ -107,6 +123,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/tasks?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().tasks();\n"
     }
   ],
   "specification/cat/indices/examples/request/CatIndicesRequestExample1.yaml": [
@@ -129,6 +149,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/indices/my-index-*?v=true&s=index&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().indices();\n"
     }
   ],
   "specification/cat/thread_pool/examples/request/CatThreadPoolRequestExample1.yaml": [
@@ -151,6 +175,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/thread_pool?format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().threadPool();\n"
     }
   ],
   "specification/cat/pending_tasks/examples/request/CatPendingTasksRequestExample1.yaml": [
@@ -173,6 +201,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/pending_tasks?v=trueh=insertOrder,timeInQueue,priority,source&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().pendingTasks();\n"
     }
   ],
   "specification/cat/nodeattrs/examples/request/CatNodeAttributesRequestExample1.yaml": [
@@ -195,6 +227,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/nodeattrs?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().nodeattrs();\n"
     }
   ],
   "specification/cat/snapshots/examples/request/CatSnapshotsRequestExample1.yaml": [
@@ -217,6 +253,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/snapshots/repo1?v=true&s=id&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().snapshots();\n"
     }
   ],
   "specification/cat/nodes/examples/request/CatNodesRequestExample2.yaml": [
@@ -239,6 +279,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/nodes?v=true&h=id,ip,port,v,m&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().nodes();\n"
     }
   ],
   "specification/cat/ml_datafeeds/examples/request/CatDatafeedsRequestExample1.yaml": [
@@ -261,6 +305,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/ml/datafeeds?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().mlDatafeeds();\n"
     }
   ],
   "specification/cat/plugins/examples/request/CatPluginsRequestExample1.yaml": [
@@ -283,6 +331,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/plugins?v=true&s=component&h=name,component,version,description&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().plugins();\n"
     }
   ],
   "specification/cat/recovery/examples/request/CatRecoveryRequestExample1.yaml": [
@@ -305,6 +357,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/recovery?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().recovery();\n"
     }
   ],
   "specification/cat/health/examples/request/CatHealthRequestExample1.yaml": [
@@ -327,6 +383,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/health?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().health();\n"
     }
   ],
   "specification/cat/ml_jobs/examples/request/CatJobsRequestExample1.yaml": [
@@ -349,6 +409,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/ml/anomaly_detectors?h=id,s,dpr,mb&v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().mlJobs();\n"
     }
   ],
   "specification/cat/count/examples/request/CatCountRequestExample1.yaml": [
@@ -371,6 +435,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/count/my-index-000001?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().count();\n"
     }
   ],
   "specification/cat/repositories/examples/request/CatRepositoriesRequestExample1.yaml": [
@@ -393,6 +461,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/repositories?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().repositories();\n"
     }
   ],
   "specification/cat/ml_data_frame_analytics/examples/request/CatDataframeanalyticsRequestExample1.yaml": [
@@ -415,6 +487,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/ml/data_frame/analytics?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().mlDataFrameAnalytics();\n"
     }
   ],
   "specification/cat/transforms/examples/request/CatTransformsRequestExample1.yaml": [
@@ -437,6 +513,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/transforms?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().transforms();\n"
     }
   ],
   "specification/cat/master/examples/request/CatMasterRequestExample1.yaml": [
@@ -459,6 +539,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/master?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().master();\n"
     }
   ],
   "specification/cat/templates/examples/request/CatTemplatesRequestExample1.yaml": [
@@ -481,6 +565,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/templates/my-template-*?v=true&s=name&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().templates();\n"
     }
   ],
   "specification/cat/ml_trained_models/examples/request/CatTrainedModelsRequestExample1.yaml": [
@@ -503,6 +591,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/ml/trained_models?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().mlTrainedModels();\n"
     }
   ],
   "specification/cat/aliases/examples/request/CatAliasesRequestExample1.yaml": [
@@ -525,6 +617,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/aliases?format=json&v=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().aliases();\n"
     }
   ],
   "specification/cat/fielddata/examples/request/CatFielddataRequestExample1.yaml": [
@@ -547,6 +643,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/fielddata?v=true&fields=body&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().fielddata();\n"
     }
   ],
   "specification/cat/segments/examples/request/CatSegmentsRequestExample1.yaml": [
@@ -569,6 +669,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/segments?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().segments();\n"
     }
   ],
   "specification/cat/allocation/examples/request/CatAllocationRequestExample1.yaml": [
@@ -591,6 +695,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/allocation?v=true&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cat().allocation();\n"
     }
   ],
   "specification/searchable_snapshots/cache_stats/examples/request/CacheStatsRequestExample1.yaml": [
@@ -613,6 +721,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_searchable_snapshots/cache/stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchableSnapshots().cacheStats(c -> c);\n"
     }
   ],
   "specification/searchable_snapshots/clear_cache/examples/request/SearchableSnapshotsClearCacheExample1.yaml": [
@@ -635,6 +747,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index/_searchable_snapshots/cache/clear\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchableSnapshots().clearCache(c -> c\n    .index(\"my-index\")\n);\n"
     }
   ],
   "specification/searchable_snapshots/mount/examples/request/SearchableSnapshotsMountSnapshotRequestExample1.yaml": [
@@ -657,6 +773,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"my_docs\",\"renamed_index\":\"docs\",\"index_settings\":{\"index.number_of_replicas\":0},\"ignore_index_settings\":[\"index.refresh_interval\"]}' \"$ELASTICSEARCH_URL/_snapshot/my_repository/my_snapshot/_mount?wait_for_completion=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchableSnapshots().mount(m -> m\n    .ignoreIndexSettings(\"index.refresh_interval\")\n    .index(\"my_docs\")\n    .indexSettings(\"index.number_of_replicas\", JsonData.fromJson(\"0\"))\n    .renamedIndex(\"docs\")\n    .repository(\"my_repository\")\n    .snapshot(\"my_snapshot\")\n    .waitForCompletion(true)\n);\n"
     }
   ],
   "specification/searchable_snapshots/stats/examples/request/SearchableSnapshotsStatsExample1.yaml": [
@@ -679,6 +799,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index/_searchable_snapshots/stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchableSnapshots().stats(s -> s\n    .index(\"my-index\")\n);\n"
     }
   ],
   "specification/snapshot/delete_repository/examples/request/SnapshotDeleteRepositoryExample1.yaml": [
@@ -701,6 +825,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().deleteRepository(d -> d\n    .name(\"my_repository\")\n);\n"
     }
   ],
   "specification/snapshot/create_repository/examples/request/SnapshotCreateRepositoryRequestExample4.yaml": [
@@ -723,6 +851,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"s3\",\"settings\":{\"bucket\":\"my-bucket\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_s3_repository\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().createRepository(c -> c\n    .name(\"my_s3_repository\")\n    .repository(r -> r\n        .s3(s -> s\n            .settings(se -> se\n                .bucket(\"my-bucket\")\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/snapshot/create_repository/examples/request/SnapshotCreateRepositoryRequestExample5.yaml": [
@@ -745,6 +877,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"source\",\"settings\":{\"delegate_type\":\"fs\",\"location\":\"my_backup_repository\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_src_only_repository\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().createRepository(c -> c\n    .name(\"my_src_only_repository\")\n    .repository(r -> r\n        .source(s -> s\n            .settings(se -> se\n                .delegateType(\"fs\")\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/snapshot/create_repository/examples/request/SnapshotCreateRepositoryRequestExample2.yaml": [
@@ -767,6 +903,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"azure\",\"settings\":{\"client\":\"secondary\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_backup\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().createRepository(c -> c\n    .name(\"my_backup\")\n    .repository(r -> r\n        .azure(a -> a\n            .settings(s -> s\n                .client(\"secondary\")\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/snapshot/create_repository/examples/request/SnapshotCreateRepositoryRequestExample3.yaml": [
@@ -789,6 +929,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"gcs\",\"settings\":{\"bucket\":\"my_other_bucket\",\"base_path\":\"dev\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_gcs_repository\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().createRepository(c -> c\n    .name(\"my_gcs_repository\")\n    .repository(r -> r\n        .gcs(g -> g\n            .settings(s -> s\n                .bucket(\"my_other_bucket\")\n                .basePath(\"dev\")\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/snapshot/create_repository/examples/request/SnapshotCreateRepositoryRequestExample1.yaml": [
@@ -811,6 +955,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"fs\",\"settings\":{\"location\":\"my_backup_location\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_repository\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().createRepository(c -> c\n    .name(\"my_repository\")\n    .repository(r -> r\n        .fs(f -> f\n            .settings(s -> s\n                .location(\"my_backup_location\")\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/snapshot/create_repository/examples/request/SnapshotCreateRepositoryRequestExample6.yaml": [
@@ -833,6 +981,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"url\",\"settings\":{\"url\":\"file:/mount/backups/my_fs_backup_location\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_read_only_url_repository\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().createRepository(c -> c\n    .name(\"my_read_only_url_repository\")\n    .repository(r -> r\n        .url(u -> u\n            .settings(s -> s\n                .url(\"file:/mount/backups/my_fs_backup_location\")\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/snapshot/delete/examples/request/SnapshotDeleteRequestExample1.yaml": [
@@ -855,6 +1007,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository/snapshot_2,snapshot_3\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().delete(d -> d\n    .repository(\"my_repository\")\n    .snapshot(\"snapshot_2,snapshot_3\")\n);\n"
     }
   ],
   "specification/snapshot/verify_repository/examples/request/SnapshotVerifyRepositoryExample1.yaml": [
@@ -877,6 +1033,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_unverified_backup/_verify\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().verifyRepository(v -> v\n    .name(\"my_unverified_backup\")\n);\n"
     }
   ],
   "specification/snapshot/get/examples/request/SnapshotGetRequestExample1.yaml": [
@@ -899,6 +1059,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository/snapshot_*?sort=start_time&from_sort_value=1577833200000\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().get(g -> g\n    .fromSortValue(\"1577833200000\")\n    .repository(\"my_repository\")\n    .snapshot(\"snapshot_*\")\n    .sort(SnapshotSort.StartTime)\n);\n"
     }
   ],
   "specification/snapshot/repository_analyze/examples/request/SnapshotRepositoryAnalyzeRequestExample1.yaml": [
@@ -921,6 +1085,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository/_analyze?blob_count=10&max_blob_size=1mb&timeout=120s\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().repositoryAnalyze(r -> r\n    .blobCount(10)\n    .maxBlobSize(\"1mb\")\n    .name(\"my_repository\")\n    .timeout(t -> t\n        .offset(120)\n    )\n);\n"
     }
   ],
   "specification/snapshot/status/examples/request/SnapshotStatusRequestExample1.yaml": [
@@ -943,6 +1111,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository/snapshot_2/_status\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().status(s -> s\n    .repository(\"my_repository\")\n    .snapshot(\"snapshot_2\")\n);\n"
     }
   ],
   "specification/snapshot/cleanup_repository/examples/request/SnapshotCleanupRepositoryRequestExample1.yaml": [
@@ -965,6 +1137,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository/_cleanup\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().cleanupRepository(c -> c\n    .name(\"my_repository\")\n);\n"
     }
   ],
   "specification/snapshot/repository_verify_integrity/examples/request/SnapshotRepositoryVerifyIntegrityExample1.yaml": [
@@ -987,6 +1163,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository/_verify_integrity\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().repositoryVerifyIntegrity(r -> r\n    .name(\"my_repository\")\n);\n"
     }
   ],
   "specification/snapshot/clone/examples/request/SnapshotCloneRequestExample1.yaml": [
@@ -1009,6 +1189,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"indices\":\"index_a,index_b\"}' \"$ELASTICSEARCH_URL/_snapshot/my_repository/source_snapshot/_clone/target_snapshot\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().clone(c -> c\n    .indices(\"index_a,index_b\")\n    .repository(\"my_repository\")\n    .snapshot(\"source_snapshot\")\n    .targetSnapshot(\"target_snapshot\")\n);\n"
     }
   ],
   "specification/snapshot/get_repository/examples/request/SnapshotGetRepositoryRequestExample1.yaml": [
@@ -1031,6 +1215,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_snapshot/my_repository\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().getRepository(g -> g\n    .name(\"my_repository\")\n);\n"
     }
   ],
   "specification/snapshot/create/examples/request/SnapshotCreateRequestExample1.yaml": [
@@ -1053,6 +1241,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"indices\":\"index_1,index_2\",\"ignore_unavailable\":true,\"include_global_state\":false,\"metadata\":{\"taken_by\":\"user123\",\"taken_because\":\"backup before upgrading\"}}' \"$ELASTICSEARCH_URL/_snapshot/my_repository/snapshot_2?wait_for_completion=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().create(c -> c\n    .ignoreUnavailable(true)\n    .includeGlobalState(false)\n    .indices(\"index_1,index_2\")\n    .metadata(Map.of(\"taken_by\", JsonData.fromJson(\"\\\"user123\\\"\"),\"taken_because\", JsonData.fromJson(\"\\\"backup before upgrading\\\"\")))\n    .repository(\"my_repository\")\n    .snapshot(\"snapshot_2\")\n    .waitForCompletion(true)\n);\n"
     }
   ],
   "specification/snapshot/restore/examples/request/SnapshotRestoreRequestExample2.yaml": [
@@ -1075,6 +1267,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"indices\":\"index_1\"}' \"$ELASTICSEARCH_URL/_cluster/settings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cluster().putSettings();\n"
     }
   ],
   "specification/snapshot/restore/examples/request/SnapshotRestoreRequestExample1.yaml": [
@@ -1097,6 +1293,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"indices\":\"index_1,index_2\",\"ignore_unavailable\":true,\"include_global_state\":false,\"rename_pattern\":\"index_(.+)\",\"rename_replacement\":\"restored_index_$1\",\"include_aliases\":false}' \"$ELASTICSEARCH_URL/_snapshot/my_repository/snapshot_2/_restore?wait_for_completion=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.snapshot().restore(r -> r\n    .ignoreUnavailable(true)\n    .includeAliases(false)\n    .includeGlobalState(false)\n    .indices(\"index_1,index_2\")\n    .renamePattern(\"index_(.+)\")\n    .renameReplacement(\"restored_index_$1\")\n    .repository(\"my_repository\")\n    .snapshot(\"snapshot_2\")\n    .waitForCompletion(true)\n);\n"
     }
   ],
   "specification/cluster/delete_component_template/examples/request/ClusterDeleteComponentTemplateExample1.yaml": [
@@ -1119,6 +1319,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_component_template/template_1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cluster().deleteComponentTemplate(d -> d\n    .name(\"template_1\")\n);\n"
     }
   ],
   "specification/cluster/pending_tasks/examples/request/ClusterPendingTasksExample1.yaml": [
@@ -1141,6 +1345,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cluster/pending_tasks\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cluster().pendingTasks(p -> p);\n"
     }
   ],
   "specification/cluster/put_component_template/examples/request/ClusterPutComponentTemplateRequestExample1.yaml": [
@@ -1163,6 +1371,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"template\":{\"settings\":{\"number_of_shards\":1},\"mappings\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"keyword\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z yyyy\"}}}}}' \"$ELASTICSEARCH_URL/_component_template/template_1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cluster().putComponentTemplate(p -> p\n    .name(\"template_1\")\n    .template(t -> t\n        .mappings(m -> m\n            .properties(Map.of(\"created_at\", Property.of(pr -> pr\n                    .date(d -> d\n                        .format(\"EEE MMM dd HH:mm:ss Z yyyy\")\n                )),\"host_name\", Property.of(pro -> pro\n                    .keyword(k -> k\n                ))))\n            .source(s -> s\n                .enabled(false)\n            )\n        )\n        .settings(s -> s\n            .numberOfShards(\"1\")\n        )\n    )\n);\n"
     }
   ],
   "specification/cluster/put_component_template/examples/request/ClusterPutComponentTemplateRequestExample2.yaml": [
@@ -1207,6 +1419,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cluster/settings?filter_path=persistent.cluster.remote\""
+    },
+    {
+      "language": "Java",
+      "code": "\n"
     }
   ],
   "specification/cluster/reroute/examples/request/ClusterRerouteRequestExample1.yaml": [
@@ -1251,28 +1467,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"my-index-000001\",\"shard\":0,\"primary\":false,\"current_node\":\"my-node\"}' \"$ELASTICSEARCH_URL/_cluster/allocation/explain\""
-    }
-  ],
-  "specification/cluster/allocation_explain/examples/request/ClusterAllocationExplainRequestExample2.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.cluster.allocation_explain(\n    index=\"my-index-000001\",\n    shard=\"0\",\n    primary=False,\n    current_node=\"my-node\",\n)"
     },
     {
-      "language": "JavaScript",
-      "code": "const response = await client.cluster.allocationExplain({\n  index: \"my-index-000001\",\n  shard: 0,\n  primary: \"false\",\n  current_node: \"my-node\",\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.cluster.allocation_explain(\n  index: \"my-index-000001\",\n  shard: \"0\",\n  primary: \"false\",\n  current_node: \"my-node\",\n  body: {}\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->cluster()->allocationExplain([\n    \"index\" => \"my-index-000001\",\n    \"shard\" => \"0\",\n    \"primary\" => \"false\",\n    \"current_node\" => \"my-node\",\n    \"body\" => new ArrayObject([]),\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{}' \"$ELASTICSEARCH_URL/_cluster/allocation/explain?index=my-index-000001&shard=0&primary=false&current_node=my-node\""
+      "language": "Java",
+      "code": "client.cluster().allocationExplain(a -> a\n    .currentNode(\"my-node\")\n    .index(\"my-index-000001\")\n    .primary(false)\n    .shard(0)\n);\n"
     }
   ],
   "specification/cluster/put_settings/examples/request/ClusterPutSettingsRequestExample2.yaml": [
@@ -1295,6 +1493,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"persistent\":{\"action.auto_create_index\":\"my-index-000001,index10,-index1*,+ind*\"}}' \"$ELASTICSEARCH_URL/_cluster/settings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cluster().putSettings(p -> p\n    .persistent(\"action.auto_create_index\", JsonData.fromJson(\"\\\"my-index-000001,index10,-index1*,+ind*\\\"\"))\n);\n"
     }
   ],
   "specification/cluster/put_settings/examples/request/ClusterPutSettingsRequestExample1.yaml": [
@@ -1317,6 +1519,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"persistent\":{\"indices.recovery.max_bytes_per_sec\":\"50mb\"}}' \"$ELASTICSEARCH_URL/_cluster/settings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cluster().putSettings(p -> p\n    .persistent(\"indices.recovery.max_bytes_per_sec\", JsonData.fromJson(\"\\\"50mb\\\"\"))\n);\n"
     }
   ],
   "specification/cluster/health/examples/request/ClusterHealthRequestExample1.yaml": [
@@ -1339,6 +1545,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cluster/health\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cluster().health(h -> h);\n"
     }
   ],
   "specification/cluster/state/examples/request/ClusterStateExample1.yaml": [
@@ -1361,6 +1571,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cluster/state?filter_path=metadata.cluster_coordination.last_committed_config\""
+    },
+    {
+      "language": "Java",
+      "code": "\n"
     }
   ],
   "specification/cluster/info/examples/request/ClusterInfoExample1.yaml": [
@@ -1383,6 +1597,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_info/_all\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cluster().info(i -> i\n    .target(\"_all\")\n);\n"
     }
   ],
   "specification/cluster/remote_info/examples/request/ClusterRemoteInfoExample1.yaml": [
@@ -1405,6 +1623,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_remote/info\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cluster().remoteInfo();\n"
     }
   ],
   "specification/cluster/stats/examples/request/ClusterStatsExample1.yaml": [
@@ -1427,6 +1649,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cluster/stats?human&filter_path=indices.mappings.total_deduplicated_mapping_size*\""
+    },
+    {
+      "language": "Java",
+      "code": "\n"
     }
   ],
   "specification/cluster/get_component_template/examples/request/ClusterGetComponentTemplateExample1.yaml": [
@@ -1449,6 +1675,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_component_template/template_1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cluster().getComponentTemplate(g -> g\n    .name(\"template_1\")\n);\n"
     }
   ],
   "specification/ssl/certificates/examples/request/GetCertificatesRequestExample1.yaml": [
@@ -1471,6 +1701,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ssl/certificates\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ssl().certificates();\n"
     }
   ],
   "specification/tasks/cancel/examples/request/TasksCancelExample1.yaml": [
@@ -1493,6 +1727,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_tasks/<task_id>/_cancel\""
+    },
+    {
+      "language": "Java",
+      "code": "client.tasks().cancel(c -> c\n    .taskId(\"<task_id>\")\n);\n"
     }
   ],
   "specification/tasks/get/examples/request/GetTaskRequestExample2.yaml": [
@@ -1559,6 +1797,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_patterns\":[\"my-index-*\"],\"composed_of\":[\"ct2\"],\"priority\":10,\"template\":{\"settings\":{\"index.number_of_replicas\":1}}}' \"$ELASTICSEARCH_URL/_index_template/_simulate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().simulateTemplate(s -> s\n    .composedOf(\"ct2\")\n    .indexPatterns(\"my-index-*\")\n    .priority(10L)\n    .template(t -> t\n        .settings(se -> se\n            .otherSettings(\"index.number_of_replicas\", JsonData.fromJson(\"1\"))\n        )\n    )\n);\n"
     }
   ],
   "specification/indices/split/examples/request/indicesSplitRequestExample1.yaml": [
@@ -1581,6 +1823,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"settings\":{\"index.number_of_shards\":2}}' \"$ELASTICSEARCH_URL/my-index-000001/_split/split-my-index-000001\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().split(s -> s\n    .index(\"my-index-000001\")\n    .settings(\"index.number_of_shards\", JsonData.fromJson(\"2\"))\n    .target(\"split-my-index-000001\")\n);\n"
     }
   ],
   "specification/indices/update_aliases/examples/request/IndicesUpdateAliasesExample1.yaml": [
@@ -1603,6 +1849,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"actions\":[{\"add\":{\"index\":\"logs-nginx.access-prod\",\"alias\":\"logs\"}}]}' \"$ELASTICSEARCH_URL/_aliases\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().updateAliases(u -> u\n    .actions(a -> a\n        .add(ad -> ad\n            .alias(\"logs\")\n            .index(\"logs-nginx.access-prod\")\n        )\n    )\n);\n"
     }
   ],
   "specification/indices/exists_alias/examples/request/IndicesExistsAliasExample1.yaml": [
@@ -1625,6 +1875,10 @@
     {
       "language": "curl",
       "code": "curl --head -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_alias/my-alias\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().existsAlias(e -> e\n    .name(\"my-alias\")\n);\n"
     }
   ],
   "specification/indices/get_data_stream_mappings/examples/request/IndicesGetDataStreamMappingsRequestExample1.yaml": [
@@ -1647,6 +1901,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/my-data-stream/_mappings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().getDataStreamMappings(g -> g\n    .name(\"my-data-stream\")\n);\n"
     }
   ],
   "specification/indices/delete_template/examples/request/IndicesDeleteTemplateExample1.yaml": [
@@ -1669,6 +1927,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_template/.cloud-hot-warm-allocation-0\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().deleteTemplate(d -> d\n    .name(\".cloud-hot-warm-allocation-0\")\n);\n"
     }
   ],
   "specification/indices/data_streams_stats/examples/request/indicesDataStreamStatsExampleRequest1.yaml": [
@@ -1691,6 +1953,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/my-index-000001/_stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().dataStreamsStats(d -> d\n    .name(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/indices/delete_index_template/examples/request/IndicesDeleteIndexTemplateExample1.yaml": [
@@ -1713,6 +1979,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_index_template/my-index-template\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().deleteIndexTemplate(d -> d\n    .name(\"my-index-template\")\n);\n"
     }
   ],
   "specification/indices/simulate_index_template/examples/request/indicesSimulateIndexTemplateRequestExample1.yaml": [
@@ -1735,6 +2005,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_index_template/_simulate_index/my-index-000001\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().simulateIndexTemplate(s -> s\n    .name(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/indices/put_template/examples/request/indicesPutTemplateRequestExample2.yaml": [
@@ -1757,6 +2031,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_patterns\":[\"te*\"],\"settings\":{\"number_of_shards\":1},\"aliases\":{\"alias1\":{},\"alias2\":{\"filter\":{\"term\":{\"user.id\":\"kimchy\"}},\"routing\":\"shard-1\"},\"{index}-alias\":{}}}' \"$ELASTICSEARCH_URL/_template/template_1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putTemplate(p -> p\n    .aliases(Map.of(\"alias1\", Alias.of(a -> a),\"{index}-alias\", Alias.of(a -> a),\"alias2\", Alias.of(a -> a\n            .filter(f -> f\n                .term(t -> t\n                    .field(\"user.id\")\n                    .value(FieldValue.of(\"kimchy\"))\n                )\n            )\n            .routing(\"shard-1\"))))\n    .indexPatterns(\"te*\")\n    .name(\"template_1\")\n    .settings(s -> s\n        .numberOfShards(\"1\")\n    )\n);\n"
     }
   ],
   "specification/indices/put_template/examples/request/indicesPutTemplateRequestExample1.yaml": [
@@ -1779,6 +2057,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_patterns\":[\"te*\",\"bar*\"],\"settings\":{\"number_of_shards\":1},\"mappings\":{\"_source\":{\"enabled\":false},\"properties\":{\"host_name\":{\"type\":\"keyword\"},\"created_at\":{\"type\":\"date\",\"format\":\"EEE MMM dd HH:mm:ss Z yyyy\"}}}}' \"$ELASTICSEARCH_URL/_template/template_1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putTemplate(p -> p\n    .indexPatterns(List.of(\"te*\",\"bar*\"))\n    .mappings(m -> m\n        .properties(Map.of(\"created_at\", Property.of(pr -> pr\n                .date(d -> d\n                    .format(\"EEE MMM dd HH:mm:ss Z yyyy\")\n            )),\"host_name\", Property.of(pro -> pro\n                .keyword(k -> k\n            ))))\n        .source(s -> s\n            .enabled(false)\n        )\n    )\n    .name(\"template_1\")\n    .settings(s -> s\n        .numberOfShards(\"1\")\n    )\n);\n"
     }
   ],
   "specification/indices/put_data_stream_mappings/examples/request/IndicesPutDataStreamMappingsRequestExample1.yaml": [
@@ -1801,6 +2083,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"properties\":{\"field1\":{\"type\":\"ip\"},\"field3\":{\"type\":\"text\"}}}' \"$ELASTICSEARCH_URL/_data_stream/my-data-stream/_mappings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putDataStreamMappings(p -> p\n    .name(\"my-data-stream\")\n    .mappings(m -> m\n        .properties(Map.of(\"field1\", Property.of(pr -> pr\n                .ip(i -> i\n            )),\"field3\", Property.of(pro -> pro\n                .text(t -> t\n            ))))\n    )\n);\n"
     }
   ],
   "specification/indices/delete_data_lifecycle/examples/request/IndicesDeleteDataLifecycleExample1.yaml": [
@@ -1823,6 +2109,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/my-data-stream/_lifecycle\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().deleteDataLifecycle(d -> d\n    .name(\"my-data-stream\")\n);\n"
     }
   ],
   "specification/indices/create_from/examples/request/IndicesCreateFromExample1.yaml": [
@@ -1845,6 +2135,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_create_from/my-index/my-new-index\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().createFrom(c -> c\n    .dest(\"my-new-index\")\n    .source(\"my-index\")\n    .createFrom(cr -> cr)\n);\n"
     }
   ],
   "specification/indices/close/examples/request/CloseIndexRequestExample1.yaml": [
@@ -1867,6 +2161,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-00001/_close\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().close(c -> c\n    .index(\"my-index-00001\")\n);\n"
     }
   ],
   "specification/indices/get_migrate_reindex_status/examples/request/IndicesGetMigrateReindexStatusExample1.yaml": [
@@ -1889,6 +2187,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_migration/reindex/my-data-stream/_status\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().getMigrateReindexStatus(g -> g\n    .index(\"my-data-stream\")\n);\n"
     }
   ],
   "specification/indices/get_settings/examples/request/IndicesGetSettingsExample1.yaml": [
@@ -1933,6 +2235,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/_promote/my-data-stream\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().promoteDataStream(p -> p\n    .name(\"my-data-stream\")\n);\n"
     }
   ],
   "specification/indices/flush/examples/request/IndicesFlushExample1.yaml": [
@@ -1955,6 +2261,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_flush\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().flush(f -> f);\n"
     }
   ],
   "specification/indices/delete/examples/request/IndicesDeleteExample1.yaml": [
@@ -1977,6 +2287,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/books\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().delete(d -> d\n    .index(\"books\")\n);\n"
     }
   ],
   "specification/indices/refresh/examples/request/IndicesRefreshExample1.yaml": [
@@ -1999,6 +2313,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_refresh\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().refresh(r -> r);\n"
     }
   ],
   "specification/indices/resolve_index/examples/request/ResolveIndexRequestExample1.yaml": [
@@ -2043,6 +2361,10 @@
     {
       "language": "curl",
       "code": "curl --head -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-data-stream\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().exists(e -> e\n    .index(\"my-data-stream\")\n);\n"
     }
   ],
   "specification/indices/recovery/examples/request/indicesRecoveryRequestExample1.yaml": [
@@ -2065,6 +2387,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_recovery?human\""
+    },
+    {
+      "language": "Java",
+      "code": "\n"
     }
   ],
   "specification/indices/put_settings/examples/request/indicesPutSettingsRequestExample3.yaml": [
@@ -2087,6 +2413,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"analysis\":{\"analyzer\":{\"content\":{\"type\":\"custom\",\"tokenizer\":\"whitespace\"}}}}' \"$ELASTICSEARCH_URL/my-index-000001/_settings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putSettings(p -> p\n    .index(\"my-index-000001\")\n    .settings(s -> s\n        .analysis(a -> a\n            .analyzer(\"content\", an -> an\n                .custom(c -> c\n                    .tokenizer(\"whitespace\")\n                )\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/indices/put_settings/examples/request/indicesPutSettingsRequestExample2.yaml": [
@@ -2131,6 +2461,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":{\"number_of_replicas\":2}}' \"$ELASTICSEARCH_URL/my-index-000001/_settings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putSettings(p -> p\n    .index(\"my-index-000001\")\n    .settings(s -> s\n        .index(i -> i\n            .numberOfReplicas(\"2\")\n        )\n    )\n);\n"
     }
   ],
   "specification/indices/clear_cache/examples/request/IndicesClearCacheExample1.yaml": [
@@ -2153,6 +2487,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001,my-index-000002/_cache/clear?request=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().clearCache(c -> c\n    .index(List.of(\"my-index-000001\",\"my-index-000002\"))\n    .request(true)\n);\n"
     }
   ],
   "specification/indices/reload_search_analyzers/examples/request/ReloadSearchAnalyzersRequestExample1.yaml": [
@@ -2175,6 +2513,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_reload_search_analyzers\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().reloadSearchAnalyzers(r -> r\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/indices/cancel_migrate_reindex/examples/request/IndicesCancelMigrateReindexExample1.yaml": [
@@ -2197,6 +2539,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_migration/reindex/my-data-stream/_cancel\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().cancelMigrateReindex(c -> c\n    .index(\"my-data-stream\")\n);\n"
     }
   ],
   "specification/indices/delete_data_stream/examples/request/IndicesDeleteDataStreamExample1.yaml": [
@@ -2219,6 +2565,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/my-data-stream\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().deleteDataStream(d -> d\n    .name(\"my-data-stream\")\n);\n"
     }
   ],
   "specification/indices/get/examples/request/IndicesGetExample1.yaml": [
@@ -2241,9 +2591,13 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().get(g -> g\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
-  "specification/indices/disk_usage/examples/request/IndicesDiskUsageRequestExample1.yaml": [
+  "specification/indices/disk_usage/examples/request/IndicesDiskUsageExample1.yaml": [
     {
       "language": "Python",
       "code": "resp = client.indices.disk_usage(\n    index=\"my-index-000001\",\n    run_expensive_tasks=True,\n)"
@@ -2263,6 +2617,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_disk_usage?run_expensive_tasks=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().diskUsage(d -> d\n    .index(\"my-index-000001\")\n    .runExpensiveTasks(true)\n);\n"
     }
   ],
   "specification/indices/create_data_stream/examples/request/IndicesCreateDataStreamExample1.yaml": [
@@ -2285,6 +2643,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/logs-foo-bar\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().createDataStream(c -> c\n    .name(\"logs-foo-bar\")\n);\n"
     }
   ],
   "specification/indices/delete_alias/examples/request/IndicesDeleteAliasExample1.yaml": [
@@ -2307,6 +2669,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-data-stream/_alias/my-alias\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().deleteAlias(d -> d\n    .index(\"my-data-stream\")\n    .name(\"my-alias\")\n);\n"
     }
   ],
   "specification/indices/forcemerge/examples/request/IndicesForcemergeExample1.yaml": [
@@ -2329,6 +2695,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_forcemerge\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().forcemerge(f -> f\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/indices/downsample/examples/request/DownsampleRequestExample1.yaml": [
@@ -2351,6 +2721,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"fixed_interval\":\"1d\"}' \"$ELASTICSEARCH_URL/my-time-series-index/_downsample/my-downsampled-time-series-index\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().downsample(d -> d\n    .index(\"my-time-series-index\")\n    .targetIndex(\"my-downsampled-time-series-index\")\n    .config(c -> c\n        .fixedInterval(f -> f\n            .time(\"1d\")\n        )\n    )\n);\n"
     }
   ],
   "specification/indices/get_template/examples/request/IndicesGetTemplateExample1.yaml": [
@@ -2373,6 +2747,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_template/.monitoring-*\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().getTemplate(g -> g\n    .name(\".monitoring-*\")\n);\n"
     }
   ],
   "specification/indices/shrink/examples/request/indicesShrinkRequestExample1.yaml": [
@@ -2395,6 +2773,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"settings\":{\"index.routing.allocation.require._name\":null,\"index.blocks.write\":null}}' \"$ELASTICSEARCH_URL/my_source_index/_shrink/my_target_index\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().shrink(s -> s\n    .index(\"my_source_index\")\n    .settings(Map.of(\"index.blocks.write\", JsonData.fromJson(\"null\"),\"index.routing.allocation.require._name\", JsonData.fromJson(\"null\")))\n    .target(\"my_target_index\")\n);\n"
     }
   ],
   "specification/indices/explain_data_lifecycle/examples/request/IndicesExplainDataLifecycleRequestExample1.yaml": [
@@ -2417,6 +2799,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/.ds-metrics-2023.03.22-000001/_lifecycle/explain\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().explainDataLifecycle(e -> e\n    .index(\".ds-metrics-2023.03.22-000001\")\n);\n"
     }
   ],
   "specification/indices/get_mapping/examples/request/IndicesGetMappingExample1.yaml": [
@@ -2439,6 +2825,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/books/_mapping\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().getMapping(g -> g\n    .index(\"books\")\n);\n"
     }
   ],
   "specification/indices/get_data_lifecycle_stats/examples/request/IndicesGetDataLifecycleStatsRequestExample1.yaml": [
@@ -2461,6 +2851,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_lifecycle/stats?human&pretty\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().getDataLifecycleStats();\n"
     }
   ],
   "specification/indices/add_block/examples/request/IndicesAddBlockRequestExample1.yaml": [
@@ -2483,6 +2877,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_block/write\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().addBlock(a -> a\n    .block(IndicesBlockOptions.Write)\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/indices/rollover/examples/request/indicesRolloverRequestExample1.yaml": [
@@ -2505,28 +2903,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"conditions\":{\"max_age\":\"7d\",\"max_docs\":1000,\"max_primary_shard_size\":\"50gb\",\"max_primary_shard_docs\":\"2000\"}}' \"$ELASTICSEARCH_URL/my-data-stream/_rollover\""
-    }
-  ],
-  "specification/indices/rollover/examples/request/indicesRolloverRequestExample2.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.indices.rollover(\n    alias=\"my-data-stream\",\n)"
     },
     {
-      "language": "JavaScript",
-      "code": "const response = await client.indices.rollover({\n  alias: \"my-data-stream\",\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.indices.rollover(\n  alias: \"my-data-stream\",\n  body: {}\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->indices()->rollover([\n    \"alias\" => \"my-data-stream\",\n    \"body\" => new ArrayObject([]),\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{}' \"$ELASTICSEARCH_URL/my-data-stream/_rollover\""
+      "language": "Java",
+      "code": "client.indices().rollover(r -> r\n    .alias(\"my-data-stream\")\n    .conditions(c -> c\n        .maxAge(m -> m\n            .time(\"7d\")\n        )\n        .maxDocs(1000L)\n        .maxPrimaryShardSize(\"50gb\")\n        .maxPrimaryShardDocs(2000L)\n    )\n);\n"
     }
   ],
   "specification/indices/put_data_lifecycle/examples/request/IndicesPutDataLifecycleRequestExample1.yaml": [
@@ -2549,6 +2929,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"data_retention\":\"7d\"}' \"$ELASTICSEARCH_URL/_data_stream/my-data-stream/_lifecycle\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putDataLifecycle(p -> p\n    .dataRetention(d -> d\n        .time(\"7d\")\n    )\n    .name(\"my-data-stream\")\n);\n"
     }
   ],
   "specification/indices/put_data_lifecycle/examples/request/IndicesPutDataLifecycleRequestExample2.yaml": [
@@ -2593,6 +2977,10 @@
     {
       "language": "curl",
       "code": "curl --head -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_template/template_1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().existsTemplate(e -> e\n    .name(\"template_1\")\n);\n"
     }
   ],
   "specification/indices/validate_query/examples/request/IndicesValidateQueryExample1.yaml": [
@@ -2615,6 +3003,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_validate/query?q=user.id:kimchy\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().validateQuery(v -> v\n    .index(\"my-index-000001\")\n    .q(\"user.id:kimchy\")\n);\n"
     }
   ],
   "specification/indices/put_index_template/examples/request/IndicesPutIndexTemplateRequestExample1.yaml": [
@@ -2637,6 +3029,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_patterns\":[\"template*\"],\"priority\":1,\"template\":{\"settings\":{\"number_of_shards\":2}}}' \"$ELASTICSEARCH_URL/_index_template/template_1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putIndexTemplate(p -> p\n    .indexPatterns(\"template*\")\n    .name(\"template_1\")\n    .priority(1L)\n    .template(t -> t\n        .settings(s -> s\n            .numberOfShards(\"2\")\n        )\n    )\n);\n"
     }
   ],
   "specification/indices/put_index_template/examples/request/IndicesPutIndexTemplateRequestExample2.yaml": [
@@ -2659,6 +3055,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_patterns\":[\"template*\"],\"template\":{\"settings\":{\"number_of_shards\":1},\"aliases\":{\"alias1\":{},\"alias2\":{\"filter\":{\"term\":{\"user.id\":\"kimchy\"}},\"routing\":\"shard-1\"},\"{index}-alias\":{}}}}' \"$ELASTICSEARCH_URL/_index_template/template_1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putIndexTemplate(p -> p\n    .indexPatterns(\"template*\")\n    .name(\"template_1\")\n    .template(t -> t\n        .aliases(Map.of(\"alias1\", Alias.of(a -> a),\"{index}-alias\", Alias.of(a -> a),\"alias2\", Alias.of(a -> a\n                .filter(f -> f\n                    .term(te -> te\n                        .field(\"user.id\")\n                        .value(FieldValue.of(\"kimchy\"))\n                    )\n                )\n                .routing(\"shard-1\"))))\n        .settings(s -> s\n            .numberOfShards(\"1\")\n        )\n    )\n);\n"
     }
   ],
   "specification/indices/clone/examples/request/indicesCloneRequestExample1.yaml": [
@@ -2681,6 +3081,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"settings\":{\"index.refresh_interval\":\"2s\"},\"aliases\":{\"my_search_indices\":{}}}' \"$ELASTICSEARCH_URL/my_source_index/_clone/my_target_index\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().clone(c -> c\n    .aliases(\"my_search_indices\", a -> a)\n    .index(\"my_source_index\")\n    .settings(\"index.refresh_interval\", JsonData.fromJson(\"\\\"2s\\\"\"))\n    .target(\"my_target_index\")\n);\n"
     }
   ],
   "specification/indices/get_index_template/examples/request/IndicesGetIndexTemplateExample1.yaml": [
@@ -2703,6 +3107,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_index_template/*?filter_path=index_templates.name,index_templates.index_template.index_patterns,index_templates.index_template.data_stream\""
+    },
+    {
+      "language": "Java",
+      "code": "\n"
     }
   ],
   "specification/indices/get_data_lifecycle/examples/request/IndicesGetDataLifecycleRequestExample1.yaml": [
@@ -2725,6 +3133,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/%7Bname%7D/_lifecycle?human&pretty\""
+    },
+    {
+      "language": "Java",
+      "code": "\n"
     }
   ],
   "specification/indices/get_data_stream/examples/request/IndicesGetDataStreamExample1.yaml": [
@@ -2747,6 +3159,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/my-data-stream\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().getDataStream(g -> g\n    .name(\"my-data-stream\")\n);\n"
     }
   ],
   "specification/indices/modify_data_stream/examples/request/IndicesModifyDataStreamExample1.yaml": [
@@ -2769,6 +3185,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"actions\":[{\"remove_backing_index\":{\"data_stream\":\"my-data-stream\",\"index\":\".ds-my-data-stream-2023.07.26-000001\"}},{\"add_backing_index\":{\"data_stream\":\"my-data-stream\",\"index\":\".ds-my-data-stream-2023.07.26-000001-downsample\"}}]}' \"$ELASTICSEARCH_URL/_data_stream/_modify\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().modifyDataStream(m -> m\n    .actions(List.of(Action.of(a -> a\n            .removeBackingIndex(r -> r\n                .dataStream(\"my-data-stream\")\n                .index(\".ds-my-data-stream-2023.07.26-000001\")\n        )),Action.of(ac -> ac\n            .addBackingIndex(ad -> ad\n                .dataStream(\"my-data-stream\")\n                .index(\".ds-my-data-stream-2023.07.26-000001-downsample\")\n        ))))\n);\n"
     }
   ],
   "specification/indices/analyze/examples/request/indicesAnalyzeRequestExample3.yaml": [
@@ -2791,6 +3211,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"tokenizer\":\"keyword\",\"filter\":[\"lowercase\"],\"char_filter\":[\"html_strip\"],\"text\":\"this is a test</b>\"}' \"$ELASTICSEARCH_URL/_analyze\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().analyze(a -> a\n    .charFilter(c -> c\n        .name(\"html_strip\")\n    )\n    .filter(f -> f\n        .name(\"lowercase\")\n    )\n    .text(\"this is a test</b>\")\n    .tokenizer(t -> t\n        .name(\"keyword\")\n    )\n);\n"
     }
   ],
   "specification/indices/analyze/examples/request/indicesAnalyzeRequestExample2.yaml": [
@@ -2813,6 +3237,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"analyzer\":\"standard\",\"text\":[\"this is a test\",\"the second text\"]}' \"$ELASTICSEARCH_URL/_analyze\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().analyze(a -> a\n    .analyzer(\"standard\")\n    .text(List.of(\"this is a test\",\"the second text\"))\n);\n"
     }
   ],
   "specification/indices/analyze/examples/request/indicesAnalyzeRequestExample5.yaml": [
@@ -2835,6 +3263,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"field\":\"obj1.field1\",\"text\":\"this is a test\"}' \"$ELASTICSEARCH_URL/analyze_sample/_analyze\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().analyze(a -> a\n    .field(\"obj1.field1\")\n    .index(\"analyze_sample\")\n    .text(\"this is a test\")\n);\n"
     }
   ],
   "specification/indices/analyze/examples/request/indicesAnalyzeRequestExample4.yaml": [
@@ -2857,6 +3289,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"tokenizer\":\"whitespace\",\"filter\":[\"lowercase\",{\"type\":\"stop\",\"stopwords\":[\"a\",\"is\",\"this\"]}],\"text\":\"this is a test\"}' \"$ELASTICSEARCH_URL/_analyze\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().analyze(a -> a\n    .filter(List.of(TokenFilter.of(t -> t\n            .name(\"lowercase\"\n        )),TokenFilter.of(to -> to\n            .definition(d -> d\n                .stop(s -> s\n                    .stopwords(List.of(\"a\",\"is\",\"this\"))\n            )\n        ))))\n    .text(\"this is a test\")\n    .tokenizer(tok -> tok\n        .name(\"whitespace\")\n    )\n);\n"
     }
   ],
   "specification/indices/analyze/examples/request/indicesAnalyzeRequestExample7.yaml": [
@@ -2879,6 +3315,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"tokenizer\":\"standard\",\"filter\":[\"snowball\"],\"text\":\"detailed output\",\"explain\":true,\"attributes\":[\"keyword\"]}' \"$ELASTICSEARCH_URL/_analyze\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().analyze(a -> a\n    .attributes(\"keyword\")\n    .explain(true)\n    .filter(f -> f\n        .name(\"snowball\")\n    )\n    .text(\"detailed output\")\n    .tokenizer(t -> t\n        .name(\"standard\")\n    )\n);\n"
     }
   ],
   "specification/indices/analyze/examples/request/indicesAnalyzeRequestExample6.yaml": [
@@ -2901,6 +3341,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"normalizer\":\"my_normalizer\",\"text\":\"BaR\"}' \"$ELASTICSEARCH_URL/analyze_sample/_analyze\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().analyze(a -> a\n    .index(\"analyze_sample\")\n    .normalizer(\"my_normalizer\")\n    .text(\"BaR\")\n);\n"
     }
   ],
   "specification/indices/analyze/examples/request/indicesAnalyzeRequestExample1.yaml": [
@@ -2923,6 +3367,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"analyzer\":\"standard\",\"text\":\"this is a test\"}' \"$ELASTICSEARCH_URL/_analyze\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().analyze(a -> a\n    .analyzer(\"standard\")\n    .text(\"this is a test\")\n);\n"
     }
   ],
   "specification/indices/shard_stores/examples/request/indicesShardStoresRequestExample1.yaml": [
@@ -2967,6 +3415,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/my-data-stream/_settings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().getDataStreamSettings(g -> g\n    .name(\"my-data-stream\")\n);\n"
     }
   ],
   "specification/indices/get_alias/examples/request/IndicesGetAliasExample1.yaml": [
@@ -2989,6 +3441,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_alias\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().getAlias(g -> g);\n"
     }
   ],
   "specification/indices/remove_block/examples/request/IndicesRemoveBlockRequestExample1.yaml": [
@@ -3011,28 +3467,36 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_block/write\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().removeBlock(r -> r\n    .block(IndicesBlockOptions.Write)\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/indices/put_alias/examples/request/indicesPutAliasRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.indices.update_aliases(\n    actions=[\n        {\n            \"add\": {\n                \"index\": \"my-data-stream\",\n                \"alias\": \"my-alias\"\n            }\n        }\n    ],\n)"
+      "code": "resp = client.indices.put_alias(\n    index=\"my-index-2099.05.06-000001\",\n    name=\"my-alias\",\n    filter={\n        \"bool\": {\n            \"filter\": [\n                {\n                    \"range\": {\n                        \"@timestamp\": {\n                            \"gte\": \"now-1d/d\",\n                            \"lt\": \"now/d\"\n                        }\n                    }\n                },\n                {\n                    \"term\": {\n                        \"user.id\": \"kimchy\"\n                    }\n                }\n            ]\n        }\n    },\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.indices.updateAliases({\n  actions: [\n    {\n      add: {\n        index: \"my-data-stream\",\n        alias: \"my-alias\",\n      },\n    },\n  ],\n});"
+      "code": "const response = await client.indices.putAlias({\n  index: \"my-index-2099.05.06-000001\",\n  name: \"my-alias\",\n  filter: {\n    bool: {\n      filter: [\n        {\n          range: {\n            \"@timestamp\": {\n              gte: \"now-1d/d\",\n              lt: \"now/d\",\n            },\n          },\n        },\n        {\n          term: {\n            \"user.id\": \"kimchy\",\n          },\n        },\n      ],\n    },\n  },\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.indices.update_aliases(\n  body: {\n    \"actions\": [\n      {\n        \"add\": {\n          \"index\": \"my-data-stream\",\n          \"alias\": \"my-alias\"\n        }\n      }\n    ]\n  }\n)"
+      "code": "response = client.indices.put_alias(\n  index: \"my-index-2099.05.06-000001\",\n  name: \"my-alias\",\n  body: {\n    \"filter\": {\n      \"bool\": {\n        \"filter\": [\n          {\n            \"range\": {\n              \"@timestamp\": {\n                \"gte\": \"now-1d/d\",\n                \"lt\": \"now/d\"\n              }\n            }\n          },\n          {\n            \"term\": {\n              \"user.id\": \"kimchy\"\n            }\n          }\n        ]\n      }\n    }\n  }\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->indices()->updateAliases([\n    \"body\" => [\n        \"actions\" => array(\n            [\n                \"add\" => [\n                    \"index\" => \"my-data-stream\",\n                    \"alias\" => \"my-alias\",\n                ],\n            ],\n        ),\n    ],\n]);"
+      "code": "$resp = $client->indices()->putAlias([\n    \"index\" => \"my-index-2099.05.06-000001\",\n    \"name\" => \"my-alias\",\n    \"body\" => [\n        \"filter\" => [\n            \"bool\" => [\n                \"filter\" => array(\n                    [\n                        \"range\" => [\n                            \"@timestamp\" => [\n                                \"gte\" => \"now-1d/d\",\n                                \"lt\" => \"now/d\",\n                            ],\n                        ],\n                    ],\n                    [\n                        \"term\" => [\n                            \"user.id\" => \"kimchy\",\n                        ],\n                    ],\n                ),\n            ],\n        ],\n    ],\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"actions\":[{\"add\":{\"index\":\"my-data-stream\",\"alias\":\"my-alias\"}}]}' \"$ELASTICSEARCH_URL/_aliases\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"filter\":{\"bool\":{\"filter\":[{\"range\":{\"@timestamp\":{\"gte\":\"now-1d/d\",\"lt\":\"now/d\"}}},{\"term\":{\"user.id\":\"kimchy\"}}]}}}' \"$ELASTICSEARCH_URL/my-index-2099.05.06-000001/_alias/my-alias\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putAlias(p -> p\n    .filter(f -> f\n        .bool(b -> b\n            .filter(List.of(Query.of(q -> q\n                    .range(r -> r\n                        .untyped(u -> u\n                            .field(\"@timestamp\")\n                            .gte(JsonData.fromJson(\"\\\"now-1d/d\\\"\"))\n                            .lt(JsonData.fromJson(\"\\\"now/d\\\"\"))\n                    )\n                )),Query.of(qu -> qu\n                    .term(t -> t\n                        .field(\"user.id\")\n                        .value(FieldValue.of(\"kimchy\"))\n                ))))\n        )\n    )\n    .index(\"my-index-2099.05.06-000001\")\n    .name(\"my-alias\")\n);\n"
     }
   ],
   "specification/indices/put_data_stream_settings/examples/request/IndicesPutDataStreamSettingsRequestExample1.yaml": [
@@ -3055,6 +3519,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index.lifecycle.name\":\"new-test-policy\",\"index.number_of_shards\":11}' \"$ELASTICSEARCH_URL/_data_stream/my-data-stream/_settings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putDataStreamSettings(p -> p\n    .name(\"my-data-stream\")\n    .settings(s -> s\n        .otherSettings(Map.of(\"index.lifecycle.name\", JsonData.fromJson(\"\\\"new-test-policy\\\"\"),\"index.number_of_shards\", JsonData.fromJson(\"11\")))\n    )\n);\n"
     }
   ],
   "specification/indices/get_field_mapping/examples/request/indicesGetFieldMappingRequestExample1.yaml": [
@@ -3077,6 +3545,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/publications/_mapping/field/title\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().getFieldMapping(g -> g\n    .fields(\"title\")\n    .index(\"publications\")\n);\n"
     }
   ],
   "specification/indices/migrate_reindex/examples/request/IndicesMigrateReindexExample1.yaml": [
@@ -3099,6 +3571,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-data-stream\"},\"mode\":\"upgrade\"}' \"$ELASTICSEARCH_URL/_migration/reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().migrateReindex(m -> m\n    .reindex(r -> r\n        .mode(ModeEnum.Upgrade)\n        .source(s -> s\n            .index(\"my-data-stream\")\n        )\n    )\n);\n"
     }
   ],
   "specification/indices/create/examples/request/indicesCreateRequestExample1.yaml": [
@@ -3121,6 +3597,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"settings\":{\"number_of_shards\":3,\"number_of_replicas\":2}}' \"$ELASTICSEARCH_URL/my-index-000001\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().create(c -> c\n    .index(\"my-index-000001\")\n    .settings(s -> s\n        .numberOfShards(\"3\")\n        .numberOfReplicas(\"2\")\n    )\n);\n"
     }
   ],
   "specification/indices/create/examples/request/indicesCreateRequestExample2.yaml": [
@@ -3143,6 +3623,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"settings\":{\"number_of_shards\":1},\"mappings\":{\"properties\":{\"field1\":{\"type\":\"text\"}}}}' \"$ELASTICSEARCH_URL/test\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().create(c -> c\n    .index(\"test\")\n    .mappings(m -> m\n        .properties(\"field1\", p -> p\n            .text(t -> t)\n        )\n    )\n    .settings(s -> s\n        .numberOfShards(\"1\")\n    )\n);\n"
     }
   ],
   "specification/indices/create/examples/request/indicesCreateRequestExample3.yaml": [
@@ -3165,6 +3649,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"aliases\":{\"alias_1\":{},\"alias_2\":{\"filter\":{\"term\":{\"user.id\":\"kimchy\"}},\"routing\":\"shard-1\"}}}' \"$ELASTICSEARCH_URL/test\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().create(c -> c\n    .aliases(Map.of(\"alias_2\", Alias.of(a -> a\n            .filter(f -> f\n                .term(t -> t\n                    .field(\"user.id\")\n                    .value(FieldValue.of(\"kimchy\"))\n                )\n            )\n            .routing(\"shard-1\")),\"alias_1\", Alias.of(al -> al)))\n    .index(\"test\")\n);\n"
     }
   ],
   "specification/indices/field_usage_stats/examples/request/indicesFieldUsageStatsRequestExample1.yaml": [
@@ -3187,6 +3675,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_field_usage_stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().fieldUsageStats(f -> f\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/indices/migrate_to_data_stream/examples/request/IndicesMigrateToDataStreamExample1.yaml": [
@@ -3209,6 +3701,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_data_stream/_migrate/my-time-series-data\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().migrateToDataStream(m -> m\n    .name(\"my-time-series-data\")\n);\n"
     }
   ],
   "specification/indices/open/examples/request/IndicesOpenExample1.yaml": [
@@ -3231,6 +3727,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/.ds-my-data-stream-2099.03.07-000001/_open/\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().open(o -> o\n    .index(\".ds-my-data-stream-2099.03.07-000001\")\n);\n"
     }
   ],
   "specification/indices/stats/examples/request/IndicesStatsExample1.yaml": [
@@ -3253,6 +3753,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_stats/fielddata?human&fields=my_join_field#question\""
+    },
+    {
+      "language": "Java",
+      "code": "\n"
     }
   ],
   "specification/indices/segments/examples/request/IndicesSegmentsExample1.yaml": [
@@ -3275,6 +3779,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_segments\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().segments(s -> s\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/indices/put_mapping/examples/request/indicesPutMappingRequestExample1.yaml": [
@@ -3297,6 +3805,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"properties\":{\"user\":{\"properties\":{\"name\":{\"type\":\"keyword\"}}}}}' \"$ELASTICSEARCH_URL/my-index-000001/_mapping\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putMapping(p -> p\n    .index(\"my-index-000001\")\n    .properties(\"user\", pr -> pr\n        .object(o -> o\n            .properties(\"name\", pro -> pro\n                .keyword(k -> k)\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/indices/resolve_cluster/examples/request/ResolveClusterRequestExample2.yaml": [
@@ -3319,6 +3831,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_resolve/cluster/not-present,clust*:my-index*,oldcluster:*?ignore_unavailable=false&timeout=5s\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().resolveCluster(r -> r\n    .ignoreUnavailable(false)\n    .name(List.of(\"not-present\",\"clust*:my-index*\",\"oldcluster:*\"))\n    .timeout(t -> t\n        .offset(5)\n    )\n);\n"
     }
   ],
   "specification/_global/get_source/examples/request/GetSourceRequestExample1.yaml": [
@@ -3341,6 +3857,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_source/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.getSource(g -> g\n    .id(\"1\")\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/_global/get_script_languages/examples/request/GetScriptLanguagesRequestExample1.yaml": [
@@ -3363,6 +3883,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_script_language\""
+    },
+    {
+      "language": "Java",
+      "code": "client.getScriptLanguages();\n"
     }
   ],
   "specification/_global/update_by_query_rethrottle/examples/request/UpdateByQueryRethrottleRequestExample1.yaml": [
@@ -3385,6 +3909,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_update_by_query/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.updateByQueryRethrottle(u -> u\n    .requestsPerSecond(-1.0F)\n    .taskId(\"r1A2WoRbTwKZ516z6NEs5A:36619\")\n);\n"
     }
   ],
   "specification/_global/scripts_painless_execute/examples/request/ExecutePainlessScriptRequestExample2.yaml": [
@@ -3407,6 +3935,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"doc['\"'\"'field'\"'\"'].value.length() <= params.max_length\",\"params\":{\"max_length\":4}},\"context\":\"filter\",\"context_setup\":{\"index\":\"my-index-000001\",\"document\":{\"field\":\"four\"}}}' \"$ELASTICSEARCH_URL/_scripts/painless/_execute\""
+    },
+    {
+      "language": "Java",
+      "code": "client.scriptsPainlessExecute(s -> s\n    .context(PainlessContext.Filter)\n    .contextSetup(c -> c\n        .document(JsonData.fromJson(\"{\\\"field\\\":\\\"four\\\"}\"))\n        .index(\"my-index-000001\")\n    )\n    .script(sc -> sc\n        .source(so -> so\n            .scriptString(\"doc['field'].value.length() <= params.max_length\")\n        )\n        .params(\"max_length\", JsonData.fromJson(\"4\"))\n    )\n);\n"
     }
   ],
   "specification/_global/scripts_painless_execute/examples/request/ExecutePainlessScriptRequestExample3.yaml": [
@@ -3429,6 +3961,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"doc['\"'\"'rank'\"'\"'].value / params.max_rank\",\"params\":{\"max_rank\":5}},\"context\":\"score\",\"context_setup\":{\"index\":\"my-index-000001\",\"document\":{\"rank\":4}}}' \"$ELASTICSEARCH_URL/_scripts/painless/_execute\""
+    },
+    {
+      "language": "Java",
+      "code": "client.scriptsPainlessExecute(s -> s\n    .context(PainlessContext.Score)\n    .contextSetup(c -> c\n        .document(JsonData.fromJson(\"{\\\"rank\\\":4}\"))\n        .index(\"my-index-000001\")\n    )\n    .script(sc -> sc\n        .source(so -> so\n            .scriptString(\"doc['rank'].value / params.max_rank\")\n        )\n        .params(\"max_rank\", JsonData.fromJson(\"5\"))\n    )\n);\n"
     }
   ],
   "specification/_global/scripts_painless_execute/examples/request/ExecutePainlessScriptRequestExample1.yaml": [
@@ -3451,6 +3987,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"params.count / params.total\",\"params\":{\"count\":100,\"total\":1000}}}' \"$ELASTICSEARCH_URL/_scripts/painless/_execute\""
+    },
+    {
+      "language": "Java",
+      "code": "client.scriptsPainlessExecute(s -> s\n    .script(sc -> sc\n        .source(so -> so\n            .scriptString(\"params.count / params.total\")\n        )\n        .params(Map.of(\"total\", JsonData.fromJson(\"1000\"),\"count\", JsonData.fromJson(\"100\")))\n    )\n);\n"
     }
   ],
   "specification/_global/get_script_context/examples/request/GetScriptContextRequestExample1.yaml": [
@@ -3473,6 +4013,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_script_context\""
+    },
+    {
+      "language": "Java",
+      "code": "client.getScriptContext();\n"
     }
   ],
   "specification/_global/msearch_template/examples/request/MultiSearchTemplateRequestExample1.yaml": [
@@ -3517,6 +4061,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"field\":\"tags\",\"string\":\"kiba\"}' \"$ELASTICSEARCH_URL/stackoverflow/_terms_enum\""
+    },
+    {
+      "language": "Java",
+      "code": "client.termsEnum(t -> t\n    .field(\"tags\")\n    .index(\"stackoverflow\")\n    .string(\"kiba\")\n);\n"
     }
   ],
   "specification/_global/bulk/examples/request/BulkRequestExample4.yaml": [
@@ -3627,6 +4175,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"match\":{\"message\":\"elasticsearch\"}}}' \"$ELASTICSEARCH_URL/my-index-000001/_explain/0\""
+    },
+    {
+      "language": "Java",
+      "code": "client.explain(e -> e\n    .id(\"0\")\n    .index(\"my-index-000001\")\n    .query(q -> q\n        .match(m -> m\n            .field(\"message\")\n            .query(FieldValue.of(\"elasticsearch\"))\n        )\n    )\n);\n"
     }
   ],
   "specification/_global/get_script/examples/request/GetScriptRequestExample1.yaml": [
@@ -3649,6 +4201,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_scripts/my-search-template\""
+    },
+    {
+      "language": "Java",
+      "code": "client.getScript(g -> g\n    .id(\"my-search-template\")\n);\n"
     }
   ],
   "specification/_global/search_template/examples/request/SearchTemplateRequestExample1.yaml": [
@@ -3671,6 +4227,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"id\":\"my-search-template\",\"params\":{\"query_string\":\"hello world\",\"from\":0,\"size\":10}}' \"$ELASTICSEARCH_URL/my-index/_search/template\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchTemplate(s -> s\n    .id(\"my-search-template\")\n    .index(\"my-index\")\n    .params(Map.of(\"size\", JsonData.fromJson(\"10\"),\"from\", JsonData.fromJson(\"0\"),\"query_string\", JsonData.fromJson(\"\\\"hello world\\\"\")))\n);\n"
     }
   ],
   "specification/_global/scroll/examples/request/ScrollRequestExample1.yaml": [
@@ -3693,6 +4253,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"scroll_id\":\"DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==\"}' \"$ELASTICSEARCH_URL/_search/scroll\""
+    },
+    {
+      "language": "Java",
+      "code": "client.scroll(s -> s\n    .scrollId(\"DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==\")\n);\n"
     }
   ],
   "specification/_global/update/examples/request/UpdateRequestExample7.yaml": [
@@ -3715,6 +4279,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"if (ctx._source.tags.contains(params.tag)) { ctx.op = '\"'\"'delete'\"'\"' } else { ctx.op = '\"'\"'noop'\"'\"' }\",\"lang\":\"painless\",\"params\":{\"tag\":\"green\"}}}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"if (ctx._source.tags.contains(params.tag)) { ctx.op = 'delete' } else { ctx.op = 'noop' }\")\n        )\n        .params(\"tag\", JsonData.fromJson(\"\\\"green\\\"\"))\n        .lang(\"painless\")\n    )\n,Void.class);\n"
     }
   ],
   "specification/_global/update/examples/request/UpdateRequestExample6.yaml": [
@@ -3737,6 +4305,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":\"ctx._source['\"'\"'my-object'\"'\"'].remove('\"'\"'my-subfield'\"'\"')\"}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source['my-object'].remove('my-subfield')\")\n        )\n    )\n,Void.class);\n"
     }
   ],
   "specification/_global/update/examples/request/UpdateRequestExample1.yaml": [
@@ -3759,6 +4331,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"ctx._source.counter += params.count\",\"lang\":\"painless\",\"params\":{\"count\":4}}}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source.counter += params.count\")\n        )\n        .params(\"count\", JsonData.fromJson(\"4\"))\n        .lang(\"painless\")\n    )\n,Void.class);\n"
     }
   ],
   "specification/_global/update/examples/request/UpdateRequestExample3.yaml": [
@@ -3781,6 +4357,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"if (ctx._source.tags.contains(params.tag)) { ctx._source.tags.remove(ctx._source.tags.indexOf(params.tag)) }\",\"lang\":\"painless\",\"params\":{\"tag\":\"blue\"}}}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"if (ctx._source.tags.contains(params.tag)) { ctx._source.tags.remove(ctx._source.tags.indexOf(params.tag)) }\")\n        )\n        .params(\"tag\", JsonData.fromJson(\"\\\"blue\\\"\"))\n        .lang(\"painless\")\n    )\n,Void.class);\n"
     }
   ],
   "specification/_global/update/examples/request/UpdateRequestExample2.yaml": [
@@ -3803,6 +4383,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"ctx._source.tags.add(params.tag)\",\"lang\":\"painless\",\"params\":{\"tag\":\"blue\"}}}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source.tags.add(params.tag)\")\n        )\n        .params(\"tag\", JsonData.fromJson(\"\\\"blue\\\"\"))\n        .lang(\"painless\")\n    )\n,Void.class);\n"
     }
   ],
   "specification/_global/update/examples/request/UpdateRequestExample5.yaml": [
@@ -3825,6 +4409,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":\"ctx._source.remove('\"'\"'new_field'\"'\"')\"}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source.remove('new_field')\")\n        )\n    )\n,Void.class);\n"
     }
   ],
   "specification/_global/update/examples/request/UpdateRequestExample10.yaml": [
@@ -3847,6 +4435,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"scripted_upsert\":true,\"script\":{\"source\":\"\\n      if ( ctx.op == '\"'\"'create'\"'\"' ) {\\n        ctx._source.counter = params.count\\n      } else {\\n        ctx._source.counter += params.count\\n      }\\n    \",\"params\":{\"count\":4}},\"upsert\":{}}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"\n      if ( ctx.op == 'create' ) {\n        ctx._source.counter = params.count\n      } else {\n        ctx._source.counter += params.count\n      }\n    \")\n        )\n        .params(\"count\", JsonData.fromJson(\"4\"))\n    )\n    .scriptedUpsert(true)\n    .upsert(JsonData.fromJson(\"{}\"))\n,Void.class);\n"
     }
   ],
   "specification/_global/update/examples/request/UpdateRequestExample9.yaml": [
@@ -3869,6 +4461,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"ctx._source.counter += params.count\",\"lang\":\"painless\",\"params\":{\"count\":4}},\"upsert\":{\"counter\":1}}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source.counter += params.count\")\n        )\n        .params(\"count\", JsonData.fromJson(\"4\"))\n        .lang(\"painless\")\n    )\n    .upsert(JsonData.fromJson(\"{\\\"counter\\\":1}\"))\n,Void.class);\n"
     }
   ],
   "specification/_global/update/examples/request/UpdateRequestExample8.yaml": [
@@ -3891,6 +4487,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"doc\":{\"name\":\"new_name\"}}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.update(u -> u\n    .doc(JsonData.fromJson(\"{\\\"name\\\":\\\"new_name\\\"}\"))\n    .id(\"1\")\n    .index(\"test\")\n,Void.class);\n"
     }
   ],
   "specification/_global/update/examples/request/UpdateRequestExample11.yaml": [
@@ -3913,6 +4513,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"doc\":{\"name\":\"new_name\"},\"doc_as_upsert\":true}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.update(u -> u\n    .doc(JsonData.fromJson(\"{\\\"name\\\":\\\"new_name\\\"}\"))\n    .docAsUpsert(true)\n    .id(\"1\")\n    .index(\"test\")\n,Void.class);\n"
     }
   ],
   "specification/_global/update/examples/request/UpdateRequestExample4.yaml": [
@@ -3935,6 +4539,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":\"ctx._source.new_field = '\"'\"'value_of_new_field'\"'\"'\"}' \"$ELASTICSEARCH_URL/test/_update/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.update(u -> u\n    .id(\"1\")\n    .index(\"test\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source.new_field = 'value_of_new_field'\")\n        )\n    )\n,Void.class);\n"
     }
   ],
   "specification/_global/delete/examples/request/DeleteRequestExample1.yaml": [
@@ -3957,6 +4565,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_doc/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.delete(d -> d\n    .id(\"1\")\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/_global/update_by_query/examples/request/UpdateByQueryRequestExample4.yaml": [
@@ -3979,6 +4591,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"ctx._source['\"'\"'extra'\"'\"'] = '\"'\"'test'\"'\"'\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_update_by_query?refresh&slices=5\""
+    },
+    {
+      "language": "Java",
+      "code": "client.updateByQuery(u -> u\n    .index(\"my-index-000001\")\n    .refresh(true)\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source['extra'] = 'test'\")\n        )\n    )\n    .slices(sl -> sl\n        .value(5)\n    )\n);\n"
     }
   ],
   "specification/_global/update_by_query/examples/request/UpdateByQueryRequestExample2.yaml": [
@@ -4001,6 +4617,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"source\":\"ctx._source.count++\",\"lang\":\"painless\"},\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}' \"$ELASTICSEARCH_URL/my-index-000001/_update_by_query\""
+    },
+    {
+      "language": "Java",
+      "code": "client.updateByQuery(u -> u\n    .index(\"my-index-000001\")\n    .query(q -> q\n        .term(t -> t\n            .field(\"user.id\")\n            .value(FieldValue.of(\"kimchy\"))\n        )\n    )\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source.count++\")\n        )\n        .lang(\"painless\")\n    )\n);\n"
     }
   ],
   "specification/_global/update_by_query/examples/request/UpdateByQueryRequestExample3.yaml": [
@@ -4023,6 +4643,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"slice\":{\"id\":0,\"max\":2},\"script\":{\"source\":\"ctx._source['\"'\"'extra'\"'\"'] = '\"'\"'test'\"'\"'\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_update_by_query\""
+    },
+    {
+      "language": "Java",
+      "code": "client.updateByQuery(u -> u\n    .index(\"my-index-000001\")\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source['extra'] = 'test'\")\n        )\n    )\n    .slice(sl -> sl\n        .id(\"0\")\n        .max(2)\n    )\n);\n"
     }
   ],
   "specification/_global/update_by_query/examples/request/UpdateByQueryRequestExample1.yaml": [
@@ -4045,6 +4669,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}' \"$ELASTICSEARCH_URL/my-index-000001/_update_by_query?conflicts=proceed\""
+    },
+    {
+      "language": "Java",
+      "code": "client.updateByQuery(u -> u\n    .conflicts(Conflicts.Proceed)\n    .index(\"my-index-000001\")\n    .query(q -> q\n        .term(t -> t\n            .field(\"user.id\")\n            .value(FieldValue.of(\"kimchy\"))\n        )\n    )\n);\n"
     }
   ],
   "specification/_global/exists/examples/request/DocumentExistsRequestExample1.yaml": [
@@ -4067,6 +4695,10 @@
     {
       "language": "curl",
       "code": "curl --head -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_doc/0\""
+    },
+    {
+      "language": "Java",
+      "code": "client.exists(e -> e\n    .id(\"0\")\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/_global/put_script/examples/request/PutScriptRequestExample1.yaml": [
@@ -4111,6 +4743,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"script\":{\"lang\":\"painless\",\"source\":\"Math.log(_score * 2) + params['\"'\"'my_modifier'\"'\"']\"}}' \"$ELASTICSEARCH_URL/_scripts/my-stored-script\""
+    },
+    {
+      "language": "Java",
+      "code": "client.putScript(p -> p\n    .id(\"my-stored-script\")\n    .script(s -> s\n        .lang(\"painless\")\n        .source(so -> so\n            .scriptString(\"Math.log(_score * 2) + params['my_modifier']\")\n        )\n    )\n);\n"
     }
   ],
   "specification/_global/reindex_rethrottle/examples/request/ReindexRethrottleRequestExample1.yaml": [
@@ -4133,6 +4769,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_reindex/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindexRethrottle(r -> r\n    .requestsPerSecond(-1.0F)\n    .taskId(\"r1A2WoRbTwKZ516z6NEs5A:36619\")\n);\n"
     }
   ],
   "specification/_global/count/examples/request/CountRequestExample1.yaml": [
@@ -4155,6 +4795,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}' \"$ELASTICSEARCH_URL/my-index-000001/_count\""
+    },
+    {
+      "language": "Java",
+      "code": "client.count(c -> c\n    .index(\"my-index-000001\")\n    .query(q -> q\n        .term(t -> t\n            .field(\"user.id\")\n            .value(FieldValue.of(\"kimchy\"))\n        )\n    )\n);\n"
     }
   ],
   "specification/_global/termvectors/examples/request/TermVectorsRequestExample3.yaml": [
@@ -4177,6 +4821,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"doc\":{\"plot\":\"When wealthy industrialist Tony Stark is forced to build an armored suit after a life-threatening incident, he ultimately decides to use its technology to fight against evil.\"},\"term_statistics\":true,\"field_statistics\":true,\"positions\":false,\"offsets\":false,\"filter\":{\"max_num_terms\":3,\"min_term_freq\":1,\"min_doc_freq\":1}}' \"$ELASTICSEARCH_URL/imdb/_termvectors\""
+    },
+    {
+      "language": "Java",
+      "code": "client.termvectors(t -> t\n    .doc(JsonData.fromJson(\"{\\\"plot\\\":\\\"When wealthy industrialist Tony Stark is forced to build an armored suit after a life-threatening incident, he ultimately decides to use its technology to fight against evil.\\\"}\"))\n    .fieldStatistics(true)\n    .filter(f -> f\n        .maxNumTerms(3)\n        .minDocFreq(1)\n        .minTermFreq(1)\n    )\n    .index(\"imdb\")\n    .offsets(false)\n    .positions(false)\n    .termStatistics(true)\n);\n"
     }
   ],
   "specification/_global/termvectors/examples/request/TermVectorsRequestExample2.yaml": [
@@ -4199,6 +4847,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"doc\":{\"fullname\":\"John Doe\",\"text\":\"test test test\"},\"fields\":[\"fullname\"],\"per_field_analyzer\":{\"fullname\":\"keyword\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_termvectors\""
+    },
+    {
+      "language": "Java",
+      "code": "client.termvectors(t -> t\n    .doc(JsonData.fromJson(\"{\\\"fullname\\\":\\\"John Doe\\\",\\\"text\\\":\\\"test test test\\\"}\"))\n    .fields(\"fullname\")\n    .index(\"my-index-000001\")\n    .perFieldAnalyzer(\"fullname\", \"keyword\")\n);\n"
     }
   ],
   "specification/_global/termvectors/examples/request/TermVectorsRequestExample5.yaml": [
@@ -4221,6 +4873,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"doc\":{\"fullname\":\"John Doe\",\"text\":\"test test test\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_termvectors\""
+    },
+    {
+      "language": "Java",
+      "code": "client.termvectors(t -> t\n    .doc(JsonData.fromJson(\"{\\\"fullname\\\":\\\"John Doe\\\",\\\"text\\\":\\\"test test test\\\"}\"))\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/_global/termvectors/examples/request/TermVectorsRequestExample4.yaml": [
@@ -4243,6 +4899,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"fields\":[\"text\",\"some_field_without_term_vectors\"],\"offsets\":true,\"positions\":true,\"term_statistics\":true,\"field_statistics\":true}' \"$ELASTICSEARCH_URL/my-index-000001/_termvectors/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.termvectors(t -> t\n    .fieldStatistics(true)\n    .fields(List.of(\"text\",\"some_field_without_term_vectors\"))\n    .id(\"1\")\n    .index(\"my-index-000001\")\n    .offsets(true)\n    .positions(true)\n    .termStatistics(true)\n);\n"
     }
   ],
   "specification/_global/termvectors/examples/request/TermVectorsRequestExample1.yaml": [
@@ -4265,6 +4925,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"fields\":[\"text\"],\"offsets\":true,\"payloads\":true,\"positions\":true,\"term_statistics\":true,\"field_statistics\":true}' \"$ELASTICSEARCH_URL/my-index-000001/_termvectors/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.termvectors(t -> t\n    .fieldStatistics(true)\n    .fields(\"text\")\n    .id(\"1\")\n    .index(\"my-index-000001\")\n    .offsets(true)\n    .payloads(true)\n    .positions(true)\n    .termStatistics(true)\n);\n"
     }
   ],
   "specification/_global/search_mvt/examples/request/SearchMvtRequestExample1.yaml": [
@@ -4309,6 +4973,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_delete_by_query/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.deleteByQueryRethrottle(d -> d\n    .requestsPerSecond(-1.0F)\n    .taskId(\"r1A2WoRbTwKZ516z6NEs5A:36619\")\n);\n"
     }
   ],
   "specification/_global/get/examples/request/GetRequestExample2.yaml": [
@@ -4353,6 +5021,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"id\":\"my-search-template\",\"params\":{\"query_string\":\"hello world\",\"from\":20,\"size\":10}}' \"$ELASTICSEARCH_URL/_render/template\""
+    },
+    {
+      "language": "Java",
+      "code": "client.renderSearchTemplate(r -> r\n    .id(\"my-search-template\")\n    .params(Map.of(\"size\", JsonData.fromJson(\"10\"),\"from\", JsonData.fromJson(\"20\"),\"query_string\", JsonData.fromJson(\"\\\"hello world\\\"\")))\n);\n"
     }
   ],
   "specification/_global/open_point_in_time/examples/request/OpenPointInTimeRequestExample1.yaml": [
@@ -4375,6 +5047,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_pit?keep_alive=1m&allow_partial_search_results=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.openPointInTime(o -> o\n    .allowPartialSearchResults(true)\n    .index(\"my-index-000001\")\n    .keepAlive(k -> k\n        .offset(1)\n    )\n);\n"
     }
   ],
   "specification/_global/search_shards/examples/request/SearchShardsRequestExample1.yaml": [
@@ -4397,6 +5073,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_search_shards\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchShards(s -> s\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample1.yaml": [
@@ -4419,6 +5099,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"match_all\":{}}}' \"$ELASTICSEARCH_URL/my-index-000001,my-index-000002/_delete_by_query\""
+    },
+    {
+      "language": "Java",
+      "code": "client.deleteByQuery(d -> d\n    .index(List.of(\"my-index-000001\",\"my-index-000002\"))\n    .query(q -> q\n        .matchAll(m -> m)\n    )\n);\n"
     }
   ],
   "specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample2.yaml": [
@@ -4441,6 +5125,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"term\":{\"user.id\":\"kimchy\"}},\"max_docs\":1}' \"$ELASTICSEARCH_URL/my-index-000001/_delete_by_query\""
+    },
+    {
+      "language": "Java",
+      "code": "client.deleteByQuery(d -> d\n    .index(\"my-index-000001\")\n    .maxDocs(1L)\n    .query(q -> q\n        .term(t -> t\n            .field(\"user.id\")\n            .value(FieldValue.of(\"kimchy\"))\n        )\n    )\n);\n"
     }
   ],
   "specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample3.yaml": [
@@ -4463,6 +5151,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"slice\":{\"id\":0,\"max\":2},\"query\":{\"range\":{\"http.response.bytes\":{\"lt\":2000000}}}}' \"$ELASTICSEARCH_URL/my-index-000001/_delete_by_query\""
+    },
+    {
+      "language": "Java",
+      "code": "client.deleteByQuery(d -> d\n    .index(\"my-index-000001\")\n    .query(q -> q\n        .range(r -> r\n            .untyped(u -> u\n                .field(\"http.response.bytes\")\n                .lt(JsonData.fromJson(\"2000000\"))\n            )\n        )\n    )\n    .slice(s -> s\n        .id(\"0\")\n        .max(2)\n    )\n);\n"
     }
   ],
   "specification/_global/delete_by_query/examples/request/DeleteByQueryRequestExample4.yaml": [
@@ -4485,6 +5177,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"range\":{\"http.response.bytes\":{\"lt\":2000000}}}}' \"$ELASTICSEARCH_URL/my-index-000001/_delete_by_query?refresh&slices=5\""
+    },
+    {
+      "language": "Java",
+      "code": "client.deleteByQuery(d -> d\n    .index(\"my-index-000001\")\n    .query(q -> q\n        .range(r -> r\n            .untyped(u -> u\n                .field(\"http.response.bytes\")\n                .lt(JsonData.fromJson(\"2000000\"))\n            )\n        )\n    )\n    .refresh(true)\n    .slices(s -> s\n        .value(5)\n    )\n);\n"
     }
   ],
   "specification/_global/health_report/examples/request/HealthReportRequestExample1.yaml": [
@@ -4507,6 +5203,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_health_report\""
+    },
+    {
+      "language": "Java",
+      "code": "client.healthReport(h -> h);\n"
     }
   ],
   "specification/_global/field_caps/examples/request/FieldCapabilitiesRequestExample1.yaml": [
@@ -4551,6 +5251,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"term\":{\"user.id\":\"kimchy\"}}}' \"$ELASTICSEARCH_URL/my-index-000001/_search?from=40&size=20\""
+    },
+    {
+      "language": "Java",
+      "code": "client.search(s -> s\n    .from(40)\n    .index(\"my-index-000001\")\n    .query(q -> q\n        .term(t -> t\n            .field(\"user.id\")\n            .value(FieldValue.of(\"kimchy\"))\n        )\n    )\n    .size(20)\n,Void.class);\n"
     }
   ],
   "specification/_global/search/examples/request/SearchRequestExample2.yaml": [
@@ -4573,6 +5277,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"size\":100,\"query\":{\"match\":{\"title\":\"elasticsearch\"}},\"pit\":{\"id\":\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\",\"keep_alive\":\"1m\"}}' \"$ELASTICSEARCH_URL/_search\""
+    },
+    {
+      "language": "Java",
+      "code": "client.search(s -> s\n    .pit(p -> p\n        .id(\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\")\n        .keepAlive(k -> k\n            .time(\"1m\")\n        )\n    )\n    .query(q -> q\n        .match(m -> m\n            .field(\"title\")\n            .query(FieldValue.of(\"elasticsearch\"))\n        )\n    )\n    .size(100)\n,Void.class);\n"
     }
   ],
   "specification/_global/search/examples/request/SearchRequestExample3.yaml": [
@@ -4595,6 +5303,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"slice\":{\"id\":0,\"max\":2},\"query\":{\"match\":{\"message\":\"foo\"}},\"pit\":{\"id\":\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\"}}' \"$ELASTICSEARCH_URL/_search\""
+    },
+    {
+      "language": "Java",
+      "code": "client.search(s -> s\n    .pit(p -> p\n        .id(\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\")\n    )\n    .query(q -> q\n        .match(m -> m\n            .field(\"message\")\n            .query(FieldValue.of(\"foo\"))\n        )\n    )\n    .slice(sl -> sl\n        .id(\"0\")\n        .max(2)\n    )\n,Void.class);\n"
     }
   ],
   "specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample1.yaml": [
@@ -4617,6 +5329,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_id\":\"2\",\"fields\":[\"message\"],\"term_statistics\":true},{\"_id\":\"1\"}]}' \"$ELASTICSEARCH_URL/my-index-000001/_mtermvectors\""
+    },
+    {
+      "language": "Java",
+      "code": "client.mtermvectors(m -> m\n    .docs(List.of(MultiTermVectorsOperation.of(mu -> mu\n            .id(\"2\")\n            .fields(\"message\")\n            .termStatistics(true)),MultiTermVectorsOperation.of(mu -> mu\n            .id(\"1\"))))\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample2.yaml": [
@@ -4639,6 +5355,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"ids\":[\"1\",\"2\"],\"fields\":[\"message\"],\"term_statistics\":true}' \"$ELASTICSEARCH_URL/my-index-000001/_mtermvectors\""
+    },
+    {
+      "language": "Java",
+      "code": "client.mtermvectors(m -> m\n    .ids(List.of(\"1\",\"2\"))\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/_global/mtermvectors/examples/request/MultiTermVectorsRequestExample3.yaml": [
@@ -4661,6 +5381,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_index\":\"my-index-000001\",\"doc\":{\"message\":\"test test test\"}},{\"_index\":\"my-index-000001\",\"doc\":{\"message\":\"Another test ...\"}}]}' \"$ELASTICSEARCH_URL/_mtermvectors\""
+    },
+    {
+      "language": "Java",
+      "code": "client.mtermvectors(m -> m\n    .docs(List.of(MultiTermVectorsOperation.of(mu -> mu\n            .index(\"my-index-000001\")\n            .doc(JsonData.fromJson(\"{\\\"message\\\":\\\"test test test\\\"}\"))),MultiTermVectorsOperation.of(mu -> mu\n            .index(\"my-index-000001\")\n            .doc(JsonData.fromJson(\"{\\\"message\\\":\\\"Another test ...\\\"}\")))))\n);\n"
     }
   ],
   "specification/_global/info/examples/request/RootNodeInfoRequestExample1.yaml": [
@@ -4683,6 +5407,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/\""
+    },
+    {
+      "language": "Java",
+      "code": "client.info();\n"
     }
   ],
   "specification/_global/clear_scroll/examples/request/ClearScrollRequestExample1.yaml": [
@@ -4705,6 +5433,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"scroll_id\":\"DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==\"}' \"$ELASTICSEARCH_URL/_search/scroll\""
+    },
+    {
+      "language": "Java",
+      "code": "client.clearScroll(c -> c\n    .scrollId(\"DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAD4WYm9laVYtZndUQlNsdDcwakFMNjU1QQ==\")\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample9.yaml": [
@@ -4727,6 +5459,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-index-000001\"},\"dest\":{\"index\":\"my-new-index-000001\"},\"script\":{\"source\":\"ctx._source.tag = ctx._source.remove(\\\"flag\\\")\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"my-new-index-000001\")\n    )\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._source.tag = ctx._source.remove(\"flag\")\")\n        )\n    )\n    .source(so -> so\n        .index(\"my-index-000001\")\n    )\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample5.yaml": [
@@ -4749,6 +5485,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"source\"},\"dest\":{\"index\":\"dest\",\"pipeline\":\"some_ingest_pipeline\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"dest\")\n        .pipeline(\"some_ingest_pipeline\")\n    )\n    .source(s -> s\n        .index(\"source\")\n    )\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample11.yaml": [
@@ -4771,6 +5511,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"max_docs\":10,\"source\":{\"index\":\"my-index-000001\",\"query\":{\"function_score\":{\"random_score\":{},\"min_score\":0.9}}},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"my-new-index-000001\")\n    )\n    .maxDocs(10L)\n    .source(s -> s\n        .index(\"my-index-000001\")\n        .query(q -> q\n            .functionScore(f -> f\n                .minScore(0.9D)\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample10.yaml": [
@@ -4793,6 +5537,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"metricbeat-*\"},\"dest\":{\"index\":\"metricbeat\"},\"script\":{\"lang\":\"painless\",\"source\":\"ctx._index = '\"'\"'metricbeat-'\"'\"' + (ctx._index.substring('\"'\"'metricbeat-'\"'\"'.length(), ctx._index.length())) + '\"'\"'-1'\"'\"'\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"metricbeat\")\n    )\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"ctx._index = 'metricbeat-' + (ctx._index.substring('metricbeat-'.length(), ctx._index.length())) + '-1'\")\n        )\n        .lang(\"painless\")\n    )\n    .source(so -> so\n        .index(\"metricbeat-*\")\n    )\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample4.yaml": [
@@ -4815,6 +5563,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"source\",\"query\":{\"match\":{\"company\":\"cat\"}}},\"dest\":{\"index\":\"dest\",\"routing\":\"=cat\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"dest\")\n        .routing(\"=cat\")\n    )\n    .source(s -> s\n        .index(\"source\")\n        .query(q -> q\n            .match(m -> m\n                .field(\"company\")\n                .query(FieldValue.of(\"cat\"))\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample8.yaml": [
@@ -4837,6 +5589,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-index-000001\",\"_source\":[\"user.id\",\"_doc\"]},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"my-new-index-000001\")\n    )\n    .source(s -> s\n        .index(\"my-index-000001\")\n        .sourceFields(List.of(\"user.id\",\"_doc\"))\n    )\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample3.yaml": [
@@ -4859,6 +5615,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-index-000001\"},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex?slices=5&refresh\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"my-new-index-000001\")\n    )\n    .refresh(true)\n    .slices(s -> s\n        .value(5)\n    )\n    .source(so -> so\n        .index(\"my-index-000001\")\n    )\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample2.yaml": [
@@ -4881,6 +5641,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-index-000001\",\"slice\":{\"id\":0,\"max\":2}},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"my-new-index-000001\")\n    )\n    .source(s -> s\n        .index(\"my-index-000001\")\n        .slice(sl -> sl\n            .id(\"0\")\n            .max(2)\n        )\n    )\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample1.yaml": [
@@ -4903,6 +5667,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":[\"my-index-000001\",\"my-index-000002\"]},\"dest\":{\"index\":\"my-new-index-000002\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"my-new-index-000002\")\n    )\n    .source(s -> s\n        .index(List.of(\"my-index-000001\",\"my-index-000002\"))\n    )\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample13.yaml": [
@@ -4925,6 +5693,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"remote\":{\"host\":\"http://otherhost:9200\",\"username\":\"user\",\"password\":\"pass\"},\"index\":\"my-index-000001\",\"query\":{\"match\":{\"test\":\"data\"}}},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"my-new-index-000001\")\n    )\n    .source(s -> s\n        .index(\"my-index-000001\")\n        .query(q -> q\n            .match(m -> m\n                .field(\"test\")\n                .query(FieldValue.of(\"data\"))\n            )\n        )\n        .remote(re -> re\n            .host(\"http://otherhost:9200\")\n            .username(\"user\")\n            .password(\"pass\")\n        )\n    )\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample7.yaml": [
@@ -4947,6 +5719,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"max_docs\":1,\"source\":{\"index\":\"my-index-000001\"},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"my-new-index-000001\")\n    )\n    .maxDocs(1L)\n    .source(s -> s\n        .index(\"my-index-000001\")\n    )\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample6.yaml": [
@@ -4969,6 +5745,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-index-000001\",\"query\":{\"term\":{\"user.id\":\"kimchy\"}}},\"dest\":{\"index\":\"my-new-index-000001\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"my-new-index-000001\")\n    )\n    .source(s -> s\n        .index(\"my-index-000001\")\n        .query(q -> q\n            .term(t -> t\n                .field(\"user.id\")\n                .value(FieldValue.of(\"kimchy\"))\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/_global/reindex/examples/request/ReindexRequestExample12.yaml": [
@@ -4991,6 +5771,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"my-index-000001\"},\"dest\":{\"index\":\"my-new-index-000001\",\"version_type\":\"external\"},\"script\":{\"source\":\"if (ctx._source.foo == '\"'\"'bar'\"'\"') {ctx._version++; ctx._source.remove('\"'\"'foo'\"'\"')}\",\"lang\":\"painless\"}}' \"$ELASTICSEARCH_URL/_reindex\""
+    },
+    {
+      "language": "Java",
+      "code": "client.reindex(r -> r\n    .dest(d -> d\n        .index(\"my-new-index-000001\")\n        .versionType(VersionType.External)\n    )\n    .script(s -> s\n        .source(so -> so\n            .scriptString(\"if (ctx._source.foo == 'bar') {ctx._version++; ctx._source.remove('foo')}\")\n        )\n        .lang(\"painless\")\n    )\n    .source(so -> so\n        .index(\"my-index-000001\")\n    )\n);\n"
     }
   ],
   "specification/_global/index/examples/request/IndexRequestExample1.yaml": [
@@ -5013,6 +5797,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"@timestamp\":\"2099-11-15T13:12:00\",\"message\":\"GET /search HTTP/1.1 200 1070000\",\"user\":{\"id\":\"kimchy\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_doc/\""
+    },
+    {
+      "language": "Java",
+      "code": "client.index(i -> i\n    .index(\"my-index-000001\")\n    .document(JsonData.fromJson(\"{\\\"@timestamp\\\":\\\"2099-11-15T13:12:00\\\",\\\"message\\\":\\\"GET /search HTTP/1.1 200 1070000\\\",\\\"user\\\":{\\\"id\\\":\\\"kimchy\\\"}}\"))\n);\n"
     }
   ],
   "specification/_global/index/examples/request/IndexRequestExample2.yaml": [
@@ -5035,6 +5823,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"@timestamp\":\"2099-11-15T13:12:00\",\"message\":\"GET /search HTTP/1.1 200 1070000\",\"user\":{\"id\":\"kimchy\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_doc/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.index(i -> i\n    .id(\"1\")\n    .index(\"my-index-000001\")\n    .document(JsonData.fromJson(\"{\\\"@timestamp\\\":\\\"2099-11-15T13:12:00\\\",\\\"message\\\":\\\"GET /search HTTP/1.1 200 1070000\\\",\\\"user\\\":{\\\"id\\\":\\\"kimchy\\\"}}\"))\n);\n"
     }
   ],
   "specification/_global/msearch/examples/request/MsearchRequestExample1.yaml": [
@@ -5079,6 +5871,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_scripts/my-search-template\""
+    },
+    {
+      "language": "Java",
+      "code": "client.deleteScript(d -> d\n    .id(\"my-search-template\")\n);\n"
     }
   ],
   "specification/_global/mget/examples/request/MultiGetRequestExample2.yaml": [
@@ -5123,6 +5919,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_index\":\"test\",\"_id\":\"1\",\"stored_fields\":[\"field1\",\"field2\"]},{\"_index\":\"test\",\"_id\":\"2\",\"stored_fields\":[\"field3\",\"field4\"]}]}' \"$ELASTICSEARCH_URL/_mget\""
+    },
+    {
+      "language": "Java",
+      "code": "client.mget(m -> m\n    .docs(List.of(MultiGetOperation.of(mu -> mu\n            .id(\"1\")\n            .index(\"test\")\n            .storedFields(List.of(\"field1\",\"field2\"))),MultiGetOperation.of(mu -> mu\n            .id(\"2\")\n            .index(\"test\")\n            .storedFields(List.of(\"field3\",\"field4\")))))\n);\n"
     }
   ],
   "specification/_global/mget/examples/request/MultiGetRequestExample4.yaml": [
@@ -5145,6 +5945,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_index\":\"test\",\"_id\":\"1\",\"routing\":\"key2\"},{\"_index\":\"test\",\"_id\":\"2\"}]}' \"$ELASTICSEARCH_URL/_mget?routing=key1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.mget(m -> m\n    .docs(List.of(MultiGetOperation.of(mu -> mu\n            .id(\"1\")\n            .index(\"test\")\n            .routing(\"key2\")),MultiGetOperation.of(mu -> mu\n            .id(\"2\")\n            .index(\"test\"))))\n    .routing(\"key1\")\n);\n"
     }
   ],
   "specification/_global/mget/examples/request/MultiGetRequestExample1.yaml": [
@@ -5167,6 +5971,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_id\":\"1\"},{\"_id\":\"2\"}]}' \"$ELASTICSEARCH_URL/my-index-000001/_mget\""
+    },
+    {
+      "language": "Java",
+      "code": "client.mget(m -> m\n    .docs(List.of(MultiGetOperation.of(mu -> mu\n            .id(\"1\")),MultiGetOperation.of(mu -> mu\n            .id(\"2\"))))\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/_global/create/examples/request/CreateRequestExample1.yaml": [
@@ -5189,6 +5997,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"@timestamp\":\"2099-11-15T13:12:00\",\"message\":\"GET /search HTTP/1.1 200 1070000\",\"user\":{\"id\":\"kimchy\"}}' \"$ELASTICSEARCH_URL/my-index-000001/_create/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.create(c -> c\n    .id(\"1\")\n    .index(\"my-index-000001\")\n    .document(JsonData.fromJson(\"{\\\"@timestamp\\\":\\\"2099-11-15T13:12:00\\\",\\\"message\\\":\\\"GET /search HTTP/1.1 200 1070000\\\",\\\"user\\\":{\\\"id\\\":\\\"kimchy\\\"}}\"))\n);\n"
     }
   ],
   "specification/_global/rank_eval/examples/request/RankEvalRequestExample1.yaml": [
@@ -5211,6 +6023,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"requests\":[{\"id\":\"JFK query\",\"request\":{\"query\":{\"match_all\":{}}},\"ratings\":[]}],\"metric\":{\"precision\":{\"k\":20,\"relevant_rating_threshold\":1,\"ignore_unlabeled\":false}}}' \"$ELASTICSEARCH_URL/my-index-000001/_rank_eval\""
+    },
+    {
+      "language": "Java",
+      "code": "client.rankEval(r -> r\n    .index(\"my-index-000001\")\n    .metric(m -> m\n        .precision(p -> p\n            .ignoreUnlabeled(false)\n            .relevantRatingThreshold(1)\n            .k(20)\n        )\n    )\n    .requests(re -> re\n        .id(\"JFK query\")\n        .request(req -> req\n            .query(q -> q\n                .matchAll(m -> m)\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/_global/exists_source/examples/request/ExistsSourceRequestExample1.yaml": [
@@ -5233,6 +6049,10 @@
     {
       "language": "curl",
       "code": "curl --head -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_source/1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.existsSource(e -> e\n    .id(\"1\")\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/_global/close_point_in_time/examples/request/ClosePointInTimeRequestExample1.yaml": [
@@ -5255,6 +6075,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"id\":\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\"}' \"$ELASTICSEARCH_URL/_pit\""
+    },
+    {
+      "language": "Java",
+      "code": "client.closePointInTime(c -> c\n    .id(\"46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==\")\n);\n"
     }
   ],
   "specification/shutdown/put_node/examples/request/ShutdownPutNodeRequestExample1.yaml": [
@@ -5277,6 +6101,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"type\":\"restart\",\"reason\":\"Demonstrating how the node shutdown API works\",\"allocation_delay\":\"20m\"}' \"$ELASTICSEARCH_URL/_nodes/USpTGYaBSIKbgSUJR2Z9lg/shutdown\""
+    },
+    {
+      "language": "Java",
+      "code": "client.shutdown().putNode(p -> p\n    .allocationDelay(\"20m\")\n    .nodeId(\"USpTGYaBSIKbgSUJR2Z9lg\")\n    .reason(\"Demonstrating how the node shutdown API works\")\n    .type(Type.Restart)\n);\n"
     }
   ],
   "specification/shutdown/delete_node/examples/request/ShutdownDeleteNodeRequestExample1.yaml": [
@@ -5299,6 +6127,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_nodes/USpTGYaBSIKbgSUJR2Z9lg/shutdown\""
+    },
+    {
+      "language": "Java",
+      "code": "client.shutdown().deleteNode(d -> d\n    .nodeId(\"USpTGYaBSIKbgSUJR2Z9lg\")\n);\n"
     }
   ],
   "specification/shutdown/get_node/examples/request/ShutdownGetNodeRequestExample1.yaml": [
@@ -5321,6 +6153,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_nodes/USpTGYaBSIKbgSUJR2Z9lg/shutdown\""
+    },
+    {
+      "language": "Java",
+      "code": "client.shutdown().getNode(g -> g\n    .nodeId(\"USpTGYaBSIKbgSUJR2Z9lg\")\n);\n"
     }
   ],
   "specification/watcher/update_settings/examples/request/WatcherUpdateSettingsRequestExample1.yaml": [
@@ -5343,6 +6179,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index.auto_expand_replicas\":\"0-4\"}' \"$ELASTICSEARCH_URL/_watcher/settings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().updateSettings(u -> u\n    .indexAutoExpandReplicas(\"0-4\")\n);\n"
     }
   ],
   "specification/watcher/activate_watch/examples/request/WatcherActivateWatchExample1.yaml": [
@@ -5365,6 +6205,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_watcher/watch/my_watch/_activate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().activateWatch(a -> a\n    .watchId(\"my_watch\")\n);\n"
     }
   ],
   "specification/watcher/get_settings/examples/request/WatcherGetSettingsExample1.yaml": [
@@ -5387,6 +6231,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_watcher/settings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().getSettings(g -> g);\n"
     }
   ],
   "specification/watcher/deactivate_watch/examples/request/WatcherDeactivateWatchExample1.yaml": [
@@ -5409,6 +6257,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_watcher/watch/my_watch/_deactivate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().deactivateWatch(d -> d\n    .watchId(\"my_watch\")\n);\n"
     }
   ],
   "specification/watcher/execute_watch/examples/request/WatcherExecuteRequestExample1.yaml": [
@@ -5431,6 +6283,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"trigger_data\":{\"triggered_time\":\"now\",\"scheduled_time\":\"now\"},\"alternative_input\":{\"foo\":\"bar\"},\"ignore_condition\":true,\"action_modes\":{\"my-action\":\"force_simulate\"},\"record_execution\":true}' \"$ELASTICSEARCH_URL/_watcher/watch/my_watch/_execute\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().executeWatch(e -> e\n    .actionModes(\"my-action\", ActionExecutionMode.ForceSimulate)\n    .alternativeInput(\"foo\", JsonData.fromJson(\"\\\"bar\\\"\"))\n    .id(\"my_watch\")\n    .ignoreCondition(true)\n    .recordExecution(true)\n    .triggerData(t -> t\n        .scheduledTime(DateTime.of(\"now\"))\n        .triggeredTime(DateTime.of(\"now\"))\n    )\n);\n"
     }
   ],
   "specification/watcher/execute_watch/examples/request/WatcherExecuteRequestExample2.yaml": [
@@ -5453,6 +6309,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"action_modes\":{\"action1\":\"force_simulate\",\"action2\":\"skip\"}}' \"$ELASTICSEARCH_URL/_watcher/watch/my_watch/_execute\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().executeWatch(e -> e\n    .actionModes(Map.of(\"action1\", ActionExecutionMode.ForceSimulate,\"action2\", ActionExecutionMode.Skip))\n    .id(\"my_watch\")\n);\n"
     }
   ],
   "specification/watcher/execute_watch/examples/request/WatcherExecuteRequestExample3.yaml": [
@@ -5475,6 +6335,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"watch\":{\"trigger\":{\"schedule\":{\"interval\":\"10s\"}},\"input\":{\"search\":{\"request\":{\"indices\":[\"logs\"],\"body\":{\"query\":{\"match\":{\"message\":\"error\"}}}}}},\"condition\":{\"compare\":{\"ctx.payload.hits.total\":{\"gt\":0}}},\"actions\":{\"log_error\":{\"logging\":{\"text\":\"Found {{ctx.payload.hits.total}} errors in the logs\"}}}}}' \"$ELASTICSEARCH_URL/_watcher/watch/_execute\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().executeWatch(e -> e\n    .watch(w -> w\n        .actions(\"log_error\", a -> a\n            .logging(l -> l\n                .text(\"Found {{ctx.payload.hits.total}} errors in the logs\")\n            )\n        )\n        .condition(c -> c\n            .compare(NamedValue.of(\"ctx.payload.hits.total\",Pair.of(ConditionOp.Gt,FieldValue.of(0))))\n        )\n        .input(i -> i\n            .search(s -> s\n                .request(r -> r\n                    .body(b -> b\n                        .query(q -> q\n                            .match(m -> m\n                                .field(\"message\")\n                                .query(FieldValue.of(\"error\"))\n                            )\n                        )\n                    )\n                    .indices(\"logs\")\n                )\n            )\n        )\n        .trigger(t -> t\n            .schedule(sc -> sc\n                .interval(in -> in\n                    .time(\"10s\")\n                )\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/watcher/start/examples/request/WatcherStartRequestExample1.yaml": [
@@ -5497,6 +6361,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_watcher/_start\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().start(s -> s);\n"
     }
   ],
   "specification/watcher/query_watches/examples/request/WatcherQueryWatchesRequestExample1.yaml": [
@@ -5519,6 +6387,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_watcher/_query/watches\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().queryWatches();\n"
     }
   ],
   "specification/watcher/stop/examples/request/WatcherStopRequestExample1.yaml": [
@@ -5541,6 +6413,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_watcher/_stop\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().stop(s -> s);\n"
     }
   ],
   "specification/watcher/put_watch/examples/request/WatcherPutWatchRequestExample1.yaml": [
@@ -5563,6 +6439,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"trigger\":{\"schedule\":{\"cron\":\"0 0/1 * * * ?\"}},\"input\":{\"search\":{\"request\":{\"indices\":[\"logstash*\"],\"body\":{\"query\":{\"bool\":{\"must\":{\"match\":{\"response\":404}},\"filter\":{\"range\":{\"@timestamp\":{\"from\":\"{{ctx.trigger.scheduled_time}}||-5m\",\"to\":\"{{ctx.trigger.triggered_time}}\"}}}}}}}}},\"condition\":{\"compare\":{\"ctx.payload.hits.total\":{\"gt\":0}}},\"actions\":{\"email_admin\":{\"email\":{\"to\":\"admin@domain.host.com\",\"subject\":\"404 recently encountered\"}}}}' \"$ELASTICSEARCH_URL/_watcher/watch/my-watch\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().putWatch(p -> p\n    .actions(\"email_admin\", a -> a\n        .email(e -> e\n            .subject(\"404 recently encountered\")\n            .to(\"admin@domain.host.com\")\n        )\n    )\n    .condition(c -> c\n        .compare(NamedValue.of(\"ctx.payload.hits.total\",Pair.of(ConditionOp.Gt,FieldValue.of(0))))\n    )\n    .id(\"my-watch\")\n    .input(i -> i\n        .search(s -> s\n            .request(r -> r\n                .body(b -> b\n                    .query(q -> q\n                        .bool(bo -> bo\n                            .filter(f -> f\n                                .range(ra -> ra\n                                    .untyped(u -> u\n                                        .field(\"@timestamp\")\n                                    )\n                                )\n                            )\n                            .must(m -> m\n                                .match(ma -> ma\n                                    .field(\"response\")\n                                    .query(FieldValue.of(404))\n                                )\n                            )\n                        )\n                    )\n                )\n                .indices(\"logstash*\")\n            )\n        )\n    )\n    .trigger(t -> t\n        .schedule(sc -> sc\n            .cron(\"0 0/1 * * * ?\")\n        )\n    )\n);\n"
     }
   ],
   "specification/watcher/get_watch/examples/request/GetWatchRequestExample1.yaml": [
@@ -5585,6 +6465,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_watcher/watch/my_watch\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().getWatch(g -> g\n    .id(\"my_watch\")\n);\n"
     }
   ],
   "specification/watcher/ack_watch/examples/request/WatcherAckWatchRequestExample1.yaml": [
@@ -5607,6 +6491,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_watcher/watch/my_watch/_ack\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().ackWatch(a -> a\n    .watchId(\"my_watch\")\n);\n"
     }
   ],
   "specification/watcher/delete_watch/examples/request/DeleteWatchRequestExample1.yaml": [
@@ -5629,6 +6517,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_watcher/watch/my_watch\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().deleteWatch(d -> d\n    .id(\"my_watch\")\n);\n"
     }
   ],
   "specification/watcher/stats/examples/request/WatcherStatsRequestExample1.yaml": [
@@ -5651,6 +6543,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_watcher/stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.watcher().stats(s -> s);\n"
     }
   ],
   "specification/license/post/examples/request/PostLicenseRequestExample1.yaml": [
@@ -5673,6 +6569,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"licenses\":[{\"uid\":\"893361dc-9749-4997-93cb-802e3d7fa4xx\",\"type\":\"basic\",\"issue_date_in_millis\":1411948800000,\"expiry_date_in_millis\":1914278399999,\"max_nodes\":1,\"issued_to\":\"issuedTo\",\"issuer\":\"issuer\",\"signature\":\"xx\"}]}' \"$ELASTICSEARCH_URL/_license\""
+    },
+    {
+      "language": "Java",
+      "code": "client.license().post(p -> p\n    .licenses(l -> l\n        .expiryDateInMillis(1914278399999L)\n        .issueDateInMillis(1411948800000L)\n        .issuedTo(\"issuedTo\")\n        .issuer(\"issuer\")\n        .maxNodes(1L)\n        .signature(\"xx\")\n        .type(LicenseType.Basic)\n        .uid(\"893361dc-9749-4997-93cb-802e3d7fa4xx\")\n    )\n);\n"
     }
   ],
   "specification/license/delete/examples/request/LicenseDeleteExample1.yaml": [
@@ -5695,6 +6595,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_license\""
+    },
+    {
+      "language": "Java",
+      "code": "client.license().delete(d -> d);\n"
     }
   ],
   "specification/license/get/examples/request/GetLicenseRequestExample1.yaml": [
@@ -5717,6 +6621,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_license\""
+    },
+    {
+      "language": "Java",
+      "code": "client.license().get(g -> g);\n"
     }
   ],
   "specification/license/get_trial_status/examples/request/GetTrialLicenseStatusRequestExample1.yaml": [
@@ -5739,6 +6647,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_license/trial_status\""
+    },
+    {
+      "language": "Java",
+      "code": "client.license().getTrialStatus();\n"
     }
   ],
   "specification/license/post_start_trial/examples/request/StartTrialLicenseRequestExample1.yaml": [
@@ -5761,6 +6673,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_license/start_trial?acknowledge=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.license().postStartTrial(p -> p\n    .acknowledge(true)\n);\n"
     }
   ],
   "specification/license/get_basic_status/examples/request/GetBasicLicenseStatusRequestExample1.yaml": [
@@ -5783,6 +6699,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_license/basic_status\""
+    },
+    {
+      "language": "Java",
+      "code": "client.license().getBasicStatus();\n"
     }
   ],
   "specification/license/post_start_basic/examples/request/StartBasicLicenseRequestExample1.yaml": [
@@ -5805,6 +6725,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_license/start_basic?acknowledge=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.license().postStartBasic(p -> p\n    .acknowledge(true)\n);\n"
     }
   ],
   "specification/logstash/get_pipeline/examples/request/LogstashGetPipelineRequestExample1.yaml": [
@@ -5827,6 +6751,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_logstash/pipeline/my_pipeline\""
+    },
+    {
+      "language": "Java",
+      "code": "client.logstash().getPipeline(g -> g\n    .id(\"my_pipeline\")\n);\n"
     }
   ],
   "specification/logstash/put_pipeline/examples/request/LogstashPutPipelineRequestExample1.yaml": [
@@ -5849,6 +6777,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"Sample pipeline for illustration purposes\",\"last_modified\":\"2021-01-02T02:50:51.250Z\",\"pipeline_metadata\":{\"type\":\"logstash_pipeline\",\"version\":1},\"username\":\"elastic\",\"pipeline\":\"input {}\\\\n filter { grok {} }\\\\n output {}\",\"pipeline_settings\":{\"pipeline.workers\":1,\"pipeline.batch.size\":125,\"pipeline.batch.delay\":50,\"queue.type\":\"memory\",\"queue.max_bytes\":\"1gb\",\"queue.checkpoint.writes\":1024}}' \"$ELASTICSEARCH_URL/_logstash/pipeline/my_pipeline\""
+    },
+    {
+      "language": "Java",
+      "code": "client.logstash().putPipeline(p -> p\n    .id(\"my_pipeline\")\n    .pipeline(pi -> pi\n        .description(\"Sample pipeline for illustration purposes\")\n        .lastModified(DateTime.of(\"2021-01-02T02:50:51.250Z\"))\n        .pipeline(\"input {}\\n filter { grok {} }\\n output {}\")\n        .pipelineMetadata(pip -> pip\n            .type(\"logstash_pipeline\")\n            .version(\"1\")\n        )\n        .pipelineSettings(pip -> pip\n            .pipelineWorkers(1)\n            .pipelineBatchSize(125)\n            .pipelineBatchDelay(50)\n            .queueType(\"memory\")\n            .queueMaxBytes(\"1gb\")\n            .queueCheckpointWrites(1024)\n        )\n        .username(\"elastic\")\n    )\n);\n"
     }
   ],
   "specification/logstash/delete_pipeline/examples/request/LogstashDeletePipelineExample1.yaml": [
@@ -5871,6 +6803,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_logstash/pipeline/my_pipeline\""
+    },
+    {
+      "language": "Java",
+      "code": "client.logstash().deletePipeline(d -> d\n    .id(\"my_pipeline\")\n);\n"
     }
   ],
   "specification/security/saml_complete_logout/examples/request/SamlCompleteLogoutRequestExample2.yaml": [
@@ -5893,6 +6829,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm\":\"saml1\",\"ids\":[\"_1c368075e0b3...\"],\"content\":\"PHNhbWxwOkxvZ291dFJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46...\"}' \"$ELASTICSEARCH_URL/_security/saml/complete_logout\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().samlCompleteLogout(s -> s\n    .content(\"PHNhbWxwOkxvZ291dFJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46...\")\n    .ids(\"_1c368075e0b3...\")\n    .realm(\"saml1\")\n);\n"
     }
   ],
   "specification/security/saml_complete_logout/examples/request/SamlCompleteLogoutRequestExample1.yaml": [
@@ -5915,6 +6855,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm\":\"saml1\",\"ids\":[\"_1c368075e0b3...\"],\"query_string\":\"SAMLResponse=fZHLasMwEEVbfb1bf...&SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1&Signature=CuCmFn%2BLqnaZGZJqK...\"}' \"$ELASTICSEARCH_URL/_security/saml/complete_logout\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().samlCompleteLogout(s -> s\n    .ids(\"_1c368075e0b3...\")\n    .queryString(\"SAMLResponse=fZHLasMwEEVbfb1bf...&SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1&Signature=CuCmFn%2BLqnaZGZJqK...\")\n    .realm(\"saml1\")\n);\n"
     }
   ],
   "specification/security/disable_user/examples/request/SecurityDisableUserExample1.yaml": [
@@ -5937,6 +6881,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/user/jacknich/_disable\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().disableUser(d -> d\n    .username(\"jacknich\")\n);\n"
     }
   ],
   "specification/security/update_settings/examples/request/SecurityUpdateSettingsRequestExample1.yaml": [
@@ -5959,6 +6907,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"security\":{\"index.auto_expand_replicas\":\"0-all\"},\"security-tokens\":{\"index.auto_expand_replicas\":\"0-all\"},\"security-profile\":{\"index.auto_expand_replicas\":\"0-all\"}}' \"$ELASTICSEARCH_URL/_security/settings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().updateSettings(u -> u\n    .security(s -> s)\n    .securityProfile(s -> s)\n    .securityTokens(s -> s)\n);\n"
     }
   ],
   "specification/security/get_user_profile/examples/request/GetUserProfileRequestExample1.yaml": [
@@ -5981,6 +6933,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/profile/u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getUserProfile(g -> g\n    .uid(\"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\")\n);\n"
     }
   ],
   "specification/security/create_api_key/examples/request/SecurityCreateApiKeyRequestExample1.yaml": [
@@ -6003,6 +6959,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"name\":\"my-api-key\",\"expiration\":\"1d\",\"role_descriptors\":{\"role-a\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index-a*\"],\"privileges\":[\"read\"]}]},\"role-b\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index-b*\"],\"privileges\":[\"all\"]}]}},\"metadata\":{\"application\":\"my-application\",\"environment\":{\"level\":1,\"trusted\":true,\"tags\":[\"dev\",\"staging\"]}}}' \"$ELASTICSEARCH_URL/_security/api_key\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().createApiKey(c -> c\n    .expiration(e -> e\n        .time(\"1d\")\n    )\n    .metadata(Map.of(\"environment\", JsonData.fromJson(\"{\\\"level\\\":1,\\\"trusted\\\":true,\\\"tags\\\":[\\\"dev\\\",\\\"staging\\\"]}\"),\"application\", JsonData.fromJson(\"\\\"my-application\\\"\")))\n    .name(\"my-api-key\")\n    .roleDescriptors(Map.of(\"role-b\", RoleDescriptor.of(r -> r\n            .cluster(\"all\")\n            .indices(i -> i\n                .names(\"index-b*\")\n                .privileges(\"all\")\n            )),\"role-a\", RoleDescriptor.of(r -> r\n            .cluster(\"all\")\n            .indices(i -> i\n                .names(\"index-a*\")\n                .privileges(\"read\")\n            ))))\n);\n"
     }
   ],
   "specification/security/get_privileges/examples/request/SecurityGetPrivilegesRequestExample1.yaml": [
@@ -6025,6 +6985,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/privilege/myapp/read\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getPrivileges(g -> g\n    .application(\"myapp\")\n    .name(\"read\")\n);\n"
     }
   ],
   "specification/security/update_cross_cluster_api_key/examples/request/UpdateCrossClusterApiKeyRequestExample1.yaml": [
@@ -6047,6 +7011,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"access\":{\"replication\":[{\"names\":[\"archive\"]}]},\"metadata\":{\"application\":\"replication\"}}' \"$ELASTICSEARCH_URL/_security/cross_cluster/api_key/VuaCfGcBCdbkQm-e5aOx\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().updateCrossClusterApiKey(u -> u\n    .access(a -> a\n        .replication(r -> r\n            .names(\"archive\")\n        )\n    )\n    .id(\"VuaCfGcBCdbkQm-e5aOx\")\n    .metadata(\"application\", JsonData.fromJson(\"\\\"replication\\\"\"))\n);\n"
     }
   ],
   "specification/security/get_settings/examples/request/SecurityGetSettingsExample1.yaml": [
@@ -6069,6 +7037,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/settings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getSettings(g -> g);\n"
     }
   ],
   "specification/security/get_builtin_privileges/examples/request/SecurityGetBuiltinPrivilegesRequestExample1.yaml": [
@@ -6091,6 +7063,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/privilege/_builtin\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getBuiltinPrivileges();\n"
     }
   ],
   "specification/security/has_privileges_user_profile/examples/request/HasPrivilegesUserProfileRequestExample1.yaml": [
@@ -6113,6 +7089,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"uids\":[\"u_LQPnxDxEjIH0GOUoFkZr5Y57YUwSkL9Joiq-g4OCbPc_0\",\"u_rzRnxDgEHIH0GOUoFkZr5Y27YUwSk19Joiq=g4OCxxB_1\",\"u_does-not-exist_0\"],\"privileges\":{\"cluster\":[\"monitor\",\"create_snapshot\",\"manage_ml\"],\"index\":[{\"names\":[\"suppliers\",\"products\"],\"privileges\":[\"create_doc\"]},{\"names\":[\"inventory\"],\"privileges\":[\"read\",\"write\"]}],\"application\":[{\"application\":\"inventory_manager\",\"privileges\":[\"read\",\"data:write/inventory\"],\"resources\":[\"product/1852563\"]}]}}' \"$ELASTICSEARCH_URL/_security/profile/_has_privileges\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().hasPrivilegesUserProfile(h -> h\n    .privileges(p -> p\n        .application(a -> a\n            .application(\"inventory_manager\")\n            .privileges(List.of(\"read\",\"data:write/inventory\"))\n            .resources(\"product/1852563\")\n        )\n        .cluster(List.of(\"monitor\",\"create_snapshot\",\"manage_ml\"))\n        .index(List.of(IndexPrivilegesCheck.of(i -> i\n                .names(List.of(\"suppliers\",\"products\"))\n                .privileges(\"create_doc\")),IndexPrivilegesCheck.of(i -> i\n                .names(\"inventory\")\n                .privileges(List.of(\"read\",\"write\")))))\n    )\n    .uids(List.of(\"u_LQPnxDxEjIH0GOUoFkZr5Y57YUwSkL9Joiq-g4OCbPc_0\",\"u_rzRnxDgEHIH0GOUoFkZr5Y27YUwSk19Joiq=g4OCxxB_1\",\"u_does-not-exist_0\"))\n);\n"
     }
   ],
   "specification/security/clear_cached_roles/examples/request/SecurityClearCachedRolesExample1.yaml": [
@@ -6135,6 +7115,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/role/my_admin_role/_clear_cache\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().clearCachedRoles(c -> c\n    .name(\"my_admin_role\")\n);\n"
     }
   ],
   "specification/security/authenticate/examples/request/SecurityAuthenticateRequestExample1.yaml": [
@@ -6157,6 +7141,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/_authenticate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().authenticate();\n"
     }
   ],
   "specification/security/activate_user_profile/examples/request/ActivateUserProfileRequestExample1.yaml": [
@@ -6179,6 +7167,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grant_type\":\"password\",\"username\":\"jacknich\",\"password\":\"l0ng-r4nd0m-p@ssw0rd\"}' \"$ELASTICSEARCH_URL/_security/profile/_activate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().activateUserProfile(a -> a\n    .grantType(GrantType.Password)\n    .password(\"l0ng-r4nd0m-p@ssw0rd\")\n    .username(\"jacknich\")\n);\n"
     }
   ],
   "specification/security/oidc_prepare_authentication/examples/request/OidcPrepareAuthenticationRequestExample2.yaml": [
@@ -6201,6 +7193,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm\":\"oidc1\",\"state\":\"lGYK0EcSLjqH6pkT5EVZjC6eIW5YCGgywj2sxROO\",\"nonce\":\"zOBXLJGUooRrbLbQk5YCcyC8AXw3iloynvluYhZ5\"}' \"$ELASTICSEARCH_URL/_security/oidc/prepare\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().oidcPrepareAuthentication(o -> o\n    .nonce(\"zOBXLJGUooRrbLbQk5YCcyC8AXw3iloynvluYhZ5\")\n    .realm(\"oidc1\")\n    .state(\"lGYK0EcSLjqH6pkT5EVZjC6eIW5YCGgywj2sxROO\")\n);\n"
     }
   ],
   "specification/security/oidc_prepare_authentication/examples/request/OidcPrepareAuthenticationRequestExample3.yaml": [
@@ -6223,6 +7219,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"iss\":\"http://127.0.0.1:8080\",\"login_hint\":\"this_is_an_opaque_string\"}' \"$ELASTICSEARCH_URL/_security/oidc/prepare\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().oidcPrepareAuthentication(o -> o\n    .iss(\"http://127.0.0.1:8080\")\n    .loginHint(\"this_is_an_opaque_string\")\n);\n"
     }
   ],
   "specification/security/oidc_prepare_authentication/examples/request/OidcPrepareAuthenticationRequestExample1.yaml": [
@@ -6245,6 +7245,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm\":\"oidc1\"}' \"$ELASTICSEARCH_URL/_security/oidc/prepare\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().oidcPrepareAuthentication(o -> o\n    .realm(\"oidc1\")\n);\n"
     }
   ],
   "specification/security/has_privileges/examples/request/SecurityHasPrivilegesRequestExample1.yaml": [
@@ -6267,6 +7271,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"cluster\":[\"monitor\",\"manage\"],\"index\":[{\"names\":[\"suppliers\",\"products\"],\"privileges\":[\"read\"]},{\"names\":[\"inventory\"],\"privileges\":[\"read\",\"write\"]}],\"application\":[{\"application\":\"inventory_manager\",\"privileges\":[\"read\",\"data:write/inventory\"],\"resources\":[\"product/1852563\"]}]}' \"$ELASTICSEARCH_URL/_security/user/_has_privileges\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().hasPrivileges(h -> h\n    .application(a -> a\n        .application(\"inventory_manager\")\n        .privileges(List.of(\"read\",\"data:write/inventory\"))\n        .resources(\"product/1852563\")\n    )\n    .cluster(List.of(\"monitor\",\"manage\"))\n    .index(List.of(IndexPrivilegesCheck.of(i -> i\n            .names(List.of(\"suppliers\",\"products\"))\n            .privileges(\"read\")),IndexPrivilegesCheck.of(i -> i\n            .names(\"inventory\")\n            .privileges(List.of(\"read\",\"write\")))))\n);\n"
     }
   ],
   "specification/security/oidc_logout/examples/request/OidcLogoutRequestExample1.yaml": [
@@ -6289,6 +7297,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"token\":\"dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==\",\"refresh_token\":\"vLBPvmAB6KvwvJZr27cS\"}' \"$ELASTICSEARCH_URL/_security/oidc/logout\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().oidcLogout(o -> o\n    .refreshToken(\"vLBPvmAB6KvwvJZr27cS\")\n    .token(\"dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==\")\n);\n"
     }
   ],
   "specification/security/invalidate_api_key/examples/request/SecurityInvalidateApiKeyRequestExample1.yaml": [
@@ -6311,6 +7323,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"ids\":[\"VuaCfGcBCdbkQm-e5aOx\"]}' \"$ELASTICSEARCH_URL/_security/api_key\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().invalidateApiKey(i -> i\n    .ids(\"VuaCfGcBCdbkQm-e5aOx\")\n);\n"
     }
   ],
   "specification/security/invalidate_api_key/examples/request/SecurityInvalidateApiKeyRequestExample6.yaml": [
@@ -6333,6 +7349,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"username\":\"myuser\",\"realm_name\":\"native1\"}' \"$ELASTICSEARCH_URL/_security/api_key\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().invalidateApiKey(i -> i\n    .realmName(\"native1\")\n    .username(\"myuser\")\n);\n"
     }
   ],
   "specification/security/invalidate_api_key/examples/request/SecurityInvalidateApiKeyRequestExample5.yaml": [
@@ -6355,6 +7375,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"ids\":[\"VuaCfGcBCdbkQm-e5aOx\"],\"owner\":\"true\"}' \"$ELASTICSEARCH_URL/_security/api_key\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().invalidateApiKey(i -> i\n    .ids(\"VuaCfGcBCdbkQm-e5aOx\")\n    .owner(true)\n);\n"
     }
   ],
   "specification/security/invalidate_api_key/examples/request/SecurityInvalidateApiKeyRequestExample4.yaml": [
@@ -6377,6 +7401,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"username\":\"myuser\"}' \"$ELASTICSEARCH_URL/_security/api_key\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().invalidateApiKey(i -> i\n    .username(\"myuser\")\n);\n"
     }
   ],
   "specification/security/invalidate_api_key/examples/request/SecurityInvalidateApiKeyRequestExample3.yaml": [
@@ -6399,6 +7427,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm_name\":\"native1\"}' \"$ELASTICSEARCH_URL/_security/api_key\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().invalidateApiKey(i -> i\n    .realmName(\"native1\")\n);\n"
     }
   ],
   "specification/security/invalidate_api_key/examples/request/SecurityInvalidateApiKeyRequestExample2.yaml": [
@@ -6421,6 +7453,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"name\":\"my-api-key\"}' \"$ELASTICSEARCH_URL/_security/api_key\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().invalidateApiKey(i -> i\n    .name(\"my-api-key\")\n);\n"
     }
   ],
   "specification/security/bulk_update_api_keys/examples/request/SecurityBulkUpdateApiKeysRequestExample1.yaml": [
@@ -6443,6 +7479,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"ids\":[\"VuaCfGcBCdbkQm-e5aOx\",\"H3_AhoIBA9hmeQJdg7ij\"],\"role_descriptors\":{\"role-a\":{\"indices\":[{\"names\":[\"*\"],\"privileges\":[\"write\"]}]}},\"metadata\":{\"environment\":{\"level\":2,\"trusted\":true,\"tags\":[\"production\"]}},\"expiration\":\"30d\"}' \"$ELASTICSEARCH_URL/_security/api_key/_bulk_update\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().bulkUpdateApiKeys(b -> b\n    .expiration(e -> e\n        .time(\"30d\")\n    )\n    .ids(List.of(\"VuaCfGcBCdbkQm-e5aOx\",\"H3_AhoIBA9hmeQJdg7ij\"))\n    .metadata(\"environment\", JsonData.fromJson(\"{\\\"level\\\":2,\\\"trusted\\\":true,\\\"tags\\\":[\\\"production\\\"]}\"))\n    .roleDescriptors(\"role-a\", r -> r\n        .indices(i -> i\n            .names(\"*\")\n            .privileges(\"write\")\n        )\n    )\n);\n"
     }
   ],
   "specification/security/bulk_update_api_keys/examples/request/SecurityBulkUpdateApiKeysRequestExample2.yaml": [
@@ -6465,6 +7505,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"ids\":[\"VuaCfGcBCdbkQm-e5aOx\",\"H3_AhoIBA9hmeQJdg7ij\"],\"role_descriptors\":{}}' \"$ELASTICSEARCH_URL/_security/api_key/_bulk_update\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().bulkUpdateApiKeys(b -> b\n    .ids(List.of(\"VuaCfGcBCdbkQm-e5aOx\",\"H3_AhoIBA9hmeQJdg7ij\"))\n);\n"
     }
   ],
   "specification/security/suggest_user_profiles/examples/request/SuggestUserProfilesRequestExample1.yaml": [
@@ -6487,6 +7531,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"name\":\"jack\",\"hint\":{\"uids\":[\"u_8RKO7AKfEbSiIHZkZZ2LJy2MUSDPWDr3tMI_CkIGApU_0\",\"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\"],\"labels\":{\"direction\":[\"north\",\"east\"]}}}' \"$ELASTICSEARCH_URL/_security/profile/_suggest\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().suggestUserProfiles(s -> s\n    .hint(h -> h\n        .uids(List.of(\"u_8RKO7AKfEbSiIHZkZZ2LJy2MUSDPWDr3tMI_CkIGApU_0\",\"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\"))\n        .labels(\"direction\", List.of(\"north\",\"east\"))\n    )\n    .name(\"jack\")\n);\n"
     }
   ],
   "specification/security/query_api_keys/examples/request/QueryApiKeysRequestExample3.yaml": [
@@ -6509,6 +7557,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"term\":{\"name\":{\"value\":\"application-key-1\"}}}}' \"$ELASTICSEARCH_URL/_security/_query/api_key\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().queryApiKeys(q -> q\n    .query(qu -> qu\n        .term(t -> t\n            .field(\"name\")\n            .value(FieldValue.of(\"application-key-1\"))\n        )\n    )\n);\n"
     }
   ],
   "specification/security/query_api_keys/examples/request/QueryApiKeysRequestExample2.yaml": [
@@ -6531,6 +7583,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"bool\":{\"must\":[{\"prefix\":{\"name\":\"app1-key-\"}},{\"term\":{\"invalidated\":\"false\"}}],\"must_not\":[{\"term\":{\"name\":\"app1-key-01\"}}],\"filter\":[{\"wildcard\":{\"username\":\"org-*-user\"}},{\"term\":{\"metadata.environment\":\"production\"}}]}},\"from\":20,\"size\":10,\"sort\":[{\"creation\":{\"order\":\"desc\",\"format\":\"date_time\"}},\"name\"]}' \"$ELASTICSEARCH_URL/_security/_query/api_key\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().queryApiKeys(q -> q\n    .from(20)\n    .query(qu -> qu\n        .bool(b -> b\n            .filter(List.of(Query.of(que -> que\n                    .wildcard(w -> w\n                        .field(\"username\")\n                        .value(\"org-*-user\")\n                )),Query.of(quer -> quer\n                    .term(t -> t\n                        .field(\"metadata.environment\")\n                        .value(FieldValue.of(\"production\"))\n                ))))\n            .must(List.of(Query.of(query -> query\n                    .prefix(p -> p\n                        .field(\"name\")\n                        .value(\"app1-key-\")\n                )),Query.of(query1 -> query1\n                    .term(t -> t\n                        .field(\"invalidated\")\n                        .value(FieldValue.of(\"false\"))\n                ))))\n            .mustNot(m -> m\n                .term(t -> t\n                    .field(\"name\")\n                    .value(FieldValue.of(\"app1-key-01\"))\n                )\n            )\n        )\n    )\n    .size(10)\n    .sort(List.of(SortOptions.of(s -> s\n            .field(f -> f\n                .field(\"creation\")\n                .order(SortOrder.Desc)\n                .format(\"date_time\")\n        )),SortOptions.of(so -> so\n            .field(f -> f\n                .field(\"name\")\n        ))))\n);\n"
     }
   ],
   "specification/security/query_api_keys/examples/request/QueryApiKeysRequestExample1.yaml": [
@@ -6553,6 +7609,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"ids\":{\"values\":[\"VuaCfGcBCdbkQm-e5aOx\"]}}}' \"$ELASTICSEARCH_URL/_security/_query/api_key?with_limited_by=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().queryApiKeys(q -> q\n    .query(qu -> qu\n        .ids(i -> i\n            .values(\"VuaCfGcBCdbkQm-e5aOx\")\n        )\n    )\n    .withLimitedBy(true)\n);\n"
     }
   ],
   "specification/security/create_cross_cluster_api_key/examples/request/CreateCrossClusterApiKeyRequestExample1.yaml": [
@@ -6575,6 +7635,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"name\":\"my-cross-cluster-api-key\",\"expiration\":\"1d\",\"access\":{\"search\":[{\"names\":[\"logs*\"]}],\"replication\":[{\"names\":[\"archive*\"]}]},\"metadata\":{\"description\":\"phase one\",\"environment\":{\"level\":1,\"trusted\":true,\"tags\":[\"dev\",\"staging\"]}}}' \"$ELASTICSEARCH_URL/_security/cross_cluster/api_key\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().createCrossClusterApiKey(c -> c\n    .access(a -> a\n        .replication(r -> r\n            .names(\"archive*\")\n        )\n        .search(s -> s\n            .names(\"logs*\")\n        )\n    )\n    .expiration(e -> e\n        .time(\"1d\")\n    )\n    .metadata(Map.of(\"environment\", JsonData.fromJson(\"{\\\"level\\\":1,\\\"trusted\\\":true,\\\"tags\\\":[\\\"dev\\\",\\\"staging\\\"]}\"),\"description\", JsonData.fromJson(\"\\\"phase one\\\"\")))\n    .name(\"my-cross-cluster-api-key\")\n);\n"
     }
   ],
   "specification/security/saml_authenticate/examples/request/SamlAuthenticateRequestExample1.yaml": [
@@ -6597,6 +7661,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"content\":\"PHNhbWxwOlJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIHhtbG5zOnNhbWw9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMD.....\",\"ids\":[\"4fee3b046395c4e751011e97f8900b5273d56685\"]}' \"$ELASTICSEARCH_URL/_security/saml/authenticate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().samlAuthenticate(s -> s\n    .content(\"PHNhbWxwOlJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIHhtbG5zOnNhbWw9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMD.....\")\n    .ids(\"4fee3b046395c4e751011e97f8900b5273d56685\")\n);\n"
     }
   ],
   "specification/security/change_password/examples/request/SecurityChangePasswordRequestExample1.yaml": [
@@ -6619,6 +7687,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"password\":\"new-test-password\"}' \"$ELASTICSEARCH_URL/_security/user/jacknich/_password\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().changePassword(c -> c\n    .password(\"new-test-password\")\n    .username(\"jacknich\")\n);\n"
     }
   ],
   "specification/security/get_service_credentials/examples/request/GetServiceCredentialsRequestExample1.yaml": [
@@ -6641,6 +7713,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/service/elastic/fleet-server/credential\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getServiceCredentials(g -> g\n    .namespace(\"elastic\")\n    .service(\"fleet-server\")\n);\n"
     }
   ],
   "specification/security/get_role_mapping/examples/request/SecurityGetRoleMappingRequestExample1.yaml": [
@@ -6663,6 +7739,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/role_mapping/mapping1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getRoleMapping(g -> g\n    .name(\"mapping1\")\n);\n"
     }
   ],
   "specification/security/disable_user_profile/examples/request/SecurityDisableUserProfileExample1.yaml": [
@@ -6685,6 +7765,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/profile/u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0/_disable\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().disableUserProfile(d -> d\n    .uid(\"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\")\n);\n"
     }
   ],
   "specification/security/get_user_privileges/examples/request/SecurityGetUserPrivilegesRequestExample1.yaml": [
@@ -6707,6 +7791,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/user/_privileges\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getUserPrivileges(g -> g);\n"
     }
   ],
   "specification/security/query_role/examples/request/QueryRolesRequestExample2.yaml": [
@@ -6729,6 +7817,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"match\":{\"description\":{\"query\":\"user access\"}}},\"size\":1}' \"$ELASTICSEARCH_URL/_security/_query/role\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().queryRole(q -> q\n    .query(qu -> qu\n        .match(m -> m\n            .field(\"description\")\n            .query(FieldValue.of(\"user access\"))\n        )\n    )\n    .size(1)\n);\n"
     }
   ],
   "specification/security/query_role/examples/request/QueryRolesRequestExample1.yaml": [
@@ -6751,6 +7843,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"sort\":[\"name\"]}' \"$ELASTICSEARCH_URL/_security/_query/role\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().queryRole(q -> q\n    .sort(s -> s\n        .field(f -> f\n            .field(\"name\")\n        )\n    )\n);\n"
     }
   ],
   "specification/security/delete_privileges/examples/request/SecurityDeletePrivilegesRequestExample1.yaml": [
@@ -6773,6 +7869,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/privilege/myapp/read\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().deletePrivileges(d -> d\n    .application(\"myapp\")\n    .name(\"read\")\n);\n"
     }
   ],
   "specification/security/clear_cached_privileges/examples/request/SecurityClearCachedPrivilegesExample1.yaml": [
@@ -6795,6 +7895,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/privilege/myapp/_clear_cache\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().clearCachedPrivileges(c -> c\n    .application(\"myapp\")\n);\n"
     }
   ],
   "specification/security/create_service_token/examples/request/CreateServiceTokenRequestExample1.yaml": [
@@ -6817,6 +7921,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/service/elastic/fleet-server/credential/token/token1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().createServiceToken(c -> c\n    .name(\"token1\")\n    .namespace(\"elastic\")\n    .service(\"fleet-server\")\n);\n"
     }
   ],
   "specification/security/delete_user/examples/request/SecurityDeleteUserRequestExample1.yaml": [
@@ -6839,6 +7947,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/user/jacknich\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().deleteUser(d -> d\n    .username(\"jacknich\")\n);\n"
     }
   ],
   "specification/security/clear_cached_realms/examples/request/SecurityClearCachedRealmsExample1.yaml": [
@@ -6861,6 +7973,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/realm/default_file/_clear_cache\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().clearCachedRealms(c -> c\n    .realms(\"default_file\")\n);\n"
     }
   ],
   "specification/security/get_user/examples/request/SecurityGetUserRequestExample1.yaml": [
@@ -6883,6 +7999,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/user/jacknich?with_profile_uid=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getUser(g -> g\n    .username(\"jacknich\")\n    .withProfileUid(true)\n);\n"
     }
   ],
   "specification/security/update_user_profile_data/examples/request/UpdateUserProfileDataRequestExample1.yaml": [
@@ -6905,6 +8025,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"labels\":{\"direction\":\"east\"},\"data\":{\"app1\":{\"theme\":\"default\"}}}' \"$ELASTICSEARCH_URL/_security/profile/u_P_0BMHgaOK3p7k-PFWUCbw9dQ-UFjt01oWJ_Dp2PmPc_0/_data\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().updateUserProfileData(u -> u\n    .data(\"app1\", JsonData.fromJson(\"{\\\"theme\\\":\\\"default\\\"}\"))\n    .labels(\"direction\", JsonData.fromJson(\"\\\"east\\\"\"))\n    .uid(\"u_P_0BMHgaOK3p7k-PFWUCbw9dQ-UFjt01oWJ_Dp2PmPc_0\")\n);\n"
     }
   ],
   "specification/security/delegate_pki/examples/request/SecurityDelegatePkiRequestExample1.yaml": [
@@ -6927,6 +8051,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"x509_certificate_chain\":[\"MIIDeDCCAmCgAwIBAgIUBzj/nGGKxP2iXawsSquHmQjCJmMwDQYJKoZIhvcNAQELBQAwUzErMCkGA1UEAxMiRWxhc3RpY3NlYXJjaCBUZXN0IEludGVybWVkaWF0ZSBDQTEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMB4XDTIzMDcxODE5MjkwNloXDTQzMDcxMzE5MjkwNlowSjEiMCAGA1UEAxMZRWxhc3RpY3NlYXJjaCBUZXN0IENsaWVudDEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAllHL4pQkkfwAm/oLkxYYO+r950DEy1bjH+4viCHzNADLCTWO+lOZJVlNx7QEzJE3QGMdif9CCBBxQFMapA7oUFCLq84fPSQQu5AnvvbltVD9nwVtCs+9ZGDjMKsz98RhSLMFIkxdxi6HkQ3Lfa4ZSI4lvba4oo+T/GveazBDS+NgmKyq00EOXt3tWi1G9vEVItommzXWfv0agJWzVnLMldwkPqsw0W7zrpyT7FZS4iLbQADGceOW8fiauOGMkscu9zAnDR/SbWl/chYioQOdw6ndFLn1YIFPd37xL0WsdsldTpn0vH3YfzgLMffT/3P6YlwBegWzsx6FnM/93Ecb4wIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBQKNRwjW+Ad/FN1Rpoqme/5+jrFWzAfBgNVHSMEGDAWgBRcya0c0x/PaI7MbmJVIylWgLqXNjANBgkqhkiG9w0BAQsFAAOCAQEACZ3PF7Uqu47lplXHP6YlzYL2jL0D28hpj5lGtdha4Muw1m/BjDb0Pu8l0NQ1z3AP6AVcvjNDkQq6Y5jeSz0bwQlealQpYfo7EMXjOidrft1GbqOMFmTBLpLA9SvwYGobSTXWTkJzonqVaTcf80HpMgM2uEhodwTcvz6v1WEfeT/HMjmdIsq4ImrOL9RNrcZG6nWfw0HR3JNOgrbfyEztEI471jHznZ336OEcyX7gQuvHE8tOv5+oD1d7s3Xg1yuFp+Ynh+FfOi3hPCuaHA+7F6fLmzMDLVUBAllugst1C3U+L/paD7tqIa4ka+KNPCbSfwazmJrt4XNiivPR4hwH5g==\"]}' \"$ELASTICSEARCH_URL/_security/delegate_pki\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().delegatePki(d -> d\n    .x509CertificateChain(\"MIIDeDCCAmCgAwIBAgIUBzj/nGGKxP2iXawsSquHmQjCJmMwDQYJKoZIhvcNAQELBQAwUzErMCkGA1UEAxMiRWxhc3RpY3NlYXJjaCBUZXN0IEludGVybWVkaWF0ZSBDQTEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMB4XDTIzMDcxODE5MjkwNloXDTQzMDcxMzE5MjkwNlowSjEiMCAGA1UEAxMZRWxhc3RpY3NlYXJjaCBUZXN0IENsaWVudDEWMBQGA1UECxMNRWxhc3RpY3NlYXJjaDEMMAoGA1UEChMDb3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAllHL4pQkkfwAm/oLkxYYO+r950DEy1bjH+4viCHzNADLCTWO+lOZJVlNx7QEzJE3QGMdif9CCBBxQFMapA7oUFCLq84fPSQQu5AnvvbltVD9nwVtCs+9ZGDjMKsz98RhSLMFIkxdxi6HkQ3Lfa4ZSI4lvba4oo+T/GveazBDS+NgmKyq00EOXt3tWi1G9vEVItommzXWfv0agJWzVnLMldwkPqsw0W7zrpyT7FZS4iLbQADGceOW8fiauOGMkscu9zAnDR/SbWl/chYioQOdw6ndFLn1YIFPd37xL0WsdsldTpn0vH3YfzgLMffT/3P6YlwBegWzsx6FnM/93Ecb4wIDAQABo00wSzAJBgNVHRMEAjAAMB0GA1UdDgQWBBQKNRwjW+Ad/FN1Rpoqme/5+jrFWzAfBgNVHSMEGDAWgBRcya0c0x/PaI7MbmJVIylWgLqXNjANBgkqhkiG9w0BAQsFAAOCAQEACZ3PF7Uqu47lplXHP6YlzYL2jL0D28hpj5lGtdha4Muw1m/BjDb0Pu8l0NQ1z3AP6AVcvjNDkQq6Y5jeSz0bwQlealQpYfo7EMXjOidrft1GbqOMFmTBLpLA9SvwYGobSTXWTkJzonqVaTcf80HpMgM2uEhodwTcvz6v1WEfeT/HMjmdIsq4ImrOL9RNrcZG6nWfw0HR3JNOgrbfyEztEI471jHznZ336OEcyX7gQuvHE8tOv5+oD1d7s3Xg1yuFp+Ynh+FfOi3hPCuaHA+7F6fLmzMDLVUBAllugst1C3U+L/paD7tqIa4ka+KNPCbSfwazmJrt4XNiivPR4hwH5g==\")\n);\n"
     }
   ],
   "specification/security/enable_user/examples/request/SecurityEnableUserExample1.yaml": [
@@ -6949,6 +8077,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/user/logstash_system/_enable\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().enableUser(e -> e\n    .username(\"logstash_system\")\n);\n"
     }
   ],
   "specification/security/put_user/examples/request/SecurityPutUserRequestExample1.yaml": [
@@ -6971,6 +8103,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"password\":\"l0ng-r4nd0m-p@ssw0rd\",\"roles\":[\"admin\",\"other_role1\"],\"full_name\":\"Jack Nicholson\",\"email\":\"jacknich@example.com\",\"metadata\":{\"intelligence\":7}}' \"$ELASTICSEARCH_URL/_security/user/jacknich\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putUser(p -> p\n    .email(\"jacknich@example.com\")\n    .fullName(\"Jack Nicholson\")\n    .metadata(\"intelligence\", JsonData.fromJson(\"7\"))\n    .password(\"l0ng-r4nd0m-p@ssw0rd\")\n    .roles(List.of(\"admin\",\"other_role1\"))\n    .username(\"jacknich\")\n);\n"
     }
   ],
   "specification/security/clear_api_key_cache/examples/request/SecurityClearApiKeyCacheExample1.yaml": [
@@ -6993,6 +8129,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/api_key/yVGMr3QByxdh1MSaicYx/_clear_cache\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().clearApiKeyCache(c -> c\n    .ids(\"yVGMr3QByxdh1MSaicYx\")\n);\n"
     }
   ],
   "specification/security/get_api_key/examples/request/SecurityGetApiKeyRequestExample2.yaml": [
@@ -7015,6 +8155,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/api_key?username=myuser&realm_name=native1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getApiKey(g -> g\n    .realmName(\"native1\")\n    .username(\"myuser\")\n);\n"
     }
   ],
   "specification/security/clear_cached_service_tokens/examples/request/SecurityClearCachedServiceTokensExample1.yaml": [
@@ -7037,6 +8181,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/service/elastic/fleet-server/credential/token/token1/_clear_cache\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().clearCachedServiceTokens(c -> c\n    .name(\"token1\")\n    .namespace(\"elastic\")\n    .service(\"fleet-server\")\n);\n"
     }
   ],
   "specification/security/enable_user_profile/examples/request/SecurityEnableUserProfileExample1.yaml": [
@@ -7059,6 +8207,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/profile/u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0/_enable\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().enableUserProfile(e -> e\n    .uid(\"u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0\")\n);\n"
     }
   ],
   "specification/security/put_role_mapping/examples/request/SecurityPutRoleMappingRequestExample7.yaml": [
@@ -7081,6 +8233,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"ldap-example-user\"],\"enabled\":true,\"rules\":{\"all\":[{\"field\":{\"dn\":\"*,ou=subtree,dc=example,dc=com\"}},{\"field\":{\"realm.name\":\"ldap1\"}}]}}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping7\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .name(\"mapping7\")\n    .roles(\"ldap-example-user\")\n    .rules(r -> r\n        .all(List.of(RoleMappingRule.of(ro -> ro\n                .field(NamedValue.of(\"dn\",List.of(FieldValue.of(\"*,ou=subtree,dc=example,dc=com\"))\n                ))), RoleMappingRule.of(rol -> rol\n                .field(NamedValue.of(\"realm.name\",List.of(FieldValue.of(\"ldap1\"))\n                )))\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/security/put_role_mapping/examples/request/SecurityPutRoleMappingRequestExample6.yaml": [
@@ -7103,6 +8259,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"role_templates\":[{\"template\":{\"source\":\"{{#tojson}}groups{{/tojson}}\"},\"format\":\"json\"}],\"rules\":{\"field\":{\"realm.name\":\"saml1\"}},\"enabled\":true}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping6\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .name(\"mapping6\")\n    .roleTemplates(r -> r\n        .format(TemplateFormat.Json)\n        .template(t -> t\n            .source(s -> s\n                .scriptString(\"{{#tojson}}groups{{/tojson}}\")\n            )\n        )\n    )\n    .rules(ru -> ru\n        .field(NamedValue.of(\"realm.name\",List.of(FieldValue.of(\"saml1\"))))\n    )\n);\n"
     }
   ],
   "specification/security/put_role_mapping/examples/request/SecurityPutRoleMappingRequestExample1.yaml": [
@@ -7125,6 +8285,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"user\"],\"enabled\":true,\"rules\":{\"field\":{\"username\":\"*\"}},\"metadata\":{\"version\":1}}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .metadata(\"version\", JsonData.fromJson(\"1\"))\n    .name(\"mapping1\")\n    .roles(\"user\")\n    .rules(r -> r\n        .field(NamedValue.of(\"username\",List.of(FieldValue.of(\"*\"))))\n    )\n);\n"
     }
   ],
   "specification/security/put_role_mapping/examples/request/SecurityPutRoleMappingRequestExample3.yaml": [
@@ -7147,6 +8311,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"ldap-user\"],\"enabled\":true,\"rules\":{\"field\":{\"realm.name\":\"ldap1\"}}}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping3\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .name(\"mapping3\")\n    .roles(\"ldap-user\")\n    .rules(r -> r\n        .field(NamedValue.of(\"realm.name\",List.of(FieldValue.of(\"ldap1\"))))\n    )\n);\n"
     }
   ],
   "specification/security/put_role_mapping/examples/request/SecurityPutRoleMappingRequestExample2.yaml": [
@@ -7169,6 +8337,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"user\",\"admin\"],\"enabled\":true,\"rules\":{\"field\":{\"username\":[\"esadmin01\",\"esadmin02\"]}}}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping2\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .name(\"mapping2\")\n    .roles(List.of(\"user\",\"admin\"))\n    .rules(r -> r\n        .field(NamedValue.of(\"username\",List.of(FieldValue.of(\"esadmin01\"),FieldValue.of(\"esadmin02\"))))\n    )\n);\n"
     }
   ],
   "specification/security/put_role_mapping/examples/request/SecurityPutRoleMappingRequestExample9.yaml": [
@@ -7191,6 +8363,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"rules\":{\"field\":{\"realm.name\":\"cloud-saml\"}},\"role_templates\":[{\"template\":{\"source\":\"saml_user\"}},{\"template\":{\"source\":\"_user_{{username}}\"}}],\"enabled\":true}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping9\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .name(\"mapping9\")\n    .roleTemplates(List.of(RoleTemplate.of(r -> r\n            .template(t -> t\n                .source(s -> s\n                    .scriptString(\"saml_user\")\n                )\n            )),RoleTemplate.of(ro -> ro\n            .template(t -> t\n                .source(s -> s\n                    .scriptString(\"_user_{{username}}\")\n                )\n            ))))\n    .rules(ru -> ru\n        .field(NamedValue.of(\"realm.name\",List.of(FieldValue.of(\"cloud-saml\"))))\n    )\n);\n"
     }
   ],
   "specification/security/put_role_mapping/examples/request/SecurityPutRoleMappingRequestExample5.yaml": [
@@ -7213,6 +8389,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"role_templates\":[{\"template\":{\"source\":\"{{#tojson}}groups{{/tojson}}\"},\"format\":\"json\"}],\"rules\":{\"field\":{\"realm.name\":\"saml1\"}},\"enabled\":true}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping5\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .name(\"mapping5\")\n    .roleTemplates(r -> r\n        .format(TemplateFormat.Json)\n        .template(t -> t\n            .source(s -> s\n                .scriptString(\"{{#tojson}}groups{{/tojson}}\")\n            )\n        )\n    )\n    .rules(ru -> ru\n        .field(NamedValue.of(\"realm.name\",List.of(FieldValue.of(\"saml1\"))))\n    )\n);\n"
     }
   ],
   "specification/security/put_role_mapping/examples/request/SecurityPutRoleMappingRequestExample4.yaml": [
@@ -7235,6 +8415,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"superuser\"],\"enabled\":true,\"rules\":{\"any\":[{\"field\":{\"username\":\"esadmin\"}},{\"field\":{\"groups\":\"cn=admins,dc=example,dc=com\"}}]}}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping4\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .name(\"mapping4\")\n    .roles(\"superuser\")\n    .rules(r -> r\n        .any(List.of(RoleMappingRule.of(ro -> ro\n                .field(NamedValue.of(\"username\",List.of(FieldValue.of(\"esadmin\"))\n                ))), RoleMappingRule.of(rol -> rol\n                .field(NamedValue.of(\"groups\",List.of(FieldValue.of(\"cn=admins,dc=example,dc=com\"))\n                )))\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/security/put_role_mapping/examples/request/SecurityPutRoleMappingRequestExample8.yaml": [
@@ -7257,6 +8441,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"superuser\"],\"enabled\":true,\"rules\":{\"all\":[{\"any\":[{\"field\":{\"dn\":\"*,ou=admin,dc=example,dc=com\"}},{\"field\":{\"username\":[\"es-admin\",\"es-system\"]}}]},{\"field\":{\"groups\":\"cn=people,dc=example,dc=com\"}},{\"except\":{\"field\":{\"metadata.terminated_date\":null}}}]}}' \"$ELASTICSEARCH_URL/_security/role_mapping/mapping8\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRoleMapping(p -> p\n    .enabled(true)\n    .name(\"mapping8\")\n    .roles(\"superuser\")\n    .rules(r -> r\n        .all(List.of(RoleMappingRule.of(ro -> ro\n                    .any(List.of(RoleMappingRule.of(rol -> rol\n                            .field(NamedValue.of(\"dn\", List.of(FieldValue.of(\"*,ou=admin,\" +\n                                \"dc=example,dc=com\"))\n                            ))\n                        ), RoleMappingRule.of(role -> role\n                            .field(NamedValue.of(\"username\", List.of(FieldValue.of(\"es-admin\"),\n                                FieldValue.of(\"es-system\"))\n                            )))), RoleMappingRule.of(roleM -> roleM\n                            .field(NamedValue.of(\"groups\", List.of(FieldValue.of(\"cn=people,\" +\n                                \"dc=example,dc=com\"))\n                            )), RoleMappingRule.of(roleMa -> roleMa\n                            .except(e -> e\n                                .field(NamedValue.of(\"metadata.terminated_date\",\n                                    List.of(FieldValue.of(null))\n                                    )\n                                ))))\n                    )\n                )\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/security/saml_prepare_authentication/examples/request/SamlPrepareAuthenticationRequestExample1.yaml": [
@@ -7279,6 +8467,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm\":\"saml1\"}' \"$ELASTICSEARCH_URL/_security/saml/prepare\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().samlPrepareAuthentication(s -> s\n    .realm(\"saml1\")\n);\n"
     }
   ],
   "specification/security/saml_prepare_authentication/examples/request/SamlPrepareAuthenticationRequestExample2.yaml": [
@@ -7301,6 +8493,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"acs\":\"https://kibana.org/api/security/saml/callback\"}' \"$ELASTICSEARCH_URL/_security/saml/prepare\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().samlPrepareAuthentication(s -> s\n    .acs(\"https://kibana.org/api/security/saml/callback\")\n);\n"
     }
   ],
   "specification/security/saml_invalidate/examples/request/SamlInvalidateRequestExample1.yaml": [
@@ -7323,6 +8519,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query_string\":\"SAMLRequest=nZFda4MwFIb%2FiuS%2BmviRpqFaClKQdbvo2g12M2KMraCJ9cRR9utnW4Wyi13sMie873MeznJ1aWrnS3VQGR0j4mLkKC1NUeljjA77zYyhVbIE0dR%2By7fmaHq7U%2BdegXWGpAZ%2B%2F4pR32luBFTAtWgUcCv56%2Fp5y30X87Yz1khTIycdgpUW9kY7WdsC9zxoXTvMvWuVV98YyMnSGH2SYE5pwALBIr9QKiwDGpW0oGVUznGeMyJZKFkQ4jBf5HnhUymjIhzCAL3KNFihbYx8TBYzzGaY7EnIyZwHzCWMfiDnbRIftkSjJr%2BFu0e9v%2B0EgOquRiiZjKpiVFp6j50T4WXoyNJ%2FEWC9fdqc1t%2F1%2B2F3aUpjzhPiXpqMz1%2FHSn4A&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=MsAYz2NFdovMG2mXf6TSpu5vlQQyEJAg%2B4KCwBqJTmrb3yGXKUtIgvjqf88eCAK32v3eN8vupjPC8LglYmke1ZnjK0%2FKxzkvSjTVA7mMQe2AQdKbkyC038zzRq%2FYHcjFDE%2Bz0qISwSHZY2NyLePmwU7SexEXnIz37jKC6NMEhus%3D\",\"realm\":\"saml1\"}' \"$ELASTICSEARCH_URL/_security/saml/invalidate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().samlInvalidate(s -> s\n    .queryString(\"SAMLRequest=nZFda4MwFIb%2FiuS%2BmviRpqFaClKQdbvo2g12M2KMraCJ9cRR9utnW4Wyi13sMie873MeznJ1aWrnS3VQGR0j4mLkKC1NUeljjA77zYyhVbIE0dR%2By7fmaHq7U%2BdegXWGpAZ%2B%2F4pR32luBFTAtWgUcCv56%2Fp5y30X87Yz1khTIycdgpUW9kY7WdsC9zxoXTvMvWuVV98YyMnSGH2SYE5pwALBIr9QKiwDGpW0oGVUznGeMyJZKFkQ4jBf5HnhUymjIhzCAL3KNFihbYx8TBYzzGaY7EnIyZwHzCWMfiDnbRIftkSjJr%2BFu0e9v%2B0EgOquRiiZjKpiVFp6j50T4WXoyNJ%2FEWC9fdqc1t%2F1%2B2F3aUpjzhPiXpqMz1%2FHSn4A&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=MsAYz2NFdovMG2mXf6TSpu5vlQQyEJAg%2B4KCwBqJTmrb3yGXKUtIgvjqf88eCAK32v3eN8vupjPC8LglYmke1ZnjK0%2FKxzkvSjTVA7mMQe2AQdKbkyC038zzRq%2FYHcjFDE%2Bz0qISwSHZY2NyLePmwU7SexEXnIz37jKC6NMEhus%3D\")\n    .realm(\"saml1\")\n);\n"
     }
   ],
   "specification/security/get_token/examples/request/GetUserAccessTokenRequestExample1.yaml": [
@@ -7345,6 +8545,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grant_type\":\"client_credentials\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getToken(g -> g\n    .grantType(AccessTokenGrantType.ClientCredentials)\n);\n"
     }
   ],
   "specification/security/get_token/examples/request/GetUserAccessTokenRequestExample2.yaml": [
@@ -7367,6 +8571,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grant_type\":\"password\",\"username\":\"test_admin\",\"password\":\"x-pack-test-password\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getToken(g -> g\n    .grantType(AccessTokenGrantType.Password)\n    .password(\"x-pack-test-password\")\n    .username(\"test_admin\")\n);\n"
     }
   ],
   "specification/security/bulk_put_role/examples/request/SecurityBulkPutRoleRequestExample1.yaml": [
@@ -7389,6 +8597,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":{\"my_admin_role\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index1\",\"index2\"],\"privileges\":[\"all\"],\"field_security\":{\"grant\":[\"title\",\"body\"]},\"query\":\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\"}],\"applications\":[{\"application\":\"myapp\",\"privileges\":[\"admin\",\"read\"],\"resources\":[\"*\"]}],\"run_as\":[\"other_user\"],\"metadata\":{\"version\":1}},\"my_user_role\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index1\"],\"privileges\":[\"read\"],\"field_security\":{\"grant\":[\"title\",\"body\"]},\"query\":\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\"}],\"applications\":[{\"application\":\"myapp\",\"privileges\":[\"admin\",\"read\"],\"resources\":[\"*\"]}],\"run_as\":[\"other_user\"],\"metadata\":{\"version\":1}}}}' \"$ELASTICSEARCH_URL/_security/role\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().bulkPutRole(b -> b\n    .roles(Map.of(\"my_admin_role\", RoleDescriptor.of(r -> r\n            .cluster(\"all\")\n            .indices(i -> i\n                .fieldSecurity(f -> f\n                    .grant(List.of(\"title\",\"body\"))\n                )\n                .names(List.of(\"index1\",\"index2\"))\n                .privileges(\"all\")\n                .query(q -> q\n                    .match(m -> m\n                        .field(\"title\")\n                        .query(FieldValue.of(\"foo\"))\n                    )\n                )\n            )\n            .applications(a -> a\n                .application(\"myapp\")\n                .privileges(List.of(\"admin\",\"read\"))\n                .resources(\"*\")\n            )\n            .metadata(\"version\", JsonData.fromJson(\"1\"))\n            .runAs(\"other_user\")),\"my_user_role\", RoleDescriptor.of(ro -> ro\n            .cluster(\"all\")\n            .indices(i -> i\n                .fieldSecurity(f -> f\n                    .grant(List.of(\"title\",\"body\"))\n                )\n                .names(\"index1\")\n                .privileges(\"read\")\n                .query(q -> q\n                    .match(m -> m\n                        .field(\"title\")\n                        .query(FieldValue.of(\"foo\"))\n                    )\n                )\n            )\n            .applications(a -> a\n                .application(\"myapp\")\n                .privileges(List.of(\"admin\",\"read\"))\n                .resources(\"*\")\n            )\n            .metadata(\"version\", JsonData.fromJson(\"1\"))\n            .runAs(\"other_user\"))))\n);\n"
     }
   ],
   "specification/security/bulk_put_role/examples/request/SecurityBulkPutRoleRequestExample3.yaml": [
@@ -7411,6 +8623,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"remote_indices\":[{\"clusters\":[\"my_remote\"],\"names\":[\"logs*\"],\"privileges\":[\"read\",\"read_cross_cluster\",\"view_index_metadata\"]}],\"remote_cluster\":[{\"clusters\":[\"my_remote\"],\"privileges\":[\"monitor_stats\"]}]}' \"$ELASTICSEARCH_URL/_security/role/only_remote_access_role\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRole(p -> p\n    .name(\"only_remote_access_role\")\n    .remoteCluster(r -> r\n        .clusters(\"my_remote\")\n        .privileges(RemoteClusterPrivilege.MonitorStats)\n    )\n    .remoteIndices(r -> r\n        .clusters(\"my_remote\")\n        .names(\"logs*\")\n        .privileges(List.of(\"read\",\"read_cross_cluster\",\"view_index_metadata\"))\n    )\n);\n"
     }
   ],
   "specification/security/bulk_put_role/examples/request/SecurityBulkPutRoleRequestExample2.yaml": [
@@ -7433,6 +8649,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":{\"my_admin_role\":{\"cluster\":[\"bad_cluster_privilege\"],\"indices\":[{\"names\":[\"index1\",\"index2\"],\"privileges\":[\"all\"],\"field_security\":{\"grant\":[\"title\",\"body\"]},\"query\":\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\"}],\"applications\":[{\"application\":\"myapp\",\"privileges\":[\"admin\",\"read\"],\"resources\":[\"*\"]}],\"run_as\":[\"other_user\"],\"metadata\":{\"version\":1}},\"my_user_role\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index1\"],\"privileges\":[\"read\"],\"field_security\":{\"grant\":[\"title\",\"body\"]},\"query\":\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\"}],\"applications\":[{\"application\":\"myapp\",\"privileges\":[\"admin\",\"read\"],\"resources\":[\"*\"]}],\"run_as\":[\"other_user\"],\"metadata\":{\"version\":1}}}}' \"$ELASTICSEARCH_URL/_security/role\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().bulkPutRole(b -> b\n    .roles(Map.of(\"my_admin_role\", RoleDescriptor.of(r -> r\n            .cluster(\"bad_cluster_privilege\")\n            .indices(i -> i\n                .fieldSecurity(f -> f\n                    .grant(List.of(\"title\",\"body\"))\n                )\n                .names(List.of(\"index1\",\"index2\"))\n                .privileges(\"all\")\n                .query(q -> q\n                    .match(m -> m\n                        .field(\"title\")\n                        .query(FieldValue.of(\"foo\"))\n                    )\n                )\n            )\n            .applications(a -> a\n                .application(\"myapp\")\n                .privileges(List.of(\"admin\",\"read\"))\n                .resources(\"*\")\n            )\n            .metadata(\"version\", JsonData.fromJson(\"1\"))\n            .runAs(\"other_user\")),\"my_user_role\", RoleDescriptor.of(ro -> ro\n            .cluster(\"all\")\n            .indices(i -> i\n                .fieldSecurity(f -> f\n                    .grant(List.of(\"title\",\"body\"))\n                )\n                .names(\"index1\")\n                .privileges(\"read\")\n                .query(q -> q\n                    .match(m -> m\n                        .field(\"title\")\n                        .query(FieldValue.of(\"foo\"))\n                    )\n                )\n            )\n            .applications(a -> a\n                .application(\"myapp\")\n                .privileges(List.of(\"admin\",\"read\"))\n                .resources(\"*\")\n            )\n            .metadata(\"version\", JsonData.fromJson(\"1\"))\n            .runAs(\"other_user\"))))\n);\n"
     }
   ],
   "specification/security/get_role/examples/request/SecurityGetRoleRequestExample1.yaml": [
@@ -7455,6 +8675,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/role/my_admin_role\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getRole(g -> g\n    .name(\"my_admin_role\")\n);\n"
     }
   ],
   "specification/security/delete_role/examples/request/SecurityDeleteRoleRequestExample1.yaml": [
@@ -7477,6 +8701,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/role/my_admin_role\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().deleteRole(d -> d\n    .name(\"my_admin_role\")\n);\n"
     }
   ],
   "specification/security/invalidate_token/examples/request/SecurityInvalidateTokenRequestExample5.yaml": [
@@ -7499,6 +8727,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"username\":\"myuser\",\"realm_name\":\"saml1\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().invalidateToken(i -> i\n    .realmName(\"saml1\")\n    .username(\"myuser\")\n);\n"
     }
   ],
   "specification/security/invalidate_token/examples/request/SecurityInvalidateTokenRequestExample4.yaml": [
@@ -7521,6 +8753,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"username\":\"myuser\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().invalidateToken(i -> i\n    .username(\"myuser\")\n);\n"
     }
   ],
   "specification/security/invalidate_token/examples/request/SecurityInvalidateTokenRequestExample3.yaml": [
@@ -7543,6 +8779,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"realm_name\":\"saml1\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().invalidateToken(i -> i\n    .realmName(\"saml1\")\n);\n"
     }
   ],
   "specification/security/invalidate_token/examples/request/SecurityInvalidateTokenRequestExample2.yaml": [
@@ -7565,6 +8805,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"refresh_token\":\"vLBPvmAB6KvwvJZr27cS\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().invalidateToken(i -> i\n    .refreshToken(\"vLBPvmAB6KvwvJZr27cS\")\n);\n"
     }
   ],
   "specification/security/invalidate_token/examples/request/SecurityInvalidateTokenRequestExample1.yaml": [
@@ -7587,6 +8831,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"token\":\"dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==\"}' \"$ELASTICSEARCH_URL/_security/oauth2/token\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().invalidateToken(i -> i\n    .token(\"dGhpcyBpcyBub3QgYSByZWFsIHRva2VuIGJ1dCBpdCBpcyBvbmx5IHRlc3QgZGF0YS4gZG8gbm90IHRyeSB0byByZWFkIHRva2VuIQ==\")\n);\n"
     }
   ],
   "specification/security/query_user/examples/request/SecurityQueryUserRequestExample2.yaml": [
@@ -7609,6 +8857,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"bool\":{\"must\":[{\"wildcard\":{\"email\":\"*example.com\"}},{\"term\":{\"enabled\":true}}],\"filter\":[{\"wildcard\":{\"roles\":\"*other*\"}}]}},\"from\":1,\"size\":2,\"sort\":[{\"username\":{\"order\":\"desc\"}}]}' \"$ELASTICSEARCH_URL/_security/_query/user\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().queryUser(q -> q\n    .from(1)\n    .query(qu -> qu\n        .bool(b -> b\n            .filter(f -> f\n                .wildcard(w -> w\n                    .field(\"roles\")\n                    .value(\"*other*\")\n                )\n            )\n            .must(List.of(Query.of(que -> que\n                    .wildcard(w -> w\n                        .field(\"email\")\n                        .value(\"*example.com\")\n                )),Query.of(quer -> quer\n                    .term(t -> t\n                        .field(\"enabled\")\n                        .value(FieldValue.of(true))\n                ))))\n        )\n    )\n    .size(2)\n    .sort(s -> s\n        .field(fi -> fi\n            .field(\"username\")\n            .order(SortOrder.Desc)\n        )\n    )\n);\n"
     }
   ],
   "specification/security/query_user/examples/request/SecurityQueryUserRequestExample1.yaml": [
@@ -7631,6 +8883,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"prefix\":{\"roles\":\"other\"}}}' \"$ELASTICSEARCH_URL/_security/_query/user?with_profile_uid=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().queryUser(q -> q\n    .query(qu -> qu\n        .prefix(p -> p\n            .field(\"roles\")\n            .value(\"other\")\n        )\n    )\n    .withProfileUid(true)\n);\n"
     }
   ],
   "specification/security/saml_service_provider_metadata/examples/request/SamlServiceProviderMetadataRequestExample1.yaml": [
@@ -7653,6 +8909,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/profile/u_P_0BMHgaOK3p7k-PFWUCbw9dQ-UFjt01oWJ_Dp2PmPc_0/_data\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().updateUserProfileData(u -> u\n    .uid(\"u_P_0BMHgaOK3p7k-PFWUCbw9dQ-UFjt01oWJ_Dp2PmPc_0\")\n);\n"
     }
   ],
   "specification/security/update_api_key/examples/request/UpdateApiKeyRequestExample1.yaml": [
@@ -7675,6 +8935,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"role_descriptors\":{\"role-a\":{\"indices\":[{\"names\":[\"*\"],\"privileges\":[\"write\"]}]}},\"metadata\":{\"environment\":{\"level\":2,\"trusted\":true,\"tags\":[\"production\"]}}}' \"$ELASTICSEARCH_URL/_security/api_key/VuaCfGcBCdbkQm-e5aOx\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().updateApiKey(u -> u\n    .id(\"VuaCfGcBCdbkQm-e5aOx\")\n    .metadata(\"environment\", JsonData.fromJson(\"{\\\"level\\\":2,\\\"trusted\\\":true,\\\"tags\\\":[\\\"production\\\"]}\"))\n    .roleDescriptors(\"role-a\", r -> r\n        .indices(i -> i\n            .names(\"*\")\n            .privileges(\"write\")\n        )\n    )\n);\n"
     }
   ],
   "specification/security/update_api_key/examples/request/UpdateApiKeyRequestExample2.yaml": [
@@ -7697,6 +8961,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"role_descriptors\":{}}' \"$ELASTICSEARCH_URL/_security/api_key/VuaCfGcBCdbkQm-e5aOx\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().updateApiKey(u -> u\n    .id(\"VuaCfGcBCdbkQm-e5aOx\")\n);\n"
     }
   ],
   "specification/security/delete_service_token/examples/request/DeleteServiceTokenRequestExample1.yaml": [
@@ -7719,6 +8987,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/service/elastic/fleet-server/credential/token/token42\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().deleteServiceToken(d -> d\n    .name(\"token42\")\n    .namespace(\"elastic\")\n    .service(\"fleet-server\")\n);\n"
     }
   ],
   "specification/security/saml_logout/examples/request/SamlLogoutRequestExample1.yaml": [
@@ -7741,6 +9013,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"token\":\"46ToAxZVaXVVZTVKOVF5YU04ZFJVUDVSZlV3\",\"refresh_token\":\"mJdXLtmvTUSpoLwMvdBt_w\"}' \"$ELASTICSEARCH_URL/_security/saml/logout\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().samlLogout(s -> s\n    .refreshToken(\"mJdXLtmvTUSpoLwMvdBt_w\")\n    .token(\"46ToAxZVaXVVZTVKOVF5YU04ZFJVUDVSZlV3\")\n);\n"
     }
   ],
   "specification/security/oidc_authenticate/examples/request/OidcAuthenticateRequestExample1.yaml": [
@@ -7763,6 +9039,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"redirect_uri\":\"https://oidc-kibana.elastic.co:5603/api/security/oidc/callback?code=jtI3Ntt8v3_XvcLzCFGq&state=4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I\",\"state\":\"4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I\",\"nonce\":\"WaBPH0KqPVdG5HHdSxPRjfoZbXMCicm5v1OiAj0DUFM\",\"realm\":\"oidc1\"}' \"$ELASTICSEARCH_URL/_security/oidc/authenticate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().oidcAuthenticate(o -> o\n    .nonce(\"WaBPH0KqPVdG5HHdSxPRjfoZbXMCicm5v1OiAj0DUFM\")\n    .realm(\"oidc1\")\n    .redirectUri(\"https://oidc-kibana.elastic.co:5603/api/security/oidc/callback?code=jtI3Ntt8v3_XvcLzCFGq&state=4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I\")\n    .state(\"4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I\")\n);\n"
     }
   ],
   "specification/security/grant_api_key/examples/request/SecurityGrantApiKeyRequestExample2.yaml": [
@@ -7785,6 +9065,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grant_type\":\"password\",\"username\":\"test_admin\",\"password\":\"x-pack-test-password\",\"run_as\":\"test_user\",\"api_key\":{\"name\":\"another-api-key\"}}' \"$ELASTICSEARCH_URL/_security/api_key/grant\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().grantApiKey(g -> g\n    .apiKey(a -> a\n        .name(\"another-api-key\")\n    )\n    .grantType(ApiKeyGrantType.Password)\n    .password(\"x-pack-test-password\")\n    .runAs(\"test_user\")\n    .username(\"test_admin\")\n);\n"
     }
   ],
   "specification/security/grant_api_key/examples/request/SecurityGrantApiKeyRequestExample1.yaml": [
@@ -7807,6 +9091,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grant_type\":\"password\",\"username\":\"test_admin\",\"password\":\"x-pack-test-password\",\"api_key\":{\"name\":\"my-api-key\",\"expiration\":\"1d\",\"role_descriptors\":{\"role-a\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index-a*\"],\"privileges\":[\"read\"]}]},\"role-b\":{\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index-b*\"],\"privileges\":[\"all\"]}]}},\"metadata\":{\"application\":\"my-application\",\"environment\":{\"level\":1,\"trusted\":true,\"tags\":[\"dev\",\"staging\"]}}}}' \"$ELASTICSEARCH_URL/_security/api_key/grant\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().grantApiKey(g -> g\n    .apiKey(a -> a\n        .name(\"my-api-key\")\n        .expiration(e -> e\n            .time(\"1d\")\n        )\n        .roleDescriptors(Map.of(\"role-b\", RoleDescriptor.of(r -> r\n                .cluster(\"all\")\n                .indices(i -> i\n                    .names(\"index-b*\")\n                    .privileges(\"all\")\n                )),\"role-a\", RoleDescriptor.of(r -> r\n                .cluster(\"all\")\n                .indices(i -> i\n                    .names(\"index-a*\")\n                    .privileges(\"read\")\n                ))))\n        .metadata(Map.of(\"environment\", JsonData.fromJson(\"{\\\"level\\\":1,\\\"trusted\\\":true,\\\"tags\\\":[\\\"dev\\\",\\\"staging\\\"]}\"),\"application\", JsonData.fromJson(\"\\\"my-application\\\"\")))\n    )\n    .grantType(ApiKeyGrantType.Password)\n    .password(\"x-pack-test-password\")\n    .username(\"test_admin\")\n);\n"
     }
   ],
   "specification/security/get_service_accounts/examples/request/GetServiceAccountsRequestExample1.yaml": [
@@ -7829,6 +9117,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/service/elastic/fleet-server\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().getServiceAccounts(g -> g\n    .namespace(\"elastic\")\n    .service(\"fleet-server\")\n);\n"
     }
   ],
   "specification/security/delete_role_mapping/examples/request/SecurityDeleteRoleMappingRequestExample1.yaml": [
@@ -7851,6 +9143,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/role_mapping/mapping1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().deleteRoleMapping(d -> d\n    .name(\"mapping1\")\n);\n"
     }
   ],
   "specification/security/put_role/examples/request/SecurityPutRoleRequestExample3.yaml": [
@@ -7873,6 +9169,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"remote_indices\":[{\"clusters\":[\"my_remote\"],\"names\":[\"logs*\"],\"privileges\":[\"read\",\"read_cross_cluster\",\"view_index_metadata\"]}],\"remote_cluster\":[{\"clusters\":[\"my_remote\"],\"privileges\":[\"monitor_stats\"]}]}' \"$ELASTICSEARCH_URL/_security/role/only_remote_access_role\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRole(p -> p\n    .name(\"only_remote_access_role\")\n    .remoteCluster(r -> r\n        .clusters(\"my_remote\")\n        .privileges(RemoteClusterPrivilege.MonitorStats)\n    )\n    .remoteIndices(r -> r\n        .clusters(\"my_remote\")\n        .names(\"logs*\")\n        .privileges(List.of(\"read\",\"read_cross_cluster\",\"view_index_metadata\"))\n    )\n);\n"
     }
   ],
   "specification/security/put_role/examples/request/SecurityPutRoleRequestExample2.yaml": [
@@ -7895,6 +9195,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"cluster\":[\"cluster:monitor/main\"],\"indices\":[{\"names\":[\"test\"],\"privileges\":[\"read\",\"indices:admin/get\"]}]}' \"$ELASTICSEARCH_URL/_security/role/cli_or_drivers_minimal\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRole(p -> p\n    .cluster(\"cluster:monitor/main\")\n    .indices(i -> i\n        .names(\"test\")\n        .privileges(List.of(\"read\",\"indices:admin/get\"))\n    )\n    .name(\"cli_or_drivers_minimal\")\n);\n"
     }
   ],
   "specification/security/put_role/examples/request/SecurityPutRoleRequestExample1.yaml": [
@@ -7917,6 +9221,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"Grants full access to all management features within the cluster.\",\"cluster\":[\"all\"],\"indices\":[{\"names\":[\"index1\",\"index2\"],\"privileges\":[\"all\"],\"field_security\":{\"grant\":[\"title\",\"body\"]},\"query\":\"{\\\"match\\\": {\\\"title\\\": \\\"foo\\\"}}\"}],\"applications\":[{\"application\":\"myapp\",\"privileges\":[\"admin\",\"read\"],\"resources\":[\"*\"]}],\"run_as\":[\"other_user\"],\"metadata\":{\"version\":1}}' \"$ELASTICSEARCH_URL/_security/role/my_admin_role\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putRole(p -> p\n    .applications(a -> a\n        .application(\"myapp\")\n        .privileges(List.of(\"admin\",\"read\"))\n        .resources(\"*\")\n    )\n    .cluster(\"all\")\n    .description(\"Grants full access to all management features within the cluster.\")\n    .indices(i -> i\n        .fieldSecurity(f -> f\n            .grant(List.of(\"title\",\"body\"))\n        )\n        .names(List.of(\"index1\",\"index2\"))\n        .privileges(\"all\")\n        .query(q -> q\n            .match(m -> m\n                .field(\"title\")\n                .query(FieldValue.of(\"foo\"))\n            )\n        )\n    )\n    .metadata(\"version\", JsonData.fromJson(\"1\"))\n    .name(\"my_admin_role\")\n    .runAs(\"other_user\")\n);\n"
     }
   ],
   "specification/security/bulk_delete_role/examples/request/SecurityBulkDeleteRoleRequestExample1.yaml": [
@@ -7939,6 +9247,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"names\":[\"my_admin_role\",\"my_user_role\"]}' \"$ELASTICSEARCH_URL/_security/role\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().bulkDeleteRole(b -> b\n    .names(List.of(\"my_admin_role\",\"my_user_role\"))\n);\n"
     }
   ],
   "specification/security/put_privileges/examples/request/SecurityPutPrivilegesRequestExample1.yaml": [
@@ -7961,6 +9273,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"myapp\":{\"read\":{\"actions\":[\"data:read/*\",\"action:login\"],\"metadata\":{\"description\":\"Read access to myapp\"}}}}' \"$ELASTICSEARCH_URL/_security/privilege\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putPrivileges(p -> p\n    .privileges(\"myapp\", \"read\", pr -> pr\n        .actions(List.of(\"data:read/*\",\"action:login\"))\n        .metadata(\"description\", JsonData.fromJson(\"\\\"Read access to myapp\\\"\"))\n    )\n);\n"
     }
   ],
   "specification/security/put_privileges/examples/request/SecurityPutPrivilegesRequestExample2.yaml": [
@@ -7983,6 +9299,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"app01\":{\"read\":{\"actions\":[\"action:login\",\"data:read/*\"]},\"write\":{\"actions\":[\"action:login\",\"data:write/*\"]}},\"app02\":{\"all\":{\"actions\":[\"*\"]}}}' \"$ELASTICSEARCH_URL/_security/privilege\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().putPrivileges(p -> p\n    .privileges(Map.of(\"app02\", \"all\", pr -> pr\n        .actions(\"*\"),\"app01\", Map.of(\"read\", Actions.of(a -> a\n            .actions(List.of(\"action:login\",\"data:read/*\"))),\"write\", Actions.of(a -> a\n            .actions(List.of(\"action:login\",\"data:write/*\"))))))\n);\n"
     }
   ],
   "specification/security/enroll_kibana/examples/request/EnrollKibanaRequestExample1.yaml": [
@@ -8005,6 +9325,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_security/enroll/kibana\""
+    },
+    {
+      "language": "Java",
+      "code": "client.security().enrollKibana();\n"
     }
   ],
   "specification/nodes/usage/examples/request/NodesUsageExample1.yaml": [
@@ -8027,6 +9351,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_nodes/usage\""
+    },
+    {
+      "language": "Java",
+      "code": "client.nodes().usage(u -> u);\n"
     }
   ],
   "specification/nodes/info/examples/request/NodesInfoExample1.yaml": [
@@ -8049,6 +9377,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_nodes/_all/jvm\""
+    },
+    {
+      "language": "Java",
+      "code": "client.nodes().info(i -> i\n    .metric(\"jvm\")\n    .nodeId(\"_all\")\n);\n"
     }
   ],
   "specification/nodes/hot_threads/examples/request/NodesHotThreadsExample1.yaml": [
@@ -8071,6 +9403,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_nodes/hot_threads\""
+    },
+    {
+      "language": "Java",
+      "code": "client.nodes().hotThreads(h -> h);\n"
     }
   ],
   "specification/nodes/reload_secure_settings/examples/request/ReloadSecureSettingsRequestExample1.yaml": [
@@ -8093,6 +9429,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"secure_settings_password\":\"keystore-password\"}' \"$ELASTICSEARCH_URL/_nodes/reload_secure_settings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.nodes().reloadSecureSettings(r -> r\n    .secureSettingsPassword(\"keystore-password\")\n);\n"
     }
   ],
   "specification/nodes/stats/examples/request/NodesStatsExample1.yaml": [
@@ -8115,6 +9455,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_nodes/stats/process?filter_path=**.max_file_descriptors\""
+    },
+    {
+      "language": "Java",
+      "code": "\n"
     }
   ],
   "specification/ingest/get_pipeline/examples/request/IngestGetPipelineExample1.yaml": [
@@ -8137,6 +9481,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ingest/pipeline/my-pipeline-id\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ingest().getPipeline(g -> g\n    .id(\"my-pipeline-id\")\n);\n"
     }
   ],
   "specification/ingest/put_pipeline/examples/request/PutPipelineRequestExample1.yaml": [
@@ -8159,6 +9507,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"My optional pipeline description\",\"processors\":[{\"set\":{\"description\":\"My optional processor description\",\"field\":\"my-keyword-field\",\"value\":\"foo\"}}]}' \"$ELASTICSEARCH_URL/_ingest/pipeline/my-pipeline-id\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ingest().putPipeline(p -> p\n    .description(\"My optional pipeline description\")\n    .id(\"my-pipeline-id\")\n    .processors(pr -> pr\n        .set(s -> s\n            .field(\"my-keyword-field\")\n            .value(JsonData.fromJson(\"\\\"foo\\\"\"))\n            .description(\"My optional processor description\")\n        )\n    )\n);\n"
     }
   ],
   "specification/ingest/put_pipeline/examples/request/PutPipelineRequestExample2.yaml": [
@@ -8181,6 +9533,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"My optional pipeline description\",\"processors\":[{\"set\":{\"description\":\"My optional processor description\",\"field\":\"my-keyword-field\",\"value\":\"foo\"}}],\"_meta\":{\"reason\":\"set my-keyword-field to foo\",\"serialization\":{\"class\":\"MyPipeline\",\"id\":10}}}' \"$ELASTICSEARCH_URL/_ingest/pipeline/my-pipeline-id\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ingest().putPipeline(p -> p\n    .meta(Map.of(\"serialization\", JsonData.fromJson(\"{\\\"class\\\":\\\"MyPipeline\\\",\\\"id\\\":10}\"),\"reason\", JsonData.fromJson(\"\\\"set my-keyword-field to foo\\\"\")))\n    .description(\"My optional pipeline description\")\n    .id(\"my-pipeline-id\")\n    .processors(pr -> pr\n        .set(s -> s\n            .field(\"my-keyword-field\")\n            .value(JsonData.fromJson(\"\\\"foo\\\"\"))\n            .description(\"My optional processor description\")\n        )\n    )\n);\n"
     }
   ],
   "specification/ingest/simulate/examples/request/SimulatePipelineRequestExample1.yaml": [
@@ -8203,6 +9559,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"pipeline\":{\"description\":\"_description\",\"processors\":[{\"set\":{\"field\":\"field2\",\"value\":\"_value\"}}]},\"docs\":[{\"_index\":\"index\",\"_id\":\"id\",\"_source\":{\"foo\":\"bar\"}},{\"_index\":\"index\",\"_id\":\"id\",\"_source\":{\"foo\":\"rab\"}}]}' \"$ELASTICSEARCH_URL/_ingest/pipeline/_simulate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ingest().simulate(s -> s\n    .docs(List.of(Document.of(d -> d\n            .id(\"id\")\n            .index(\"index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"bar\\\"}\"))),Document.of(d -> d\n            .id(\"id\")\n            .index(\"index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"rab\\\"}\")))))\n    .pipeline(p -> p\n        .description(\"_description\")\n        .processors(pr -> pr\n            .set(se -> se\n                .field(\"field2\")\n                .value(JsonData.fromJson(\"\\\"_value\\\"\"))\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/ingest/delete_pipeline/examples/request/IngestDeletePipelineExample1.yaml": [
@@ -8225,6 +9585,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ingest/pipeline/my-pipeline-id\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ingest().deletePipeline(d -> d\n    .id(\"my-pipeline-id\")\n);\n"
     }
   ],
   "specification/ingest/geo_ip_stats/examples/request/IngestGeoIpStatsExample1.yaml": [
@@ -8247,6 +9611,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ingest/geoip/stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ingest().geoIpStats();\n"
     }
   ],
   "specification/ingest/put_ip_location_database/examples/request/IngestPutIpLocationDatabaseExample1.yaml": [
@@ -8269,6 +9637,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"name\":\"GeoIP2-Domain\",\"maxmind\":{\"account_id\":\"1234567\"}}' \"$ELASTICSEARCH_URL/_ingest/ip_location/database/my-database-1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ingest().putIpLocationDatabase(p -> p\n    .id(\"my-database-1\")\n    .configuration(c -> c\n        .maxmind(m -> m\n            .accountId(\"1234567\")\n        )\n        .name(\"GeoIP2-Domain\")\n    )\n);\n"
     }
   ],
   "specification/ingest/delete_ip_location_database/examples/request/IngestDeleteIpLocationDatabaseExample1.yaml": [
@@ -8291,6 +9663,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ingest/ip_location/database/my-database-id\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ingest().deleteIpLocationDatabase(d -> d\n    .id(\"my-database-id\")\n);\n"
     }
   ],
   "specification/ingest/get_ip_location_database/examples/request/IngestGetIpLocationDatabaseExample1.yaml": [
@@ -8313,6 +9689,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ingest/ip_location/database/my-database-id\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ingest().getIpLocationDatabase(g -> g\n    .id(\"my-database-id\")\n);\n"
     }
   ],
   "specification/ingest/processor_grok/examples/request/IngestProcessorGrokExample1.yaml": [
@@ -8335,6 +9715,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ingest/processor/grok\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ingest().processorGrok();\n"
     }
   ],
   "specification/simulate/ingest/examples/request/SimulateIngestRequestExample2.yaml": [
@@ -8357,6 +9741,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_index\":\"my-index\",\"_id\":\"123\",\"_source\":{\"foo\":\"bar\"}},{\"_index\":\"my-index\",\"_id\":\"456\",\"_source\":{\"foo\":\"rab\"}}],\"pipeline_substitutions\":{\"my-pipeline\":{\"processors\":[{\"uppercase\":{\"field\":\"foo\"}}]}}}' \"$ELASTICSEARCH_URL/_ingest/_simulate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.simulate().ingest(i -> i\n    .docs(List.of(Document.of(d -> d\n            .id(\"123\")\n            .index(\"my-index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"bar\\\"}\"))),Document.of(d -> d\n            .id(\"456\")\n            .index(\"my-index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"rab\\\"}\")))))\n    .pipelineSubstitutions(\"my-pipeline\", p -> p\n        .processors(pr -> pr\n            .uppercase(u -> u\n                .field(\"foo\")\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/simulate/ingest/examples/request/SimulateIngestRequestExample3.yaml": [
@@ -8379,6 +9767,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_index\":\"my-index\",\"_id\":\"123\",\"_source\":{\"foo\":\"foo\"}},{\"_index\":\"my-index\",\"_id\":\"456\",\"_source\":{\"bar\":\"rab\"}}],\"component_template_substitutions\":{\"my-mappings_template\":{\"template\":{\"mappings\":{\"dynamic\":\"strict\",\"properties\":{\"foo\":{\"type\":\"keyword\"},\"bar\":{\"type\":\"keyword\"}}}}}}}' \"$ELASTICSEARCH_URL/_ingest/_simulate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.simulate().ingest(i -> i\n    .componentTemplateSubstitutions(\"my-mappings_template\", c -> c\n        .template(t -> t\n            .mappings(m -> m\n                .dynamic(DynamicMapping.Strict)\n                .properties(Map.of(\"bar\", Property.of(p -> p\n                        .keyword(k -> k\n                    )),\"foo\", Property.of(pr -> pr\n                        .keyword(k -> k\n                    ))))\n            )\n        )\n    )\n    .docs(List.of(Document.of(d -> d\n            .id(\"123\")\n            .index(\"my-index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"foo\\\"}\"))),Document.of(d -> d\n            .id(\"456\")\n            .index(\"my-index\")\n            .source(JsonData.fromJson(\"{\\\"bar\\\":\\\"rab\\\"}\")))))\n);\n"
     }
   ],
   "specification/simulate/ingest/examples/request/SimulateIngestRequestExample4.yaml": [
@@ -8401,6 +9793,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_id\":\"id\",\"_index\":\"my-index\",\"_source\":{\"foo\":\"bar\"}},{\"_id\":\"id\",\"_index\":\"my-index\",\"_source\":{\"foo\":\"rab\"}}],\"pipeline_substitutions\":{\"my-pipeline\":{\"processors\":[{\"set\":{\"field\":\"field3\",\"value\":\"value3\"}}]}},\"component_template_substitutions\":{\"my-component-template\":{\"template\":{\"mappings\":{\"dynamic\":true,\"properties\":{\"field3\":{\"type\":\"keyword\"}}},\"settings\":{\"index\":{\"default_pipeline\":\"my-pipeline\"}}}}},\"index_template_substitutions\":{\"my-index-template\":{\"index_patterns\":[\"my-index-*\"],\"composed_of\":[\"component_template_1\",\"component_template_2\"]}},\"mapping_addition\":{\"dynamic\":\"strict\",\"properties\":{\"foo\":{\"type\":\"keyword\"}}}}' \"$ELASTICSEARCH_URL/_ingest/_simulate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.simulate().ingest(i -> i\n    .componentTemplateSubstitutions(\"my-component-template\", c -> c\n        .template(t -> t\n            .settings(\"index\", s -> s\n                .defaultPipeline(\"my-pipeline\")\n            )\n            .mappings(m -> m\n                .dynamic(DynamicMapping.True)\n                .properties(\"field3\", p -> p\n                    .keyword(k -> k)\n                )\n            )\n        )\n    )\n    .docs(List.of(Document.of(d -> d\n            .id(\"id\")\n            .index(\"my-index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"bar\\\"}\"))),Document.of(d -> d\n            .id(\"id\")\n            .index(\"my-index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"rab\\\"}\")))))\n    .indexTemplateSubstitutions(\"my-index-template\", in -> in\n        .indexPatterns(\"my-index-*\")\n        .composedOf(List.of(\"component_template_1\",\"component_template_2\"))\n    )\n    .mappingAddition(m -> m\n        .dynamic(DynamicMapping.Strict)\n        .properties(\"foo\", p -> p\n            .keyword(k -> k)\n        )\n    )\n    .pipelineSubstitutions(\"my-pipeline\", p -> p\n        .processors(pr -> pr\n            .set(s -> s\n                .field(\"field3\")\n                .value(JsonData.fromJson(\"\\\"value3\\\"\"))\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/simulate/ingest/examples/request/SimulateIngestRequestExample1.yaml": [
@@ -8423,6 +9819,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"_id\":\"123\",\"_index\":\"my-index\",\"_source\":{\"foo\":\"bar\"}},{\"_id\":\"456\",\"_index\":\"my-index\",\"_source\":{\"foo\":\"rab\"}}]}' \"$ELASTICSEARCH_URL/_ingest/_simulate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.simulate().ingest(i -> i\n    .docs(List.of(Document.of(d -> d\n            .id(\"123\")\n            .index(\"my-index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"bar\\\"}\"))),Document.of(d -> d\n            .id(\"456\")\n            .index(\"my-index\")\n            .source(JsonData.fromJson(\"{\\\"foo\\\":\\\"rab\\\"}\")))))\n);\n"
     }
   ],
   "specification/slm/get_stats/examples/request/GetSnapshotLifecycleManagementStatsRequestExample1.yaml": [
@@ -8445,6 +9845,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.slm().getStats(g -> g);\n"
     }
   ],
   "specification/slm/get_status/examples/request/GetSnapshotLifecycleManagementStatusRequestExample1.yaml": [
@@ -8467,6 +9871,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/status\""
+    },
+    {
+      "language": "Java",
+      "code": "client.slm().getStatus(g -> g);\n"
     }
   ],
   "specification/slm/delete_lifecycle/examples/request/SlmDeleteLifecycleExample1.yaml": [
@@ -8489,6 +9897,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/policy/daily-snapshots\""
+    },
+    {
+      "language": "Java",
+      "code": "client.slm().deleteLifecycle(d -> d\n    .policyId(\"daily-snapshots\")\n);\n"
     }
   ],
   "specification/slm/start/examples/request/StartSnapshotLifecycleManagementRequestExample1.yaml": [
@@ -8511,6 +9923,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/start\""
+    },
+    {
+      "language": "Java",
+      "code": "client.slm().start(s -> s);\n"
     }
   ],
   "specification/slm/get_lifecycle/examples/request/GetSnapshotLifecycleRequestExample1.yaml": [
@@ -8533,6 +9949,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/policy/daily-snapshots?human\""
+    },
+    {
+      "language": "Java",
+      "code": "\n"
     }
   ],
   "specification/slm/put_lifecycle/examples/request/PutSnapshotLifecycleRequestExample1 copy.yaml": [
@@ -8555,6 +9975,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"schedule\":\"0 30 1 * * ?\",\"name\":\"<daily-snap-{now/d}>\",\"repository\":\"my_repository\",\"config\":{\"indices\":[\"data-*\",\"important\"],\"ignore_unavailable\":false,\"include_global_state\":false},\"retention\":{\"expire_after\":\"30d\",\"min_count\":5,\"max_count\":50}}' \"$ELASTICSEARCH_URL/_slm/policy/daily-snapshots\""
+    },
+    {
+      "language": "Java",
+      "code": "client.slm().putLifecycle(p -> p\n    .config(c -> c\n        .ignoreUnavailable(false)\n        .indices(List.of(\"data-*\",\"important\"))\n        .includeGlobalState(false)\n    )\n    .name(\"<daily-snap-{now/d}>\")\n    .policyId(\"daily-snapshots\")\n    .repository(\"my_repository\")\n    .retention(r -> r\n        .expireAfter(e -> e\n            .time(\"30d\")\n        )\n        .maxCount(50)\n        .minCount(5)\n    )\n    .schedule(\"0 30 1 * * ?\")\n);\n"
     }
   ],
   "specification/slm/put_lifecycle/examples/request/PutSnapshotLifecycleRequestExample2.yaml": [
@@ -8577,6 +10001,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"schedule\":\"1h\",\"name\":\"<hourly-snap-{now/d}>\",\"repository\":\"my_repository\",\"config\":{\"indices\":[\"data-*\",\"important\"]}}' \"$ELASTICSEARCH_URL/_slm/policy/hourly-snapshots\""
+    },
+    {
+      "language": "Java",
+      "code": "client.slm().putLifecycle(p -> p\n    .config(c -> c\n        .indices(List.of(\"data-*\",\"important\"))\n    )\n    .name(\"<hourly-snap-{now/d}>\")\n    .policyId(\"hourly-snapshots\")\n    .repository(\"my_repository\")\n    .schedule(\"1h\")\n);\n"
     }
   ],
   "specification/slm/execute_retention/examples/request/SlmExecuteRetentionExample1.yaml": [
@@ -8599,6 +10027,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/_execute_retention\""
+    },
+    {
+      "language": "Java",
+      "code": "client.slm().executeRetention(e -> e);\n"
     }
   ],
   "specification/slm/execute_lifecycle/examples/request/ExecuteSnapshotLifecycleRequestExample1.yaml": [
@@ -8621,6 +10053,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_slm/policy/daily-snapshots/_execute\""
+    },
+    {
+      "language": "Java",
+      "code": "client.slm().executeLifecycle(e -> e\n    .policyId(\"daily-snapshots\")\n);\n"
     }
   ],
   "specification/features/reset_features/examples/request/FeaturesResetFeaturesExample1.yaml": [
@@ -8643,6 +10079,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_features/_reset\""
+    },
+    {
+      "language": "Java",
+      "code": "client.features().resetFeatures(r -> r);\n"
     }
   ],
   "specification/features/get_features/examples/request/FeaturesGetFeaturesExample1.yaml": [
@@ -8665,6 +10105,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_features\""
+    },
+    {
+      "language": "Java",
+      "code": "client.features().getFeatures(g -> g);\n"
     }
   ],
   "specification/graph/explore/examples/request/GraphExploreRequestExample1.yaml": [
@@ -8687,6 +10131,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"match\":{\"query.raw\":\"midi\"}},\"vertices\":[{\"field\":\"product\"}],\"connections\":{\"vertices\":[{\"field\":\"query.raw\"}]}}' \"$ELASTICSEARCH_URL/clicklogs/_graph/explore\""
+    },
+    {
+      "language": "Java",
+      "code": "client.graph().explore(e -> e\n    .connections(c -> c\n        .vertices(v -> v\n            .field(\"query.raw\")\n        )\n    )\n    .index(\"clicklogs\")\n    .query(q -> q\n        .match(m -> m\n            .field(\"query.raw\")\n            .query(FieldValue.of(\"midi\"))\n        )\n    )\n    .vertices(v -> v\n        .field(\"product\")\n    )\n);\n"
     }
   ],
   "specification/synonyms/get_synonym_rule/examples/request/SynonymRuleGetRequestExample1.yaml": [
@@ -8709,6 +10157,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_synonyms/my-synonyms-set/test-1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.synonyms().getSynonymRule(g -> g\n    .ruleId(\"test-1\")\n    .setId(\"my-synonyms-set\")\n);\n"
     }
   ],
   "specification/synonyms/put_synonym_rule/examples/request/SynonymRulePutRequestExample1.yaml": [
@@ -8731,6 +10183,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"synonyms\":\"hello, hi, howdy\"}' \"$ELASTICSEARCH_URL/_synonyms/my-synonyms-set/test-1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.synonyms().putSynonymRule(p -> p\n    .ruleId(\"test-1\")\n    .setId(\"my-synonyms-set\")\n    .synonyms(\"hello, hi, howdy\")\n);\n"
     }
   ],
   "specification/synonyms/delete_synonym_rule/examples/request/SynonymRuleDeleteRequestExample1.yaml": [
@@ -8753,6 +10209,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_synonyms/my-synonyms-set/test-1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.synonyms().deleteSynonymRule(d -> d\n    .ruleId(\"test-1\")\n    .setId(\"my-synonyms-set\")\n);\n"
     }
   ],
   "specification/synonyms/delete_synonym/examples/request/SynonymsDeleteSynonymExample1.yaml": [
@@ -8775,6 +10235,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_synonyms/my-synonyms-set\""
+    },
+    {
+      "language": "Java",
+      "code": "client.synonyms().deleteSynonym(d -> d\n    .id(\"my-synonyms-set\")\n);\n"
     }
   ],
   "specification/synonyms/get_synonym/examples/request/SynonymsGetRequestExample1.yaml": [
@@ -8797,6 +10261,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_synonyms/my-synonyms-set\""
+    },
+    {
+      "language": "Java",
+      "code": "client.synonyms().getSynonym(g -> g\n    .id(\"my-synonyms-set\")\n);\n"
     }
   ],
   "specification/synonyms/get_synonyms_sets/examples/request/SynonymsSetsGetRequestExample1.yaml": [
@@ -8819,6 +10287,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_synonyms\""
+    },
+    {
+      "language": "Java",
+      "code": "client.synonyms().getSynonymsSets(g -> g);\n"
     }
   ],
   "specification/synonyms/put_synonym/examples/request/SynonymsPutRequestExample1.yaml": [
@@ -8863,6 +10335,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_dangling\""
+    },
+    {
+      "language": "Java",
+      "code": "client.danglingIndices().listDanglingIndices();\n"
     }
   ],
   "specification/dangling_indices/delete_dangling_index/examples/request/DanglingIndicesDeleteDanglingIndexExample1.yaml": [
@@ -8885,6 +10361,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_dangling/<index-uuid>?accept_data_loss=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.danglingIndices().deleteDanglingIndex(d -> d\n    .acceptDataLoss(true)\n    .indexUuid(\"<index-uuid>\")\n);\n"
     }
   ],
   "specification/dangling_indices/import_dangling_index/examples/request/ImportDanglingIndexRequestExample1.yaml": [
@@ -8907,6 +10387,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_dangling/zmM4e0JtBkeUjiHD-MihPQ?accept_data_loss=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.danglingIndices().importDanglingIndex(i -> i\n    .acceptDataLoss(true)\n    .indexUuid(\"zmM4e0JtBkeUjiHD-MihPQ\")\n);\n"
     }
   ],
   "specification/ml/forecast/examples/request/MlForecastExample1.yaml": [
@@ -8929,6 +10413,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"duration\":\"10d\"}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/_forecast\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().forecast(f -> f\n    .duration(d -> d\n        .time(\"10d\")\n    )\n    .jobId(\"low_request_rate\")\n);\n"
     }
   ],
   "specification/ml/stop_data_frame_analytics/examples/request/MlStopDataFrameAnalyticsExample1.yaml": [
@@ -8951,6 +10439,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/loganalytics/_stop\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().stopDataFrameAnalytics(s -> s\n    .id(\"loganalytics\")\n);\n"
     }
   ],
   "specification/ml/delete_model_snapshot/examples/request/MlDeleteModelSnapshotExample1.yaml": [
@@ -8973,6 +10465,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/farequote/model_snapshots/1491948163\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().deleteModelSnapshot(d -> d\n    .jobId(\"farequote\")\n    .snapshotId(\"1491948163\")\n);\n"
     }
   ],
   "specification/ml/get_datafeed_stats/examples/request/MlGetDatafeedStatsExample1.yaml": [
@@ -8995,6 +10491,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-high_sum_total_sales/_stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getDatafeedStats(g -> g\n    .datafeedId(\"datafeed-high_sum_total_sales\")\n);\n"
     }
   ],
   "specification/ml/delete_datafeed/examples/request/MlDeleteDatafeedExample1.yaml": [
@@ -9017,6 +10517,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-total-requests\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().deleteDatafeed(d -> d\n    .datafeedId(\"datafeed-total-requests\")\n);\n"
     }
   ],
   "specification/ml/delete_calendar_job/examples/request/MlDeleteCalendarJobExample1.yaml": [
@@ -9039,6 +10543,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages/jobs/total-requests\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().deleteCalendarJob(d -> d\n    .calendarId(\"planned-outages\")\n    .jobId(\"total-requests\")\n);\n"
     }
   ],
   "specification/ml/get_datafeeds/examples/request/MlGetDatafeedsExample1.yaml": [
@@ -9061,6 +10569,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-high_sum_total_sales\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getDatafeeds(g -> g\n    .datafeedId(\"datafeed-high_sum_total_sales\")\n);\n"
     }
   ],
   "specification/ml/stop_trained_model_deployment/examples/request/MlStopTrainedModelDeploymentExample1.yaml": [
@@ -9083,6 +10595,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/my_model_for_search/deployment/_stop\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().stopTrainedModelDeployment(s -> s\n    .modelId(\"my_model_for_search\")\n);\n"
     }
   ],
   "specification/ml/stop_datafeed/examples/request/MlStopDatafeedExample1.yaml": [
@@ -9105,6 +10621,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"timeout\":\"30s\"}' \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-low_request_rate/_stop\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().stopDatafeed(s -> s\n    .datafeedId(\"datafeed-low_request_rate\")\n    .timeout(t -> t\n        .time(\"30s\")\n    )\n);\n"
     }
   ],
   "specification/ml/get_calendar_events/examples/request/MlGetCalendarEventsExample1.yaml": [
@@ -9127,6 +10647,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages/events\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getCalendarEvents(g -> g\n    .calendarId(\"planned-outages\")\n);\n"
     }
   ],
   "specification/ml/infer_trained_model/examples/request/MlInferTrainedModelExample1.yaml": [
@@ -9149,6 +10673,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"docs\":[{\"text\":\"The fool doth think he is wise, but the wise man knows himself to be a fool.\"}]}' \"$ELASTICSEARCH_URL/_ml/trained_models/lang_ident_model_1/_infer\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().inferTrainedModel(i -> i\n    .docs(Map.of(\"text\", JsonData.fromJson(\"\\\"The fool doth think he is wise, but the wise man knows himself to be a fool.\\\"\")))\n    .modelId(\"lang_ident_model_1\")\n);\n"
     }
   ],
   "specification/ml/put_datafeed/examples/request/MlPutDatafeedExample1.yaml": [
@@ -9171,6 +10699,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"indices\":[\"kibana_sample_data_logs\"],\"query\":{\"bool\":{\"must\":[{\"match_all\":{}}]}},\"job_id\":\"test-job\"}' \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-test-job?pretty\""
+    },
+    {
+      "language": "Java",
+      "code": "\n"
     }
   ],
   "specification/ml/update_job/examples/request/MlUpdateJobExample1.yaml": [
@@ -9193,6 +10725,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"An updated job\",\"detectors\":{\"detector_index\":0,\"description\":\"An updated detector description\"},\"groups\":[\"kibana_sample_data\",\"kibana_sample_web_logs\"],\"model_plot_config\":{\"enabled\":true},\"renormalization_window_days\":30,\"background_persist_interval\":\"2h\",\"model_snapshot_retention_days\":7,\"results_retention_days\":60}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/_update\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().updateJob(u -> u\n    .backgroundPersistInterval(b -> b\n        .time(\"2h\")\n    )\n    .description(\"An updated job\")\n    .detectors(d -> d\n        .detectorIndex(0)\n        .description(\"An updated detector description\")\n    )\n    .groups(List.of(\"kibana_sample_data\",\"kibana_sample_web_logs\"))\n    .jobId(\"low_request_rate\")\n    .modelPlotConfig(m -> m\n        .enabled(true)\n    )\n    .modelSnapshotRetentionDays(7L)\n    .renormalizationWindowDays(30L)\n    .resultsRetentionDays(60L)\n);\n"
     }
   ],
   "specification/ml/upgrade_job_snapshot/examples/request/MlUpgradeJobSnapshotExample1.yaml": [
@@ -9215,6 +10751,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/model_snapshots/1828371/_upgrade?timeout=45m&wait_for_completion=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().upgradeJobSnapshot(u -> u\n    .jobId(\"low_request_rate\")\n    .snapshotId(\"1828371\")\n    .timeout(t -> t\n        .offset(45)\n    )\n    .waitForCompletion(true)\n);\n"
     }
   ],
   "specification/ml/get_jobs/examples/request/MlGetJobsExample1.yaml": [
@@ -9237,6 +10777,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/high_sum_total_sales\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getJobs(g -> g\n    .jobId(\"high_sum_total_sales\")\n);\n"
     }
   ],
   "specification/ml/get_model_snapshot_upgrade_stats/examples/request/MlGetModelSnapshotUpgradeStatsExample1.yaml": [
@@ -9259,6 +10803,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/model_snapshots/_all/_upgrade/_stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getModelSnapshotUpgradeStats(g -> g\n    .jobId(\"low_request_rate\")\n    .snapshotId(\"_all\")\n);\n"
     }
   ],
   "specification/ml/update_model_snapshot/examples/request/MlUpdateModelSnapshotExample1.yaml": [
@@ -9281,6 +10829,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"Snapshot 1\",\"retain\":true}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/it_ops_new_logs/model_snapshots/1491852978/_update\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().updateModelSnapshot(u -> u\n    .description(\"Snapshot 1\")\n    .jobId(\"it_ops_new_logs\")\n    .retain(true)\n    .snapshotId(\"1491852978\")\n);\n"
     }
   ],
   "specification/ml/put_calendar_job/examples/request/MlPutCalendarJobExample1.yaml": [
@@ -9303,6 +10855,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages/jobs/total-requests\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().putCalendarJob(p -> p\n    .calendarId(\"planned-outages\")\n    .jobId(\"total-requests\")\n);\n"
     }
   ],
   "specification/ml/estimate_model_memory/examples/request/MlEstimateModelMemoryRequestExample1.yaml": [
@@ -9325,6 +10881,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"analysis_config\":{\"bucket_span\":\"5m\",\"detectors\":[{\"function\":\"sum\",\"field_name\":\"bytes\",\"by_field_name\":\"status\",\"partition_field_name\":\"app\"}],\"influencers\":[\"source_ip\",\"dest_ip\"]},\"overall_cardinality\":{\"status\":10,\"app\":50},\"max_bucket_cardinality\":{\"source_ip\":300,\"dest_ip\":30}}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/_estimate_model_memory\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().estimateModelMemory(e -> e\n    .analysisConfig(a -> a\n        .bucketSpan(b -> b\n            .time(\"5m\")\n        )\n        .detectors(d -> d\n            .byFieldName(\"status\")\n            .fieldName(\"bytes\")\n            .function(\"sum\")\n            .partitionFieldName(\"app\")\n        )\n        .influencers(List.of(\"source_ip\",\"dest_ip\"))\n    )\n    .maxBucketCardinality(Map.of(\"dest_ip\", 30L,\"source_ip\", 300L))\n    .overallCardinality(Map.of(\"app\", 50L,\"status\", 10L))\n);\n"
     }
   ],
   "specification/ml/get_categories/examples/request/MlGetCategoriesExample1.yaml": [
@@ -9347,6 +10907,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"page\":{\"size\":1}}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/esxi_log/results/categories\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getCategories(g -> g\n    .jobId(\"esxi_log\")\n    .page(p -> p\n        .size(1)\n    )\n);\n"
     }
   ],
   "specification/ml/post_calendar_events/examples/request/MlPostCalendarEventsExample1.yaml": [
@@ -9369,6 +10933,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"events\":[{\"description\":\"event 1\",\"start_time\":1513641600000,\"end_time\":1513728000000},{\"description\":\"event 2\",\"start_time\":1513814400000,\"end_time\":1513900800000},{\"description\":\"event 3\",\"start_time\":1514160000000,\"end_time\":1514246400000}]}' \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages/events\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().postCalendarEvents(p -> p\n    .calendarId(\"planned-outages\")\n    .events(List.of(CalendarEvent.of(c -> c\n            .description(\"event 1\")\n            .endTime(DateTime.ofEpochMilli(1513728000000L))\n            .startTime(DateTime.ofEpochMilli(1513641600000L))),CalendarEvent.of(c -> c\n            .description(\"event 2\")\n            .endTime(DateTime.ofEpochMilli(1513900800000L))\n            .startTime(DateTime.ofEpochMilli(1513814400000L))),CalendarEvent.of(c -> c\n            .description(\"event 3\")\n            .endTime(DateTime.ofEpochMilli(1514246400000L))\n            .startTime(DateTime.ofEpochMilli(1514160000000L)))))\n);\n"
     }
   ],
   "specification/ml/update_datafeed/examples/request/MlUpdateDatafeedExample1.yaml": [
@@ -9391,6 +10959,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":{\"term\":{\"geo.src\":\"US\"}}}' \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-test-job/_update\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().updateDatafeed(u -> u\n    .datafeedId(\"datafeed-test-job\")\n    .query(q -> q\n        .term(t -> t\n            .field(\"geo.src\")\n            .value(FieldValue.of(\"US\"))\n        )\n    )\n);\n"
     }
   ],
   "specification/ml/put_job/examples/request/MlPutJobRequestExample1.yaml": [
@@ -9413,6 +10985,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"analysis_config\":{\"bucket_span\":\"15m\",\"detectors\":[{\"detector_description\":\"Sum of bytes\",\"function\":\"sum\",\"field_name\":\"bytes\"}]},\"data_description\":{\"time_field\":\"timestamp\",\"time_format\":\"epoch_ms\"},\"analysis_limits\":{\"model_memory_limit\":\"11MB\"},\"model_plot_config\":{\"enabled\":true,\"annotations_enabled\":true},\"results_index_name\":\"test-job1\",\"datafeed_config\":{\"indices\":[\"kibana_sample_data_logs\"],\"query\":{\"bool\":{\"must\":[{\"match_all\":{}}]}},\"runtime_mappings\":{\"hour_of_day\":{\"type\":\"long\",\"script\":{\"source\":\"emit(doc['\"'\"'timestamp'\"'\"'].value.getHour());\"}}},\"datafeed_id\":\"datafeed-test-job1\"}}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/job-01\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().putJob(p -> p\n    .analysisConfig(a -> a\n        .bucketSpan(b -> b\n            .time(\"15m\")\n        )\n        .detectors(d -> d\n            .detectorDescription(\"Sum of bytes\")\n            .fieldName(\"bytes\")\n            .function(\"sum\")\n        )\n    )\n    .analysisLimits(an -> an\n        .modelMemoryLimit(\"11MB\")\n    )\n    .dataDescription(d -> d\n        .timeField(\"timestamp\")\n        .timeFormat(\"epoch_ms\")\n    )\n    .datafeedConfig(d -> d\n        .datafeedId(\"datafeed-test-job1\")\n        .indices(\"kibana_sample_data_logs\")\n        .query(q -> q\n            .bool(b -> b\n                .must(m -> m\n                    .matchAll(ma -> ma)\n                )\n            )\n        )\n        .runtimeMappings(\"hour_of_day\", r -> r\n            .script(s -> s\n                .source(so -> so\n                    .scriptString(\"emit(doc['timestamp'].value.getHour());\")\n                )\n            )\n            .type(RuntimeFieldType.Long)\n        )\n    )\n    .jobId(\"job-01\")\n    .modelPlotConfig(m -> m\n        .annotationsEnabled(true)\n        .enabled(true)\n    )\n    .resultsIndexName(\"test-job1\")\n);\n"
     }
   ],
   "specification/ml/evaluate_data_frame/examples/request/MlEvaluateDataFrameRequestExample5.yaml": [
@@ -9435,6 +11011,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"house_price_predictions\",\"query\":{\"term\":{\"ml.is_training\":{\"value\":true}}},\"evaluation\":{\"regression\":{\"actual_field\":\"price\",\"predicted_field\":\"ml.price_prediction\",\"metrics\":{\"r_squared\":{},\"mse\":{},\"msle\":{},\"huber\":{}}}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/_evaluate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().evaluateDataFrame(e -> e\n    .evaluation(ev -> ev\n        .regression(r -> r\n            .actualField(\"price\")\n            .predictedField(\"ml.price_prediction\")\n            .metrics(m -> m\n                .msle(ms -> ms)\n                .huber(h -> h)\n            )\n        )\n    )\n    .index(\"house_price_predictions\")\n    .query(q -> q\n        .term(t -> t\n            .field(\"ml.is_training\")\n            .value(FieldValue.of(true))\n        )\n    )\n);\n"
     }
   ],
   "specification/ml/evaluate_data_frame/examples/request/MlEvaluateDataFrameRequestExample4.yaml": [
@@ -9457,6 +11037,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"house_price_predictions\",\"query\":{\"bool\":{\"filter\":[{\"term\":{\"ml.is_training\":false}}]}},\"evaluation\":{\"regression\":{\"actual_field\":\"price\",\"predicted_field\":\"ml.price_prediction\",\"metrics\":{\"r_squared\":{},\"mse\":{},\"msle\":{\"offset\":10},\"huber\":{\"delta\":1.5}}}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/_evaluate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().evaluateDataFrame(e -> e\n    .evaluation(ev -> ev\n        .regression(r -> r\n            .actualField(\"price\")\n            .predictedField(\"ml.price_prediction\")\n            .metrics(m -> m\n                .msle(ms -> ms\n                    .offset(10.0D)\n                )\n                .huber(h -> h\n                    .delta(1.5D)\n                )\n            )\n        )\n    )\n    .index(\"house_price_predictions\")\n    .query(q -> q\n        .bool(b -> b\n            .filter(f -> f\n                .term(t -> t\n                    .field(\"ml.is_training\")\n                    .value(FieldValue.of(false))\n                )\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/ml/evaluate_data_frame/examples/request/MlEvaluateDataFrameRequestExample3.yaml": [
@@ -9479,6 +11063,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"my_analytics_dest_index\",\"evaluation\":{\"outlier_detection\":{\"actual_field\":\"is_outlier\",\"predicted_probability_field\":\"ml.outlier_score\"}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/_evaluate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().evaluateDataFrame(e -> e\n    .evaluation(ev -> ev\n        .outlierDetection(o -> o\n            .actualField(\"is_outlier\")\n            .predictedProbabilityField(\"ml.outlier_score\")\n        )\n    )\n    .index(\"my_analytics_dest_index\")\n);\n"
     }
   ],
   "specification/ml/evaluate_data_frame/examples/request/MlEvaluateDataFrameRequestExample2.yaml": [
@@ -9501,6 +11089,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"animal_classification\",\"evaluation\":{\"classification\":{\"actual_field\":\"animal_class\",\"metrics\":{\"auc_roc\":{\"class_name\":\"dog\"}}}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/_evaluate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().evaluateDataFrame(e -> e\n    .evaluation(ev -> ev\n        .classification(c -> c\n            .actualField(\"animal_class\")\n            .metrics(m -> m\n                .aucRoc(a -> a\n                    .className(\"dog\")\n                )\n            )\n        )\n    )\n    .index(\"animal_classification\")\n);\n"
     }
   ],
   "specification/ml/evaluate_data_frame/examples/request/MlEvaluateDataFrameRequestExample1.yaml": [
@@ -9523,6 +11115,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index\":\"animal_classification\",\"evaluation\":{\"classification\":{\"actual_field\":\"animal_class\",\"predicted_field\":\"ml.animal_class_prediction\",\"metrics\":{\"multiclass_confusion_matrix\":{}}}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/_evaluate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().evaluateDataFrame(e -> e\n    .evaluation(ev -> ev\n        .classification(c -> c\n            .actualField(\"animal_class\")\n            .predictedField(\"ml.animal_class_prediction\")\n            .metrics(m -> m)\n        )\n    )\n    .index(\"animal_classification\")\n);\n"
     }
   ],
   "specification/ml/delete_forecast/examples/request/MlDeleteForecastExample1.yaml": [
@@ -9545,6 +11141,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/total-requests/_forecast/_all\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().deleteForecast(d -> d\n    .forecastId(\"_all\")\n    .jobId(\"total-requests\")\n);\n"
     }
   ],
   "specification/ml/get_trained_models/examples/request/MlGetTrainedModelsExample1.yaml": [
@@ -9567,6 +11167,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getTrainedModels(g -> g);\n"
     }
   ],
   "specification/ml/get_trained_models_stats/examples/request/MlGetTrainedModelsStatsExample1.yaml": [
@@ -9589,6 +11193,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/_stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getTrainedModelsStats(g -> g);\n"
     }
   ],
   "specification/ml/get_influencers/examples/request/MlGetInfluencersExample1.yaml": [
@@ -9611,6 +11219,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"sort\":\"influencer_score\",\"desc\":true}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/high_sum_total_sales/results/influencers\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getInfluencers(g -> g\n    .jobId(\"high_sum_total_sales\")\n);\n"
     }
   ],
   "specification/ml/reset_job/examples/request/MlResetJobExample1.yaml": [
@@ -9633,6 +11245,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/total-requests/_reset\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().resetJob(r -> r\n    .jobId(\"total-requests\")\n);\n"
     }
   ],
   "specification/ml/get_data_frame_analytics_stats/examples/request/MlGetDataFrameAnalyticsStatsExample1.yaml": [
@@ -9655,6 +11271,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/weblog-outliers/_stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getDataFrameAnalyticsStats(g -> g\n    .id(\"weblog-outliers\")\n);\n"
     }
   ],
   "specification/ml/put_calendar/examples/request/MlPutCalendarExample1.yaml": [
@@ -9677,6 +11297,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().putCalendar(p -> p\n    .calendarId(\"planned-outages\")\n);\n"
     }
   ],
   "specification/ml/delete_filter/examples/request/MlDeleteFilterExample1.yaml": [
@@ -9699,6 +11323,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/filters/safe_domains\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().deleteFilter(d -> d\n    .filterId(\"safe_domains\")\n);\n"
     }
   ],
   "specification/ml/update_filter/examples/request/MlUpdateFilterExample1.yaml": [
@@ -9721,6 +11349,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"Updated list of domains\",\"add_items\":[\"*.myorg.com\"],\"remove_items\":[\"wikipedia.org\"]}' \"$ELASTICSEARCH_URL/_ml/filters/safe_domains/_update\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().updateFilter(u -> u\n    .addItems(\"*.myorg.com\")\n    .description(\"Updated list of domains\")\n    .filterId(\"safe_domains\")\n    .removeItems(\"wikipedia.org\")\n);\n"
     }
   ],
   "specification/ml/delete_expired_data/examples/request/MlDeleteExpiredDataExample1.yaml": [
@@ -9743,6 +11375,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/_delete_expired_data?timeout=1h\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().deleteExpiredData(d -> d\n    .timeout(t -> t\n        .offset(1)\n    )\n);\n"
     }
   ],
   "specification/ml/clear_trained_model_deployment_cache/examples/request/MlClearTrainedModelDeploymentCacheExample1.yaml": [
@@ -9765,6 +11401,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/deployment/cache/_clear\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().clearTrainedModelDeploymentCache(c -> c\n    .modelId(\"elastic__distilbert-base-uncased-finetuned-conll03-english\")\n);\n"
     }
   ],
   "specification/ml/delete_calendar/examples/request/MlDeleteCalendarExample1.yaml": [
@@ -9787,6 +11427,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().deleteCalendar(d -> d\n    .calendarId(\"planned-outages\")\n);\n"
     }
   ],
   "specification/ml/get_filters/examples/request/MlGetFiltersExample1.yaml": [
@@ -9809,6 +11453,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/filters/safe_domains\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getFilters(g -> g\n    .filterId(\"safe_domains\")\n);\n"
     }
   ],
   "specification/ml/put_trained_model_alias/examples/request/MlPutTrainedModelAliasExample1.yaml": [
@@ -9831,6 +11479,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/flight-delay-prediction-1574775339910/model_aliases/flight_delay_model\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().putTrainedModelAlias(p -> p\n    .modelAlias(\"flight_delay_model\")\n    .modelId(\"flight-delay-prediction-1574775339910\")\n);\n"
     }
   ],
   "specification/ml/update_trained_model_deployment/examples/request/MlUpdateTrainedModelDeploymentExample1.yaml": [
@@ -9853,6 +11505,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"number_of_allocations\":4}' \"$ELASTICSEARCH_URL/_ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/deployment/_update\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().updateTrainedModelDeployment(u -> u\n    .modelId(\"elastic__distilbert-base-uncased-finetuned-conll03-english\")\n    .numberOfAllocations(4)\n);\n"
     }
   ],
   "specification/ml/info/examples/request/MlInfoExample1.yaml": [
@@ -9875,6 +11531,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/info\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().info();\n"
     }
   ],
   "specification/ml/delete_job/examples/request/MlDeleteJobExample1.yaml": [
@@ -9897,6 +11557,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/total-requests\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().deleteJob(d -> d\n    .jobId(\"total-requests\")\n);\n"
     }
   ],
   "specification/ml/get_buckets/examples/request/MlGetBucketsExample1.yaml": [
@@ -9919,6 +11583,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"anomaly_score\":80,\"start\":\"1454530200001\"}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/results/buckets\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getBuckets(g -> g\n    .anomalyScore(80.0D)\n    .jobId(\"low_request_rate\")\n    .start(DateTime.of(\"1454530200001\"))\n);\n"
     }
   ],
   "specification/ml/start_trained_model_deployment/examples/request/MlStartTrainedModelDeploymentExample1.yaml": [
@@ -9941,6 +11609,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/deployment/_start?wait_for=started&timeout=1m\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().startTrainedModelDeployment(s -> s\n    .modelId(\"elastic__distilbert-base-uncased-finetuned-conll03-english\")\n    .timeout(t -> t\n        .offset(1)\n    )\n    .waitFor(DeploymentAllocationState.Started)\n);\n"
     }
   ],
   "specification/ml/delete_calendar_event/examples/request/MlDeleteCalendarEventExample1.yaml": [
@@ -9963,6 +11635,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages/events/LS8LJGEBMTCMA-qz49st\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().deleteCalendarEvent(d -> d\n    .calendarId(\"planned-outages\")\n    .eventId(\"LS8LJGEBMTCMA-qz49st\")\n);\n"
     }
   ],
   "specification/ml/get_records/examples/request/MlGetRecordsExample1.yaml": [
@@ -9985,6 +11661,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"sort\":\"record_score\",\"desc\":true,\"start\":\"1454944100000\"}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/results/records\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getRecords(g -> g\n    .desc(true)\n    .jobId(\"low_request_rate\")\n    .sort(\"record_score\")\n    .start(DateTime.of(\"1454944100000\"))\n);\n"
     }
   ],
   "specification/ml/get_memory_stats/examples/request/MlGetMemoryStatsExample1.yaml": [
@@ -10007,6 +11687,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/memory/_stats?human\""
+    },
+    {
+      "language": "Java",
+      "code": "\n"
     }
   ],
   "specification/ml/start_datafeed/examples/request/MlStartDatafeedExample1.yaml": [
@@ -10029,6 +11713,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"start\":\"2019-04-07T18:22:16Z\"}' \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-low_request_rate/_start\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().startDatafeed(s -> s\n    .datafeedId(\"datafeed-low_request_rate\")\n    .start(DateTime.of(\"2019-04-07T18:22:16Z\"))\n);\n"
     }
   ],
   "specification/ml/explain_data_frame_analytics/examples/request/MlExplainDataFrameAnalyticsRequestExample1.yaml": [
@@ -10051,6 +11739,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"houses_sold_last_10_yrs\"},\"analysis\":{\"regression\":{\"dependent_variable\":\"price\"}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/_explain\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().explainDataFrameAnalytics(e -> e\n    .analysis(a -> a\n        .regression(r -> r\n            .dependentVariable(\"price\")\n        )\n    )\n    .source(s -> s\n        .index(\"houses_sold_last_10_yrs\")\n    )\n);\n"
     }
   ],
   "specification/ml/flush_job/examples/request/MlFlushJobExample1.yaml": [
@@ -10073,6 +11765,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"calc_interim\":true}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/_flush\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().flushJob(f -> f\n    .calcInterim(true)\n    .jobId(\"low_request_rate\")\n);\n"
     }
   ],
   "specification/ml/get_model_snapshots/examples/request/MlGetModelSnapshotsExample1.yaml": [
@@ -10095,6 +11791,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"start\":\"1575402236000\"}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/high_sum_total_sales/model_snapshots\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getModelSnapshots(g -> g\n    .jobId(\"high_sum_total_sales\")\n    .start(DateTime.of(\"1575402236000\"))\n);\n"
     }
   ],
   "specification/ml/set_upgrade_mode/examples/request/MlSetUpgradeModeExample1.yaml": [
@@ -10117,6 +11817,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/set_upgrade_mode?enabled=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().setUpgradeMode(s -> s\n    .enabled(true)\n);\n"
     }
   ],
   "specification/ml/update_data_frame_analytics/examples/request/MlUpdateDataFrameAnalyticsExample1.yaml": [
@@ -10139,6 +11843,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"model_memory_limit\":\"200mb\"}' \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/loganalytics/_update\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().updateDataFrameAnalytics(u -> u\n    .id(\"loganalytics\")\n    .modelMemoryLimit(\"200mb\")\n);\n"
     }
   ],
   "specification/ml/delete_trained_model/examples/request/MlDeleteTrainedModelExample1.yaml": [
@@ -10161,6 +11869,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/regression-job-one-1574775307356\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().deleteTrainedModel(d -> d\n    .modelId(\"regression-job-one-1574775307356\")\n);\n"
     }
   ],
   "specification/ml/get_overall_buckets/examples/request/MlGetOverallBucketsExample1.yaml": [
@@ -10183,6 +11895,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"overall_score\":80,\"start\":\"1403532000000\"}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/job-*/results/overall_buckets\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getOverallBuckets(g -> g\n    .jobId(\"job-*\")\n    .overallScore(80.0D)\n    .start(DateTime.of(\"1403532000000\"))\n);\n"
     }
   ],
   "specification/ml/preview_datafeed/examples/request/MlPreviewDatafeedExample1.yaml": [
@@ -10205,6 +11921,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/datafeeds/datafeed-high_sum_total_sales/_preview\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().previewDatafeed(p -> p\n    .datafeedId(\"datafeed-high_sum_total_sales\")\n);\n"
     }
   ],
   "specification/ml/put_trained_model_vocabulary/examples/request/MlPutTrainedModelVocabularyExample1.yaml": [
@@ -10227,6 +11947,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"vocabulary\":[\"[PAD]\",\"[unused0]\"]}' \"$ELASTICSEARCH_URL/_ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/vocabulary\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().putTrainedModelVocabulary(p -> p\n    .modelId(\"elastic__distilbert-base-uncased-finetuned-conll03-english\")\n    .vocabulary(List.of(\"[PAD]\",\"[unused0]\"))\n);\n"
     }
   ],
   "specification/ml/get_data_frame_analytics/examples/request/MlGetDataFrameAnalyticsExample1.yaml": [
@@ -10249,6 +11973,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/loganalytics\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getDataFrameAnalytics(g -> g\n    .id(\"loganalytics\")\n);\n"
     }
   ],
   "specification/ml/delete_trained_model_alias/examples/request/MlDeleteTrainedModelAliasExample1.yaml": [
@@ -10271,6 +11999,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/trained_models/flight-delay-prediction-1574775339910/model_aliases/flight_delay_model\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().deleteTrainedModelAlias(d -> d\n    .modelAlias(\"flight_delay_model\")\n    .modelId(\"flight-delay-prediction-1574775339910\")\n);\n"
     }
   ],
   "specification/ml/revert_model_snapshot/examples/request/MlRevertModelSnapshotExample1.yaml": [
@@ -10293,6 +12025,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"delete_intervening_results\":true}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/model_snapshots/1637092688/_revert\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().revertModelSnapshot(r -> r\n    .deleteInterveningResults(true)\n    .jobId(\"low_request_rate\")\n    .snapshotId(\"1637092688\")\n);\n"
     }
   ],
   "specification/ml/close_job/examples/request/MlCloseJobExample1.yaml": [
@@ -10315,6 +12051,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/_close\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().closeJob(c -> c\n    .jobId(\"low_request_rate\")\n);\n"
     }
   ],
   "specification/ml/put_trained_model_definition_part/examples/request/MlPutTrainedModelDefinitionPartExample1.yaml": [
@@ -10359,6 +12099,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":[\"kibana_sample_data_flights\"],\"query\":{\"range\":{\"DistanceKilometers\":{\"gt\":0}}},\"_source\":{\"includes\":[],\"excludes\":[\"FlightDelay\",\"FlightDelayType\"]}},\"dest\":{\"index\":\"df-flight-delays\",\"results_field\":\"ml-results\"},\"analysis\":{\"regression\":{\"dependent_variable\":\"FlightDelayMin\",\"training_percent\":90}},\"analyzed_fields\":{\"includes\":[],\"excludes\":[\"FlightNum\"]},\"model_memory_limit\":\"100mb\"}' \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/model-flight-delays-pre\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().putDataFrameAnalytics(p -> p\n    .analysis(a -> a\n        .regression(r -> r\n            .dependentVariable(\"FlightDelayMin\")\n            .trainingPercent(\"90\")\n        )\n    )\n    .analyzedFields(an -> an\n        .excludes(\"FlightNum\")\n    )\n    .dest(d -> d\n        .index(\"df-flight-delays\")\n        .resultsField(\"ml-results\")\n    )\n    .id(\"model-flight-delays-pre\")\n    .modelMemoryLimit(\"100mb\")\n    .source(s -> s\n        .index(\"kibana_sample_data_flights\")\n        .query(q -> q\n            .range(r -> r\n                .untyped(u -> u\n                    .field(\"DistanceKilometers\")\n                    .gt(JsonData.fromJson(\"0\"))\n                )\n            )\n        )\n        .source(so -> so\n            .excludes(List.of(\"FlightDelay\",\"FlightDelayType\"))\n        )\n    )\n);\n"
     }
   ],
   "specification/ml/delete_data_frame_analytics/examples/request/MlDeleteDataFrameAnalyticsExample1.yaml": [
@@ -10381,6 +12125,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/loganalytics\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().deleteDataFrameAnalytics(d -> d\n    .id(\"loganalytics\")\n);\n"
     }
   ],
   "specification/ml/preview_data_frame_analytics/examples/request/MlPreviewDataFrameAnalyticsExample1.yaml": [
@@ -10403,6 +12151,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"config\":{\"source\":{\"index\":\"houses_sold_last_10_yrs\"},\"analysis\":{\"regression\":{\"dependent_variable\":\"price\"}}}}' \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/_preview\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().previewDataFrameAnalytics(p -> p\n    .config(c -> c\n        .source(s -> s\n            .index(\"houses_sold_last_10_yrs\")\n        )\n        .analysis(a -> a\n            .regression(r -> r\n                .dependentVariable(\"price\")\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/ml/put_filter/examples/request/MlPutFilterExample1.yaml": [
@@ -10425,6 +12177,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"description\":\"A list of safe domains\",\"items\":[\"*.google.com\",\"wikipedia.org\"]}' \"$ELASTICSEARCH_URL/_ml/filters/safe_domains\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().putFilter(p -> p\n    .description(\"A list of safe domains\")\n    .filterId(\"safe_domains\")\n    .items(List.of(\"*.google.com\",\"wikipedia.org\"))\n);\n"
     }
   ],
   "specification/ml/start_data_frame_analytics/examples/request/MlStartDataFrameAnalyticsExample1.yaml": [
@@ -10447,6 +12203,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/data_frame/analytics/loganalytics/_start\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().startDataFrameAnalytics(s -> s\n    .id(\"loganalytics\")\n);\n"
     }
   ],
   "specification/ml/get_calendars/examples/request/MlGetCalendarsExample1.yaml": [
@@ -10469,6 +12229,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/calendars/planned-outages\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getCalendars(g -> g\n    .calendarId(\"planned-outages\")\n);\n"
     }
   ],
   "specification/ml/get_job_stats/examples/request/MlGetJobStatsExample1.yaml": [
@@ -10491,6 +12255,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/low_request_rate/_stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().getJobStats(g -> g\n    .jobId(\"low_request_rate\")\n);\n"
     }
   ],
   "specification/ml/open_job/examples/request/MlOpenJobRequestExample1.yaml": [
@@ -10513,6 +12281,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"timeout\":\"35m\"}' \"$ELASTICSEARCH_URL/_ml/anomaly_detectors/job-01/_open\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ml().openJob(o -> o\n    .jobId(\"job-01\")\n    .timeout(t -> t\n        .time(\"35m\")\n    )\n);\n"
     }
   ],
   "specification/text_structure/test_grok_pattern/examples/request/TestGrokPatternRequestExample1.yaml": [
@@ -10535,6 +12307,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"grok_pattern\":\"Hello %{WORD:first_name} %{WORD:last_name}\",\"text\":[\"Hello John Doe\",\"this does not match\"]}' \"$ELASTICSEARCH_URL/_text_structure/test_grok_pattern\""
+    },
+    {
+      "language": "Java",
+      "code": "client.textStructure().testGrokPattern(t -> t\n    .grokPattern(\"Hello %{WORD:first_name} %{WORD:last_name}\")\n    .text(List.of(\"Hello John Doe\",\"this does not match\"))\n);\n"
     }
   ],
   "specification/text_structure/find_structure/examples/request/FindStructureRequestExample1.yaml": [
@@ -10579,6 +12355,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_text_structure/find_field_structure?index=test-logs&field=message\""
+    },
+    {
+      "language": "Java",
+      "code": "client.textStructure().findFieldStructure(f -> f\n    .field(\"message\")\n    .index(\"test-logs\")\n);\n"
     }
   ],
   "specification/text_structure/find_message_structure/examples/request/FindMessageStructureRequestExample1.yaml": [
@@ -10601,6 +12381,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"messages\":[\"[2024-03-05T10:52:36,256][INFO ][o.a.l.u.VectorUtilPanamaProvider] [laptop] Java vector incubator API enabled; uses preferredBitSize=128\",\"[2024-03-05T10:52:41,038][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [repository-url]\",\"[2024-03-05T10:52:41,042][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [rest-root]\",\"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-core]\",\"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-redact]\",\"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [ingest-user-agent]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-monitoring]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [repository-s3]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-analytics]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-ent-search]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-autoscaling]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [lang-painless]]\",\"[2024-03-05T10:52:41,059][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [lang-expression]\",\"[2024-03-05T10:52:41,059][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-eql]\",\"[2024-03-05T10:52:43,291][INFO ][o.e.e.NodeEnvironment    ] [laptop] heap size [16gb], compressed ordinary object pointers [true]\",\"[2024-03-05T10:52:46,098][INFO ][o.e.x.s.Security         ] [laptop] Security is enabled\",\"[2024-03-05T10:52:47,227][INFO ][o.e.x.p.ProfilingPlugin  ] [laptop] Profiling is enabled\",\"[2024-03-05T10:52:47,259][INFO ][o.e.x.p.ProfilingPlugin  ] [laptop] profiling index templates will not be installed or reinstalled\",\"[2024-03-05T10:52:47,755][INFO ][o.e.i.r.RecoverySettings ] [laptop] using rate limit [40mb] with [default=40mb, read=0b, write=0b, max=0b]\",\"[2024-03-05T10:52:47,787][INFO ][o.e.d.DiscoveryModule    ] [laptop] using discovery type [multi-node] and seed hosts providers [settings]\",\"[2024-03-05T10:52:49,188][INFO ][o.e.n.Node               ] [laptop] initialized\",\"[2024-03-05T10:52:49,199][INFO ][o.e.n.Node               ] [laptop] starting ...\"]}' \"$ELASTICSEARCH_URL/_text_structure/find_message_structure\""
+    },
+    {
+      "language": "Java",
+      "code": "client.textStructure().findMessageStructure(f -> f\n    .messages(List.of(\"[2024-03-05T10:52:36,256][INFO ][o.a.l.u.VectorUtilPanamaProvider] [laptop] Java vector incubator API enabled; uses preferredBitSize=128\",\"[2024-03-05T10:52:41,038][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [repository-url]\",\"[2024-03-05T10:52:41,042][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [rest-root]\",\"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-core]\",\"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-redact]\",\"[2024-03-05T10:52:41,043][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [ingest-user-agent]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-monitoring]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [repository-s3]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-analytics]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-ent-search]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-autoscaling]\",\"[2024-03-05T10:52:41,044][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [lang-painless]]\",\"[2024-03-05T10:52:41,059][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [lang-expression]\",\"[2024-03-05T10:52:41,059][INFO ][o.e.p.PluginsService     ] [laptop] loaded module [x-pack-eql]\",\"[2024-03-05T10:52:43,291][INFO ][o.e.e.NodeEnvironment    ] [laptop] heap size [16gb], compressed ordinary object pointers [true]\",\"[2024-03-05T10:52:46,098][INFO ][o.e.x.s.Security         ] [laptop] Security is enabled\",\"[2024-03-05T10:52:47,227][INFO ][o.e.x.p.ProfilingPlugin  ] [laptop] Profiling is enabled\",\"[2024-03-05T10:52:47,259][INFO ][o.e.x.p.ProfilingPlugin  ] [laptop] profiling index templates will not be installed or reinstalled\",\"[2024-03-05T10:52:47,755][INFO ][o.e.i.r.RecoverySettings ] [laptop] using rate limit [40mb] with [default=40mb, read=0b, write=0b, max=0b]\",\"[2024-03-05T10:52:47,787][INFO ][o.e.d.DiscoveryModule    ] [laptop] using discovery type [multi-node] and seed hosts providers [settings]\",\"[2024-03-05T10:52:49,188][INFO ][o.e.n.Node               ] [laptop] initialized\",\"[2024-03-05T10:52:49,199][INFO ][o.e.n.Node               ] [laptop] starting ...\"))\n);\n"
     }
   ],
   "specification/rollup/get_rollup_index_caps/examples/request/GetRollupIndexCapabilitiesRequestExample1.yaml": [
@@ -10623,6 +12407,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/sensor_rollup/_rollup/data\""
+    },
+    {
+      "language": "Java",
+      "code": "client.rollup().getRollupIndexCaps(g -> g\n    .index(\"sensor_rollup\")\n);\n"
     }
   ],
   "specification/rollup/get_jobs/examples/request/GetRollupJobRequestExample1.yaml": [
@@ -10645,6 +12433,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_rollup/job/sensor\""
+    },
+    {
+      "language": "Java",
+      "code": "client.rollup().getJobs(g -> g\n    .id(\"sensor\")\n);\n"
     }
   ],
   "specification/rollup/stop_job/examples/request/RollupStopJobExample1.yaml": [
@@ -10667,6 +12459,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_rollup/job/sensor/_stop?wait_for_completion=true&timeout=10s\""
+    },
+    {
+      "language": "Java",
+      "code": "client.rollup().stopJob(s -> s\n    .id(\"sensor\")\n    .timeout(t -> t\n        .offset(10)\n    )\n    .waitForCompletion(true)\n);\n"
     }
   ],
   "specification/rollup/get_rollup_caps/examples/request/GetRollupCapabilitiesRequestExample1.yaml": [
@@ -10689,6 +12485,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_rollup/data/sensor-*\""
+    },
+    {
+      "language": "Java",
+      "code": "client.rollup().getRollupCaps(g -> g\n    .id(\"sensor-*\")\n);\n"
     }
   ],
   "specification/rollup/rollup_search/examples/request/RollupSearchRequestExample1.yaml": [
@@ -10711,6 +12511,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"size\":0,\"aggregations\":{\"max_temperature\":{\"max\":{\"field\":\"temperature\"}}}}' \"$ELASTICSEARCH_URL/sensor_rollup/_rollup_search\""
+    },
+    {
+      "language": "Java",
+      "code": "client.rollup().rollupSearch(r -> r\n    .aggregations(\"max_temperature\", a -> a\n        .max(m -> m\n            .field(\"temperature\")\n        )\n    )\n    .index(\"sensor_rollup\")\n    .size(0)\n);\n"
     }
   ],
   "specification/rollup/put_job/examples/request/CreateRollupJobRequestExample1.yaml": [
@@ -10733,6 +12537,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_pattern\":\"sensor-*\",\"rollup_index\":\"sensor_rollup\",\"cron\":\"*/30 * * * * ?\",\"page_size\":1000,\"groups\":{\"date_histogram\":{\"field\":\"timestamp\",\"fixed_interval\":\"1h\",\"delay\":\"7d\"},\"terms\":{\"fields\":[\"node\"]}},\"metrics\":[{\"field\":\"temperature\",\"metrics\":[\"min\",\"max\",\"sum\"]},{\"field\":\"voltage\",\"metrics\":[\"avg\"]}]}' \"$ELASTICSEARCH_URL/_rollup/job/sensor\""
+    },
+    {
+      "language": "Java",
+      "code": "client.rollup().putJob(p -> p\n    .cron(\"*/30 * * * * ?\")\n    .groups(g -> g\n        .dateHistogram(d -> d\n            .delay(de -> de\n                .time(\"7d\")\n            )\n            .field(\"timestamp\")\n            .fixedInterval(f -> f\n                .time(\"1h\")\n            )\n        )\n        .terms(t -> t\n            .fields(\"node\")\n        )\n    )\n    .id(\"sensor\")\n    .indexPattern(\"sensor-*\")\n    .metrics(List.of(FieldMetric.of(f -> f\n            .field(\"temperature\")\n            .metrics(List.of(Metric.Min,Metric.Max,Metric.Sum))),FieldMetric.of(f -> f\n            .field(\"voltage\")\n            .metrics(Metric.Avg))))\n    .pageSize(1000)\n    .rollupIndex(\"sensor_rollup\")\n);\n"
     }
   ],
   "specification/rollup/delete_job/examples/request/DeleteRollupJobRequestExample1.yaml": [
@@ -10755,6 +12563,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_rollup/job/sensor\""
+    },
+    {
+      "language": "Java",
+      "code": "client.rollup().deleteJob(d -> d\n    .id(\"sensor\")\n);\n"
     }
   ],
   "specification/rollup/start_job/examples/request/StartRollupJobRequestExample1.yaml": [
@@ -10777,6 +12589,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_rollup/job/sensor/_start\""
+    },
+    {
+      "language": "Java",
+      "code": "client.rollup().startJob(s -> s\n    .id(\"sensor\")\n);\n"
     }
   ],
   "specification/connector/update_service_type/examples/request/ConnectorUpdateServiceTypeRequestExample1.yaml": [
@@ -10799,6 +12615,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service_type\":\"sharepoint_online\"}' \"$ELASTICSEARCH_URL/_connector/my-connector/_service_type\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateServiceType(u -> u\n    .connectorId(\"my-connector\")\n    .serviceType(\"sharepoint_online\")\n);\n"
     }
   ],
   "specification/connector/update_scheduling/examples/request/ConnectorUpdateSchedulingRequestExample2.yaml": [
@@ -10821,6 +12641,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"scheduling\":{\"full\":{\"enabled\":true,\"interval\":\"0 10 0 * * ?\"}}}' \"$ELASTICSEARCH_URL/_connector/my-connector/_scheduling\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateScheduling(u -> u\n    .connectorId(\"my-connector\")\n    .scheduling(s -> s\n        .full(f -> f\n            .enabled(true)\n            .interval(\"0 10 0 * * ?\")\n        )\n    )\n);\n"
     }
   ],
   "specification/connector/update_scheduling/examples/request/ConnectorUpdateSchedulingRequestExample1.yaml": [
@@ -10843,6 +12667,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"scheduling\":{\"access_control\":{\"enabled\":true,\"interval\":\"0 10 0 * * ?\"},\"full\":{\"enabled\":true,\"interval\":\"0 20 0 * * ?\"},\"incremental\":{\"enabled\":false,\"interval\":\"0 30 0 * * ?\"}}}' \"$ELASTICSEARCH_URL/_connector/my-connector/_scheduling\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateScheduling(u -> u\n    .connectorId(\"my-connector\")\n    .scheduling(s -> s\n        .accessControl(a -> a\n            .enabled(true)\n            .interval(\"0 10 0 * * ?\")\n        )\n        .full(f -> f\n            .enabled(true)\n            .interval(\"0 20 0 * * ?\")\n        )\n        .incremental(i -> i\n            .enabled(false)\n            .interval(\"0 30 0 * * ?\")\n        )\n    )\n);\n"
     }
   ],
   "specification/connector/update_pipeline/examples/request/ConnectorUpdatePipelineRequestExample1.yaml": [
@@ -10865,6 +12693,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"pipeline\":{\"extract_binary_content\":true,\"name\":\"my-connector-pipeline\",\"reduce_whitespace\":true,\"run_ml_inference\":true}}' \"$ELASTICSEARCH_URL/_connector/my-connector/_pipeline\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updatePipeline(u -> u\n    .connectorId(\"my-connector\")\n    .pipeline(p -> p\n        .extractBinaryContent(true)\n        .name(\"my-connector-pipeline\")\n        .reduceWhitespace(true)\n        .runMlInference(true)\n    )\n);\n"
     }
   ],
   "specification/connector/sync_job_get/examples/request/ConnectorSyncJobGetExample1.yaml": [
@@ -10887,6 +12719,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_connector/_sync_job/my-connector-sync-job\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().syncJobGet(s -> s\n    .connectorSyncJobId(\"my-connector-sync-job\")\n);\n"
     }
   ],
   "specification/connector/sync_job_update_stats/examples/request/ConnectorSyncJobUpdateStatsExample1.yaml": [
@@ -10909,6 +12745,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"deleted_document_count\":10,\"indexed_document_count\":20,\"indexed_document_volume\":1000,\"total_document_count\":2000,\"last_seen\":\"2023-01-02T10:00:00Z\"}' \"$ELASTICSEARCH_URL/_connector/_sync_job/my-connector-sync-job/_stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().syncJobUpdateStats(s -> s\n    .connectorSyncJobId(\"my-connector-sync-job\")\n    .deletedDocumentCount(10L)\n    .indexedDocumentCount(20L)\n    .indexedDocumentVolume(1000L)\n    .lastSeen(l -> l\n        .time(\"2023-01-02T10:00:00Z\")\n    )\n    .totalDocumentCount(2000)\n);\n"
     }
   ],
   "specification/connector/sync_job_post/examples/request/SyncJobPostRequestExample1.yaml": [
@@ -10931,6 +12771,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"id\":\"connector-id\",\"job_type\":\"full\",\"trigger_method\":\"on_demand\"}' \"$ELASTICSEARCH_URL/_connector/_sync_job\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().syncJobPost(s -> s\n    .id(\"connector-id\")\n    .jobType(SyncJobType.Full)\n    .triggerMethod(SyncJobTriggerMethod.OnDemand)\n);\n"
     }
   ],
   "specification/connector/delete/examples/request/ConnectorDeleteExample1.yaml": [
@@ -10953,6 +12797,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_connector/my-connector-id&delete_sync_jobs=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().delete(d -> d\n    .connectorId(\"my-connector-id&delete_sync_jobs=true\")\n);\n"
     }
   ],
   "specification/connector/put/examples/request/ConnectorPutRequestExample2.yaml": [
@@ -10975,6 +12823,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_name\":\"search-google-drive\",\"name\":\"My Connector\",\"description\":\"My Connector to sync data to Elastic index from Google Drive\",\"service_type\":\"google_drive\",\"language\":\"english\"}' \"$ELASTICSEARCH_URL/_connector/my-connector\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().put(p -> p\n    .connectorId(\"my-connector\")\n    .description(\"My Connector to sync data to Elastic index from Google Drive\")\n    .indexName(\"search-google-drive\")\n    .language(\"english\")\n    .name(\"My Connector\")\n    .serviceType(\"google_drive\")\n);\n"
     }
   ],
   "specification/connector/put/examples/request/ConnectorPutRequestExample1.yaml": [
@@ -10997,6 +12849,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_name\":\"search-google-drive\",\"name\":\"My Connector\",\"service_type\":\"google_drive\"}' \"$ELASTICSEARCH_URL/_connector/my-connector\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().put(p -> p\n    .connectorId(\"my-connector\")\n    .indexName(\"search-google-drive\")\n    .name(\"My Connector\")\n    .serviceType(\"google_drive\")\n);\n"
     }
   ],
   "specification/connector/update_features/examples/request/ConnectorUpdateFeaturesRequestExample2.yaml": [
@@ -11019,6 +12875,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"features\":{\"document_level_security\":{\"enabled\":true}}}' \"$ELASTICSEARCH_URL/_connector/my-connector/_features\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateFeatures(u -> u\n    .connectorId(\"my-connector\")\n    .features(f -> f\n        .documentLevelSecurity(d -> d\n            .enabled(true)\n        )\n    )\n);\n"
     }
   ],
   "specification/connector/update_features/examples/request/ConnectorUpdateFeaturesRequestExample1.yaml": [
@@ -11041,6 +12901,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"features\":{\"document_level_security\":{\"enabled\":true},\"incremental_sync\":{\"enabled\":true},\"sync_rules\":{\"advanced\":{\"enabled\":false},\"basic\":{\"enabled\":true}}}}' \"$ELASTICSEARCH_URL/_connector/my-connector/_features\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateFeatures(u -> u\n    .connectorId(\"my-connector\")\n    .features(f -> f\n        .documentLevelSecurity(d -> d\n            .enabled(true)\n        )\n        .incrementalSync(i -> i\n            .enabled(true)\n        )\n        .syncRules(s -> s\n            .advanced(a -> a\n                .enabled(false)\n            )\n            .basic(b -> b\n                .enabled(true)\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/connector/update_configuration/examples/request/ConnectorUpdateConfigurationRequestExample1.yaml": [
@@ -11063,6 +12927,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"values\":{\"tenant_id\":\"my-tenant-id\",\"tenant_name\":\"my-sharepoint-site\",\"client_id\":\"foo\",\"secret_value\":\"bar\",\"site_collections\":\"*\"}}' \"$ELASTICSEARCH_URL/_connector/my-spo-connector/_configuration\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateConfiguration(u -> u\n    .connectorId(\"my-spo-connector\")\n    .values(Map.of(\"tenant_id\", JsonData.fromJson(\"\\\"my-tenant-id\\\"\"),\"tenant_name\", JsonData.fromJson(\"\\\"my-sharepoint-site\\\"\"),\"secret_value\", JsonData.fromJson(\"\\\"bar\\\"\"),\"client_id\", JsonData.fromJson(\"\\\"foo\\\"\"),\"site_collections\", JsonData.fromJson(\"\\\"*\\\"\")))\n);\n"
     }
   ],
   "specification/connector/update_configuration/examples/request/ConnectorUpdateConfigurationRequestExample2.yaml": [
@@ -11085,6 +12953,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"values\":{\"secret_value\":\"foo-bar\"}}' \"$ELASTICSEARCH_URL/_connector/my-spo-connector/_configuration\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateConfiguration(u -> u\n    .connectorId(\"my-spo-connector\")\n    .values(\"secret_value\", JsonData.fromJson(\"\\\"foo-bar\\\"\"))\n);\n"
     }
   ],
   "specification/connector/sync_job_check_in/examples/request/ConnectorSyncJobCheckInExample1.yaml": [
@@ -11107,6 +12979,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_connector/_sync_job/my-connector-sync-job/_check_in\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().syncJobCheckIn(s -> s\n    .connectorSyncJobId(\"my-connector-sync-job\")\n);\n"
     }
   ],
   "specification/connector/get/examples/request/ConnectorGetExample1.yaml": [
@@ -11129,6 +13005,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_connector/my-connector-id\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().get(g -> g\n    .connectorId(\"my-connector-id\")\n);\n"
     }
   ],
   "specification/connector/sync_job_error/examples/request/SyncJobErrorRequestExample1.yaml": [
@@ -11151,6 +13031,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"error\":\"some-error\"}' \"$ELASTICSEARCH_URL/_connector/_sync_job/my-connector-sync-job/_error\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().syncJobError(s -> s\n    .connectorSyncJobId(\"my-connector-sync-job\")\n    .error(\"some-error\")\n);\n"
     }
   ],
   "specification/connector/sync_job_claim/examples/request/ConnectorSyncJobClaimExample1.yaml": [
@@ -11173,6 +13057,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"worker_hostname\":\"some-machine\"}' \"$ELASTICSEARCH_URL/_connector/_sync_job/my-connector-sync-job-id/_claim\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().syncJobClaim(s -> s\n    .connectorSyncJobId(\"my-connector-sync-job-id\")\n    .workerHostname(\"some-machine\")\n);\n"
     }
   ],
   "specification/connector/list/examples/request/ConnectorListExample1.yaml": [
@@ -11195,6 +13083,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_connector\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().list(l -> l);\n"
     }
   ],
   "specification/connector/update_error/examples/request/ConnectorUpdateErrorRequestExample1.yaml": [
@@ -11217,6 +13109,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"error\":\"Houston, we have a problem!\"}' \"$ELASTICSEARCH_URL/_connector/my-connector/_error\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateError(u -> u\n    .connectorId(\"my-connector\")\n    .error(\"Houston, we have a problem!\")\n);\n"
     }
   ],
   "specification/connector/sync_job_list/examples/request/ConnectorSyncJobListExample1.yaml": [
@@ -11239,6 +13135,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_connector/_sync_job?connector_id=my-connector-id&size=1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().syncJobList(s -> s\n    .connectorId(\"my-connector-id\")\n    .size(1)\n);\n"
     }
   ],
   "specification/connector/update_index_name/examples/request/ConnectorUpdateIndexNameRequestExample1.yaml": [
@@ -11261,6 +13161,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"index_name\":\"data-from-my-google-drive\"}' \"$ELASTICSEARCH_URL/_connector/my-connector/_index_name\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateIndexName(u -> u\n    .connectorId(\"my-connector\")\n    .indexName(\"data-from-my-google-drive\")\n);\n"
     }
   ],
   "specification/connector/update_api_key_id/examples/request/ConnectorUpdateApiKeyIDRequestExample1.yaml": [
@@ -11283,6 +13187,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"api_key_id\":\"my-api-key-id\",\"api_key_secret_id\":\"my-connector-secret-id\"}' \"$ELASTICSEARCH_URL/_connector/my-connector/_api_key_id\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateApiKeyId(u -> u\n    .apiKeyId(\"my-api-key-id\")\n    .apiKeySecretId(\"my-connector-secret-id\")\n    .connectorId(\"my-connector\")\n);\n"
     }
   ],
   "specification/connector/check_in/examples/request/ConnectorCheckInExample1.yaml": [
@@ -11305,6 +13213,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_connector/my-connector/_check_in\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().checkIn(c -> c\n    .connectorId(\"my-connector\")\n);\n"
     }
   ],
   "specification/connector/update_status/examples/request/ConnectorUpdateStatusRequestExample1.yaml": [
@@ -11327,6 +13239,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"status\":\"needs_configuration\"}' \"$ELASTICSEARCH_URL/_connector/my-connector/_status\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateStatus(u -> u\n    .connectorId(\"my-connector\")\n    .status(ConnectorStatus.NeedsConfiguration)\n);\n"
     }
   ],
   "specification/connector/sync_job_cancel/examples/request/ConnectorSyncJobCancelExample1.yaml": [
@@ -11349,6 +13265,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_connector/_sync_job/my-connector-sync-job-id/_cancel\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().syncJobCancel(s -> s\n    .connectorSyncJobId(\"my-connector-sync-job-id\")\n);\n"
     }
   ],
   "specification/connector/sync_job_delete/examples/request/ConnectorSyncJobDeleteExample1.yaml": [
@@ -11371,6 +13291,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_connector/_sync_job/my-connector-sync-job-id\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().syncJobDelete(s -> s\n    .connectorSyncJobId(\"my-connector-sync-job-id\")\n);\n"
     }
   ],
   "specification/connector/update_name/examples/request/ConnectorUpdateNameRequestExample1.yaml": [
@@ -11393,6 +13317,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"name\":\"Custom connector\",\"description\":\"This is my customized connector\"}' \"$ELASTICSEARCH_URL/_connector/my-connector/_name\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateName(u -> u\n    .connectorId(\"my-connector\")\n    .description(\"This is my customized connector\")\n    .name(\"Custom connector\")\n);\n"
     }
   ],
   "specification/connector/last_sync/examples/request/ConnectorUpdateLastSyncRequestExample1.yaml": [
@@ -11437,6 +13365,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"advanced_snippet\":{\"value\":[{\"tables\":[\"users\",\"orders\"],\"query\":\"SELECT users.id AS id, orders.order_id AS order_id FROM users JOIN orders ON users.id = orders.user_id\"}]}}' \"$ELASTICSEARCH_URL/_connector/my-sql-connector/_filtering\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateFiltering(u -> u\n    .advancedSnippet(a -> a\n        .value(JsonData.fromJson(\"[{\\\"tables\\\":[\\\"users\\\",\\\"orders\\\"],\\\"query\\\":\\\"SELECT users.id AS id, orders.order_id AS order_id FROM users JOIN orders ON users.id = orders.user_id\\\"}]\"))\n    )\n    .connectorId(\"my-sql-connector\")\n);\n"
     }
   ],
   "specification/connector/update_filtering/examples/request/ConnectorUpdateFilteringRequestExample1.yaml": [
@@ -11459,6 +13391,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"rules\":[{\"field\":\"file_extension\",\"id\":\"exclude-txt-files\",\"order\":0,\"policy\":\"exclude\",\"rule\":\"equals\",\"value\":\"txt\"},{\"field\":\"_\",\"id\":\"DEFAULT\",\"order\":1,\"policy\":\"include\",\"rule\":\"regex\",\"value\":\".*\"}]}' \"$ELASTICSEARCH_URL/_connector/my-g-drive-connector/_filtering\""
+    },
+    {
+      "language": "Java",
+      "code": "client.connector().updateFiltering(u -> u\n    .connectorId(\"my-g-drive-connector\")\n    .rules(List.of(FilteringRule.of(f -> f\n            .field(\"file_extension\")\n            .id(\"exclude-txt-files\")\n            .order(0)\n            .policy(FilteringPolicy.Exclude)\n            .rule(FilteringRuleRule.Equals)\n            .value(\"txt\")),FilteringRule.of(f -> f\n            .field(\"_\")\n            .id(\"DEFAULT\")\n            .order(1)\n            .policy(FilteringPolicy.Include)\n            .rule(FilteringRuleRule.Regex)\n            .value(\".*\"))))\n);\n"
     }
   ],
   "specification/inference/put_mistral/examples/request/PutMistralRequestExample1.yaml": [
@@ -11481,6 +13417,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"mistral\",\"service_settings\":{\"api_key\":\"Mistral-API-Key\",\"model\":\"mistral-embed\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/mistral-embeddings-test\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"mistral-embeddings-test\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"mistral\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Mistral-API-Key\\\",\\\"model\\\":\\\"mistral-embed\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/chat_completion_unified/examples/request/PostChatCompletionRequestExample1.yaml": [
@@ -11503,6 +13443,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"model\":\"gpt-4o\",\"messages\":[{\"role\":\"user\",\"content\":\"What is Elastic?\"}]}' \"$ELASTICSEARCH_URL/_inference/chat_completion/openai-completion/_stream\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().chatCompletionUnified(c -> c\n    .inferenceId(\"openai-completion\")\n    .chatCompletionRequest(ch -> ch\n        .messages(m -> m\n            .content(co -> co\n                .string(\"What is Elastic?\")\n            )\n            .role(\"user\")\n        )\n        .model(\"gpt-4o\")\n    )\n);\n"
     }
   ],
   "specification/inference/chat_completion_unified/examples/request/PostChatCompletionRequestExample3.yaml": [
@@ -11525,6 +13469,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What'\"'\"'s the price of a scarf?\"}]}],\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_current_price\",\"description\":\"Get the current price of a item\",\"parameters\":{\"type\":\"object\",\"properties\":{\"item\":{\"id\":\"123\"}}}}}],\"tool_choice\":{\"type\":\"function\",\"function\":{\"name\":\"get_current_price\"}}}' \"$ELASTICSEARCH_URL/_inference/chat_completion/openai-completion/_stream\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().chatCompletionUnified(c -> c\n    .inferenceId(\"openai-completion\")\n    .chatCompletionRequest(ch -> ch\n        .messages(m -> m\n            .content(co -> co\n                .object(o -> o\n                    .text(\"What's the price of a scarf?\")\n                    .type(\"text\")\n                )\n            )\n            .role(\"user\")\n        )\n        .toolChoice(t -> t\n            .object(o -> o\n                .type(\"function\")\n                .function(f -> f\n                    .name(\"get_current_price\")\n                )\n            )\n        )\n        .tools(to -> to\n            .type(\"function\")\n            .function(f -> f\n                .description(\"Get the current price of a item\")\n                .name(\"get_current_price\")\n                .parameters(JsonData.fromJson(\"{\\\"type\\\":\\\"object\\\",\\\"properties\\\":{\\\"item\\\":{\\\"id\\\":\\\"123\\\"}}}\"))\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/inference/chat_completion_unified/examples/request/PostChatCompletionRequestExample2.yaml": [
@@ -11547,28 +13495,36 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"messages\":[{\"role\":\"assistant\",\"content\":\"Let'\"'\"'s find out what the weather is\",\"tool_calls\":[{\"id\":\"call_KcAjWtAww20AihPHphUh46Gd\",\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\",\"arguments\":\"{\\\"location\\\":\\\"Boston, MA\\\"}\"}}]},{\"role\":\"tool\",\"content\":\"The weather is cold\",\"tool_call_id\":\"call_KcAjWtAww20AihPHphUh46Gd\"}]}' \"$ELASTICSEARCH_URL/_inference/chat_completion/openai-completion/_stream\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().chatCompletionUnified(c -> c\n    .inferenceId(\"openai-completion\")\n    .chatCompletionRequest(ch -> ch\n        .messages(List.of(Message.of(m -> m\n                .content(co -> co\n                    .string(\"Let's find out what the weather is\")\n                )\n                .role(\"assistant\")\n                .toolCalls(t -> t\n                    .id(\"call_KcAjWtAww20AihPHphUh46Gd\")\n                    .function(f -> f\n                        .arguments(\"{\"location\":\"Boston, MA\"}\")\n                        .name(\"get_current_weather\")\n                    )\n                    .type(\"function\")\n                )),Message.of(me -> me\n                .content(co -> co\n                    .string(\"The weather is cold\")\n                )\n                .role(\"tool\")\n                .toolCallId(\"call_KcAjWtAww20AihPHphUh46Gd\"))))\n    )\n);\n"
     }
   ],
   "specification/inference/text_embedding/examples/request/TextEmbeddingRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.inference.text_embedding(\n    inference_id=\"my-cohere-endpoint\",\n    input=\"The sky above the port was the color of television tuned to a dead channel.\",\n    task_settings={\n        \"input_type\": \"ingest\"\n    },\n)"
+      "code": "resp = client.inference.text_embedding(\n    inference_id=\"my-cohere-endpoint\",\n    input=\"The sky above the port was the color of television tuned to a dead channel.\",\n    input_type=\"ingest\",\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.inference.textEmbedding({\n  inference_id: \"my-cohere-endpoint\",\n  input:\n    \"The sky above the port was the color of television tuned to a dead channel.\",\n  task_settings: {\n    input_type: \"ingest\",\n  },\n});"
+      "code": "const response = await client.inference.textEmbedding({\n  inference_id: \"my-cohere-endpoint\",\n  input:\n    \"The sky above the port was the color of television tuned to a dead channel.\",\n  input_type: \"ingest\",\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.inference.text_embedding(\n  inference_id: \"my-cohere-endpoint\",\n  body: {\n    \"input\": \"The sky above the port was the color of television tuned to a dead channel.\",\n    \"task_settings\": {\n      \"input_type\": \"ingest\"\n    }\n  }\n)"
+      "code": "response = client.inference.text_embedding(\n  inference_id: \"my-cohere-endpoint\",\n  body: {\n    \"input\": \"The sky above the port was the color of television tuned to a dead channel.\",\n    \"input_type\": \"ingest\"\n  }\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->inference()->textEmbedding([\n    \"inference_id\" => \"my-cohere-endpoint\",\n    \"body\" => [\n        \"input\" => \"The sky above the port was the color of television tuned to a dead channel.\",\n        \"task_settings\" => [\n            \"input_type\" => \"ingest\",\n        ],\n    ],\n]);"
+      "code": "$resp = $client->inference()->textEmbedding([\n    \"inference_id\" => \"my-cohere-endpoint\",\n    \"body\" => [\n        \"input\" => \"The sky above the port was the color of television tuned to a dead channel.\",\n        \"input_type\" => \"ingest\",\n    ],\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":\"The sky above the port was the color of television tuned to a dead channel.\",\"task_settings\":{\"input_type\":\"ingest\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/my-cohere-endpoint\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":\"The sky above the port was the color of television tuned to a dead channel.\",\"input_type\":\"ingest\"}' \"$ELASTICSEARCH_URL/_inference/text_embedding/my-cohere-endpoint\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().textEmbedding(t -> t\n    .inferenceId(\"my-cohere-endpoint\")\n    .input(\"The sky above the port was the color of television tuned to a dead channel.\")\n    .inputType(\"ingest\")\n);\n"
     }
   ],
   "specification/inference/put_jinaai/examples/request/PutJinaAiRequestExample1.yaml": [
@@ -11591,6 +13547,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"jinaai\",\"service_settings\":{\"model_id\":\"jina-embeddings-v3\",\"api_key\":\"JinaAi-Api-key\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/jinaai-embeddings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"jinaai-embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"jinaai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"model_id\\\":\\\"jina-embeddings-v3\\\",\\\"api_key\\\":\\\"JinaAi-Api-key\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_jinaai/examples/request/PutJinaAiRequestExample2.yaml": [
@@ -11613,72 +13573,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"jinaai\",\"service_settings\":{\"api_key\":\"JinaAI-Api-key\",\"model_id\":\"jina-reranker-v2-base-multilingual\"},\"task_settings\":{\"top_n\":10,\"return_documents\":true}}' \"$ELASTICSEARCH_URL/_inference/rerank/jinaai-rerank\""
-    }
-  ],
-  "specification/inference/put_llama/examples/request/PutLlamaRequestExample3.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"chat-completion\",\n    inference_id=\"llama-chat-completion\",\n    inference_config={\n        \"service\": \"llama\",\n        \"service_settings\": {\n            \"url\": \"http://localhost:8321/v1/openai/v1/chat/completions\",\n            \"model_id\": \"llama3.2:3b\"\n        }\n    },\n)"
     },
     {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"chat-completion\",\n  inference_id: \"llama-chat-completion\",\n  inference_config: {\n    service: \"llama\",\n    service_settings: {\n      url: \"http://localhost:8321/v1/openai/v1/chat/completions\",\n      model_id: \"llama3.2:3b\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"chat-completion\",\n  inference_id: \"llama-chat-completion\",\n  body: {\n    \"service\": \"llama\",\n    \"service_settings\": {\n      \"url\": \"http://localhost:8321/v1/openai/v1/chat/completions\",\n      \"model_id\": \"llama3.2:3b\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"chat-completion\",\n    \"inference_id\" => \"llama-chat-completion\",\n    \"body\" => [\n        \"service\" => \"llama\",\n        \"service_settings\" => [\n            \"url\" => \"http://localhost:8321/v1/openai/v1/chat/completions\",\n            \"model_id\" => \"llama3.2:3b\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"llama\",\"service_settings\":{\"url\":\"http://localhost:8321/v1/openai/v1/chat/completions\",\"model_id\":\"llama3.2:3b\"}}' \"$ELASTICSEARCH_URL/_inference/chat-completion/llama-chat-completion\""
-    }
-  ],
-  "specification/inference/put_llama/examples/request/PutLlamaRequestExample2.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"llama-completion\",\n    inference_config={\n        \"service\": \"llama\",\n        \"service_settings\": {\n            \"url\": \"http://localhost:8321/v1/openai/v1/chat/completions\",\n            \"model_id\": \"llama3.2:3b\"\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"llama-completion\",\n  inference_config: {\n    service: \"llama\",\n    service_settings: {\n      url: \"http://localhost:8321/v1/openai/v1/chat/completions\",\n      model_id: \"llama3.2:3b\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"llama-completion\",\n  body: {\n    \"service\": \"llama\",\n    \"service_settings\": {\n      \"url\": \"http://localhost:8321/v1/openai/v1/chat/completions\",\n      \"model_id\": \"llama3.2:3b\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"llama-completion\",\n    \"body\" => [\n        \"service\" => \"llama\",\n        \"service_settings\" => [\n            \"url\" => \"http://localhost:8321/v1/openai/v1/chat/completions\",\n            \"model_id\" => \"llama3.2:3b\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"llama\",\"service_settings\":{\"url\":\"http://localhost:8321/v1/openai/v1/chat/completions\",\"model_id\":\"llama3.2:3b\"}}' \"$ELASTICSEARCH_URL/_inference/completion/llama-completion\""
-    }
-  ],
-  "specification/inference/put_llama/examples/request/PutLlamaRequestExample1.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"llama-text-embedding\",\n    inference_config={\n        \"service\": \"llama\",\n        \"service_settings\": {\n            \"url\": \"http://localhost:8321/v1/inference/embeddings\",\n            \"dimensions\": 384,\n            \"model_id\": \"all-MiniLM-L6-v2\"\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"llama-text-embedding\",\n  inference_config: {\n    service: \"llama\",\n    service_settings: {\n      url: \"http://localhost:8321/v1/inference/embeddings\",\n      dimensions: 384,\n      model_id: \"all-MiniLM-L6-v2\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"llama-text-embedding\",\n  body: {\n    \"service\": \"llama\",\n    \"service_settings\": {\n      \"url\": \"http://localhost:8321/v1/inference/embeddings\",\n      \"dimensions\": 384,\n      \"model_id\": \"all-MiniLM-L6-v2\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"llama-text-embedding\",\n    \"body\" => [\n        \"service\" => \"llama\",\n        \"service_settings\" => [\n            \"url\" => \"http://localhost:8321/v1/inference/embeddings\",\n            \"dimensions\" => 384,\n            \"model_id\" => \"all-MiniLM-L6-v2\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"llama\",\"service_settings\":{\"url\":\"http://localhost:8321/v1/inference/embeddings\",\"dimensions\":384,\"model_id\":\"all-MiniLM-L6-v2\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/llama-text-embedding\""
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"jinaai-rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"jinaai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"JinaAI-Api-key\\\",\\\"model_id\\\":\\\"jina-reranker-v2-base-multilingual\\\"}\"))\n        .taskSettings(JsonData.fromJson(\"{\\\"top_n\\\":10,\\\"return_documents\\\":true}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/update/examples/request/InferenceUpdateExample1.yaml": [
@@ -11723,6 +13621,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elser\",\"service_settings\":{\"num_allocations\":1,\"num_threads\":1}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/my-elser-model\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"my-elser-model\")\n    .taskType(TaskType.SparseEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"elser\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"num_allocations\\\":1,\\\"num_threads\\\":1}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_elser/examples/request/PutElserRequestExample2.yaml": [
@@ -11745,116 +13647,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elser\",\"service_settings\":{\"adaptive_allocations\":{\"enabled\":true,\"min_number_of_allocations\":3,\"max_number_of_allocations\":10},\"num_threads\":1}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/my-elser-model\""
-    }
-  ],
-  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample1.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"amazon_sagemaker_embeddings\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\",\n            \"dimensions\": 384,\n            \"element_type\": \"float\"\n        }\n    },\n)"
     },
     {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"amazon_sagemaker_embeddings\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n      dimensions: 384,\n      element_type: \"float\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"amazon_sagemaker_embeddings\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\",\n      \"dimensions\": 384,\n      \"element_type\": \"float\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"amazon_sagemaker_embeddings\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n            \"dimensions\" => 384,\n            \"element_type\" => \"float\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\",\"dimensions\":384,\"element_type\":\"float\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/amazon_sagemaker_embeddings\""
-    }
-  ],
-  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample2.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"amazon_sagemaker_completion\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\"\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"amazon_sagemaker_completion\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"amazon_sagemaker_completion\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"amazon_sagemaker_completion\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/completion/amazon_sagemaker_completion\""
-    }
-  ],
-  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample3.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"chat_completion\",\n    inference_id=\"amazon_sagemaker_chat_completion\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\"\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"chat_completion\",\n  inference_id: \"amazon_sagemaker_chat_completion\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"chat_completion\",\n  inference_id: \"amazon_sagemaker_chat_completion\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"chat_completion\",\n    \"inference_id\" => \"amazon_sagemaker_chat_completion\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/chat_completion/amazon_sagemaker_chat_completion\""
-    }
-  ],
-  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample4.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"sparse_embedding\",\n    inference_id=\"amazon_sagemaker_sparse_embedding\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\"\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"sparse_embedding\",\n  inference_id: \"amazon_sagemaker_sparse_embedding\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"sparse_embedding\",\n  inference_id: \"amazon_sagemaker_sparse_embedding\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"sparse_embedding\",\n    \"inference_id\" => \"amazon_sagemaker_sparse_embedding\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/amazon_sagemaker_sparse_embedding\""
-    }
-  ],
-  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample5.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"amazon_sagemaker_rerank\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\"\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"amazon_sagemaker_rerank\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"amazon_sagemaker_rerank\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"amazon_sagemaker_rerank\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/amazon_sagemaker_rerank\""
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"my-elser-model\")\n    .taskType(TaskType.SparseEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"elser\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"adaptive_allocations\\\":{\\\"enabled\\\":true,\\\"min_number_of_allocations\\\":3,\\\"max_number_of_allocations\\\":10},\\\"num_threads\\\":1}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/delete/examples/request/InferenceDeleteExample1.yaml": [
@@ -11877,50 +13673,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_inference/sparse_embedding/my-elser-model\""
-    }
-  ],
-  "specification/inference/put_ai21/examples/request/PutAi21RequestExample1.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"ai21-completion\",\n    inference_config={\n        \"service\": \"ai21\",\n        \"service_settings\": {\n            \"api_key\": \"ai21-api-key\",\n            \"model_id\": \"jamba-large\"\n        }\n    },\n)"
     },
     {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"ai21-completion\",\n  inference_config: {\n    service: \"ai21\",\n    service_settings: {\n      api_key: \"ai21-api-key\",\n      model_id: \"jamba-large\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"ai21-completion\",\n  body: {\n    \"service\": \"ai21\",\n    \"service_settings\": {\n      \"api_key\": \"ai21-api-key\",\n      \"model_id\": \"jamba-large\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"ai21-completion\",\n    \"body\" => [\n        \"service\" => \"ai21\",\n        \"service_settings\" => [\n            \"api_key\" => \"ai21-api-key\",\n            \"model_id\" => \"jamba-large\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"ai21\",\"service_settings\":{\"api_key\":\"ai21-api-key\",\"model_id\":\"jamba-large\"}}' \"$ELASTICSEARCH_URL/_inference/completion/ai21-completion\""
-    }
-  ],
-  "specification/inference/put_ai21/examples/request/PutAi21RequestExample2.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"chat-completion\",\n    inference_id=\"ai21-chat-completion\",\n    inference_config={\n        \"service\": \"ai21\",\n        \"service_settings\": {\n            \"api_key\": \"ai21-api-key\",\n            \"model_id\": \"jamba-mini\"\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"chat-completion\",\n  inference_id: \"ai21-chat-completion\",\n  inference_config: {\n    service: \"ai21\",\n    service_settings: {\n      api_key: \"ai21-api-key\",\n      model_id: \"jamba-mini\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"chat-completion\",\n  inference_id: \"ai21-chat-completion\",\n  body: {\n    \"service\": \"ai21\",\n    \"service_settings\": {\n      \"api_key\": \"ai21-api-key\",\n      \"model_id\": \"jamba-mini\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"chat-completion\",\n    \"inference_id\" => \"ai21-chat-completion\",\n    \"body\" => [\n        \"service\" => \"ai21\",\n        \"service_settings\" => [\n            \"api_key\" => \"ai21-api-key\",\n            \"model_id\" => \"jamba-mini\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"ai21\",\"service_settings\":{\"api_key\":\"ai21-api-key\",\"model_id\":\"jamba-mini\"}}' \"$ELASTICSEARCH_URL/_inference/chat-completion/ai21-chat-completion\""
+      "language": "Java",
+      "code": "client.inference().delete(d -> d\n    .inferenceId(\"my-elser-model\")\n    .taskType(TaskType.SparseEmbedding)\n);\n"
     }
   ],
   "specification/inference/put_cohere/examples/request/PutCohereRequestExample1.yaml": [
@@ -11943,28 +13699,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"cohere\",\"service_settings\":{\"api_key\":\"Cohere-Api-key\",\"model_id\":\"embed-english-light-v3.0\",\"embedding_type\":\"byte\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/cohere-embeddings\""
-    }
-  ],
-  "specification/inference/put_cohere/examples/request/PutCohereRequestExample3.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"cohere-completion\",\n    inference_config={\n        \"service\": \"cohere\",\n        \"service_settings\": {\n            \"api_key\": \"Cohere-API-key\",\n            \"model_id\": \"command-a-03-2025\"\n        }\n    },\n)"
     },
     {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"cohere-completion\",\n  inference_config: {\n    service: \"cohere\",\n    service_settings: {\n      api_key: \"Cohere-API-key\",\n      model_id: \"command-a-03-2025\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"cohere-completion\",\n  body: {\n    \"service\": \"cohere\",\n    \"service_settings\": {\n      \"api_key\": \"Cohere-API-key\",\n      \"model_id\": \"command-a-03-2025\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"cohere-completion\",\n    \"body\" => [\n        \"service\" => \"cohere\",\n        \"service_settings\" => [\n            \"api_key\" => \"Cohere-API-key\",\n            \"model_id\" => \"command-a-03-2025\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"cohere\",\"service_settings\":{\"api_key\":\"Cohere-API-key\",\"model_id\":\"command-a-03-2025\"}}' \"$ELASTICSEARCH_URL/_inference/completion/cohere-completion\""
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"cohere-embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"cohere\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Cohere-Api-key\\\",\\\"model_id\\\":\\\"embed-english-light-v3.0\\\",\\\"embedding_type\\\":\\\"byte\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_cohere/examples/request/PutCohereRequestExample2.yaml": [
@@ -11987,6 +13725,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"cohere\",\"service_settings\":{\"api_key\":\"Cohere-API-key\",\"model_id\":\"rerank-english-v3.0\"},\"task_settings\":{\"top_n\":10,\"return_documents\":true}}' \"$ELASTICSEARCH_URL/_inference/rerank/cohere-rerank\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"cohere-rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"cohere\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Cohere-API-key\\\",\\\"model_id\\\":\\\"rerank-english-v3.0\\\"}\"))\n        .taskSettings(JsonData.fromJson(\"{\\\"top_n\\\":10,\\\"return_documents\\\":true}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_googleaistudio/examples/request/PutGoogleAiStudioRequestExample1.yaml": [
@@ -12009,28 +13751,36 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"googleaistudio\",\"service_settings\":{\"api_key\":\"api-key\",\"model_id\":\"model-id\"}}' \"$ELASTICSEARCH_URL/_inference/completion/google_ai_studio_completion\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"google_ai_studio_completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"googleaistudio\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"api-key\\\",\\\"model_id\\\":\\\"model-id\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put/examples/request/InferencePutExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"my-rerank-model\",\n    inference_config={\n        \"service\": \"cohere\",\n        \"service_settings\": {\n            \"model_id\": \"rerank-english-v3.0\",\n            \"api_key\": \"{{COHERE_API_KEY}}\"\n        },\n        \"chunking_settings\": {\n            \"strategy\": \"recursive\",\n            \"max_chunk_size\": 200,\n            \"separator_group\": \"markdown\"\n        }\n    },\n)"
+      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"my-rerank-model\",\n    inference_config={\n        \"service\": \"cohere\",\n        \"service_settings\": {\n            \"model_id\": \"rerank-english-v3.0\",\n            \"api_key\": \"{{COHERE_API_KEY}}\"\n        }\n    },\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"my-rerank-model\",\n  inference_config: {\n    service: \"cohere\",\n    service_settings: {\n      model_id: \"rerank-english-v3.0\",\n      api_key: \"{{COHERE_API_KEY}}\",\n    },\n    chunking_settings: {\n      strategy: \"recursive\",\n      max_chunk_size: 200,\n      separator_group: \"markdown\",\n    },\n  },\n});"
+      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"my-rerank-model\",\n  inference_config: {\n    service: \"cohere\",\n    service_settings: {\n      model_id: \"rerank-english-v3.0\",\n      api_key: \"{{COHERE_API_KEY}}\",\n    },\n  },\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"my-rerank-model\",\n  body: {\n    \"service\": \"cohere\",\n    \"service_settings\": {\n      \"model_id\": \"rerank-english-v3.0\",\n      \"api_key\": \"{{COHERE_API_KEY}}\"\n    },\n    \"chunking_settings\": {\n      \"strategy\": \"recursive\",\n      \"max_chunk_size\": 200,\n      \"separator_group\": \"markdown\"\n    }\n  }\n)"
+      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"my-rerank-model\",\n  body: {\n    \"service\": \"cohere\",\n    \"service_settings\": {\n      \"model_id\": \"rerank-english-v3.0\",\n      \"api_key\": \"{{COHERE_API_KEY}}\"\n    }\n  }\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"my-rerank-model\",\n    \"body\" => [\n        \"service\" => \"cohere\",\n        \"service_settings\" => [\n            \"model_id\" => \"rerank-english-v3.0\",\n            \"api_key\" => \"{{COHERE_API_KEY}}\",\n        ],\n        \"chunking_settings\" => [\n            \"strategy\" => \"recursive\",\n            \"max_chunk_size\" => 200,\n            \"separator_group\" => \"markdown\",\n        ],\n    ],\n]);"
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"my-rerank-model\",\n    \"body\" => [\n        \"service\" => \"cohere\",\n        \"service_settings\" => [\n            \"model_id\" => \"rerank-english-v3.0\",\n            \"api_key\" => \"{{COHERE_API_KEY}}\",\n        ],\n    ],\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"cohere\",\"service_settings\":{\"model_id\":\"rerank-english-v3.0\",\"api_key\":\"{{COHERE_API_KEY}}\"},\"chunking_settings\":{\"strategy\":\"recursive\",\"max_chunk_size\":200,\"separator_group\":\"markdown\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/my-rerank-model\""
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"cohere\",\"service_settings\":{\"model_id\":\"rerank-english-v3.0\",\"api_key\":\"{{COHERE_API_KEY}}\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/my-rerank-model\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"my-rerank-model\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"cohere\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"model_id\\\":\\\"rerank-english-v3.0\\\",\\\"api_key\\\":\\\"{{COHERE_API_KEY}}\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_voyageai/examples/request/PutVoyageAIRequestExample2.yaml": [
@@ -12053,6 +13803,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"voyageai\",\"service_settings\":{\"model_id\":\"rerank-2\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/voyageai-rerank\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"voyageai-rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"voyageai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"model_id\\\":\\\"rerank-2\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_voyageai/examples/request/PutVoyageAIRequestExample1.yaml": [
@@ -12075,6 +13829,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"voyageai\",\"service_settings\":{\"model_id\":\"voyage-3-large\",\"dimensions\":512}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/openai-embeddings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"openai-embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"voyageai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"model_id\\\":\\\"voyage-3-large\\\",\\\"dimensions\\\":512}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_watsonx/examples/request/PutWatsonxRequestExample1.yaml": [
@@ -12097,28 +13855,36 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"watsonxai\",\"service_settings\":{\"api_key\":\"Watsonx-API-Key\",\"url\":\"Wastonx-URL\",\"model_id\":\"ibm/slate-30m-english-rtrvr\",\"project_id\":\"IBM-Cloud-ID\",\"api_version\":\"2024-03-14\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/watsonx-embeddings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"watsonx-embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"watsonxai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Watsonx-API-Key\\\",\\\"url\\\":\\\"Wastonx-URL\\\",\\\"model_id\\\":\\\"ibm/slate-30m-english-rtrvr\\\",\\\"project_id\\\":\\\"IBM-Cloud-ID\\\",\\\"api_version\\\":\\\"2024-03-14\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/completion/examples/request/CompletionRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.inference.completion(\n    inference_id=\"openai_chat_completions\",\n    input=\"What is Elastic?\",\n)"
+      "code": "resp = client.inference.completion(\n    inference_id=\"openai_completions\",\n    input=\"What is Elastic?\",\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.inference.completion({\n  inference_id: \"openai_chat_completions\",\n  input: \"What is Elastic?\",\n});"
+      "code": "const response = await client.inference.completion({\n  inference_id: \"openai_completions\",\n  input: \"What is Elastic?\",\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.inference.completion(\n  inference_id: \"openai_chat_completions\",\n  body: {\n    \"input\": \"What is Elastic?\"\n  }\n)"
+      "code": "response = client.inference.completion(\n  inference_id: \"openai_completions\",\n  body: {\n    \"input\": \"What is Elastic?\"\n  }\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->inference()->completion([\n    \"inference_id\" => \"openai_chat_completions\",\n    \"body\" => [\n        \"input\" => \"What is Elastic?\",\n    ],\n]);"
+      "code": "$resp = $client->inference()->completion([\n    \"inference_id\" => \"openai_completions\",\n    \"body\" => [\n        \"input\" => \"What is Elastic?\",\n    ],\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":\"What is Elastic?\"}' \"$ELASTICSEARCH_URL/_inference/completion/openai_chat_completions\""
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":\"What is Elastic?\"}' \"$ELASTICSEARCH_URL/_inference/completion/openai_completions\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().completion(c -> c\n    .inferenceId(\"openai_completions\")\n    .input(\"What is Elastic?\")\n);\n"
     }
   ],
   "specification/inference/get/examples/request/InferenceGetExample1.yaml": [
@@ -12141,6 +13907,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_inference/sparse_embedding/my-elser-model\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().get(g -> g\n    .inferenceId(\"my-elser-model\")\n    .taskType(TaskType.SparseEmbedding)\n);\n"
     }
   ],
   "specification/inference/put_anthropic/examples/request/PutAnthropicRequestExample1.yaml": [
@@ -12163,6 +13933,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"anthropic\",\"service_settings\":{\"api_key\":\"Anthropic-Api-Key\",\"model_id\":\"Model-ID\"},\"task_settings\":{\"max_tokens\":1024}}' \"$ELASTICSEARCH_URL/_inference/completion/anthropic_completion\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"anthropic_completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"anthropic\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Anthropic-Api-Key\\\",\\\"model_id\\\":\\\"Model-ID\\\"}\"))\n        .taskSettings(JsonData.fromJson(\"{\\\"max_tokens\\\":1024}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/sparse_embedding/examples/request/SparseEmbeddingRequestExample1.yaml": [
@@ -12185,6 +13959,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":\"The sky above the port was the color of television tuned to a dead channel.\"}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/my-elser-model\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().sparseEmbedding(s -> s\n    .inferenceId(\"my-elser-model\")\n    .input(\"The sky above the port was the color of television tuned to a dead channel.\")\n);\n"
     }
   ],
   "specification/inference/put_googlevertexai/examples/request/PutGoogleVertexAiRequestExample2.yaml": [
@@ -12207,6 +13985,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"googlevertexai\",\"service_settings\":{\"service_account_json\":\"service-account-json\",\"project_id\":\"project-id\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/google_vertex_ai_rerank\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"google_vertex_ai_rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"googlevertexai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"service_account_json\\\":\\\"service-account-json\\\",\\\"project_id\\\":\\\"project-id\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_googlevertexai/examples/request/PutGoogleVertexAiRequestExample1.yaml": [
@@ -12229,6 +14011,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"googlevertexai\",\"service_settings\":{\"service_account_json\":\"service-account-json\",\"model_id\":\"model-id\",\"location\":\"location\",\"project_id\":\"project-id\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/google_vertex_ai_embeddingss\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"google_vertex_ai_embeddingss\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"googlevertexai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"service_account_json\\\":\\\"service-account-json\\\",\\\"model_id\\\":\\\"model-id\\\",\\\"location\\\":\\\"location\\\",\\\"project_id\\\":\\\"project-id\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_hugging_face/examples/request/PutHuggingFaceRequestExample1.yaml": [
@@ -12251,6 +14037,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"hugging_face\",\"service_settings\":{\"api_key\":\"hugging-face-access-token\",\"url\":\"url-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/hugging-face-embeddings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"hugging-face-embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"hugging_face\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"hugging-face-access-token\\\",\\\"url\\\":\\\"url-endpoint\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_hugging_face/examples/request/PutHuggingFaceRequestExample2.yaml": [
@@ -12273,6 +14063,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"hugging_face\",\"service_settings\":{\"api_key\":\"hugging-face-access-token\",\"url\":\"url-endpoint\"},\"task_settings\":{\"return_documents\":true,\"top_n\":3}}' \"$ELASTICSEARCH_URL/_inference/rerank/hugging-face-rerank\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"hugging-face-rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"hugging_face\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"hugging-face-access-token\\\",\\\"url\\\":\\\"url-endpoint\\\"}\"))\n        .taskSettings(JsonData.fromJson(\"{\\\"return_documents\\\":true,\\\"top_n\\\":3}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_amazonbedrock/examples/request/PutAmazonBedrockRequestExample1.yaml": [
@@ -12295,31 +14089,13 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazonbedrock\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"provider\":\"amazontitan\",\"model\":\"amazon.titan-embed-text-v2:0\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/amazon_bedrock_embeddings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"amazon_bedrock_embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"amazonbedrock\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"access_key\\\":\\\"AWS-access-key\\\",\\\"secret_key\\\":\\\"AWS-secret-key\\\",\\\"region\\\":\\\"us-east-1\\\",\\\"provider\\\":\\\"amazontitan\\\",\\\"model\\\":\\\"amazon.titan-embed-text-v2:0\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_amazonbedrock/examples/request/PutAmazonBedrockRequestExample2.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"openai-completion\",\n    inference_config={\n        \"service\": \"openai\",\n        \"service_settings\": {\n            \"api_key\": \"OpenAI-API-Key\",\n            \"model_id\": \"gpt-3.5-turbo\"\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"openai-completion\",\n  inference_config: {\n    service: \"openai\",\n    service_settings: {\n      api_key: \"OpenAI-API-Key\",\n      model_id: \"gpt-3.5-turbo\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"openai-completion\",\n  body: {\n    \"service\": \"openai\",\n    \"service_settings\": {\n      \"api_key\": \"OpenAI-API-Key\",\n      \"model_id\": \"gpt-3.5-turbo\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"openai-completion\",\n    \"body\" => [\n        \"service\" => \"openai\",\n        \"service_settings\" => [\n            \"api_key\" => \"OpenAI-API-Key\",\n            \"model_id\" => \"gpt-3.5-turbo\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"openai\",\"service_settings\":{\"api_key\":\"OpenAI-API-Key\",\"model_id\":\"gpt-3.5-turbo\"}}' \"$ELASTICSEARCH_URL/_inference/completion/openai-completion\""
-    }
-  ],
-  "specification/inference/put_openai/examples/request/PutOpenAiRequestExample2.yaml": [
     {
       "language": "Python",
       "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"amazon_bedrock_completion\",\n    inference_config={\n        \"service\": \"amazonbedrock\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"provider\": \"amazontitan\",\n            \"model\": \"amazon.titan-text-premier-v1:0\"\n        }\n    },\n)"
@@ -12339,6 +14115,36 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazonbedrock\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"provider\":\"amazontitan\",\"model\":\"amazon.titan-text-premier-v1:0\"}}' \"$ELASTICSEARCH_URL/_inference/completion/amazon_bedrock_completion\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"amazon_bedrock_completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"amazonbedrock\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"access_key\\\":\\\"AWS-access-key\\\",\\\"secret_key\\\":\\\"AWS-secret-key\\\",\\\"region\\\":\\\"us-east-1\\\",\\\"provider\\\":\\\"amazontitan\\\",\\\"model\\\":\\\"amazon.titan-text-premier-v1:0\\\"}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_openai/examples/request/PutOpenAiRequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"openai-completion\",\n    inference_config={\n        \"service\": \"openai\",\n        \"service_settings\": {\n            \"api_key\": \"OpenAI-API-Key\",\n            \"model_id\": \"gpt-3.5-turbo\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"openai-completion\",\n  inference_config: {\n    service: \"openai\",\n    service_settings: {\n      api_key: \"OpenAI-API-Key\",\n      model_id: \"gpt-3.5-turbo\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"openai-completion\",\n  body: {\n    \"service\": \"openai\",\n    \"service_settings\": {\n      \"api_key\": \"OpenAI-API-Key\",\n      \"model_id\": \"gpt-3.5-turbo\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"openai-completion\",\n    \"body\" => [\n        \"service\" => \"openai\",\n        \"service_settings\" => [\n            \"api_key\" => \"OpenAI-API-Key\",\n            \"model_id\" => \"gpt-3.5-turbo\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"openai\",\"service_settings\":{\"api_key\":\"OpenAI-API-Key\",\"model_id\":\"gpt-3.5-turbo\"}}' \"$ELASTICSEARCH_URL/_inference/completion/openai-completion\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"openai-completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"openai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"OpenAI-API-Key\\\",\\\"model_id\\\":\\\"gpt-3.5-turbo\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_openai/examples/request/PutOpenAiRequestExample1.yaml": [
@@ -12361,6 +14167,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"openai\",\"service_settings\":{\"api_key\":\"OpenAI-API-Key\",\"model_id\":\"text-embedding-3-small\",\"dimensions\":128}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/openai-embeddings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"openai-embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"openai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"OpenAI-API-Key\\\",\\\"model_id\\\":\\\"text-embedding-3-small\\\",\\\"dimensions\\\":128}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/rerank/examples/request/RerankRequestExample1.yaml": [
@@ -12383,6 +14193,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":[\"luke\",\"like\",\"leia\",\"chewy\",\"r2d2\",\"star\",\"wars\"],\"query\":\"star wars main character\"}' \"$ELASTICSEARCH_URL/_inference/rerank/cohere_rerank\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().rerank(r -> r\n    .inferenceId(\"cohere_rerank\")\n    .input(List.of(\"luke\",\"like\",\"leia\",\"chewy\",\"r2d2\",\"star\",\"wars\"))\n    .query(\"star wars main character\")\n);\n"
     }
   ],
   "specification/inference/rerank/examples/request/RerankRequestExample2.yaml": [
@@ -12405,6 +14219,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":[\"luke\",\"like\",\"leia\",\"chewy\",\"r2d2\",\"star\",\"wars\"],\"query\":\"star wars main character\",\"return_documents\":false,\"top_n\":2}' \"$ELASTICSEARCH_URL/_inference/rerank/bge-reranker-base-mkn\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().rerank(r -> r\n    .inferenceId(\"bge-reranker-base-mkn\")\n    .input(List.of(\"luke\",\"like\",\"leia\",\"chewy\",\"r2d2\",\"star\",\"wars\"))\n    .query(\"star wars main character\")\n);\n"
     }
   ],
   "specification/inference/rerank/examples/request/RerankRequestExample3.yaml": [
@@ -12427,6 +14245,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":[\"luke\",\"like\",\"leia\",\"chewy\",\"r2d2\",\"star\",\"wars\"],\"query\":\"star wars main character\",\"return_documents\":true,\"top_n\":3}' \"$ELASTICSEARCH_URL/_inference/rerank/bge-reranker-base-mkn\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().rerank(r -> r\n    .inferenceId(\"bge-reranker-base-mkn\")\n    .input(List.of(\"luke\",\"like\",\"leia\",\"chewy\",\"r2d2\",\"star\",\"wars\"))\n    .query(\"star wars main character\")\n);\n"
     }
   ],
   "specification/inference/put_alibabacloud/examples/request/PutAlibabaCloudRequestExample4.yaml": [
@@ -12449,6 +14271,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"alibabacloud-ai-search\",\"service_settings\":{\"api_key\":\"AlibabaCloud-API-Key\",\"service_id\":\"ops-text-embedding-001\",\"host\":\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\"workspace\":\"default\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/alibabacloud_ai_search_embeddings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"alibabacloud_ai_search_embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"alibabacloud-ai-search\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"AlibabaCloud-API-Key\\\",\\\"service_id\\\":\\\"ops-text-embedding-001\\\",\\\"host\\\":\\\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\\\",\\\"workspace\\\":\\\"default\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_alibabacloud/examples/request/PutAlibabaCloudRequestExample3.yaml": [
@@ -12471,6 +14297,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"alibabacloud-ai-search\",\"service_settings\":{\"api_key\":\"AlibabaCloud-API-Key\",\"service_id\":\"ops-text-sparse-embedding-001\",\"host\":\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\"workspace\":\"default\"}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/alibabacloud_ai_search_sparse\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"alibabacloud_ai_search_sparse\")\n    .taskType(TaskType.SparseEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"alibabacloud-ai-search\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"AlibabaCloud-API-Key\\\",\\\"service_id\\\":\\\"ops-text-sparse-embedding-001\\\",\\\"host\\\":\\\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\\\",\\\"workspace\\\":\\\"default\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_alibabacloud/examples/request/PutAlibabaCloudRequestExample2.yaml": [
@@ -12493,6 +14323,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"alibabacloud-ai-search\",\"service_settings\":{\"api_key\":\"AlibabaCloud-API-Key\",\"service_id\":\"ops-bge-reranker-larger\",\"host\":\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\"workspace\":\"default\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/alibabacloud_ai_search_rerank\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"alibabacloud_ai_search_rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"alibabacloud-ai-search\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"AlibabaCloud-API-Key\\\",\\\"service_id\\\":\\\"ops-bge-reranker-larger\\\",\\\"host\\\":\\\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\\\",\\\"workspace\\\":\\\"default\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_alibabacloud/examples/request/PutAlibabaCloudRequestExample1.yaml": [
@@ -12515,6 +14349,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"alibabacloud-ai-search\",\"service_settings\":{\"host\":\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\",\"api_key\":\"AlibabaCloud-API-Key\",\"service_id\":\"ops-qwen-turbo\",\"workspace\":\"default\"}}' \"$ELASTICSEARCH_URL/_inference/completion/alibabacloud_ai_search_completion\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"alibabacloud_ai_search_completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"alibabacloud-ai-search\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"host\\\":\\\"default-j01.platform-cn-shanghai.opensearch.aliyuncs.com\\\",\\\"api_key\\\":\\\"AlibabaCloud-API-Key\\\",\\\"service_id\\\":\\\"ops-qwen-turbo\\\",\\\"workspace\\\":\\\"default\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_azureopenai/examples/request/PutAzureOpenAiRequestExample1.yaml": [
@@ -12537,6 +14375,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"azureopenai\",\"service_settings\":{\"api_key\":\"Api-Key\",\"resource_name\":\"Resource-name\",\"deployment_id\":\"Deployment-id\",\"api_version\":\"2024-02-01\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/azure_openai_embeddings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"azure_openai_embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"azureopenai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Api-Key\\\",\\\"resource_name\\\":\\\"Resource-name\\\",\\\"deployment_id\\\":\\\"Deployment-id\\\",\\\"api_version\\\":\\\"2024-02-01\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_azureopenai/examples/request/PutAzureOpenAiRequestExample2.yaml": [
@@ -12559,116 +14401,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"azureopenai\",\"service_settings\":{\"api_key\":\"Api-Key\",\"resource_name\":\"Resource-name\",\"deployment_id\":\"Deployment-id\",\"api_version\":\"2024-02-01\"}}' \"$ELASTICSEARCH_URL/_inference/completion/azure_openai_completion\""
-    }
-  ],
-  "specification/inference/put_custom/examples/request/PutCustomRequestExample1.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"custom-embeddings\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"https://api.openai.com/v1/embeddings\",\n            \"headers\": {\n                \"Authorization\": \"Bearer ${api_key}\",\n                \"Content-Type\": \"application/json;charset=utf-8\"\n            },\n            \"request\": \"{\\\"input\\\": ${input}, \\\"model\\\": \\\"text-embedding-3-small\\\"}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"text_embeddings\": \"$.data[*].embedding[*]\"\n                }\n            }\n        }\n    },\n)"
     },
     {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"custom-embeddings\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"https://api.openai.com/v1/embeddings\",\n      headers: {\n        Authorization: \"Bearer ${api_key}\",\n        \"Content-Type\": \"application/json;charset=utf-8\",\n      },\n      request: '{\"input\": ${input}, \"model\": \"text-embedding-3-small\"}',\n      response: {\n        json_parser: {\n          text_embeddings: \"$.data[*].embedding[*]\",\n        },\n      },\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"custom-embeddings\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"https://api.openai.com/v1/embeddings\",\n      \"headers\": {\n        \"Authorization\": \"Bearer ${api_key}\",\n        \"Content-Type\": \"application/json;charset=utf-8\"\n      },\n      \"request\": \"{\\\"input\\\": ${input}, \\\"model\\\": \\\"text-embedding-3-small\\\"}\",\n      \"response\": {\n        \"json_parser\": {\n          \"text_embeddings\": \"$.data[*].embedding[*]\"\n        }\n      }\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"custom-embeddings\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"https://api.openai.com/v1/embeddings\",\n            \"headers\" => [\n                \"Authorization\" => \"Bearer ${api_key}\",\n                \"Content-Type\" => \"application/json;charset=utf-8\",\n            ],\n            \"request\" => \"{\\\"input\\\": ${input}, \\\"model\\\": \\\"text-embedding-3-small\\\"}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"text_embeddings\" => \"$.data[*].embedding[*]\",\n                ],\n            ],\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"https://api.openai.com/v1/embeddings\",\"headers\":{\"Authorization\":\"Bearer ${api_key}\",\"Content-Type\":\"application/json;charset=utf-8\"},\"request\":\"{\\\"input\\\": ${input}, \\\"model\\\": \\\"text-embedding-3-small\\\"}\",\"response\":{\"json_parser\":{\"text_embeddings\":\"$.data[*].embedding[*]\"}}}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/custom-embeddings\""
-    }
-  ],
-  "specification/inference/put_custom/examples/request/PutCustomRequestExample3.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"custom-text-embedding\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"https://api.cohere.com/v2/embed\",\n            \"headers\": {\n                \"Authorization\": \"bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n            },\n            \"request\": \"{\\\"texts\\\": ${input}, \\\"model\\\": \\\"embed-v4.0\\\", \\\"input_type\\\": ${input_type}}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"text_embeddings\": \"$.embeddings.float[*]\"\n                }\n            },\n            \"input_type\": {\n                \"translation\": {\n                    \"ingest\": \"search_document\",\n                    \"search\": \"search_query\"\n                },\n                \"default\": \"search_document\"\n            }\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"custom-text-embedding\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"https://api.cohere.com/v2/embed\",\n      headers: {\n        Authorization: \"bearer ${api_key}\",\n        \"Content-Type\": \"application/json\",\n      },\n      request:\n        '{\"texts\": ${input}, \"model\": \"embed-v4.0\", \"input_type\": ${input_type}}',\n      response: {\n        json_parser: {\n          text_embeddings: \"$.embeddings.float[*]\",\n        },\n      },\n      input_type: {\n        translation: {\n          ingest: \"search_document\",\n          search: \"search_query\",\n        },\n        default: \"search_document\",\n      },\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"custom-text-embedding\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"https://api.cohere.com/v2/embed\",\n      \"headers\": {\n        \"Authorization\": \"bearer ${api_key}\",\n        \"Content-Type\": \"application/json\"\n      },\n      \"request\": \"{\\\"texts\\\": ${input}, \\\"model\\\": \\\"embed-v4.0\\\", \\\"input_type\\\": ${input_type}}\",\n      \"response\": {\n        \"json_parser\": {\n          \"text_embeddings\": \"$.embeddings.float[*]\"\n        }\n      },\n      \"input_type\": {\n        \"translation\": {\n          \"ingest\": \"search_document\",\n          \"search\": \"search_query\"\n        },\n        \"default\": \"search_document\"\n      }\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"custom-text-embedding\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"https://api.cohere.com/v2/embed\",\n            \"headers\" => [\n                \"Authorization\" => \"bearer ${api_key}\",\n                \"Content-Type\" => \"application/json\",\n            ],\n            \"request\" => \"{\\\"texts\\\": ${input}, \\\"model\\\": \\\"embed-v4.0\\\", \\\"input_type\\\": ${input_type}}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"text_embeddings\" => \"$.embeddings.float[*]\",\n                ],\n            ],\n            \"input_type\" => [\n                \"translation\" => [\n                    \"ingest\" => \"search_document\",\n                    \"search\" => \"search_query\",\n                ],\n                \"default\" => \"search_document\",\n            ],\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"https://api.cohere.com/v2/embed\",\"headers\":{\"Authorization\":\"bearer ${api_key}\",\"Content-Type\":\"application/json\"},\"request\":\"{\\\"texts\\\": ${input}, \\\"model\\\": \\\"embed-v4.0\\\", \\\"input_type\\\": ${input_type}}\",\"response\":{\"json_parser\":{\"text_embeddings\":\"$.embeddings.float[*]\"}},\"input_type\":{\"translation\":{\"ingest\":\"search_document\",\"search\":\"search_query\"},\"default\":\"search_document\"}}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/custom-text-embedding\""
-    }
-  ],
-  "specification/inference/put_custom/examples/request/PutCustomRequestExample2.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"custom-rerank\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"https://api.cohere.com/v2/rerank\",\n            \"headers\": {\n                \"Authorization\": \"bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n            },\n            \"request\": \"{\\\"documents\\\": ${input}, \\\"query\\\": ${query}, \\\"model\\\": \\\"rerank-v3.5\\\"}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"reranked_index\": \"$.results[*].index\",\n                    \"relevance_score\": \"$.results[*].relevance_score\"\n                }\n            }\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"custom-rerank\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"https://api.cohere.com/v2/rerank\",\n      headers: {\n        Authorization: \"bearer ${api_key}\",\n        \"Content-Type\": \"application/json\",\n      },\n      request:\n        '{\"documents\": ${input}, \"query\": ${query}, \"model\": \"rerank-v3.5\"}',\n      response: {\n        json_parser: {\n          reranked_index: \"$.results[*].index\",\n          relevance_score: \"$.results[*].relevance_score\",\n        },\n      },\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"custom-rerank\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"https://api.cohere.com/v2/rerank\",\n      \"headers\": {\n        \"Authorization\": \"bearer ${api_key}\",\n        \"Content-Type\": \"application/json\"\n      },\n      \"request\": \"{\\\"documents\\\": ${input}, \\\"query\\\": ${query}, \\\"model\\\": \\\"rerank-v3.5\\\"}\",\n      \"response\": {\n        \"json_parser\": {\n          \"reranked_index\": \"$.results[*].index\",\n          \"relevance_score\": \"$.results[*].relevance_score\"\n        }\n      }\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"custom-rerank\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"https://api.cohere.com/v2/rerank\",\n            \"headers\" => [\n                \"Authorization\" => \"bearer ${api_key}\",\n                \"Content-Type\" => \"application/json\",\n            ],\n            \"request\" => \"{\\\"documents\\\": ${input}, \\\"query\\\": ${query}, \\\"model\\\": \\\"rerank-v3.5\\\"}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"reranked_index\" => \"$.results[*].index\",\n                    \"relevance_score\" => \"$.results[*].relevance_score\",\n                ],\n            ],\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"https://api.cohere.com/v2/rerank\",\"headers\":{\"Authorization\":\"bearer ${api_key}\",\"Content-Type\":\"application/json\"},\"request\":\"{\\\"documents\\\": ${input}, \\\"query\\\": ${query}, \\\"model\\\": \\\"rerank-v3.5\\\"}\",\"response\":{\"json_parser\":{\"reranked_index\":\"$.results[*].index\",\"relevance_score\":\"$.results[*].relevance_score\"}}}}' \"$ELASTICSEARCH_URL/_inference/rerank/custom-rerank\""
-    }
-  ],
-  "specification/inference/put_custom/examples/request/PutCustomRequestExample5.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"custom-text-embedding-hf\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"<dedicated inference endpoint on HF>/v1/embeddings\",\n            \"headers\": {\n                \"Authorization\": \"Bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n            },\n            \"request\": \"{\\\"input\\\": ${input}}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"text_embeddings\": \"$.data[*].embedding[*]\"\n                }\n            }\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"custom-text-embedding-hf\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"<dedicated inference endpoint on HF>/v1/embeddings\",\n      headers: {\n        Authorization: \"Bearer ${api_key}\",\n        \"Content-Type\": \"application/json\",\n      },\n      request: '{\"input\": ${input}}',\n      response: {\n        json_parser: {\n          text_embeddings: \"$.data[*].embedding[*]\",\n        },\n      },\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"custom-text-embedding-hf\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"<dedicated inference endpoint on HF>/v1/embeddings\",\n      \"headers\": {\n        \"Authorization\": \"Bearer ${api_key}\",\n        \"Content-Type\": \"application/json\"\n      },\n      \"request\": \"{\\\"input\\\": ${input}}\",\n      \"response\": {\n        \"json_parser\": {\n          \"text_embeddings\": \"$.data[*].embedding[*]\"\n        }\n      }\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"custom-text-embedding-hf\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"<dedicated inference endpoint on HF>/v1/embeddings\",\n            \"headers\" => [\n                \"Authorization\" => \"Bearer ${api_key}\",\n                \"Content-Type\" => \"application/json\",\n            ],\n            \"request\" => \"{\\\"input\\\": ${input}}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"text_embeddings\" => \"$.data[*].embedding[*]\",\n                ],\n            ],\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"<dedicated inference endpoint on HF>/v1/embeddings\",\"headers\":{\"Authorization\":\"Bearer ${api_key}\",\"Content-Type\":\"application/json\"},\"request\":\"{\\\"input\\\": ${input}}\",\"response\":{\"json_parser\":{\"text_embeddings\":\"$.data[*].embedding[*]\"}}}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/custom-text-embedding-hf\""
-    }
-  ],
-  "specification/inference/put_custom/examples/request/PutCustomRequestExample4.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"custom-rerank-jina\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"https://api.jina.ai/v1/rerank\",\n            \"headers\": {\n                \"Content-Type\": \"application/json\",\n                \"Authorization\": \"Bearer ${api_key}\"\n            },\n            \"request\": \"{\\\"model\\\": \\\"jina-reranker-v2-base-multilingual\\\",\\\"query\\\": ${query},\\\"documents\\\":${input}}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"relevance_score\": \"$.results[*].relevance_score\",\n                    \"reranked_index\": \"$.results[*].index\"\n                }\n            }\n        }\n    },\n)"
-    },
-    {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"custom-rerank-jina\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"https://api.jina.ai/v1/rerank\",\n      headers: {\n        \"Content-Type\": \"application/json\",\n        Authorization: \"Bearer ${api_key}\",\n      },\n      request:\n        '{\"model\": \"jina-reranker-v2-base-multilingual\",\"query\": ${query},\"documents\":${input}}',\n      response: {\n        json_parser: {\n          relevance_score: \"$.results[*].relevance_score\",\n          reranked_index: \"$.results[*].index\",\n        },\n      },\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"custom-rerank-jina\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"https://api.jina.ai/v1/rerank\",\n      \"headers\": {\n        \"Content-Type\": \"application/json\",\n        \"Authorization\": \"Bearer ${api_key}\"\n      },\n      \"request\": \"{\\\"model\\\": \\\"jina-reranker-v2-base-multilingual\\\",\\\"query\\\": ${query},\\\"documents\\\":${input}}\",\n      \"response\": {\n        \"json_parser\": {\n          \"relevance_score\": \"$.results[*].relevance_score\",\n          \"reranked_index\": \"$.results[*].index\"\n        }\n      }\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"custom-rerank-jina\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"https://api.jina.ai/v1/rerank\",\n            \"headers\" => [\n                \"Content-Type\" => \"application/json\",\n                \"Authorization\" => \"Bearer ${api_key}\",\n            ],\n            \"request\" => \"{\\\"model\\\": \\\"jina-reranker-v2-base-multilingual\\\",\\\"query\\\": ${query},\\\"documents\\\":${input}}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"relevance_score\" => \"$.results[*].relevance_score\",\n                    \"reranked_index\" => \"$.results[*].index\",\n                ],\n            ],\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"https://api.jina.ai/v1/rerank\",\"headers\":{\"Content-Type\":\"application/json\",\"Authorization\":\"Bearer ${api_key}\"},\"request\":\"{\\\"model\\\": \\\"jina-reranker-v2-base-multilingual\\\",\\\"query\\\": ${query},\\\"documents\\\":${input}}\",\"response\":{\"json_parser\":{\"relevance_score\":\"$.results[*].relevance_score\",\"reranked_index\":\"$.results[*].index\"}}}}' \"$ELASTICSEARCH_URL/_inference/rerank/custom-rerank-jina\""
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"azure_openai_completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"azureopenai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Api-Key\\\",\\\"resource_name\\\":\\\"Resource-name\\\",\\\"deployment_id\\\":\\\"Deployment-id\\\",\\\"api_version\\\":\\\"2024-02-01\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/stream_completion/examples/request/StreamInferenceRequestExample1.yaml": [
@@ -12691,6 +14427,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"input\":\"What is Elastic?\"}' \"$ELASTICSEARCH_URL/_inference/completion/openai-completion/_stream\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().streamCompletion(s -> s\n    .inferenceId(\"openai-completion\")\n    .input(\"What is Elastic?\")\n);\n"
     }
   ],
   "specification/inference/put_elasticsearch/examples/request/PutElasticsearchRequestExample5.yaml": [
@@ -12713,6 +14453,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elasticsearch\",\"service_settings\":{\"adaptive_allocations\":{\"enabled\":true,\"min_number_of_allocations\":3,\"max_number_of_allocations\":10},\"num_threads\":1,\"model_id\":\".multilingual-e5-small\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/my-e5-model\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"my-e5-model\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"elasticsearch\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"adaptive_allocations\\\":{\\\"enabled\\\":true,\\\"min_number_of_allocations\\\":3,\\\"max_number_of_allocations\\\":10},\\\"num_threads\\\":1,\\\"model_id\\\":\\\".multilingual-e5-small\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_elasticsearch/examples/request/PutElasticsearchRequestExample4.yaml": [
@@ -12735,6 +14479,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elasticsearch\",\"service_settings\":{\"num_allocations\":1,\"num_threads\":1,\"model_id\":\"msmarco-MiniLM-L12-cos-v5\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/my-msmarco-minilm-model\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"my-msmarco-minilm-model\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"elasticsearch\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"num_allocations\\\":1,\\\"num_threads\\\":1,\\\"model_id\\\":\\\"msmarco-MiniLM-L12-cos-v5\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_elasticsearch/examples/request/PutElasticsearchRequestExample3.yaml": [
@@ -12757,6 +14505,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elasticsearch\",\"service_settings\":{\"num_allocations\":1,\"num_threads\":1,\"model_id\":\".multilingual-e5-small\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/my-e5-model\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"my-e5-model\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"elasticsearch\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"num_allocations\\\":1,\\\"num_threads\\\":1,\\\"model_id\\\":\\\".multilingual-e5-small\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_elasticsearch/examples/request/PutElasticsearchRequestExample2.yaml": [
@@ -12779,6 +14531,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elasticsearch\",\"service_settings\":{\"model_id\":\".rerank-v1\",\"num_threads\":1,\"adaptive_allocations\":{\"enabled\":true,\"min_number_of_allocations\":1,\"max_number_of_allocations\":4}}}' \"$ELASTICSEARCH_URL/_inference/rerank/my-elastic-rerank\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"my-elastic-rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"elasticsearch\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"model_id\\\":\\\".rerank-v1\\\",\\\"num_threads\\\":1,\\\"adaptive_allocations\\\":{\\\"enabled\\\":true,\\\"min_number_of_allocations\\\":1,\\\"max_number_of_allocations\\\":4}}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_elasticsearch/examples/request/PutElasticsearchRequestExample1.yaml": [
@@ -12801,6 +14557,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elasticsearch\",\"service_settings\":{\"adaptive_allocations\":{\"enabled\":true,\"min_number_of_allocations\":1,\"max_number_of_allocations\":4},\"num_threads\":1,\"model_id\":\".elser_model_2\"}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/my-elser-model\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"my-elser-model\")\n    .taskType(TaskType.SparseEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"elasticsearch\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"adaptive_allocations\\\":{\\\"enabled\\\":true,\\\"min_number_of_allocations\\\":1,\\\"max_number_of_allocations\\\":4},\\\"num_threads\\\":1,\\\"model_id\\\":\\\".elser_model_2\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_elasticsearch/examples/request/PutElasticsearchRequestExample6.yaml": [
@@ -12823,6 +14583,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"elasticsearch\",\"service_settings\":{\"deployment_id\":\".elser_model_2\"}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/use_existing_deployment\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"use_existing_deployment\")\n    .taskType(TaskType.SparseEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"elasticsearch\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"deployment_id\\\":\\\".elser_model_2\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_azureaistudio/examples/request/PutAzureAiStudioRequestExample2.yaml": [
@@ -12845,28 +14609,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"azureaistudio\",\"service_settings\":{\"api_key\":\"Azure-AI-Studio-API-key\",\"target\":\"Target-URI\",\"provider\":\"databricks\",\"endpoint_type\":\"realtime\"}}' \"$ELASTICSEARCH_URL/_inference/completion/azure_ai_studio_completion\""
-    }
-  ],
-  "specification/inference/put_azureaistudio/examples/request/PutAzureAiStudioRequestExample3.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"azure_ai_studio_rerank\",\n    inference_config={\n        \"service\": \"azureaistudio\",\n        \"service_settings\": {\n            \"api_key\": \"Azure-AI-Studio-API-key\",\n            \"target\": \"Target-URI\",\n            \"provider\": \"cohere\",\n            \"endpoint_type\": \"token\"\n        }\n    },\n)"
     },
     {
-      "language": "JavaScript",
-      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"azure_ai_studio_rerank\",\n  inference_config: {\n    service: \"azureaistudio\",\n    service_settings: {\n      api_key: \"Azure-AI-Studio-API-key\",\n      target: \"Target-URI\",\n      provider: \"cohere\",\n      endpoint_type: \"token\",\n    },\n  },\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"azure_ai_studio_rerank\",\n  body: {\n    \"service\": \"azureaistudio\",\n    \"service_settings\": {\n      \"api_key\": \"Azure-AI-Studio-API-key\",\n      \"target\": \"Target-URI\",\n      \"provider\": \"cohere\",\n      \"endpoint_type\": \"token\"\n    }\n  }\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"azure_ai_studio_rerank\",\n    \"body\" => [\n        \"service\" => \"azureaistudio\",\n        \"service_settings\" => [\n            \"api_key\" => \"Azure-AI-Studio-API-key\",\n            \"target\" => \"Target-URI\",\n            \"provider\" => \"cohere\",\n            \"endpoint_type\" => \"token\",\n        ],\n    ],\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"azureaistudio\",\"service_settings\":{\"api_key\":\"Azure-AI-Studio-API-key\",\"target\":\"Target-URI\",\"provider\":\"cohere\",\"endpoint_type\":\"token\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/azure_ai_studio_rerank\""
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"azure_ai_studio_completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"azureaistudio\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Azure-AI-Studio-API-key\\\",\\\"target\\\":\\\"Target-URI\\\",\\\"provider\\\":\\\"databricks\\\",\\\"endpoint_type\\\":\\\"realtime\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/inference/put_azureaistudio/examples/request/PutAzureAiStudioRequestExample1.yaml": [
@@ -12889,6 +14635,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"azureaistudio\",\"service_settings\":{\"api_key\":\"Azure-AI-Studio-API-key\",\"target\":\"Target-Uri\",\"provider\":\"openai\",\"endpoint_type\":\"token\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/azure_ai_studio_embeddings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"azure_ai_studio_embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"azureaistudio\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Azure-AI-Studio-API-key\\\",\\\"target\\\":\\\"Target-Uri\\\",\\\"provider\\\":\\\"openai\\\",\\\"endpoint_type\\\":\\\"token\\\"}\"))\n    )\n);\n"
     }
   ],
   "specification/query_rules/list_rulesets/examples/request/QueryRulesetListRequestExample1.yaml": [
@@ -12911,6 +14661,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query_rules/?from=0&size=3\""
+    },
+    {
+      "language": "Java",
+      "code": "client.queryRules().listRulesets(l -> l\n    .from(0)\n    .size(3)\n);\n"
     }
   ],
   "specification/query_rules/test/examples/request/QueryRulesetTestRequestExample1.yaml": [
@@ -12933,6 +14687,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"rules\":[{\"rule_id\":\"my-rule1\",\"type\":\"pinned\",\"criteria\":[{\"type\":\"contains\",\"metadata\":\"user_query\",\"values\":[\"pugs\",\"puggles\"]},{\"type\":\"exact\",\"metadata\":\"user_country\",\"values\":[\"us\"]}],\"actions\":{\"ids\":[\"id1\",\"id2\"]}},{\"rule_id\":\"my-rule2\",\"type\":\"pinned\",\"criteria\":[{\"type\":\"fuzzy\",\"metadata\":\"user_query\",\"values\":[\"rescue dogs\"]}],\"actions\":{\"docs\":[{\"_index\":\"index1\",\"_id\":\"id3\"},{\"_index\":\"index2\",\"_id\":\"id4\"}]}}]}' \"$ELASTICSEARCH_URL/_query_rules/my-ruleset\""
+    },
+    {
+      "language": "Java",
+      "code": "client.queryRules().putRuleset(p -> p\n    .rules(List.of(QueryRule.queryRuleOf(q -> q\n            .ruleId(\"my-rule1\")\n            .type(QueryRuleType.Pinned)\n            .criteria(List.of(QueryRuleCriteria.of(qu -> qu\n                    .type(QueryRuleCriteriaType.Contains)\n                    .metadata(\"user_query\")\n                    .values(List.of(JsonData.fromJson(\"\\\"pugs\\\"\"),JsonData.fromJson(\"\\\"puggles\\\"\")))),QueryRuleCriteria.of(qu -> qu\n                    .type(QueryRuleCriteriaType.Exact)\n                    .metadata(\"user_country\")\n                    .values(JsonData.fromJson(\"\\\"us\\\"\")))))\n            .actions(a -> a\n                .ids(List.of(\"id1\",\"id2\"))\n            )),QueryRule.queryRuleOf(q -> q\n            .ruleId(\"my-rule2\")\n            .type(QueryRuleType.Pinned)\n            .criteria(c -> c\n                .type(QueryRuleCriteriaType.Fuzzy)\n                .metadata(\"user_query\")\n                .values(JsonData.fromJson(\"\\\"rescue dogs\\\"\"))\n            )\n            .actions(a -> a\n                .docs(List.of(PinnedDoc.of(pi -> pi\n                        .id(\"id3\")\n                        .index(\"index1\")),PinnedDoc.of(pi -> pi\n                        .id(\"id4\")\n                        .index(\"index2\"))))\n            ))))\n    .rulesetId(\"my-ruleset\")\n);\n"
     }
   ],
   "specification/query_rules/put_rule/examples/request/QueryRulePutRequestExample1.yaml": [
@@ -12955,6 +14713,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"match_criteria\":{\"query_string\":\"puggles\"}}' \"$ELASTICSEARCH_URL/_query_rules/my-ruleset/_test\""
+    },
+    {
+      "language": "Java",
+      "code": "client.queryRules().test(t -> t\n    .matchCriteria(\"query_string\", JsonData.fromJson(\"\\\"puggles\\\"\"))\n    .rulesetId(\"my-ruleset\")\n);\n"
     }
   ],
   "specification/query_rules/delete_rule/examples/request/QueryRulesDeleteRuleExample1.yaml": [
@@ -12977,6 +14739,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query_rules/my-ruleset/_rule/my-rule1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.queryRules().deleteRule(d -> d\n    .ruleId(\"my-rule1\")\n    .rulesetId(\"my-ruleset\")\n);\n"
     }
   ],
   "specification/query_rules/get_rule/examples/request/QueryRuleGetRequestExample1.yaml": [
@@ -12999,6 +14765,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query_rules/my-ruleset/_rule/my-rule1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.queryRules().getRule(g -> g\n    .ruleId(\"my-rule1\")\n    .rulesetId(\"my-ruleset\")\n);\n"
     }
   ],
   "specification/query_rules/get_ruleset/examples/request/QueryRulesetGetRequestExample1.yaml": [
@@ -13021,6 +14791,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query_rules/my-ruleset/\""
+    },
+    {
+      "language": "Java",
+      "code": "client.queryRules().getRuleset(g -> g\n    .rulesetId(\"my-ruleset\")\n);\n"
     }
   ],
   "specification/query_rules/delete_ruleset/examples/request/QueryRulesDeleteRulesetExample1.yaml": [
@@ -13043,6 +14817,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_query_rules/my-ruleset/\""
+    },
+    {
+      "language": "Java",
+      "code": "client.queryRules().deleteRuleset(d -> d\n    .rulesetId(\"my-ruleset\")\n);\n"
     }
   ],
   "specification/query_rules/put_ruleset/examples/request/QueryRulesetPutRequestExample1.yaml": [
@@ -13065,6 +14843,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"rules\":[{\"rule_id\":\"my-rule1\",\"type\":\"pinned\",\"criteria\":[{\"type\":\"contains\",\"metadata\":\"user_query\",\"values\":[\"pugs\",\"puggles\"]},{\"type\":\"exact\",\"metadata\":\"user_country\",\"values\":[\"us\"]}],\"actions\":{\"ids\":[\"id1\",\"id2\"]}},{\"rule_id\":\"my-rule2\",\"type\":\"pinned\",\"criteria\":[{\"type\":\"fuzzy\",\"metadata\":\"user_query\",\"values\":[\"rescue dogs\"]}],\"actions\":{\"docs\":[{\"_index\":\"index1\",\"_id\":\"id3\"},{\"_index\":\"index2\",\"_id\":\"id4\"}]}}]}' \"$ELASTICSEARCH_URL/_query_rules/my-ruleset\""
+    },
+    {
+      "language": "Java",
+      "code": "client.queryRules().putRuleset(p -> p\n    .rules(List.of(QueryRule.queryRuleOf(q -> q\n            .ruleId(\"my-rule1\")\n            .type(QueryRuleType.Pinned)\n            .criteria(List.of(QueryRuleCriteria.of(qu -> qu\n                    .type(QueryRuleCriteriaType.Contains)\n                    .metadata(\"user_query\")\n                    .values(List.of(JsonData.fromJson(\"\\\"pugs\\\"\"),JsonData.fromJson(\"\\\"puggles\\\"\")))),QueryRuleCriteria.of(qu -> qu\n                    .type(QueryRuleCriteriaType.Exact)\n                    .metadata(\"user_country\")\n                    .values(JsonData.fromJson(\"\\\"us\\\"\")))))\n            .actions(a -> a\n                .ids(List.of(\"id1\",\"id2\"))\n            )),QueryRule.queryRuleOf(q -> q\n            .ruleId(\"my-rule2\")\n            .type(QueryRuleType.Pinned)\n            .criteria(c -> c\n                .type(QueryRuleCriteriaType.Fuzzy)\n                .metadata(\"user_query\")\n                .values(JsonData.fromJson(\"\\\"rescue dogs\\\"\"))\n            )\n            .actions(a -> a\n                .docs(List.of(PinnedDoc.of(pi -> pi\n                        .id(\"id3\")\n                        .index(\"index1\")),PinnedDoc.of(pi -> pi\n                        .id(\"id4\")\n                        .index(\"index2\"))))\n            ))))\n    .rulesetId(\"my-ruleset\")\n);\n"
     }
   ],
   "specification/enrich/delete_policy/examples/request/EnrichDeletePolicyExample1.yaml": [
@@ -13087,6 +14869,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_enrich/policy/my-policy\""
+    },
+    {
+      "language": "Java",
+      "code": "client.enrich().deletePolicy(d -> d\n    .name(\"my-policy\")\n);\n"
     }
   ],
   "specification/enrich/execute_policy/examples/request/EnrichExecutePolicyExample1.yaml": [
@@ -13109,6 +14895,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_enrich/policy/my-policy/_execute?wait_for_completion=false\""
+    },
+    {
+      "language": "Java",
+      "code": "client.enrich().executePolicy(e -> e\n    .name(\"my-policy\")\n    .waitForCompletion(false)\n);\n"
     }
   ],
   "specification/enrich/get_policy/examples/request/EnrichGetPolicyExample1.yaml": [
@@ -13131,6 +14921,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_enrich/policy/my-policy\""
+    },
+    {
+      "language": "Java",
+      "code": "client.enrich().getPolicy(g -> g\n    .name(\"my-policy\")\n);\n"
     }
   ],
   "specification/enrich/put_policy/examples/request/EnrichPutPolicyExample1.yaml": [
@@ -13153,6 +14947,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"geo_match\":{\"indices\":\"postal_codes\",\"match_field\":\"location\",\"enrich_fields\":[\"location\",\"postal_code\"]}}' \"$ELASTICSEARCH_URL/_enrich/policy/postal_policy\""
+    },
+    {
+      "language": "Java",
+      "code": "client.enrich().putPolicy(p -> p\n    .geoMatch(g -> g\n        .enrichFields(List.of(\"location\",\"postal_code\"))\n        .indices(\"postal_codes\")\n        .matchField(\"location\")\n    )\n    .name(\"postal_policy\")\n);\n"
     }
   ],
   "specification/enrich/stats/examples/request/EnrichStatsExample1.yaml": [
@@ -13175,6 +14973,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_enrich/_stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.enrich().stats(s -> s)\n);\n"
     }
   ],
   "specification/async_search/submit/examples/request/AsyncSearchSubmitRequestExample1.yaml": [
@@ -13197,6 +14999,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"sort\":[{\"date\":{\"order\":\"asc\"}}],\"aggs\":{\"sale_date\":{\"date_histogram\":{\"field\":\"date\",\"calendar_interval\":\"1d\"}}}}' \"$ELASTICSEARCH_URL/sales*/_async_search?size=0\""
+    },
+    {
+      "language": "Java",
+      "code": "client.asyncSearch().submit(s -> s\n    .aggregations(\"sale_date\", a -> a\n        .dateHistogram(d -> d\n            .calendarInterval(CalendarInterval.Day)\n            .field(\"date\")\n        )\n    )\n    .index(\"sales*\")\n    .size(0)\n    .sort(so -> so\n        .field(f -> f\n            .field(\"date\")\n            .order(SortOrder.Asc)\n        )\n    )\n,Void.class);\n"
     }
   ],
   "specification/async_search/delete/examples/request/AsyncSearchDeleteExample1.yaml": [
@@ -13219,6 +15025,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\""
+    },
+    {
+      "language": "Java",
+      "code": "client.asyncSearch().delete(d -> d\n    .id(\"FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\")\n);\n"
     }
   ],
   "specification/async_search/get/examples/request/AsyncSearchGetRequestExample1.yaml": [
@@ -13241,6 +15051,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\""
+    },
+    {
+      "language": "Java",
+      "code": "client.asyncSearch().get(g -> g\n    .id(\"FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\")\n);\n"
     }
   ],
   "specification/async_search/status/examples/request/AsyncSearchStatusRequestExample1.yaml": [
@@ -13263,6 +15077,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_async_search/status/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\""
+    },
+    {
+      "language": "Java",
+      "code": "client.asyncSearch().status(s -> s\n    .id(\"FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=\")\n);\n"
     }
   ],
   "specification/eql/get_status/examples/request/EqlGetStatusExample1.yaml": [
@@ -13285,6 +15103,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_eql/search/status/FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\""
+    },
+    {
+      "language": "Java",
+      "code": "client.eql().getStatus(g -> g\n    .id(\"FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\")\n);\n"
     }
   ],
   "specification/eql/delete/examples/request/EqlDeleteExample1.yaml": [
@@ -13307,6 +15129,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_eql/search/FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\""
+    },
+    {
+      "language": "Java",
+      "code": "client.eql().delete(d -> d\n    .id(\"FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\")\n);\n"
     }
   ],
   "specification/eql/get/examples/request/EqlGetExample1.yaml": [
@@ -13329,6 +15155,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_eql/search/FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=?wait_for_completion_timeout=2s\""
+    },
+    {
+      "language": "Java",
+      "code": "client.eql().get(g -> g\n    .id(\"FmNJRUZ1YWZCU3dHY1BIOUhaenVSRkEaaXFlZ3h4c1RTWFNocDdnY2FSaERnUTozNDE=\")\n    .waitForCompletionTimeout(w -> w\n        .offset(2)\n    )\n);\n"
     }
   ],
   "specification/eql/search/examples/request/EqlSearchRequestExample1.yaml": [
@@ -13351,6 +15181,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":\"\\n    process where (process.name == \\\"cmd.exe\\\" and process.pid != 2013)\\n  \"}' \"$ELASTICSEARCH_URL/my-data-stream/_eql/search\""
+    },
+    {
+      "language": "Java",
+      "code": "client.eql().search(s -> s\n    .index(\"my-data-stream\")\n    .query(\"\n    process where (process.name == \"cmd.exe\" and process.pid != 2013)\n  \")\n);\n"
     }
   ],
   "specification/eql/search/examples/request/EqlSearchRequestExample2.yaml": [
@@ -13373,6 +15207,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":\"\\n    sequence by process.pid\\n      [ file where file.name == \\\"cmd.exe\\\" and process.pid != 2013 ]\\n      [ process where stringContains(process.executable, \\\"regsvr32\\\") ]\\n  \"}' \"$ELASTICSEARCH_URL/my-data-stream/_eql/search\""
+    },
+    {
+      "language": "Java",
+      "code": "client.eql().search(s -> s\n    .index(\"my-data-stream\")\n    .query(\"\n    sequence by process.pid\n      [ file where file.name == \"cmd.exe\" and process.pid != 2013 ]\n      [ process where stringContains(process.executable, \"regsvr32\") ]\n  \")\n);\n"
     }
   ],
   "specification/esql/async_query_stop/examples/request/EsqlAsyncQueryStopExample1.yaml": [
@@ -13461,6 +15299,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":\"\\n    FROM library,remote-*:library\\n    | EVAL year = DATE_TRUNC(1 YEARS, release_date)\\n    | STATS MAX(page_count) BY year\\n    | SORT year\\n    | LIMIT 5\\n  \",\"include_ccs_metadata\":true}' \"$ELASTICSEARCH_URL/_query\""
+    },
+    {
+      "language": "Java",
+      "code": "client.esql().query(q -> q\n    .includeCcsMetadata(true)\n    .query(\"\n    FROM library,remote-*:library\n    | EVAL year = DATE_TRUNC(1 YEARS, release_date)\n    | STATS MAX(page_count) BY year\n    | SORT year\n    | LIMIT 5\n  \")\n);\n"
     }
   ],
   "specification/esql/async_query_delete/examples/request/EsqlAsyncQueryDeleteExample1.yaml": [
@@ -13505,6 +15347,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[],\"deciders\":{\"fixed\":{}}}' \"$ELASTICSEARCH_URL/_autoscaling/policy/<name>\""
+    },
+    {
+      "language": "Java",
+      "code": "client.autoscaling().putAutoscalingPolicy(p -> p\n    .name(\"<name>\")\n    .policy(po -> po\n        .deciders(\"fixed\", JsonData.fromJson(\"{}\"))\n    )\n);\n"
     }
   ],
   "specification/autoscaling/put_autoscaling_policy/examples/request/PutAutoscalingPolicyRequestExample2.yaml": [
@@ -13527,6 +15373,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"roles\":[\"data_hot\"],\"deciders\":{\"fixed\":{}}}' \"$ELASTICSEARCH_URL/_autoscaling/policy/my_autoscaling_policy\""
+    },
+    {
+      "language": "Java",
+      "code": "client.autoscaling().putAutoscalingPolicy(p -> p\n    .name(\"my_autoscaling_policy\")\n    .policy(po -> po\n        .roles(\"data_hot\")\n        .deciders(\"fixed\", JsonData.fromJson(\"{}\"))\n    )\n);\n"
     }
   ],
   "specification/autoscaling/delete_autoscaling_policy/examples/request/DeleteAutoscalingPolicyRequestExample1.yaml": [
@@ -13549,6 +15399,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_autoscaling/policy/*\""
+    },
+    {
+      "language": "Java",
+      "code": "client.autoscaling().deleteAutoscalingPolicy(d -> d\n    .name(\"*\")\n);\n"
     }
   ],
   "specification/autoscaling/get_autoscaling_policy/examples/request/GetAutoscalingPolicyRequestExample1.yaml": [
@@ -13571,6 +15425,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_autoscaling/policy/my_autoscaling_policy\""
+    },
+    {
+      "language": "Java",
+      "code": "client.autoscaling().getAutoscalingPolicy(g -> g\n    .name(\"my_autoscaling_policy\")\n);\n"
     }
   ],
   "specification/autoscaling/get_autoscaling_capacity/examples/request/GetAutoscalingCapacityRequestExample1.yaml": [
@@ -13593,6 +15451,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_autoscaling/capacity\""
+    },
+    {
+      "language": "Java",
+      "code": "client.autoscaling().getAutoscalingCapacity(g -> g)\n);\n"
     }
   ],
   "specification/search_application/render_query/examples/request/SearchApplicationsRenderQueryRequestExample1.yaml": [
@@ -13615,6 +15477,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"params\":{\"query_string\":\"my first query\",\"text_fields\":[{\"name\":\"title\",\"boost\":5},{\"name\":\"description\",\"boost\":1}]}}' \"$ELASTICSEARCH_URL/_application/search_application/my-app/_render_query\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchApplication().renderQuery(r -> r\n    .name(\"my-app\")\n    .params(Map.of(\"text_fields\", JsonData.fromJson(\"[{\\\"name\\\":\\\"title\\\",\\\"boost\\\":5},{\\\"name\\\":\\\"description\\\",\\\"boost\\\":1}]\"),\"query_string\", JsonData.fromJson(\"\\\"my first query\\\"\")))\n);\n"
     }
   ],
   "specification/search_application/delete/examples/request/SearchApplicationDeleteExample1.yaml": [
@@ -13637,6 +15503,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_application/search_application/my-app/\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchApplication().delete(d -> d\n    .name(\"my-app\")\n);\n"
     }
   ],
   "specification/search_application/put/examples/request/SearchApplicationPutRequestExample1.yaml": [
@@ -13659,6 +15529,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"indices\":[\"index1\",\"index2\"],\"template\":{\"script\":{\"source\":{\"query\":{\"query_string\":{\"query\":\"{{query_string}}\",\"default_field\":\"{{default_field}}\"}}},\"params\":{\"query_string\":\"*\",\"default_field\":\"*\"}},\"dictionary\":{\"properties\":{\"query_string\":{\"type\":\"string\"},\"default_field\":{\"type\":\"string\",\"enum\":[\"title\",\"description\"]},\"additionalProperties\":false},\"required\":[\"query_string\"]}}}' \"$ELASTICSEARCH_URL/_application/search_application/my-app\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchApplication().put(p -> p\n    .name(\"my-app\")\n    .searchApplication(s -> s\n        .indices(List.of(\"index1\",\"index2\"))\n        .template(t -> t\n            .script(sc -> sc\n                .source(so -> so\n                    .scriptTemplate(scr -> scr\n                        .query(q -> q\n                            .queryString(qu -> qu\n                                .defaultField(\"{{default_field}}\")\n                                .query(\"{{query_string}}\")\n                            )\n                        )\n                    )\n                )\n                .params(Map.of(\"default_field\", JsonData.fromJson(\"\\\"*\\\"\"),\"query_string\", JsonData.fromJson(\"\\\"*\\\"\")))\n            )\n        )\n    )\n);\n"
     }
   ],
   "specification/search_application/get/examples/request/SearchApplicationGetRequestExample1.yaml": [
@@ -13681,6 +15555,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_application/search_application/my-app/\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchApplication().get(g -> g\n    .name(\"my-app\")\n);\n"
     }
   ],
   "specification/search_application/post_behavioral_analytics_event/examples/request/BehavioralAnalyticsEventPostRequestExample1.yaml": [
@@ -13703,6 +15581,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"session\":{\"id\":\"1797ca95-91c9-4e2e-b1bd-9c38e6f386a9\"},\"user\":{\"id\":\"5f26f01a-bbee-4202-9298-81261067abbd\"},\"search\":{\"query\":\"search term\",\"results\":{\"items\":[{\"document\":{\"id\":\"123\",\"index\":\"products\"}}],\"total_results\":10},\"sort\":{\"name\":\"relevance\"},\"search_application\":\"website\"},\"document\":{\"id\":\"123\",\"index\":\"products\"}}' \"$ELASTICSEARCH_URL/_application/analytics/my_analytics_collection/event/search_click\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchApplication().postBehavioralAnalyticsEvent(p -> p\n    .collectionName(\"my_analytics_collection\")\n    .eventType(EventType.SearchClick)\n    .payload(JsonData.fromJson(\"{\\\"session\\\":{\\\"id\\\":\\\"1797ca95-91c9-4e2e-b1bd-9c38e6f386a9\\\"},\\\"user\\\":{\\\"id\\\":\\\"5f26f01a-bbee-4202-9298-81261067abbd\\\"},\\\"search\\\":{\\\"query\\\":\\\"search term\\\",\\\"results\\\":{\\\"items\\\":[{\\\"document\\\":{\\\"id\\\":\\\"123\\\",\\\"index\\\":\\\"products\\\"}}],\\\"total_results\\\":10},\\\"sort\\\":{\\\"name\\\":\\\"relevance\\\"},\\\"search_application\\\":\\\"website\\\"},\\\"document\\\":{\\\"id\\\":\\\"123\\\",\\\"index\\\":\\\"products\\\"}}\"))\n);\n"
     }
   ],
   "specification/search_application/get_behavioral_analytics/examples/request/BehavioralAnalyticsGetRequestExample1.yaml": [
@@ -13725,6 +15607,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_application/analytics/my*\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchApplication().getBehavioralAnalytics(g -> g\n    .name(\"my*\")\n);\n"
     }
   ],
   "specification/search_application/delete_behavioral_analytics/examples/request/SearchApplicationDeleteBehavioralAnalyticsExample1.yaml": [
@@ -13747,6 +15633,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_application/analytics/my_analytics_collection/\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchApplication().deleteBehavioralAnalytics(d -> d\n    .name(\"my_analytics_collection\")\n);\n"
     }
   ],
   "specification/search_application/put_behavioral_analytics/examples/request/SearchApplicationPutBehavioralAnalyticsExample1.yaml": [
@@ -13769,6 +15659,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_application/analytics/my_analytics_collection\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchApplication().putBehavioralAnalytics(p -> p\n    .name(\"my_analytics_collection\")\n);\n"
     }
   ],
   "specification/search_application/search/examples/request/SearchApplicationsSearchRequestExample1.yaml": [
@@ -13791,6 +15685,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"params\":{\"query_string\":\"my first query\",\"text_fields\":[{\"name\":\"title\",\"boost\":5},{\"name\":\"description\",\"boost\":1}]}}' \"$ELASTICSEARCH_URL/_application/search_application/my-app/_search\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchApplication().search(s -> s\n    .name(\"my-app\")\n    .params(Map.of(\"text_fields\", JsonData.fromJson(\"[{\\\"name\\\":\\\"title\\\",\\\"boost\\\":5},{\\\"name\\\":\\\"description\\\",\\\"boost\\\":1}]\"),\"query_string\", JsonData.fromJson(\"\\\"my first query\\\"\")))\n);\n"
     }
   ],
   "specification/search_application/list/examples/request/SearchApplicationsListRequestExample1.yaml": [
@@ -13813,6 +15711,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_application/search_application?from=0&size=3&q=app*\""
+    },
+    {
+      "language": "Java",
+      "code": "client.searchApplication().list(l -> l\n    .from(0)\n    .q(\"app*\")\n    .size(3)\n);\n"
     }
   ],
   "specification/migration/get_feature_upgrade_status/examples/request/GetFeatureUpgradeStatusRequestExample1.yaml": [
@@ -13835,6 +15737,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_migration/system_features\""
+    },
+    {
+      "language": "Java",
+      "code": "client.migration().getFeatureUpgradeStatus();\n"
     }
   ],
   "specification/migration/post_feature_upgrade/examples/request/PostFeatureUpgradeRequestExample1.yaml": [
@@ -13857,6 +15763,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_migration/system_features\""
+    },
+    {
+      "language": "Java",
+      "code": "client.migration().postFeatureUpgrade();\n"
     }
   ],
   "specification/migration/deprecations/examples/request/DeprecationInfoRequestExample1.yaml": [
@@ -13879,6 +15789,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_migration/deprecations\""
+    },
+    {
+      "language": "Java",
+      "code": "client.migration().deprecations(d -> d)\n);\n"
     }
   ],
   "specification/transform/start_transform/examples/request/TransformStartTransformExample1.yaml": [
@@ -13901,6 +15815,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/ecommerce-customer-transform/_start\""
+    },
+    {
+      "language": "Java",
+      "code": "client.transform().startTransform(s -> s\n    .transformId(\"ecommerce-customer-transform\")\n);\n"
     }
   ],
   "specification/transform/schedule_now_transform/examples/request/TransformScheduleNowTransformExample1.yaml": [
@@ -13923,6 +15841,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/ecommerce_transform/_schedule_now\""
+    },
+    {
+      "language": "Java",
+      "code": "client.transform().scheduleNowTransform(s -> s\n    .transformId(\"ecommerce_transform\")\n);\n"
     }
   ],
   "specification/transform/get_transform/examples/request/TransformGetTransformExample1.yaml": [
@@ -13945,6 +15867,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform?size=10\""
+    },
+    {
+      "language": "Java",
+      "code": "client.transform().getTransform(g -> g\n    .size(10)\n);\n"
     }
   ],
   "specification/transform/upgrade_transforms/examples/request/TransformUpgradeTransformsExample1.yaml": [
@@ -13967,6 +15893,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/_upgrade\""
+    },
+    {
+      "language": "Java",
+      "code": "client.transform().upgradeTransforms(u -> u)\n);\n"
     }
   ],
   "specification/transform/preview_transform/examples/request/PreviewTransformRequestExample1.yaml": [
@@ -13989,6 +15919,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"kibana_sample_data_ecommerce\"},\"pivot\":{\"group_by\":{\"customer_id\":{\"terms\":{\"field\":\"customer_id\",\"missing_bucket\":true}}},\"aggregations\":{\"max_price\":{\"max\":{\"field\":\"taxful_total_price\"}}}}}' \"$ELASTICSEARCH_URL/_transform/_preview\""
+    },
+    {
+      "language": "Java",
+      "code": "client.transform().previewTransform(p -> p\n    .pivot(pi -> pi\n        .aggregations(\"max_price\", a -> a\n            .max(m -> m\n                .field(\"taxful_total_price\")\n            )\n        )\n        .groupBy(\"customer_id\", g -> g\n            .terms(t -> t\n                .field(\"customer_id\")\n                .missingBucket(true)\n            )\n        )\n    )\n    .source(s -> s\n        .index(\"kibana_sample_data_ecommerce\")\n    )\n);\n"
     }
   ],
   "specification/transform/put_transform/examples/request/PutTransformRequestExample2.yaml": [
@@ -14011,6 +15945,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"kibana_sample_data_ecommerce\"},\"latest\":{\"unique_key\":[\"customer_id\"],\"sort\":\"order_date\"},\"description\":\"Latest order for each customer\",\"dest\":{\"index\":\"kibana_sample_data_ecommerce_transform2\"},\"frequency\":\"5m\",\"sync\":{\"time\":{\"field\":\"order_date\",\"delay\":\"60s\"}}}' \"$ELASTICSEARCH_URL/_transform/ecommerce_transform2\""
+    },
+    {
+      "language": "Java",
+      "code": "client.transform().putTransform(p -> p\n    .description(\"Latest order for each customer\")\n    .dest(d -> d\n        .index(\"kibana_sample_data_ecommerce_transform2\")\n    )\n    .frequency(f -> f\n        .time(\"5m\")\n    )\n    .latest(l -> l\n        .sort(\"order_date\")\n        .uniqueKey(\"customer_id\")\n    )\n    .source(s -> s\n        .index(\"kibana_sample_data_ecommerce\")\n    )\n    .sync(s -> s\n        .time(t -> t\n            .delay(d -> d\n                .time(\"60s\")\n            )\n            .field(\"order_date\")\n        )\n    )\n    .transformId(\"ecommerce_transform2\")\n);\n"
     }
   ],
   "specification/transform/put_transform/examples/request/PutTransformRequestExample1.yaml": [
@@ -14033,6 +15971,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"kibana_sample_data_ecommerce\",\"query\":{\"term\":{\"geoip.continent_name\":{\"value\":\"Asia\"}}}},\"pivot\":{\"group_by\":{\"customer_id\":{\"terms\":{\"field\":\"customer_id\",\"missing_bucket\":true}}},\"aggregations\":{\"max_price\":{\"max\":{\"field\":\"taxful_total_price\"}}}},\"description\":\"Maximum priced ecommerce data by customer_id in Asia\",\"dest\":{\"index\":\"kibana_sample_data_ecommerce_transform1\",\"pipeline\":\"add_timestamp_pipeline\"},\"frequency\":\"5m\",\"sync\":{\"time\":{\"field\":\"order_date\",\"delay\":\"60s\"}},\"retention_policy\":{\"time\":{\"field\":\"order_date\",\"max_age\":\"30d\"}}}' \"$ELASTICSEARCH_URL/_transform/ecommerce_transform1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.transform().putTransform(p -> p\n    .description(\"Maximum priced ecommerce data by customer_id in Asia\")\n    .dest(d -> d\n        .index(\"kibana_sample_data_ecommerce_transform1\")\n        .pipeline(\"add_timestamp_pipeline\")\n    )\n    .frequency(f -> f\n        .time(\"5m\")\n    )\n    .pivot(pi -> pi\n        .aggregations(\"max_price\", a -> a\n            .max(m -> m\n                .field(\"taxful_total_price\")\n            )\n        )\n        .groupBy(\"customer_id\", g -> g\n            .terms(t -> t\n                .field(\"customer_id\")\n                .missingBucket(true)\n            )\n        )\n    )\n    .retentionPolicy(r -> r\n        .time(t -> t\n            .field(\"order_date\")\n            .maxAge(m -> m\n                .time(\"30d\")\n            )\n        )\n    )\n    .source(s -> s\n        .index(\"kibana_sample_data_ecommerce\")\n        .query(q -> q\n            .term(te -> te\n                .field(\"geoip.continent_name\")\n                .value(FieldValue.of(\"Asia\"))\n            )\n        )\n    )\n    .sync(sy -> sy\n        .time(ti -> ti\n            .delay(d -> d\n                .time(\"60s\")\n            )\n            .field(\"order_date\")\n        )\n    )\n    .transformId(\"ecommerce_transform1\")\n);\n"
     }
   ],
   "specification/transform/update_transform/examples/request/UpdateTransformRequestExample1.yaml": [
@@ -14055,6 +15997,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"source\":{\"index\":\"kibana_sample_data_ecommerce\",\"query\":{\"term\":{\"geoip.continent_name\":{\"value\":\"Asia\"}}}},\"description\":\"Maximum priced ecommerce data by customer_id in Asia\",\"dest\":{\"index\":\"kibana_sample_data_ecommerce_transform_v2\",\"pipeline\":\"add_timestamp_pipeline\"},\"frequency\":\"15m\",\"sync\":{\"time\":{\"field\":\"order_date\",\"delay\":\"120s\"}}}' \"$ELASTICSEARCH_URL/_transform/simple-kibana-ecomm-pivot/_update\""
+    },
+    {
+      "language": "Java",
+      "code": "client.transform().updateTransform(u -> u\n    .description(\"Maximum priced ecommerce data by customer_id in Asia\")\n    .dest(d -> d\n        .index(\"kibana_sample_data_ecommerce_transform_v2\")\n        .pipeline(\"add_timestamp_pipeline\")\n    )\n    .frequency(f -> f\n        .time(\"15m\")\n    )\n    .source(s -> s\n        .index(\"kibana_sample_data_ecommerce\")\n        .query(q -> q\n            .term(t -> t\n                .field(\"geoip.continent_name\")\n                .value(FieldValue.of(\"Asia\"))\n            )\n        )\n    )\n    .sync(sy -> sy\n        .time(t -> t\n            .delay(d -> d\n                .time(\"120s\")\n            )\n            .field(\"order_date\")\n        )\n    )\n    .transformId(\"simple-kibana-ecomm-pivot\")\n);\n"
     }
   ],
   "specification/transform/reset_transform/examples/request/TransformResetTransformExample1.yaml": [
@@ -14077,6 +16023,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/ecommerce_transform/_reset\""
+    },
+    {
+      "language": "Java",
+      "code": "client.transform().resetTransform(r -> r\n    .transformId(\"ecommerce_transform\")\n);\n"
     }
   ],
   "specification/transform/stop_transform/examples/request/TransformStopTransformExample1.yaml": [
@@ -14099,28 +16049,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/ecommerce_transform/_stop\""
-    }
-  ],
-  "specification/transform/set_upgrade_mode/examples/request/TransformSetUpgradeModeExample1.yaml": [
-    {
-      "language": "Python",
-      "code": "resp = client.transform.set_upgrade_mode(\n    enabled=True,\n)"
     },
     {
-      "language": "JavaScript",
-      "code": "const response = await client.transform.setUpgradeMode({\n  enabled: \"true\",\n});"
-    },
-    {
-      "language": "Ruby",
-      "code": "response = client.transform.set_upgrade_mode(\n  enabled: \"true\"\n)"
-    },
-    {
-      "language": "PHP",
-      "code": "$resp = $client->transform()->setUpgradeMode([\n    \"enabled\" => \"true\",\n]);"
-    },
-    {
-      "language": "curl",
-      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/set_upgrade_mode?enabled=true\""
+      "language": "Java",
+      "code": "client.transform().stopTransform(s -> s\n    .transformId(\"ecommerce_transform\")\n);\n"
     }
   ],
   "specification/transform/get_transform_stats/examples/request/TransformGetTransformStatsExample1.yaml": [
@@ -14143,6 +16075,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/ecommerce-customer-transform/_stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.transform().getTransformStats(g -> g\n    .transformId(\"ecommerce-customer-transform\")\n);\n"
     }
   ],
   "specification/transform/delete_transform/examples/request/TransformDeleteTransformExample1.yaml": [
@@ -14165,6 +16101,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/ecommerce_transform\""
+    },
+    {
+      "language": "Java",
+      "code": "client.transform().deleteTransform(d -> d\n    .transformId(\"ecommerce_transform\")\n);\n"
     }
   ],
   "specification/ccr/forget_follower/examples/request/ForgetFollowerIndexRequestExample1.yaml": [
@@ -14187,6 +16127,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"follower_cluster\":\"<follower_cluster>\",\"follower_index\":\"<follower_index>\",\"follower_index_uuid\":\"<follower_index_uuid>\",\"leader_remote_cluster\":\"<leader_remote_cluster>\"}' \"$ELASTICSEARCH_URL/<leader_index>/_ccr/forget_follower\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().forgetFollower(f -> f\n    .followerCluster(\"<follower_cluster>\")\n    .followerIndex(\"<follower_index>\")\n    .followerIndexUuid(\"<follower_index_uuid>\")\n    .index(\"<leader_index>\")\n    .leaderRemoteCluster(\"<leader_remote_cluster>\")\n);\n"
     }
   ],
   "specification/ccr/delete_auto_follow_pattern/examples/request/DeleteAutoFollowPatternRequestExample1.yaml": [
@@ -14209,6 +16153,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ccr/auto_follow/my_auto_follow_pattern\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().deleteAutoFollowPattern(d -> d\n    .name(\"my_auto_follow_pattern\")\n);\n"
     }
   ],
   "specification/ccr/resume_auto_follow_pattern/examples/request/ResumeAutoFollowPatternRequestExample1.yaml": [
@@ -14231,6 +16179,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ccr/auto_follow/my_auto_follow_pattern/resume\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().resumeAutoFollowPattern(r -> r\n    .name(\"my_auto_follow_pattern\")\n);\n"
     }
   ],
   "specification/ccr/pause_follow/examples/request/PauseFollowIndexRequestExample1.yaml": [
@@ -14253,6 +16205,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/follower_index/_ccr/pause_follow\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().pauseFollow(p -> p\n    .index(\"follower_index\")\n);\n"
     }
   ],
   "specification/ccr/follow/examples/request/CreateFollowIndexRequestExample1.yaml": [
@@ -14275,6 +16231,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"remote_cluster\":\"remote_cluster\",\"leader_index\":\"leader_index\",\"settings\":{\"index.number_of_replicas\":0},\"max_read_request_operation_count\":1024,\"max_outstanding_read_requests\":16,\"max_read_request_size\":\"1024k\",\"max_write_request_operation_count\":32768,\"max_write_request_size\":\"16k\",\"max_outstanding_write_requests\":8,\"max_write_buffer_count\":512,\"max_write_buffer_size\":\"512k\",\"max_retry_delay\":\"10s\",\"read_poll_timeout\":\"30s\"}' \"$ELASTICSEARCH_URL/follower_index/_ccr/follow?wait_for_active_shards=1\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().follow(f -> f\n    .index(\"follower_index\")\n    .leaderIndex(\"leader_index\")\n    .maxOutstandingReadRequests(16L)\n    .maxOutstandingWriteRequests(8)\n    .maxReadRequestOperationCount(1024)\n    .maxReadRequestSize(\"1024k\")\n    .maxRetryDelay(m -> m\n        .time(\"10s\")\n    )\n    .maxWriteBufferCount(512)\n    .maxWriteBufferSize(\"512k\")\n    .maxWriteRequestOperationCount(32768)\n    .maxWriteRequestSize(\"16k\")\n    .readPollTimeout(r -> r\n        .time(\"30s\")\n    )\n    .remoteCluster(\"remote_cluster\")\n    .settings(s -> s\n        .otherSettings(\"index.number_of_replicas\", JsonData.fromJson(\"0\"))\n    )\n    .waitForActiveShards(w -> w\n        .count(1)\n    )\n);\n"
     }
   ],
   "specification/ccr/get_auto_follow_pattern/examples/request/GetAutoFollowPatternRequestExample1.yaml": [
@@ -14297,6 +16257,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ccr/auto_follow/my_auto_follow_pattern\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().getAutoFollowPattern(g -> g\n    .name(\"my_auto_follow_pattern\")\n);\n"
     }
   ],
   "specification/ccr/put_auto_follow_pattern/examples/request/PutAutoFollowPatternRequestExample1.yaml": [
@@ -14319,6 +16283,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"remote_cluster\":\"remote_cluster\",\"leader_index_patterns\":[\"leader_index*\"],\"follow_index_pattern\":\"{{leader_index}}-follower\",\"settings\":{\"index.number_of_replicas\":0},\"max_read_request_operation_count\":1024,\"max_outstanding_read_requests\":16,\"max_read_request_size\":\"1024k\",\"max_write_request_operation_count\":32768,\"max_write_request_size\":\"16k\",\"max_outstanding_write_requests\":8,\"max_write_buffer_count\":512,\"max_write_buffer_size\":\"512k\",\"max_retry_delay\":\"10s\",\"read_poll_timeout\":\"30s\"}' \"$ELASTICSEARCH_URL/_ccr/auto_follow/my_auto_follow_pattern\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().putAutoFollowPattern(p -> p\n    .followIndexPattern(\"{{leader_index}}-follower\")\n    .leaderIndexPatterns(\"leader_index*\")\n    .maxOutstandingReadRequests(16)\n    .maxOutstandingWriteRequests(8)\n    .maxReadRequestOperationCount(1024)\n    .maxReadRequestSize(\"1024k\")\n    .maxRetryDelay(m -> m\n        .time(\"10s\")\n    )\n    .maxWriteBufferCount(512)\n    .maxWriteBufferSize(\"512k\")\n    .maxWriteRequestOperationCount(32768)\n    .maxWriteRequestSize(\"16k\")\n    .name(\"my_auto_follow_pattern\")\n    .readPollTimeout(r -> r\n        .time(\"30s\")\n    )\n    .remoteCluster(\"remote_cluster\")\n    .settings(\"index.number_of_replicas\", JsonData.fromJson(\"0\"))\n);\n"
     }
   ],
   "specification/ccr/follow_info/examples/request/FollowInfoRequestExample1.yaml": [
@@ -14341,6 +16309,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/follower_index/_ccr/info\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().followInfo(f -> f\n    .index(\"follower_index\")\n);\n"
     }
   ],
   "specification/ccr/unfollow/examples/request/UnfollowIndexRequestExample1.yaml": [
@@ -14363,6 +16335,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/follower_index/_ccr/unfollow\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().unfollow(u -> u\n    .index(\"follower_index\")\n);\n"
     }
   ],
   "specification/ccr/resume_follow/examples/request/ResumeFollowIndexRequestExample1.yaml": [
@@ -14385,6 +16361,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"max_read_request_operation_count\":1024,\"max_outstanding_read_requests\":16,\"max_read_request_size\":\"1024k\",\"max_write_request_operation_count\":32768,\"max_write_request_size\":\"16k\",\"max_outstanding_write_requests\":8,\"max_write_buffer_count\":512,\"max_write_buffer_size\":\"512k\",\"max_retry_delay\":\"10s\",\"read_poll_timeout\":\"30s\"}' \"$ELASTICSEARCH_URL/follower_index/_ccr/resume_follow\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().resumeFollow(r -> r\n    .index(\"follower_index\")\n    .maxOutstandingReadRequests(16L)\n    .maxOutstandingWriteRequests(8L)\n    .maxReadRequestOperationCount(1024L)\n    .maxReadRequestSize(\"1024k\")\n    .maxRetryDelay(m -> m\n        .time(\"10s\")\n    )\n    .maxWriteBufferCount(512L)\n    .maxWriteBufferSize(\"512k\")\n    .maxWriteRequestOperationCount(32768L)\n    .maxWriteRequestSize(\"16k\")\n    .readPollTimeout(re -> re\n        .time(\"30s\")\n    )\n);\n"
     }
   ],
   "specification/ccr/follow_stats/examples/request/FollowIndexStatsRequestExample1.yaml": [
@@ -14407,6 +16387,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/follower_index/_ccr/stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().followStats(f -> f\n    .index(\"follower_index\")\n);\n"
     }
   ],
   "specification/ccr/stats/examples/request/CcrStatsRequestExample1.yaml": [
@@ -14429,6 +16413,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ccr/stats\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().stats(s -> s)\n);\n"
     }
   ],
   "specification/ccr/pause_auto_follow_pattern/examples/request/PauseAutoFollowPatternRequestExample1.yaml": [
@@ -14451,6 +16439,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ccr/auto_follow/my_auto_follow_pattern/pause\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ccr().pauseAutoFollowPattern(p -> p\n    .name(\"my_auto_follow_pattern\")\n);\n"
     }
   ],
   "specification/ilm/get_status/examples/request/IlmGetStatusExample1.yaml": [
@@ -14473,6 +16465,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ilm/status\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ilm().getStatus();\n"
     }
   ],
   "specification/ilm/move_to_step/examples/request/MoveToStepRequestExample1.yaml": [
@@ -14495,6 +16491,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"current_step\":{\"phase\":\"new\",\"action\":\"complete\",\"name\":\"complete\"},\"next_step\":{\"phase\":\"warm\",\"action\":\"forcemerge\",\"name\":\"forcemerge\"}}' \"$ELASTICSEARCH_URL/_ilm/move/my-index-000001\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ilm().moveToStep(m -> m\n    .currentStep(c -> c\n        .action(\"complete\")\n        .name(\"complete\")\n        .phase(\"new\")\n    )\n    .index(\"my-index-000001\")\n    .nextStep(n -> n\n        .action(\"forcemerge\")\n        .name(\"forcemerge\")\n        .phase(\"warm\")\n    )\n);\n"
     }
   ],
   "specification/ilm/move_to_step/examples/request/MoveToStepRequestExample2.yaml": [
@@ -14517,6 +16517,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"current_step\":{\"phase\":\"hot\",\"action\":\"complete\",\"name\":\"complete\"},\"next_step\":{\"phase\":\"warm\"}}' \"$ELASTICSEARCH_URL/_ilm/move/my-index-000001\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ilm().moveToStep(m -> m\n    .currentStep(c -> c\n        .action(\"complete\")\n        .name(\"complete\")\n        .phase(\"hot\")\n    )\n    .index(\"my-index-000001\")\n    .nextStep(n -> n\n        .phase(\"warm\")\n    )\n);\n"
     }
   ],
   "specification/ilm/migrate_to_data_tiers/examples/request/MigrateToDataTiersRequestExample1.yaml": [
@@ -14539,6 +16543,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"legacy_template_to_delete\":\"global-template\",\"node_attribute\":\"custom_attribute_name\"}' \"$ELASTICSEARCH_URL/_ilm/migrate_to_data_tiers\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ilm().migrateToDataTiers(m -> m\n    .legacyTemplateToDelete(\"global-template\")\n    .nodeAttribute(\"custom_attribute_name\")\n);\n"
     }
   ],
   "specification/ilm/retry/examples/request/IlmRetryExample1.yaml": [
@@ -14561,6 +16569,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_ilm/retry\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ilm().retry(r -> r\n    .index(\"my-index-000001\")\n);\n"
     }
   ],
   "specification/ilm/delete_lifecycle/examples/request/IlmDeleteLifecycleExample1.yaml": [
@@ -14583,6 +16595,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ilm/policy/my_policy\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ilm().deleteLifecycle(d -> d\n    .name(\"my_policy\")\n);\n"
     }
   ],
   "specification/ilm/start/examples/request/IlmStartExample1.yaml": [
@@ -14605,6 +16621,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ilm/start\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ilm().start(s -> s)\n);\n"
     }
   ],
   "specification/ilm/explain_lifecycle/examples/request/IlmExplainLifecycleExample1.yaml": [
@@ -14627,6 +16647,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/.ds-timeseries-*/_ilm/explain\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ilm().explainLifecycle(e -> e\n    .index(\".ds-timeseries-*\")\n);\n"
     }
   ],
   "specification/ilm/stop/examples/request/IlmStopExample1.yaml": [
@@ -14649,6 +16673,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ilm/stop\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ilm().stop(s -> s)\n);\n"
     }
   ],
   "specification/ilm/remove_policy/examples/request/IlmRemovePolicyExample1.yaml": [
@@ -14671,6 +16699,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/logs-my_app-default/_ilm/remove\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ilm().removePolicy(r -> r\n    .index(\"logs-my_app-default\")\n);\n"
     }
   ],
   "specification/ilm/get_lifecycle/examples/request/IlmGetLifecycleExample1.yaml": [
@@ -14693,6 +16725,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_ilm/policy/my_policy\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ilm().getLifecycle(g -> g\n    .name(\"my_policy\")\n);\n"
     }
   ],
   "specification/ilm/put_lifecycle/examples/request/PutLifecycleRequestExample1.yaml": [
@@ -14715,6 +16751,10 @@
     {
       "language": "curl",
       "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"policy\":{\"_meta\":{\"description\":\"used for nginx log\",\"project\":{\"name\":\"myProject\",\"department\":\"myDepartment\"}},\"phases\":{\"warm\":{\"min_age\":\"10d\",\"actions\":{\"forcemerge\":{\"max_num_segments\":1}}},\"delete\":{\"min_age\":\"30d\",\"actions\":{\"delete\":{}}}}}}' \"$ELASTICSEARCH_URL/_ilm/policy/my_policy\""
+    },
+    {
+      "language": "Java",
+      "code": "client.ilm().putLifecycle(p -> p\n    .name(\"my_policy\")\n    .policy(po -> po\n        .phases(ph -> ph\n            .delete(d -> d\n                .actions(a -> a\n                    .delete(de -> de)\n                )\n                .minAge(m -> m\n                    .time(\"30d\")\n                )\n            )\n            .warm(w -> w\n                .actions(a -> a\n                    .forcemerge(f -> f\n                        .maxNumSegments(1)\n                    )\n                )\n                .minAge(m -> m\n                    .time(\"10d\")\n                )\n            )\n        )\n        .meta(Map.of(\"description\", JsonData.fromJson(\"\\\"used for nginx log\\\"\"),\"project\", JsonData.fromJson(\"{\\\"name\\\":\\\"myProject\\\",\\\"department\\\":\\\"myDepartment\\\"}\")))\n    )\n);\n"
     }
   ],
   "specification/sql/delete_async/examples/request/SqlDeleteAsyncExample1.yaml": [
@@ -14737,6 +16777,10 @@
     {
       "language": "curl",
       "code": "curl -X DELETE -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_sql/async/delete/FmdMX2pIang3UWhLRU5QS0lqdlppYncaMUpYQ05oSkpTc3kwZ21EdC1tbFJXQToxOTI=\""
+    },
+    {
+      "language": "Java",
+      "code": "client.sql().deleteAsync(d -> d\n    .id(\"FmdMX2pIang3UWhLRU5QS0lqdlppYncaMUpYQ05oSkpTc3kwZ21EdC1tbFJXQToxOTI=\")\n);\n"
     }
   ],
   "specification/sql/translate/examples/request/TranslateSqlRequestExample1.yaml": [
@@ -14759,6 +16803,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":\"SELECT * FROM library ORDER BY page_count DESC\",\"fetch_size\":10}' \"$ELASTICSEARCH_URL/_sql/translate\""
+    },
+    {
+      "language": "Java",
+      "code": "client.sql().translate(t -> t\n    .fetchSize(10)\n    .query(\"SELECT * FROM library ORDER BY page_count DESC\")\n);\n"
     }
   ],
   "specification/sql/clear_cursor/examples/request/ClearSqlCursorRequestExample1.yaml": [
@@ -14781,6 +16829,10 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"cursor\":\"sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWYUpOYklQMHhRUEtld3RsNnFtYU1hQQ==:BAFmBGRhdGUBZgVsaWtlcwFzB21lc3NhZ2UBZgR1c2Vy9f///w8=\"}' \"$ELASTICSEARCH_URL/_sql/close\""
+    },
+    {
+      "language": "Java",
+      "code": "client.sql().clearCursor(c -> c\n    .cursor(\"sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWYUpOYklQMHhRUEtld3RsNnFtYU1hQQ==:BAFmBGRhdGUBZgVsaWtlcwFzB21lc3NhZ2UBZgR1c2Vy9f///w8=\")\n);\n"
     }
   ],
   "specification/sql/get_async/examples/request/SqlGetAsyncExample1.yaml": [
@@ -14803,6 +16855,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_sql/async/FnR0TDhyWUVmUmVtWXRWZER4MXZiNFEad2F5UDk2ZVdTVHV1S0xDUy00SklUdzozMTU=?wait_for_completion_timeout=2s&format=json\""
+    },
+    {
+      "language": "Java",
+      "code": "client.sql().getAsync(g -> g\n    .format(\"json\")\n    .id(\"FnR0TDhyWUVmUmVtWXRWZER4MXZiNFEad2F5UDk2ZVdTVHV1S0xDUy00SklUdzozMTU=\")\n    .waitForCompletionTimeout(w -> w\n        .offset(2)\n    )\n);\n"
     }
   ],
   "specification/sql/get_async_status/examples/request/SqlGetAsyncStatusExample1.yaml": [
@@ -14825,6 +16881,10 @@
     {
       "language": "curl",
       "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_sql/async/status/FnR0TDhyWUVmUmVtWXRWZER4MXZiNFEad2F5UDk2ZVdTVHV1S0xDUy00SklUdzozMTU=\""
+    },
+    {
+      "language": "Java",
+      "code": "client.sql().getAsyncStatus(g -> g\n    .id(\"FnR0TDhyWUVmUmVtWXRWZER4MXZiNFEad2F5UDk2ZVdTVHV1S0xDUy00SklUdzozMTU=\")\n);\n"
     }
   ],
   "specification/sql/query/examples/request/QuerySqlRequestExample1.yaml": [
@@ -14847,6 +16907,848 @@
     {
       "language": "curl",
       "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"query\":\"SELECT * FROM library ORDER BY page_count DESC LIMIT 5\"}' \"$ELASTICSEARCH_URL/_sql?format=txt\""
+    },
+    {
+      "language": "Java",
+      "code": "client.sql().query(q -> q\n    .format(SqlFormat.Txt)\n    .query(\"SELECT * FROM library ORDER BY page_count DESC LIMIT 5\")\n);\n"
+    }
+  ],
+  "specification/cluster/allocation_explain/examples/request/ClusterAllocationExplainRequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.cluster.allocation_explain(\n    index=\"my-index-000001\",\n    shard=\"0\",\n    primary=False,\n    current_node=\"my-node\",\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.cluster.allocationExplain({\n  index: \"my-index-000001\",\n  shard: 0,\n  primary: \"false\",\n  current_node: \"my-node\",\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.cluster.allocation_explain(\n  index: \"my-index-000001\",\n  shard: \"0\",\n  primary: \"false\",\n  current_node: \"my-node\",\n  body: {}\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->cluster()->allocationExplain([\n    \"index\" => \"my-index-000001\",\n    \"shard\" => \"0\",\n    \"primary\" => \"false\",\n    \"current_node\" => \"my-node\",\n    \"body\" => new ArrayObject([]),\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{}' \"$ELASTICSEARCH_URL/_cluster/allocation/explain?index=my-index-000001&shard=0&primary=false&current_node=my-node\""
+    },
+    {
+      "language": "Java",
+      "code": "client.cluster().allocationExplain(a -> a\n    .currentNode(\"my-node\")\n    .index(\"my-index-000001\")\n    .primary(false)\n    .shard(0)\n);\n"
+    }
+  ],
+  "specification/inference/put_cohere/examples/request/PutCohereRequestExample3.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"cohere-completion\",\n    inference_config={\n        \"service\": \"cohere\",\n        \"service_settings\": {\n            \"api_key\": \"Cohere-API-key\",\n            \"model_id\": \"command-a-03-2025\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"cohere-completion\",\n  inference_config: {\n    service: \"cohere\",\n    service_settings: {\n      api_key: \"Cohere-API-key\",\n      model_id: \"command-a-03-2025\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"cohere-completion\",\n  body: {\n    \"service\": \"cohere\",\n    \"service_settings\": {\n      \"api_key\": \"Cohere-API-key\",\n      \"model_id\": \"command-a-03-2025\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"cohere-completion\",\n    \"body\" => [\n        \"service\" => \"cohere\",\n        \"service_settings\" => [\n            \"api_key\" => \"Cohere-API-key\",\n            \"model_id\" => \"command-a-03-2025\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"cohere\",\"service_settings\":{\"api_key\":\"Cohere-API-key\",\"model_id\":\"command-a-03-2025\"}}' \"$ELASTICSEARCH_URL/_inference/completion/cohere-completion\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"cohere-completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"cohere\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Cohere-API-key\\\",\\\"model_id\\\":\\\"command-a-03-2025\\\"}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"amazon_sagemaker_embeddings\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\",\n            \"dimensions\": 384,\n            \"element_type\": \"float\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"amazon_sagemaker_embeddings\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n      dimensions: 384,\n      element_type: \"float\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"amazon_sagemaker_embeddings\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\",\n      \"dimensions\": 384,\n      \"element_type\": \"float\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"amazon_sagemaker_embeddings\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n            \"dimensions\" => 384,\n            \"element_type\" => \"float\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\",\"dimensions\":384,\"element_type\":\"float\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/amazon_sagemaker_embeddings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"amazon_sagemaker_embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"amazon_sagemaker\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"access_key\\\":\\\"AWS-access-key\\\",\\\"secret_key\\\":\\\"AWS-secret-key\\\",\\\"region\\\":\\\"us-east-1\\\",\\\"api\\\":\\\"elastic\\\",\\\"endpoint_name\\\":\\\"my-endpoint\\\",\\\"dimensions\\\":384,\\\"element_type\\\":\\\"float\\\"}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"amazon_sagemaker_completion\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"amazon_sagemaker_completion\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"amazon_sagemaker_completion\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"amazon_sagemaker_completion\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/completion/amazon_sagemaker_completion\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"amazon_sagemaker_completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"amazon_sagemaker\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"access_key\\\":\\\"AWS-access-key\\\",\\\"secret_key\\\":\\\"AWS-secret-key\\\",\\\"region\\\":\\\"us-east-1\\\",\\\"api\\\":\\\"elastic\\\",\\\"endpoint_name\\\":\\\"my-endpoint\\\"}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample3.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"chat_completion\",\n    inference_id=\"amazon_sagemaker_chat_completion\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"chat_completion\",\n  inference_id: \"amazon_sagemaker_chat_completion\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"chat_completion\",\n  inference_id: \"amazon_sagemaker_chat_completion\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"chat_completion\",\n    \"inference_id\" => \"amazon_sagemaker_chat_completion\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/chat_completion/amazon_sagemaker_chat_completion\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"amazon_sagemaker_chat_completion\")\n    .taskType(TaskType.ChatCompletion)\n    .inferenceConfig(i -> i\n        .service(\"amazon_sagemaker\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"access_key\\\":\\\"AWS-access-key\\\",\\\"secret_key\\\":\\\"AWS-secret-key\\\",\\\"region\\\":\\\"us-east-1\\\",\\\"api\\\":\\\"elastic\\\",\\\"endpoint_name\\\":\\\"my-endpoint\\\"}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample4.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"sparse_embedding\",\n    inference_id=\"amazon_sagemaker_sparse_embedding\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"sparse_embedding\",\n  inference_id: \"amazon_sagemaker_sparse_embedding\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"sparse_embedding\",\n  inference_id: \"amazon_sagemaker_sparse_embedding\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"sparse_embedding\",\n    \"inference_id\" => \"amazon_sagemaker_sparse_embedding\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/sparse_embedding/amazon_sagemaker_sparse_embedding\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"amazon_sagemaker_sparse_embedding\")\n    .taskType(TaskType.SparseEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"amazon_sagemaker\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"access_key\\\":\\\"AWS-access-key\\\",\\\"secret_key\\\":\\\"AWS-secret-key\\\",\\\"region\\\":\\\"us-east-1\\\",\\\"api\\\":\\\"elastic\\\",\\\"endpoint_name\\\":\\\"my-endpoint\\\"}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_amazonsagemaker/examples/request/PutAmazonSageMakerRequestExample5.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"amazon_sagemaker_rerank\",\n    inference_config={\n        \"service\": \"amazon_sagemaker\",\n        \"service_settings\": {\n            \"access_key\": \"AWS-access-key\",\n            \"secret_key\": \"AWS-secret-key\",\n            \"region\": \"us-east-1\",\n            \"api\": \"elastic\",\n            \"endpoint_name\": \"my-endpoint\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"amazon_sagemaker_rerank\",\n  inference_config: {\n    service: \"amazon_sagemaker\",\n    service_settings: {\n      access_key: \"AWS-access-key\",\n      secret_key: \"AWS-secret-key\",\n      region: \"us-east-1\",\n      api: \"elastic\",\n      endpoint_name: \"my-endpoint\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"amazon_sagemaker_rerank\",\n  body: {\n    \"service\": \"amazon_sagemaker\",\n    \"service_settings\": {\n      \"access_key\": \"AWS-access-key\",\n      \"secret_key\": \"AWS-secret-key\",\n      \"region\": \"us-east-1\",\n      \"api\": \"elastic\",\n      \"endpoint_name\": \"my-endpoint\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"amazon_sagemaker_rerank\",\n    \"body\" => [\n        \"service\" => \"amazon_sagemaker\",\n        \"service_settings\" => [\n            \"access_key\" => \"AWS-access-key\",\n            \"secret_key\" => \"AWS-secret-key\",\n            \"region\" => \"us-east-1\",\n            \"api\" => \"elastic\",\n            \"endpoint_name\" => \"my-endpoint\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"amazon_sagemaker\",\"service_settings\":{\"access_key\":\"AWS-access-key\",\"secret_key\":\"AWS-secret-key\",\"region\":\"us-east-1\",\"api\":\"elastic\",\"endpoint_name\":\"my-endpoint\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/amazon_sagemaker_rerank\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"amazon_sagemaker_rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"amazon_sagemaker\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"access_key\\\":\\\"AWS-access-key\\\",\\\"secret_key\\\":\\\"AWS-secret-key\\\",\\\"region\\\":\\\"us-east-1\\\",\\\"api\\\":\\\"elastic\\\",\\\"endpoint_name\\\":\\\"my-endpoint\\\"}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_ai21/examples/request/PutAi21RequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"ai21-completion\",\n    inference_config={\n        \"service\": \"ai21\",\n        \"service_settings\": {\n            \"api_key\": \"ai21-api-key\",\n            \"model_id\": \"jamba-large\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"ai21-completion\",\n  inference_config: {\n    service: \"ai21\",\n    service_settings: {\n      api_key: \"ai21-api-key\",\n      model_id: \"jamba-large\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"ai21-completion\",\n  body: {\n    \"service\": \"ai21\",\n    \"service_settings\": {\n      \"api_key\": \"ai21-api-key\",\n      \"model_id\": \"jamba-large\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"ai21-completion\",\n    \"body\" => [\n        \"service\" => \"ai21\",\n        \"service_settings\" => [\n            \"api_key\" => \"ai21-api-key\",\n            \"model_id\" => \"jamba-large\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"ai21\",\"service_settings\":{\"api_key\":\"ai21-api-key\",\"model_id\":\"jamba-large\"}}' \"$ELASTICSEARCH_URL/_inference/completion/ai21-completion\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"ai21-completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"ai21\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"ai21-api-key\\\",\\\"model_id\\\":\\\"jamba-large\\\"}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_ai21/examples/request/PutAi21RequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"chat-completion\",\n    inference_id=\"ai21-chat-completion\",\n    inference_config={\n        \"service\": \"ai21\",\n        \"service_settings\": {\n            \"api_key\": \"ai21-api-key\",\n            \"model_id\": \"jamba-mini\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"chat-completion\",\n  inference_id: \"ai21-chat-completion\",\n  inference_config: {\n    service: \"ai21\",\n    service_settings: {\n      api_key: \"ai21-api-key\",\n      model_id: \"jamba-mini\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"chat-completion\",\n  inference_id: \"ai21-chat-completion\",\n  body: {\n    \"service\": \"ai21\",\n    \"service_settings\": {\n      \"api_key\": \"ai21-api-key\",\n      \"model_id\": \"jamba-mini\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"chat-completion\",\n    \"inference_id\" => \"ai21-chat-completion\",\n    \"body\" => [\n        \"service\" => \"ai21\",\n        \"service_settings\" => [\n            \"api_key\" => \"ai21-api-key\",\n            \"model_id\" => \"jamba-mini\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"ai21\",\"service_settings\":{\"api_key\":\"ai21-api-key\",\"model_id\":\"jamba-mini\"}}' \"$ELASTICSEARCH_URL/_inference/chat-completion/ai21-chat-completion\""
+    }
+  ],
+  "specification/inference/put_custom/examples/request/PutCustomRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"custom-embeddings\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"https://api.openai.com/v1/embeddings\",\n            \"headers\": {\n                \"Authorization\": \"Bearer ${api_key}\",\n                \"Content-Type\": \"application/json;charset=utf-8\"\n            },\n            \"request\": \"{\\\"input\\\": ${input}, \\\"model\\\": \\\"text-embedding-3-small\\\"}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"text_embeddings\": \"$.data[*].embedding[*]\"\n                }\n            }\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"custom-embeddings\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"https://api.openai.com/v1/embeddings\",\n      headers: {\n        Authorization: \"Bearer ${api_key}\",\n        \"Content-Type\": \"application/json;charset=utf-8\",\n      },\n      request: '{\"input\": ${input}, \"model\": \"text-embedding-3-small\"}',\n      response: {\n        json_parser: {\n          text_embeddings: \"$.data[*].embedding[*]\",\n        },\n      },\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"custom-embeddings\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"https://api.openai.com/v1/embeddings\",\n      \"headers\": {\n        \"Authorization\": \"Bearer ${api_key}\",\n        \"Content-Type\": \"application/json;charset=utf-8\"\n      },\n      \"request\": \"{\\\"input\\\": ${input}, \\\"model\\\": \\\"text-embedding-3-small\\\"}\",\n      \"response\": {\n        \"json_parser\": {\n          \"text_embeddings\": \"$.data[*].embedding[*]\"\n        }\n      }\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"custom-embeddings\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"https://api.openai.com/v1/embeddings\",\n            \"headers\" => [\n                \"Authorization\" => \"Bearer ${api_key}\",\n                \"Content-Type\" => \"application/json;charset=utf-8\",\n            ],\n            \"request\" => \"{\\\"input\\\": ${input}, \\\"model\\\": \\\"text-embedding-3-small\\\"}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"text_embeddings\" => \"$.data[*].embedding[*]\",\n                ],\n            ],\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"https://api.openai.com/v1/embeddings\",\"headers\":{\"Authorization\":\"Bearer ${api_key}\",\"Content-Type\":\"application/json;charset=utf-8\"},\"request\":\"{\\\"input\\\": ${input}, \\\"model\\\": \\\"text-embedding-3-small\\\"}\",\"response\":{\"json_parser\":{\"text_embeddings\":\"$.data[*].embedding[*]\"}}}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/custom-embeddings\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"custom-embeddings\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"custom\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"secret_parameters\\\":{\\\"api_key\\\":\\\"<api key>\\\"},\\\"url\\\":\\\"https://api.openai.com/v1/embeddings\\\",\\\"headers\\\":{\\\"Authorization\\\":\\\"Bearer ${api_key}\\\",\\\"Content-Type\\\":\\\"application/json;charset=utf-8\\\"},\\\"request\\\":\\\"{\\\\\"input\\\\\": ${input}, \\\\\"model\\\\\": \\\\\"text-embedding-3-small\\\\\"}\\\",\\\"response\\\":{\\\"json_parser\\\":{\\\"text_embeddings\\\":\\\"$.data[*].embedding[*]\\\"}}}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_custom/examples/request/PutCustomRequestExample3.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"custom-text-embedding\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"https://api.cohere.com/v2/embed\",\n            \"headers\": {\n                \"Authorization\": \"bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n            },\n            \"request\": \"{\\\"texts\\\": ${input}, \\\"model\\\": \\\"embed-v4.0\\\", \\\"input_type\\\": ${input_type}}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"text_embeddings\": \"$.embeddings.float[*]\"\n                }\n            },\n            \"input_type\": {\n                \"translation\": {\n                    \"ingest\": \"search_document\",\n                    \"search\": \"search_query\"\n                },\n                \"default\": \"search_document\"\n            }\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"custom-text-embedding\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"https://api.cohere.com/v2/embed\",\n      headers: {\n        Authorization: \"bearer ${api_key}\",\n        \"Content-Type\": \"application/json\",\n      },\n      request:\n        '{\"texts\": ${input}, \"model\": \"embed-v4.0\", \"input_type\": ${input_type}}',\n      response: {\n        json_parser: {\n          text_embeddings: \"$.embeddings.float[*]\",\n        },\n      },\n      input_type: {\n        translation: {\n          ingest: \"search_document\",\n          search: \"search_query\",\n        },\n        default: \"search_document\",\n      },\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"custom-text-embedding\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"https://api.cohere.com/v2/embed\",\n      \"headers\": {\n        \"Authorization\": \"bearer ${api_key}\",\n        \"Content-Type\": \"application/json\"\n      },\n      \"request\": \"{\\\"texts\\\": ${input}, \\\"model\\\": \\\"embed-v4.0\\\", \\\"input_type\\\": ${input_type}}\",\n      \"response\": {\n        \"json_parser\": {\n          \"text_embeddings\": \"$.embeddings.float[*]\"\n        }\n      },\n      \"input_type\": {\n        \"translation\": {\n          \"ingest\": \"search_document\",\n          \"search\": \"search_query\"\n        },\n        \"default\": \"search_document\"\n      }\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"custom-text-embedding\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"https://api.cohere.com/v2/embed\",\n            \"headers\" => [\n                \"Authorization\" => \"bearer ${api_key}\",\n                \"Content-Type\" => \"application/json\",\n            ],\n            \"request\" => \"{\\\"texts\\\": ${input}, \\\"model\\\": \\\"embed-v4.0\\\", \\\"input_type\\\": ${input_type}}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"text_embeddings\" => \"$.embeddings.float[*]\",\n                ],\n            ],\n            \"input_type\" => [\n                \"translation\" => [\n                    \"ingest\" => \"search_document\",\n                    \"search\" => \"search_query\",\n                ],\n                \"default\" => \"search_document\",\n            ],\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"https://api.cohere.com/v2/embed\",\"headers\":{\"Authorization\":\"bearer ${api_key}\",\"Content-Type\":\"application/json\"},\"request\":\"{\\\"texts\\\": ${input}, \\\"model\\\": \\\"embed-v4.0\\\", \\\"input_type\\\": ${input_type}}\",\"response\":{\"json_parser\":{\"text_embeddings\":\"$.embeddings.float[*]\"}},\"input_type\":{\"translation\":{\"ingest\":\"search_document\",\"search\":\"search_query\"},\"default\":\"search_document\"}}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/custom-text-embedding\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"custom-text-embedding\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"custom\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"secret_parameters\\\":{\\\"api_key\\\":\\\"<api key>\\\"},\\\"url\\\":\\\"https://api.cohere.com/v2/embed\\\",\\\"headers\\\":{\\\"Authorization\\\":\\\"bearer ${api_key}\\\",\\\"Content-Type\\\":\\\"application/json\\\"},\\\"request\\\":\\\"{\\\\\"texts\\\\\": ${input}, \\\\\"model\\\\\": \\\\\"embed-v4.0\\\\\", \\\\\"input_type\\\\\": ${input_type}}\\\",\\\"response\\\":{\\\"json_parser\\\":{\\\"text_embeddings\\\":\\\"$.embeddings.float[*]\\\"}},\\\"input_type\\\":{\\\"translation\\\":{\\\"ingest\\\":\\\"search_document\\\",\\\"search\\\":\\\"search_query\\\"},\\\"default\\\":\\\"search_document\\\"}}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_custom/examples/request/PutCustomRequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"custom-rerank\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"https://api.cohere.com/v2/rerank\",\n            \"headers\": {\n                \"Authorization\": \"bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n            },\n            \"request\": \"{\\\"documents\\\": ${input}, \\\"query\\\": ${query}, \\\"model\\\": \\\"rerank-v3.5\\\"}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"reranked_index\": \"$.results[*].index\",\n                    \"relevance_score\": \"$.results[*].relevance_score\"\n                }\n            }\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"custom-rerank\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"https://api.cohere.com/v2/rerank\",\n      headers: {\n        Authorization: \"bearer ${api_key}\",\n        \"Content-Type\": \"application/json\",\n      },\n      request:\n        '{\"documents\": ${input}, \"query\": ${query}, \"model\": \"rerank-v3.5\"}',\n      response: {\n        json_parser: {\n          reranked_index: \"$.results[*].index\",\n          relevance_score: \"$.results[*].relevance_score\",\n        },\n      },\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"custom-rerank\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"https://api.cohere.com/v2/rerank\",\n      \"headers\": {\n        \"Authorization\": \"bearer ${api_key}\",\n        \"Content-Type\": \"application/json\"\n      },\n      \"request\": \"{\\\"documents\\\": ${input}, \\\"query\\\": ${query}, \\\"model\\\": \\\"rerank-v3.5\\\"}\",\n      \"response\": {\n        \"json_parser\": {\n          \"reranked_index\": \"$.results[*].index\",\n          \"relevance_score\": \"$.results[*].relevance_score\"\n        }\n      }\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"custom-rerank\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"https://api.cohere.com/v2/rerank\",\n            \"headers\" => [\n                \"Authorization\" => \"bearer ${api_key}\",\n                \"Content-Type\" => \"application/json\",\n            ],\n            \"request\" => \"{\\\"documents\\\": ${input}, \\\"query\\\": ${query}, \\\"model\\\": \\\"rerank-v3.5\\\"}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"reranked_index\" => \"$.results[*].index\",\n                    \"relevance_score\" => \"$.results[*].relevance_score\",\n                ],\n            ],\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"https://api.cohere.com/v2/rerank\",\"headers\":{\"Authorization\":\"bearer ${api_key}\",\"Content-Type\":\"application/json\"},\"request\":\"{\\\"documents\\\": ${input}, \\\"query\\\": ${query}, \\\"model\\\": \\\"rerank-v3.5\\\"}\",\"response\":{\"json_parser\":{\"reranked_index\":\"$.results[*].index\",\"relevance_score\":\"$.results[*].relevance_score\"}}}}' \"$ELASTICSEARCH_URL/_inference/rerank/custom-rerank\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"custom-rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"custom\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"secret_parameters\\\":{\\\"api_key\\\":\\\"<api key>\\\"},\\\"url\\\":\\\"https://api.cohere.com/v2/rerank\\\",\\\"headers\\\":{\\\"Authorization\\\":\\\"bearer ${api_key}\\\",\\\"Content-Type\\\":\\\"application/json\\\"},\\\"request\\\":\\\"{\\\\\"documents\\\\\": ${input}, \\\\\"query\\\\\": ${query}, \\\\\"model\\\\\": \\\\\"rerank-v3.5\\\\\"}\\\",\\\"response\\\":{\\\"json_parser\\\":{\\\"reranked_index\\\":\\\"$.results[*].index\\\",\\\"relevance_score\\\":\\\"$.results[*].relevance_score\\\"}}}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_custom/examples/request/PutCustomRequestExample5.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"custom-text-embedding-hf\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"<dedicated inference endpoint on HF>/v1/embeddings\",\n            \"headers\": {\n                \"Authorization\": \"Bearer ${api_key}\",\n                \"Content-Type\": \"application/json\"\n            },\n            \"request\": \"{\\\"input\\\": ${input}}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"text_embeddings\": \"$.data[*].embedding[*]\"\n                }\n            }\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"custom-text-embedding-hf\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"<dedicated inference endpoint on HF>/v1/embeddings\",\n      headers: {\n        Authorization: \"Bearer ${api_key}\",\n        \"Content-Type\": \"application/json\",\n      },\n      request: '{\"input\": ${input}}',\n      response: {\n        json_parser: {\n          text_embeddings: \"$.data[*].embedding[*]\",\n        },\n      },\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"custom-text-embedding-hf\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"<dedicated inference endpoint on HF>/v1/embeddings\",\n      \"headers\": {\n        \"Authorization\": \"Bearer ${api_key}\",\n        \"Content-Type\": \"application/json\"\n      },\n      \"request\": \"{\\\"input\\\": ${input}}\",\n      \"response\": {\n        \"json_parser\": {\n          \"text_embeddings\": \"$.data[*].embedding[*]\"\n        }\n      }\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"custom-text-embedding-hf\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"<dedicated inference endpoint on HF>/v1/embeddings\",\n            \"headers\" => [\n                \"Authorization\" => \"Bearer ${api_key}\",\n                \"Content-Type\" => \"application/json\",\n            ],\n            \"request\" => \"{\\\"input\\\": ${input}}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"text_embeddings\" => \"$.data[*].embedding[*]\",\n                ],\n            ],\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"<dedicated inference endpoint on HF>/v1/embeddings\",\"headers\":{\"Authorization\":\"Bearer ${api_key}\",\"Content-Type\":\"application/json\"},\"request\":\"{\\\"input\\\": ${input}}\",\"response\":{\"json_parser\":{\"text_embeddings\":\"$.data[*].embedding[*]\"}}}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/custom-text-embedding-hf\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"custom-text-embedding-hf\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"custom\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"secret_parameters\\\":{\\\"api_key\\\":\\\"<api key>\\\"},\\\"url\\\":\\\"<dedicated inference endpoint on HF>/v1/embeddings\\\",\\\"headers\\\":{\\\"Authorization\\\":\\\"Bearer ${api_key}\\\",\\\"Content-Type\\\":\\\"application/json\\\"},\\\"request\\\":\\\"{\\\\\"input\\\\\": ${input}}\\\",\\\"response\\\":{\\\"json_parser\\\":{\\\"text_embeddings\\\":\\\"$.data[*].embedding[*]\\\"}}}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_custom/examples/request/PutCustomRequestExample4.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"custom-rerank-jina\",\n    inference_config={\n        \"service\": \"custom\",\n        \"service_settings\": {\n            \"secret_parameters\": {\n                \"api_key\": \"<api key>\"\n            },\n            \"url\": \"https://api.jina.ai/v1/rerank\",\n            \"headers\": {\n                \"Content-Type\": \"application/json\",\n                \"Authorization\": \"Bearer ${api_key}\"\n            },\n            \"request\": \"{\\\"model\\\": \\\"jina-reranker-v2-base-multilingual\\\",\\\"query\\\": ${query},\\\"documents\\\":${input}}\",\n            \"response\": {\n                \"json_parser\": {\n                    \"relevance_score\": \"$.results[*].relevance_score\",\n                    \"reranked_index\": \"$.results[*].index\"\n                }\n            }\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"custom-rerank-jina\",\n  inference_config: {\n    service: \"custom\",\n    service_settings: {\n      secret_parameters: {\n        api_key: \"<api key>\",\n      },\n      url: \"https://api.jina.ai/v1/rerank\",\n      headers: {\n        \"Content-Type\": \"application/json\",\n        Authorization: \"Bearer ${api_key}\",\n      },\n      request:\n        '{\"model\": \"jina-reranker-v2-base-multilingual\",\"query\": ${query},\"documents\":${input}}',\n      response: {\n        json_parser: {\n          relevance_score: \"$.results[*].relevance_score\",\n          reranked_index: \"$.results[*].index\",\n        },\n      },\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"custom-rerank-jina\",\n  body: {\n    \"service\": \"custom\",\n    \"service_settings\": {\n      \"secret_parameters\": {\n        \"api_key\": \"<api key>\"\n      },\n      \"url\": \"https://api.jina.ai/v1/rerank\",\n      \"headers\": {\n        \"Content-Type\": \"application/json\",\n        \"Authorization\": \"Bearer ${api_key}\"\n      },\n      \"request\": \"{\\\"model\\\": \\\"jina-reranker-v2-base-multilingual\\\",\\\"query\\\": ${query},\\\"documents\\\":${input}}\",\n      \"response\": {\n        \"json_parser\": {\n          \"relevance_score\": \"$.results[*].relevance_score\",\n          \"reranked_index\": \"$.results[*].index\"\n        }\n      }\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"custom-rerank-jina\",\n    \"body\" => [\n        \"service\" => \"custom\",\n        \"service_settings\" => [\n            \"secret_parameters\" => [\n                \"api_key\" => \"<api key>\",\n            ],\n            \"url\" => \"https://api.jina.ai/v1/rerank\",\n            \"headers\" => [\n                \"Content-Type\" => \"application/json\",\n                \"Authorization\" => \"Bearer ${api_key}\",\n            ],\n            \"request\" => \"{\\\"model\\\": \\\"jina-reranker-v2-base-multilingual\\\",\\\"query\\\": ${query},\\\"documents\\\":${input}}\",\n            \"response\" => [\n                \"json_parser\" => [\n                    \"relevance_score\" => \"$.results[*].relevance_score\",\n                    \"reranked_index\" => \"$.results[*].index\",\n                ],\n            ],\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"custom\",\"service_settings\":{\"secret_parameters\":{\"api_key\":\"<api key>\"},\"url\":\"https://api.jina.ai/v1/rerank\",\"headers\":{\"Content-Type\":\"application/json\",\"Authorization\":\"Bearer ${api_key}\"},\"request\":\"{\\\"model\\\": \\\"jina-reranker-v2-base-multilingual\\\",\\\"query\\\": ${query},\\\"documents\\\":${input}}\",\"response\":{\"json_parser\":{\"relevance_score\":\"$.results[*].relevance_score\",\"reranked_index\":\"$.results[*].index\"}}}}' \"$ELASTICSEARCH_URL/_inference/rerank/custom-rerank-jina\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"custom-rerank-jina\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"custom\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"secret_parameters\\\":{\\\"api_key\\\":\\\"<api key>\\\"},\\\"url\\\":\\\"https://api.jina.ai/v1/rerank\\\",\\\"headers\\\":{\\\"Content-Type\\\":\\\"application/json\\\",\\\"Authorization\\\":\\\"Bearer ${api_key}\\\"},\\\"request\\\":\\\"{\\\\\"model\\\\\": \\\\\"jina-reranker-v2-base-multilingual\\\\\",\\\\\"query\\\\\": ${query},\\\\\"documents\\\\\":${input}}\\\",\\\"response\\\":{\\\"json_parser\\\":{\\\"relevance_score\\\":\\\"$.results[*].relevance_score\\\",\\\"reranked_index\\\":\\\"$.results[*].index\\\"}}}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_azureaistudio/examples/request/PutAzureAiStudioRequestExample3.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"azure_ai_studio_rerank\",\n    inference_config={\n        \"service\": \"azureaistudio\",\n        \"service_settings\": {\n            \"api_key\": \"Azure-AI-Studio-API-key\",\n            \"target\": \"Target-URI\",\n            \"provider\": \"cohere\",\n            \"endpoint_type\": \"token\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"azure_ai_studio_rerank\",\n  inference_config: {\n    service: \"azureaistudio\",\n    service_settings: {\n      api_key: \"Azure-AI-Studio-API-key\",\n      target: \"Target-URI\",\n      provider: \"cohere\",\n      endpoint_type: \"token\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"azure_ai_studio_rerank\",\n  body: {\n    \"service\": \"azureaistudio\",\n    \"service_settings\": {\n      \"api_key\": \"Azure-AI-Studio-API-key\",\n      \"target\": \"Target-URI\",\n      \"provider\": \"cohere\",\n      \"endpoint_type\": \"token\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"azure_ai_studio_rerank\",\n    \"body\" => [\n        \"service\" => \"azureaistudio\",\n        \"service_settings\" => [\n            \"api_key\" => \"Azure-AI-Studio-API-key\",\n            \"target\" => \"Target-URI\",\n            \"provider\" => \"cohere\",\n            \"endpoint_type\" => \"token\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"azureaistudio\",\"service_settings\":{\"api_key\":\"Azure-AI-Studio-API-key\",\"target\":\"Target-URI\",\"provider\":\"cohere\",\"endpoint_type\":\"token\"}}' \"$ELASTICSEARCH_URL/_inference/rerank/azure_ai_studio_rerank\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"azure_ai_studio_rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"azureaistudio\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"Azure-AI-Studio-API-key\\\",\\\"target\\\":\\\"Target-URI\\\",\\\"provider\\\":\\\"cohere\\\",\\\"endpoint_type\\\":\\\"token\\\"}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/indices/disk_usage/examples/request/indicesDiskUsageRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.indices.disk_usage(\n    index=\"my-index-000001\",\n    run_expensive_tasks=True,\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.indices.diskUsage({\n  index: \"my-index-000001\",\n  run_expensive_tasks: \"true\",\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.indices.disk_usage(\n  index: \"my-index-000001\",\n  run_expensive_tasks: \"true\"\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->indices()->diskUsage([\n    \"index\" => \"my-index-000001\",\n    \"run_expensive_tasks\" => \"true\",\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_disk_usage?run_expensive_tasks=true\""
+    }
+  ],
+  "specification/indices/rollover/examples/request/indicesRolloverRequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.indices.rollover(\n    alias=\"my-data-stream\",\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.indices.rollover({\n  alias: \"my-data-stream\",\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.indices.rollover(\n  alias: \"my-data-stream\",\n  body: {}\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->indices()->rollover([\n    \"alias\" => \"my-data-stream\",\n    \"body\" => new ArrayObject([]),\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{}' \"$ELASTICSEARCH_URL/my-data-stream/_rollover\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().rollover(r -> r\n    .alias(\"my-data-stream\")\n);\n"
+    }
+  ],
+  "specification/inference/put_llama/examples/request/PutLlamaRequestExample3.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"chat-completion\",\n    inference_id=\"llama-chat-completion\",\n    inference_config={\n        \"service\": \"llama\",\n        \"service_settings\": {\n            \"url\": \"http://localhost:8321/v1/openai/v1/chat/completions\",\n            \"model_id\": \"llama3.2:3b\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"chat-completion\",\n  inference_id: \"llama-chat-completion\",\n  inference_config: {\n    service: \"llama\",\n    service_settings: {\n      url: \"http://localhost:8321/v1/openai/v1/chat/completions\",\n      model_id: \"llama3.2:3b\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"chat-completion\",\n  inference_id: \"llama-chat-completion\",\n  body: {\n    \"service\": \"llama\",\n    \"service_settings\": {\n      \"url\": \"http://localhost:8321/v1/openai/v1/chat/completions\",\n      \"model_id\": \"llama3.2:3b\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"chat-completion\",\n    \"inference_id\" => \"llama-chat-completion\",\n    \"body\" => [\n        \"service\" => \"llama\",\n        \"service_settings\" => [\n            \"url\" => \"http://localhost:8321/v1/openai/v1/chat/completions\",\n            \"model_id\" => \"llama3.2:3b\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"llama\",\"service_settings\":{\"url\":\"http://localhost:8321/v1/openai/v1/chat/completions\",\"model_id\":\"llama3.2:3b\"}}' \"$ELASTICSEARCH_URL/_inference/chat-completion/llama-chat-completion\""
+    }
+  ],
+  "specification/inference/put_llama/examples/request/PutLlamaRequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"llama-completion\",\n    inference_config={\n        \"service\": \"llama\",\n        \"service_settings\": {\n            \"url\": \"http://localhost:8321/v1/openai/v1/chat/completions\",\n            \"model_id\": \"llama3.2:3b\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"llama-completion\",\n  inference_config: {\n    service: \"llama\",\n    service_settings: {\n      url: \"http://localhost:8321/v1/openai/v1/chat/completions\",\n      model_id: \"llama3.2:3b\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"llama-completion\",\n  body: {\n    \"service\": \"llama\",\n    \"service_settings\": {\n      \"url\": \"http://localhost:8321/v1/openai/v1/chat/completions\",\n      \"model_id\": \"llama3.2:3b\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"llama-completion\",\n    \"body\" => [\n        \"service\" => \"llama\",\n        \"service_settings\" => [\n            \"url\" => \"http://localhost:8321/v1/openai/v1/chat/completions\",\n            \"model_id\" => \"llama3.2:3b\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"llama\",\"service_settings\":{\"url\":\"http://localhost:8321/v1/openai/v1/chat/completions\",\"model_id\":\"llama3.2:3b\"}}' \"$ELASTICSEARCH_URL/_inference/completion/llama-completion\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"llama-completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"llama\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"url\\\":\\\"http://localhost:8321/v1/openai/v1/chat/completions\\\",\\\"model_id\\\":\\\"llama3.2:3b\\\"}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_llama/examples/request/PutLlamaRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"text_embedding\",\n    inference_id=\"llama-text-embedding\",\n    inference_config={\n        \"service\": \"llama\",\n        \"service_settings\": {\n            \"url\": \"http://localhost:8321/v1/inference/embeddings\",\n            \"dimensions\": 384,\n            \"model_id\": \"all-MiniLM-L6-v2\"\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"text_embedding\",\n  inference_id: \"llama-text-embedding\",\n  inference_config: {\n    service: \"llama\",\n    service_settings: {\n      url: \"http://localhost:8321/v1/inference/embeddings\",\n      dimensions: 384,\n      model_id: \"all-MiniLM-L6-v2\",\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"text_embedding\",\n  inference_id: \"llama-text-embedding\",\n  body: {\n    \"service\": \"llama\",\n    \"service_settings\": {\n      \"url\": \"http://localhost:8321/v1/inference/embeddings\",\n      \"dimensions\": 384,\n      \"model_id\": \"all-MiniLM-L6-v2\"\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"text_embedding\",\n    \"inference_id\" => \"llama-text-embedding\",\n    \"body\" => [\n        \"service\" => \"llama\",\n        \"service_settings\" => [\n            \"url\" => \"http://localhost:8321/v1/inference/embeddings\",\n            \"dimensions\" => 384,\n            \"model_id\" => \"all-MiniLM-L6-v2\",\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"llama\",\"service_settings\":{\"url\":\"http://localhost:8321/v1/inference/embeddings\",\"dimensions\":384,\"model_id\":\"all-MiniLM-L6-v2\"}}' \"$ELASTICSEARCH_URL/_inference/text_embedding/llama-text-embedding\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"llama-text-embedding\")\n    .taskType(TaskType.TextEmbedding)\n    .inferenceConfig(i -> i\n        .service(\"llama\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"url\\\":\\\"http://localhost:8321/v1/inference/embeddings\\\",\\\"dimensions\\\":384,\\\"model_id\\\":\\\"all-MiniLM-L6-v2\\\"}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/transform/set_upgrade_mode/examples/request/TransformSetUpgradeModeExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.transform.set_upgrade_mode(\n    enabled=True,\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.transform.setUpgradeMode({\n  enabled: \"true\",\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.transform.set_upgrade_mode(\n  enabled: \"true\"\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->transform()->setUpgradeMode([\n    \"enabled\" => \"true\",\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_transform/set_upgrade_mode?enabled=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.transform().setUpgradeMode(s -> s\n    .enabled(true)\n);\n"
+    }
+  ],
+  "specification/indices/disk_usage/examples/request/IndicesDiskUsageRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.indices.disk_usage(\n    index=\"my-index-000001\",\n    run_expensive_tasks=True,\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.indices.diskUsage({\n  index: \"my-index-000001\",\n  run_expensive_tasks: \"true\",\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.indices.disk_usage(\n  index: \"my-index-000001\",\n  run_expensive_tasks: \"true\"\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->indices()->diskUsage([\n    \"index\" => \"my-index-000001\",\n    \"run_expensive_tasks\" => \"true\",\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_disk_usage?run_expensive_tasks=true\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().diskUsage(d -> d\n    .index(\"my-index-000001\")\n    .runExpensiveTasks(true)\n);\n"
+    }
+  ],
+  "specification/streams/status/examples/request/GetStreamsStatusRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.streams.status()"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.streams.status();"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.streams.status"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->streams()->status();"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_streams/status\""
+    },
+    {
+      "language": "Java",
+      "code": "client.streams().status(s -> s)\n);\n"
+    }
+  ],
+  "specification/streams/logs_enable/examples/request/PostStreamsEnableRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.streams.logs_enable()"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.streams.logsEnable();"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.streams.logs_enable"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->streams()->logsEnable();"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_streams/logs/_enable\""
+    },
+    {
+      "language": "Java",
+      "code": "client.streams().logsEnable(l -> l)\n);\n"
+    }
+  ],
+  "specification/streams/logs_disable/examples/request/PostStreamsDisableRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.streams.logs_disable()"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.streams.logsDisable();"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.streams.logs_disable"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->streams()->logsDisable();"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_streams/logs/_disable\""
+    },
+    {
+      "language": "Java",
+      "code": "client.streams().logsDisable(l -> l)\n);\n"
+    }
+  ],
+  "specification/project/tags/examples/request/ProjectTagsRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.project.tags()"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.project.tags();"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.project.tags"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->project()->tags();"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_project/tags\""
+    },
+    {
+      "language": "Java",
+      "code": "client.project().tags();\n"
+    }
+  ],
+  "specification/inference/put_googlevertexai/examples/request/PutGoogleVertexAiRequestExample4.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"chat_completion\",\n    inference_id=\"google_model_garden_anthropic_chat_completion\",\n    inference_config={\n        \"service\": \"googlevertexai\",\n        \"service_settings\": {\n            \"provider\": \"anthropic\",\n            \"service_account_json\": \"service-account-json\",\n            \"url\": \"https://url:rawPredict\",\n            \"streaming_url\": \"https://streaming_url:streamRawPredict\"\n        },\n        \"task_settings\": {\n            \"max_tokens\": 128\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"chat_completion\",\n  inference_id: \"google_model_garden_anthropic_chat_completion\",\n  inference_config: {\n    service: \"googlevertexai\",\n    service_settings: {\n      provider: \"anthropic\",\n      service_account_json: \"service-account-json\",\n      url: \"https://url:rawPredict\",\n      streaming_url: \"https://streaming_url:streamRawPredict\",\n    },\n    task_settings: {\n      max_tokens: 128,\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"chat_completion\",\n  inference_id: \"google_model_garden_anthropic_chat_completion\",\n  body: {\n    \"service\": \"googlevertexai\",\n    \"service_settings\": {\n      \"provider\": \"anthropic\",\n      \"service_account_json\": \"service-account-json\",\n      \"url\": \"https://url:rawPredict\",\n      \"streaming_url\": \"https://streaming_url:streamRawPredict\"\n    },\n    \"task_settings\": {\n      \"max_tokens\": 128\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"chat_completion\",\n    \"inference_id\" => \"google_model_garden_anthropic_chat_completion\",\n    \"body\" => [\n        \"service\" => \"googlevertexai\",\n        \"service_settings\" => [\n            \"provider\" => \"anthropic\",\n            \"service_account_json\" => \"service-account-json\",\n            \"url\" => \"https://url:rawPredict\",\n            \"streaming_url\" => \"https://streaming_url:streamRawPredict\",\n        ],\n        \"task_settings\" => [\n            \"max_tokens\" => 128,\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"googlevertexai\",\"service_settings\":{\"provider\":\"anthropic\",\"service_account_json\":\"service-account-json\",\"url\":\"https://url:rawPredict\",\"streaming_url\":\"https://streaming_url:streamRawPredict\"},\"task_settings\":{\"max_tokens\":128}}' \"$ELASTICSEARCH_URL/_inference/chat_completion/google_model_garden_anthropic_chat_completion\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"google_model_garden_anthropic_chat_completion\")\n    .taskType(TaskType.ChatCompletion)\n    .inferenceConfig(i -> i\n        .service(\"googlevertexai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"provider\\\":\\\"anthropic\\\",\\\"service_account_json\\\":\\\"service-account-json\\\",\\\"url\\\":\\\"https://url:rawPredict\\\",\\\"streaming_url\\\":\\\"https://streaming_url:streamRawPredict\\\"}\"))\n        .taskSettings(JsonData.fromJson(\"{\\\"max_tokens\\\":128}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_googlevertexai/examples/request/PutGoogleVertexAiRequestExample3.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"completion\",\n    inference_id=\"google_model_garden_anthropic_completion\",\n    inference_config={\n        \"service\": \"googlevertexai\",\n        \"service_settings\": {\n            \"provider\": \"anthropic\",\n            \"service_account_json\": \"service-account-json\",\n            \"url\": \"https://url:rawPredict\",\n            \"streaming_url\": \"https://streaming_url:streamRawPredict\"\n        },\n        \"task_settings\": {\n            \"max_tokens\": 128\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"completion\",\n  inference_id: \"google_model_garden_anthropic_completion\",\n  inference_config: {\n    service: \"googlevertexai\",\n    service_settings: {\n      provider: \"anthropic\",\n      service_account_json: \"service-account-json\",\n      url: \"https://url:rawPredict\",\n      streaming_url: \"https://streaming_url:streamRawPredict\",\n    },\n    task_settings: {\n      max_tokens: 128,\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"completion\",\n  inference_id: \"google_model_garden_anthropic_completion\",\n  body: {\n    \"service\": \"googlevertexai\",\n    \"service_settings\": {\n      \"provider\": \"anthropic\",\n      \"service_account_json\": \"service-account-json\",\n      \"url\": \"https://url:rawPredict\",\n      \"streaming_url\": \"https://streaming_url:streamRawPredict\"\n    },\n    \"task_settings\": {\n      \"max_tokens\": 128\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"completion\",\n    \"inference_id\" => \"google_model_garden_anthropic_completion\",\n    \"body\" => [\n        \"service\" => \"googlevertexai\",\n        \"service_settings\" => [\n            \"provider\" => \"anthropic\",\n            \"service_account_json\" => \"service-account-json\",\n            \"url\" => \"https://url:rawPredict\",\n            \"streaming_url\" => \"https://streaming_url:streamRawPredict\",\n        ],\n        \"task_settings\" => [\n            \"max_tokens\" => 128,\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"googlevertexai\",\"service_settings\":{\"provider\":\"anthropic\",\"service_account_json\":\"service-account-json\",\"url\":\"https://url:rawPredict\",\"streaming_url\":\"https://streaming_url:streamRawPredict\"},\"task_settings\":{\"max_tokens\":128}}' \"$ELASTICSEARCH_URL/_inference/completion/google_model_garden_anthropic_completion\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"google_model_garden_anthropic_completion\")\n    .taskType(TaskType.Completion)\n    .inferenceConfig(i -> i\n        .service(\"googlevertexai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"provider\\\":\\\"anthropic\\\",\\\"service_account_json\\\":\\\"service-account-json\\\",\\\"url\\\":\\\"https://url:rawPredict\\\",\\\"streaming_url\\\":\\\"https://streaming_url:streamRawPredict\\\"}\"))\n        .taskSettings(JsonData.fromJson(\"{\\\"max_tokens\\\":128}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/inference/put_contextualai/examples/request/PutContextualAiRequestExample1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.inference.put(\n    task_type=\"rerank\",\n    inference_id=\"contextualai-rerank\",\n    inference_config={\n        \"service\": \"contextualai\",\n        \"service_settings\": {\n            \"api_key\": \"ContextualAI-Api-key\",\n            \"model_id\": \"ctxl-rerank-v2-instruct-multilingual-mini\"\n        },\n        \"task_settings\": {\n            \"instruction\": \"Rerank the following documents based on their relevance to the query.\",\n            \"top_k\": 3\n        }\n    },\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.inference.put({\n  task_type: \"rerank\",\n  inference_id: \"contextualai-rerank\",\n  inference_config: {\n    service: \"contextualai\",\n    service_settings: {\n      api_key: \"ContextualAI-Api-key\",\n      model_id: \"ctxl-rerank-v2-instruct-multilingual-mini\",\n    },\n    task_settings: {\n      instruction:\n        \"Rerank the following documents based on their relevance to the query.\",\n      top_k: 3,\n    },\n  },\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.inference.put(\n  task_type: \"rerank\",\n  inference_id: \"contextualai-rerank\",\n  body: {\n    \"service\": \"contextualai\",\n    \"service_settings\": {\n      \"api_key\": \"ContextualAI-Api-key\",\n      \"model_id\": \"ctxl-rerank-v2-instruct-multilingual-mini\"\n    },\n    \"task_settings\": {\n      \"instruction\": \"Rerank the following documents based on their relevance to the query.\",\n      \"top_k\": 3\n    }\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->inference()->put([\n    \"task_type\" => \"rerank\",\n    \"inference_id\" => \"contextualai-rerank\",\n    \"body\" => [\n        \"service\" => \"contextualai\",\n        \"service_settings\" => [\n            \"api_key\" => \"ContextualAI-Api-key\",\n            \"model_id\" => \"ctxl-rerank-v2-instruct-multilingual-mini\",\n        ],\n        \"task_settings\" => [\n            \"instruction\" => \"Rerank the following documents based on their relevance to the query.\",\n            \"top_k\" => 3,\n        ],\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X PUT -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"service\":\"contextualai\",\"service_settings\":{\"api_key\":\"ContextualAI-Api-key\",\"model_id\":\"ctxl-rerank-v2-instruct-multilingual-mini\"},\"task_settings\":{\"instruction\":\"Rerank the following documents based on their relevance to the query.\",\"top_k\":3}}' \"$ELASTICSEARCH_URL/_inference/rerank/contextualai-rerank\""
+    },
+    {
+      "language": "Java",
+      "code": "client.inference().put(p -> p\n    .inferenceId(\"contextualai-rerank\")\n    .taskType(TaskType.Rerank)\n    .inferenceConfig(i -> i\n        .service(\"contextualai\")\n        .serviceSettings(JsonData.fromJson(\"{\\\"api_key\\\":\\\"ContextualAI-Api-key\\\",\\\"model_id\\\":\\\"ctxl-rerank-v2-instruct-multilingual-mini\\\"}\"))\n        .taskSettings(JsonData.fromJson(\"{\\\"instruction\\\":\\\"Rerank the following documents based on their relevance to the query.\\\",\\\"top_k\\\":3}\"))\n    )\n);\n"
+    }
+  ],
+  "specification/indices/get_sample/examples/request/GetRandomSampleRequest1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.indices.get_sample(\n    index=\"my-index-000001\",\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.indices.getSample({\n  index: \"my-index-000001\",\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.indices.get_sample(\n  index: \"my-index-000001\"\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->indices()->getSample([\n    \"index\" => \"my-index-000001\",\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_sample\""
+    }
+  ],
+  "specification/indices/put_alias/examples/request/indicesPutAliasRequestExample3.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.indices.put_alias(\n    index=\"my-index-2099.05.06-000001\",\n    name=\"my-alias\",\n    routing=\"1\",\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.indices.putAlias({\n  index: \"my-index-2099.05.06-000001\",\n  name: \"my-alias\",\n  routing: 1,\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.indices.put_alias(\n  index: \"my-index-2099.05.06-000001\",\n  name: \"my-alias\",\n  body: {\n    \"routing\": \"1\"\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->indices()->putAlias([\n    \"index\" => \"my-index-2099.05.06-000001\",\n    \"name\" => \"my-alias\",\n    \"body\" => [\n        \"routing\" => \"1\",\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"routing\":\"1\"}' \"$ELASTICSEARCH_URL/my-index-2099.05.06-000001/_alias/my-alias\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putAlias(p -> p\n    .index(\"my-index-2099.05.06-000001\")\n    .name(\"my-alias\")\n    .routing(\"1\")\n);\n"
+    }
+  ],
+  "specification/indices/put_alias/examples/request/indicesPutAliasRequestExample2.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.indices.put_alias(\n    index=\"logs-my_app-default\",\n    name=\"logs\",\n    is_write_index=True,\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.indices.putAlias({\n  index: \"logs-my_app-default\",\n  name: \"logs\",\n  is_write_index: true,\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.indices.put_alias(\n  index: \"logs-my_app-default\",\n  name: \"logs\",\n  body: {\n    \"is_write_index\": true\n  }\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->indices()->putAlias([\n    \"index\" => \"logs-my_app-default\",\n    \"name\" => \"logs\",\n    \"body\" => [\n        \"is_write_index\" => true,\n    ],\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X POST -H \"Authorization: ApiKey $ELASTIC_API_KEY\" -H \"Content-Type: application/json\" -d '{\"is_write_index\":true}' \"$ELASTICSEARCH_URL/logs-my_app-default/_alias/logs\""
+    },
+    {
+      "language": "Java",
+      "code": "client.indices().putAlias(p -> p\n    .index(\"logs-my_app-default\")\n    .isWriteIndex(true)\n    .name(\"logs\")\n);\n"
+    }
+  ],
+  "specification/indices/get_sample_stats/examples/request/GetRandomSampleStatsRequest1.yaml": [
+    {
+      "language": "Python",
+      "code": "resp = client.indices.get_sample_stats(\n    index=\"my-index-000001\",\n)"
+    },
+    {
+      "language": "JavaScript",
+      "code": "const response = await client.indices.getSampleStats({\n  index: \"my-index-000001\",\n});"
+    },
+    {
+      "language": "Ruby",
+      "code": "response = client.indices.get_sample_stats(\n  index: \"my-index-000001\"\n)"
+    },
+    {
+      "language": "PHP",
+      "code": "$resp = $client->indices()->getSampleStats([\n    \"index\" => \"my-index-000001\",\n]);"
+    },
+    {
+      "language": "curl",
+      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/my-index-000001/_sample/stats\""
     }
   ]
 }


### PR DESCRIPTION
Java examples have been accidentally removed from the language example files. 
File was accidentally removed: https://github.com/elastic/elasticsearch-specification/pull/5265
Then restored, but without java examples: https://github.com/elastic/elasticsearch-specification/pull/5281
Restoring the java examples and updating them using the 9.2 client. 
