### PR TITLE
[8.19] Remove redundant code comments (#5596)

### DIFF
--- a/specification/indices/add_block/IndicesAddBlockRequest.ts
+++ b/specification/indices/add_block/IndicesAddBlockRequest.ts
@@ -58,33 +58,33 @@ export interface Request extends RequestBase {
      * For example, a request targeting `foo*,bar*` returns an error if an index starts with `foo` but no index starts with `bar`.
      * @server_default true
      */
-    allow_no_indices?: boolean // default: true
+    allow_no_indices?: boolean
     /**
      * The type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
      * It supports comma-separated values, such as `open,hidden`.
      * @server_default open
      */
-    expand_wildcards?: ExpandWildcards // default: open
+    expand_wildcards?: ExpandWildcards
     /**
      * If `false`, the request returns an error if it targets a missing or closed index.
      * @server_default false
      */
-    ignore_unavailable?: boolean // default: false
+    ignore_unavailable?: boolean
     /**
      * The period to wait for the master node.
      * If the master node is not available before the timeout expires, the request fails and returns an error.
      * It can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
-    master_timeout?: Duration // default: 30s
+    master_timeout?: Duration
     /**
      * The period to wait for a response from all relevant nodes in the cluster after updating the cluster metadata.
      * If no response is received before the timeout expires, the cluster metadata update still applies but the response will indicate that it was not completely acknowledged.
      * It can also be set to `-1` to indicate that the request should never timeout.
      * @server_default 30s
      */
-    timeout?: Duration // default: 30s
+    timeout?: Duration
   }
 }
 

--- a/specification/ml/_types/Datafeed.ts
+++ b/specification/ml/_types/Datafeed.ts
@@ -125,7 +125,7 @@ export class DelayedDataCheckConfig {
    * It defaults to null, which causes an appropriate `check_window` to be calculated when the real-time datafeed runs.
    * In particular, the default `check_window` span calculation is based on the maximum of `2h` or `8 * bucket_span`.
    */
-  check_window?: Duration // default: null
+  check_window?: Duration
   /**
    * Specifies whether the datafeed periodically checks for delayed data.
    */

--- a/specification/snapshot/status/SnapshotStatusRequest.ts
+++ b/specification/snapshot/status/SnapshotStatusRequest.ts
@@ -78,7 +78,7 @@ export interface Request extends RequestBase {
      * If `true`, the request ignores snapshots that are unavailable, such as those that are corrupted or temporarily cannot be returned.
      * @server_default false
      */
-    ignore_unavailable?: boolean // default: false
+    ignore_unavailable?: boolean
     /**
      * The period to wait for the master node.
      * If the master node is not available before the timeout expires, the request fails and returns an error.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Remove redundant code comments (#5596)](https://github.com/elastic/elasticsearch-specification/pull/5596)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)