### PR TITLE
[9.1] Allow triggering validate-apis CI (#5595)

### DIFF
--- a/.github/workflows/validate-apis.yml
+++ b/.github/workflows/validate-apis.yml
@@ -1,6 +1,7 @@
 name: Validate APIs
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `9.1`:
 - [Allow triggering validate-apis CI (#5595)](https://github.com/elastic/elasticsearch-specification/pull/5595)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)