### PR TITLE
[8.19] Fix and expand deprecation information (#5620)

### DIFF
--- a/specification/_global/delete_by_query/DeleteByQueryRequest.ts
+++ b/specification/_global/delete_by_query/DeleteByQueryRequest.ts
@@ -258,6 +258,7 @@ export interface Request extends RequestBase {
     slices?: Slices
     /**
      * A comma-separated list of `<field>:<direction>` pairs.
+     * @deprecated 9.0.0 This query parameter is not supported and will be removed in a future version
      */
     sort?: string[]
     /**

--- a/specification/_global/msearch/MultiSearchRequest.ts
+++ b/specification/_global/msearch/MultiSearchRequest.ts
@@ -81,6 +81,7 @@ export interface Request extends RequestBase {
     expand_wildcards?: ExpandWildcards
     /**
      * If true, concrete, expanded or aliased indices are ignored when frozen.
+     * @deprecated 7.16.0 This parameter is deprecated because frozen indices have been deprecated.
      * @server_default false
      */
     ignore_throttled?: boolean

--- a/specification/cluster/exists_component_template/ClusterComponentTemplateExistsRequest.ts
+++ b/specification/cluster/exists_component_template/ClusterComponentTemplateExistsRequest.ts
@@ -55,6 +55,7 @@ export interface Request extends RequestBase {
     /**
      * If true, the request retrieves information from the local node only.
      * Defaults to false, which means information is retrieved from the master node.
+     * @deprecated 9.0.0 This parameter has no effect, is now deprecated, and will be removed in a future version.
      * @server_default false
      */
     local?: boolean

--- a/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
+++ b/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
@@ -68,6 +68,7 @@ export interface Request extends RequestBase {
     /**
      * If `true`, the request retrieves information from the local node only.
      * If `false`, information is retrieved from the master node.
+     * @deprecated 9.0.0 This parameter has no effect, is now deprecated, and will be removed in a future version.
      * @server_default false
      */
     local?: boolean

--- a/specification/cluster/state/ClusterStateRequest.ts
+++ b/specification/cluster/state/ClusterStateRequest.ts
@@ -79,9 +79,15 @@ export interface Request extends RequestBase {
     flat_settings?: boolean
     /** @server_default false */
     ignore_unavailable?: boolean
-    /** @server_default false */
+    /**
+     * @deprecated 9.0.0 This parameter has no effect, is now deprecated, and will be removed in a future version.
+     * @server_default false
+     */
     local?: boolean
-    /** @server_default 30s */
+    /**
+     * Timeout for waiting for new cluster state in case it is blocked
+     * @server_default 30s
+     * */
     master_timeout?: Duration
     wait_for_metadata_version?: VersionNumber
     wait_for_timeout?: Duration

--- a/specification/indices/exists_template/IndicesExistsTemplateRequest.ts
+++ b/specification/indices/exists_template/IndicesExistsTemplateRequest.ts
@@ -55,6 +55,7 @@ export interface Request extends RequestBase {
     flat_settings?: boolean
     /**
      * Indicates whether to get information from the local node only.
+     * @deprecated 9.0.0 This parameter has no effect, is now deprecated, and will be removed in a future version.
      * @server_default false
      */
     local?: boolean

--- a/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
+++ b/specification/indices/get_index_template/IndicesGetIndexTemplateRequest.ts
@@ -48,6 +48,7 @@ export interface Request extends RequestBase {
   query_parameters: {
     /**
      * If true, the request retrieves information from the local node only. Defaults to false, which means information is retrieved from the master node.
+     * @deprecated 9.0.0 This parameter has no effect, is now deprecated, and will be removed in a future version.
      * @server_default false
      */
     local?: boolean

--- a/specification/indices/get_settings/IndicesGetSettingsRequest.ts
+++ b/specification/indices/get_settings/IndicesGetSettingsRequest.ts
@@ -97,6 +97,7 @@ export interface Request extends RequestBase {
     /**
      * If `true`, the request retrieves information from the local node only. If
      * `false`, information is retrieved from the master node.
+     * @deprecated 9.1.0 This parameter is a no-op and settings are always retrieved locally.
      * @server_default false
      */
     local?: boolean

--- a/specification/indices/get_template/IndicesGetTemplateRequest.ts
+++ b/specification/indices/get_template/IndicesGetTemplateRequest.ts
@@ -60,6 +60,7 @@ export interface Request extends RequestBase {
     flat_settings?: boolean
     /**
      * If `true`, the request retrieves information from the local node only.
+     * @deprecated 9.0.0 This parameter is a no-op and templates are always retrieved locally.
      * @server_default false
      */
     local?: boolean

--- a/specification/xpack/info/XPackInfoRequest.ts
+++ b/specification/xpack/info/XPackInfoRequest.ts
@@ -45,6 +45,9 @@ export interface Request extends RequestBase {
      * For example, `build,license,features`.
      */
     categories?: XPackCategory[]
+    /**
+     * @deprecated 8.0.0 Supported for backwards compatibility with 7.x
+     */
     accept_enterprise?: boolean
     /**
      * Defines whether additional human-readable information is included in the response.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix and expand deprecation information (#5620)](https://github.com/elastic/elasticsearch-specification/pull/5620)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)