### PR TITLE
[Backport 9.1] add eslint rule `no-duplicate-class-names`

### DIFF
--- a/specification/eslint.config.js
+++ b/specification/eslint.config.js
@@ -36,6 +36,61 @@ export default defineConfig({
     'es-spec-validator/no-native-types': 'error',
     'es-spec-validator/invalid-node-types': 'error',
     'es-spec-validator/no-generic-number': 'error',
-    'es-spec-validator/request-must-have-urls': 'error'
+    'es-spec-validator/request-must-have-urls': 'error',
+    'es-spec-validator/no-duplicate-type-names': [
+      'error',
+      {
+        ignoreNames: ['Request', 'Response', 'ResponseBase'],
+        existingDuplicates: {
+          Action: [
+            'indices.modify_data_stream',
+            'indices.update_aliases',
+            'watcher._types'
+          ],
+          Actions: ['ilm._types', 'security.put_privileges', 'watcher._types'],
+          ComponentTemplate: ['cat.component_templates', 'cluster._types'],
+          Context: [
+            '_global.get_script_context',
+            '_global.search._types',
+            'nodes._types'
+          ],
+          DatabaseConfigurationMetadata: [
+            'ingest.get_geoip_database',
+            'ingest.get_ip_location_database'
+          ],
+          Datafeed: ['ml._types', 'xpack.usage'],
+          Destination: ['_global.reindex', 'transform._types'],
+          Feature: ['features._types', 'indices.get', 'xpack.info'],
+          Features: ['indices.get', 'xpack.info'],
+          Filter: ['_global.termvectors', 'ml._types'],
+          IndexingPressure: ['cluster.stats', 'indices._types', 'nodes._types'],
+          IndexingPressureMemory: ['indices._types', 'nodes._types'],
+          Ingest: ['ingest._types', 'nodes._types'],
+          MigrationFeature: [
+            'migration.get_feature_upgrade_status',
+            'migration.post_feature_upgrade'
+          ],
+          Operation: ['_global.mget', '_global.mtermvectors'],
+          ResponseBody: ['_global.search', 'ml.evaluate_data_frame'],
+          Phase: ['ilm._types', 'xpack.usage'],
+          Phases: ['ilm._types', 'xpack.usage'],
+          Pipeline: ['ingest._types', 'logstash._types'],
+          Policy: ['enrich._types', 'ilm._types', 'slm._types'],
+          RequestItem: ['_global.msearch', '_global.msearch_template'],
+          ResponseItem: ['_global.bulk', '_global.mget', '_global.msearch'],
+          RoleMapping: ['security._types', 'xpack.usage'],
+          RuntimeFieldTypes: ['cluster.stats', 'xpack.usage'],
+          ShardsStats: ['indices.field_usage_stats', 'snapshot._types'],
+          ShardStats: ['ccr._types', 'indices.stats'],
+          Source: ['_global.reindex', 'transform._types'],
+          Token: [
+            '_global.termvectors',
+            'security.authenticate',
+            'security.create_service_token',
+            'security.enroll_kibana'
+          ]
+        }
+      }
+    ]
   }
 })

--- a/validator/README.md
+++ b/validator/README.md
@@ -13,6 +13,7 @@ It is configured [in the specification directory](../specification/eslint.config
 | `invalid-node-types`                  | The spec uses a subset of TypeScript, so some types, clauses and expressions are not allowed. |
 | `no-generic-number`                   | Generic `number` type is not allowed outside of `_types/Numeric.ts`. Use concrete numeric types like `integer`, `long`, `float`, `double`, etc. |
 | `request-must-have-urls`              | All Request interfaces extending `RequestBase` must have a `urls` property defining their endpoint paths and HTTP methods. |
+| `no-duplicate-type-names`             | All types must be unique across class and enum definitions.                                                                                                                                |
 
 ## Usage
 

--- a/validator/eslint-plugin-es-spec.js
+++ b/validator/eslint-plugin-es-spec.js
@@ -22,14 +22,16 @@ import noNativeTypes from './rules/no-native-types.js'
 import invalidNodeTypes from './rules/invalid-node-types.js'
 import noGenericNumber from './rules/no-generic-number.js'
 import requestMustHaveUrls from './rules/request-must-have-urls.js'
+import noDuplicateTypeNames from './rules/no-duplicate-type-names.js'
 
 export default {
-  rules: {
-    'single-key-dictionary-key-is-string': singleKeyDict,
-    'dictionary-key-is-string': dict,
-    'no-native-types': noNativeTypes,
-    'invalid-node-types': invalidNodeTypes,
-    'no-generic-number': noGenericNumber,
-    'request-must-have-urls': requestMustHaveUrls,
-  }
+    rules: {
+        'single-key-dictionary-key-is-string': singleKeyDict,
+        'dictionary-key-is-string': dict,
+        'no-native-types': noNativeTypes,
+        'invalid-node-types': invalidNodeTypes,
+        'no-generic-number': noGenericNumber,
+        'request-must-have-urls': requestMustHaveUrls,
+        'no-duplicate-type-names': noDuplicateTypeNames
+    }
 }

--- a/validator/rules/no-duplicate-type-names.js
+++ b/validator/rules/no-duplicate-type-names.js
@@ -1,0 +1,190 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { ESLintUtils } from '@typescript-eslint/utils';
+import ts from 'typescript';
+
+/**
+ * Formats location information for error messages
+ * @param {Array} classes - Array of class locations
+ * @returns {string} Formatted location string
+ */
+function formatLocation(classes) {
+    const locations = classes.slice(0, 3).map(c =>
+        `\n\t${c.fileName}:${c.line}:${c.column}`
+    ).join('');
+
+    const additionalCount = classes.length > 3 ? `\n        ... and ${classes.length - 3} more` : '';
+    const plural = classes.length > 1 ? 's' : '';
+
+    return `${classes.length} other location${plural}:${locations}${additionalCount}`;
+}
+
+const typeCache = new Map();
+let clearCache = true;
+
+function getNamespace(context) {
+    const filename = context.filename;
+    const specIndex = filename.indexOf('/specification/');
+
+    if (specIndex === -1) {
+        return filename;
+    }
+
+    const pathAfterSpec = filename.substring(specIndex + '/specification/'.length);
+    return pathAfterSpec.split('/').slice(0, -1).join('.');
+}
+
+export const noDuplicateTypeNamesFactory = (getParserServices) => {
+    if (!getParserServices) {
+        throw new Error('getParserServices is required');
+    }
+    return ESLintUtils.RuleCreator.withoutDocs(
+        {
+            name: 'no-duplicate-type-names',
+            meta: {
+                type: 'problem',
+                docs: {
+                    description: 'Ensure type aliases and interfaces have unique names across the package',
+                },
+                messages: {
+                    duplicateTypeName: 'Duplicate: "{{typeName}}" is already declared in {{location}}\nRename this type to avoid conflicts with other types in the specification.'
+                },
+                schema: [
+                    {
+                        type: 'object',
+                        properties: {
+                            ignoreNames: {
+                                type: 'array',
+                                items: {
+                                    type: 'string'
+                                },
+                                description: 'Array of type names to ignore when checking for duplicates'
+                            },
+                            existingDuplicates: {
+                                type: 'object',
+                                additionalProperties: {
+                                    type: 'array',
+                                    items: {
+                                        type: 'string'
+                                    }
+                                },
+                                description: 'Object mapping type names to arrays of locations where duplicates are expected'
+                            }
+                        },
+                        additionalProperties: false
+                    }
+                ],
+            },
+            defaultOptions: [{ ignoreNames: [], existingDuplicates: {} }],
+            create(context) {
+                const parserServices = getParserServices(context);
+                const { ignoreNames, existingDuplicates } = context.options[0];
+                const kinds = [
+                    ts.SyntaxKind.FunctionDeclaration,
+                    ts.SyntaxKind.ClassDeclaration,
+                    ts.SyntaxKind.InterfaceDeclaration,
+                    ts.SyntaxKind.TypeAliasDeclaration,
+                    ts.SyntaxKind.EnumDeclaration,
+                ];
+
+                if (clearCache) {
+                    typeCache.clear();
+                    clearCache = false;
+                }
+
+                function findDuplicates(node) {
+                    try {
+                        if (!node.id || !node.id.name) {
+                            return;
+                        }
+
+                        if (ignoreNames.includes(node.id.name)) {
+                            return;
+                        }
+
+                        const existingDuplicatesForName = existingDuplicates[node.id.name];
+                        if (existingDuplicatesForName && existingDuplicatesForName.includes(getNamespace(context))) {
+                            return;
+                        }
+
+                        let types = typeCache.get(node.id.name);
+                        if (!types) {
+                            types = [];
+                            parserServices.program.getSourceFiles().forEach(sourceFile => {
+                                if (sourceFile.fileName.includes('node_modules')) {
+                                    return;
+                                }
+
+                                sourceFile.forEachChild(fnDecl => {
+                                    if (kinds.includes(fnDecl.kind)) {
+                                        fnDecl.forEachChild(identifier => {
+                                            if (identifier.kind === ts.SyntaxKind.Identifier &&
+                                                identifier.escapedText === node.id.name) {
+                                                const { line, character } = sourceFile.getLineAndCharacterOfPosition(identifier.pos);
+                                                types.push({
+                                                    typeName: identifier.escapedText,
+                                                    fileName: sourceFile.fileName,
+                                                    line: line + 1,
+                                                    column: character + 2
+                                                });
+                                            }
+                                        });
+                                    }
+                                });
+                            });
+                            typeCache.set(node.id.name, types);
+                        }
+
+                        const filteredClasses = types.filter(c => c.fileName !== context.filename);
+                        if (filteredClasses.length > 0) {
+                            context.report({
+                                node: node.id,
+                                messageId: 'duplicateTypeName',
+                                data: {
+                                    typeName: node.id.name,
+                                    location: formatLocation(filteredClasses)
+                                }
+                            });
+                        }
+                    } catch (error) {
+                        console.error('ERROR in findDuplicates:', error.message, error.stack);
+                        throw error;
+                    }
+                }
+
+                return {
+                    'ClassDeclaration, InterfaceDeclaration, TypedAliasDeclaration, TSEnumDeclaration, TSInterfaceDeclaration, TSTypeAliasDeclaration'(node) {
+                        findDuplicates(node);
+                    },
+                }
+            }
+        }
+    )
+}
+
+export const noDuplicateTypeNames = noDuplicateTypeNamesFactory(ESLintUtils.getParserServices);
+
+export default noDuplicateTypeNames;
+
+export const ___testing_only = {
+    cache: typeCache,
+    setClearCache(value) {
+        clearCache = value;
+    }
+}

--- a/validator/test/no-duplicate-type-names.js
+++ b/validator/test/no-duplicate-type-names.js
@@ -1,0 +1,229 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { RuleTester } from '@typescript-eslint/rule-tester'
+import { noDuplicateTypeNamesFactory, ___testing_only} from '../rules/no-duplicate-type-names.js'
+
+// TypeScript SyntaxKind constants
+const TS_SYNTAX_KIND_CLASS = 264
+const TS_SYNTAX_KIND_IDENTIFIER = 80
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parserOptions: {
+            projectService: {
+                allowDefaultProject: ['*.ts*', 'root/specification/*/*/*.ts*'],
+            },
+            tsconfigRootDir: import.meta.dirname,
+        },
+    },
+})
+
+class MockChild {
+    kind;
+    escapedText;
+    children = [];
+    constructor(kind, escapedText, children = []) {
+        this.kind = kind
+        this.escapedText = escapedText
+        this.children = children
+    }
+    forEachChild(callback) {
+        this.children.forEach(child => callback(child))
+    }
+    getLineAndCharacterOfPosition(position) {
+        return { line: 0, character: 0 }
+    }
+
+}
+
+class MockSourceFile {
+    fileName;
+    children = [];
+    constructor(fileName, children = []) {
+        this.fileName = fileName
+        this.children = children
+    }
+    forEachChild(callback) {
+        this.children.forEach(child => callback(child))
+    }
+    getLineAndCharacterOfPosition(position) {
+        return { line: 0, character: 0 }
+    }
+}
+
+class MockProgram {
+    sourceFiles = [];
+    constructor(sourceFiles = []) {
+        this.sourceFiles = sourceFiles
+    }
+    getSourceFiles() {
+        return this.sourceFiles
+    }
+}
+
+class MockParserServices {
+    program;
+    constructor() {
+        this.program = new MockProgram();
+    }
+    getProgram() {
+        return this.program
+    }
+    reset() {
+        this.program = new MockProgram();
+    }
+    setProgram(program) {
+        this.program = program
+    }
+}
+
+const mockParserServices = new MockParserServices()
+
+const mockGetParserServices = (context) => {
+    return mockParserServices
+}
+
+const rule = noDuplicateTypeNamesFactory(mockGetParserServices)
+
+// Helper functions for creating test data
+function createMockType(typeName, fileName, kind = TS_SYNTAX_KIND_CLASS) {
+    return new MockSourceFile(fileName, [
+        new MockChild(kind, `export class ${typeName} {};`, [
+            new MockChild(TS_SYNTAX_KIND_IDENTIFIER, typeName)
+        ])
+    ])
+}
+
+function createTestOptions(existingDuplicates = {}, ignoreNames = []) {
+    return [{ ignoreNames, existingDuplicates }]
+}
+
+function setupCachedTest(cacheEntries) {
+    ___testing_only.setClearCache(false)
+    ___testing_only.cache.clear()
+    Object.entries(cacheEntries).forEach(([typeName, locations]) => {
+        ___testing_only.cache.set(typeName, locations)
+    })
+}
+
+function setupProgramTest(mockSourceFiles) {
+    ___testing_only.setClearCache(true)
+    mockParserServices.setProgram(new MockProgram(mockSourceFiles))
+}
+
+function cleanupTest() {
+    mockParserServices.reset()
+}
+
+ruleTester.run('no-duplicate-type-names', rule, {
+    valid: [
+        {
+            before() {
+                ___testing_only.setClearCache(true)
+            },
+            name: 'No duplicate class declaration, empty cache',
+            filename: 'root/specification/some/namespace/MyFile.ts',
+            code: `export class MyType {};`,
+            options: createTestOptions(),
+        },
+        {
+            before() {
+                setupCachedTest({
+                    MyType: [
+                        {typeName: 'MyType', fileName: 'root/specification/some/namespace/MyFile.ts', line: 1, column: 1},
+                        {typeName: 'MyType', fileName: 'root/specification/other/namespace/MyOtherFile.ts', line: 1, column: 1},
+                    ]
+                })
+            },
+            filename: 'root/specification/other/namespace/MyOtherFile.ts',
+            name: 'Cached duplicate class declaration, but in existingDuplicates',
+            code: `export class MyType {};`,
+            options: createTestOptions({ MyType: ['some.namespace', 'other.namespace'] }),
+        },
+        {
+            before() {
+                setupProgramTest([
+                    createMockType('MyType', 'root/specification/some/namespace/MyFile.ts')
+                ])
+            },
+            after() {
+                cleanupTest()
+            },
+            filename: 'root/specification/other/namespace/MyOtherFile.ts',
+            name: 'Not cached duplicate class declaration, but in existingDuplicates',
+            code: `export class MyType {};`,
+            options: createTestOptions({ MyType: ['some.namespace', 'other.namespace'] }),
+        }
+    ],
+    invalid: [
+        {
+            before() {
+                setupCachedTest({
+                    MyType: [
+                        {typeName: 'MyType', fileName: 'root/specification/some/namespace/MyFile.ts', line: 1, column: 1},
+                        {typeName: 'MyType', fileName: 'root/specification/other/namespace/MyOtherFile.ts', line: 1, column: 1},
+                    ]
+                })
+            },
+            filename: 'root/specification/other/namespace/MyOtherFile.ts',
+            name: 'Cached duplicate class declaration, not in existingDuplicates',
+            code: `export class MyType {};`,
+            options: createTestOptions(),
+            errors: [{ messageId: 'duplicateTypeName' }],
+        },
+        {
+            before() {
+                setupProgramTest([
+                    createMockType('MyType', 'root/specification/some/namespace/MyFile.ts')
+                ])
+            },
+            after() {
+                cleanupTest()
+            },
+            filename: 'root/specification/other/namespace/MyOtherFile.ts',
+            name: 'Not cached duplicate class declaration',
+            code: `export class MyType {};`,
+            options: createTestOptions(),
+            errors: [{ messageId: 'duplicateTypeName' }],
+        },
+        // Parameterized tests for different type kinds
+        ...['TypeAlias', 'Enum', 'Interface'].map(typeKind => {
+            const codeMap = {
+                TypeAlias: 'type MyType = string;',
+                Enum: 'enum MyType { A, B, C }',
+                Interface: 'interface MyType { a: string; }'
+            }
+            return {
+                before() {
+                    setupProgramTest([
+                        createMockType('MyType', 'root/specification/some/namespace/MyFile.ts')
+                    ])
+                },
+                after() {
+                    cleanupTest()
+                },
+                filename: 'root/specification/other/namespace/MyOtherFile.ts',
+                name: `Not cached duplicate, ${typeKind}`,
+                code: codeMap[typeKind],
+                options: createTestOptions(),
+                errors: [{ messageId: 'duplicateTypeName' }],
+            }
+        })
+    ]
+})


### PR DESCRIPTION
Backport 53f4f629a452456bc76bfaf5f45fd627d90daf6a from #9049
