### PR TITLE
[8.19] Fix expand_wildcards default values (#5599)

### DIFF
--- a/specification/_global/msearch/MultiSearchRequest.ts
+++ b/specification/_global/msearch/MultiSearchRequest.ts
@@ -77,6 +77,7 @@ export interface Request extends RequestBase {
     ccs_minimize_roundtrips?: boolean
     /**
      * Type of index that wildcard expressions can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
+     * @server_default open
      */
     expand_wildcards?: ExpandWildcards
     /**

--- a/specification/_global/rank_eval/RankEvalRequest.ts
+++ b/specification/_global/rank_eval/RankEvalRequest.ts
@@ -57,6 +57,9 @@ export interface Request extends RequestBase {
      * @server_default true
      */
     allow_no_indices?: boolean
+    /**
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards
     /**
      * If `true`, missing or closed indices are not included in the response.

--- a/specification/_global/search_template/SearchTemplateRequest.ts
+++ b/specification/_global/search_template/SearchTemplateRequest.ts
@@ -73,6 +73,7 @@ export interface Request extends RequestBase {
      * The type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
      * Supports comma-separated values, such as `open,hidden`.
+     * @server_default open
      */
     expand_wildcards?: ExpandWildcards
     /**

--- a/specification/_global/update_by_query/UpdateByQueryRequest.ts
+++ b/specification/_global/update_by_query/UpdateByQueryRequest.ts
@@ -180,6 +180,7 @@ export interface Request extends RequestBase {
      * The type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
      * It supports comma-separated values, such as `open,hidden`.
+     * @server_default open
      */
     expand_wildcards?: ExpandWildcards
     /**

--- a/specification/async_search/submit/AsyncSearchSubmitRequest.ts
+++ b/specification/async_search/submit/AsyncSearchSubmitRequest.ts
@@ -125,6 +125,9 @@ export interface Request extends RequestBase {
     default_operator?: Operator
     df?: string
     docvalue_fields?: Fields
+    /**
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards
     explain?: boolean
     ignore_throttled?: boolean

--- a/specification/cat/aliases/CatAliasesRequest.ts
+++ b/specification/cat/aliases/CatAliasesRequest.ts
@@ -63,6 +63,7 @@ export interface Request extends CatRequestBase {
      * The type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
      * It supports comma-separated values, such as `open,hidden`.
+     * @server_default all
      */
     expand_wildcards?: ExpandWildcards
     /**

--- a/specification/cat/indices/CatIndicesRequest.ts
+++ b/specification/cat/indices/CatIndicesRequest.ts
@@ -66,6 +66,7 @@ export interface Request extends CatRequestBase {
   query_parameters: {
     /**
      * The type of index that wildcard patterns can match.
+     * @server_default all
      */
     expand_wildcards?: ExpandWildcards
     /** The health status used to limit returned indices. By default, the response includes indices of any health status. */

--- a/specification/cluster/health/ClusterHealthRequest.ts
+++ b/specification/cluster/health/ClusterHealthRequest.ts
@@ -66,6 +66,9 @@ export interface Request extends RequestBase {
     index?: Indices
   }
   query_parameters: {
+    /**
+     * @server_default all
+     */
     expand_wildcards?: ExpandWildcards
     /**
      * Can be one of cluster, indices or shards. Controls the details level of the health information returned.

--- a/specification/cluster/state/ClusterStateRequest.ts
+++ b/specification/cluster/state/ClusterStateRequest.ts
@@ -74,6 +74,7 @@ export interface Request extends RequestBase {
   query_parameters: {
     /** @server_default true */
     allow_no_indices?: boolean
+    /** @server_default open */
     expand_wildcards?: ExpandWildcards
     /** @server_default false */
     flat_settings?: boolean

--- a/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
+++ b/specification/indices/data_streams_stats/IndicesDataStreamsStatsRequest.ts
@@ -54,7 +54,7 @@ export interface Request extends RequestBase {
     /**
      * Type of data stream that wildcard patterns can match.
      * Supports comma-separated values, such as `open,hidden`.
-     * @server_default open
+     * @server_default open,closed
      */
     expand_wildcards?: ExpandWildcards
   }

--- a/specification/indices/delete/IndicesDeleteRequest.ts
+++ b/specification/indices/delete/IndicesDeleteRequest.ts
@@ -62,7 +62,7 @@ export interface Request extends RequestBase {
      * Type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
      * Supports comma-separated values, such as `open,hidden`.
-     * @server_default open
+     * @server_default open,closed
      */
     expand_wildcards?: ExpandWildcards
     /**

--- a/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
+++ b/specification/indices/delete_data_lifecycle/IndicesDeleteDataLifecycleRequest.ts
@@ -41,6 +41,9 @@ export interface Request extends RequestBase {
     name: DataStreamNames
   }
   query_parameters: {
+    /**
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards
     /**
      * @server_default 30s

--- a/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
+++ b/specification/indices/exists_alias/IndicesExistsAliasRequest.ts
@@ -62,7 +62,7 @@ export interface Request extends RequestBase {
      * Type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
      * Supports comma-separated values, such as `open,hidden`.
-     * @server_default open
+     * @server_default all
      */
     expand_wildcards?: ExpandWildcards
     /**

--- a/specification/indices/field_usage_stats/IndicesFieldUsageStatsRequest.ts
+++ b/specification/indices/field_usage_stats/IndicesFieldUsageStatsRequest.ts
@@ -58,6 +58,7 @@ export interface Request extends RequestBase {
      * Type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
      * Supports comma-separated values, such as `open,hidden`.
+     * @server_default open
      */
     expand_wildcards?: ExpandWildcards
     /**

--- a/specification/indices/forcemerge/IndicesForceMergeRequest.ts
+++ b/specification/indices/forcemerge/IndicesForceMergeRequest.ts
@@ -98,6 +98,9 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     allow_no_indices?: boolean
+    /**
+     * @server_default open
+     */
     expand_wildcards?: ExpandWildcards
     flush?: boolean
     ignore_unavailable?: boolean

--- a/specification/indices/get_alias/IndicesGetAliasRequest.ts
+++ b/specification/indices/get_alias/IndicesGetAliasRequest.ts
@@ -73,7 +73,7 @@ export interface Request extends RequestBase {
      * Type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
      * Supports comma-separated values, such as `open,hidden`.
-     * @server_default open
+     * @server_default all
      */
     expand_wildcards?: ExpandWildcards
     /**

--- a/specification/indices/open/IndicesOpenRequest.ts
+++ b/specification/indices/open/IndicesOpenRequest.ts
@@ -80,7 +80,7 @@ export interface Request extends RequestBase {
      * Type of index that wildcard patterns can match.
      * If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams.
      * Supports comma-separated values, such as `open,hidden`.
-     * @server_default open
+     * @server_default closed
      */
     expand_wildcards?: ExpandWildcards
     /**

--- a/specification/indices/reload_search_analyzers/ReloadSearchAnalyzersRequest.ts
+++ b/specification/indices/reload_search_analyzers/ReloadSearchAnalyzersRequest.ts
@@ -53,6 +53,7 @@ export interface Request extends RequestBase {
   }
   query_parameters: {
     allow_no_indices?: boolean
+    /** @server_default open */
     expand_wildcards?: ExpandWildcards
     ignore_unavailable?: boolean
     /**

--- a/specification/indices/stats/IndicesStatsRequest.ts
+++ b/specification/indices/stats/IndicesStatsRequest.ts
@@ -76,6 +76,7 @@ export interface Request extends RequestBase {
      * Type of index that wildcard patterns can match. If the request can target data streams, this argument
      * determines whether wildcard expressions match hidden data streams. Supports comma-separated values,
      * such as `open,hidden`.
+     * @server_default open
      */
     expand_wildcards?: ExpandWildcards
     /**

--- a/specification/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheRequest.ts
+++ b/specification/searchable_snapshots/clear_cache/SearchableSnapshotsClearCacheRequest.ts
@@ -49,6 +49,7 @@ export interface Request extends RequestBase {
     index?: Indices
   }
   query_parameters: {
+    /** @server_default open */
     expand_wildcards?: ExpandWildcards
     allow_no_indices?: boolean
     ignore_unavailable?: boolean


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix expand_wildcards default values (#5599)](https://github.com/elastic/elasticsearch-specification/pull/5599)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)