### PR TITLE
Allow string[] for routing parameters

### DIFF
--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -65,7 +65,7 @@ export type IndexPatterns = IndexPattern[]
 
 export type ProjectRouting = string
 
-export type Routing = string
+export type Routing = string | string[]
 export type LongId = string
 
 export type ClusterAlias = string


### PR DESCRIPTION
This means that comma-separated values are allowed.
 
As documented in https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/mapping-routing-field#_searching_with_custom_routing and mentioned in the code, even if the data itself is often stored as a string.

Relates https://github.com/elastic/elasticsearch/pull/137673