### PR TITLE
Adds tech preview tag to the 'Create an Elasticsearch inference' endpoint's parameters

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -1340,6 +1340,7 @@ export class ElasticsearchServiceSettings {
    * When `long_document_strategy` is set to `chunk`, Elasticsearch splits each document into smaller parts but still returns a single score per document.
    * That score reflects the highest relevance score among all chunks.
    * @availability stack stability=experimental visibility=public
+   * @availability serverless stability=experimental visibility=public
    */
   long_document_strategy?: string
   /**
@@ -1347,6 +1348,7 @@ export class ElasticsearchServiceSettings {
    * Limits the number of chunks per document that are sent for inference when chunking is enabled.
    * If not set, all chunks generated for the document are processed.
    * @availability stack stability=experimental visibility=public
+   * @availability serverless stability=experimental visibility=public
    */
   max_chunks_per_doc?: integer
 }


### PR DESCRIPTION
This PR adds tech preview tags to `long_document_strategy` and `max_chunks_per_doc` parameters in the inference API. Both parameters are now marked as being in tech preview in version 9.2.

<img width="809" height="113" alt="Screenshot 2025-11-17 at 13 48 20" src="https://github.com/user-attachments/assets/02a87210-1125-4fef-a34d-4dc21605fc08" />

Related issue: https://github.com/elastic/docs-content/issues/3949
