### PR TITLE
Remove typed monitoring endpoint

### DIFF
--- a/specification/monitoring/bulk/BulkMonitoringRequest.ts
+++ b/specification/monitoring/bulk/BulkMonitoringRequest.ts
@@ -34,31 +34,17 @@ export interface Request<TDocument, TPartialDocument> extends RequestBase {
     {
       path: '/_monitoring/bulk'
       methods: ['POST', 'PUT']
-    },
-    {
-      /** @deprecated 7.0.0 Specifying types in urls has been deprecated */
-      path: '/_monitoring/{type}/bulk'
-      methods: ['POST', 'PUT']
     }
   ]
-  path_parts: {
-    /**
-     * @deprecated 7.0.0
-     */
-    type?: string
-  }
-
   query_parameters: {
     /**
      * Identifier of the monitored system
      */
     system_id: string
-
     /**
      *
      */
     system_api_version: string
-
     /**
      * Collection interval (e.g., '10s' or '10000ms') of the payload
      */


### PR DESCRIPTION
This was removed in https://github.com/elastic/elasticsearch/pull/39888 and has not worked for years.