### PR TITLE
Fix type of CategoryId

### DIFF
--- a/specification/_types/common.ts
+++ b/specification/_types/common.ts
@@ -49,7 +49,7 @@ export type Uri = string
 export type ScrollId = string
 export type ScrollIds = ScrollId | ScrollId[]
 
-export type CategoryId = string
+export type CategoryId = long
 export type ActionIds = string // TODO: check if this should be an array of ActionId
 
 export type Id = string


### PR DESCRIPTION
This type is only used in a single API, `ml.get_categories`.

Server code: https://github.com/elastic/elasticsearch/blob/f86f58fbf3ebfb4e54fd711acae8290e3669e835/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/results/RestGetCategoriesAction.java#L53-L55