### PR TITLE
Mark find_structure column_names as string | string[]

### DIFF
--- a/specification/text_structure/find_structure/FindStructureRequest.ts
+++ b/specification/text_structure/find_structure/FindStructureRequest.ts
@@ -67,7 +67,7 @@ export interface Request<TJsonDocument> {
      * If this parameter is not specified, the structure finder uses the column names from the header row of the text.
      * If the text does not have a header role, columns are named "column1", "column2", "column3", for example.
      */
-    column_names?: string
+    column_names?: string | string[]
     /**
      * If you have set `format` to `delimited`, you can specify the character used to delimit the values in each row.
      * Only a single character is supported; the delimiter cannot have multiple characters.


### PR DESCRIPTION
As mentioned in the comment, comma-separated lists are accepted.

Server code: https://github.com/elastic/elasticsearch/blob/ea040c3d3996ae46545485e60d8f450035c6faef/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/rest/RestFindStructureArgumentsParser.java#L58