### PR TITLE
Add new options for generic vector formats to dense_vector

### DIFF
--- a/specification/_types/mapping/DenseVectorProperty.ts
+++ b/specification/_types/mapping/DenseVectorProperty.ts
@@ -172,7 +172,8 @@ export class DenseVectorIndexOptions {
    * `true` if vector rescoring should be done on-disk
    *
    * Only applicable to `bbq_disk`, `bbq_hnsw`, `int4_hnsw`, `int8_hnsw`
-   * @availability stack since=9.3.0 stability=preview
+   * @server_default false
+   * @availability stack since=9.3.0 stability=experimental
    */
   on_disk_rescore?: boolean
 }


### PR DESCRIPTION
Update the spec for changes in https://github.com/elastic/elasticsearch/pull/138492 in 9.3