### PR TITLE
[8.19] Add private capabilities API (#5741)

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -43,6 +43,7 @@ behavioral-analytics-event-reference,https://www.elastic.co/guide/en/elasticsear
 byte-units,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/api-conventions.html#byte-units,,
 bytes-processor,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/bytes-processor.html,,
 calendar-and-fixed-intervals,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/search-aggregations-bucket-datehistogram-aggregation.html#calendar_and_fixed_intervals,,
+capabilities,https://github.com/elastic/elasticsearch/blob/8.19/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc#require-or-skip-api-capabilities,,
 cat-alias,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-alias.html,,
 cat-allocation,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-allocation.html,,
 cat-anomaly-detectors,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/cat-anomaly-detectors.html,,

--- a/specification/_global/capabilities/CapabilitiesRequest.ts
+++ b/specification/_global/capabilities/CapabilitiesRequest.ts
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+import { Duration } from '@_types/Time'
+
+/**
+ * Checks if the specified combination of method, API, parameters, and arbitrary capabilities are supported.
+ *
+ * @rest_spec_name capabilities
+ * @availability stack stability=experimental visibility=private
+ * @doc_id capabilities
+ */
+export interface Request extends RequestBase {
+  urls: [
+    {
+      path: '/_capabilities'
+      methods: ['GET']
+    }
+  ]
+  query_parameters: {
+    /**
+     * REST method to check
+     * @server_default GET
+     */
+    method?: RestMethod
+    /**
+     * API path to check
+     * @server_default /
+     */
+    path?: string
+    /**
+     * Comma-separated list of API parameters to check
+     */
+    parameters?: string | string[]
+    /**
+     * Comma-separated list of arbitrary API capabilities to check
+     */
+    capabilities?: string | string[]
+    /**
+     * True if only the node being called should be considered
+     * @server_default false
+     */
+    local_only?: boolean
+    /**
+     * Period to wait for a response.
+     * If no response is received before the timeout expires, the request fails and returns an error.
+     */
+    timeout?: Duration
+  }
+}
+
+export enum RestMethod {
+  GET,
+  HEAD,
+  POST,
+  PUT,
+  DELETE
+}

--- a/specification/_global/capabilities/CapabilitiesResponse.ts
+++ b/specification/_global/capabilities/CapabilitiesResponse.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Id, Name } from '@_types/common'
+import { NodeStatistics } from '@_types/Node'
+
+export class Response {
+  body: {
+    _nodes: NodeStatistics
+    cluster_name: Name
+    supported: boolean | null
+    failures?: FailedNodeException[]
+  }
+}
+
+export class FailedNodeException {
+  node_id: Id
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add private capabilities API (#5741)](https://github.com/elastic/elasticsearch-specification/pull/5741)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)