### PR TITLE
[8.19] Add transform.get_node_stats API (#5771)

### DIFF
--- a/specification/_doc_ids/table.csv
+++ b/specification/_doc_ids/table.csv
@@ -251,6 +251,7 @@ get-features-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch
 get-global-checkpoints,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-global-checkpoints.html,,
 get-license,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-license.html,,
 get-ml-info,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-ml-info.html,,
+get-node-stats,,,
 get-pipeline-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-pipeline-api.html,,
 get-repositories-metering-api,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-repositories-metering-api.html,,
 get-synonym-rule,https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/get-synonym-rule.html,,

--- a/specification/transform/get_node_stats/GetNodeStatsRequest.ts
+++ b/specification/transform/get_node_stats/GetNodeStatsRequest.ts
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { RequestBase } from '@_types/Base'
+
+/**
+ * Get node stats.
+ *
+ * Get per-node information about transform usage.
+ * @rest_spec_name transform.get_node_stats
+ * @availability stack since=8.15.0 stability=stable
+ * @availability serverless stability=stable visibility=public
+ * @doc_id get-node-stats
+ */
+export interface Request extends RequestBase {
+  urls: [
+    {
+      path: '/_transform/_node_stats'
+      methods: ['GET']
+    }
+  ]
+}

--- a/specification/transform/get_node_stats/GetNodeStatsResponse.ts
+++ b/specification/transform/get_node_stats/GetNodeStatsResponse.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TransformNodeStats } from './types'
+
+export class Response {
+  /** @codegen_name stats */
+  body: TransformNodeStats
+}

--- a/specification/transform/get_node_stats/types.ts
+++ b/specification/transform/get_node_stats/types.ts
@@ -1,0 +1,40 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { NodeId } from '@_types/common'
+import { integer } from '@_types/Numeric'
+import { AdditionalProperties } from '@spec_utils/behaviors'
+
+/**
+ * @behavior_meta AdditionalProperties fieldname=nodes description="Per node statistics"
+ */
+export class TransformNodeStats
+  implements AdditionalProperties<NodeId, Scheduler>
+{
+  total: Scheduler
+}
+
+export interface Scheduler {
+  scheduler: TransformNodeStatsDetails
+}
+
+export interface TransformNodeStatsDetails {
+  registered_transform_count: integer
+  peek_transform?: string
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Add transform.get_node_stats API (#5771)](https://github.com/elastic/elasticsearch-specification/pull/5771)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)