### PR TITLE
Improve transform.get_node_stats type names

### DIFF
--- a/specification/transform/get_node_stats/GetNodeStatsResponse.ts
+++ b/specification/transform/get_node_stats/GetNodeStatsResponse.ts
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-import { TransformNodeStats } from './types'
+import { TransformNodeFullStats } from './types'
 
 export class Response {
   /** @codegen_name stats */
-  body: TransformNodeStats
+  body: TransformNodeFullStats
 }

--- a/specification/transform/get_node_stats/types.ts
+++ b/specification/transform/get_node_stats/types.ts
@@ -24,17 +24,17 @@ import { AdditionalProperties } from '@spec_utils/behaviors'
 /**
  * @behavior_meta AdditionalProperties fieldname=nodes description="Per node statistics"
  */
-export class TransformNodeStats
-  implements AdditionalProperties<NodeId, Scheduler>
+export class TransformNodeFullStats
+  implements AdditionalProperties<NodeId, TransformNodeStats>
 {
-  total: Scheduler
+  total: TransformNodeStats
 }
 
-export interface Scheduler {
-  scheduler: TransformNodeStatsDetails
+export interface TransformNodeStats {
+  scheduler: TransformSchedulerStats
 }
 
-export interface TransformNodeStatsDetails {
+export interface TransformSchedulerStats {
   registered_transform_count: integer
   peek_transform?: string
 }


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch-specification/issues/5778 and https://github.com/elastic/elasticsearch-specification/pull/5771

In Elasticsearch, the inner type is called [TransformSchedulerStats](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformSchedulerStats.java), so I worked backwards from that.