### PR TITLE
Add externalDocs for multiple tags

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -112,7 +112,7 @@ actions:
           description: >
             The feature APIs enable you to introspect and manage features provided by Elasticsearch and Elasticsearch plugins.
           externalDocs:
-            url: https://www.elastic.co/docs/deploy-manage/tools/snapshot-and-restore
+            url: https://www.elastic.co/docs/deploy-manage/tools/snapshot-and-restore#feature-state
             description: Learn more about feature states.
         - name: fleet
           x-displayName: Fleet


### PR DESCRIPTION
Porting https://github.com/elastic/elasticsearch-specification/pull/5781 to branch-not-fork by request now that I have permissions, cheers.

This adds externalDocs links for multiple tags so that users can cross-reference from API docs back to Elasticserch documentation.