### PR TITLE
[DOCS] Edits cluster health parameter descriptions

### DIFF
--- a/specification/cluster/health/ClusterHealthRequest.ts
+++ b/specification/cluster/health/ClusterHealthRequest.ts
@@ -61,61 +61,74 @@ export interface Request extends RequestBase {
   ]
   path_parts: {
     /**
-     * Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard expressions (`*`) are supported. To target all data streams and indices in a cluster, omit this parameter or use _all or `*`.
+     * A comma-separated list of data streams, indices, and index aliases that limit the request.
+     * Wildcard expressions (`*`) are supported.
+     * To target all data streams and indices in a cluster, omit this parameter or use _all or `*`.
      */
     index?: Indices
   }
   query_parameters: {
     /**
-     * Whether to expand wildcard expression to concrete indices that are open, closed or both.
+     * Expand wildcard expression to concrete indices that are open, closed or both.
      * @server_default all
      */
     expand_wildcards?: ExpandWildcards
     /**
-     * Can be one of cluster, indices or shards. Controls the details level of the health information returned.
+     * Return health information at a specific level of detail.
      * @server_default cluster
      */
     level?: Level
     /**
-     * If true, the request retrieves information from the local node only. Defaults to false, which means information is retrieved from the master node.
+     * If true, retrieve information from the local node only.
+     * If false, retrieve information from the master node.
      * @server_default false
      */
     local?: boolean
     /**
-     * Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error.
+     * The period to wait for a connection to the master node.
+     * If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
     master_timeout?: Duration
     /**
-     * Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error.
+     * The period to wait for a response.
+     * If no response is received before the timeout expires, the request fails and returns an error.
      * @server_default 30s
      */
     timeout?: Duration
     /**
-     * A number controlling to how many active shards to wait for, all to wait for all shards in the cluster to be active, or 0 to not wait.
+     * Wait for the specified number of active shards.
+     * Use `all` to wait for all shards in the cluster to be active.
+     * Use `0` to not wait.
      * @server_default 0
      */
     wait_for_active_shards?: WaitForActiveShards
     /**
-     * Can be one of immediate, urgent, high, normal, low, languid. Wait until all currently queued events with the given priority are processed.
+     * Wait until all currently queued events with the given priority are processed.
      */
     wait_for_events?: WaitForEvents
     /**
-     * The request waits until the specified number N of nodes is available. It also accepts >=N, <=N, >N and <N. Alternatively, it is possible to use ge(N), le(N), gt(N) and lt(N) notation.
+     * Wait until the specified number (N) of nodes is available.
+     * It also accepts `>=N`, `<=N`, `>N` and `<N`.
+     * Alternatively, use the notations `ge(N)`, `le(N)`, `gt(N)`, and `lt(N)`.
      */
     wait_for_nodes?: WaitForNodes
     /**
-     * A boolean value which controls whether to wait (until the timeout provided) for the cluster to have no shard initializations. Defaults to false, which means it will not wait for initializing shards.
+     * Wait (until the timeout expires) for the cluster to have no shard initializations.
+     * If false, the request does not wait for initializing shards.
      * @server_default false
      */
     wait_for_no_initializing_shards?: boolean
     /**
-     * A boolean value which controls whether to wait (until the timeout provided) for the cluster to have no shard relocations. Defaults to false, which means it will not wait for relocating shards.
+     * Wait (until the timeout expires) for the cluster to have no shard relocations.
+     * If false, the request not wait for relocating shards.
      * @server_default false
      */
     wait_for_no_relocating_shards?: boolean
     /**
-     * One of green, yellow or red. Will wait (until the timeout provided) until the status of the cluster changes to the one provided or better, i.e. green > yellow > red. By default, will not wait for any status.
+     * Wait (until the timeout expires) for the cluster to reach a specific health status (or a better status).
+     * A green status is better than yellow and yellow is better than red.
+     * By default, the request does not wait for a particular status.
      */
     wait_for_status?: HealthStatus
   }


### PR DESCRIPTION
While reviewing https://github.com/elastic/logstash/pull/18377 I realized it used the same `wait_for_status` text that exists here and that it ought to be improved in both locations.

Relates to the guidelines provided in https://www.elastic.co/docs/contribute-docs/api-docs/guidelines#description-examples