### PR TITLE
Fix typo

### DIFF
--- a/specification/indices/forcemerge/IndicesForceMergeRequest.ts
+++ b/specification/indices/forcemerge/IndicesForceMergeRequest.ts
@@ -121,7 +121,7 @@ export interface Request extends RequestBase {
      */
     ignore_unavailable?: boolean
     /**
-     * The number of segments the index should be merged into (defayult: dynamic)
+     * The number of segments the index should be merged into (default: dynamic)
      */
     max_num_segments?: long
     /**


### PR DESCRIPTION
Note that we can't use `server_default` here because the type is not compatible.