### PR TITLE
Compile specification as part of CI

### DIFF
--- a/.github/workflows/code-format.yml
+++ b/.github/workflows/code-format.yml
@@ -21,5 +21,6 @@ jobs:
 
     - name: Code style check
       run: |
+        npm run compile:specification --prefix compiler
         npm run format:check --prefix compiler
 


### PR DESCRIPTION
It can generate TypeScript errors that are not otherwise caught.