### PR TITLE
Adds close_job param to the stop datafeed request

### DIFF
--- a/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
+++ b/specification/ml/stop_datafeed/MlStopDatafeedRequest.ts
@@ -71,6 +71,10 @@ export interface Request extends RequestBase {
      * Specifies the amount of time to wait until a datafeed stops.
      *  @server_default 20s */
     timeout?: Duration
+    /**
+     * If `true` the job associated with the datafeed is closed.
+     * @server_default false */
+    close_job?: boolean
   }
   body?: {
     /**
@@ -85,5 +89,9 @@ export interface Request extends RequestBase {
      * Refer to the description for the `timeout` query parameter.
      *  @server_default 20s */
     timeout?: Duration
+    /**
+     * Refer to the description for the `close_job` query parameter.
+     * @server_default false */
+    close_job?: boolean
   }
 }


### PR DESCRIPTION
Adds the specification for the new `close_job` parameter to the specification for the stop datafeed request.

Added in https://github.com/elastic/elasticsearch/pull/138634
