### PR TITLE
Update tag for project routing

### DIFF
--- a/docs/overlays/elasticsearch-shared-overlays.yaml
+++ b/docs/overlays/elasticsearch-shared-overlays.yaml
@@ -226,7 +226,11 @@ actions:
       # P
         - name: project
           x-displayName: Project
-          # description: 
+          description: >
+            The project APIs enable you to get project tags and manage your project routing expressions.
+          # externalDocs:
+            # url: 
+            # description:
       # Q
         - name: query_rules
           x-displayName: Query rules

--- a/specification/project_routing/create/CreateRoutingRequest.ts
+++ b/specification/project_routing/create/CreateRoutingRequest.ts
@@ -29,7 +29,7 @@ import { ProjectRoutingExpression } from '../_types/RoutingExpression'
  * @rest_spec_name project_routing.create
  * @availability serverless stability=experimental visibility=public
  * @cluster_privileges manage
- * @doc_tag project-routing
+ * @doc_tag project
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/project_routing/create_many/CreateRoutingRequest.ts
+++ b/specification/project_routing/create_many/CreateRoutingRequest.ts
@@ -29,7 +29,7 @@ import { NamedProjectRoutingExpressions } from '../_types/RoutingExpression'
  * @rest_spec_name project_routing.create_many
  * @availability serverless stability=experimental visibility=public
  * @cluster_privileges manage
- * @doc_tag project-routing
+ * @doc_tag project
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/project_routing/delete/DeleteRoutingRequest.ts
+++ b/specification/project_routing/delete/DeleteRoutingRequest.ts
@@ -28,7 +28,7 @@ import { MediaType } from '@_types/common'
  * @rest_spec_name project_routing.delete
  * @availability serverless stability=experimental visibility=public
  * @cluster_privileges manage
- * @doc_tag project-routing
+ * @doc_tag project
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/project_routing/get/GetRoutingRequest.ts
+++ b/specification/project_routing/get/GetRoutingRequest.ts
@@ -28,7 +28,7 @@ import { MediaType } from '@_types/common'
  * @rest_spec_name project_routing.get
  * @availability serverless stability=experimental visibility=public
  * @cluster_privileges monitor
- * @doc_tag project-routing
+ * @doc_tag project
  */
 export interface Request extends RequestBase {
   urls: [

--- a/specification/project_routing/get_many/GetRoutingRequest.ts
+++ b/specification/project_routing/get_many/GetRoutingRequest.ts
@@ -28,7 +28,7 @@ import { MediaType } from '@_types/common'
  * @rest_spec_name project_routing.get_many
  * @availability serverless stability=experimental visibility=public
  * @cluster_privileges monitor
- * @doc_tag project-routing
+ * @doc_tag project
  */
 export interface Request extends RequestBase {
   urls: [


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch-specification/pull/5860

This PR updates the project routing CRUD REST API endpoints to use the `@doc_tag project` instead of `@doc_tag project-routing` since IMO they can share this existing grouping and be published in this section: https://www.elastic.co/docs/api/doc/elasticsearch-serverless/group/endpoint-project

If they must remain separate, we need to update the overlay to add the new `project-routing` tag, since these APIs just appear at the bottom of the navigation otherwise.
