### PR TITLE
Fix cluster.get_component_template name parameter description

### DIFF
--- a/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
+++ b/specification/cluster/get_component_template/ClusterGetComponentTemplateRequest.ts
@@ -44,10 +44,7 @@ export interface Request extends RequestBase {
     }
   ]
   path_parts: {
-    /**
-     * Comma-separated list of component template names used to limit the request.
-     * Wildcard (`*`) expressions are supported.
-     */
+    /** Name of component template to retrieve. Wildcard (`*`) expressions are supported. */
     name?: Name
   }
   response_media_type: MediaType.Json


### PR DESCRIPTION
As done in https://github.com/elastic/elasticsearch/pull/138284 and fixed in https://github.com/elastic/elasticsearch-specification/pull/5636 for a similar API.