### PR TITLE
Add rerank to supported task types for Watsonx

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -2158,6 +2158,7 @@ export class WatsonxServiceSettings {
 
 export enum WatsonxTaskType {
   text_embedding,
+  rerank,
   chat_completion,
   completion
 }

--- a/specification/inference/put/PutRequest.ts
+++ b/specification/inference/put/PutRequest.ts
@@ -53,7 +53,7 @@ import { TaskType } from '@inference/_types/TaskType'
  * * OpenAI (`chat_completion`, `completion`, `text_embedding`)
  * * OpenShift AI (`chat_completion`, `completion`, `rerank`, `text_embedding`)
  * * VoyageAI (`rerank`, `text_embedding`)
- * * Watsonx inference integration (`text_embedding`)
+ * * Watsonx (`chat_completion`, `completion`, `rerank`, `text_embedding`)
  * @rest_spec_name inference.put
  * @availability stack since=8.11.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public

--- a/specification/inference/put_watsonx/PutWatsonxRequest.ts
+++ b/specification/inference/put_watsonx/PutWatsonxRequest.ts
@@ -69,7 +69,7 @@ export interface Request extends RequestBase {
     /**
      * The chunking configuration object.
      * Applies only to the `text_embedding` task type.
-     * Not applicable to the `completion` or `chat_completion` task types.
+     * Not applicable to the `rerank`, `completion` or `chat_completion` task types.
      * @ext_doc_id inference-chunking
      */
     chunking_settings?: InferenceChunkingSettings


### PR DESCRIPTION
Only merge after https://github.com/elastic/elasticsearch/pull/140331 is merged