### PR TITLE
[8.19] Fix ephemeral token usage (#5897)

### DIFF
--- a/.github/workflows/validate-apis.yml
+++ b/.github/workflows/validate-apis.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Checkout clients-flight-recorder
         uses: actions/checkout@v5
-        env:
-          GITHUB_TOKEN: ${{ steps.fetch-ephemeral-token.outputs.token }}
         with:
           repository: elastic/clients-flight-recorder
           path: ./clients-flight-recorder


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Fix ephemeral token usage (#5897)](https://github.com/elastic/elasticsearch-specification/pull/5897)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)