### PR TITLE
[Backport 8.19] Add rerank to supported task types for Watsonx

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -1695,7 +1695,8 @@ export class WatsonxServiceSettings {
 }
 
 export enum WatsonxTaskType {
-  text_embedding
+  text_embedding,
+  rerank
 }
 
 export enum WatsonxServiceType {

--- a/specification/inference/put/PutRequest.ts
+++ b/specification/inference/put/PutRequest.ts
@@ -49,7 +49,7 @@ import { TaskType } from '@inference/_types/TaskType'
  * * Mistral (`chat_completion`, `completion`, `text_embedding`)
  * * OpenAI (`chat_completion`, `completion`, `text_embedding`)
  * * VoyageAI (`rerank`, `text_embedding`)
- * * Watsonx inference integration (`text_embedding`)
+ * * Watsonx (`rerank`, `text_embedding`)
  * @rest_spec_name inference.put
  * @availability stack since=8.11.0 stability=stable visibility=public
  * @availability serverless stability=stable visibility=public


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch-specification/commit/f5e5356891a71aa9b0c1b6e65260edff1c43d84f from https://github.com/elastic/elasticsearch-specification/pull/5890.
