### PR TITLE
Add missing similarity field to PUT OpenAI inference API

### DIFF
--- a/specification/inference/_types/CommonTypes.ts
+++ b/specification/inference/_types/CommonTypes.ts
@@ -1958,7 +1958,7 @@ export class OpenAIServiceSettings {
    */
   rate_limit?: RateLimitSetting
   /**
-   * For a `text_embedding` task, the similarity measure. One of cosine, dot_product, l2_norm.
+   * For a `text_embedding` task, the similarity measure. One of cosine, dot_product, l2_norm. Defaults to `dot_product`.
    */
   similarity?: OpenAISimilarityType
   /**


### PR DESCRIPTION
## Overview

Relates to https://github.com/elastic/enhancements/issues/22952

This PR adds the `similarity` service setting to the PUT OpenAI inference API docs.