### PR TITLE
[8.19] Install bump-cli as part of make setup (#5930)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ setup:	## Install dependencies for contrib target
 	@make clean-dep
 	@npm install --prefix compiler
 	@npm install --prefix typescript-generator
-	@npm install @redocly/cli
+	@npm install @redocly/cli bump-cli
 	@npm install --prefix docs/examples
 
 clean-dep:	## Clean npm dependencies


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.19`:
 - [Install bump-cli as part of make setup (#5930)](https://github.com/elastic/elasticsearch-specification/pull/5930)

<!--- Backport version: 10.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)