### PR TITLE
[Backport 9.2] Fix missing `&` in `/_cat/pending_tasks`

### DIFF
--- a/docs/examples/languageExamples.json
+++ b/docs/examples/languageExamples.json
@@ -156,23 +156,23 @@
   "specification/cat/pending_tasks/examples/request/CatPendingTasksRequestExample1.yaml": [
     {
       "language": "Python",
-      "code": "resp = client.cat.pending_tasks(\n    v=\"trueh=insertOrder,timeInQueue,priority,source\",\n    format=\"json\",\n)"
+      "code": "resp = client.cat.pending_tasks(\n    v=\"true&h=insertOrder,timeInQueue,priority,source\",\n    format=\"json\",\n)"
     },
     {
       "language": "JavaScript",
-      "code": "const response = await client.cat.pendingTasks({\n  v: \"trueh=insertOrder,timeInQueue,priority,source\",\n  format: \"json\",\n});"
+      "code": "const response = await client.cat.pendingTasks({\n  v: \"true&h=insertOrder,timeInQueue,priority,source\",\n  format: \"json\",\n});"
     },
     {
       "language": "Ruby",
-      "code": "response = client.cat.pending_tasks(\n  v: \"trueh=insertOrder,timeInQueue,priority,source\",\n  format: \"json\"\n)"
+      "code": "response = client.cat.pending_tasks(\n  v: \"true&h=insertOrder,timeInQueue,priority,source\",\n  format: \"json\"\n)"
     },
     {
       "language": "PHP",
-      "code": "$resp = $client->cat()->pendingTasks([\n    \"v\" => \"trueh=insertOrder,timeInQueue,priority,source\",\n    \"format\" => \"json\",\n]);"
+      "code": "$resp = $client->cat()->pendingTasks([\n    \"v\" => \"true&h=insertOrder,timeInQueue,priority,source\",\n    \"format\" => \"json\",\n]);"
     },
     {
       "language": "curl",
-      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/pending_tasks?v=trueh=insertOrder,timeInQueue,priority,source&format=json\""
+      "code": "curl -X GET -H \"Authorization: ApiKey $ELASTIC_API_KEY\" \"$ELASTICSEARCH_URL/_cat/pending_tasks?v=true&h=insertOrder,timeInQueue,priority,source&format=json\""
     }
   ],
   "specification/cat/nodeattrs/examples/request/CatNodeAttributesRequestExample1.yaml": [

--- a/specification/cat/pending_tasks/examples/200_response/CatPendingTasksResponseExample1.yaml
+++ b/specification/cat/pending_tasks/examples/200_response/CatPendingTasksResponseExample1.yaml
@@ -1,6 +1,6 @@
 # summary:
 description: >
-  A successful response from `GET /_cat/pending_tasks?v=trueh=insertOrder,timeInQueue,priority,source&format=json`.
+  A successful response from `GET /_cat/pending_tasks?v=true&h=insertOrder,timeInQueue,priority,source&format=json`.
 # type: response
 # response_code: 200
 value: |-

--- a/specification/cat/pending_tasks/examples/request/CatPendingTasksRequestExample1.yaml
+++ b/specification/cat/pending_tasks/examples/request/CatPendingTasksRequestExample1.yaml
@@ -1,1 +1,1 @@
-method_request: GET /_cat/pending_tasks?v=trueh=insertOrder,timeInQueue,priority,source&format=json
+method_request: GET /_cat/pending_tasks?v=true&h=insertOrder,timeInQueue,priority,source&format=json


### PR DESCRIPTION
(cherry picked from commit 34ba93263d4d84ec42ebc14013c76c0a9e9f4299)

<!-- Hello there! Thank you for opening a pull request. See CONTRIBUTING.md for instructions. -->
