### PR TITLE
ESQL named parameters

### DIFF
--- a/specification/esql/_types/types.ts
+++ b/specification/esql/_types/types.ts
@@ -20,7 +20,7 @@
 import { FieldValue } from '@_types/common'
 import { Dictionary } from '@spec_utils/Dictionary'
 
-export type ESQLParam  = FieldValue | FieldValue[] | NamedValue
+export type ESQLParam = FieldValue | FieldValue[] | NamedValue
 export type NamedValue = Dictionary<string, FieldValue | FieldValue[]>
 
 /**


### PR DESCRIPTION
@ivancea identified a gap in our specifications in https://github.com/elastic/elasticsearch-specification/pull/5956 regarding ESQL named parameters.  Named parameters are provided as a json list of objects of the form `{ "name": value }` which the specification does not allow.  This change amends the specification to allow these.

See also [rest-api-spec example](https://github.com/elastic/elasticsearch/pull/138051/files#diff-9e4a38fbf1ed2267447b4ac4c492670d5b2cc4186b316475f141a0eeccee5375R648) and our [slack discussion from 1/21](https://docs.google.com/document/d/1v5BJQPAkGjZxqpZ_wdLBXsMHRzvEwFRXTmfPgZls2tQ/edit?usp=sharing)