### PR TITLE
Change `codegen_name` for `EmbeddingRequest` body

### DIFF
--- a/specification/inference/embedding/EmbeddingRequest.ts
+++ b/specification/inference/embedding/EmbeddingRequest.ts
@@ -52,6 +52,6 @@ export interface Request extends RequestBase {
      */
     timeout?: Duration
   }
-  /** @codegen_name embedding_request */
+  /** @codegen_name embedding */
   body: RequestEmbedding
 }


### PR DESCRIPTION
The `request` portion in the codegen name is redundant.