### PR TITLE
fix: make 'field' optional and add 'script' field to MultiTermLookup

### DIFF
--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -643,6 +643,9 @@ export class MultiTermsAggregation extends BucketAggregationBase {
   terms: MultiTermLookup[]
 }
 
+/**
+ * @variants container
+ */
 export class MultiTermLookup {
   /**
    * A field from which to retrieve terms.
@@ -657,6 +660,7 @@ export class MultiTermLookup {
   /**
    * The value to apply to documents that do not have a value.
    * By default, documents without a value are ignored.
+   * @variant container_property
    */
   missing?: Missing
 }


### PR DESCRIPTION
In MultiTermLookup, field is actually optional if you pass a script instead

Therefore, I've made `field` optional and added `script`

See:

- https://github.com/elastic/go-elasticsearch/issues/1022
- [Gist of reproducible use of scripts in Kibana Dev Tools](https://gist.github.com/MattDevy/4b37aa97cb1dac946331f54f72a459c7)
- [Source showing script can be set](https://github.com/elastic/elasticsearch/blob/52658362e74acaff995ffec4d0b2111c1320009a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceFieldConfig.java#L330-L351)
- [Source showing field is scriptable](https://github.com/elastic/elasticsearch/blob/52658362e74acaff995ffec4d0b2111c1320009a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregationBuilder.java#L62)
