### PR TITLE
ESQL: Move time_zone to GA

### DIFF
--- a/specification/esql/async_query/AsyncQueryRequest.ts
+++ b/specification/esql/async_query/AsyncQueryRequest.ts
@@ -91,8 +91,8 @@ export interface Request extends RequestBase {
     filter?: QueryContainer
     /**
      * Sets the default timezone of the query.
-     * @availability stack since=9.4.0 stability=experimental
-     * @availability serverless stability=experimental
+     * @availability stack since=9.4.0 stability=stable
+     * @availability serverless stability=stable
      * @doc_id esql-timezones
      */
     time_zone?: string

--- a/specification/esql/query/QueryRequest.ts
+++ b/specification/esql/query/QueryRequest.ts
@@ -85,8 +85,8 @@ export interface Request extends RequestBase {
     filter?: QueryContainer
     /**
      * Sets the default timezone of the query.
-     * @availability stack since=9.4.0 stability=experimental
-     * @availability serverless stability=experimental
+     * @availability stack since=9.4.0 stability=stable
+     * @availability serverless stability=stable
      * @doc_id esql-timezones
      */
     time_zone?: string


### PR DESCRIPTION
Time_zone is currently in preview. This change moves it to GA.

Main docs PR: https://github.com/elastic/elasticsearch/pull/142287