### PR TITLE
Adds shrink action note to the "Shrink an index" API

### DIFF
--- a/specification/indices/shrink/IndicesShrinkRequest.ts
+++ b/specification/indices/shrink/IndicesShrinkRequest.ts
@@ -42,7 +42,7 @@ import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
  * For example an index with 8 primary shards can be shrunk into 4, 2 or 1 primary shards or an index with 15 primary shards can be shrunk into 5, 3 or 1.
  * If the number of shards in the index is a prime number it can only be shrunk into a single primary shard
  *  Before shrinking, a (primary or replica) copy of every shard in the index must be present on the same node.
- * 
+ *
  * IMPORTANT: If the source index already has one primary shard, configuring the shrink operation with 'index.number_of_shards: 1' will cause the request to fail. An index with one primary shard cannot be shrunk further.
  *
  * The current write index on a data stream cannot be shrunk. In order to shrink the current write index, the data stream must first be rolled over so that a new write index is created and then the previous write index can be shrunk.


### PR DESCRIPTION
This PR adds a note on shrinking behavior to the [Shrink an index API](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-indices-shrink#operation-indices-shrink-body-application-json-aliases-search_routing).

Related issue: https://github.com/elastic/docs-content/issues/2573