### PR TITLE
Fix default value for the size parameter of GetSnapshots API

### DIFF
--- a/specification/snapshot/get/SnapshotGetRequest.ts
+++ b/specification/snapshot/get/SnapshotGetRequest.ts
@@ -124,8 +124,8 @@ export interface Request extends RequestBase {
     offset?: integer
     /**
      * The maximum number of snapshots to return.
-     * The default is 0, which means to return all that match the request without limit.
-     * @server_default 0
+     * The default is -1, which means to return all that match the request without limit.
+     * @server_default -1
      * @availability stack since=7.14.0
      * @availability serverless
      */


### PR DESCRIPTION
The default is -1 for no limit instead of 0 which triggers validation error.

