### PR TITLE
[Transform] Add project routing

### DIFF
--- a/specification/transform/_types/Transform.ts
+++ b/specification/transform/_types/Transform.ts
@@ -24,7 +24,7 @@ import {
   HistogramAggregation,
   TermsAggregation
 } from '@_types/aggregations/bucket'
-import { Field, IndexName, Indices } from '@_types/common'
+import { Field, IndexName, Indices, ProjectRouting } from '@_types/common'
 import { RuntimeFields } from '@_types/mapping/RuntimeFields'
 import { float, integer } from '@_types/Numeric'
 import { QueryContainer } from '@_types/query_dsl/abstractions'
@@ -172,6 +172,18 @@ export class Source {
    * @availability serverless
    */
   runtime_mappings?: RuntimeFields
+  /**
+   * Specifies a subset of projects to target using project
+   * metadata tags in a subset of Lucene query syntax.
+   * Allowed Lucene queries: the _alias tag and a single value (possibly wildcarded).
+   * Examples:
+   *  _alias:my-project
+   *  _alias:_origin
+   *  _alias:*pr*
+   * Supported in serverless only.
+   * @availability serverless stability=stable visibility=feature_flag feature_flag=serverless.cross_project.enabled
+   */
+  project_routing?: ProjectRouting
 }
 
 export class Sync {}


### PR DESCRIPTION
Add documentation for project routing in source config. This is currently only enabled for serverless behind a feature flag.