### PR TITLE
Validate query - fix index optional + missing shard field

### DIFF
--- a/specification/indices/validate_query/IndicesValidateQueryResponse.ts
+++ b/specification/indices/validate_query/IndicesValidateQueryResponse.ts
@@ -18,6 +18,7 @@
  */
 
 import { IndexName } from '@_types/common'
+import { integer } from '@_types/Numeric'
 import { ShardStatistics } from '@_types/Stats'
 
 export class Response {
@@ -32,6 +33,7 @@ export class Response {
 export class IndicesValidationExplanation {
   error?: string
   explanation?: string
-  index: IndexName
+  index?: IndexName
+  shard?: integer
   valid: boolean
 }


### PR DESCRIPTION
Originally reported in https://github.com/elastic/elasticsearch-java/issues/1178, server code proof: https://github.com/elastic/elasticsearch/blob/a59c182f9f7e9d1bf3d6eecbc0e44f24ff91d053/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/QueryExplanation.java#L45
