### PR TITLE
Update reindex-from-remote spec for serverless

### DIFF
--- a/specification/_global/reindex/ReindexRequest.ts
+++ b/specification/_global/reindex/ReindexRequest.ts
@@ -51,7 +51,7 @@ import { Destination, Source } from './types'
  * * If reindexing from a remote cluster, the `source.remote.user` must have the `monitor` cluster privilege and the `read` index privilege for the source data stream, index, or alias.
  *
  * If reindexing from a remote cluster into a cluster using Elastic Stack, you must explicitly allow the remote host using the `reindex.remote.whitelist` node setting on the destination cluster.
- * If reindexing from a remote cluster into an Elastic Cloud Serverless project, only remote hosts from Elastic Cloud Hosted are allowed.
+ * If reindexing from a remote cluster into an Elastic Cloud Serverless project, only remote hosts from Elastic Cloud Hosted and Elastic Cloud Serverless are allowed.
  * Automatic data stream creation requires a matching index template with data stream enabled.
  *
  * The `dest` element can be configured like the index API to control optimistic concurrency control.


### PR DESCRIPTION
We are changing the whitelisting for reindex-from-remote in serverless to allow serverless hosts (in addition to ECH, which is all we allow now). This updates the spec to reflect that.

ES-14414

<!-- Hello there! Thank you for opening a pull request. See CONTRIBUTING.md for instructions. -->
