### PR TITLE
Field date math double to long

### DIFF
--- a/specification/_types/aggregations/bucket.ts
+++ b/specification/_types/aggregations/bucket.ts
@@ -316,7 +316,7 @@ export class DateRangeAggregation extends BucketAggregationBase {
  * @codegen_names expr, value
  */
 // ES: DateRangeAggregationBuilder.innerBuild()
-export type FieldDateMath = DateMath | double
+export type FieldDateMath = DateMath | long
 
 export class DateRangeExpression {
   /**


### PR DESCRIPTION
Originally reported in https://github.com/elastic/elasticsearch-java/issues/1198.
FieldDateMath is used in [Date range aggregation](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-daterange-aggregation), which accepts both string formatted dates and numeric dates. Numeric dates can only be epochs, which should be sent as `long`, and not `double`. [Server side code](https://github.com/elastic/elasticsearch/blob/a10002792f5164d45f088c88002a559fcaa80436/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/DateRangeAggregationBuilder.java#L338), where the double value is parsed from `long`. 
