### PR TITLE
New long number range query variant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ spec-format-check:	## Check specification formatting rules
 spec-format-fix:	## Format/fix the specification according to the formatting rules
 	@npm run format:fix --prefix compiler
 
-spec-dangling-types:	## Generate the dangling types rreport
+spec-dangling-types:	## Generate the dangling types report
 	@npm run generate-dangling --prefix compiler
 
 spec-inspect:  ## Run the command line schema browser tool

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Usage:
   license-add      Add the license headers to the files
   spec-format-check  Check specification formatting rules
   spec-format-fix  Format/fix the specification according to the formatting rules
-  spec-dangling-types  Generate the dangling types rreport
+  spec-dangling-types  Generate the dangling types report
   setup            Install dependencies for contrib target
   clean-dep        Clean npm dependencies
   transform-expand-generics  Create a new schema with all generics expanded

--- a/specification/_types/query_dsl/term.ts
+++ b/specification/_types/query_dsl/term.ts
@@ -27,7 +27,7 @@ import {
   MinimumShouldMatch,
   MultiTermQueryRewrite
 } from '@_types/common'
-import { double, integer } from '@_types/Numeric'
+import { double, integer, long } from '@_types/Numeric'
 import { Script } from '@_types/Scripting'
 import { DateFormat, DateMath, TimeZone } from '@_types/Time'
 import { AdditionalProperty } from '@spec_utils/behaviors'
@@ -167,10 +167,12 @@ export class DateRangeQuery extends RangeQueryBase<DateMath> {
 
 export class NumberRangeQuery extends RangeQueryBase<double> {}
 
+export class LongNumberRangeQuery extends RangeQueryBase<long> {}
+
 export class TermRangeQuery extends RangeQueryBase<string> {}
 
 /**
- * @codegen_names untyped, date, number, term
+ * @codegen_names untyped, date, number, long_number, term
  * @variants untagged untyped=_types.query_dsl.UntypedRangeQuery
  * @ext_doc_id query-dsl-range-query
  */
@@ -179,6 +181,7 @@ export type RangeQuery =
   | UntypedRangeQuery
   | DateRangeQuery
   | NumberRangeQuery
+  | LongNumberRangeQuery
   | TermRangeQuery
 
 export enum RangeRelation {


### PR DESCRIPTION
Current number range query only covers doubles, meaning in the java client it won't work with epochs. Originally reported in https://github.com/elastic/elasticsearch-java/issues/1199