### PR TITLE
Add follow_relocations request param to GET /_tasks/{task_id}

### DIFF
--- a/specification/tasks/get/GetTaskRequest.ts
+++ b/specification/tasks/get/GetTaskRequest.ts
@@ -64,6 +64,7 @@ export interface Request extends RequestBase {
     wait_for_completion?: boolean
     /**
      * Internal use only
+     * @availability stack since=9.5.0 stability=experimental visibility=private
      * @server_default true
      */
     follow_relocations?: boolean

--- a/specification/tasks/get/GetTaskRequest.ts
+++ b/specification/tasks/get/GetTaskRequest.ts
@@ -62,5 +62,10 @@ export interface Request extends RequestBase {
      * @server_default false
      */
     wait_for_completion?: boolean
+    /**
+     * Internal use only
+     * @server_default true
+     */
+    follow_relocations?: boolean
   }
 }


### PR DESCRIPTION
Adds an internal only param `follow_relocations` to `GET /_tasks/{task_id}`.

Relates to https://github.com/elastic/elasticsearch/pull/146161
Relates to https://github.com/elastic/elasticsearch-team/issues/2588