### PR TITLE
Add wildcard to FieldType enum

### DIFF
--- a/specification/_types/mapping/Property.ts
+++ b/specification/_types/mapping/Property.ts
@@ -201,6 +201,7 @@ export enum FieldType {
   keyword,
   text,
   search_as_you_type,
+  wildcard,
   date,
   date_nanos,
   boolean,


### PR DESCRIPTION
## Summary

Adds the missing `wildcard` member to the `FieldType` enum in `specification/_types/mapping/Property.ts`.

`WildcardProperty` (with `type: 'wildcard'`) already exists in `specification/_types/mapping/core.ts` and is part of the `Property` union, but the sibling `FieldType` enum — used by consumers like `SortOptions.unmapped_type` — was missing the value.

Closes #6104.