### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/compiler-rs/openapi_to_clients_schema/src/lib.rs
+++ b/compiler-rs/openapi_to_clients_schema/src/lib.rs
@@ -44,14 +44,21 @@ pub fn generate(open_api: &OpenAPI) -> anyhow::Result<clients_schema::IndexedMod
 fn generate_types(open_api: &OpenAPI, model: &mut IndexedModel) -> anyhow::Result<()> {
     if let Some(ref components) = open_api.components {
         let mut types = types::Types::default();
+        let mut generation_errors = 0;
         for (id, schema) in &components.schemas {
             let result = types::generate_type(open_api, id, &schema.into(), &mut types);
 
             if let Err(err) = result {
+                generation_errors += 1;
                 warn!("Problem with type '{id}'\n    {err}\n    Definition: {:?}", &schema);
             }
         }
-        let _ = types.check_tracker(); // TODO: actually fail
+        types.check_tracker()?;
+        if generation_errors > 0 {
+            return Err(anyhow::anyhow!(
+                "Failed to generate {generation_errors} type(s)"
+            ));
+        }
         model.types = types.types().into_iter().map(|t| (t.name().clone(), t)).collect();
     }
 

--- a/compiler/src/transform/schema-to-openapi.ts
+++ b/compiler/src/transform/schema-to-openapi.ts
@@ -25,5 +25,6 @@ const realArgs = process.argv.slice(2)
 try {
   convert_schema_to_openapi(realArgs, '..')
 } catch (e) {
-  console.log(e)
+  console.error(e)
+  process.exit(1)
 }


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `compiler-rs/openapi_to_clients_schema/src/lib.rs:L40`

During OpenAPI-to-clients-schema conversion, failures in individual type generation are only logged with `warn!` and processing continues. Additionally, `types.check_tracker()` is called but its result is explicitly ignored (`// TODO: actually fail`). This can produce partially generated or inconsistent schemas without failing the build, which can weaken downstream validation and allow malformed API contracts to be published unnoticed.

## Solution

Fail closed on conversion inconsistencies: accumulate generation errors and return an `Err` when any type fails, and enforce `check_tracker()` results instead of ignoring them. Optionally provide a strict mode defaulting to hard-fail in CI.

## Changes

- `compiler-rs/openapi_to_clients_schema/src/lib.rs` (modified)
- `compiler/src/transform/schema-to-openapi.ts` (modified)