### PR TITLE
ci: bump ephemeralStorage to 25Gi for Kibana type checks

### DIFF
--- a/.buildkite/kibana.yml
+++ b/.buildkite/kibana.yml
@@ -1,7 +1,7 @@
 agents:
   memory: "48G"
   cpu: "4"
-  ephemeralStorage: 15Gi
+  ephemeralStorage: 25Gi
 
 steps:
   - label: "Run Kibana type checks"


### PR DESCRIPTION
bumping ephemeralStorage for failed kibana checks