### PR TITLE
Improve docs on the PUT shutdown allocation_delay

### DIFF
--- a/specification/shutdown/put_node/ShutdownPutNodeRequest.ts
+++ b/specification/shutdown/put_node/ShutdownPutNodeRequest.ts
@@ -96,7 +96,9 @@ export interface Request extends RequestBase {
      * Only valid if type is restart.
      * Controls how long Elasticsearch will wait for the node to restart and join the cluster before reassigning its shards to other nodes.
      * This works the same as delaying allocation with the index.unassigned.node_left.delayed_timeout setting.
-     * If you specify both a restart allocation delay and an index-level allocation delay, the longer of the two is used.
+     * If you don't specify a restart allocation delay, a default value of 5 minutes will be used.
+     * If both a restart allocation delay and an index-level allocation delay are configured, the longer of the two is used.
+     * @server_default 5m
      */
     allocation_delay?: string
     /**


### PR DESCRIPTION
Add an extra piece of information to the docs on the `PUT /_nodes/{node_id}/shutdown` API about the `allocation_delay` parameter: namely, the existence of the default value and how it relates to the unassigned node allocation delay.

Part of https://github.com/elastic/elasticsearch/issues/125643

