### PR TITLE
Search query profile contains original request, target indices 

### DIFF
--- a/output/typescript/types.ts
+++ b/output/typescript/types.ts
@@ -1746,6 +1746,7 @@ export interface SearchPointInTimeReference {
 
 export interface SearchProfile {
   shards: SearchShardProfile[]
+  request?: SearchSearchRequestCoordinatorMetadata
 }
 
 export interface SearchQueryBreakdown {
@@ -1846,6 +1847,11 @@ export interface SearchSearchRequestBody {
   pit?: SearchPointInTimeReference
   runtime_mappings?: MappingRuntimeFields
   stats?: string[]
+}
+
+export interface SearchSearchRequestCoordinatorMetadata {
+  source?: SearchSearchRequestBody
+  indices?: IndexName[]
 }
 
 export interface SearchShardProfile {

--- a/specification/_global/search/_types/profile.ts
+++ b/specification/_global/search/_types/profile.ts
@@ -20,6 +20,7 @@
 import { IndexName, NodeId } from '@_types/common'
 import { integer, long } from '@_types/Numeric'
 import { Duration, DurationValue, UnitNanos } from '@_types/Time'
+import { SearchRequestBody } from '@global/search/_types/SearchRequestBody'
 import { Dictionary } from '@spec_utils/Dictionary'
 import { UserDefinedValue } from '@spec_utils/UserDefinedValue'
 
@@ -98,8 +99,27 @@ export class Collector {
   children?: Collector[]
 }
 
+/**
+ * Coordinator snapshot of the original search request, serialized under `profile.request` when profiling is enabled.
+ * Introduced in Elasticsearch 9.5; omitted when the cluster contains mixed-version nodes that do not serialize this metadata.
+ */
+export class SearchRequestCoordinatorMetadata {
+  /**
+   * Original query source from the search request (`SearchSourceBuilder` as JSON).
+   */
+  source?: SearchRequestBody
+  /**
+   * Target index expressions from the request (before index resolution).
+   */
+  indices?: IndexName[]
+}
+
 export class Profile {
   shards: ShardProfile[]
+  /**
+   * When profiling is enabled, the original query source and target indices from the coordinating request.
+   */
+  request?: SearchRequestCoordinatorMetadata
 }
 
 export class QueryBreakdown {


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/143783

- Added a new SearchRequestCoordinatorMetadata object under the search response Profile object


