### PR TITLE
Fixing reindex rethrottle resp

### DIFF
--- a/specification/_global/reindex_rethrottle/types.ts
+++ b/specification/_global/reindex_rethrottle/types.ts
@@ -22,6 +22,7 @@ import { long } from '@_types/Numeric'
 import { ReindexStatus } from '@_types/Reindex'
 import { DurationValue, EpochTime, UnitMillis, UnitNanos } from '@_types/Time'
 import { BaseNode } from '@spec_utils/BaseNode'
+import { OverloadOf } from '@spec_utils/behaviors'
 import { Dictionary } from '@spec_utils/Dictionary'
 
 export class ReindexNode extends BaseNode {
@@ -37,9 +38,13 @@ export class ReindexTask {
   node: Name
   running_time_in_nanos: DurationValue<UnitNanos>
   start_time_in_millis: EpochTime<UnitMillis>
-  status: ReindexStatus
+  status: ParentReindexStatus
   type: string
   headers: HttpHeaders
+}
+
+export class ParentReindexStatus implements OverloadOf<ReindexStatus> {
+  slices?: ReindexStatus[]
 }
 
 /**


### PR DESCRIPTION
server code: https://github.com/elastic/elasticsearch/blob/c0f12daed819d1c1135275f52446d693daf7b5f5/modules/reindex/src/main/java/org/elasticsearch/reindex/RestReindexRethrottleAction.java#L66

side note: ReindexRethrottleRequest has a `groupBy` param that changes the structure of the response, it's likely that we don't have a full mapping for it.
