### PR TITLE
Add missing fields to DataStreamLifecycle

### DIFF
--- a/specification/indices/_types/DataStreamLifecycle.ts
+++ b/specification/indices/_types/DataStreamLifecycle.ts
@@ -33,6 +33,16 @@ export class DataStreamLifecycle {
    * When empty, every document in this data stream will be stored indefinitely.
    */
   data_retention?: Duration
+
+  /**
+   * The least amount of time data should be kept by elasticsearch.
+   */
+  effective_retention?: Duration
+
+  /**
+   * Configuration source that can influence the retention of a data stream.
+   */
+  retention_determined_by?: RetentionSource
   /**
    * The list of downsampling rounds to execute as part of this downsampling configuration
    */
@@ -52,6 +62,13 @@ export class DataStreamLifecycle {
    * Only available with feature flag dlm_searchable_snapshots.
    */
   frozen_after?: Duration
+}
+
+export enum RetentionSource {
+  data_stream_configuration,
+  default_global_retention,
+  max_global_retention,
+  default_failures_retention
 }
 
 /**

--- a/specification/indices/get_data_lifecycle/_types/response.ts
+++ b/specification/indices/get_data_lifecycle/_types/response.ts
@@ -17,18 +17,9 @@
  * under the License.
  */
 
-import { DataStreamName } from '@_types/common'
-import { DataStreamLifecycleWithRollover } from '@indices/_types/DataStreamLifecycle'
-import { GlobalRetention } from '@indices/get_data_lifecycle/_types/response'
+import { Duration } from '@_types/Time'
 
-export class Response {
-  body: {
-    data_streams: DataStreamWithLifecycle[]
-    global_retention: GlobalRetention
-  }
-}
-
-class DataStreamWithLifecycle {
-  name: DataStreamName
-  lifecycle?: DataStreamLifecycleWithRollover
+export class GlobalRetention {
+  max_retention?: Duration
+  default_retention?: Duration
 }


### PR DESCRIPTION
Server PR: https://github.com/elastic/elasticsearch/pull/106221

also added `global_retention` to IndicesGetDataLifecycleResponse.ts since it's part of the same feature server side
